### PR TITLE
fix: typos and improve clarity in documentation

### DIFF
--- a/coprocessor/README.md
+++ b/coprocessor/README.md
@@ -2,7 +2,7 @@
 **FHEVM Coprocessor** provides the execution service for FHE computations.
 
 It includes a **Coprocessor** service [FHEVM-coprocessor](docs/getting_started/fhevm/coprocessor/coprocessor_backend.md). The Coprocessor
-itself consists of multiple microservices, e.g. for FHE compute, input verify, transaction sending, listenting to events, etc.
+itself consists of multiple microservices, e.g. for FHE compute, input verify, transaction sending, listening to events, etc.
 
 ## Main features
 

--- a/coprocessor/docs/fundamentals/fhevm/contracts.md
+++ b/coprocessor/docs/fundamentals/fhevm/contracts.md
@@ -12,7 +12,7 @@ _Note_: All those contracts are initially deployed behind UUPS proxies, so could
 
 ## FHEVMExecutor Contract
 
-Symbolic execution on the blockchain is implemented via the [FHEVMExecutor](../../../contracts/contracts/FHEVMExecutor.sol) contract. One of its main responsibilites is to deterministically generate ciphertext handles. For this, we hash the FHE operation requested and the inputs to produce the result handle H:
+Symbolic execution on the blockchain is implemented via the [FHEVMExecutor](../../../contracts/contracts/FHEVMExecutor.sol) contract. One of its main responsibilities is to deterministically generate ciphertext handles. For this, we hash the FHE operation requested and the inputs to produce the result handle H:
 
 ```
 H = keccak256(fheOperation, input1, input2, ..., inputN)
@@ -24,7 +24,7 @@ Inputs can either be other handles or plaintext values.
 
 The [ACL](../../../contracts/contracts/ACL.sol) contract enforces access control for ciphertexts. The model we adopt is very simple - a ciphertext is either allowed for an address or not. An address can be any address - either an EOA address or a contract address. Essentially, it is a mapping from handle to a set of addresses that are allowed to use the handle.
 
-Access control applies to transfering ciphertexts from one contract to another, for FHE computation on ciphertexts, for decryption and for reencryption of a ciphertext to a user-provided key.
+Access control applies to transferring ciphertexts from one contract to another, for FHE computation on ciphertexts, for decryption and for reencryption of a ciphertext to a user-provided key.
 
 ### Garbage Collection of Allowed Ciphertexts Data
 

--- a/docs/solidity-guides/functions.md
+++ b/docs/solidity-guides/functions.md
@@ -177,7 +177,7 @@ More information about the behavior of these operators can be found at the [TFHE
 
 #### Bitwise operations (`AND`, `OR`, `XOR`)
 
-Unlike other binary operations, bitwise operations do not natively accept a mix of ciphertext and plaintext inputs. To ease developer experience, the `FHE` library adds function overloads for these operations. Such overloads implicitely do a trivial encryption before actually calling the operation function, as shown in the examples below.
+Unlike other binary operations, bitwise operations do not natively accept a mix of ciphertext and plaintext inputs. To ease developer experience, the `FHE` library adds function overloads for these operations. Such overloads implicitly do a trivial encryption before actually calling the operation function, as shown in the examples below.
 
 Available for euint\* types:
 


### PR DESCRIPTION


**Description:**  
This pull request corrects several typos and improves the clarity of the documentation across multiple files. Minor wording adjustments were made to enhance readability and maintain consistency. 