### PR TITLE
feat(coprocessor): gas limit oveprovision in txn-sender

### DIFF
--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -119,6 +119,9 @@ struct Conf {
         value_parser = clap::value_parser!(Level),
         default_value_t = Level::INFO)]
     log_level: Level,
+
+    #[arg(long, default_value = "120", value_parser = clap::value_parser!(u32).range(100..))]
+    gas_limit_overprovision_percent: u32,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -223,6 +226,7 @@ async fn main() -> anyhow::Result<()> {
         review_after_unlimited_retries: conf.review_after_unlimited_retries,
         health_check_port: conf.health_check_port,
         health_check_timeout: conf.health_check_timeout,
+        gas_limit_overprovision_percent: conf.gas_limit_overprovision_percent,
     };
 
     let transaction_sender = std::sync::Arc::new(

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -33,6 +33,8 @@ pub struct ConfigSettings {
     // Health check related settings
     pub health_check_port: u16,
     pub health_check_timeout: Duration,
+
+    pub gas_limit_overprovision_percent: u32,
 }
 
 impl Default for ConfigSettings {
@@ -59,6 +61,7 @@ impl Default for ConfigSettings {
             review_after_unlimited_retries: 30,
             health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
+            gas_limit_overprovision_percent: 120,
         }
     }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod overprovision_gas_limit;
 pub mod http_server;
 mod nonce_managed_provider;
 mod ops;

--- a/coprocessor/fhevm-engine/transaction-sender/src/overprovision_gas_limit.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/overprovision_gas_limit.rs
@@ -1,0 +1,42 @@
+use alloy::network::{Ethereum, TransactionBuilder};
+use alloy_provider::Provider;
+use alloy_rpc_types::TransactionRequest;
+use tracing::{debug, warn};
+
+// If `txn_request.gas` is set, overprovision it by the given percent.
+// If `txn_request.gas` is not set, estimate the gas limit and then overprovision it by the given percent.
+// If the percent is less than 100, code will assert.
+// If the gas estimation fails, it will not set the gas limit for overprovisioning and will log a warning.
+pub async fn try_overprovision_gas_limit<T: Provider<Ethereum>>(
+    txn_request: impl Into<TransactionRequest>,
+    provider: &T,
+    percent: u32,
+) -> TransactionRequest {
+    assert!(percent >= 100, "Overprovision percent must be at least 100");
+
+    let overprovision = |gas: u64| (gas as u128 * percent as u128 / 100) as u64;
+
+    let mut txn: TransactionRequest = txn_request.into();
+
+    let new_gas = match txn.gas {
+        Some(existing_gas) => Some(existing_gas),
+        None => match provider.estimate_gas(txn.clone()).await {
+            Ok(estimated_gas) => Some(estimated_gas),
+            Err(err) => {
+                warn!(error = %err, gas_limit_overprovision_percent = percent, "Failed to estimate gas for overprovisioning, not setting gas limit for overprovisioning");
+                None
+            }
+        },
+    }.map(overprovision);
+
+    if let Some(gas) = new_gas {
+        debug!(
+            gas_limit = gas,
+            gas_limit_overprovision_percent = percent,
+            "Overprovisioned gas limit"
+        );
+        txn.set_gas_limit(gas);
+    }
+
+    txn
+}

--- a/coprocessor/fhevm-engine/transaction-sender/tests/allow_handle_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/allow_handle_tests.rs
@@ -204,7 +204,12 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
             .await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+        .connect_ws(
+            // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
+            WsConnect::new(env.ws_endpoint_url())
+                .with_max_retries(2)
+                .with_retry_interval(Duration::from_millis(100)),
+        )
         .await?;
     let provider = NonceManagedProvider::new(
         ProviderBuilder::default()

--- a/coprocessor/fhevm-engine/transaction-sender/tests/overprovision_gas_limit_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/overprovision_gas_limit_tests.rs
@@ -1,0 +1,99 @@
+mod common;
+
+use alloy::primitives::{FixedBytes, U256};
+use alloy_provider::{Provider, ProviderBuilder, WsConnect};
+use common::SignerType;
+use common::{CiphertextCommits, TestEnvironment};
+use rstest::*;
+use serial_test::serial;
+use std::time::Duration;
+use transaction_sender::overprovision_gas_limit::try_overprovision_gas_limit;
+
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[case::aws_kms(SignerType::AwsKms)]
+#[tokio::test]
+#[serial(db)]
+async fn overprovision_gas_limit(#[case] signer_type: SignerType) -> anyhow::Result<()> {
+    let env = TestEnvironment::new(signer_type).await?;
+    let provider = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+        .await?;
+
+    let already_added_revert = false;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider, already_added_revert).await?;
+
+    let txn_req = ciphertext_commits
+        .addCiphertextMaterial(
+            FixedBytes([1u8; 32]),
+            U256::from(1),
+            FixedBytes([2u8; 32]),
+            FixedBytes([3u8; 32]),
+        )
+        .into_transaction_request();
+
+    assert!(
+        txn_req.gas.is_none(),
+        "Gas limit should not be set initially"
+    );
+
+    let without_overprovision = provider.estimate_gas(txn_req.clone()).await?;
+    let with_overprovision = try_overprovision_gas_limit(txn_req, &provider, 120)
+        .await
+        .gas
+        .expect("Gas limit is set after overprovisioning");
+
+    assert_eq!(
+        with_overprovision,
+        (without_overprovision * 120) / 100,
+        "Overprovisioned gas limit should be greater than the estimated gas limit"
+    );
+
+    Ok(())
+}
+
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[case::aws_kms(SignerType::AwsKms)]
+#[tokio::test]
+#[serial(db)]
+async fn overprovision_estimate_failure(#[case] signer_type: SignerType) -> anyhow::Result<()> {
+    let mut env = TestEnvironment::new(signer_type).await?;
+    let provider = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .connect_ws(
+            // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
+            WsConnect::new(env.ws_endpoint_url())
+                .with_max_retries(2)
+                .with_retry_interval(Duration::from_millis(100)),
+        )
+        .await?;
+
+    let already_added_revert = false;
+    let ciphertext_commits = CiphertextCommits::deploy(&provider, already_added_revert).await?;
+
+    let txn_req = ciphertext_commits
+        .addCiphertextMaterial(
+            FixedBytes([1u8; 32]),
+            U256::from(1),
+            FixedBytes([2u8; 32]),
+            FixedBytes([3u8; 32]),
+        )
+        .into_transaction_request();
+
+    assert!(
+        txn_req.gas.is_none(),
+        "Gas limit should not be set initially"
+    );
+
+    env.drop_anvil();
+
+    let with_overprovision = try_overprovision_gas_limit(txn_req, &provider, 120)
+        .await
+        .gas;
+
+    assert!(with_overprovision.is_none(), "Gas limit should not be set");
+
+    Ok(())
+}


### PR DESCRIPTION
Add a config option to overprovision gas limit in transaction sender (in percentage).

Reason is that sometimes we need more gas on rollups such as Arbitrum, due to the way gas is calculater there. Intention is to reduce the likelihood of transaction failure due to insufficient gas.

Resolves https://github.com/zama-ai/fhevm-internal/issues/56