### PR TITLE
chore(kms-connector): improve integration tests

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -3516,6 +3516,7 @@ dependencies = [
  "connector-utils",
  "fhevm_gateway_rust_bindings",
  "prometheus",
+ "rstest",
  "serde",
  "serial_test",
  "sqlx",

--- a/kms-connector/crates/gw-listener/Cargo.toml
+++ b/kms-connector/crates/gw-listener/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 connector-utils = { workspace = true, features = ["tests"] }
+rstest.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true
 testcontainers.workspace = true

--- a/kms-connector/crates/gw-listener/tests/integration_test.rs
+++ b/kms-connector/crates/gw-listener/tests/integration_test.rs
@@ -11,19 +11,25 @@ use connector_utils::tests::{
 use connector_utils::types::db::SnsCiphertextMaterialDbItem;
 use fhevm_gateway_rust_bindings::decryption::IDecryption::RequestValidity;
 use gw_listener::core::{Config, DbEventPublisher, GatewayListener};
+use rstest::rstest;
 use sqlx::Row;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_public_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next PublicDecryptionRequest...")
+        .await;
 
     info!("Mocking PublicDecryptionRequest on Anvil...");
     let pending_tx = test_instance
@@ -39,7 +45,10 @@ async fn test_publish_public_decryption() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query("SELECT decryption_id, sns_ct_materials FROM public_decryption_requests")
         .fetch_one(test_instance.db())
@@ -59,13 +68,18 @@ async fn test_publish_public_decryption() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_user_decryption() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next UserDecryptionRequest...")
+        .await;
 
     info!("Mocking UserDecryptionRequest on Anvil...");
     let rand_user_addr = rand_address();
@@ -91,7 +105,10 @@ async fn test_publish_user_decryption() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query("SELECT decryption_id, sns_ct_materials, user_address, public_key FROM user_decryption_requests")
         .fetch_one(test_instance.db())
@@ -116,13 +133,18 @@ async fn test_publish_user_decryption() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_preprocess_keygen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next PreprocessKeygenRequest...")
+        .await;
 
     info!("Mocking PreprocessKeygenRequest on Anvil...");
     let pending_tx = test_instance
@@ -138,7 +160,10 @@ async fn test_publish_preprocess_keygen() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query(
         "SELECT pre_keygen_request_id, fhe_params_digest FROM preprocess_keygen_requests",
@@ -156,13 +181,18 @@ async fn test_publish_preprocess_keygen() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_preprocess_kskgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next PreprocessKskgenRequest...")
+        .await;
 
     info!("Mocking PreprocessKskgenRequest on Anvil...");
     let pending_tx = test_instance
@@ -178,7 +208,10 @@ async fn test_publish_preprocess_kskgen() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query(
         "SELECT pre_kskgen_request_id, fhe_params_digest FROM preprocess_kskgen_requests",
@@ -196,13 +229,18 @@ async fn test_publish_preprocess_kskgen() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_keygen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next KeygenRequest...")
+        .await;
 
     info!("Mocking KeygenRequest on Anvil...");
     let rand_id = rand_u256();
@@ -219,7 +257,10 @@ async fn test_publish_keygen() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query("SELECT pre_key_id, fhe_params_digest FROM keygen_requests")
         .fetch_one(test_instance.db())
@@ -235,13 +276,18 @@ async fn test_publish_keygen() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_kskgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next KskgenRequest...")
+        .await;
 
     info!("Mocking KskgenRequest on Anvil...");
     let rand_id = rand_u256();
@@ -260,7 +306,10 @@ async fn test_publish_kskgen() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query(
         "SELECT pre_ksk_id, source_key_id, dest_key_id, fhe_params_digest FROM kskgen_requests",
@@ -282,13 +331,18 @@ async fn test_publish_kskgen() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_publish_crsgen() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task = start_test_listener(&test_instance, cancel_token.clone(), None);
-    tokio::time::sleep(Duration::from_millis(200)).await; // Waiting for the gw_listener to subscribe events
+
+    test_instance
+        .wait_for_log("Waiting for next CrsgenRequest...")
+        .await;
 
     info!("Mocking CrsgenRequest on Anvil...");
     let pending_tx = test_instance
@@ -304,7 +358,10 @@ async fn test_publish_crsgen() -> anyhow::Result<()> {
         .unwrap();
     info!("Tx successfully sent!");
 
-    tokio::time::sleep(Duration::from_millis(600)).await; // Waiting for the gw_listener to process event
+    test_instance
+        .wait_for_log("Event successfully stored in DB!")
+        .await;
+
     info!("Checking event is stored in DB...");
     let row = sqlx::query("SELECT crsgen_request_id, fhe_params_digest FROM crsgen_requests")
         .fetch_one(test_instance.db())
@@ -320,10 +377,12 @@ async fn test_publish_crsgen() -> anyhow::Result<()> {
     Ok(gw_listener_task?.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(120))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_catchup() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
 
     info!("Mocking PublicDecryptionRequest on Anvil...");
@@ -369,39 +428,38 @@ async fn test_catchup() -> anyhow::Result<()> {
         Some(tx1.block_number.unwrap()),
     );
 
-    loop {
-        info!("Checking event is stored in DB...");
-        let row =
-            sqlx::query("SELECT decryption_id, sns_ct_materials FROM public_decryption_requests")
-                .fetch_all(test_instance.db())
-                .await?;
-
-        if row.len() < 2 {
-            info!("Not all events found yet, retrying...");
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            continue;
-        }
-
-        let decryption_id1 = U256::from_le_bytes(row[0].try_get::<[u8; 32], _>("decryption_id")?);
-        let sns_ct_materials =
-            row[0].try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
-        assert_eq!(decryption_id1, U256::from(1));
-        assert_eq!(
-            sns_ct_materials,
-            vec![SnsCiphertextMaterialDbItem::default()]
-        );
-
-        let decryption_id2 = U256::from_le_bytes(row[1].try_get::<[u8; 32], _>("decryption_id")?);
-        let sns_ct_materials =
-            row[1].try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
-        assert_eq!(decryption_id2, U256::from(2));
-        assert_eq!(
-            sns_ct_materials,
-            vec![SnsCiphertextMaterialDbItem::default()]
-        );
-        break;
+    for _ in 0..2 {
+        test_instance
+            .wait_for_log("Event successfully stored in DB!")
+            .await;
     }
 
+    info!("Checking event is stored in DB...");
+    let row = sqlx::query("SELECT decryption_id, sns_ct_materials FROM public_decryption_requests")
+        .fetch_all(test_instance.db())
+        .await?;
+
+    if row.len() < 2 {
+        panic!("Not all events found yet...");
+    }
+
+    let decryption_id1 = U256::from_le_bytes(row[0].try_get::<[u8; 32], _>("decryption_id")?);
+    let sns_ct_materials =
+        row[0].try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
+    assert_eq!(decryption_id1, U256::from(1));
+    assert_eq!(
+        sns_ct_materials,
+        vec![SnsCiphertextMaterialDbItem::default()]
+    );
+
+    let decryption_id2 = U256::from_le_bytes(row[1].try_get::<[u8; 32], _>("decryption_id")?);
+    let sns_ct_materials =
+        row[1].try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?;
+    assert_eq!(decryption_id2, U256::from(2));
+    assert_eq!(
+        sns_ct_materials,
+        vec![SnsCiphertextMaterialDbItem::default()]
+    );
     info!("Event successfully stored! Stopping GatewayListener...");
 
     cancel_token.cancel();

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -19,11 +19,17 @@ use tx_sender::core::{
 };
 
 #[rstest]
-#[timeout(Duration::from_secs(10))]
+#[timeout(Duration::from_secs(20))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_process_public_decryption_response() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut response_stream = test_instance
+        .decryption_contract()
+        .PublicDecryptionResponse_filter()
+        .watch()
+        .await?
+        .into_stream();
 
     let cancel_token = CancellationToken::new();
     let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
@@ -33,12 +39,6 @@ async fn test_process_public_decryption_response() -> anyhow::Result<()> {
     info!("PublicDecryptionResponse successfully stored!");
 
     info!("Checking response has been sent to Anvil...");
-    let mut response_stream = test_instance
-        .decryption_contract()
-        .PublicDecryptionResponse_filter()
-        .watch()
-        .await?
-        .into_stream();
     let (response, _) = response_stream
         .next()
         .await
@@ -51,8 +51,11 @@ async fn test_process_public_decryption_response() -> anyhow::Result<()> {
     }
     info!("Response successfully sent to Anvil!");
 
+    test_instance
+        .wait_for_log("Successfully removed response from DB!")
+        .await;
+
     info!("Checking response has been removed from DB...");
-    tokio::time::sleep(Duration::from_millis(300)).await; // give some time for the removal
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(decryption_id) FROM public_decryption_responses")
             .fetch_one(test_instance.db())
@@ -65,11 +68,17 @@ async fn test_process_public_decryption_response() -> anyhow::Result<()> {
 }
 
 #[rstest]
-#[timeout(Duration::from_secs(10))]
+#[timeout(Duration::from_secs(20))]
 #[tokio::test]
 #[ignore = "flaky tests to be fixed"]
 async fn test_process_user_decryption_response() -> anyhow::Result<()> {
-    let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let mut response_stream = test_instance
+        .decryption_contract()
+        .UserDecryptionResponse_filter()
+        .watch()
+        .await?
+        .into_stream();
 
     let cancel_token = CancellationToken::new();
     let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
@@ -79,12 +88,6 @@ async fn test_process_user_decryption_response() -> anyhow::Result<()> {
     info!("UserDecryptionResponse successfully stored!");
 
     info!("Checking response has been sent to Anvil...");
-    let mut response_stream = test_instance
-        .decryption_contract()
-        .UserDecryptionResponse_filter()
-        .watch()
-        .await?
-        .into_stream();
     let (response, _) = response_stream
         .next()
         .await
@@ -97,8 +100,11 @@ async fn test_process_user_decryption_response() -> anyhow::Result<()> {
     }
     info!("Response successfully sent to Anvil!");
 
+    test_instance
+        .wait_for_log("Successfully removed response from DB!")
+        .await;
+
     info!("Checking response has been removed from DB...");
-    tokio::time::sleep(Duration::from_millis(300)).await; // give some time for the removal
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(decryption_id) FROM user_decryption_responses")
             .fetch_one(test_instance.db())
@@ -110,10 +116,18 @@ async fn test_process_user_decryption_response() -> anyhow::Result<()> {
     Ok(tx_sender_task.await?)
 }
 
+#[rstest]
+#[timeout(Duration::from_secs(30))]
 #[tokio::test]
-#[ignore = "to enable when performance will be improved"]
+#[ignore = "flaky tests to be fixed"]
 async fn stress_test() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_gw_setup().await?;
+    let response_stream = test_instance
+        .decryption_contract()
+        .UserDecryptionResponse_filter()
+        .watch()
+        .await?
+        .into_stream();
 
     let cancel_token = CancellationToken::new();
     let tx_sender_task = start_test_tx_sender(&test_instance, cancel_token.clone()).await?;
@@ -132,13 +146,6 @@ async fn stress_test() -> anyhow::Result<()> {
     info!("{nb_response} UserDecryptionResponse successfully stored!");
 
     info!("Checking responses has been sent to Anvil...");
-    let response_stream = test_instance
-        .decryption_contract()
-        .UserDecryptionResponse_filter()
-        .watch()
-        .await?
-        .into_stream();
-
     let mut anvil_responses_id = response_stream
         .map(|res| res.unwrap())
         .map(|(r, _)| r.decryptionId)

--- a/kms-connector/crates/utils/src/tests/setup/mod.rs
+++ b/kms-connector/crates/utils/src/tests/setup/mod.rs
@@ -4,6 +4,7 @@ mod gw;
 mod instance;
 mod kms;
 mod s3;
+mod writer;
 
 pub use common::*;
 pub use db::*;
@@ -11,3 +12,4 @@ pub use gw::*;
 pub use instance::*;
 pub use kms::*;
 pub use s3::*;
+pub use writer::*;

--- a/kms-connector/crates/utils/src/tests/setup/writer.rs
+++ b/kms-connector/crates/utils/src/tests/setup/writer.rs
@@ -1,0 +1,45 @@
+use std::io;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// Custom `tracing` writer for tests.
+///
+/// It both prints every trace, and sends them to its channel for later analysis.
+///
+/// Heavily inspired by the `tracing-subscriber::fmt::TestWriter`.
+pub struct CustomTestWriter {
+    log_tx: UnboundedSender<String>,
+}
+
+impl CustomTestWriter {
+    pub fn new(log_tx: UnboundedSender<String>) -> Self {
+        Self { log_tx }
+    }
+}
+
+impl io::Write for CustomTestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let out_str = String::from_utf8_lossy(buf);
+        print!("{out_str}");
+
+        self.log_tx
+            .send(out_str.to_string())
+            .expect("log channel was closed!");
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CustomTestWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        Self {
+            log_tx: self.log_tx.clone(),
+        }
+    }
+}


### PR DESCRIPTION
Rely on custom `wait_for_log` function instead of `sleep` to avoid race condition in tests.