### PR TITLE
fix(kms-connector): fix build & lint errors

### DIFF
--- a/.github/workflows/kms-connector-test-docker-build.yml
+++ b/.github/workflows/kms-connector-test-docker-build.yml
@@ -47,9 +47,11 @@ jobs:
           connector:
             - '.github/workflows/kms-connector-*'
             - 'kms-connector/config/**'
-            - 'docker/kms-connector/**'
-            - 'kms-connector/src/**'
+            - 'kms-connector/connector-db/**'
+            - 'kms-connector/crates/**'
+            - 'kms-connector/simple-connector/**'
             - 'kms-connector/Cargo.toml'
+            - 'kms-connector/Dockerfile'
 
 
   ############################################################################

--- a/kms-connector/simple-connector/src/core/utils/s3.rs
+++ b/kms-connector/simple-connector/src/core/utils/s3.rs
@@ -152,7 +152,6 @@ async fn direct_http_retrieval(url: &str) -> Result<Vec<u8>> {
     // Create a reqwest client with appropriate timeouts
     let client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(2))
-        .timeout(None) // no overall deadline to allow for long-running requests
         .build()
         .map_err(|e| Error::S3Error(format!("Failed to create HTTP client: {}", e)))?;
 

--- a/kms-connector/simple-connector/src/core/utils/wallet.rs
+++ b/kms-connector/simple-connector/src/core/utils/wallet.rs
@@ -16,7 +16,7 @@ pub enum WalletError {
     #[error("Invalid private key: {0}")]
     InvalidPrivateKey(String),
     #[error("AWS KMS error: {0}")]
-    AwsKmsError(#[from] alloy::signers::aws::AwsSignerError),
+    AwsKmsError(#[from] Box<alloy::signers::aws::AwsSignerError>),
 }
 
 pub type Result<T> = std::result::Result<T, WalletError>;
@@ -111,7 +111,9 @@ impl KmsWallet {
         let kms_client = KmsClient::new(&config);
 
         // Create AWS KMS signer
-        let aws_signer = AwsSigner::new(kms_client, key_id, chain_id).await?;
+        let aws_signer = AwsSigner::new(kms_client, key_id, chain_id)
+            .await
+            .map_err(Box::new)?;
 
         info!(
             "Created wallet from AWS KMS with address: {}",

--- a/kms-connector/simple-connector/src/error.rs
+++ b/kms-connector/simple-connector/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     Channel(String),
 
     #[error("Wallet error: {0}")]
-    Wallet(#[from] WalletError),
+    Wallet(#[from] Box<WalletError>),
 
     #[error("RPC error: {0}")]
     Rpc(String),
@@ -86,6 +86,12 @@ impl From<SolError> for Error {
 impl From<tonic::Status> for Error {
     fn from(status: tonic::Status) -> Self {
         Error::Other(anyhow::anyhow!("gRPC error: {}", status))
+    }
+}
+
+impl From<WalletError> for Error {
+    fn from(error: WalletError) -> Self {
+        Error::Wallet(Box::new(error))
     }
 }
 


### PR DESCRIPTION
According to `reqwest` [docs](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout), there is no timeout by default, so I just remove the problematic line.

Also, clippy was raising some errors due to [large enums](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant) so I fix that.