### PR TITLE
chore(gateway-contracts): update mock script, makefile and forge version

### DIFF
--- a/.github/workflows/gateway-contracts-integrity-checks.yml
+++ b/.github/workflows/gateway-contracts-integrity-checks.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
         with:
-          version: v1.2.1
+          version: v1.2.2
 
       - name: Install dependencies
         working-directory: gateway-contracts

--- a/gateway-contracts/.husky/pre-commit
+++ b/gateway-contracts/.husky/pre-commit
@@ -14,8 +14,8 @@ printf "> make check-selectors\n\n"
 make check-selectors
 
 # Lints the crate's code.
-printf "> cd rust_bindings && cargo clippy -- -D warnings && cd ..\n\n"
-cd rust_bindings && cargo clippy -- -D warnings && cd ..
+printf "> make lint-bindings\n\n"
+make lint-bindings
 
 # Check license compliance
 printf "> make check-licenses\n\n"

--- a/gateway-contracts/.prettierignore
+++ b/gateway-contracts/.prettierignore
@@ -1,0 +1,19 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+artifacts/
+cache/
+
+# Version control
+.git/
+.gitignore
+
+# Environment
+.env
+
+# Rust
+rust_bindings/
+
+# Typechain
+typechain-types/

--- a/gateway-contracts/Makefile
+++ b/gateway-contracts/Makefile
@@ -26,7 +26,6 @@ start-local-node: clean
 
 deploy-contracts-local:
 	cp $(ENV_PATH) .env
-	HARDHAT_NETWORK=$(LOCAL_NETWORK_NAME) npx hardhat task:faucetToPrivate --private-key $(DEPLOYER_PRIVATE_KEY)
 	HARDHAT_NETWORK=$(LOCAL_NETWORK_NAME) npx hardhat task:deployAllGatewayContracts
 	HARDHAT_NETWORK=$(LOCAL_NETWORK_NAME) npx hardhat task:addHostChainsToGatewayConfig --use-internal-gateway-config-address true
 
@@ -51,6 +50,9 @@ check-bindings: ensure-addresses
 update-bindings: ensure-addresses
 	python3 scripts/bindings_update.py update
 
+lint-bindings:
+	cd rust_bindings && cargo clippy -- -D warnings && cd ..
+
 check-mocks:
 	node scripts/mock_contracts_cli.js check
 
@@ -73,11 +75,15 @@ update-selectors: ensure-addresses
 # Conform to pre-commit checks
 conformance: prettier update-bindings update-mocks update-selectors
 
-# Ensure that the empty proxy addresses exists. These are required for contract compilation.
+# Deploy the empty proxy addresses
+deploy-empty-proxies:
+	DOTENV_CONFIG_PATH=$(ENV_PATH) npx hardhat task:deployEmptyUUPSProxies
+
+# Ensure that the empty proxy addresses exists as these are required for contract compilation.
+# In addition, ensure that the addresses match the ones used in local development in order to
+# avoid discrepancies between local and CI (e.g., when generating and checking rust bindings).
 ensure-addresses:
-	@if [ ! -d addresses ]; then \
-		DOTENV_CONFIG_PATH=$(ENV_PATH) npx hardhat task:deployEmptyUUPSProxies; \
-	fi
+	ENV_PATH=$(ENV_PATH) npx ts-node scripts/ensure_proxy_addresses.ts
 
 # Make sure we only use allowed licenses for dependencies
 check-licenses:
@@ -97,3 +103,7 @@ prerelease:
 	npm version prerelease
 	$(MAKE) update-bindings
 	git add ./rust_bindings && git commit --amend --no-edit
+
+# Get the size of the contracts
+get-contracts-sized: 
+	forge build --sizes

--- a/gateway-contracts/contracts/mocks/CiphertextCommitsMock.sol
+++ b/gateway-contracts/contracts/mocks/CiphertextCommitsMock.sol
@@ -17,6 +17,7 @@ contract CiphertextCommitsMock {
         bytes32 snsCiphertextDigest
     ) external {
         address[] memory coprocessorTxSenders = new address[](1);
+
         emit AddCiphertextMaterial(ctHandle, ciphertextDigest, snsCiphertextDigest, coprocessorTxSenders);
     }
 }

--- a/gateway-contracts/contracts/mocks/DecryptionMock.sol
+++ b/gateway-contracts/contracts/mocks/DecryptionMock.sol
@@ -27,6 +27,7 @@ contract DecryptionMock {
         _decryptionRequestCounter++;
         uint256 decryptionId = _decryptionRequestCounter;
         SnsCiphertextMaterial[] memory snsCtMaterials = new SnsCiphertextMaterial[](1);
+
         emit PublicDecryptionRequest(decryptionId, snsCtMaterials);
     }
 
@@ -36,6 +37,7 @@ contract DecryptionMock {
         bytes calldata signature
     ) external {
         bytes[] memory signatures = new bytes[](1);
+
         emit PublicDecryptionResponse(decryptionId, decryptedResult, signatures);
     }
 
@@ -79,6 +81,7 @@ contract DecryptionMock {
     ) external {
         bytes[] memory userDecryptedShares = new bytes[](1);
         bytes[] memory signatures = new bytes[](1);
+
         emit UserDecryptionResponse(decryptionId, userDecryptedShares, signatures);
     }
 }

--- a/gateway-contracts/contracts/mocks/GatewayConfigMock.sol
+++ b/gateway-contracts/contracts/mocks/GatewayConfigMock.sol
@@ -35,6 +35,7 @@ contract GatewayConfigMock {
         uint256 mpcThreshold;
         KmsNode[] memory kmsNodes = new KmsNode[](1);
         Coprocessor[] memory coprocessors = new Coprocessor[](1);
+
         emit Initialization(pauser, metadata, mpcThreshold, kmsNodes, coprocessors);
     }
 

--- a/gateway-contracts/contracts/mocks/InputVerificationMock.sol
+++ b/gateway-contracts/contracts/mocks/InputVerificationMock.sol
@@ -30,6 +30,7 @@ contract InputVerificationMock {
 
     function verifyProofResponse(uint256 zkProofId, bytes32[] calldata ctHandles, bytes calldata signature) external {
         bytes[] memory signatures = new bytes[](1);
+
         emit VerifyProofResponse(zkProofId, ctHandles, signatures);
     }
 

--- a/gateway-contracts/contracts/mocks/KmsManagementMock.sol
+++ b/gateway-contracts/contracts/mocks/KmsManagementMock.sol
@@ -38,6 +38,7 @@ contract KmsManagementMock {
         _preKeygenRequestCounter++;
         uint256 preKeygenRequestId = _preKeygenRequestCounter;
         bytes32 fheParamsDigest;
+
         emit PreprocessKeygenRequest(preKeygenRequestId, fheParamsDigest);
     }
 
@@ -49,6 +50,7 @@ contract KmsManagementMock {
         _preKskgenRequestCounter++;
         uint256 preKskgenRequestId = _preKskgenRequestCounter;
         bytes32 fheParamsDigest;
+
         emit PreprocessKskgenRequest(preKskgenRequestId, fheParamsDigest);
     }
 
@@ -58,12 +60,14 @@ contract KmsManagementMock {
 
     function keygenRequest(uint256 preKeyId) external {
         bytes32 fheParamsDigest;
+
         emit KeygenRequest(preKeyId, fheParamsDigest);
     }
 
     function keygenResponse(uint256 preKeyId, uint256 keyId) external {
         uint256 keygenId;
         bytes32 fheParamsDigest;
+
         emit KeygenResponse(preKeyId, keygenId, fheParamsDigest);
     }
 
@@ -71,21 +75,25 @@ contract KmsManagementMock {
         _crsgenRequestCounter++;
         uint256 crsgenRequestId = _crsgenRequestCounter;
         bytes32 fheParamsDigest;
+
         emit CrsgenRequest(crsgenRequestId, fheParamsDigest);
     }
 
     function crsgenResponse(uint256 crsgenRequestId, uint256 crsId) external {
         bytes32 fheParamsDigest;
+
         emit CrsgenResponse(crsgenRequestId, crsId, fheParamsDigest);
     }
 
     function kskgenRequest(uint256 preKskId, uint256 sourceKeyId, uint256 destKeyId) external {
         bytes32 fheParamsDigest;
+
         emit KskgenRequest(preKskId, sourceKeyId, destKeyId, fheParamsDigest);
     }
 
     function kskgenResponse(uint256 preKskId, uint256 kskId) external {
         bytes32 fheParamsDigest;
+
         emit KskgenResponse(preKskId, kskId, fheParamsDigest);
     }
 

--- a/gateway-contracts/scripts/bindings_update.py
+++ b/gateway-contracts/scripts/bindings_update.py
@@ -16,7 +16,7 @@ GW_CRATE_DIR = GW_ROOT_DIR.joinpath("rust_bindings")
 GW_CONTRACTS_DIR = GW_ROOT_DIR.joinpath("contracts")
 GW_MOCKS_DIR = GW_CONTRACTS_DIR.joinpath("mocks")
 
-ALLOWED_FORGE_VERSIONS = ["1.2.1-v1.2.1", "1.2.1-stable"]
+ALLOWED_FORGE_VERSIONS = ["1.2.2-v1.2.2", "1.2.2-stable"]
 
 
 def init_cli() -> ArgumentParser:
@@ -131,8 +131,7 @@ class BindingsUpdater:
         if return_code != 0:
             log_error("ERROR: Some binding files are outdated.")
             log_info(
-                "Run `./scripts/bindings_update.py update` to update the "
-                "bindings."
+                "Run `make update-bindings` to update the bindings."
             )
             sys.exit(ExitStatus.BINDINGS_NOT_UP_TO_DATE.value)
 
@@ -189,8 +188,7 @@ class BindingsUpdater:
                 f"Cargo.toml version: {cargo_toml_version}\n"
             )
             log_info(
-                "Run `./bindings_update.py update` to update the crate's "
-                "version."
+                "Run `make update-bindings` to update the crate's version."
             )
             sys.exit(ExitStatus.CRATE_VERSION_NOT_UP_TO_DATE.value)
         log_success(

--- a/gateway-contracts/scripts/ensure_proxy_addresses.ts
+++ b/gateway-contracts/scripts/ensure_proxy_addresses.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { execSync } from "child_process";
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+import * as path from "path";
+
+function main(): void {
+  try {
+    // Get env path
+    const envPath = process.env.ENV_PATH;
+
+    if (!envPath) {
+      console.error("ENV_PATH is not set");
+      process.exit(1);
+    } else if (!fs.existsSync(envPath)) {
+      console.error("ENV_PATH does not exist");
+      process.exit(1);
+    }
+
+    // Get addresses directory
+    const addressesDir = "addresses";
+
+    // Get gateway config address env file
+    const gatewayConfigAddressEnv = path.join(addressesDir, ".env.gateway_config");
+
+    let shouldGenerateAddresses = false;
+
+    // If addresses/ directory doesn't exist, is empty, or gatewayConfig address file missing
+    if (
+      !fs.existsSync(addressesDir) ||
+      fs.readdirSync(addressesDir).length === 0 ||
+      !fs.existsSync(gatewayConfigAddressEnv)
+    ) {
+      shouldGenerateAddresses = true;
+    } else {
+      const envVars = dotenv.parse(fs.readFileSync(envPath));
+      const configVars = dotenv.parse(fs.readFileSync(gatewayConfigAddressEnv));
+
+      const envAddress = envVars.GATEWAY_CONFIG_ADDRESS;
+      const fileAddress = configVars.GATEWAY_CONFIG_ADDRESS;
+
+      if (!envAddress) {
+        console.error(`GATEWAY_CONFIG_ADDRESS is not set in ${envPath}`);
+        process.exit(1);
+      }
+      if (!fileAddress) {
+        console.error(`GATEWAY_CONFIG_ADDRESS is not set in ${gatewayConfigAddressEnv}`);
+        process.exit(1);
+      }
+
+      // If GATEWAY_CONFIG_ADDRESS in env path does not match the one in addresses/ directory,
+      // this most likely indicates that the addresses need to be regenerated in order to match
+      // the ones used in local development.
+      if (envAddress !== fileAddress) {
+        shouldGenerateAddresses = true;
+      }
+    }
+
+    if (shouldGenerateAddresses) {
+      console.log(`Generating contract addresses in development environment.`);
+      // Deploy empty proxies and generate addresses
+      execSync(`make deploy-empty-proxies`, {
+        stdio: "inherit",
+        env: process.env,
+      });
+    } else {
+      console.log("Contract addresses match local development environment.");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Small PR that extracts general fixes from https://github.com/zama-ai/fhevm/pull/106 

In particular for the mock script : 
- allows a function to emit several events in mock contracts
- anticipate the use of a new shared file (`enums.sol`) for contexts

Also, in scripts : 
- I needed to introduce a new script that makes sure contract addresses are the matching the default ones we have in the dev env. Else, following fixes introduced in https://github.com/zama-ai/fhevm-internal/issues/117, the rust binding check could fail if the local addresses used at compilation (ex: in `make conformance) are different from the ones generated in the CI (the default ones)
- I updated forge version to `1.2.2`, which can be updated locally by running `foundryup`

Finally in the makefile : 
- `.prettierignore` makes `prettier` ignore the rust bindings, making `make conformance` much quicker
- add a `make lint-binding` for better local checks
- add a `deploy-empty-proxies` for locally create the address files
- add a `get-contracts-sized` to get the contracts' size easily 