### PR TITLE
feat(coprocessor): add log level configurations

### DIFF
--- a/.github/workflows/coprocessor-gpu-tests.yml
+++ b/.github/workflows/coprocessor-gpu-tests.yml
@@ -82,6 +82,7 @@ jobs:
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     permissions:
       contents: read
+      packages: read
     strategy:
       fail-fast: false
       # explicit include-based build matrix, of known valid options
@@ -139,6 +140,13 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Init database
         run: make init_db

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3466,6 +3466,8 @@ dependencies = [
  "serial_test",
  "sqlx",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/coprocessor/src/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/coprocessor/src/daemon_cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use tracing::Level;
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
@@ -75,6 +76,13 @@ pub struct Args {
     /// Coprocessor service name in OTLP traces
     #[arg(long, default_value = "coprocessor")]
     pub service_name: String,
+
+    /// Log level for the application
+    #[arg(
+        long,
+        value_parser = clap::value_parser!(Level),
+        default_value_t = Level::INFO)]
+    pub log_level: Level,
 }
 
 pub fn parse_args() -> Args {

--- a/coprocessor/fhevm-engine/coprocessor/src/lib.rs
+++ b/coprocessor/fhevm-engine/coprocessor/src/lib.rs
@@ -51,7 +51,11 @@ pub async fn async_main(
     args: daemon_cli::Args,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     TRACING_INIT.call_once(|| {
-        tracing_subscriber::fmt().json().with_level(true).init();
+        tracing_subscriber::fmt()
+            .json()
+            .with_level(true)
+            .with_max_level(args.log_level)
+            .init();
     });
 
     info!(target: "async_main", "Starting runtime with args: {:?}", args);

--- a/coprocessor/fhevm-engine/coprocessor/src/tests/operators_from_events.rs
+++ b/coprocessor/fhevm-engine/coprocessor/src/tests/operators_from_events.rs
@@ -1,10 +1,11 @@
-use alloy::primitives::{Bytes, FixedBytes, Log};
+use alloy::primitives::{FixedBytes, Log};
 use bigdecimal::num_bigint::BigInt;
 
 use fhevm_listener::contracts::TfheContract;
 use fhevm_listener::contracts::TfheContract::TfheContractEvents;
-use fhevm_listener::database::tfhe_event_propagate::{ClearConst, Database as ListenerDatabase, Handle, ToType};
-
+use fhevm_listener::database::tfhe_event_propagate::{
+    ClearConst, Database as ListenerDatabase, Handle, ToType,
+};
 
 use crate::tests::operators::{generate_binary_test_cases, generate_unary_test_cases};
 use crate::tests::utils::{decrypt_ciphertexts, wait_until_all_ciphertexts_computed};
@@ -44,11 +45,6 @@ fn as_scalar_handle(big_int: &BigInt) -> Handle {
 fn as_scalar_uint(big_int: &BigInt) -> ClearConst {
     let (_, bytes) = big_int.to_bytes_be();
     ClearConst::from_be_slice(&bytes)
-}
-
-fn to_bytes(big_int: &BigInt) -> Bytes {
-    let (_, bytes) = big_int.to_bytes_be();
-    Bytes::copy_from_slice(&bytes)
 }
 
 fn to_ty(ty: i32) -> ToType {

--- a/coprocessor/fhevm-engine/coprocessor/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/coprocessor/src/tests/utils.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU16, Ordering};
 use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 use tokio::sync::watch::Receiver;
+use tracing::Level;
 
 pub struct TestInstance {
     // just to destroy container
@@ -102,6 +103,7 @@ async fn start_coprocessor(rx: Receiver<bool>, app_port: u16, db_url: &str) {
         maximimum_compact_inputs_upload: 10,
         coprocessor_private_key: "./coprocessor.key".to_string(),
         service_name: "coprocessor".to_string(),
+        log_level: Level::INFO,
     };
 
     std::thread::spawn(move || {

--- a/coprocessor/fhevm-engine/fhevm-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/fhevm-listener/Cargo.toml
@@ -26,6 +26,8 @@ rustls = { workspace = true }
 serde = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # local dependencies
 fhevm-engine-common = { path = "../fhevm-engine-common" }

--- a/coprocessor/fhevm-engine/fhevm-listener/src/bin/main.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/src/bin/main.rs
@@ -3,5 +3,12 @@ use clap::Parser;
 #[tokio::main]
 async fn main() {
     let args = fhevm_listener::cmd::Args::parse();
+
+    tracing_subscriber::fmt()
+        .json()
+        .with_level(true)
+        .with_max_level(args.log_level)
+        .init();
+
     fhevm_listener::cmd::main(args).await;
 }

--- a/coprocessor/fhevm-engine/sns-executor/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-executor/src/bin/sns_worker.rs
@@ -4,7 +4,7 @@ use sns_executor::{
 };
 use tokio::{signal::unix, spawn, sync::mpsc};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, Level};
+use tracing::error;
 mod utils;
 
 fn handle_sigint(token: CancellationToken) {
@@ -46,6 +46,7 @@ fn construct_config() -> Config {
                 regular_recheck_duration: args.s3_regular_recheck_duration,
             },
         },
+        log_level: args.log_level,
     }
 }
 
@@ -57,7 +58,7 @@ async fn main() {
     tracing_subscriber::fmt()
         .json()
         .with_level(true)
-        .with_max_level(Level::INFO)
+        .with_max_level(config.log_level)
         .init();
 
     // Handle SIGINIT signals

--- a/coprocessor/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use clap::{command, Parser};
 use humantime::parse_duration;
+use tracing::Level;
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
@@ -71,6 +72,12 @@ pub struct Args {
 
     #[arg(long, default_value = "120s", value_parser = parse_duration)]
     pub s3_regular_recheck_duration: Duration,
+
+    #[arg(
+        long,
+        value_parser = clap::value_parser!(Level),
+        default_value_t = Level::INFO)]
+    pub log_level: Level,
 }
 
 pub fn parse_args() -> Args {

--- a/coprocessor/fhevm-engine/sns-executor/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-executor/src/lib.rs
@@ -14,7 +14,7 @@ use sqlx::{Postgres, Transaction};
 use thiserror::Error;
 use tokio::sync::mpsc::{self, Sender};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, Level};
 
 pub const UPLOAD_QUEUE_SIZE: usize = 20;
 pub const SAFE_SER_LIMIT: u64 = 1024 * 1024 * 66;
@@ -58,6 +58,7 @@ pub struct Config {
     pub service_name: String,
     pub db: DBConfig,
     pub s3: S3Config,
+    pub log_level: Level,
 }
 
 /// Implement Display for Config

--- a/coprocessor/fhevm-engine/sns-executor/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-executor/src/tests/mod.rs
@@ -9,6 +9,7 @@ use std::{
 use test_harness::instance::DBInstance;
 use tfhe::{prelude::FheDecrypt, ClientKey, SquashedNoiseFheUint};
 use tokio::{sync::mpsc, time::sleep};
+use tracing::Level;
 
 const LISTEN_CHANNEL: &str = "sns_worker_chan";
 const TENANT_API_KEY: &str = "a1503fb6-d79b-4e9e-826d-44cf262f3e05";
@@ -101,6 +102,7 @@ async fn setup() -> anyhow::Result<(
         },
         s3: crate::S3Config::default(),
         service_name: "test-sns-worker".to_owned(),
+        log_level: Level::INFO,
     };
 
     let pool = sqlx::postgres::PgPoolOptions::new()

--- a/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
@@ -91,12 +91,8 @@ impl TestEnvironment {
         .await?;
 
         let anvil = Self::new_anvil()?;
-        let chain_id = get_chain_id(
-            anvil.ws_endpoint_url(),
-            10,
-            std::time::Duration::from_secs(1),
-        )
-        .await?;
+        let chain_id =
+            get_chain_id(anvil.ws_endpoint_url(), std::time::Duration::from_secs(1)).await;
         let abstract_signer;
         let localstack;
         match signer_type {


### PR DESCRIPTION
Add the `log-level` cmd line option to configure the log level.

Also, make sure gw-listener and transaction-sender retry connecting to the node infinitely at startup as the `WsConnect` options don't apply to connect during provider creation.

Finally, add structured logging to fhevm-listener instead of println!s. Also, added some TODOs to remove panics and, instead, propagate errors. Will be done in a separate PR.

As a side note, using structured logging in all other services where it is applicable will be done in a separate PR as well (as we usually only utilize the `message` field in the log macros).

Resolves https://github.com/zama-ai/fhevm-internal/issues/88