### PR TITLE
chore(sdk): make keys directory optional

### DIFF
--- a/sdk/rust-sdk/examples/minimal-public-decryption-request.rs
+++ b/sdk/rust-sdk/examples/minimal-public-decryption-request.rs
@@ -1,5 +1,4 @@
 use gateway_sdk::{FhevmError, FhevmSdkBuilder, utils::parse_hex_string};
-use std::path::PathBuf;
 use tracing::{Level, info};
 
 fn main() -> Result<(), FhevmError> {
@@ -10,7 +9,6 @@ fn main() -> Result<(), FhevmError> {
 
     // 1. Create SDK instance
     let sdk = FhevmSdkBuilder::new()
-        .with_keys_directory(PathBuf::from("./keys"))
         .with_gateway_chain_id(43113) // Avalanche testnet
         .with_host_chain_id(11155111) // Ethereum Sepolia
         .with_decryption_contract("0xc9bAE822fE6793e3B456144AdB776D5A318CB71e")

--- a/sdk/rust-sdk/examples/minimal-public-decryption-response.rs
+++ b/sdk/rust-sdk/examples/minimal-public-decryption-response.rs
@@ -1,5 +1,4 @@
 use gateway_sdk::{FhevmError, FhevmSdkBuilder};
-use std::path::PathBuf;
 use tracing::{Level, info};
 
 fn main() -> Result<(), FhevmError> {
@@ -10,7 +9,6 @@ fn main() -> Result<(), FhevmError> {
 
     // 1. Create SDK instance
     let sdk = FhevmSdkBuilder::new()
-        .with_keys_directory(PathBuf::from("./keys"))
         .with_gateway_chain_id(43113) // Avalanche testnet
         .with_host_chain_id(11155111) // Ethereum Sepolia
         .with_decryption_contract("0xc9bAE822fE6793e3B456144AdB776D5A318CB71e")

--- a/sdk/rust-sdk/examples/minimal-user-decryption-request.rs
+++ b/sdk/rust-sdk/examples/minimal-user-decryption-request.rs
@@ -12,7 +12,7 @@ use gateway_sdk::{
     FhevmSdkBuilder, Result, blockchain::bindings::Decryption::CtHandleContractPair,
     utils::validate_address_from_str,
 };
-use std::{path, str::FromStr};
+use std::str::FromStr;
 fn main() -> Result<()> {
     println!("🔓 Processing user decryption...");
 
@@ -25,7 +25,6 @@ fn main() -> Result<()> {
     };
 
     let sdk = FhevmSdkBuilder::new()
-        .with_keys_directory(path::PathBuf::from("./keys"))
         .with_gateway_chain_id(43113)
         .with_host_chain_id(11155111) // Example: Ethereum Sepolia
         .with_decryption_contract("0xc9bAE822fE6793e3B456144AdB776D5A318CB71e")

--- a/sdk/rust-sdk/examples/minimal-user-decryption-response.rs
+++ b/sdk/rust-sdk/examples/minimal-user-decryption-response.rs
@@ -12,12 +12,11 @@ use gateway_sdk::{
     FhevmSdkBuilder, Result, blockchain::bindings::Decryption::CtHandleContractPair,
     utils::validate_address_from_str,
 };
-use std::{path, str::FromStr};
+use std::str::FromStr;
 fn main() -> Result<()> {
     println!("🔓 Processing user decryption...");
 
     let sdk = FhevmSdkBuilder::new()
-        .with_keys_directory(path::PathBuf::from("./keys"))
         .with_gateway_chain_id(43113)
         .with_host_chain_id(11155111) // Example: Ethereum Sepolia
         .with_decryption_contract("0x1234567890123456789012345678901234567bbb")


### PR DESCRIPTION
Make the `keys_directory` optional if the SDK user does not want to create any inputs.