### PR TITLE
fix(kms-connector): crash on gw connection lost

### DIFF
--- a/kms-connector/simple-connector/src/gw_adapters/events/adapter.rs
+++ b/kms-connector/simple-connector/src/gw_adapters/events/adapter.rs
@@ -161,7 +161,11 @@ impl<P: Provider + Clone + 'static> EventsAdapter<P> {
                             for task in &tasks {
                                 task.abort();
                             }
-                            return error!("Task {} failed: {}", idx, e);
+                            error!("Task {} failed: {}", idx, e);
+                            if &e.to_string() == "backend connection task has stopped" {
+                                std::process::exit(1); // Crash if Gateway connection is lost
+                            }
+                            return;
                         }
                         Err(e) => {
                             // Abort other tasks


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/210

- Crash when the connection to the Gateway is lost
- Crash when the connection to the Gateway can't be established in the first place