### PR TITLE
feat(kms-connector): make test setup podman-friendly

### DIFF
--- a/kms-connector/crates/utils/src/tests/setup/common.rs
+++ b/kms-connector/crates/utils/src/tests/setup/common.rs
@@ -1,0 +1,9 @@
+use std::net::TcpListener;
+
+pub fn pick_free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}

--- a/kms-connector/crates/utils/src/tests/setup/db.rs
+++ b/kms-connector/crates/utils/src/tests/setup/db.rs
@@ -2,6 +2,10 @@ use sqlx::{Pool, Postgres};
 use testcontainers::{ContainerAsync, GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
 use tracing::info;
 
+use crate::tests::setup::pick_free_port;
+
+const POSTGRES_PORT: u16 = 5432;
+
 pub struct DbInstance {
     /// Use to keep the database container running during the tests.
     _db_container: ContainerAsync<GenericImage>,
@@ -11,11 +15,13 @@ pub struct DbInstance {
 
 impl DbInstance {
     pub async fn setup() -> anyhow::Result<Self> {
+        let host_port = pick_free_port();
         info!("Starting Postgres container...");
         let container = GenericImage::new("postgres", "17.5")
             .with_wait_for(WaitFor::message_on_stderr(
                 "database system is ready to accept connections",
             ))
+            .with_mapped_port(host_port, POSTGRES_PORT.into())
             .with_env_var("POSTGRES_USER", "postgres")
             .with_env_var("POSTGRES_PASSWORD", "postgres")
             .start()
@@ -23,11 +29,10 @@ impl DbInstance {
         info!("Postgres container ready!");
 
         let cont_host = container.get_host().await?;
-        let cont_port = container.get_host_port_ipv4(5432).await?;
         let admin_db_url =
-            format!("postgresql://postgres:postgres@{cont_host}:{cont_port}/postgres");
+            format!("postgresql://postgres:postgres@{cont_host}:{host_port}/postgres");
         let db_url =
-            format!("postgresql://postgres:postgres@{cont_host}:{cont_port}/kms-connector");
+            format!("postgresql://postgres:postgres@{cont_host}:{host_port}/kms-connector");
 
         info!("Creating KMS Connector db...");
         let admin_pool = sqlx::postgres::PgPoolOptions::new()

--- a/kms-connector/crates/utils/src/tests/setup/gw.rs
+++ b/kms-connector/crates/utils/src/tests/setup/gw.rs
@@ -1,6 +1,5 @@
-use crate::{config::KmsWallet, conn::WalletGatewayProvider};
+use crate::{config::KmsWallet, conn::WalletGatewayProvider, tests::setup::pick_free_port};
 use alloy::{
-    node_bindings::{Anvil, AnvilInstance},
     primitives::{Address, ChainId, FixedBytes},
     providers::{ProviderBuilder, WsConnect},
 };
@@ -10,7 +9,11 @@ use fhevm_gateway_rust_bindings::{
     kmsmanagement::KmsManagement::{self, KmsManagementInstance},
 };
 use std::sync::LazyLock;
-use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{WaitFor, client::docker_client_instance},
+    runners::AsyncRunner,
+};
 use tracing::info;
 
 pub const DECRYPTION_MOCK_ADDRESS: Address = Address(FixedBytes([
@@ -31,16 +34,23 @@ pub static CHAIN_ID: LazyLock<u32> = LazyLock::new(rand::random::<u32>);
 pub const DEPLOYER_PRIVATE_KEY: &str =
     "0xe746bc71f6bee141a954e6a49bc9384d334e393a7ea1e70b50241cb2e78e9e4c";
 
+const ANVIL_PORT: u16 = 8545;
+
 pub struct GatewayInstance {
-    pub anvil: AnvilInstance,
     pub provider: WalletGatewayProvider,
     pub decryption_contract: DecryptionInstance<(), WalletGatewayProvider>,
     pub gateway_config_contract: GatewayConfigInstance<(), WalletGatewayProvider>,
     pub kms_management_contract: KmsManagementInstance<(), WalletGatewayProvider>,
+    _anvil: ContainerAsync<GenericImage>,
+    pub anvil_host_port: u16,
 }
 
 impl GatewayInstance {
-    pub fn new(anvil: AnvilInstance, provider: WalletGatewayProvider) -> Self {
+    pub fn new(
+        anvil: ContainerAsync<GenericImage>,
+        anvil_host_port: u16,
+        provider: WalletGatewayProvider,
+    ) -> Self {
         let decryption_contract = Decryption::new(DECRYPTION_MOCK_ADDRESS, provider.clone());
         let gateway_config_contract =
             GatewayConfig::new(GATEWAY_CONFIG_MOCK_ADDRESS, provider.clone());
@@ -48,16 +58,18 @@ impl GatewayInstance {
             KmsManagement::new(KMS_MANAGEMENT_MOCK_ADDRESS, provider.clone());
 
         GatewayInstance {
-            anvil,
             provider,
             decryption_contract,
             gateway_config_contract,
             kms_management_contract,
+            _anvil: anvil,
+            anvil_host_port,
         }
     }
 
     pub async fn setup() -> anyhow::Result<Self> {
-        let anvil = setup_anvil_gateway().await?;
+        let anvil_host_port = pick_free_port();
+        let anvil: ContainerAsync<GenericImage> = setup_anvil_gateway(anvil_host_port).await?;
         let wallet = KmsWallet::from_private_key_str(
             DEPLOYER_PRIVATE_KEY,
             Some(ChainId::from(*CHAIN_ID as u64)),
@@ -65,28 +77,59 @@ impl GatewayInstance {
 
         let provider = ProviderBuilder::new()
             .wallet(wallet)
-            .on_ws(WsConnect::new(anvil.ws_endpoint_url()))
+            .on_ws(WsConnect::new(Self::anvil_ws_endpoint_impl(
+                anvil_host_port,
+            )))
             .await?;
 
-        Ok(GatewayInstance::new(anvil, provider))
+        Ok(GatewayInstance::new(anvil, anvil_host_port, provider))
+    }
+
+    fn anvil_ws_endpoint_impl(anvil_host_port: u16) -> String {
+        format!("ws://localhost:{anvil_host_port}")
+    }
+
+    pub fn anvil_ws_endpoint(&self) -> String {
+        Self::anvil_ws_endpoint_impl(self.anvil_host_port)
     }
 }
 
-pub async fn setup_anvil_gateway() -> anyhow::Result<AnvilInstance> {
+pub async fn setup_anvil_gateway(host_port: u16) -> anyhow::Result<ContainerAsync<GenericImage>> {
     info!("Starting Anvil...");
-    let anvil = Anvil::new()
-        .mnemonic(TEST_MNEMONIC)
-        .block_time(1)
-        .chain_id(*CHAIN_ID as u64)
-        .try_spawn()?;
-    info!("Anvil started!");
+    let anvil = GenericImage::new("ghcr.io/foundry-rs/foundry", "v1.2.3")
+        .with_wait_for(WaitFor::message_on_stdout("Listening"))
+        .with_entrypoint("anvil")
+        .with_cmd([
+            "--host",
+            "0.0.0.0",
+            "--port",
+            ANVIL_PORT.to_string().as_str(),
+            "--chain-id",
+            CHAIN_ID.to_string().as_str(),
+            "--mnemonic",
+            TEST_MNEMONIC,
+            "--block-time",
+            "1",
+        ])
+        .with_mapped_port(host_port, ANVIL_PORT.into())
+        .start()
+        .await?;
+
+    let docker = docker_client_instance().await?;
+    let inspect = docker.inspect_container(anvil.id(), None).await?;
+    let networks = inspect.network_settings.unwrap().networks.unwrap();
+    let endpoint_settings = networks.values().next().unwrap();
+    let anvil_internal_ip = endpoint_settings.ip_address.clone().unwrap();
 
     info!("Deploying Gateway mock contracts...");
     let _deploy_mock_container =
         GenericImage::new("ghcr.io/zama-ai/fhevm/gateway-contracts", "v0.7.6")
             .with_wait_for(WaitFor::message_on_stdout("Mock contract deployment done!"))
             .with_env_var("HARDHAT_NETWORK", "staging")
-            .with_env_var("RPC_URL", anvil.endpoint_url().as_str())
+            .with_env_var(
+                "RPC_URL",
+                format!("http://{anvil_internal_ip}:{ANVIL_PORT}"),
+            )
             .with_env_var("CHAIN_ID_GATEWAY", format!("{}", *CHAIN_ID))
             .with_env_var("MNEMONIC", TEST_MNEMONIC)
             .with_env_var(
@@ -98,7 +141,6 @@ pub async fn setup_anvil_gateway() -> anyhow::Result<AnvilInstance> {
                 "PAUSER_ADDRESS",
                 "0xfCefe53c7012a075b8a711df391100d9c431c468",
             )
-            .with_network("host")
             .with_cmd(["npx hardhat task:deployGatewayMockContracts"])
             .start()
             .await?;

--- a/kms-connector/crates/utils/src/tests/setup/instance.rs
+++ b/kms-connector/crates/utils/src/tests/setup/instance.rs
@@ -2,7 +2,6 @@ use crate::{
     conn::WalletGatewayProvider,
     tests::setup::{DbInstance, KmsInstance, S3Instance, gw::GatewayInstance},
 };
-use alloy::node_bindings::AnvilInstance;
 use fhevm_gateway_rust_bindings::{
     decryption::Decryption::DecryptionInstance,
     gatewayconfig::GatewayConfig::GatewayConfigInstance,
@@ -42,10 +41,6 @@ impl TestInstance {
             .url
     }
 
-    pub fn anvil(&self) -> &AnvilInstance {
-        &self.gateway().anvil
-    }
-
     pub fn provider(&self) -> &WalletGatewayProvider {
         &self.gateway().provider
     }
@@ -70,6 +65,10 @@ impl TestInstance {
 
     pub fn s3_url(&self) -> &str {
         &self.s3.as_ref().expect("S3 has not been setup").url
+    }
+
+    pub fn anvil_ws_endpoint(&self) -> String {
+        self.gateway().anvil_ws_endpoint()
     }
 }
 

--- a/kms-connector/crates/utils/src/tests/setup/mod.rs
+++ b/kms-connector/crates/utils/src/tests/setup/mod.rs
@@ -1,9 +1,11 @@
+mod common;
 mod db;
 mod gw;
 mod instance;
 mod kms;
 mod s3;
 
+pub use common::*;
 pub use db::*;
 pub use gw::*;
 pub use instance::*;

--- a/kms-connector/tests/lib.rs
+++ b/kms-connector/tests/lib.rs
@@ -97,7 +97,7 @@ impl KmsConnector {
         info!("Setting up KMS Connector sub-components...");
         let mut gw_listener_conf = gw_listener::core::Config {
             database_url: test_instance.db_url().to_string(),
-            gateway_url: test_instance.anvil().ws_endpoint(),
+            gateway_url: test_instance.anvil_ws_endpoint(),
             chain_id: *CHAIN_ID as u64,
             ..Default::default()
         };
@@ -108,7 +108,7 @@ impl KmsConnector {
         let mut kms_worker_conf = kms_worker::core::Config {
             database_url: test_instance.db_url().to_string(),
             kms_core_endpoint: test_instance.kms_url().to_string(),
-            gateway_url: test_instance.anvil().ws_endpoint(),
+            gateway_url: test_instance.anvil_ws_endpoint(),
             chain_id: *CHAIN_ID as u64,
             ..Default::default()
         };
@@ -118,7 +118,7 @@ impl KmsConnector {
 
         let mut tx_sender_conf = tx_sender::core::Config::default().await;
         tx_sender_conf.database_url = test_instance.db_url().to_string();
-        tx_sender_conf.gateway_url = test_instance.anvil().ws_endpoint();
+        tx_sender_conf.gateway_url = test_instance.anvil_ws_endpoint();
         tx_sender_conf.chain_id = *CHAIN_ID as u64;
         tx_sender_conf.decryption_contract.address = DECRYPTION_MOCK_ADDRESS;
         tx_sender_conf.kms_management_contract.address = KMS_MANAGEMENT_MOCK_ADDRESS;


### PR DESCRIPTION
Do not use host networking.

Use port mapping for the Postgres container.

Run Anvil inside a container and also use port mapping for it. Make sure the gateway-contracts container can connect to Anvil to deploy.