### PR TITLE
fix argument order in Update benchmark_parser.py

### DIFF
--- a/ci/benchmark_parser.py
+++ b/ci/benchmark_parser.py
@@ -304,11 +304,11 @@ def _parse_key_results(result_file, crate, bench_type):
                 _create_point(
                     value,
                     test_name,
-                    display_name,
                     "keygen",
                     bench_type,
                     operator,
                     params,
+                    display_name,
                 )
             )
 


### PR DESCRIPTION
This PR fixes an incorrect argument order in the _create_point() call inside the _parse_key_results function.

passes display_name as the third argument, which is expected to be bench_class, but instead this causes bench_class, bench_type, operator, and params to be shifted, resulting in incorrect values in the parsed result.

create_point(
    value,
    test_name,
    "keygen",  # bench_class
    bench_type,
    operator,
    params,
    display_name

This ensures the parsed points have consistent structure and correctly reflect the benchmark metadata.

Impact
Fixes incorrect or malformed benchmark result entries when parsing key-related CSV files.

Prevents potential issues in downstream analysis that relies on correct fields.