### PR TITLE
chore(coprocessor): add contextId in VerifyProofRequest

### DIFF
--- a/coprocessor/fhevm-engine/gw-listener/contracts/InputVerification.sol
+++ b/coprocessor/fhevm-engine/gw-listener/contracts/InputVerification.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.28;
 contract InputVerification {
     event VerifyProofRequest(
         uint256 indexed zkProofId,
+        uint256 indexed contextId,
         uint256 indexed contractChainId,
         address contractAddress,
         address userAddress,
@@ -13,6 +14,7 @@ contract InputVerification {
     );
 
     uint256 zkProofIdCounter = 0;
+    uint256 contextId = 1;
 
     function verifyProofRequest(
         uint256 contractChainId,
@@ -24,6 +26,7 @@ contract InputVerification {
         zkProofIdCounter += 1;
         emit VerifyProofRequest(
             zkProofId,
+            contextId,
             contractChainId,
             contractAddress,
             userAddress,


### PR DESCRIPTION
I start to need to update some parts in order to run e2e tests with the gateway changes from https://github.com/zama-ai/fhevm/pull/211

- e2e tests running [here](https://github.com/zama-ai/fhevm/actions/runs/16147181463/job/45569033476) using : 
    - the latest gateway image from [#211](https://github.com/zama-ai/fhevm/pull/211) : `8711336`
    - the gw-listener image from here : `2649512 `

note that this PR shouldn't be merged until https://github.com/zama-ai/fhevm/pull/211 is ready

it does not add full support of coprocessor contexts like discussed in https://github.com/zama-ai/planning-blockchain/issues/548 and https://github.com/zama-ai/fhevm-internal/issues/7

finally, this kind of change won't be needed once we integrate the gateway rust bindings as explained in https://github.com/zama-ai/fhevm-internal/issues/10

refs https://github.com/zama-ai/fhevm-internal/issues/172