### PR TITLE
chore(kms-connector): only trigger test workflow if changes

### DIFF
--- a/.github/workflows/kms-connector-tests.yml
+++ b/.github/workflows/kms-connector-tests.yml
@@ -45,6 +45,8 @@ jobs:
 
   start-runner:
     name: kms-connector-tests/start-runner
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.changes-connector == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}


### PR DESCRIPTION
to avoid running connector tests in all PRs