### PR TITLE
chore(sdk): change mutability

### DIFF
--- a/sdk/rust-sdk/README.md
+++ b/sdk/rust-sdk/README.md
@@ -34,7 +34,7 @@ use std::path::PathBuf;
 
 fn main() -> Result<()> {
     // Initialize SDK
-    let mut sdk = FhevmSdkBuilder::new()
+    let sdk = FhevmSdkBuilder::new()
         .with_keys_directory(PathBuf::from("./keys"))
         .with_gateway_chain_id(43113)
         .with_host_chain_id(11155111)

--- a/sdk/rust-sdk/examples/minimal-encrypted-input.rs
+++ b/sdk/rust-sdk/examples/minimal-encrypted-input.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     println!("🔐 Creating encrypted input...");
 
     // Setup SDK
-    let mut sdk = FhevmSdkBuilder::new()
+    let sdk = FhevmSdkBuilder::new()
         .with_keys_directory("./keys")
         .with_gateway_chain_id(54321)
         .with_host_chain_id(12345)

--- a/sdk/rust-sdk/src/lib.rs
+++ b/sdk/rust-sdk/src/lib.rs
@@ -386,8 +386,8 @@ impl FhevmSdk {
         Ok(calldata.to_vec())
     }
 
-    /// Get an input builder factory for creating encrypted inputs
-    pub fn get_input_factory(&mut self) -> Result<&InputBuilderFactory> {
+    /// Create an input builder factory for creating encrypted inputs
+    pub fn create_input_factory(&mut self) -> Result<()> {
         if self.input_factory.is_none() {
             // Load public key and CRS from config
 
@@ -418,13 +418,19 @@ impl FhevmSdk {
                 crs,
             ));
         }
+
+        Ok(())
+    }
+
+    /// Get an input builder factory for creating encrypted inputs
+    pub fn get_input_factory(&self) -> Result<&InputBuilderFactory> {
         self.input_factory
             .as_ref()
             .ok_or_else(|| FhevmError::InvalidParams("Failed to create input factory".to_string()))
     }
 
     /// Create a new encrypted input builder
-    pub fn create_input_builder(&mut self) -> Result<EncryptedInputBuilder> {
+    pub fn create_input_builder(&self) -> Result<EncryptedInputBuilder> {
         debug!("Creating encrypted input builder");
         let factory = self.get_input_factory()?;
         Ok(factory.create_builder())
@@ -789,7 +795,12 @@ impl FhevmSdkBuilder {
         let config = self.to_config()?;
 
         info!("SDK configuration validated successfully");
+
+        let mut fhevm = FhevmSdk::new(config);
+        fhevm.ensure_keys_loaded()?;
+        fhevm.create_input_factory()?;
+
         // Create and return the SDK
-        Ok(FhevmSdk::new(config))
+        Ok(fhevm)
     }
 }


### PR DESCRIPTION
Usage of the SDK has two stages:

The build (through the builder pattern)
Usage
The code currently imposes sdk instances to be mutable when encrypting data. More specifically:

```rust
let mut builder = sdk.create_input_builder()?;
builder.add_u8(42)?;
```

Most clients would initialize the sdk once and then use that same instance multiple times to call `create_input_builder` to encrypt new data. This function though expects a `&mut self.` This introduces a bottleneck when using the sdk instance in a concurrent scenario. More specifically, it would require wrapping the instance in the slow `Arc<Mutex<FhevmSdk>>`.

We can avoid this by changing `create_input_builder` into a simple &self and move the logic that requires mutability into the first stage i.e. the build stage.