### PR TITLE
build(coprocessor): fix fhevm-listener build for ACL

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/src/database/tfhe_event_propagate.rs
@@ -418,6 +418,18 @@ impl Database {
             AclContractEvents::Upgraded(upgraded) => {
                 println!("unhandled Acl::Upgraded event {:?}", upgraded);
             }
+            AclContractEvents::Paused(paused) => {
+                println!("unhandled Acl::Paused event {:?}", paused);
+            }
+            AclContractEvents::Unpaused(unpaused) => {
+                println!("unhandled Acl::Unpaused event {:?}", unpaused);
+            }
+            AclContractEvents::UpdatePauser(update_pauser) => {
+                println!(
+                    "unhandled Acl::UpdatePauser event {:?}",
+                    update_pauser
+                );
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Add missing match arms for AclContractEvents in fhevm-listener.