### PR TITLE
chore(kms-connector): static test setup

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2547,6 +2547,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -2746,6 +2747,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,6 +2954,21 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dunce"
@@ -3511,8 +3543,11 @@ dependencies = [
  "alloy",
  "anyhow",
  "connector-utils",
+ "ctor",
  "fhevm_gateway_rust_bindings",
+ "futures",
  "prometheus",
+ "rstest",
  "serde",
  "serial_test",
  "sqlx",
@@ -4251,6 +4286,7 @@ dependencies = [
  "fhevm_gateway_rust_bindings",
  "kms-grpc",
  "prometheus",
+ "rstest",
  "serde",
  "serial_test",
  "sha3",
@@ -7498,6 +7534,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "connector-utils",
+ "ctor",
  "fhevm_gateway_rust_bindings",
  "prometheus",
  "rstest",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -85,6 +85,7 @@ tracing-subscriber = { version = "=0.3.19", default-features = true, features = 
 #                       Testing dependencies                        #
 #####################################################################
 connector-tests.path = "tests"
+ctor = "=0.4.2"
 rand = "=0.9.2"
 rstest = "=0.25.0"
 serial_test = "3.2.0"

--- a/kms-connector/crates/gw-listener/Cargo.toml
+++ b/kms-connector/crates/gw-listener/Cargo.toml
@@ -24,6 +24,9 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 connector-utils = { workspace = true, features = ["tests"] }
+ctor.workspace = true
+futures.workspace = true
+rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 testcontainers.workspace = true

--- a/kms-connector/crates/gw-listener/tests/integration_test.rs
+++ b/kms-connector/crates/gw-listener/tests/integration_test.rs
@@ -5,319 +5,351 @@ use alloy::{
 use connector_utils::tests::{
     rand::{rand_address, rand_public_key, rand_u256},
     setup::{
-        DECRYPTION_MOCK_ADDRESS, KMS_MANAGEMENT_MOCK_ADDRESS, TestInstance, TestInstanceBuilder,
+        DECRYPTION_MOCK_ADDRESS, KMS_MANAGEMENT_MOCK_ADDRESS, TestInstance,
+        shared::{clean_test_instance, run_with_shared_db_gw_setup},
     },
 };
 use connector_utils::types::db::SnsCiphertextMaterialDbItem;
+use ctor::dtor;
 use fhevm_gateway_rust_bindings::decryption::IDecryption::RequestValidity;
 use gw_listener::core::{Config, DbEventPublisher, GatewayListener};
-use sqlx::Row;
+use rstest::rstest;
+use serial_test::serial;
+use sqlx::{Pool, Postgres, Row, postgres::PgRow};
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_public_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
-
-    info!("Mocking PublicDecryptionRequest on Anvil...");
-    let pending_tx = test_instance
-        .decryption_contract()
-        .publicDecryptionRequest(vec![])
-        .send()
-        .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
-
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query("SELECT decryption_id, sns_ct_materials FROM public_decryption_requests")
-        .fetch_one(test_instance.db())
-        .await?;
-
-    let decryption_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?);
-    let sns_ct_materials =
-        row.try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
-    assert_eq!(decryption_id, U256::ONE);
-    assert_eq!(
-        sns_ct_materials,
-        vec![SnsCiphertextMaterialDbItem::default()]
-    );
-    info!("Event successfully stored! Stopping GatewayListener...");
-
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+#[dtor]
+fn on_shutdown() {
+    clean_test_instance();
 }
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_user_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_public_decryption() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
 
-    info!("Mocking UserDecryptionRequest on Anvil...");
-    let rand_user_addr = rand_address();
-    let rand_pub_key = rand_public_key();
-    let pending_tx = test_instance
-        .decryption_contract()
-        .userDecryptionRequest(
-            vec![],
-            RequestValidity::default(),
-            U256::default(),
-            vec![],
-            rand_user_addr,
-            rand_pub_key.clone().into(),
-            vec![].into(),
+        info!("Mocking PublicDecryptionRequest on Anvil...");
+        let pending_tx = test_instance
+            .decryption_contract()
+            .publicDecryptionRequest(vec![])
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
+
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(
+            test_instance.db(),
+            "SELECT decryption_id, sns_ct_materials FROM public_decryption_requests",
         )
-        .send()
-        .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
-
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query("SELECT decryption_id, sns_ct_materials, user_address, public_key FROM user_decryption_requests")
-        .fetch_one(test_instance.db())
         .await?;
 
-    let decryption_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?);
-    let user_address = Address::from(row.try_get::<[u8; 20], _>("user_address")?);
-    let pub_key = row.try_get::<Vec<u8>, _>("public_key")?;
-    let sns_ct_materials =
-        row.try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
+        let sns_ct_materials =
+            row.try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
+        assert_eq!(
+            sns_ct_materials,
+            vec![SnsCiphertextMaterialDbItem::default()]
+        );
+        info!("Event successfully stored! Stopping GatewayListener...");
 
-    assert_eq!(decryption_id, U256::ONE);
-    assert_eq!(
-        sns_ct_materials,
-        vec![SnsCiphertextMaterialDbItem::default()]
-    );
-    assert_eq!(rand_user_addr, user_address);
-    assert_eq!(rand_pub_key, pub_key);
-    info!("Event successfully stored! Stopping GatewayListener...");
-
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
 }
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_preprocess_keygen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_user_decryption() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
 
-    info!("Mocking PreprocessKeygenRequest on Anvil...");
-    let pending_tx = test_instance
-        .kms_management_contract()
-        .preprocessKeygenRequest(String::new())
-        .send()
-        .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
+        info!("Mocking UserDecryptionRequest on Anvil...");
+        let rand_user_addr = rand_address();
+        let rand_pub_key = rand_public_key();
+        let pending_tx = test_instance
+            .decryption_contract()
+            .userDecryptionRequest(
+                vec![],
+                RequestValidity::default(),
+                U256::default(),
+                vec![],
+                rand_user_addr,
+                rand_pub_key.clone().into(),
+                vec![].into(),
+            )
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query(
-        "SELECT pre_keygen_request_id, fhe_params_digest FROM preprocess_keygen_requests",
-    )
-    .fetch_one(test_instance.db())
-    .await?;
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(test_instance.db(), "SELECT decryption_id, sns_ct_materials, user_address, public_key FROM user_decryption_requests")
+            .await?;
 
-    let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_keygen_request_id")?);
-    let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
-    assert_eq!(id, U256::ONE);
-    assert_eq!(digest, U256::default());
-    info!("Event successfully stored! Stopping GatewayListener...");
+        let user_address = Address::from(row.try_get::<[u8; 20], _>("user_address")?);
+        let pub_key = row.try_get::<Vec<u8>, _>("public_key")?;
+        let sns_ct_materials =
+            row.try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
 
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+        assert_eq!(
+            sns_ct_materials,
+            vec![SnsCiphertextMaterialDbItem::default()]
+        );
+        assert_eq!(rand_user_addr, user_address);
+        assert_eq!(rand_pub_key, pub_key);
+        info!("Event successfully stored! Stopping GatewayListener...");
+
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
 }
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_preprocess_kskgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_preprocess_keygen() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
 
-    info!("Mocking PreprocessKskgenRequest on Anvil...");
-    let pending_tx = test_instance
-        .kms_management_contract()
-        .preprocessKskgenRequest(String::new())
-        .send()
+        info!("Mocking PreprocessKeygenRequest on Anvil...");
+        let pending_tx = test_instance
+            .kms_management_contract()
+            .preprocessKeygenRequest(String::new())
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
+
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(
+            test_instance.db(),
+            "SELECT pre_keygen_request_id, fhe_params_digest FROM preprocess_keygen_requests",
+        )
         .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query(
-        "SELECT pre_kskgen_request_id, fhe_params_digest FROM preprocess_kskgen_requests",
-    )
-    .fetch_one(test_instance.db())
-    .await?;
+        let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_keygen_request_id")?);
+        let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
+        assert_eq!(id, U256::ONE);
+        assert_eq!(digest, U256::default());
+        info!("Event successfully stored! Stopping GatewayListener...");
 
-    let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_kskgen_request_id")?);
-    let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
-    assert_eq!(id, U256::ONE);
-    assert_eq!(digest, U256::default());
-    info!("Event successfully stored! Stopping GatewayListener...");
-
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
 }
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_keygen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_preprocess_kskgen() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
 
-    info!("Mocking KeygenRequest on Anvil...");
-    let rand_id = rand_u256();
-    let pending_tx = test_instance
-        .kms_management_contract()
-        .keygenRequest(rand_id)
-        .send()
+        info!("Mocking PreprocessKskgenRequest on Anvil...");
+        let pending_tx = test_instance
+            .kms_management_contract()
+            .preprocessKskgenRequest(String::new())
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
+
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(
+            test_instance.db(),
+            "SELECT pre_kskgen_request_id, fhe_params_digest FROM preprocess_kskgen_requests",
+        )
         .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query("SELECT pre_key_id, fhe_params_digest FROM keygen_requests")
-        .fetch_one(test_instance.db())
-        .await?;
+        let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_kskgen_request_id")?);
+        let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
+        assert_eq!(id, U256::ONE);
+        assert_eq!(digest, U256::default());
+        info!("Event successfully stored! Stopping GatewayListener...");
 
-    let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_key_id")?);
-    let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
-    assert_eq!(id, rand_id);
-    assert_eq!(digest, U256::default());
-    info!("Event successfully stored! Stopping GatewayListener...");
-
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
 }
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_kskgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_keygen() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
 
-    info!("Mocking KskgenRequest on Anvil...");
-    let rand_id = rand_u256();
-    let rand_source_key_id = rand_u256();
-    let rand_dest_key_id = rand_u256();
-    let pending_tx = test_instance
-        .kms_management_contract()
-        .kskgenRequest(rand_id, rand_source_key_id, rand_dest_key_id)
-        .send()
+        info!("Mocking KeygenRequest on Anvil...");
+        let rand_id = rand_u256();
+        let pending_tx = test_instance
+            .kms_management_contract()
+            .keygenRequest(rand_id)
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
+
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(
+            test_instance.db(),
+            "SELECT pre_key_id, fhe_params_digest FROM keygen_requests",
+        )
         .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query(
-        "SELECT pre_ksk_id, source_key_id, dest_key_id, fhe_params_digest FROM kskgen_requests",
-    )
-    .fetch_one(test_instance.db())
-    .await?;
+        let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_key_id")?);
+        let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
+        assert_eq!(id, rand_id);
+        assert_eq!(digest, U256::default());
+        info!("Event successfully stored! Stopping GatewayListener...");
 
-    let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_ksk_id")?);
-    let source_key_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("source_key_id")?);
-    let dest_key_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("dest_key_id")?);
-    let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
-    assert_eq!(id, rand_id);
-    assert_eq!(rand_source_key_id, source_key_id);
-    assert_eq!(rand_dest_key_id, dest_key_id);
-    assert_eq!(digest, U256::default());
-    info!("Event successfully stored! Stopping GatewayListener...");
-
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
 }
 
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_publish_crsgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-    let cancel_token = CancellationToken::new();
-    let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone());
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_kskgen() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
 
-    info!("Mocking CrsgenRequest on Anvil...");
-    let pending_tx = test_instance
-        .kms_management_contract()
-        .crsgenRequest(String::new())
-        .send()
+        info!("Mocking KskgenRequest on Anvil...");
+        let rand_id = rand_u256();
+        let rand_source_key_id = rand_u256();
+        let rand_dest_key_id = rand_u256();
+        let pending_tx = test_instance
+            .kms_management_contract()
+            .kskgenRequest(rand_id, rand_source_key_id, rand_dest_key_id)
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
+
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(
+            test_instance.db(),
+            "SELECT pre_ksk_id, source_key_id, dest_key_id, fhe_params_digest FROM kskgen_requests",
+        )
         .await?;
-    let receipt = pending_tx.get_receipt().await?;
-    let _tx = test_instance
-        .provider()
-        .get_transaction_by_hash(receipt.transaction_hash)
-        .await?
-        .unwrap();
-    info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
-    info!("Checking event is stored in DB...");
-    let row = sqlx::query("SELECT crsgen_request_id, fhe_params_digest FROM crsgen_requests")
-        .fetch_one(test_instance.db())
+        let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("pre_ksk_id")?);
+        let source_key_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("source_key_id")?);
+        let dest_key_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("dest_key_id")?);
+        let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
+        assert_eq!(id, rand_id);
+        assert_eq!(rand_source_key_id, source_key_id);
+        assert_eq!(rand_dest_key_id, dest_key_id);
+        assert_eq!(digest, U256::default());
+        info!("Event successfully stored! Stopping GatewayListener...");
+
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(90))]
+#[serial]
+fn test_publish_crsgen() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let cancel_token = CancellationToken::new();
+        let gw_listener_task = start_test_listener(test_instance, cancel_token.clone());
+        tokio::time::sleep(Duration::from_millis(800)).await; // Waiting for the gw_listener to subscribe events
+
+        info!("Mocking CrsgenRequest on Anvil...");
+        let pending_tx = test_instance
+            .kms_management_contract()
+            .crsgenRequest(String::new())
+            .send()
+            .await?;
+        let receipt = pending_tx.get_receipt().await?;
+        let _tx = test_instance
+            .provider()
+            .get_transaction_by_hash(receipt.transaction_hash)
+            .await?
+            .unwrap();
+        info!("Tx successfully sent!");
+
+        info!("Checking event is stored in DB...");
+        let row = query_with_retry(
+            test_instance.db(),
+            "SELECT crsgen_request_id, fhe_params_digest FROM crsgen_requests",
+        )
         .await?;
 
-    let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("crsgen_request_id")?);
-    let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
-    assert_eq!(id, U256::ONE);
-    assert_eq!(digest, U256::default());
-    info!("Event successfully stored! Stopping GatewayListener...");
+        let id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("crsgen_request_id")?);
+        let digest = U256::from_le_bytes(row.try_get::<[u8; 32], _>("fhe_params_digest")?);
+        assert_eq!(id, U256::ONE);
+        assert_eq!(digest, U256::default());
+        info!("Event successfully stored! Stopping GatewayListener...");
 
-    cancel_token.cancel();
-    Ok(gw_listener_task?.await?)
+        cancel_token.cancel();
+        Ok(gw_listener_task?.await?)
+    })
+}
+
+async fn query_with_retry(db: &Pool<Postgres>, query: &str) -> sqlx::Result<PgRow> {
+    let mut error = sqlx::Error::RowNotFound;
+    for i in 1..=5 {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        match sqlx::query(query).fetch_one(db).await {
+            Ok(row) => return Ok(row),
+            Err(e) => {
+                warn!("{i}/5 attempt: {e}");
+                error = e;
+            }
+        };
+    }
+    Err(error)
 }
 
 fn start_test_listener(

--- a/kms-connector/crates/kms-worker/Cargo.toml
+++ b/kms-connector/crates/kms-worker/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 connector-utils = { workspace = true, features = ["tests"] }
+rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 testcontainers.workspace = true

--- a/kms-connector/crates/kms-worker/tests/event_picker/simple.rs
+++ b/kms-connector/crates/kms-worker/tests/event_picker/simple.rs
@@ -1,7 +1,7 @@
 use connector_utils::{
     tests::{
         rand::{rand_address, rand_digest, rand_public_key, rand_sns_ct, rand_u256},
-        setup::TestInstanceBuilder,
+        setup::shared::run_with_shared_db_setup,
     },
     types::{GatewayEvent, db::SnsCiphertextMaterialDbItem},
 };
@@ -13,254 +13,278 @@ use fhevm_gateway_rust_bindings::{
     },
 };
 use kms_worker::core::{DbEventPicker, EventPicker};
+use rstest::rstest;
+use serial_test::serial;
+use std::time::Duration;
+use tracing::info;
 
-#[tokio::test]
-async fn test_pick_public_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
+fn test_pick_public_decryption() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+        let decryption_id = rand_u256();
+        let sns_ct = vec![rand_sns_ct()];
+        let sns_ciphertexts_db = sns_ct
+            .iter()
+            .map(SnsCiphertextMaterialDbItem::from)
+            .collect::<Vec<SnsCiphertextMaterialDbItem>>();
 
-    let decryption_id = rand_u256();
-    let sns_ct = vec![rand_sns_ct()];
-    let sns_ciphertexts_db = sns_ct
-        .iter()
-        .map(SnsCiphertextMaterialDbItem::from)
-        .collect::<Vec<SnsCiphertextMaterialDbItem>>();
+        info!("Triggering Postgres notification with PublicDecryptionRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO public_decryption_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            decryption_id.as_le_slice(),
+            sns_ciphertexts_db as Vec<SnsCiphertextMaterialDbItem>,
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Triggering Postgres notification with PublicDecryptionRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO public_decryption_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        decryption_id.as_le_slice(),
-        sns_ciphertexts_db as Vec<SnsCiphertextMaterialDbItem>,
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Picking PublicDecryptionRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Picking PublicDecryptionRequest...");
-    let events = event_picker.pick_events().await?;
-
-    println!("Checking PublicDecryptionRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::PublicDecryption(PublicDecryptionRequest {
-            decryptionId: decryption_id,
-            snsCtMaterials: sns_ct,
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking PublicDecryptionRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::PublicDecryption(PublicDecryptionRequest {
+                decryptionId: decryption_id,
+                snsCtMaterials: sns_ct,
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_pick_user_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+fn test_pick_user_decryption() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let decryption_id = rand_u256();
-    let sns_ct = vec![rand_sns_ct()];
-    let user_address = rand_address();
-    let public_key = rand_public_key();
-    let sns_ciphertexts_db = sns_ct
-        .iter()
-        .map(SnsCiphertextMaterialDbItem::from)
-        .collect::<Vec<SnsCiphertextMaterialDbItem>>();
+        let decryption_id = rand_u256();
+        let sns_ct = vec![rand_sns_ct()];
+        let user_address = rand_address();
+        let public_key = rand_public_key();
+        let sns_ciphertexts_db = sns_ct
+            .iter()
+            .map(SnsCiphertextMaterialDbItem::from)
+            .collect::<Vec<SnsCiphertextMaterialDbItem>>();
 
-    println!("Triggering Postgres notification with UserDecryptionRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO user_decryption_requests VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
-        decryption_id.as_le_slice(),
-        sns_ciphertexts_db as Vec<SnsCiphertextMaterialDbItem>,
-        user_address.as_slice(),
-        &public_key,
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Triggering Postgres notification with UserDecryptionRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO user_decryption_requests VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+            decryption_id.as_le_slice(),
+            sns_ciphertexts_db as Vec<SnsCiphertextMaterialDbItem>,
+            user_address.as_slice(),
+            &public_key,
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Picking UserDecryptionRequest...");
-    let events = event_picker.pick_events().await?;
+        info!("Picking UserDecryptionRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Checking UserDecryptionRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::UserDecryption(UserDecryptionRequest {
-            decryptionId: decryption_id,
-            snsCtMaterials: sns_ct,
-            userAddress: user_address,
-            publicKey: public_key.into(),
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking UserDecryptionRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::UserDecryption(UserDecryptionRequest {
+                decryptionId: decryption_id,
+                snsCtMaterials: sns_ct,
+                userAddress: user_address,
+                publicKey: public_key.into(),
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_pick_preprocess_keygen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+fn test_pick_preprocess_keygen() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let pre_keygen_request_id = rand_u256();
-    let fhe_params_digest = rand_digest();
+        let pre_keygen_request_id = rand_u256();
+        let fhe_params_digest = rand_digest();
 
-    println!("Triggering Postgres notification with PreprocessKeygenRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO preprocess_keygen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        pre_keygen_request_id.as_le_slice(),
-        fhe_params_digest.as_slice(),
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Triggering Postgres notification with PreprocessKeygenRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO preprocess_keygen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            pre_keygen_request_id.as_le_slice(),
+            fhe_params_digest.as_slice(),
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Picking PreprocessKeygenRequest...");
-    let events = event_picker.pick_events().await?;
+        info!("Picking PreprocessKeygenRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Checking PreprocessKeygenRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::PreprocessKeygen(PreprocessKeygenRequest {
-            preKeygenRequestId: pre_keygen_request_id,
-            fheParamsDigest: fhe_params_digest,
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking PreprocessKeygenRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::PreprocessKeygen(PreprocessKeygenRequest {
+                preKeygenRequestId: pre_keygen_request_id,
+                fheParamsDigest: fhe_params_digest,
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_pick_preprocess_kskgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+fn test_pick_preprocess_kskgen() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let pre_kskgen_request_id = rand_u256();
-    let fhe_params_digest = rand_digest();
+        let pre_kskgen_request_id = rand_u256();
+        let fhe_params_digest = rand_digest();
 
-    println!("Triggering Postgres notification with PreprocessKskgenRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO preprocess_kskgen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        pre_kskgen_request_id.as_le_slice(),
-        fhe_params_digest.as_slice(),
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Triggering Postgres notification with PreprocessKskgenRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO preprocess_kskgen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            pre_kskgen_request_id.as_le_slice(),
+            fhe_params_digest.as_slice(),
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Picking PreprocessKskgenRequest...");
-    let events = event_picker.pick_events().await?;
+        info!("Picking PreprocessKskgenRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Checking PreprocessKskgenRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::PreprocessKskgen(PreprocessKskgenRequest {
-            preKskgenRequestId: pre_kskgen_request_id,
-            fheParamsDigest: fhe_params_digest,
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking PreprocessKskgenRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::PreprocessKskgen(PreprocessKskgenRequest {
+                preKskgenRequestId: pre_kskgen_request_id,
+                fheParamsDigest: fhe_params_digest,
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_pick_keygen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+fn test_pick_keygen() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let pre_key_id = rand_u256();
-    let fhe_params_digest = rand_digest();
+        let pre_key_id = rand_u256();
+        let fhe_params_digest = rand_digest();
 
-    println!("Triggering Postgres notification with KeygenRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO keygen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        pre_key_id.as_le_slice(),
-        fhe_params_digest.as_slice(),
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Triggering Postgres notification with KeygenRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO keygen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            pre_key_id.as_le_slice(),
+            fhe_params_digest.as_slice(),
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Picking KeygenRequest...");
-    let events = event_picker.pick_events().await?;
+        info!("Picking KeygenRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Checking KeygenRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::Keygen(KeygenRequest {
-            preKeyId: pre_key_id,
-            fheParamsDigest: fhe_params_digest,
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking KeygenRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::Keygen(KeygenRequest {
+                preKeyId: pre_key_id,
+                fheParamsDigest: fhe_params_digest,
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_pick_kskgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+fn test_pick_kskgen() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let pre_ksk_id = rand_u256();
-    let source_key_id = rand_u256();
-    let dest_key_id = rand_u256();
-    let fhe_params_digest = rand_digest();
+        let pre_ksk_id = rand_u256();
+        let source_key_id = rand_u256();
+        let dest_key_id = rand_u256();
+        let fhe_params_digest = rand_digest();
 
-    println!("Triggering Postgres notification with KskgenRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO kskgen_requests VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
-        pre_ksk_id.as_le_slice(),
-        source_key_id.as_le_slice(),
-        dest_key_id.as_le_slice(),
-        fhe_params_digest.as_slice(),
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Triggering Postgres notification with KskgenRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO kskgen_requests VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+            pre_ksk_id.as_le_slice(),
+            source_key_id.as_le_slice(),
+            dest_key_id.as_le_slice(),
+            fhe_params_digest.as_slice(),
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Picking KskgenRequest...");
-    let events = event_picker.pick_events().await?;
+        info!("Picking KskgenRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Checking KskgenRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::Kskgen(KskgenRequest {
-            preKskId: pre_ksk_id,
-            sourceKeyId: source_key_id,
-            destKeyId: dest_key_id,
-            fheParamsDigest: fhe_params_digest,
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking KskgenRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::Kskgen(KskgenRequest {
+                preKskId: pre_ksk_id,
+                sourceKeyId: source_key_id,
+                destKeyId: dest_key_id,
+                fheParamsDigest: fhe_params_digest,
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_pick_crsgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+fn test_pick_crsgen() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
 
-    let crsgen_request_id = rand_u256();
-    let fhe_params_digest = rand_digest();
+        let crsgen_request_id = rand_u256();
+        let fhe_params_digest = rand_digest();
 
-    println!("Triggering Postgres notification with CrsgenRequest insertion...");
-    sqlx::query!(
-        "INSERT INTO crsgen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
-        crsgen_request_id.as_le_slice(),
-        fhe_params_digest.as_slice(),
-    )
-    .execute(test_instance.db())
-    .await?;
+        info!("Triggering Postgres notification with CrsgenRequest insertion...");
+        sqlx::query!(
+            "INSERT INTO crsgen_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            crsgen_request_id.as_le_slice(),
+            fhe_params_digest.as_slice(),
+        )
+        .execute(test_instance.db())
+        .await?;
 
-    println!("Picking CrsgenRequest...");
-    let events = event_picker.pick_events().await?;
+        info!("Picking CrsgenRequest...");
+        let events = event_picker.pick_events().await?;
 
-    println!("Checking CrsgenRequest data...");
-    assert_eq!(
-        events,
-        vec![GatewayEvent::Crsgen(CrsgenRequest {
-            crsgenRequestId: crsgen_request_id,
-            fheParamsDigest: fhe_params_digest,
-        })]
-    );
-    println!("Data OK!");
-    Ok(())
+        info!("Checking CrsgenRequest data...");
+        assert_eq!(
+            events,
+            vec![GatewayEvent::Crsgen(CrsgenRequest {
+                crsgenRequestId: crsgen_request_id,
+                fheParamsDigest: fhe_params_digest,
+            })]
+        );
+        info!("Data OK!");
+        Ok(())
+    })
 }

--- a/kms-connector/crates/kms-worker/tests/response_publisher.rs
+++ b/kms-connector/crates/kms-worker/tests/response_publisher.rs
@@ -2,7 +2,7 @@ use alloy::primitives::U256;
 use connector_utils::{
     tests::{
         rand::{rand_signature, rand_u256},
-        setup::TestInstanceBuilder,
+        setup::shared::run_with_shared_db_setup,
     },
     types::{KmsGrpcResponse, KmsResponse},
 };
@@ -11,80 +11,87 @@ use kms_grpc::kms::v1::{
     UserDecryptionResponsePayload,
 };
 use kms_worker::core::{DbKmsResponsePublisher, KmsResponsePublisher};
+use rstest::rstest;
+use serial_test::serial;
 use sqlx::Row;
+use std::time::Duration;
 
-#[tokio::test]
-async fn test_publish_public_decryption_response() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
+fn test_publish_public_decryption_response() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let publisher = DbKmsResponsePublisher::new(test_instance.db().clone());
 
-    let publisher = DbKmsResponsePublisher::new(test_instance.db().clone());
+        println!("Mocking PublicDecryptionResponse from KMS Core...");
+        let rand_decryption_id = rand_u256();
+        let rand_signature = rand_signature();
+        let grpc_response = KmsGrpcResponse::PublicDecryption {
+            decryption_id: rand_decryption_id,
+            grpc_response: PublicDecryptionResponse {
+                signature: rand_signature.clone(),
+                payload: Some(PublicDecryptionResponsePayload {
+                    external_signature: Some(rand_signature.clone()),
+                    ..Default::default()
+                }),
+            },
+        };
+        let response = KmsResponse::process(grpc_response)?;
 
-    println!("Mocking PublicDecryptionResponse from KMS Core...");
-    let rand_decryption_id = rand_u256();
-    let rand_signature = rand_signature();
-    let grpc_response = KmsGrpcResponse::PublicDecryption {
-        decryption_id: rand_decryption_id,
-        grpc_response: PublicDecryptionResponse {
-            signature: rand_signature.clone(),
-            payload: Some(PublicDecryptionResponsePayload {
-                external_signature: Some(rand_signature.clone()),
-                ..Default::default()
-            }),
-        },
-    };
-    let response = KmsResponse::process(grpc_response)?;
+        publisher.publish(response).await?;
+        println!("PublicDecryptionResponse successfully published!");
 
-    publisher.publish(response).await?;
-    println!("PublicDecryptionResponse successfully published!");
+        println!("Checking PublicDecryptionResponse is stored in DB...");
+        let row = sqlx::query(
+            "SELECT decryption_id, decrypted_result, signature FROM public_decryption_responses",
+        )
+        .fetch_one(test_instance.db())
+        .await?;
 
-    println!("Checking PublicDecryptionResponse is stored in DB...");
-    let row = sqlx::query(
-        "SELECT decryption_id, decrypted_result, signature FROM public_decryption_responses",
-    )
-    .fetch_one(test_instance.db())
-    .await?;
-
-    let decryption_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?);
-    let signature = row.try_get::<Vec<u8>, _>("signature")?;
-    assert_eq!(decryption_id, rand_decryption_id);
-    assert_eq!(signature, rand_signature);
-    println!("Response successfully stored!");
-    Ok(())
+        let decryption_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?);
+        let signature = row.try_get::<Vec<u8>, _>("signature")?;
+        assert_eq!(decryption_id, rand_decryption_id);
+        assert_eq!(signature, rand_signature);
+        println!("Response successfully stored!");
+        Ok(())
+    })
 }
 
-#[tokio::test]
-async fn test_publish_user_decryption_response() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
+fn test_publish_user_decryption_response() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let publisher = DbKmsResponsePublisher::new(test_instance.db().clone());
 
-    let publisher = DbKmsResponsePublisher::new(test_instance.db().clone());
+        println!("Mocking UserDecryptionResponse from KMS Core...");
+        let rand_decryption_id = rand_u256();
+        let rand_signature = rand_signature();
+        let grpc_response = KmsGrpcResponse::UserDecryption {
+            decryption_id: rand_decryption_id,
+            grpc_response: UserDecryptionResponse {
+                signature: rand_signature.clone(),
+                external_signature: rand_signature.clone(),
+                payload: Some(UserDecryptionResponsePayload::default()),
+            },
+        };
+        let response = KmsResponse::process(grpc_response)?;
 
-    println!("Mocking UserDecryptionResponse from KMS Core...");
-    let rand_decryption_id = rand_u256();
-    let rand_signature = rand_signature();
-    let grpc_response = KmsGrpcResponse::UserDecryption {
-        decryption_id: rand_decryption_id,
-        grpc_response: UserDecryptionResponse {
-            signature: rand_signature.clone(),
-            external_signature: rand_signature.clone(),
-            payload: Some(UserDecryptionResponsePayload::default()),
-        },
-    };
-    let response = KmsResponse::process(grpc_response)?;
+        publisher.publish(response).await?;
+        println!("UserDecryptionResponse successfully published!");
 
-    publisher.publish(response).await?;
-    println!("UserDecryptionResponse successfully published!");
+        println!("Checking UserDecryptionResponse is stored in DB...");
+        let row = sqlx::query(
+            "SELECT decryption_id, user_decrypted_shares, signature FROM user_decryption_responses",
+        )
+        .fetch_one(test_instance.db())
+        .await?;
 
-    println!("Checking UserDecryptionResponse is stored in DB...");
-    let row = sqlx::query(
-        "SELECT decryption_id, user_decrypted_shares, signature FROM user_decryption_responses",
-    )
-    .fetch_one(test_instance.db())
-    .await?;
-
-    let decryption_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?);
-    let signature = row.try_get::<Vec<u8>, _>("signature")?;
-    assert_eq!(decryption_id, rand_decryption_id);
-    assert_eq!(signature, rand_signature);
-    println!("Response successfully stored!");
-    Ok(())
+        let decryption_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?);
+        let signature = row.try_get::<Vec<u8>, _>("signature")?;
+        assert_eq!(decryption_id, rand_decryption_id);
+        assert_eq!(signature, rand_signature);
+        println!("Response successfully stored!");
+        Ok(())
+    })
 }

--- a/kms-connector/crates/tx-sender/Cargo.toml
+++ b/kms-connector/crates/tx-sender/Cargo.toml
@@ -22,6 +22,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 connector-utils = { workspace = true, features = ["tests"] }
+ctor.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -5,10 +5,15 @@ use alloy::primitives::U256;
 use anyhow::anyhow;
 use common::insert_rand_public_decrypt_response;
 use connector_utils::{
-    tests::setup::{TestInstance, TestInstanceBuilder},
+    tests::setup::{
+        TestInstance,
+        shared::{clean_test_instance, run_with_shared_db_gw_setup},
+    },
     types::KmsResponse,
 };
+use ctor::dtor;
 use rstest::rstest;
+use serial_test::serial;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
@@ -18,148 +23,158 @@ use tx_sender::core::{
     DbKmsResponsePicker, DbKmsResponseRemover, TransactionSender, tx_sender::TransactionSenderInner,
 };
 
-#[rstest]
-#[timeout(Duration::from_secs(10))]
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_process_public_decryption_response() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-
-    let cancel_token = CancellationToken::new();
-    let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
-
-    info!("Mocking PublicDecryptionResponse in Postgres...");
-    let inserted_response = insert_rand_public_decrypt_response(test_instance.db()).await?;
-    info!("PublicDecryptionResponse successfully stored!");
-
-    info!("Checking response has been sent to Anvil...");
-    let mut response_stream = test_instance
-        .decryption_contract()
-        .PublicDecryptionResponse_filter()
-        .watch()
-        .await?
-        .into_stream();
-    let (response, _) = response_stream
-        .next()
-        .await
-        .ok_or_else(|| anyhow!("Failed to capture PublicDecryptionResponse"))??;
-    match inserted_response {
-        KmsResponse::PublicDecryption { decryption_id, .. } => {
-            assert_eq!(response.decryptionId, decryption_id)
-        }
-        _ => unreachable!(),
-    }
-    info!("Response successfully sent to Anvil!");
-
-    info!("Checking response has been removed from DB...");
-    tokio::time::sleep(Duration::from_millis(300)).await; // give some time for the removal
-    let count: i64 =
-        sqlx::query_scalar("SELECT COUNT(decryption_id) FROM public_decryption_responses")
-            .fetch_one(test_instance.db())
-            .await?;
-    assert_eq!(count, 0);
-    info!("Response successfully removed from DB! Stopping TransactionSender...");
-
-    cancel_token.cancel();
-    Ok(tx_sender_task.await?)
+#[dtor]
+fn on_shutdown() {
+    clean_test_instance();
 }
 
 #[rstest]
-#[timeout(Duration::from_secs(10))]
-#[tokio::test]
-#[ignore = "flaky tests to be fixed"]
-async fn test_process_user_decryption_response() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+#[timeout(Duration::from_secs(15))]
+#[serial]
+#[ignore = "events are sometime missed by the response filter..."]
+fn test_process_public_decryption_response() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let mut response_stream = test_instance
+            .decryption_contract()
+            .PublicDecryptionResponse_filter()
+            .watch()
+            .await?
+            .into_stream();
 
-    let cancel_token = CancellationToken::new();
-    let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
+        let cancel_token = CancellationToken::new();
+        let tx_sender_task = start_test_tx_sender(test_instance, cancel_token.clone()).await?;
 
-    info!("Mocking UserDecryptionResponse in Postgres...");
-    let inserted_response = insert_rand_user_decrypt_response(test_instance.db()).await?;
-    info!("UserDecryptionResponse successfully stored!");
+        info!("Mocking PublicDecryptionResponse in Postgres...");
+        let inserted_response = insert_rand_public_decrypt_response(test_instance.db()).await?;
+        info!("PublicDecryptionResponse successfully stored!");
 
-    info!("Checking response has been sent to Anvil...");
-    let mut response_stream = test_instance
-        .decryption_contract()
-        .UserDecryptionResponse_filter()
-        .watch()
-        .await?
-        .into_stream();
-    let (response, _) = response_stream
-        .next()
-        .await
-        .ok_or_else(|| anyhow!("Failed to capture UserDecryptionResponse"))??;
-    match inserted_response {
-        KmsResponse::UserDecryption { decryption_id, .. } => {
-            assert_eq!(response.decryptionId, decryption_id)
-        }
-        _ => unreachable!(),
-    }
-    info!("Response successfully sent to Anvil!");
-
-    info!("Checking response has been removed from DB...");
-    tokio::time::sleep(Duration::from_millis(300)).await; // give some time for the removal
-    let count: i64 =
-        sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
-            .fetch_one(test_instance.db())
-            .await?;
-    assert_eq!(count, 0);
-    info!("Response successfully removed from DB! Stopping TransactionSender...");
-
-    cancel_token.cancel();
-    Ok(tx_sender_task.await?)
-}
-
-#[tokio::test]
-#[ignore = "to enable when performance will be improved"]
-async fn stress_test() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
-
-    let cancel_token = CancellationToken::new();
-    let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
-
-    let nb_response = 500;
-    info!("Mocking {nb_response} UserDecryptionResponse in Postgres...");
-    let mut responses_id = Vec::with_capacity(nb_response);
-    for _ in 0..nb_response {
-        match insert_rand_user_decrypt_response(test_instance.db()).await? {
-            KmsResponse::UserDecryption { decryption_id, .. } => {
-                responses_id.push(decryption_id);
+        info!("Checking response has been sent to Anvil...");
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let (response, _) = response_stream
+            .next()
+            .await
+            .ok_or_else(|| anyhow!("Failed to capture PublicDecryptionResponse"))??;
+        match inserted_response {
+            KmsResponse::PublicDecryption { decryption_id, .. } => {
+                assert_eq!(response.decryptionId, decryption_id)
             }
             _ => unreachable!(),
         }
-    }
-    info!("{nb_response} UserDecryptionResponse successfully stored!");
+        info!("Response successfully sent to Anvil!");
 
-    info!("Checking responses has been sent to Anvil...");
-    let response_stream = test_instance
-        .decryption_contract()
-        .UserDecryptionResponse_filter()
-        .watch()
-        .await?
-        .into_stream();
+        info!("Checking response has been removed from DB...");
+        tokio::time::sleep(Duration::from_millis(300)).await; // give some time for the removal
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(decryption_id) FROM public_decryption_responses")
+                .fetch_one(test_instance.db())
+                .await?;
+        assert_eq!(count, 0);
+        info!("Response successfully removed from DB! Stopping TransactionSender...");
 
-    let mut anvil_responses_id = response_stream
-        .map(|res| res.unwrap())
-        .map(|(r, _)| r.decryptionId)
-        .take(nb_response)
-        .collect::<Vec<U256>>()
-        .await;
-    responses_id.sort();
-    anvil_responses_id.sort();
-    assert_eq!(responses_id, anvil_responses_id);
-    info!("Responses successfully sent to Anvil!");
+        cancel_token.cancel();
+        Ok(tx_sender_task.await?)
+    })
+}
 
-    info!("Checking responses have been removed from DB...");
-    let count: i64 =
-        sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
-            .fetch_one(test_instance.db())
-            .await?;
-    assert_eq!(count, 0);
-    info!("Responses successfully removed from DB! Stopping TransactionSender...");
+#[rstest]
+#[timeout(Duration::from_secs(15))]
+#[serial]
+#[ignore = "events are sometime missed by the response filter..."]
+fn test_process_user_decryption_response() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let mut response_stream = test_instance
+            .decryption_contract()
+            .UserDecryptionResponse_filter()
+            .watch()
+            .await?
+            .into_stream();
 
-    cancel_token.cancel();
-    Ok(tx_sender_task.await?)
+        let cancel_token = CancellationToken::new();
+        let tx_sender_task = start_test_tx_sender(test_instance, cancel_token.clone()).await?;
+
+        info!("Mocking UserDecryptionResponse in Postgres...");
+        let inserted_response = insert_rand_user_decrypt_response(test_instance.db()).await?;
+        info!("UserDecryptionResponse successfully stored!");
+
+        info!("Checking response has been sent to Anvil...");
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let (response, _) = response_stream
+            .next()
+            .await
+            .ok_or_else(|| anyhow!("Failed to capture UserDecryptionResponse"))??;
+        match inserted_response {
+            KmsResponse::UserDecryption { decryption_id, .. } => {
+                assert_eq!(response.decryptionId, decryption_id)
+            }
+            _ => unreachable!(),
+        }
+        info!("Response successfully sent to Anvil!");
+
+        info!("Checking response has been removed from DB...");
+        tokio::time::sleep(Duration::from_millis(300)).await; // give some time for the removal
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
+                .fetch_one(test_instance.db())
+                .await?;
+        assert_eq!(count, 0);
+        info!("Response successfully removed from DB! Stopping TransactionSender...");
+
+        cancel_token.cancel();
+        Ok(tx_sender_task.await?)
+    })
+}
+
+#[rstest]
+#[serial]
+#[ignore = "to enable when performance will be improved"]
+fn stress_test() -> anyhow::Result<()> {
+    run_with_shared_db_gw_setup(async |test_instance| {
+        let response_stream = test_instance
+            .decryption_contract()
+            .UserDecryptionResponse_filter()
+            .watch()
+            .await?
+            .into_stream();
+
+        let cancel_token = CancellationToken::new();
+        let tx_sender_task = start_test_tx_sender(test_instance, cancel_token.clone()).await?;
+
+        let nb_response = 500;
+        info!("Mocking {nb_response} UserDecryptionResponse in Postgres...");
+        let mut responses_id = Vec::with_capacity(nb_response);
+        for _ in 0..nb_response {
+            match insert_rand_user_decrypt_response(test_instance.db()).await? {
+                KmsResponse::UserDecryption { decryption_id, .. } => {
+                    responses_id.push(decryption_id);
+                }
+                _ => unreachable!(),
+            }
+        }
+        info!("{nb_response} UserDecryptionResponse successfully stored!");
+
+        info!("Checking responses has been sent to Anvil...");
+        let mut anvil_responses_id = response_stream
+            .map(|res| res.unwrap())
+            .map(|(r, _)| r.decryptionId)
+            .take(nb_response)
+            .collect::<Vec<U256>>()
+            .await;
+        responses_id.sort();
+        anvil_responses_id.sort();
+        assert_eq!(responses_id, anvil_responses_id);
+        info!("Responses successfully sent to Anvil!");
+
+        info!("Checking responses have been removed from DB...");
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
+                .fetch_one(test_instance.db())
+                .await?;
+        assert_eq!(count, 0);
+        info!("Responses successfully removed from DB! Stopping TransactionSender...");
+
+        cancel_token.cancel();
+        Ok(tx_sender_task.await?)
+    })
 }
 
 async fn start_test_tx_sender(

--- a/kms-connector/crates/tx-sender/tests/response_picker.rs
+++ b/kms-connector/crates/tx-sender/tests/response_picker.rs
@@ -1,40 +1,56 @@
 mod common;
 
 use common::{insert_rand_public_decrypt_response, insert_rand_user_decrypt_response};
-use connector_utils::tests::setup::TestInstanceBuilder;
+use connector_utils::tests::setup::shared::{clean_test_instance, run_with_shared_db_setup};
+use ctor::dtor;
+use rstest::rstest;
+use serial_test::serial;
+use std::time::Duration;
+use tracing::info;
 use tx_sender::core::{DbKmsResponsePicker, KmsResponsePicker};
 
-#[tokio::test]
-async fn test_pick_public_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
-
-    let mut response_picker = DbKmsResponsePicker::connect(test_instance.db().clone(), 1).await?;
-
-    println!("Triggering Postgres notification with PublicDecryptionResponse insertion...");
-    let inserted_response = insert_rand_public_decrypt_response(test_instance.db()).await?;
-
-    println!("Picking PublicDecryptionResponse...");
-    let responses = response_picker.pick_responses().await?;
-
-    println!("Checking PublicDecryptionResponse data...");
-    assert_eq!(responses[0], inserted_response);
-    println!("Data OK!");
-    Ok(())
+#[dtor]
+fn on_shutdown() {
+    clean_test_instance();
 }
 
-#[tokio::test]
-async fn test_pick_user_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_setup().await?;
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
+fn test_pick_public_decryption() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut response_picker =
+            DbKmsResponsePicker::connect(test_instance.db().clone(), 1).await?;
 
-    let mut response_picker = DbKmsResponsePicker::connect(test_instance.db().clone(), 1).await?;
+        info!("Triggering Postgres notification with PublicDecryptionResponse insertion...");
+        let inserted_response = insert_rand_public_decrypt_response(test_instance.db()).await?;
 
-    println!("Triggering Postgres notification with UserDecryptionResponse insertion...");
-    let inserted_response = insert_rand_user_decrypt_response(test_instance.db()).await?;
-    println!("Picking UserDecryptionResponse...");
-    let responses = response_picker.pick_responses().await?;
+        info!("Picking PublicDecryptionResponse...");
+        let responses = response_picker.pick_responses().await?;
 
-    println!("Checking UserDecryptionResponse data...");
-    assert_eq!(responses[0], inserted_response);
-    println!("Data OK!");
-    Ok(())
+        info!("Checking PublicDecryptionResponse data...");
+        assert_eq!(responses[0], inserted_response);
+        info!("Data OK!");
+        Ok(())
+    })
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[serial]
+fn test_pick_user_decryption() -> anyhow::Result<()> {
+    run_with_shared_db_setup(async |test_instance| {
+        let mut response_picker =
+            DbKmsResponsePicker::connect(test_instance.db().clone(), 1).await?;
+
+        info!("Triggering Postgres notification with UserDecryptionResponse insertion...");
+        let inserted_response = insert_rand_user_decrypt_response(test_instance.db()).await?;
+        info!("Picking UserDecryptionResponse...");
+        let responses = response_picker.pick_responses().await?;
+
+        info!("Checking UserDecryptionResponse data...");
+        assert_eq!(responses[0], inserted_response);
+        info!("Data OK!");
+        Ok(())
+    })
 }

--- a/kms-connector/crates/utils/Cargo.toml
+++ b/kms-connector/crates/utils/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber.workspace = true
 
 rand = { workspace = true, optional = true }
 testcontainers = { workspace = true, optional = true }
+tracing-test = { workspace = true, optional = true }
 
 [dev-dependencies]
 serial_test.workspace = true
@@ -46,5 +47,6 @@ tests = [
     "alloy/node-bindings",
     "dep:rand",
     "dep:testcontainers",
+    "dep:tracing-test",
     "sqlx/migrate",
 ]

--- a/kms-connector/crates/utils/src/tests/setup/mod.rs
+++ b/kms-connector/crates/utils/src/tests/setup/mod.rs
@@ -4,6 +4,7 @@ mod gw;
 mod instance;
 mod kms;
 mod s3;
+pub mod shared;
 
 pub use common::*;
 pub use db::*;

--- a/kms-connector/crates/utils/src/tests/setup/shared.rs
+++ b/kms-connector/crates/utils/src/tests/setup/shared.rs
@@ -16,6 +16,13 @@ use tokio::{
 // Note that containers spawned by the `testcontainers` crate are stopped when they are dropped.
 // However, static variables are not dropped. Thus, we wrap the static `TestInstance` in an
 // `Option`, so we can manually `take` it and drop it, using `#[dtor]` macro.
+//
+// Note on `#[dtor]`:
+// - if the tests fails, it might not be run, so running containers will be left in that case
+//   - it should not impact the next tests that are run
+// - there is warning regarding its use https://crates.io/crates/ctor
+// - the behavior might be plateform specific
+// - if we face too many issues with this in the future, we should try to find a workaround
 pub static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 pub static TEST_INSTANCE: OnceCell<TokioMutex<Option<TestInstance>>> = OnceCell::const_new();
 

--- a/kms-connector/crates/utils/src/tests/setup/shared.rs
+++ b/kms-connector/crates/utils/src/tests/setup/shared.rs
@@ -1,0 +1,75 @@
+use crate::tests::setup::{TestInstance, TestInstanceBuilder};
+use std::sync::OnceLock;
+use tokio::{
+    runtime::Runtime,
+    sync::{Mutex as TokioMutex, MutexGuard, OnceCell},
+};
+
+// We use these static variables to have a shared tokio runtime and test instance for some
+// integration tests.
+//
+// The shared test instance is to avoid spawning too many containers in parallel, which can be
+// resource intensive.
+// The shared tokio runtime is required because the `alloy::Provider` of the test instance uses a
+// `reqwest::Client` under the hood, which is tied to one `tokio::Runtime`.
+//
+// Note that containers spawned by the `testcontainers` crate are stopped when they are dropped.
+// However, static variables are not dropped. Thus, we wrap the static `TestInstance` in an
+// `Option`, so we can manually `take` it and drop it, using `#[dtor]` macro.
+pub static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+pub static TEST_INSTANCE: OnceCell<TokioMutex<Option<TestInstance>>> = OnceCell::const_new();
+
+/// Runner for DB only tests.
+pub fn run_with_shared_db_setup<F, R>(test_fn: F) -> R
+where
+    F: AsyncFnOnce(&mut TestInstance) -> R,
+{
+    get_shared_runtime().block_on(async {
+        let mut test_instance_guard =
+            lock_test_instance(TestInstanceBuilder::static_db_setup).await;
+        let test_instance = test_instance_guard.as_mut().unwrap();
+        test_fn(test_instance).await
+    })
+}
+
+/// Runner for DB + Gateway tests.
+pub fn run_with_shared_db_gw_setup<F, R>(test_fn: F) -> R
+where
+    F: AsyncFnOnce(&mut TestInstance) -> R,
+{
+    get_shared_runtime().block_on(async {
+        let mut test_instance_guard =
+            lock_test_instance(TestInstanceBuilder::static_db_gw_setup).await;
+        let test_instance = test_instance_guard.as_mut().unwrap();
+        test_fn(test_instance).await
+    })
+}
+
+fn get_shared_runtime() -> &'static Runtime {
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    })
+}
+
+/// Locks the shared test instance.
+///
+/// Uses the provided `init_fn` if the test instance has not been started yet.
+async fn lock_test_instance<F, Fut>(init_fn: F) -> MutexGuard<'static, Option<TestInstance>>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = TokioMutex<Option<TestInstance>>>,
+{
+    TEST_INSTANCE.get_or_init(init_fn).await.lock().await
+}
+
+pub fn clean_test_instance() {
+    get_shared_runtime().block_on(async {
+        if let Some(test_instance) = TEST_INSTANCE.get() {
+            let test_instance = test_instance.lock().await.take();
+            drop(test_instance); // Dropping the instance will stop the containers.
+        }
+    })
+}


### PR DESCRIPTION
* enables shared setup for tests
* fix flaky tests
* use test timeout for integration tests

Note: I still have issues for tx manager integration tests: the events filter I used to ensure tx are emitted to the Gateway sometimes miss the events, even if the tx manager claims the tx was sent... If you have any idea @dartdart26, feel free to share it