### PR TITLE
feat(kms-connector): support compressed ciphertext

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -12,7 +12,7 @@ use alloy::{
     sol_types::Eip712Domain,
 };
 use anyhow::anyhow;
-use connector_utils::types::{KmsGrpcRequest, fhe::fhe_type_to_string};
+use connector_utils::types::KmsGrpcRequest;
 use fhevm_gateway_rust_bindings::decryption::Decryption::SnsCiphertextMaterial;
 use kms_grpc::kms::v1::{
     PublicDecryptionRequest, RequestId, TypedCiphertext, UserDecryptionRequest,
@@ -128,17 +128,17 @@ where
         }
 
         // Extract and log FHE types for all ciphertexts
-        let fhe_types: Vec<String> = sns_ciphertext_materials
+        let fhe_types: Vec<_> = sns_ciphertext_materials
             .iter()
-            .map(|ct| fhe_type_to_string(ct.fhe_type).to_string())
+            .map(|ct| ct.fhe_type)
             .collect();
 
         info!(
-            "Processing {} with {} ciphertexts, key_id: {}, FHE types: [{}]",
+            "Processing {} with {} ciphertexts, key_id: {}, FHE types: {:?}",
             decryption_id,
             sns_ciphertext_materials.len(),
             key_id,
-            fhe_types.join(", ")
+            fhe_types,
         );
 
         Ok(sns_ciphertext_materials)

--- a/kms-connector/crates/kms-worker/src/core/event_processor/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/s3.rs
@@ -303,10 +303,16 @@ where
         // Direct HTTP retrieval
         let direct_url = format!("{s3_bucket_url}/{digest_hex}");
         let (ciphertext, ct_format) = self.direct_http_retrieval(&direct_url).await?;
-        let fhe_type = extract_fhe_type_from_handle(handle);
+
+        // TODO: once tfhe-rs is upgraded to 1.3, replace map().unwrap_or() by ?
+        // Right now it fails test when facing unknown types
+        let fhe_type = extract_fhe_type_from_handle(handle)
+            .map(|t| t as i32)
+            .unwrap_or(0);
+
         info!(
             handle = hex::encode(handle),
-            "S3 CIPHERTEXT RETRIEVAL SUCCESS: format: {}, length: {}, FHE Type: {}",
+            "S3 CIPHERTEXT RETRIEVAL SUCCESS: format: {}, length: {}, FHE Type: {:?}",
             ct_format.as_str_name(),
             ciphertext.len(),
             fhe_type

--- a/kms-connector/crates/kms-worker/src/core/event_processor/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/s3.rs
@@ -4,17 +4,22 @@ use crate::{
 };
 use alloy::{hex, primitives::Address, providers::Provider, transports::http::reqwest};
 use anyhow::anyhow;
+use connector_utils::types::fhe::extract_fhe_type_from_handle;
 use dashmap::DashMap;
 use fhevm_gateway_rust_bindings::{
     decryption::Decryption::SnsCiphertextMaterial,
     gatewayconfig::GatewayConfig::{self, GatewayConfigInstance},
 };
+use kms_grpc::kms::v1::{CiphertextFormat, TypedCiphertext};
 use sha3::{Digest, Keccak256};
 use std::{sync::LazyLock, time::Duration};
 use tracing::{debug, error, info, warn};
 
 /// Global cache for coprocessor S3 bucket URLs.
 static S3_BUCKET_CACHE: LazyLock<DashMap<Address, String>> = LazyLock::new(DashMap::new);
+
+/// The header used to retrieve the ciphertext format from the S3 HTTP response.
+const CT_FORMAT_HEADER: &str = "x-amz-meta-Ct-Format";
 
 /// Struct used to fetch ciphertext from S3 buckets.
 #[derive(Clone)]
@@ -215,7 +220,7 @@ where
     pub async fn retrieve_sns_ciphertext_materials(
         &self,
         sns_materials: Vec<SnsCiphertextMaterial>,
-    ) -> Vec<(Vec<u8>, Vec<u8>)> {
+    ) -> Vec<TypedCiphertext> {
         let mut sns_ciphertext_materials = Vec::new();
 
         for sns_material in sns_materials {
@@ -228,6 +233,7 @@ where
                 .prefetch_coprocessor_buckets(sns_material.coprocessorTxSenderAddresses)
                 .await;
 
+            let handle = sns_material.ctHandle.to_vec();
             let ct_digest = sns_material.snsCiphertextDigest.as_slice();
             let ct_digest_hex = hex::encode(ct_digest);
             if s3_urls.is_empty() {
@@ -236,12 +242,10 @@ where
             }
 
             match self
-                .retrieve_s3_ciphertext_with_retry(s3_urls, ct_digest, &ct_digest_hex)
+                .retrieve_s3_ciphertext_with_retry(s3_urls, &handle, ct_digest, &ct_digest_hex)
                 .await
             {
-                Some(ciphertext) => {
-                    sns_ciphertext_materials.push((sns_material.ctHandle.to_vec(), ciphertext));
-                }
+                Some(ciphertext) => sns_ciphertext_materials.push(ciphertext),
                 None => error!(
                     "Failed to retrieve ciphertext for digest {ct_digest_hex} from any S3 URL"
                 ),
@@ -255,13 +259,14 @@ where
     pub async fn retrieve_s3_ciphertext_with_retry(
         &self,
         s3_urls: Vec<String>,
+        handle: &[u8],
         ciphertext_digest: &[u8],
         digest_hex: &str,
-    ) -> Option<Vec<u8>> {
+    ) -> Option<TypedCiphertext> {
         for i in 1..=self.s3_ciphertext_retrieval_retries {
             for s3_url in s3_urls.iter() {
                 match self
-                    .retrieve_s3_ciphertext(s3_url, ciphertext_digest, digest_hex)
+                    .retrieve_s3_ciphertext(s3_url, handle, ciphertext_digest, digest_hex)
                     .await
                 {
                     Ok(ciphertext) => {
@@ -289,20 +294,22 @@ where
     pub async fn retrieve_s3_ciphertext(
         &self,
         s3_bucket_url: &str,
+        handle: &[u8],
         ciphertext_digest: &[u8],
         digest_hex: &str,
-    ) -> anyhow::Result<Vec<u8>> {
-        info!(
-            "S3 RETRIEVAL START: Retrieving ciphertext with digest {} from S3 bucket {}",
-            digest_hex, s3_bucket_url
-        );
+    ) -> anyhow::Result<TypedCiphertext> {
+        info!("S3 CIPHERTEXT RETRIEVAL START: from bucket {s3_bucket_url}, digest {digest_hex}");
 
         // Direct HTTP retrieval
         let direct_url = format!("{s3_bucket_url}/{digest_hex}");
-        let ciphertext = self.direct_http_retrieval(&direct_url).await?;
+        let (ciphertext, ct_format) = self.direct_http_retrieval(&direct_url).await?;
+        let fhe_type = extract_fhe_type_from_handle(handle);
         info!(
-            "DIRECT HTTP RETRIEVAL SUCCESS: Retrieved {} bytes",
-            ciphertext.len()
+            handle = hex::encode(handle),
+            "S3 CIPHERTEXT RETRIEVAL SUCCESS: format: {}, length: {}, FHE Type: {}",
+            ct_format.as_str_name(),
+            ciphertext.len(),
+            fhe_type
         );
 
         // Verify digest
@@ -313,13 +320,21 @@ where
                 "DIGEST MISMATCH: Expected: {digest_hex}, Got: {calculated_digest_hex}",
             ));
         }
-        info!("DIRECT HTTP RETRIEVAL COMPLETE: Successfully verified ciphertext digest");
+        info!("S3 CIPHERTEXT RETRIEVAL COMPLETE: Successfully verified ciphertext digest");
 
-        Ok(ciphertext)
+        Ok(TypedCiphertext {
+            ciphertext,
+            external_handle: handle.to_vec(),
+            fhe_type,
+            ciphertext_format: ct_format.into(),
+        })
     }
 
     /// Retrieves a file directly via HTTP.
-    async fn direct_http_retrieval(&self, url: &str) -> anyhow::Result<Vec<u8>> {
+    async fn direct_http_retrieval(
+        &self,
+        url: &str,
+    ) -> anyhow::Result<(Vec<u8>, CiphertextFormat)> {
         debug!("Attempting direct HTTP retrieval from URL: {}", url);
 
         // Create a reqwest client with appropriate timeouts
@@ -343,13 +358,21 @@ where
             ));
         }
 
+        // Read the ciphertext format from AWS metadata header
+        let ct_format = match response.headers().get(CT_FORMAT_HEADER).map(AsRef::as_ref) {
+            Some(b"compressed_on_cpu") | Some(b"compressed_on_gpu") => {
+                CiphertextFormat::BigCompressed
+            }
+            _ => CiphertextFormat::BigExpanded,
+        };
+
         // Read the response body
         let body = response
             .bytes()
             .await
             .map_err(|e| anyhow!("Failed to read HTTP response body: {}", e))?;
 
-        Ok(body.to_vec())
+        Ok((body.to_vec(), ct_format))
     }
 }
 

--- a/kms-connector/crates/kms-worker/tests/s3.rs
+++ b/kms-connector/crates/kms-worker/tests/s3.rs
@@ -2,7 +2,10 @@ use alloy::{
     hex,
     providers::{ProviderBuilder, mock::Asserter},
 };
-use connector_utils::tests::setup::{S3_CT, S3Instance, TestInstance};
+use connector_utils::tests::{
+    rand::rand_u256,
+    setup::{S3_CT, S3Instance, TestInstance},
+};
 use kms_worker::core::{Config, event_processor::s3::S3Service};
 
 #[tokio::test]
@@ -13,11 +16,11 @@ async fn test_get_ciphertext_from_s3() -> anyhow::Result<()> {
     let config = Config::default();
     let mock_provider = ProviderBuilder::new().on_mocked_client(Asserter::new());
 
-    let handle = &0_u32.to_be_bytes(); // dummy handle
+    let handle = rand_u256().to_be_bytes_vec(); // dummy handle
     let bucket_url = format!("{}/ct128", test_instance.s3_url());
     let s3_service = S3Service::new(&config, mock_provider);
     s3_service
-        .retrieve_s3_ciphertext_with_retry(vec![bucket_url], handle, &hex::decode(S3_CT)?, S3_CT)
+        .retrieve_s3_ciphertext_with_retry(vec![bucket_url], &handle, &hex::decode(S3_CT)?, S3_CT)
         .await
         .unwrap();
 
@@ -41,13 +44,13 @@ async fn test_get_unstored_s3_ciphertext() -> anyhow::Result<()> {
     let config = Config::default();
     let mock_provider = ProviderBuilder::new().on_mocked_client(Asserter::new());
 
-    let handle = &0_u32.to_be_bytes(); // dummy handle
+    let handle = rand_u256().to_be_bytes_vec(); // dummy handle
     let bucket_url = format!("{}/ct128", test_instance.s3_url());
     let s3_service = S3Service::new(&config, mock_provider);
     if let Some(ct) = s3_service
         .retrieve_s3_ciphertext_with_retry(
             vec![bucket_url],
-            handle,
+            &handle,
             &hex::decode(S3_CT_UNSTORED)?,
             S3_CT_UNSTORED,
         )

--- a/kms-connector/crates/kms-worker/tests/s3.rs
+++ b/kms-connector/crates/kms-worker/tests/s3.rs
@@ -13,10 +13,11 @@ async fn test_get_ciphertext_from_s3() -> anyhow::Result<()> {
     let config = Config::default();
     let mock_provider = ProviderBuilder::new().on_mocked_client(Asserter::new());
 
+    let handle = &0_u32.to_be_bytes(); // dummy handle
     let bucket_url = format!("{}/ct128", test_instance.s3_url());
     let s3_service = S3Service::new(&config, mock_provider);
     s3_service
-        .retrieve_s3_ciphertext_with_retry(vec![bucket_url], &hex::decode(S3_CT)?, S3_CT)
+        .retrieve_s3_ciphertext_with_retry(vec![bucket_url], handle, &hex::decode(S3_CT)?, S3_CT)
         .await
         .unwrap();
 
@@ -40,11 +41,13 @@ async fn test_get_unstored_s3_ciphertext() -> anyhow::Result<()> {
     let config = Config::default();
     let mock_provider = ProviderBuilder::new().on_mocked_client(Asserter::new());
 
+    let handle = &0_u32.to_be_bytes(); // dummy handle
     let bucket_url = format!("{}/ct128", test_instance.s3_url());
     let s3_service = S3Service::new(&config, mock_provider);
     if let Some(ct) = s3_service
         .retrieve_s3_ciphertext_with_retry(
             vec![bucket_url],
+            handle,
             &hex::decode(S3_CT_UNSTORED)?,
             S3_CT_UNSTORED,
         )

--- a/kms-connector/crates/utils/src/tests/setup/s3.rs
+++ b/kms-connector/crates/utils/src/tests/setup/s3.rs
@@ -57,7 +57,7 @@ impl S3Instance {
             mc anonymous set public myminio/kms-public &&
             mc anonymous set public myminio/ct64 &&
             mc anonymous set public myminio/ct128 &&
-            mc put /data/{S3_CT} myminio/ct128",
+            mc cp /data/{S3_CT} --attr Ct-Format=uncompressed_on_cpu myminio/ct128/{S3_CT}",
             self.url
         );
 

--- a/kms-connector/crates/utils/src/types/kms_response.rs
+++ b/kms-connector/crates/utils/src/types/kms_response.rs
@@ -1,9 +1,6 @@
 use std::fmt::Display;
 
-use crate::types::{
-    GatewayEvent, KmsGrpcResponse,
-    fhe::{abi_encode_plaintexts, fhe_type_to_string},
-};
+use crate::types::{GatewayEvent, KmsGrpcResponse, fhe::abi_encode_plaintexts};
 use alloy::primitives::U256;
 use anyhow::anyhow;
 use kms_grpc::kms::v1::{PublicDecryptionResponse, UserDecryptionResponse};
@@ -56,9 +53,8 @@ impl KmsResponse {
 
         for pt in &payload.plaintexts {
             debug!(
-                "Public decryption result type: {} for request {}",
-                fhe_type_to_string(pt.fhe_type),
-                decryption_id
+                "Public decryption result type: {:?} for request {}",
+                pt.fhe_type, decryption_id
             );
         }
 
@@ -96,9 +92,8 @@ impl KmsResponse {
 
         for ct in &payload.signcrypted_ciphertexts {
             debug!(
-                "User decryption result type: {} for request {}",
-                fhe_type_to_string(ct.fhe_type),
-                decryption_id
+                "User decryption result type: {:?} for request {}",
+                ct.fhe_type, decryption_id
             );
         }
 


### PR DESCRIPTION
Need to double check the header value I used to retrieve the ciphertext format but this requires e2e test setup.
(Comes from this AWS docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html)

EDIT: I have been able to test the header value locally with minio, should be good :slightly_smiling_face: 