### PR TITLE
fix(coprocessor): use adaptive retries in unit-test

### DIFF
--- a/coprocessor/fhevm-engine/sns-executor/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-executor/src/tests/mod.rs
@@ -12,7 +12,7 @@ use std::{
     io::{Read, Write},
     time::Duration,
 };
-use test_harness::instance::DBInstance;
+use test_harness::instance::{DBInstance, ImportMode};
 use tfhe::{prelude::FheDecrypt, ClientKey, SquashedNoiseFheUint};
 use tokio::{sync::mpsc, time::sleep};
 use tracing::Level;
@@ -88,7 +88,7 @@ async fn test_decryptable(
 #[tokio::test]
 async fn test_lifo_mode() {
     tracing_subscriber::fmt().json().with_level(true).init();
-    let test_instance = test_harness::instance::setup_test_db(false)
+    let test_instance = test_harness::instance::setup_test_db(ImportMode::None)
         .await
         .expect("valid db instance");
 
@@ -167,7 +167,7 @@ async fn test_lifo_mode() {
 
 #[tokio::test]
 async fn test_garbage_collect() {
-    let test_instance = test_harness::instance::setup_test_db(false)
+    let test_instance = test_harness::instance::setup_test_db(ImportMode::None)
         .await
         .expect("valid db instance");
 
@@ -260,7 +260,7 @@ async fn setup() -> anyhow::Result<(
     DBInstance,
 )> {
     tracing_subscriber::fmt().json().with_level(true).init();
-    let test_instance = test_harness::instance::setup_test_db(true)
+    let test_instance = test_harness::instance::setup_test_db(ImportMode::WithAllKeys)
         .await
         .expect("valid db instance");
 

--- a/coprocessor/fhevm-engine/test-harness/src/db_utils.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/db_utils.rs
@@ -131,7 +131,15 @@ pub async fn wait_for_ciphertext(
     Err(sqlx::Error::RowNotFound.into())
 }
 
-pub async fn setup_test_user(pool: &sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+/// Inserts a new tenant into the database with the specified ACL contract address
+///
+/// # Arguments
+/// * `pool` - The database connection pool
+/// * `with_sns_pk` - Enables the importing of SNS sks key which usually is 1.5GB in size
+pub async fn setup_test_user(
+    pool: &sqlx::PgPool,
+    with_sns_pk: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (sks, cks, pks, pp, sns_pk) = if !cfg!(feature = "gpu") {
         (
             "../fhevm-keys/sks",
@@ -154,7 +162,12 @@ pub async fn setup_test_user(pool: &sqlx::PgPool) -> Result<(), Box<dyn std::err
     let cks = tokio::fs::read(cks).await.expect("can't read cks key");
     let public_params = tokio::fs::read(pp).await.expect("can't read public params");
 
-    let sns_pk_oid = import_file_into_db(pool, sns_pk).await?;
+    let sns_pk_oid = if with_sns_pk {
+        import_file_into_db(pool, sns_pk).await?
+    } else {
+        Oid::default()
+    };
+
     info!("Uploaded sns_pk with Oid: {:?}", sns_pk_oid);
 
     sqlx::query!(

--- a/coprocessor/fhevm-engine/test-harness/src/instance.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/instance.rs
@@ -34,7 +34,7 @@ impl DBInstance {
 ///     Ok(())
 /// }
 /// ```
-pub async fn setup_test_db(with_keys: bool) -> Result<DBInstance, Box<dyn std::error::Error>> {
+pub async fn setup_test_db(mode: ImportMode) -> Result<DBInstance, Box<dyn std::error::Error>> {
     let is_localhost = std::env::var("COPROCESSOR_TEST_LOCALHOST").is_ok();
 
     // Drop and recreate the database in localhost mode
@@ -42,15 +42,15 @@ pub async fn setup_test_db(with_keys: bool) -> Result<DBInstance, Box<dyn std::e
     let is_localhost_with_reset = std::env::var("COPROCESSOR_TEST_LOCALHOST_RESET").is_ok();
 
     if is_localhost || is_localhost_with_reset {
-        setup_test_app_existing_localhost(is_localhost_with_reset, with_keys).await
+        setup_test_app_existing_localhost(is_localhost_with_reset, mode).await
     } else {
-        setup_test_app_custom_docker(with_keys).await
+        setup_test_app_custom_docker(mode).await
     }
 }
 
 async fn setup_test_app_existing_localhost(
     with_reset: bool,
-    with_keys: bool,
+    mode: ImportMode,
 ) -> Result<DBInstance, Box<dyn std::error::Error>> {
     const LOCALHOST: &str = "127.0.0.1";
     const LOCAL_PORT: i32 = 5432;
@@ -59,7 +59,7 @@ async fn setup_test_app_existing_localhost(
     if with_reset {
         let admin_db_url =
             format!("postgresql://postgres:postgres@{LOCALHOST}:{LOCAL_PORT}/postgres");
-        create_database(&admin_db_url, &db_url, with_keys).await?;
+        create_database(&admin_db_url, &db_url, mode).await?;
     }
 
     Ok(DBInstance {
@@ -70,7 +70,7 @@ async fn setup_test_app_existing_localhost(
 }
 
 async fn setup_test_app_custom_docker(
-    with_keys: bool,
+    mode: ImportMode,
 ) -> Result<DBInstance, Box<dyn std::error::Error>> {
     let container = GenericImage::new("postgres", "15.7")
         .with_wait_for(WaitFor::message_on_stderr(
@@ -89,7 +89,7 @@ async fn setup_test_app_custom_docker(
 
     let admin_db_url = format!("postgresql://postgres:postgres@{cont_host}:{cont_port}/postgres");
     let db_url = format!("postgresql://postgres:postgres@{cont_host}:{cont_port}/coprocessor");
-    create_database(&admin_db_url, &db_url, with_keys).await?;
+    create_database(&admin_db_url, &db_url, mode).await?;
 
     Ok(DBInstance {
         _container: Some(container),
@@ -98,10 +98,16 @@ async fn setup_test_app_custom_docker(
     })
 }
 
+pub enum ImportMode {
+    None,
+    WithKeysNoSns,
+    WithAllKeys,
+}
+
 async fn create_database(
     admin_db_url: &str,
     db_url: &str,
-    with_keys: bool,
+    mode: ImportMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Creating coprocessor db...");
     let admin_pool = sqlx::postgres::PgPoolOptions::new()
@@ -126,9 +132,18 @@ async fn create_database(
     println!("Running migrations...");
     sqlx::migrate!("./migrations").run(&pool).await?;
 
-    if with_keys {
-        println!("Creating test user with all keys...");
-        setup_test_user(&pool).await?;
+    match mode {
+        ImportMode::None => {
+            println!("No keys imported");
+        }
+        ImportMode::WithKeysNoSns => {
+            println!("Creating test user with keys, without SnS key...");
+            setup_test_user(&pool, false).await?;
+        }
+        ImportMode::WithAllKeys => {
+            println!("Creating test user with all keys...");
+            setup_test_user(&pool, true).await?;
+        }
     }
 
     println!("DB prepared");

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -22,9 +22,15 @@ async fn test_verify_proof() {
         .await
         .unwrap();
 
+    let max_retries = 1000;
+
     // Check if it's valid
-    assert!(utils::is_valid(&pool, request_id_valid).await.unwrap());
+    assert!(utils::is_valid(&pool, request_id_valid, max_retries)
+        .await
+        .unwrap(),);
 
     // Check if it's invalid
-    assert!(!utils::is_valid(&pool, request_id_invalid).await.unwrap());
+    assert!(!utils::is_valid(&pool, request_id_invalid, max_retries)
+        .await
+        .unwrap());
 }

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
@@ -45,15 +45,27 @@ pub async fn setup() -> anyhow::Result<(sqlx::PgPool, DBInstance)> {
     Ok((pool, test_instance))
 }
 
-pub(crate) async fn is_valid(pool: &sqlx::PgPool, zk_proof_id: i64) -> Result<bool, sqlx::Error> {
-    let result = sqlx::query!(
-        "SELECT verified FROM verify_proofs WHERE zk_proof_id = $1",
-        zk_proof_id
-    )
-    .fetch_one(pool)
-    .await?;
+pub(crate) async fn is_valid(
+    pool: &sqlx::PgPool,
+    zk_proof_id: i64,
+    max_retries: usize,
+) -> Result<bool, sqlx::Error> {
+    for _ in 0..max_retries {
+        sleep(Duration::from_millis(100)).await;
+        let result = sqlx::query!(
+            "SELECT verified FROM verify_proofs WHERE zk_proof_id = $1",
+            zk_proof_id
+        )
+        .fetch_one(pool)
+        .await?;
 
-    Ok(result.verified.unwrap_or(false))
+        match result.verified {
+            Some(verified) => return Ok(verified),
+            None => continue,
+        }
+    }
+
+    Ok(false)
 }
 
 pub(crate) async fn generate_zk_pok(pool: &sqlx::PgPool, aux_data: &[u8]) -> Vec<u8> {
@@ -110,8 +122,6 @@ pub(crate) async fn insert_proof(
         .execute(pool)
         .await
         .unwrap();
-
-    sleep(Duration::from_secs(5)).await;
 
     Ok(request_id)
 }

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
@@ -1,7 +1,7 @@
 use fhevm_engine_common::{tenant_keys, utils::safe_serialize};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use test_harness::instance::DBInstance;
+use test_harness::instance::{DBInstance, ImportMode};
 use tokio::sync::RwLock;
 use tokio::time::sleep;
 
@@ -9,7 +9,7 @@ use crate::auxiliary::ZkData;
 
 pub async fn setup() -> anyhow::Result<(sqlx::PgPool, DBInstance)> {
     tracing_subscriber::fmt().json().with_level(true).init();
-    let test_instance = test_harness::instance::setup_test_db(true)
+    let test_instance = test_harness::instance::setup_test_db(ImportMode::WithKeysNoSns)
         .await
         .expect("valid db instance");
 


### PR DESCRIPTION
- Use adaptive max_retries in the zkproof test
- Reduce the time of unit-tests execution when noise_squashing is not needed.