### PR TITLE
docs(common): fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="library-solidity/docs/.gitbook/assets/fhevm-header-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="library-solidity/docs/.gitbook/assets/fhevm-header-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="docs/.gitbook/assets/fhevm-header-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="docs/.gitbook/assets/fhevm-header-light.png">
   <img width=600 alt="fhevm">
 </picture>
 </p>
@@ -169,8 +169,8 @@ This software is distributed under the **BSD-3-Clause-Clear** license. Read [thi
 
 <a target="_blank" href="https://community.zama.ai">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="library-solidity/docs/.gitbook/assets/support-banner-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="library-solidity/docs/.gitbook/assets/support-banner-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="docs/.gitbook/assets/support-banner-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="docs/.gitbook/assets/support-banner-light.png">
   <img alt="Support">
 </picture>
 </a>

--- a/coprocessor/README.md
+++ b/coprocessor/README.md
@@ -310,8 +310,8 @@ A complete demo showcasing an integrated FHEVM blockchain and KMS (Key Managemen
 
 <a target="_blank" href="https://community.zama.ai">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="../docs/.gitbook/assets/support-banner-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="../docs/.gitbook/assets/support-banner-light.png">
   <img alt="Support">
 </picture>
 </a>

--- a/gateway-contracts/README.md
+++ b/gateway-contracts/README.md
@@ -29,8 +29,8 @@ Documentation can be found [here](./docs/SUMMARY.md).
 
 <a target="_blank" href="https://community.zama.ai">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="../docs/.gitbook/assets/support-banner-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="../docs/.gitbook/assets/support-banner-light.png">
   <img alt="Support">
 </picture>
 </a>

--- a/kms-connector/README.md
+++ b/kms-connector/README.md
@@ -470,8 +470,8 @@ cargo test
 
 <a target="_blank" href="https://community.zama.ai">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="../docs/.gitbook/assets/support-banner-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="../docs/.gitbook/assets/support-banner-light.png">
   <img alt="Support">
 </picture>
 </a>

--- a/library-solidity/README.md
+++ b/library-solidity/README.md
@@ -27,8 +27,8 @@ To start writing confidential smart contracts using FHEVM Solidity, follow the H
 
 <a target="_blank" href="https://community.zama.ai">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="../docs/.gitbook/assets/support-banner-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="../docs/.gitbook/assets/support-banner-light.png">
   <img alt="Support">
 </picture>
 </a>

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -115,8 +115,8 @@ Include:
 
 <a target="_blank" href="https://community.zama.ai">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-dark.png">
-  <source media="(prefers-color-scheme: light)" srcset="../library-solidity/docs/.gitbook/assets/support-banner-light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="../docs/.gitbook/assets/support-banner-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="../docs/.gitbook/assets/support-banner-light.png">
   <img alt="Support">
 </picture>
 </a>


### PR DESCRIPTION
As the docs are moved to the root level, some image paths were broken and are fixed in this PR.