### PR TITLE
chore(gateway-contracts): update forge to 1.2.3

### DIFF
--- a/.github/workflows/gateway-contracts-integrity-checks.yml
+++ b/.github/workflows/gateway-contracts-integrity-checks.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
         with:
-          version: v1.2.2
+          version: v1.2.3
 
       - name: Install dependencies
         working-directory: gateway-contracts

--- a/gateway-contracts/scripts/bindings_update.py
+++ b/gateway-contracts/scripts/bindings_update.py
@@ -16,7 +16,8 @@ GW_CRATE_DIR = GW_ROOT_DIR.joinpath("rust_bindings")
 GW_CONTRACTS_DIR = GW_ROOT_DIR.joinpath("contracts")
 GW_MOCKS_DIR = GW_CONTRACTS_DIR.joinpath("mocks")
 
-ALLOWED_FORGE_VERSIONS = ["1.2.2-v1.2.2", "1.2.2-stable", "1.2.3-stable"]
+# To update forge to the latest version locally, run `foundryup` 
+ALLOWED_FORGE_VERSIONS = ["1.2.3-v1.2.3", "1.2.3-stable"]
 
 
 def init_cli() -> ArgumentParser:


### PR DESCRIPTION
run `foundryup` locally to update its version

no changes in the bindings this time

closes https://github.com/zama-ai/fhevm-internal/issues/18