### PR TITLE
fix(coprocessor): fhevm-listener, infinite retry was disabled

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/src/cmd/mod.rs
@@ -334,7 +334,7 @@ impl InfiniteLogIter {
     }
 
     async fn next(&mut self) -> Option<Log> {
-        let mut not_initialized = true;
+        let mut not_initialized = self.stream.is_none();
         self.prev_event = self.current_event.take();
         while self.current_event.is_none() {
             if self.stream.is_none() {


### PR DESCRIPTION
at start the numbre of rety is limited to show any configutaiton issue in operation retry on conncetion loss is infinite, this was broken and limited to 20 retry