### PR TITLE
fix: wrong return with `error!` macro

### DIFF
--- a/kms-connector/simple-connector/src/gw_adapters/events/adapter.rs
+++ b/kms-connector/simple-connector/src/gw_adapters/events/adapter.rs
@@ -161,7 +161,7 @@ impl<P: Provider + Clone + 'static> EventsAdapter<P> {
                             for task in &tasks {
                                 task.abort();
                             }
-                            return error!("Task {} failed: {}", idx, e);
+                            error!("Task {} failed: {}", idx, e);
                         }
                         Err(e) => {
                             // Abort other tasks


### PR DESCRIPTION
turns out I was doing `return error!(...)`, which doesn’t make sense - the macro just returns `()`, and the function expected something else.

replaced it with a proper `error!` call + return.
