### PR TITLE
feat(kms-connector): transaction-sender implementation

### DIFF
--- a/kms-connector/.sqlx/query-820e14ed1c8a9ec5a5462025a871aedc0b319f207cb55b80886f29a3f4e2e63b.json
+++ b/kms-connector/.sqlx/query-820e14ed1c8a9ec5a5462025a871aedc0b319f207cb55b80886f29a3f4e2e63b.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM public_decryption_responses WHERE decryption_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "820e14ed1c8a9ec5a5462025a871aedc0b319f207cb55b80886f29a3f4e2e63b"
+}

--- a/kms-connector/.sqlx/query-93db5ac72e3acc12af313048a9d900371e903a45c1c172af2633129033aae5e1.json
+++ b/kms-connector/.sqlx/query-93db5ac72e3acc12af313048a9d900371e903a45c1c172af2633129033aae5e1.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM user_decryption_responses WHERE decryption_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "93db5ac72e3acc12af313048a9d900371e903a45c1c172af2633129033aae5e1"
+}

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2269,6 +2269,8 @@ version = "0.1.0-rc6"
 dependencies = [
  "alloy",
  "anyhow",
+ "aws-config",
+ "aws-sdk-kms",
  "bincode",
  "clap",
  "config",
@@ -6891,8 +6893,7 @@ version = "0.1.0-rc6"
 dependencies = [
  "alloy",
  "anyhow",
- "aws-config",
- "aws-sdk-kms",
+ "connector-tests",
  "connector-utils",
  "fhevm_gateway_rust_bindings",
  "serde",

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2261,6 +2261,8 @@ dependencies = [
  "rand 0.8.5",
  "sqlx",
  "testcontainers",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6901,6 +6903,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml",
  "tonic",

--- a/kms-connector/crates/gw-listener/tests/integration_test.rs
+++ b/kms-connector/crates/gw-listener/tests/integration_test.rs
@@ -28,7 +28,6 @@ async fn test_publish_public_decryption() -> anyhow::Result<()> {
     let pending_tx = test_instance
         .decryption_contract()
         .publicDecryptionRequest(vec![])
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;
@@ -80,7 +79,6 @@ async fn test_publish_user_decryption() -> anyhow::Result<()> {
             rand_pub_key.clone().into(),
             vec![].into(),
         )
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;
@@ -127,7 +125,6 @@ async fn test_publish_preprocess_keygen() -> anyhow::Result<()> {
     let pending_tx = test_instance
         .kms_management_contract()
         .preprocessKeygenRequest(String::new())
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;
@@ -167,7 +164,6 @@ async fn test_publish_preprocess_kskgen() -> anyhow::Result<()> {
     let pending_tx = test_instance
         .kms_management_contract()
         .preprocessKskgenRequest(String::new())
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;
@@ -208,7 +204,6 @@ async fn test_publish_keygen() -> anyhow::Result<()> {
     let pending_tx = test_instance
         .kms_management_contract()
         .keygenRequest(rand_id)
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;
@@ -249,7 +244,6 @@ async fn test_publish_kskgen() -> anyhow::Result<()> {
     let pending_tx = test_instance
         .kms_management_contract()
         .kskgenRequest(rand_id, rand_source_key_id, rand_dest_key_id)
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;
@@ -293,7 +287,6 @@ async fn test_publish_crsgen() -> anyhow::Result<()> {
     let pending_tx = test_instance
         .kms_management_contract()
         .crsgenRequest(String::new())
-        .from(test_instance.anvil().addresses()[0])
         .send()
         .await?;
     let receipt = pending_tx.get_receipt().await?;

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
@@ -54,7 +54,7 @@ impl KmsClient {
         })?;
 
         for i in 1..=RETRY_NUMBER {
-            info!("Attempting connection to DB... ({i}/{RETRY_NUMBER})");
+            info!("Attempting connection to KMS Core... ({i}/{RETRY_NUMBER})");
 
             match endpoint.connect().await {
                 Ok(channel) => {
@@ -66,7 +66,7 @@ impl KmsClient {
                         config.retry_interval,
                     ));
                 }
-                Err(e) => warn!("DB connection attempt #{i} failed: {e}"),
+                Err(e) => warn!("KMS Core connection attempt #{i} failed: {e}"),
             }
 
             if i != RETRY_NUMBER {

--- a/kms-connector/crates/tx-sender/Cargo.toml
+++ b/kms-connector/crates/tx-sender/Cargo.toml
@@ -24,5 +24,6 @@ tracing-subscriber.workspace = true
 connector-tests.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
+tokio-stream.workspace = true
 toml.workspace = true
 tracing-test.workspace = true

--- a/kms-connector/crates/tx-sender/Cargo.toml
+++ b/kms-connector/crates/tx-sender/Cargo.toml
@@ -27,3 +27,7 @@ tempfile.workspace = true
 tokio-stream.workspace = true
 toml.workspace = true
 tracing-test.workspace = true
+
+[[bin]]
+name = "tx-sender"
+path = "src/bin/tx_sender.rs"

--- a/kms-connector/crates/tx-sender/Cargo.toml
+++ b/kms-connector/crates/tx-sender/Cargo.toml
@@ -12,8 +12,6 @@ fhevm_gateway_rust_bindings.workspace = true
 
 alloy.workspace = true
 anyhow.workspace = true
-aws-config.workspace = true
-aws-sdk-kms.workspace = true
 serde.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -23,6 +21,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+connector-tests.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 toml.workspace = true

--- a/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
@@ -2,13 +2,22 @@ use connector_utils::{
     cli::{Cli, Subcommands},
     signal::install_signal_handlers,
 };
+use std::process::ExitCode;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 use tx_sender::core::{Config, TransactionSender};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> ExitCode {
+    if let Err(err) = run().await {
+        error!("{err}");
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}
+
+async fn run() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(fmt::layer())
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))

--- a/kms-connector/crates/tx-sender/src/core/config/mod.rs
+++ b/kms-connector/crates/tx-sender/src/core/config/mod.rs
@@ -1,5 +1,4 @@
 mod parsed;
 mod raw;
-mod wallet;
 
 pub use parsed::Config;

--- a/kms-connector/crates/tx-sender/src/core/config/parsed.rs
+++ b/kms-connector/crates/tx-sender/src/core/config/parsed.rs
@@ -2,10 +2,10 @@
 //!
 //! The `raw` module is first used to deserialize the configuration.
 
-use crate::core::config::wallet::{AwsKmsConfig, KmsWallet};
-
 use super::raw::RawConfig;
-use connector_utils::config::{ContractConfig, DeserializeRawConfig, Error, Result};
+use connector_utils::config::{
+    AwsKmsConfig, ContractConfig, DeserializeRawConfig, Error, KmsWallet, Result,
+};
 use std::{
     fmt::{self, Display},
     path::Path,
@@ -60,7 +60,7 @@ impl Config {
         if let Some(config_path) = &path {
             info!("Loading config from: {}", config_path.as_ref().display());
         } else {
-            info!("Loading confing using environment variables only");
+            info!("Loading config using environment variables only");
         }
 
         let raw_config = RawConfig::from_env_and_file(path)?;

--- a/kms-connector/crates/tx-sender/src/core/config/raw.rs
+++ b/kms-connector/crates/tx-sender/src/core/config/raw.rs
@@ -2,8 +2,7 @@
 //!
 //! The `RawConfig` can then be parsed into a `Config` in the `parsed` module.
 
-use crate::core::config::wallet::AwsKmsConfig;
-use connector_utils::config::{DeserializeRawConfig, RawContractConfig};
+use connector_utils::config::{AwsKmsConfig, DeserializeRawConfig, RawContractConfig};
 use serde::{Deserialize, Serialize};
 
 /// Deserializable representation of the KMS connector configuration.

--- a/kms-connector/crates/tx-sender/src/core/kms_response_picker.rs
+++ b/kms-connector/crates/tx-sender/src/core/kms_response_picker.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use connector_utils::types::KmsResponse;
 use sqlx::{Pool, Postgres, postgres::PgListener};
 use std::future::Future;
+use tracing::info;
 
 /// Interface used to pick KMS Core's responses from some storage.
 pub trait KmsResponsePicker {
@@ -53,6 +54,7 @@ impl KmsResponsePicker for DbKmsResponsePicker {
     async fn pick_response(&mut self) -> anyhow::Result<KmsResponse> {
         // Wait for notification
         let notification = self.db_listener.recv().await?;
+        info!("Received Postgres notification: {}", notification.channel());
 
         let response = match notification.channel() {
             PUBLIC_DECRYPT_NOTIFICATION => pick_public_decryption_response(&self.db_pool).await?,

--- a/kms-connector/crates/tx-sender/src/core/kms_response_picker.rs
+++ b/kms-connector/crates/tx-sender/src/core/kms_response_picker.rs
@@ -1,0 +1,93 @@
+use anyhow::anyhow;
+use connector_utils::types::KmsResponse;
+use sqlx::{Pool, Postgres, postgres::PgListener};
+use std::future::Future;
+
+/// Interface used to pick KMS Core's responses from some storage.
+pub trait KmsResponsePicker {
+    fn pick_response(&mut self) -> impl Future<Output = anyhow::Result<KmsResponse>>;
+}
+
+// Postgres notifications for KMS Core's responses
+const PUBLIC_DECRYPT_NOTIFICATION: &str = "public_decryption_response_available";
+const USER_DECRYPT_NOTIFICATION: &str = "user_decryption_response_available";
+
+/// Struct that collects KMS Core's responses from a `Postgres` database.
+pub struct DbKmsResponsePicker {
+    /// The DB connection pool used to query responses when notified.
+    db_pool: Pool<Postgres>,
+
+    /// The DB listener to watch for notifications.
+    db_listener: PgListener,
+}
+
+impl DbKmsResponsePicker {
+    pub fn new(db_pool: Pool<Postgres>, db_listener: PgListener) -> Self {
+        Self {
+            db_pool,
+            db_listener,
+        }
+    }
+
+    pub async fn connect(db_pool: Pool<Postgres>) -> anyhow::Result<Self> {
+        let db_listener = PgListener::connect_with(&db_pool)
+            .await
+            .map_err(|e| anyhow!("Failed to init Postgres Listener: {e}"))?;
+
+        let mut response_picker = DbKmsResponsePicker::new(db_pool, db_listener);
+        response_picker
+            .listen()
+            .await
+            .map_err(|e| anyhow!("Failed to listen to responses: {e}"))?;
+
+        Ok(response_picker)
+    }
+
+    async fn listen(&mut self) -> sqlx::Result<()> {
+        self.db_listener.listen(PUBLIC_DECRYPT_NOTIFICATION).await?;
+        self.db_listener.listen(USER_DECRYPT_NOTIFICATION).await
+    }
+}
+
+impl KmsResponsePicker for DbKmsResponsePicker {
+    async fn pick_response(&mut self) -> anyhow::Result<KmsResponse> {
+        // Wait for notification
+        let notification = self.db_listener.recv().await?;
+
+        let response = match notification.channel() {
+            PUBLIC_DECRYPT_NOTIFICATION => pick_public_decryption_response(&self.db_pool).await?,
+            USER_DECRYPT_NOTIFICATION => pick_user_decryption_response(&self.db_pool).await?,
+            channel => return Err(anyhow!("Unexpected notification: {channel}")),
+        };
+
+        Ok(response)
+    }
+}
+
+async fn pick_public_decryption_response(db_pool: &Pool<Postgres>) -> sqlx::Result<KmsResponse> {
+    let row = sqlx::query(
+        "
+            SELECT decryption_id, decrypted_result, signature
+            FROM public_decryption_responses
+            LIMIT 1
+        ",
+    )
+    .fetch_one(db_pool)
+    .await?;
+
+    KmsResponse::from_public_decryption_row(&row)
+}
+
+async fn pick_user_decryption_response(db_pool: &Pool<Postgres>) -> sqlx::Result<KmsResponse> {
+    let row = sqlx::query(
+        "
+            SELECT decryption_id, user_decrypted_shares, signature
+            FROM user_decryption_responses
+            LIMIT 1
+        ",
+    )
+    .fetch_one(db_pool)
+    .await?;
+
+    KmsResponse::from_user_decryption_row(&row)
+}

--- a/kms-connector/crates/tx-sender/src/core/kms_response_remover.rs
+++ b/kms-connector/crates/tx-sender/src/core/kms_response_remover.rs
@@ -19,6 +19,7 @@ pub struct DbKmsResponseRemover {
 
 impl KmsResponseRemover for DbKmsResponseRemover {
     async fn remove_response(&self, response: &KmsResponse) -> anyhow::Result<()> {
+        info!("Removing {response} from DB...");
         let query_result = match response {
             KmsResponse::PublicDecryption { decryption_id, .. } => {
                 self.remove_public_decryption(*decryption_id).await?

--- a/kms-connector/crates/tx-sender/src/core/kms_response_remover.rs
+++ b/kms-connector/crates/tx-sender/src/core/kms_response_remover.rs
@@ -1,0 +1,64 @@
+use alloy::primitives::U256;
+use connector_utils::types::KmsResponse;
+use sqlx::{Pool, Postgres, postgres::PgQueryResult};
+use tracing::{info, warn};
+
+/// Interface used to remove KMS Core's responses from some storage.
+pub trait KmsResponseRemover: Send {
+    fn remove_response(
+        &self,
+        response: &KmsResponse,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+}
+
+/// Struct that removes KMS Core's responses from a `Postgres` database.
+#[derive(Clone)]
+pub struct DbKmsResponseRemover {
+    db_pool: Pool<Postgres>,
+}
+
+impl KmsResponseRemover for DbKmsResponseRemover {
+    async fn remove_response(&self, response: &KmsResponse) -> anyhow::Result<()> {
+        let query_result = match response {
+            KmsResponse::PublicDecryption { decryption_id, .. } => {
+                self.remove_public_decryption(*decryption_id).await?
+            }
+            KmsResponse::UserDecryption { decryption_id, .. } => {
+                self.remove_user_decryption(*decryption_id).await?
+            }
+        };
+        if query_result.rows_affected() == 1 {
+            info!("Successfully removed {response} from DB!");
+        } else {
+            warn!(
+                "Unexpected query result while removing {}: {:?}",
+                response, query_result
+            )
+        }
+        Ok(())
+    }
+}
+
+impl DbKmsResponseRemover {
+    pub fn new(db_pool: Pool<Postgres>) -> Self {
+        Self { db_pool }
+    }
+
+    async fn remove_public_decryption(&self, decryption_id: U256) -> sqlx::Result<PgQueryResult> {
+        sqlx::query!(
+            "DELETE FROM public_decryption_responses WHERE decryption_id = $1",
+            decryption_id.as_le_slice()
+        )
+        .execute(&self.db_pool)
+        .await
+    }
+
+    async fn remove_user_decryption(&self, decryption_id: U256) -> sqlx::Result<PgQueryResult> {
+        sqlx::query!(
+            "DELETE FROM user_decryption_responses WHERE decryption_id = $1",
+            decryption_id.as_le_slice()
+        )
+        .execute(&self.db_pool)
+        .await
+    }
+}

--- a/kms-connector/crates/tx-sender/src/core/mod.rs
+++ b/kms-connector/crates/tx-sender/src/core/mod.rs
@@ -1,5 +1,9 @@
 mod config;
+mod kms_response_picker;
+mod kms_response_remover;
 mod tx_sender;
 
 pub use config::Config;
+pub use kms_response_picker::{DbKmsResponsePicker, KmsResponsePicker};
+pub use kms_response_remover::{DbKmsResponseRemover, KmsResponseRemover};
 pub use tx_sender::TransactionSender;

--- a/kms-connector/crates/tx-sender/src/core/mod.rs
+++ b/kms-connector/crates/tx-sender/src/core/mod.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 mod kms_response_picker;
 mod kms_response_remover;
 mod tx_sender;

--- a/kms-connector/crates/tx-sender/src/core/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/core/tx_sender.rs
@@ -98,7 +98,7 @@ where
         result: Bytes,
         signature: Vec<u8>,
     ) -> anyhow::Result<()> {
-        if signature.len() != 65 {
+        if signature.len() != EIP712_SIGNATURE_LENGTH {
             return Err(anyhow!(
                 "Invalid EIP-712 signature length: {}, expected 65 bytes",
                 signature.len()
@@ -138,7 +138,7 @@ where
         result: Bytes,
         signature: Vec<u8>,
     ) -> anyhow::Result<()> {
-        if signature.len() != 65 {
+        if signature.len() != EIP712_SIGNATURE_LENGTH {
             return Err(anyhow!(
                 "Invalid EIP-712 signature length: {}, expected 65 bytes",
                 signature.len()
@@ -170,6 +170,8 @@ where
         Ok(())
     }
 }
+
+pub const EIP712_SIGNATURE_LENGTH: usize = 65;
 
 impl TransactionSender<DbKmsResponsePicker, WalletGatewayProvider, DbKmsResponseRemover> {
     pub async fn from_config(config: Config) -> anyhow::Result<Self> {

--- a/kms-connector/crates/tx-sender/src/core/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/core/tx_sender.rs
@@ -1,9 +1,13 @@
+use std::time::Duration;
+
 use crate::core::{
     Config, DbKmsResponsePicker, DbKmsResponseRemover, KmsResponsePicker, KmsResponseRemover,
 };
 use alloy::{
+    network::Ethereum,
     primitives::{Bytes, U256},
-    providers::Provider,
+    providers::{PendingTransactionBuilder, Provider},
+    rpc::types::TransactionRequest,
 };
 use anyhow::anyhow;
 use connector_utils::{
@@ -12,14 +16,28 @@ use connector_utils::{
 };
 use fhevm_gateway_rust_bindings::decryption::Decryption::{self, DecryptionInstance};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
-/// TODO.
+/// Struct sending stored KMS Core's responses to the Gateway.
 pub struct TransactionSender<L, P: Provider, R> {
+    /// The entity used to collect stored KMS Core's responses.
     response_picker: L,
+
+    /// The `Provider` used to interact with the Gateway
+    provider: P,
+
+    /// The `Decryption` contract instance of the Gateway.
     decryption_contract: DecryptionInstance<(), P>,
+
+    /// The entity used to remove stored KMS Core's responses.
     response_remover: R,
 }
+
+/// The expected length of an EIP712 signature.
+pub const EIP712_SIGNATURE_LENGTH: usize = 65;
+
+/// The time to wait between two transactions attempt.
+const TX_INTERVAL: Duration = Duration::from_secs(3);
 
 impl<L, P, R> TransactionSender<L, P, R>
 where
@@ -30,11 +48,13 @@ where
     /// Creates a new `TransactionSender` instance.
     pub fn new(
         response_picker: L,
+        provider: P,
         decryption_contract: DecryptionInstance<(), P>,
         response_remover: R,
     ) -> Self {
         Self {
             response_picker,
+            provider,
             decryption_contract,
             response_remover,
         }
@@ -70,6 +90,7 @@ where
 
     /// Processes a KMS Core response.
     async fn process(&self, response: KmsResponse) -> anyhow::Result<()> {
+        info!("Processing {response}...");
         match response.clone() {
             KmsResponse::PublicDecryption {
                 decryption_id: id,
@@ -88,6 +109,8 @@ where
                     .await?;
             }
         }
+        info!("{response} successfully sent to the Gateway!");
+
         self.response_remover.remove_response(&response).await
     }
 
@@ -119,10 +142,14 @@ where
         );
 
         // Create and send transaction
-        let call = self
-            .decryption_contract
-            .publicDecryptionResponse(id, result, signature.into());
-        let tx = call.send().await?;
+        let call_builder =
+            self.decryption_contract
+                .publicDecryptionResponse(id, result, signature.into());
+        info!(decryption_id = ?id, "public decryption calldata length {}", call_builder.calldata().len());
+
+        let mut call = call_builder.into_transaction_request();
+        self.estimate_gas(id, &mut call).await;
+        let tx = self.send_tx_with_retry(call).await?;
 
         // TODO: optimize for low latency
         let receipt = tx.get_receipt().await?;
@@ -130,7 +157,6 @@ where
         Ok(())
     }
 
-    // Code imported from `simple-connector` codebase -> remove this comment once used
     /// Sends a UserDecryptionResponse to the Gateway.
     pub async fn send_user_decryption_response(
         &self,
@@ -159,31 +185,82 @@ where
         );
 
         // Create and send transaction
-        let call = self
-            .decryption_contract
-            .userDecryptionResponse(id, result, signature.into());
-        let tx = call.send().await?;
+        let call_builder =
+            self.decryption_contract
+                .userDecryptionResponse(id, result, signature.into());
+        info!(decryption_id = ?id, "user decryption calldata length {}", call_builder.calldata().len());
+
+        let mut call = call_builder.into_transaction_request();
+        self.estimate_gas(id, &mut call).await;
+        let tx = self.send_tx_with_retry(call).await?;
 
         // TODO: optimize for low latency
         let receipt = tx.get_receipt().await?;
         info!(decryption_id = ?id, "🎯 User Decryption response sent with tx receipt: {:?}", receipt);
         Ok(())
     }
+
+    /// Estimates the `gas_limit` for the upcoming transaction.
+    async fn estimate_gas(&self, id: U256, call: &mut TransactionRequest) {
+        let gas_estimation = match self
+            .decryption_contract
+            .provider()
+            .estimate_gas(call.clone())
+            .await
+        {
+            Ok(estimation) => estimation,
+            Err(e) => return warn!(decryption_id = ?id, "Failed to estimate gas for the tx: {e}"),
+        };
+        info!(decryption_id = ?id, "Initial gas estimation for the tx: {gas_estimation}");
+
+        // Increase estimation to 300%
+        // TODO: temporary workaround for out-of-gas errors
+        // Our automatic estimation fails during gas pikes.
+        // (see https://zama-ai.slack.com/archives/C0915Q59CKG/p1749843623276629?thread_ts=1749828466.079719&cid=C0915Q59CKG)
+        let new_gas_value = gas_estimation.saturating_mul(3);
+
+        info!(decryption_id = ?id, "Updating `gas_limit` to {new_gas_value}");
+        call.gas = Some(new_gas_value);
+    }
+
+    /// Sends the requested transactions with one retry.
+    async fn send_tx_with_retry(
+        &self,
+        call: TransactionRequest,
+    ) -> anyhow::Result<PendingTransactionBuilder<Ethereum>> {
+        match self.provider.send_transaction(call.clone()).await {
+            Ok(tx) => Ok(tx),
+            Err(e) => {
+                warn!(
+                    "Retrying to send transaction in {}s after failure: {}",
+                    TX_INTERVAL.as_secs(),
+                    e
+                );
+
+                tokio::time::sleep(TX_INTERVAL).await;
+                self.provider
+                    .send_transaction(call)
+                    .await
+                    .map_err(anyhow::Error::from)
+            }
+        }
+    }
 }
 
-pub const EIP712_SIGNATURE_LENGTH: usize = 65;
-
 impl TransactionSender<DbKmsResponsePicker, WalletGatewayProvider, DbKmsResponseRemover> {
+    /// Creates a new `TransactionSender` instance from a valid `Config`.
     pub async fn from_config(config: Config) -> anyhow::Result<Self> {
         let db_pool = connect_to_db(&config.database_url, config.database_pool_size).await?;
         let response_picker = DbKmsResponsePicker::connect(db_pool.clone()).await?;
         let response_remover = DbKmsResponseRemover::new(db_pool);
 
         let provider = connect_to_gateway_with_wallet(&config.gateway_url, config.wallet).await?;
-        let decryption_contract = Decryption::new(config.decryption_contract.address, provider);
+        let decryption_contract =
+            Decryption::new(config.decryption_contract.address, provider.clone());
 
         Ok(Self::new(
             response_picker,
+            provider,
             decryption_contract,
             response_remover,
         ))

--- a/kms-connector/crates/tx-sender/tests/common/mod.rs
+++ b/kms-connector/crates/tx-sender/tests/common/mod.rs
@@ -1,0 +1,47 @@
+use connector_tests::rand::{rand_signature, rand_u256};
+use connector_utils::types::KmsResponse;
+use sqlx::{Pool, Postgres};
+
+pub async fn insert_rand_public_decrypt_response(
+    db: &Pool<Postgres>,
+) -> anyhow::Result<KmsResponse> {
+    let decryption_id = rand_u256();
+    let decrypted_result = rand_signature();
+    let signature = rand_signature();
+
+    sqlx::query!(
+        "INSERT INTO public_decryption_responses VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+        decryption_id.as_le_slice(),
+        decrypted_result,
+        signature
+    )
+    .execute(db)
+    .await?;
+
+    Ok(KmsResponse::PublicDecryption {
+        decryption_id,
+        decrypted_result,
+        signature,
+    })
+}
+
+pub async fn insert_rand_user_decrypt_response(db: &Pool<Postgres>) -> anyhow::Result<KmsResponse> {
+    let decryption_id = rand_u256();
+    let user_decrypted_shares = rand_signature();
+    let signature = rand_signature();
+
+    sqlx::query!(
+        "INSERT INTO user_decryption_responses VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+        decryption_id.as_le_slice(),
+        user_decrypted_shares,
+        signature
+    )
+    .execute(db)
+    .await?;
+
+    Ok(KmsResponse::UserDecryption {
+        decryption_id,
+        user_decrypted_shares,
+        signature,
+    })
+}

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -1,0 +1,96 @@
+mod common;
+
+use anyhow::anyhow;
+use common::insert_rand_public_decrypt_response;
+use connector_tests::setup::{TestInstance, test_instance_with_db_and_gw};
+use connector_utils::types::KmsResponse;
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tx_sender::core::{DbKmsResponsePicker, DbKmsResponseRemover, TransactionSender};
+
+use crate::common::insert_rand_user_decrypt_response;
+
+#[tokio::test]
+async fn test_process_public_decryption_response() -> anyhow::Result<()> {
+    let test_instance = test_instance_with_db_and_gw().await?;
+
+    let cancel_token = CancellationToken::new();
+    let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
+
+    println!("Mocking PublicDecryptionResponse in Postgres...");
+    let inserted_response = insert_rand_public_decrypt_response(&test_instance.db).await?;
+    println!("PublicDecryptionResponse successfully stored!");
+
+    println!("Checking response has been sent to Anvil...");
+    let filter = test_instance
+        .decryption_contract()
+        .PublicDecryptionResponse_filter();
+    let (response, _) = filter
+        .watch()
+        .await?
+        .into_stream()
+        .next()
+        .await
+        .ok_or_else(|| anyhow!("Failed to capture PublicDecryptionResponse"))??;
+    match inserted_response {
+        KmsResponse::PublicDecryption { decryption_id, .. } => {
+            assert_eq!(response.decryptionId, decryption_id)
+        }
+        _ => unreachable!(),
+    }
+    println!("Response successfully sent! Stopping TransactionSender...");
+
+    cancel_token.cancel();
+    Ok(tx_sender_task.await?)
+}
+
+#[tokio::test]
+async fn test_process_user_decryption_response() -> anyhow::Result<()> {
+    let test_instance = test_instance_with_db_and_gw().await?;
+
+    let cancel_token = CancellationToken::new();
+    let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
+
+    println!("Mocking UserDecryptionResponse in Postgres...");
+    let inserted_response = insert_rand_user_decrypt_response(&test_instance.db).await?;
+    println!("UserDecryptionResponse successfully stored!");
+
+    println!("Checking response has been sent to Anvil...");
+    let filter = test_instance
+        .decryption_contract()
+        .UserDecryptionResponse_filter();
+    let (response, _) = filter
+        .watch()
+        .await?
+        .into_stream()
+        .next()
+        .await
+        .ok_or_else(|| anyhow!("Failed to capture UserDecryptionResponse"))??;
+    match inserted_response {
+        KmsResponse::UserDecryption { decryption_id, .. } => {
+            assert_eq!(response.decryptionId, decryption_id)
+        }
+        _ => unreachable!(),
+    }
+    println!("Response successfully sent! Stopping TransactionSender...");
+
+    cancel_token.cancel();
+    Ok(tx_sender_task.await?)
+}
+
+async fn start_test_tx_sender(
+    test_instance: &TestInstance,
+    cancel_token: CancellationToken,
+) -> anyhow::Result<JoinHandle<()>> {
+    let response_picker = DbKmsResponsePicker::connect(test_instance.db.clone()).await?;
+    let response_remover = DbKmsResponseRemover::new(test_instance.db.clone());
+
+    let tx_sender = TransactionSender::new(
+        response_picker,
+        test_instance.decryption_contract().clone(),
+        response_remover,
+    );
+
+    Ok(tokio::spawn(tx_sender.start(cancel_token)))
+}

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use alloy::primitives::U256;
 use anyhow::anyhow;
 use common::insert_rand_public_decrypt_response;
 use connector_tests::setup::{TestInstance, test_instance_with_db_and_gw};
@@ -23,13 +24,13 @@ async fn test_process_public_decryption_response() -> anyhow::Result<()> {
     println!("PublicDecryptionResponse successfully stored!");
 
     println!("Checking response has been sent to Anvil...");
-    let filter = test_instance
+    let mut response_stream = test_instance
         .decryption_contract()
-        .PublicDecryptionResponse_filter();
-    let (response, _) = filter
+        .PublicDecryptionResponse_filter()
         .watch()
         .await?
-        .into_stream()
+        .into_stream();
+    let (response, _) = response_stream
         .next()
         .await
         .ok_or_else(|| anyhow!("Failed to capture PublicDecryptionResponse"))??;
@@ -39,7 +40,15 @@ async fn test_process_public_decryption_response() -> anyhow::Result<()> {
         }
         _ => unreachable!(),
     }
-    println!("Response successfully sent! Stopping TransactionSender...");
+    println!("Response successfully sent to Anvil!");
+
+    println!("Checking response has been removed from DB...");
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(decryption_id) FROM public_decryption_responses")
+            .fetch_one(&test_instance.db)
+            .await?;
+    assert_eq!(count, 0);
+    println!("Response successfully removed from DB! Stopping TransactionSender...");
 
     cancel_token.cancel();
     Ok(tx_sender_task.await?)
@@ -57,13 +66,13 @@ async fn test_process_user_decryption_response() -> anyhow::Result<()> {
     println!("UserDecryptionResponse successfully stored!");
 
     println!("Checking response has been sent to Anvil...");
-    let filter = test_instance
+    let mut response_stream = test_instance
         .decryption_contract()
-        .UserDecryptionResponse_filter();
-    let (response, _) = filter
+        .UserDecryptionResponse_filter()
         .watch()
         .await?
-        .into_stream()
+        .into_stream();
+    let (response, _) = response_stream
         .next()
         .await
         .ok_or_else(|| anyhow!("Failed to capture UserDecryptionResponse"))??;
@@ -73,7 +82,68 @@ async fn test_process_user_decryption_response() -> anyhow::Result<()> {
         }
         _ => unreachable!(),
     }
-    println!("Response successfully sent! Stopping TransactionSender...");
+    println!("Response successfully sent to Anvil!");
+
+    println!("Checking response has been removed from DB...");
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
+            .fetch_one(&test_instance.db)
+            .await?;
+    assert_eq!(count, 0);
+    println!("Response successfully removed from DB! Stopping TransactionSender...");
+
+    cancel_token.cancel();
+    Ok(tx_sender_task.await?)
+}
+
+#[tokio::test]
+#[ignore = "to enable when performance will be improved"]
+async fn stress_test() -> anyhow::Result<()> {
+    let test_instance = test_instance_with_db_and_gw().await?;
+    // test_instance.disable_tracing();
+
+    let cancel_token = CancellationToken::new();
+    let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
+
+    let nb_response = 500;
+    println!("Mocking {nb_response} UserDecryptionResponse in Postgres...");
+    let mut responses_id = Vec::with_capacity(nb_response);
+    for _ in 0..nb_response {
+        match insert_rand_user_decrypt_response(&test_instance.db).await? {
+            KmsResponse::UserDecryption { decryption_id, .. } => {
+                responses_id.push(decryption_id);
+            }
+            _ => unreachable!(),
+        }
+    }
+    println!("{nb_response} UserDecryptionResponse successfully stored!");
+
+    println!("Checking responses has been sent to Anvil...");
+    let response_stream = test_instance
+        .decryption_contract()
+        .UserDecryptionResponse_filter()
+        .watch()
+        .await?
+        .into_stream();
+
+    let mut anvil_responses_id = response_stream
+        .map(|res| res.unwrap())
+        .map(|(r, _)| r.decryptionId)
+        .take(nb_response)
+        .collect::<Vec<U256>>()
+        .await;
+    responses_id.sort();
+    anvil_responses_id.sort();
+    assert_eq!(responses_id, anvil_responses_id);
+    println!("Responses successfully sent to Anvil!");
+
+    println!("Checking responses have been removed from DB...");
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
+            .fetch_one(&test_instance.db)
+            .await?;
+    assert_eq!(count, 0);
+    println!("Responses successfully removed from DB! Stopping TransactionSender...");
 
     cancel_token.cancel();
     Ok(tx_sender_task.await?)
@@ -88,6 +158,7 @@ async fn start_test_tx_sender(
 
     let tx_sender = TransactionSender::new(
         response_picker,
+        test_instance.provider().clone(),
         test_instance.decryption_contract().clone(),
         response_remover,
     );

--- a/kms-connector/crates/tx-sender/tests/response_picker.rs
+++ b/kms-connector/crates/tx-sender/tests/response_picker.rs
@@ -1,8 +1,7 @@
-use connector_tests::{
-    rand::{rand_signature, rand_u256},
-    setup::test_instance_with_db_only,
-};
-use connector_utils::types::KmsResponse;
+mod common;
+
+use common::{insert_rand_public_decrypt_response, insert_rand_user_decrypt_response};
+use connector_tests::setup::test_instance_with_db_only;
 use tx_sender::core::{DbKmsResponsePicker, KmsResponsePicker};
 
 #[tokio::test]
@@ -11,32 +10,14 @@ async fn test_pick_public_decryption() -> anyhow::Result<()> {
 
     let mut response_picker = DbKmsResponsePicker::connect(test_instance.db.clone()).await?;
 
-    let decryption_id = rand_u256();
-    let decrypted_result = rand_signature();
-    let signature = rand_signature();
-
     println!("Triggering Postgres notification with PublicDecryptionResponse insertion...");
-    sqlx::query!(
-        "INSERT INTO public_decryption_responses VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-        decryption_id.as_le_slice(),
-        decrypted_result,
-        signature
-    )
-    .execute(&test_instance.db)
-    .await?;
+    let inserted_response = insert_rand_public_decrypt_response(&test_instance.db).await?;
 
     println!("Picking PublicDecryptionResponse...");
     let response = response_picker.pick_response().await?;
 
     println!("Checking PublicDecryptionResponse data...");
-    assert_eq!(
-        response,
-        KmsResponse::PublicDecryption {
-            decryption_id,
-            decrypted_result,
-            signature,
-        }
-    );
+    assert_eq!(response, inserted_response,);
     println!("Data OK!");
     Ok(())
 }
@@ -47,32 +28,13 @@ async fn test_pick_user_decryption() -> anyhow::Result<()> {
 
     let mut response_picker = DbKmsResponsePicker::connect(test_instance.db.clone()).await?;
 
-    let decryption_id = rand_u256();
-    let user_decrypted_shares = rand_signature();
-    let signature = rand_signature();
-
     println!("Triggering Postgres notification with UserDecryptionResponse insertion...");
-    sqlx::query!(
-        "INSERT INTO user_decryption_responses VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-        decryption_id.as_le_slice(),
-        user_decrypted_shares,
-        signature
-    )
-    .execute(&test_instance.db)
-    .await?;
-
+    let inserted_response = insert_rand_user_decrypt_response(&test_instance.db).await?;
     println!("Picking UserDecryptionResponse...");
     let response = response_picker.pick_response().await?;
 
     println!("Checking UserDecryptionResponse data...");
-    assert_eq!(
-        response,
-        KmsResponse::UserDecryption {
-            decryption_id,
-            user_decrypted_shares,
-            signature,
-        }
-    );
+    assert_eq!(response, inserted_response);
     println!("Data OK!");
     Ok(())
 }

--- a/kms-connector/crates/tx-sender/tests/response_picker.rs
+++ b/kms-connector/crates/tx-sender/tests/response_picker.rs
@@ -1,0 +1,78 @@
+use connector_tests::{
+    rand::{rand_signature, rand_u256},
+    setup::test_instance_with_db_only,
+};
+use connector_utils::types::KmsResponse;
+use tx_sender::core::{DbKmsResponsePicker, KmsResponsePicker};
+
+#[tokio::test]
+async fn test_pick_public_decryption() -> anyhow::Result<()> {
+    let test_instance = test_instance_with_db_only().await?;
+
+    let mut response_picker = DbKmsResponsePicker::connect(test_instance.db.clone()).await?;
+
+    let decryption_id = rand_u256();
+    let decrypted_result = rand_signature();
+    let signature = rand_signature();
+
+    println!("Triggering Postgres notification with PublicDecryptionResponse insertion...");
+    sqlx::query!(
+        "INSERT INTO public_decryption_responses VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+        decryption_id.as_le_slice(),
+        decrypted_result,
+        signature
+    )
+    .execute(&test_instance.db)
+    .await?;
+
+    println!("Picking PublicDecryptionResponse...");
+    let response = response_picker.pick_response().await?;
+
+    println!("Checking PublicDecryptionResponse data...");
+    assert_eq!(
+        response,
+        KmsResponse::PublicDecryption {
+            decryption_id,
+            decrypted_result,
+            signature,
+        }
+    );
+    println!("Data OK!");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pick_user_decryption() -> anyhow::Result<()> {
+    let test_instance = test_instance_with_db_only().await?;
+
+    let mut response_picker = DbKmsResponsePicker::connect(test_instance.db.clone()).await?;
+
+    let decryption_id = rand_u256();
+    let user_decrypted_shares = rand_signature();
+    let signature = rand_signature();
+
+    println!("Triggering Postgres notification with UserDecryptionResponse insertion...");
+    sqlx::query!(
+        "INSERT INTO user_decryption_responses VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+        decryption_id.as_le_slice(),
+        user_decrypted_shares,
+        signature
+    )
+    .execute(&test_instance.db)
+    .await?;
+
+    println!("Picking UserDecryptionResponse...");
+    let response = response_picker.pick_response().await?;
+
+    println!("Checking UserDecryptionResponse data...");
+    assert_eq!(
+        response,
+        KmsResponse::UserDecryption {
+            decryption_id,
+            user_decrypted_shares,
+            signature,
+        }
+    );
+    println!("Data OK!");
+    Ok(())
+}

--- a/kms-connector/crates/utils/Cargo.toml
+++ b/kms-connector/crates/utils/Cargo.toml
@@ -13,6 +13,8 @@ tfhe.workspace = true
 
 alloy.workspace = true
 anyhow.workspace = true
+aws-config.workspace = true
+aws-sdk-kms.workspace = true
 bincode.workspace = true
 clap.workspace = true
 config.workspace = true

--- a/kms-connector/crates/utils/src/config/mod.rs
+++ b/kms-connector/crates/utils/src/config/mod.rs
@@ -1,7 +1,9 @@
 mod contract;
 mod error;
 mod raw;
+mod wallet;
 
 pub use contract::{ContractConfig, RawContractConfig};
 pub use error::{Error, Result};
 pub use raw::DeserializeRawConfig;
+pub use wallet::{AwsKmsConfig, KmsWallet};

--- a/kms-connector/crates/utils/src/config/wallet.rs
+++ b/kms-connector/crates/utils/src/config/wallet.rs
@@ -1,3 +1,4 @@
+use crate::config::{Error, Result};
 use alloy::{
     hex::decode,
     network::{EthereumWallet, IntoWallet},
@@ -6,7 +7,6 @@ use alloy::{
 };
 use aws_config::BehaviorVersion;
 use aws_sdk_kms::Client as KmsClient;
-use connector_utils::config::{Error, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -1,6 +1,13 @@
-use alloy::providers::{
-    Identity, ProviderBuilder, RootProvider, WsConnect,
-    fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
+use crate::config::KmsWallet;
+use alloy::{
+    network::EthereumWallet,
+    providers::{
+        Identity, ProviderBuilder, ProviderLayer, RootProvider, WsConnect,
+        fillers::{
+            BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, TxFiller,
+            WalletFiller,
+        },
+    },
 };
 use anyhow::anyhow;
 use sqlx::{Pool, Postgres, postgres::PgPoolOptions};
@@ -34,21 +41,49 @@ pub async fn connect_to_db(db_url: &str, db_pool_size: u32) -> anyhow::Result<Po
     Err(anyhow!("Could not connect to Postgres DB at url {db_url}"))
 }
 
-pub type GatewayProvider = FillProvider<
-    JoinFill<
-        Identity,
-        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-    >,
-    RootProvider,
+/// The default `Filler`s for an `alloy::Provider`.
+type DefaultFillers = JoinFill<
+    Identity,
+    JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
 >;
+
+/// The default `alloy::Provider` used to interact with the Gateway.
+pub type GatewayProvider = FillProvider<DefaultFillers, RootProvider>;
+
+/// The default `alloy::Provider` used to interact with the Gateway using a wallet.
+pub type WalletGatewayProvider =
+    FillProvider<JoinFill<DefaultFillers, WalletFiller<EthereumWallet>>, RootProvider>;
 
 /// Tries to establish the connection with a RPC node of the Gateway.
 pub async fn connect_to_gateway(gateway_url: &str) -> anyhow::Result<GatewayProvider> {
+    connect_to_gateway_inner(gateway_url, || ProviderBuilder::new()).await
+}
+
+/// Tries to establish the connection with a RPC node of the Gateway, with a `WalletFiller`.
+pub async fn connect_to_gateway_with_wallet(
+    gateway_url: &str,
+    wallet: KmsWallet,
+) -> anyhow::Result<WalletGatewayProvider> {
+    connect_to_gateway_inner(gateway_url, || {
+        ProviderBuilder::new().wallet(wallet.clone())
+    })
+    .await
+}
+
+/// Tries to establish the connection with a RPC node of the Gateway.
+async fn connect_to_gateway_inner<L, F>(
+    gateway_url: &str,
+    provider_builder_new: impl Fn() -> ProviderBuilder<L, F>,
+) -> anyhow::Result<F::Provider>
+where
+    L: ProviderLayer<RootProvider>,
+    F: ProviderLayer<L::Provider> + TxFiller,
+{
     for i in 1..=RETRY_NUMBER {
         info!("Attempting connection to Gateway... ({i}/{RETRY_NUMBER})");
 
         let ws_endpoint = WsConnect::new(gateway_url);
-        match ProviderBuilder::new().on_ws(ws_endpoint).await {
+        match provider_builder_new().on_ws(ws_endpoint).await {
             Ok(provider) => {
                 info!("Connected to Gateway's RPC node successfully");
                 return Ok(provider);

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -56,7 +56,7 @@ pub type WalletGatewayProvider =
 
 /// Tries to establish the connection with a RPC node of the Gateway.
 pub async fn connect_to_gateway(gateway_url: &str) -> anyhow::Result<GatewayProvider> {
-    connect_to_gateway_inner(gateway_url, || ProviderBuilder::new()).await
+    connect_to_gateway_inner(gateway_url, ProviderBuilder::new).await
 }
 
 /// Tries to establish the connection with a RPC node of the Gateway, with a `WalletFiller`.

--- a/kms-connector/crates/utils/src/types/kms_response.rs
+++ b/kms-connector/crates/utils/src/types/kms_response.rs
@@ -102,7 +102,7 @@ impl KmsResponse {
         Ok(KmsResponse::UserDecryption {
             decryption_id,
             user_decrypted_shares: serialized_response_payload,
-            signature: grpc_response.signature,
+            signature: grpc_response.external_signature,
         })
     }
 }

--- a/kms-connector/tests/Cargo.toml
+++ b/kms-connector/tests/Cargo.toml
@@ -15,3 +15,5 @@ anyhow.workspace = true
 rand.workspace = true
 sqlx = { workspace = true, features = ["migrate"] }
 testcontainers.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace= true

--- a/kms-connector/tests/src/rand.rs
+++ b/kms-connector/tests/src/rand.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::{Address, FixedBytes, U256};
 use fhevm_gateway_rust_bindings::decryption::Decryption::SnsCiphertextMaterial;
-use rand::Rng;
+use rand::{Rng, distributions::Standard};
 
 pub fn rand_u256() -> U256 {
     U256::from_le_bytes(rand::thread_rng().r#gen::<[u8; 32]>())
@@ -15,7 +15,7 @@ pub fn rand_public_key() -> Vec<u8> {
 }
 
 pub fn rand_signature() -> Vec<u8> {
-    rand::thread_rng().r#gen::<[u8; 32]>().to_vec()
+    rand::thread_rng().sample_iter(Standard).take(65).collect()
 }
 
 pub fn rand_digest() -> FixedBytes<32> {

--- a/kms-connector/tests/src/setup/gw.rs
+++ b/kms-connector/tests/src/setup/gw.rs
@@ -24,7 +24,7 @@ pub const KMS_MANAGEMENT_MOCK_ADDRESS: Address = Address(FixedBytes([
 pub const TEST_MNEMONIC: &str =
     "coyote sketch defense hover finger envelope celery urge panther venue verb cheese";
 
-pub static CHAIN_ID: LazyLock<u32> = LazyLock::new(|| rand::random::<u32>());
+pub static CHAIN_ID: LazyLock<u32> = LazyLock::new(rand::random::<u32>);
 
 pub const DEPLOYER_PRIVATE_KEY: &str =
     "0xe746bc71f6bee141a954e6a49bc9384d334e393a7ea1e70b50241cb2e78e9e4c";

--- a/kms-connector/tests/src/setup/gw.rs
+++ b/kms-connector/tests/src/setup/gw.rs
@@ -2,12 +2,13 @@ use alloy::{
     node_bindings::{Anvil, AnvilInstance},
     primitives::{Address, FixedBytes},
 };
-use connector_utils::conn::GatewayProvider;
+use connector_utils::conn::WalletGatewayProvider;
 use fhevm_gateway_rust_bindings::{
     decryption::Decryption::{self, DecryptionInstance},
     gatewayconfig::GatewayConfig::{self, GatewayConfigInstance},
     kmsmanagement::KmsManagement::{self, KmsManagementInstance},
 };
+use std::sync::LazyLock;
 use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
 
 pub const DECRYPTION_MOCK_ADDRESS: Address = Address(FixedBytes([
@@ -23,12 +24,16 @@ pub const KMS_MANAGEMENT_MOCK_ADDRESS: Address = Address(FixedBytes([
 pub const TEST_MNEMONIC: &str =
     "coyote sketch defense hover finger envelope celery urge panther venue verb cheese";
 
+pub static CHAIN_ID: LazyLock<u32> = LazyLock::new(|| rand::random::<u32>());
+
+pub const DEPLOYER_PRIVATE_KEY: &str =
+    "0xe746bc71f6bee141a954e6a49bc9384d334e393a7ea1e70b50241cb2e78e9e4c";
+
 pub async fn setup_anvil_gateway() -> anyhow::Result<AnvilInstance> {
-    let chain_id = rand::random::<u32>();
     let anvil = Anvil::new()
         .mnemonic(TEST_MNEMONIC)
         .block_time(1)
-        .chain_id(chain_id as u64)
+        .chain_id(*CHAIN_ID as u64)
         .try_spawn()?;
     println!("Anvil started...");
 
@@ -37,16 +42,13 @@ pub async fn setup_anvil_gateway() -> anyhow::Result<AnvilInstance> {
             .with_wait_for(WaitFor::message_on_stdout("Mock contract deployment done!"))
             .with_env_var("HARDHAT_NETWORK", "staging")
             .with_env_var("RPC_URL", anvil.endpoint_url().as_str())
-            .with_env_var("CHAIN_ID_GATEWAY", format!("{chain_id}"))
+            .with_env_var("CHAIN_ID_GATEWAY", format!("{}", *CHAIN_ID))
             .with_env_var("MNEMONIC", TEST_MNEMONIC)
             .with_env_var(
                 "DEPLOYER_ADDRESS",
                 "0xCf28E90D4A6dB23c34E1881aEF5fd9fF2e478634",
             ) // accounts[1]
-            .with_env_var(
-                "DEPLOYER_PRIVATE_KEY",
-                "0xe746bc71f6bee141a954e6a49bc9384d334e393a7ea1e70b50241cb2e78e9e4c",
-            ) // accounts[1]
+            .with_env_var("DEPLOYER_PRIVATE_KEY", DEPLOYER_PRIVATE_KEY) // accounts[1]
             .with_env_var(
                 "PAUSER_ADDRESS",
                 "0xfCefe53c7012a075b8a711df391100d9c431c468",
@@ -62,14 +64,14 @@ pub async fn setup_anvil_gateway() -> anyhow::Result<AnvilInstance> {
 
 pub struct GatewayInstance {
     pub anvil: AnvilInstance,
-    pub provider: GatewayProvider,
-    pub decryption_contract: DecryptionInstance<(), GatewayProvider>,
-    pub gateway_config_contract: GatewayConfigInstance<(), GatewayProvider>,
-    pub kms_management_contract: KmsManagementInstance<(), GatewayProvider>,
+    pub provider: WalletGatewayProvider,
+    pub decryption_contract: DecryptionInstance<(), WalletGatewayProvider>,
+    pub gateway_config_contract: GatewayConfigInstance<(), WalletGatewayProvider>,
+    pub kms_management_contract: KmsManagementInstance<(), WalletGatewayProvider>,
 }
 
 impl GatewayInstance {
-    pub fn new(anvil: AnvilInstance, provider: GatewayProvider) -> Self {
+    pub fn new(anvil: AnvilInstance, provider: WalletGatewayProvider) -> Self {
         let decryption_contract = Decryption::new(DECRYPTION_MOCK_ADDRESS, provider.clone());
         let gateway_config_contract =
             GatewayConfig::new(GATEWAY_CONFIG_MOCK_ADDRESS, provider.clone());

--- a/kms-connector/tests/src/setup/instance.rs
+++ b/kms-connector/tests/src/setup/instance.rs
@@ -43,7 +43,7 @@ pub async fn test_instance_with_db_and_gw() -> anyhow::Result<TestInstance> {
 /// The integration test environment.
 pub struct TestInstance {
     /// Use to enable tracing during tests.
-    pub _tracing_default_guard: tracing::subscriber::DefaultGuard,
+    pub _tracing_default_guard: Option<tracing::subscriber::DefaultGuard>,
     /// Use to keep the database container running during the tests.
     pub _db_container: ContainerAsync<GenericImage>,
     pub db: Pool<Postgres>,
@@ -60,7 +60,7 @@ impl TestInstance {
             .finish();
 
         Self {
-            _tracing_default_guard: tracing::subscriber::set_default(subscriber),
+            _tracing_default_guard: Some(tracing::subscriber::set_default(subscriber)),
             _db_container: db_container,
             db,
             gateway_instance: None,
@@ -91,6 +91,10 @@ impl TestInstance {
 
     pub fn kms_management_contract(&self) -> &KmsManagementInstance<(), WalletGatewayProvider> {
         &self.gateway().kms_management_contract
+    }
+
+    pub fn disable_tracing(&mut self) {
+        self._tracing_default_guard = None;
     }
 
     fn gateway(&self) -> &GatewayInstance {

--- a/kms-connector/tests/src/setup/instance.rs
+++ b/kms-connector/tests/src/setup/instance.rs
@@ -1,12 +1,14 @@
 use crate::setup::{
+    CHAIN_ID, DEPLOYER_PRIVATE_KEY,
     db::setup_test_db_instance,
     gw::{GatewayInstance, setup_anvil_gateway},
 };
 use alloy::{
     node_bindings::AnvilInstance,
+    primitives::ChainId,
     providers::{ProviderBuilder, WsConnect},
 };
-use connector_utils::conn::GatewayProvider;
+use connector_utils::{config::KmsWallet, conn::WalletGatewayProvider};
 use fhevm_gateway_rust_bindings::{
     decryption::Decryption::DecryptionInstance,
     gatewayconfig::GatewayConfig::GatewayConfigInstance,
@@ -23,7 +25,13 @@ pub async fn test_instance_with_db_only() -> anyhow::Result<TestInstance> {
 
 pub async fn test_instance_with_db_and_gw() -> anyhow::Result<TestInstance> {
     let anvil = setup_anvil_gateway().await?;
+    let wallet = KmsWallet::from_private_key_str(
+        DEPLOYER_PRIVATE_KEY,
+        Some(ChainId::from(*CHAIN_ID as u64)),
+    )?;
+
     let provider = ProviderBuilder::new()
+        .wallet(wallet)
         .on_ws(WsConnect::new(anvil.ws_endpoint_url()))
         .await?;
     let gw_instance = GatewayInstance::new(anvil, provider);
@@ -32,7 +40,11 @@ pub async fn test_instance_with_db_and_gw() -> anyhow::Result<TestInstance> {
     Ok(test_instance.with_gateway(gw_instance))
 }
 
+/// The integration test environment.
 pub struct TestInstance {
+    /// Use to enable tracing during tests.
+    pub _tracing_default_guard: tracing::subscriber::DefaultGuard,
+    /// Use to keep the database container running during the tests.
     pub _db_container: ContainerAsync<GenericImage>,
     pub db: Pool<Postgres>,
     pub gateway_instance: Option<GatewayInstance>,
@@ -41,13 +53,21 @@ pub struct TestInstance {
 impl TestInstance {
     /// `TestInstance` with database only.
     pub fn new(db_container: ContainerAsync<GenericImage>, db: Pool<Postgres>) -> Self {
+        // Initialize tracing for this test
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_test_writer()
+            .finish();
+
         Self {
+            _tracing_default_guard: tracing::subscriber::set_default(subscriber),
             _db_container: db_container,
             db,
             gateway_instance: None,
         }
     }
 
+    /// Adds a `GatewayInstance` to the test environment.
     pub fn with_gateway(mut self, gateway_instance: GatewayInstance) -> Self {
         self.gateway_instance = Some(gateway_instance);
         self
@@ -57,19 +77,19 @@ impl TestInstance {
         &self.gateway().anvil
     }
 
-    pub fn provider(&self) -> &GatewayProvider {
+    pub fn provider(&self) -> &WalletGatewayProvider {
         &self.gateway().provider
     }
 
-    pub fn decryption_contract(&self) -> &DecryptionInstance<(), GatewayProvider> {
+    pub fn decryption_contract(&self) -> &DecryptionInstance<(), WalletGatewayProvider> {
         &self.gateway().decryption_contract
     }
 
-    pub fn gateway_config_contract(&self) -> &GatewayConfigInstance<(), GatewayProvider> {
+    pub fn gateway_config_contract(&self) -> &GatewayConfigInstance<(), WalletGatewayProvider> {
         &self.gateway().gateway_config_contract
     }
 
-    pub fn kms_management_contract(&self) -> &KmsManagementInstance<(), GatewayProvider> {
+    pub fn kms_management_contract(&self) -> &KmsManagementInstance<(), WalletGatewayProvider> {
         &self.gateway().kms_management_contract
     }
 


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#125 

NOTE: the `tx-sender` currently handles tx sequentially, with a `alloy::SimpleNonceManager`. This is definitely not ideal for performance, but it avoids many reliability problem (related to nonce management and error handling mostly). Once we validate the new architecture and agree on whether to share a common `tx-sender` or not, we should change this.