### PR TITLE
chore(common): restrict workflows for changes in solidity

### DIFF
--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -26,7 +26,7 @@ jobs:
               - .github/workflows/coprocessor-cargo-tests.yml
               - coprocessor/fhevm-engine/**
               - coprocessor/proto/**
-              - host-contracts/**
+              - host-contracts/contracts/**
   cargo-tests:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-rust-files == 'true' }}

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -32,7 +32,7 @@ jobs:
               - .github/workflows/coprocessor-docker-build.yml
               - coprocessor/fhevm-engine/**
               - coprocessor/proto/**
-              - host-contracts/**
+              - host-contracts/contracts/**
   docker-fhevm-coprocessor:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-coprocessor-files == 'true' || github.event_name == 'release' }}


### PR DESCRIPTION
This PR prevents running coprocessor workflows (that take a lot of time) if the change in host-contracts folder is not a Solidity contract change (potentially breaking!)