### PR TITLE
fix typos in Update decryption.md

### DIFF
--- a/coprocessor/docs/fundamentals/gateway/decryption.md
+++ b/coprocessor/docs/fundamentals/gateway/decryption.md
@@ -1,7 +1,7 @@
 # Decryption
 
-Everything in fhEVM is encrypted, at some point one could need to decrypt somes values. Let's give as illustration a blind auction application.
-After reaching the end of the auction, one need to discover (only) the winner, here is where a asynchronous decrypt could appear. 
+Everything in fhEVM is encrypted, at some point one could need to decrypt some values. Let's give as illustration a blind auction application.
+After reaching the end of the auction, one needs to discover (only) the winner, here is where an asynchronous decryption might occur. 
 
 
 > :warning: **Decryption is public**: It means everyone will be able to see the value. If this is a personal information see [Reencryption](./reencryption.md)
@@ -9,13 +9,13 @@ After reaching the end of the auction, one need to discover (only) the winner, h
 ## How it's working
 
 The Gateway acts as an oracle service: it will listen to decryption request events and return the decrypted value through a callback function.
-The responsabilities of the Gateway are:
+The responsibilities of the Gateway are:
 - Listening decryption request from fhEVM that contains a handle `h` that corresponds to a  ciphertext `C`
 - Computing a storage proof `P` to attest h (i.e. C)  is decryptable
 - Retrieve C from fhEVM using `h` as key
-- Send a decyption request to TKMS which in turn is running an internal blockchain aka `KMS BC`
-- Wait and listen for `decyptionResponse` (containing the plaitext and a few signatures from KMS to attest the integrity of the palintext) event from `KMS BC`
-- Return `decyptionResponse` through the callback function
+- Send a decryption request to TKMS which in turn is running an internal blockchain aka `KMS BC`
+- Wait and listen for `decryptionResponse` (containing the plaintext and a few signatures from KMS to attest the integrity of the plaintext) event from `KMS BC`
+- Return `decryptionResponse` through the callback function
 
 ## High level overview of the decryption flow 
 


### PR DESCRIPTION
This PR addresses several typos and grammatical mistakes in the Decryption documentation page. The goal is to improve clarity and professionalism in the written content. Below are the specific changes made:

"somes values" → some values
Corrected pluralization/grammar.

"one need to discover" → one needs to discover
Subject-verb agreement fix.

"where a asynchronous decrypt could appear" → where an asynchronous decryption might occur Fixed incorrect article usage, noun form, and improved overall clarity. Alternative phrasing used: ...where asynchronous decryption comes into play.

"responsabilities" → responsibilities
Fixed spelling error.

"Send a decyption request" → Send a decryption request Fixed spelling error.

"plaitext" / "palintext" → plaintext
Corrected spelling errors.

"Return decyptionResponse" → Return decryptionResponse Fixed typo in keyword.

These changes ensure consistent terminology and better readability across the documentation.