### PR TITLE
coprocessor: Enable basic health-checking logic for sns-worker 

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/healthz_server.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/healthz_server.rs
@@ -130,17 +130,14 @@ impl<S: HealthCheckService + Send + Sync + 'static> HttpServer<S> {
 
     async fn version_handler(State(service): State<Arc<S>>) -> impl IntoResponse {
         let version = service.get_version();
-        (
-            StatusCode::OK,
-            Json(serde_json::json!(version)),
-        )
+        (StatusCode::OK, Json(serde_json::json!(version)))
     }
 }
 
 #[derive(Clone, Default)]
 pub struct HealthStatus {
-    pub checks: HashMap<&'static str, bool>,
-    pub error_details: Vec<String>,
+    checks: HashMap<&'static str, bool>,
+    error_details: Vec<String>,
 }
 
 impl HealthStatus {
@@ -159,6 +156,14 @@ impl HealthStatus {
             }
         }
         self.checks.insert("database", is_connected);
+    }
+
+    pub fn set_custom_check(&mut self, check: &'static str, value: bool) {
+        self.checks.insert(check, value);
+    }
+
+    pub fn add_error_details(&mut self, details: String) {
+        self.error_details.push(details);
     }
 
     pub fn is_healthy(&self) -> bool {

--- a/coprocessor/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
@@ -31,6 +31,10 @@ pub struct Args {
     #[arg(long, default_value_t = 10)]
     pub pg_pool_connections: u32,
 
+    /// Postgres acquire timeout
+    #[arg(long, default_value = "15s", value_parser = parse_duration)]
+    pub pg_timeout: Duration,
+
     /// Postgres database url. If unspecified DATABASE_URL environment variable
     /// is used
     #[arg(long)]
@@ -81,6 +85,16 @@ pub struct Args {
         value_parser = clap::value_parser!(Level),
         default_value_t = Level::INFO)]
     pub log_level: Level,
+
+    /// HTTP server port for health checks
+    #[arg(long, default_value_t = 8080)]
+    pub health_check_port: u16,
+
+    /// Liveness threshold for health checks
+    /// Exceeding this threshold means that the worker is stuck
+    /// and will be restarted by the orchestrator
+    #[arg(long, default_value = "70s", value_parser = parse_duration)]
+    pub liveness_threshold: Duration,
 }
 
 pub fn parse_args() -> Args {


### PR DESCRIPTION
- Expose s3 and database health checks.
- Ensure the liveness status (alive/not_responding) are never false positive.
- Simplify the main loop in the executor.