### PR TITLE
fix: use the correct values for eip712 domain

### DIFF
--- a/sdk/rust-sdk/src/lib.rs
+++ b/sdk/rust-sdk/src/lib.rs
@@ -237,7 +237,7 @@ impl FhevmSdk {
         let verifying_contract = self
             .config
             .gateway_contracts
-            .input_verification
+            .decryption
             .unwrap_or_else(|| {
                 warn!("Input verification contract not set, using zero address");
                 Address::ZERO

--- a/sdk/rust-sdk/src/signature/eip712/builder.rs
+++ b/sdk/rust-sdk/src/signature/eip712/builder.rs
@@ -284,7 +284,7 @@ impl Eip712SignatureBuilder {
         let domain = alloy::sol_types::eip712_domain! {
             name: "Decryption",
             version: "1",
-            chain_id: self.config.gateway_chain_id,
+            chain_id: self.config.contracts_chain_id,
             verifying_contract: self.config.verifying_contract,
         };
 


### PR DESCRIPTION
In the JS SDK the EIP712 has slightly different values. More specifically as shown here https://github.com/zama-ai/relayer-sdk/blob/v0.1.0/src/index.ts#L178 the two main differences are:

1. `chain_id` is `contracts_chain_id` and not the `gateway_id`
2. `verifying_contract` is the `verifyingContractAddressDecryption` rather than `inputVerifierContractAddress`

After making those changes the signature generated is the one that `v1/user-decrypt` verifies correctly.