### PR TITLE
feat(test-suite): add an optional api key for relayer sdk

### DIFF
--- a/test-suite/e2e/test/instance.ts
+++ b/test-suite/e2e/test/instance.ts
@@ -11,6 +11,7 @@ const gatewayChainID = +process.env.CHAIN_ID_GATEWAY!;
 const verifyingContractAddressDecryption = process.env.DECRYPTION_ADDRESS!;
 const verifyingContractAddressInputVerification = process.env.INPUT_VERIFICATION_ADDRESS!;
 const relayerUrl = process.env.RELAYER_URL!;
+const apiKey: string | undefined = process.env.RELAYER_API_KEY;
 
 export const createInstances = async (accounts: Signers): Promise<FhevmInstances> => {
   // Create instance
@@ -35,6 +36,7 @@ export const createInstance = async () => {
     network: network.config.url,
     relayerUrl: relayerUrl,
     gatewayChainId: gatewayChainID,
+    apiKey: apiKey,
   });
   return instance;
 };


### PR DESCRIPTION
It adds an optional API Key field when calling the relayer using the `relayer-sdk` in tests