### PR TITLE
feat(kms-connector): add catchup mode to gw-listener

### DIFF
--- a/kms-connector/crates/gw-listener/src/core/config/parsed.rs
+++ b/kms-connector/crates/gw-listener/src/core/config/parsed.rs
@@ -28,6 +28,8 @@ pub struct Config {
     pub monitoring_endpoint: SocketAddr,
     /// The timeout to perform each external service connection healthcheck.
     pub healthcheck_timeout: Duration,
+    /// Optional block number to start processing from.
+    pub from_block_number: Option<u64>,
 }
 
 impl Config {
@@ -73,6 +75,7 @@ impl Config {
             service_name: raw_config.service_name,
             monitoring_endpoint,
             healthcheck_timeout,
+            from_block_number: raw_config.from_block_number,
         })
     }
 }

--- a/kms-connector/crates/gw-listener/src/core/config/raw.rs
+++ b/kms-connector/crates/gw-listener/src/core/config/raw.rs
@@ -24,6 +24,7 @@ pub struct RawConfig {
     pub monitoring_endpoint: String,
     #[serde(default = "default_healthcheck_timeout_secs")]
     pub healthcheck_timeout_secs: u64,
+    pub from_block_number: Option<u64>,
 }
 
 fn default_service_name() -> String {
@@ -57,6 +58,7 @@ impl Default for RawConfig {
             service_name: default_service_name(),
             monitoring_endpoint: default_monitoring_endpoint(),
             healthcheck_timeout_secs: default_healthcheck_timeout_secs(),
+            from_block_number: None,
         }
     }
 }


### PR DESCRIPTION
Implemented by adding a `from_block_number` parameter to the config. If not set, start from the `latest` block.