### PR TITLE
chore(coprocessor): reduce docker images size

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0093d23bf026b580c1f66ed3a053d8209c104a446c5264d3ad99587f6edef24e"
+checksum = "4e0d1aecf3cab3d0e7383064ce488616434b4ade10d8904dff422e74203c712f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -286,7 +286,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
 ]
 
@@ -311,7 +310,7 @@ dependencies = [
  "alloy-primitives 1.2.0",
  "alloy-rlp",
  "alloy-serde",
- "alloy-trie",
+ "alloy-trie 0.8.1",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
@@ -341,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf25443920ecb9728cb087fe4dc04a0b290bd6ac85638c58fe94aba70f1a44e"
+checksum = "977b97d271159578afcb26e39e1ca5ce1a7f937697793d7d571b0166dd8b8225"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -358,6 +357,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 
@@ -422,7 +422,6 @@ checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives 1.2.0",
  "alloy-rlp",
- "k256",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -449,22 +448,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
+checksum = "5fcbae2107f3f2df2b02bb7d9e81e8aa730ae371ca9dd7fd0c81c3d0cb78a452"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 1.2.0",
  "alloy-serde",
- "alloy-trie",
+ "alloy-trie 0.9.0",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.6"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
+checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -643,15 +643,11 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -675,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
+checksum = "670d155c3e35bcaa252ca706a2757a456c56aa71b80ad1539d07d49b86304e78"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.2.0",
@@ -727,7 +723,6 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "futures",
@@ -751,20 +746,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
 dependencies = [
  "alloy-primitives 1.2.0",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+checksum = "65e80e2ffa56956a92af375df1422b239fde6552bd222dfeaeb39f07949060fa"
 dependencies = [
  "alloy-primitives 1.2.0",
  "alloy-rpc-types-eth",
@@ -781,34 +772,6 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-debug"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
-dependencies = [
- "alloy-primitives 1.2.0",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.2.0",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.0.1",
- "jsonwebtoken",
- "rand 0.8.5",
- "serde",
- "strum 0.27.1",
 ]
 
 [[package]]
@@ -832,36 +795,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-trace"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
-dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-rpc-types-txpool"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
-dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-serde"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
+checksum = "0ea08bc854235d4dff08fd57df8033285c11b8d7548b20c6da218194e7e6035f"
 dependencies = [
  "alloy-primitives 1.2.0",
  "serde",
@@ -885,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be3d371299b62eac5aa459fa58e8d1c761aabdc637573ae258ab744457fcc88"
+checksum = "7942b850ec7be43de89b2680321d7921b7620b25be53b9981aae6fb29daa9e97"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -903,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
+checksum = "14d95902d29e1290809e1c967a1e974145b44b78f6e3e12fc07a60c1225e3df0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1039,30 +976,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ipc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
-dependencies = [
- "alloy-json-rpc",
- "alloy-pubsub",
- "alloy-transport",
- "bytes",
- "futures",
- "interprocess",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "alloy-transport-ws"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
+checksum = "c5596b913d1299ee37a9c1bb5118b2639bf253dc1088957bdf2073ae63a6fdfa"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1086,7 +1003,23 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
- "nybbles",
+ "nybbles 0.3.4",
+ "serde",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bada1fc392a33665de0dc50d401a3701b62583c655e3522a323490a5da016962"
+dependencies = [
+ "alloy-primitives 1.2.0",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 2.0.1",
+ "nybbles 0.4.0",
  "serde",
  "smallvec",
  "tracing",
@@ -2936,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der"
@@ -3131,12 +3064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,7 +3240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3454,11 +3381,7 @@ name = "fhevm-listener"
 version = "0.7.0"
 dependencies = [
  "alloy",
- "alloy-eips",
  "alloy-primitives 1.2.0",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-sol-types",
  "anyhow",
  "axum",
  "clap",
@@ -4512,21 +4435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4550,7 +4458,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4609,21 +4517,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -4703,7 +4596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5058,6 +4951,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nybbles"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d51b0175c49668a033fe7cc69080110d9833b291566cdf332905f3ad9c68a0"
+dependencies = [
+ "alloy-rlp",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5330,16 +5236,6 @@ name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pem"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
-dependencies = [
- "base64 0.22.1",
- "serde",
-]
 
 [[package]]
 name = "pem-rfc7468"
@@ -5736,7 +5632,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5850,12 +5746,6 @@ name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
-
-[[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -6157,7 +6047,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6170,7 +6060,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6707,18 +6597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.12",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6851,7 +6729,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width",
 ]
@@ -6951,7 +6829,6 @@ dependencies = [
  "indexmap 2.8.0",
  "log",
  "memchr",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "serde",
@@ -7232,7 +7109,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -7341,7 +7218,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8035,10 +7912,6 @@ name = "transaction-sender"
 version = "0.7.0"
 dependencies = [
  "alloy",
- "alloy-eips",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-sol-types",
  "anyhow",
  "async-trait",
  "aws-config",
@@ -8438,12 +8311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8465,7 +8332,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8698,9 +8565,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "ws_stream_wasm"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
 dependencies = [
  "async_io_stream",
  "futures",
@@ -8709,7 +8576,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -1,7 +1,16 @@
 [workspace]
 resolver = "2"
-members = ["coprocessor", "executor", "fhevm-engine-common", "fhevm-listener", 
-            "gw-listener", "sns-executor", "transaction-sender", "zkproof-worker", "test-harness"]
+members = [
+    "coprocessor",
+    "executor",
+    "fhevm-engine-common",
+    "fhevm-listener",
+    "gw-listener",
+    "sns-executor",
+    "transaction-sender",
+    "zkproof-worker",
+    "test-harness",
+]
 
 [workspace.package]
 authors = ["Zama"]
@@ -9,7 +18,13 @@ edition = "2021"
 license = "BSD-3-Clause-Clear"
 
 [workspace.dependencies]
-alloy = { version = "1.0.9", features = ["full", "provider-anvil-api", "provider-anvil-node", "sol-types", "signer-aws"] }
+alloy = { version = "1.0.17", default-features = false, features = [
+    "essentials",
+    "std",
+    "reqwest-rustls-tls",
+    "provider-ws",
+    "signer-aws",
+] }
 alloy-primitives = "1.2.0"
 axum = "0.7"
 tower-http = { version = "0.5", features = ["trace"] }
@@ -38,11 +53,24 @@ serde_json = "1.0.140"
 serial_test = "3.2.0"
 sha3 = "0.10.8"
 strum = { version = "0.26.3", features = ["derive"] }
-rustls = { version = "0.23", features = ["aws-lc-rs"]}
-sqlx = { version = "0.8.5", default-features = false, features = ["macros", "migrate", "runtime-tokio", "tls-native-tls", "time", "postgres", "uuid"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+sqlx = { version = "0.8.5", default-features = false, features = [
+    "macros",
+    "migrate",
+    "runtime-tokio",
+    "time",
+    "postgres",
+    "uuid",
+] }
 testcontainers = "0.24.0"
 thiserror = "2.0.12"
-tfhe = { version = "=1.1.2", features = ["boolean", "shortint", "integer", "zk-pok", "experimental-force_fft_algo_dif4"] }
+tfhe = { version = "=1.1.2", features = [
+    "boolean",
+    "shortint",
+    "integer",
+    "zk-pok",
+    "experimental-force_fft_algo_dif4",
+] }
 tfhe-versionable = "=0.5.0"
 tokio = { version = "1.45.0", features = ["full"] }
 tokio-util = "0.7.15"

--- a/coprocessor/fhevm-engine/coprocessor/Dockerfile
+++ b/coprocessor/fhevm-engine/coprocessor/Dockerfile
@@ -14,22 +14,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p coprocessor
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
-# Stage 3: Runtime image
+# Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
-
 COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/coprocessor /usr/local/bin/coprocessor
 
 USER fhevm:fhevm

--- a/coprocessor/fhevm-engine/db-migration/Dockerfile
+++ b/coprocessor/fhevm-engine/db-migration/Dockerfile
@@ -17,37 +17,24 @@ COPY coprocessor/fhevm-engine/db-migration/migrations ./migrations
 
 WORKDIR /app/coprocessor/fhevm-engine
 # Build utils binary
-# Currently, this utils is used only for keys converting. 
+# Currently, this utils is used only for keys converting.
 # Later on, it will be extended to replace initialize_db.sh completely
 RUN mkdir /fhevm-keys && \
     cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p coprocessor --bin utils
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
 # Stage 2: Runtime image
-FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
-
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
-COPY --from=builder /usr/libexec/ /usr/libexec/
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
+FROM cgr.dev/chainguard/postgres:latest AS prod
 
 COPY  --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/utils /usr/local/bin/utils
 COPY  --from=builder --chown=fhevm:fhevm /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 COPY  --from=builder --chown=fhevm:fhevm /app/initialize_db.sh /initialize_db.sh
 COPY  --from=builder --chown=fhevm:fhevm /app/migrations /migrations
 COPY  --from=builder --chown=fhevm:fhevm /fhevm-keys /fhevm-keys
+COPY  --from=builder /etc/group /etc/group
+COPY  --from=builder /etc/passwd /etc/passwd
 
 USER fhevm:fhevm
-
-ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}"
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD psql --version || exit 1

--- a/coprocessor/fhevm-engine/fhevm-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/fhevm-listener/Cargo.toml
@@ -11,15 +11,9 @@ test = false
 bench = false
 
 [dependencies]
-# external dependencies
-alloy-provider = "1.0.9"
-alloy-eips = "1.0.9"
-alloy-rpc-types = "1.0.9"
-alloy-sol-types = "1.2.0"
-
 # workspace dependencies
 anyhow = { workspace = true }
-alloy = { workspace = true, features = ["contract", "json", "providers", "provider-ws", "pubsub", "rpc-types", "sol-types"] }
+alloy = { workspace = true }
 alloy-primitives = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }
@@ -38,6 +32,7 @@ tracing-subscriber = { workspace = true }
 fhevm-engine-common = { path = "../fhevm-engine-common" }
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["node-bindings"] }
 anyhow = { workspace = true }
 reqwest = "0.12.20"
 serial_test = { workspace = true }

--- a/coprocessor/fhevm-engine/fhevm-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/fhevm-listener/Dockerfile
@@ -30,22 +30,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p fhevm-listener
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
-# Stage 3: Runtime image
+# Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
-
 COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/fhevm_listener /usr/local/bin/fhevm_listener
 
 USER fhevm:fhevm

--- a/coprocessor/fhevm-engine/fhevm-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/src/cmd/mod.rs
@@ -1,20 +1,18 @@
-use alloy_provider::fillers::{
+use alloy::primitives::Address;
+use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill,
     NonceFiller,
 };
+use alloy::providers::{Provider, ProviderBuilder, RootProvider, WsConnect};
+use alloy::pubsub::SubscriptionStream;
+use alloy::rpc::types::{BlockNumberOrTag, Filter, Log};
+use alloy::sol_types::SolEventInterface;
 use futures_util::stream::StreamExt;
 use sqlx::types::Uuid;
 use std::collections::VecDeque;
 use std::str::FromStr;
 use std::time::Duration;
 use tracing::{error, info, warn, Level};
-
-use alloy::primitives::Address;
-use alloy::providers::{Provider, ProviderBuilder, RootProvider, WsConnect};
-use alloy::pubsub::SubscriptionStream;
-use alloy::rpc::types::{BlockNumberOrTag, Filter, Log};
-
-use alloy_sol_types::SolEventInterface;
 
 use clap::Parser;
 

--- a/coprocessor/fhevm-engine/fhevm-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/src/database/tfhe_event_propagate.rs
@@ -287,8 +287,8 @@ impl Database {
 
     pub async fn mark_prev_block_as_valid(
         &mut self,
-        opt_event: &Option<alloy_rpc_types::Log>,
-        opt_prev_event: &Option<alloy_rpc_types::Log>,
+        opt_event: &Option<alloy::rpc::types::Log>,
+        opt_prev_event: &Option<alloy::rpc::types::Log>,
     ) -> Option<u64> {
         let Some(prev_event) = opt_prev_event else {
             return None;

--- a/coprocessor/fhevm-engine/fhevm-listener/tests/integration_test.rs
+++ b/coprocessor/fhevm-engine/fhevm-listener/tests/integration_test.rs
@@ -7,10 +7,9 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use tracing::Level;
 
+use alloy::providers::{Provider, ProviderBuilder, WalletProvider, WsConnect};
+use alloy::rpc::types::TransactionRequest;
 use alloy_primitives::U256;
-use alloy_provider::{Provider, ProviderBuilder, WalletProvider, WsConnect};
-
-use alloy_rpc_types::TransactionRequest;
 use serial_test::serial;
 use sqlx::postgres::PgPoolOptions;
 
@@ -47,9 +46,9 @@ async fn emit_events<P, N>(
     tfhe_contract: FHEVMExecutorTestInstance<P, N>,
     acl_contract: ACLTestInstance<P, N>,
 ) where
-    P: Clone + alloy_provider::Provider<N> + 'static,
+    P: Clone + alloy::providers::Provider<N> + 'static,
     N: Clone
-        + alloy_provider::Network<TransactionRequest = TransactionRequest>
+        + alloy::providers::Network<TransactionRequest = TransactionRequest>
         + 'static,
 {
     let mut providers = vec![];

--- a/coprocessor/fhevm-engine/gw-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/gw-listener/Cargo.toml
@@ -27,4 +27,5 @@ foundry-compilers = { workspace = true }
 semver = { workspace = true }
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["node-bindings"] }
 serial_test = { workspace = true }

--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -13,22 +13,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p gw-listener
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
-# Stage 3: Runtime image
+# Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
-
 COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/gw_listener /usr/local/bin/gw_listener
 
 USER fhevm:fhevm

--- a/coprocessor/fhevm-engine/sns-executor/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-executor/Dockerfile
@@ -14,22 +14,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p sns-executor
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
 # Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
-
 COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/sns_worker /usr/local/bin/sns_worker
 
 USER fhevm:fhevm

--- a/coprocessor/fhevm-engine/transaction-sender/Cargo.toml
+++ b/coprocessor/fhevm-engine/transaction-sender/Cargo.toml
@@ -28,10 +28,6 @@ humantime = { workspace = true }
 
 # crates.io dependencies
 async-trait = "0.1.88"
-alloy-provider = "1.0.9"
-alloy-eips = "1.0.9"
-alloy-rpc-types = "1.0.9"
-alloy-sol-types = "1.2.0"
 
 # local dependencies
 fhevm-engine-common = { path = "../fhevm-engine-common" }
@@ -41,6 +37,7 @@ foundry-compilers = { workspace = true }
 semver = { workspace = true }
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["node-bindings"] }
 rstest = "0.25.0"
 serial_test = { workspace = true }
 testcontainers = { workspace = true }

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -14,22 +14,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p transaction-sender
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
-# Stage 3: Runtime image
+# Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
-
 COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/transaction_sender /usr/local/bin/transaction_sender
 
 USER fhevm:fhevm

--- a/coprocessor/fhevm-engine/transaction-sender/src/overprovision_gas_limit.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/overprovision_gas_limit.rs
@@ -1,6 +1,6 @@
 use alloy::network::{Ethereum, TransactionBuilder};
-use alloy_provider::Provider;
-use alloy_rpc_types::TransactionRequest;
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
 use tracing::{debug, warn};
 
 // If `txn_request.gas` is set, overprovision it by the given percent.

--- a/coprocessor/fhevm-engine/transaction-sender/tests/overprovision_gas_limit_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/overprovision_gas_limit_tests.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use alloy::primitives::{FixedBytes, U256};
-use alloy_provider::{Provider, ProviderBuilder, WsConnect};
+use alloy::providers::{Provider, ProviderBuilder, WsConnect};
 use common::SignerType;
 use common::{CiphertextCommits, TestEnvironment};
 use rstest::*;

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -14,22 +14,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN cargo fetch && \
     SQLX_OFFLINE=true cargo build --release -p zkproof-worker
 
-# Avoid a conflict with prod stage
-RUN rm -rf /lib/apk
-
 # Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-COPY --from=builder /lib/ /lib/
-COPY --from=builder /bin/ /bin/
-COPY --from=builder /usr/lib/ /usr/lib/
-COPY --from=builder /usr/bin/ /usr/bin/
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
-COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
-COPY --from=builder --chown=fhevm:fhevm /app /app
-
 COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/zkproof_worker /usr/local/bin/zkproof_worker
 
 USER fhevm:fhevm


### PR DESCRIPTION
Reduces the docker images of the coprocessor's services:
- removed openssl dependency to use only rustls
- removed useless `COPY` instructions from the different Dockerfile

Note: e2e tests are passing : https://github.com/zama-ai/fhevm/actions/runs/16137668812/job/45538413842