### PR TITLE
chore(coprocessor): support for global localstack in txn-sender

### DIFF
--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -72,9 +72,13 @@ jobs:
       with:
         node-version: 20.x
 
+    - name: Start localstack
+      run: |
+        docker run --rm -d -p 4566:4566 --name localstack localstack/localstack:latest
+
     - name: Run tests
       run: |
-        DATABASE_URL=postgresql://postgres:postgres@localhost:5432/coprocessor cargo test --release -- --test-threads=1
+        DATABASE_URL=postgresql://postgres:postgres@localhost:5432/coprocessor TXN_SENDER_TEST_GLOBAL_LOCALSTACK=1 cargo test --release -- --test-threads=1
       working-directory: coprocessor/fhevm-engine
 
 permissions:

--- a/coprocessor/fhevm-engine/coprocessor/Dockerfile
+++ b/coprocessor/fhevm-engine/coprocessor/Dockerfile
@@ -8,7 +8,8 @@ COPY host-contracts ./host-contracts
 
 # Compiled host-contracts for listeners
 WORKDIR /app/host-contracts
-RUN npm install && npx hardhat compile
+RUN cp .env.example .env
+RUN npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile
 
 # Stage 2: Build fhevm-engine
 FROM cgr.dev/chainguard/glibc-dynamic:latest-dev AS builder

--- a/coprocessor/fhevm-engine/fhevm-listener/build.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/build.rs
@@ -43,7 +43,7 @@ fn build_contracts() {
     }
     println!("Ran npm ci successfully");
 
-    // Step 3: Run `npm install && npx hardhat compile` in ../../contracts
+    // Step 3: Run `npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile` in ../../contracts
     let npm_install_status = Command::new("npm")
         .arg("install")
         .status()
@@ -52,6 +52,16 @@ fn build_contracts() {
         panic!("Error: npm install failed");
     }
     println!("Ran npm install successfully");
+
+    let npm_run_status = Command::new("npm")
+        .env("HARDHAT_NETWORK", "hardhat")
+        .args(["run", "deploy:emptyProxies"])
+        .status()
+        .expect("Failed to run npm run");
+    if !npm_run_status.success() {
+        panic!("Error: npm tun failed");
+    }
+    println!("Ran npm run successfully");
 
     let hardhat_compile_status = Command::new("npx")
         .args(["hardhat", "compile"])

--- a/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
@@ -337,7 +337,10 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
         ..Default::default()
     };
 
-    let mut env = TestEnvironment::new_with_config(signer_type, conf.clone()).await?;
+    let force_per_test_localstack = false;
+    let mut env =
+        TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
+            .await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
         .on_ws(WsConnect::new(env.ws_endpoint_url()))
@@ -437,7 +440,9 @@ async fn retry_mechanism(#[case] signer_type: SignerType) -> anyhow::Result<()> 
         ..Default::default()
     };
 
-    let env = TestEnvironment::new_with_config(signer_type, conf).await?;
+    let force_per_test_localstack = false;
+    let env =
+        TestEnvironment::new_with_config(signer_type, conf, force_per_test_localstack).await?;
 
     // Create a provider without a random wallet without funds.
     let wallet: EthereumWallet = PrivateKeySigner::random().into();
@@ -541,7 +546,10 @@ async fn retry_on_aws_kms_error(#[case] signer_type: SignerType) -> anyhow::Resu
         ..Default::default()
     };
 
-    let mut env = TestEnvironment::new_with_config(signer_type, conf.clone()).await?;
+    let force_per_test_localstack = true;
+    let mut env =
+        TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
+            .await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
         .on_ws(WsConnect::new(env.ws_endpoint_url()))

--- a/coprocessor/fhevm-engine/transaction-sender/tests/allow_handle_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/allow_handle_tests.rs
@@ -198,7 +198,10 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
         ..Default::default()
     };
 
-    let mut env = TestEnvironment::new_with_config(signer_type, conf.clone()).await?;
+    let force_per_test_localstack: bool = false;
+    let mut env =
+        TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
+            .await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
         .on_ws(WsConnect::new(env.ws_endpoint_url()))
@@ -294,7 +297,10 @@ async fn retry_on_aws_kms_error(#[case] signer_type: SignerType) -> anyhow::Resu
         ..Default::default()
     };
 
-    let mut env = TestEnvironment::new_with_config(signer_type, conf.clone()).await?;
+    let force_per_test_localstack = true;
+    let mut env =
+        TestEnvironment::new_with_config(signer_type, conf.clone(), force_per_test_localstack)
+            .await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
         .on_ws(WsConnect::new(env.ws_endpoint_url()))


### PR DESCRIPTION
Ability to avoid creating a localstack container for every test. Instead, an already running container is used, which is started either manually (for local development) or by CI.

This makes tests run faster.