### PR TITLE
test(gateway-contracts): add malicious scenario on public decryption responses

### DIFF
--- a/gateway-contracts/test/Decryption.ts
+++ b/gateway-contracts/test/Decryption.ts
@@ -526,6 +526,62 @@ describe("Decryption", function () {
       ).to.be.revertedWithCustomError(decryption, "EnforcedPause");
     });
 
+    it("Should public decrypt with 3 valid and 1 malicious signatures", async function () {
+      // Request public decryption
+      await decryption.publicDecryptionRequest(ctHandles);
+
+      const decryptionAddress = await decryption.getAddress();
+
+      // Create a malicious EIP712 message: the decryptedResult is different from the expected one
+      // but the signature is valid (the malicious decryptedResult will be given to the response call)
+      const fakeDecryptedResult = createBytes32();
+      const fakeEip712Message = createEIP712ResponsePublicDecrypt(
+        gatewayChainId,
+        decryptionAddress,
+        ctHandles,
+        fakeDecryptedResult,
+      );
+      const [fakeKmsSignature] = await getSignaturesPublicDecrypt(fakeEip712Message, kmsSigners);
+
+      // Trigger a malicious public decryption response with:
+      // - the first KMS transaction sender (expected)
+      // - a fake signature (unexpected)
+      await decryption
+        .connect(kmsTxSenders[0])
+        .publicDecryptionResponse(decryptionId, fakeDecryptedResult, fakeKmsSignature);
+
+      // Trigger a first valid public decryption response with:
+      // - the second KMS transaction sender
+      // - the second KMS signer's signature
+      await decryption
+        .connect(kmsTxSenders[1])
+        .publicDecryptionResponse(decryptionId, decryptedResult, kmsSignatures[1]);
+
+      // Trigger a second valid public decryption response with:
+      // - the third KMS transaction sender
+      // - the third KMS signer's signature
+      const responseTx3 = await decryption
+        .connect(kmsTxSenders[2])
+        .publicDecryptionResponse(decryptionId, decryptedResult, kmsSignatures[2]);
+
+      // Trigger a third valid proof verification response with:
+      // - the fourth coprocessor transaction sender
+      // - the fourth coprocessor signer's signature
+      const responseTx4 = await decryption
+        .connect(kmsTxSenders[3])
+        .publicDecryptionResponse(decryptionId, decryptedResult, kmsSignatures[3]);
+
+      // Consensus should not be reached at the third transaction since the first was malicious
+      // Check 3rd transaction events: it should not emit an event for public decryption response
+      await expect(responseTx3).to.not.emit(decryption, "PublicDecryptionResponse");
+
+      // Consensus should be reached at the fourth transaction
+      // Check 4th transaction events: it should only contain 3 valid signatures
+      await expect(responseTx4)
+        .to.emit(decryption, "PublicDecryptionResponse")
+        .withArgs(decryptionId, decryptedResult, kmsSignatures.slice(1, 4));
+    });
+
     describe("Checks", function () {
       it("Should not revert because public decryption is ready", async function () {
         await expect(decryption.checkPublicDecryptionReady(ctHandles)).to.not.be.reverted;
@@ -665,6 +721,7 @@ describe("Decryption", function () {
       userSignature = fixtureData.userSignature;
       kmsSignatures = fixtureData.kmsSignatures;
       kmsTxSenders = fixtureData.kmsTxSenders;
+      // kmsSigners = fixtureData.kmsSigners;
       coprocessorTxSenders = fixtureData.coprocessorTxSenders;
       userDecryptedShares = fixtureData.userDecryptedShares;
       eip712RequestMessage = fixtureData.eip712RequestMessage;
@@ -1275,6 +1332,73 @@ describe("Decryption", function () {
           .userDecryptionResponse(decryptionId, userDecryptedShares[0], kmsSignatures[0]),
       ).to.be.revertedWithCustomError(decryption, "EnforcedPause");
     });
+
+    /*
+    it("Should user decrypt with 3 valid and 1 malicious signatures", async function () {
+      // Request user decryption
+      await decryption.userDecryptionRequest(
+        ctHandleContractPairs,
+        requestValidity,
+        hostChainId,
+        contractAddresses,
+        user.address,
+        publicKey,
+        userSignature,
+      );
+
+      const decryptionAddress = await decryption.getAddress();
+
+      // Create a malicious EIP712 message: the decryptedResult is different from the expected one
+      // but the signature is valid (the malicious decryptedResult will be given to the response call)
+      const fakeUserDecryptedShare = createBytes32();
+      const fakeEip712Message = createEIP712ResponseUserDecrypt(
+        gatewayChainId,
+        decryptionAddress,
+        publicKey,
+        ctHandles,
+        fakeUserDecryptedShare,
+      );
+      const [fakeKmsSignature] = await getSignaturesUserDecryptResponse([fakeEip712Message], [kmsSigners[0]]);
+
+      // Trigger a malicious user decryption response with:
+      // - the first KMS transaction sender (expected)
+      // - a fake signature (unexpected)
+      await decryption
+        .connect(kmsTxSenders[0])
+        .userDecryptionResponse(decryptionId, fakeUserDecryptedShare, fakeKmsSignature);
+
+      // Trigger a first valid public decryption response with:
+      // - the second KMS transaction sender
+      // - the second KMS signer's signature
+      await decryption
+        .connect(kmsTxSenders[1])
+        .userDecryptionResponse(decryptionId, userDecryptedShares[1], kmsSignatures[1]);
+
+      // Trigger a second valid public decryption response with:
+      // - the third KMS transaction sender
+      // - the third KMS signer's signature
+      let responseTx3 = await decryption
+        .connect(kmsTxSenders[2])
+        .userDecryptionResponse(decryptionId, userDecryptedShares[2], kmsSignatures[2]);
+
+      // Trigger a third valid proof verification response with:
+      // - the fourth coprocessor transaction sender
+      // - the fourth coprocessor signer's signature
+      let responseTx4 = await decryption
+        .connect(kmsTxSenders[3])
+        .userDecryptionResponse(decryptionId, userDecryptedShares[3], kmsSignatures[3]);
+
+      // Consensus should not be reached at the third transaction since the first was malicious
+      // Check 3rd transaction events: it should not emit an event for public decryption response
+      await expect(responseTx3).to.not.emit(decryption, "UserDecryptionResponse");
+
+      // Consensus should be reached at the fourth transaction
+      // Check 4th transaction events: it should only contain 3 valid signatures
+      await expect(responseTx4)
+        .to.emit(decryption, "UserDecryptionResponse")
+        .withArgs(decryptionId, userDecryptedShares.slice(1, 3), kmsSignatures.slice(1, 3));
+    });
+    */
 
     describe("Checks", function () {
       it("Should not revert because user decryption is ready", async function () {

--- a/gateway-contracts/test/Decryption.ts
+++ b/gateway-contracts/test/Decryption.ts
@@ -721,7 +721,6 @@ describe("Decryption", function () {
       userSignature = fixtureData.userSignature;
       kmsSignatures = fixtureData.kmsSignatures;
       kmsTxSenders = fixtureData.kmsTxSenders;
-      // kmsSigners = fixtureData.kmsSigners;
       coprocessorTxSenders = fixtureData.coprocessorTxSenders;
       userDecryptedShares = fixtureData.userDecryptedShares;
       eip712RequestMessage = fixtureData.eip712RequestMessage;
@@ -1332,73 +1331,6 @@ describe("Decryption", function () {
           .userDecryptionResponse(decryptionId, userDecryptedShares[0], kmsSignatures[0]),
       ).to.be.revertedWithCustomError(decryption, "EnforcedPause");
     });
-
-    /*
-    it("Should user decrypt with 3 valid and 1 malicious signatures", async function () {
-      // Request user decryption
-      await decryption.userDecryptionRequest(
-        ctHandleContractPairs,
-        requestValidity,
-        hostChainId,
-        contractAddresses,
-        user.address,
-        publicKey,
-        userSignature,
-      );
-
-      const decryptionAddress = await decryption.getAddress();
-
-      // Create a malicious EIP712 message: the decryptedResult is different from the expected one
-      // but the signature is valid (the malicious decryptedResult will be given to the response call)
-      const fakeUserDecryptedShare = createBytes32();
-      const fakeEip712Message = createEIP712ResponseUserDecrypt(
-        gatewayChainId,
-        decryptionAddress,
-        publicKey,
-        ctHandles,
-        fakeUserDecryptedShare,
-      );
-      const [fakeKmsSignature] = await getSignaturesUserDecryptResponse([fakeEip712Message], [kmsSigners[0]]);
-
-      // Trigger a malicious user decryption response with:
-      // - the first KMS transaction sender (expected)
-      // - a fake signature (unexpected)
-      await decryption
-        .connect(kmsTxSenders[0])
-        .userDecryptionResponse(decryptionId, fakeUserDecryptedShare, fakeKmsSignature);
-
-      // Trigger a first valid public decryption response with:
-      // - the second KMS transaction sender
-      // - the second KMS signer's signature
-      await decryption
-        .connect(kmsTxSenders[1])
-        .userDecryptionResponse(decryptionId, userDecryptedShares[1], kmsSignatures[1]);
-
-      // Trigger a second valid public decryption response with:
-      // - the third KMS transaction sender
-      // - the third KMS signer's signature
-      let responseTx3 = await decryption
-        .connect(kmsTxSenders[2])
-        .userDecryptionResponse(decryptionId, userDecryptedShares[2], kmsSignatures[2]);
-
-      // Trigger a third valid proof verification response with:
-      // - the fourth coprocessor transaction sender
-      // - the fourth coprocessor signer's signature
-      let responseTx4 = await decryption
-        .connect(kmsTxSenders[3])
-        .userDecryptionResponse(decryptionId, userDecryptedShares[3], kmsSignatures[3]);
-
-      // Consensus should not be reached at the third transaction since the first was malicious
-      // Check 3rd transaction events: it should not emit an event for public decryption response
-      await expect(responseTx3).to.not.emit(decryption, "UserDecryptionResponse");
-
-      // Consensus should be reached at the fourth transaction
-      // Check 4th transaction events: it should only contain 3 valid signatures
-      await expect(responseTx4)
-        .to.emit(decryption, "UserDecryptionResponse")
-        .withArgs(decryptionId, userDecryptedShares.slice(1, 3), kmsSignatures.slice(1, 3));
-    });
-    */
 
     describe("Checks", function () {
       it("Should not revert because user decryption is ready", async function () {


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#176 

This PR tests the situations in which a KMS signer with a valid signature but a malicious public decryption share is "isolated" given the usage of the EIP712 message's digest.