### PR TITLE
feat(host-contracts): introduce the extraData and decryptionProof fields at KMSVerifier

### DIFF
--- a/host-contracts/codegen/templates.ts
+++ b/host-contracts/codegen/templates.ts
@@ -406,7 +406,7 @@ function generateKMSVerifierInterface(): string {
     function verifyDecryptionEIP712KMSSignatures(
         bytes32[] memory handlesList,
         bytes memory decryptedResult,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) external returns (bool);
   }
   `;
@@ -1104,9 +1104,9 @@ function generateSolidityDecryptionOracleMethods(fheTypes: AdjustedFheType[]): s
      * @dev     otherwise fake decryption results could be submitted.
      * @notice  Warning: MUST be called directly in the callback function called by the relayer.
      */
-    function checkSignatures(uint256 requestID, bytes[] memory signatures) internal {
+    function checkSignatures(uint256 requestID, bytes memory decryptionProof) internal {
         bytes32[] memory handlesList = loadRequestedHandles(requestID);
-        bool isVerified = verifySignatures(handlesList, signatures);
+        bool isVerified = verifySignatures(handlesList, decryptionProof);
         if (!isVerified) {
             revert InvalidKMSSignatures();
         }
@@ -1128,7 +1128,7 @@ function generateSolidityDecryptionOracleMethods(fheTypes: AdjustedFheType[]): s
      * @dev Private low-level function used to extract the decryptedResult bytes array and verify the KMS signatures.
      * @notice  Warning: MUST be called directly in the callback function called by the relayer.
      */
-    function verifySignatures(bytes32[] memory handlesList, bytes[] memory signatures) private returns (bool) {
+    function verifySignatures(bytes32[] memory handlesList, bytes memory decryptionProof) private returns (bool) {
       uint256 start = 4 + 32; // start position after skipping the selector (4 bytes) and the first argument (index, 32 bytes)
       uint256 length = getSignedDataLength(handlesList);
       bytes memory decryptedResult = new bytes(length);
@@ -1140,7 +1140,7 @@ function generateSolidityDecryptionOracleMethods(fheTypes: AdjustedFheType[]): s
           IKMSVerifier($.KMSVerifierAddress).verifyDecryptionEIP712KMSSignatures(
               handlesList,
               decryptedResult,
-              signatures
+              decryptionProof
           );
     }
 
@@ -1158,7 +1158,6 @@ function generateSolidityDecryptionOracleMethods(fheTypes: AdjustedFheType[]): s
                 revert UnsupportedHandleType();
             }
         }
-        signedDataLength += 32; // add offset of signatures
         return signedDataLength;
     }
   `,

--- a/host-contracts/contracts/KMSVerifier.sol
+++ b/host-contracts/contracts/KMSVerifier.sol
@@ -192,8 +192,11 @@ contract KMSVerifier is UUPSUpgradeableEmptyProxy, Ownable2StepUpgradeable, EIP7
         /// @dev The decryptionProof is the numSigners + kmsSignatures + extraData (1 + 65*numSigners + extraData bytes)
         uint256 numSigners = uint256(uint8(decryptionProof[0]));
 
+        /// @dev The extraData is the rest of the decryptionProof bytes after the numSigners + signatures.
+        uint256 extraDataOffset = 1 + 65 * numSigners;
+
         /// @dev Check that the decryptionProof is long enough to contain at least the numSigners + kmsSignatures
-        if (decryptionProof.length < 1 + 65 * numSigners) {
+        if (decryptionProof.length < extraDataOffset) {
             revert DeserializingDecryptionProofFail();
         }
 
@@ -205,11 +208,8 @@ contract KMSVerifier is UUPSUpgradeableEmptyProxy, Ownable2StepUpgradeable, EIP7
             }
         }
 
-        /// @dev The extraData is the rest of the decryptionProof bytes after the numSigners + signatures.
-        uint256 signaturesSize = uint256(numSigners) * 65;
-        uint256 extraDataOffset = 1 + signaturesSize;
+        /// @dev Extract the extraData from the decryptionProof1 + 65 * numSigners.
         uint256 extraDataSize = decryptionProof.length - extraDataOffset;
-
         bytes memory extraData = new bytes(extraDataSize);
         for (uint i = 0; i < extraDataSize; i++) {
             extraData[i] = decryptionProof[extraDataOffset + i];

--- a/host-contracts/contracts/KMSVerifier.sol
+++ b/host-contracts/contracts/KMSVerifier.sol
@@ -53,11 +53,13 @@ contract KMSVerifier is UUPSUpgradeableEmptyProxy, Ownable2StepUpgradeable, EIP7
         bytes32[] ctHandles;
         /// @notice The decrypted result of the public decryption.
         bytes decryptedResult;
+        /// @notice Generic bytes metadata for versioned payloads.
+        bytes extraData;
     }
 
     /// @notice Decryption result type.
     string public constant EIP712_PUBLIC_DECRYPT_TYPE =
-        "PublicDecryptVerification(bytes32[] ctHandles,bytes decryptedResult)";
+        "PublicDecryptVerification(bytes32[] ctHandles,bytes decryptedResult,bytes extraData)";
 
     /// @notice Decryption result typehash.
     bytes32 public constant DECRYPTION_RESULT_TYPEHASH = keccak256(bytes(EIP712_PUBLIC_DECRYPT_TYPE));
@@ -169,18 +171,41 @@ contract KMSVerifier is UUPSUpgradeableEmptyProxy, Ownable2StepUpgradeable, EIP7
      * @dev                     Calls verifySignaturesDigest internally.
      * @param handlesList       The list of handles, which where requested to be decrypted.
      * @param decryptedResult   A bytes array representing the abi-encoding of all requested decrypted values.
-     * @param signatures        An array of signatures to verify.
+     * @param decryptionProof   Decryption proof containing KMS signatures and extra data.
      * @return isVerified       true if enough provided signatures are valid, false otherwise.
      */
     function verifyDecryptionEIP712KMSSignatures(
         bytes32[] memory handlesList,
         bytes memory decryptedResult,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public virtual returns (bool) {
-        PublicDecryptVerification memory decRes;
-        decRes.ctHandles = handlesList;
-        decRes.decryptedResult = decryptedResult;
-        bytes32 digest = _hashDecryptionResult(decRes);
+        /// @dev The decryptionProof is the numSigners + signatureKMSSigners + extraData (1 + 65 * numSigners + extraData bytes)
+        uint256 numSigners = uint256(uint8(decryptionProof[0]));
+        bytes[] memory signatures = new bytes[](numSigners);
+        for (uint256 j = 0; j < numSigners; j++) {
+            signatures[j] = new bytes(65);
+            for (uint256 i = 0; i < 65; i++) {
+                signatures[j][i] = decryptionProof[1 + 65 * j + i];
+            }
+        }
+
+        /// @dev The extraData is the rest of the decryptionProof bytes after the numSigners + signatures.
+        uint256 signaturesSize = uint256(numSigners) * 65;
+        uint256 extraDataOffset = 1 + signaturesSize;
+        uint256 extraDataSize = decryptionProof.length - extraDataOffset;
+
+        bytes memory extraData = new bytes(extraDataSize);
+        for (uint i = 0; i < extraDataSize; i++) {
+            extraData[i] = decryptionProof[extraDataOffset + i];
+        }
+
+        PublicDecryptVerification memory publicDecryptVerification = PublicDecryptVerification(
+            handlesList,
+            decryptedResult,
+            extraData
+        );
+        bytes32 digest = _hashDecryptionResult(publicDecryptVerification);
+
         return _verifySignaturesDigest(digest, signatures);
     }
 
@@ -330,7 +355,8 @@ contract KMSVerifier is UUPSUpgradeableEmptyProxy, Ownable2StepUpgradeable, EIP7
                     abi.encode(
                         DECRYPTION_RESULT_TYPEHASH,
                         keccak256(abi.encodePacked(decRes.ctHandles)),
-                        keccak256(decRes.decryptedResult)
+                        keccak256(decRes.decryptedResult),
+                        keccak256(abi.encodePacked(decRes.extraData))
                     )
                 )
             );

--- a/host-contracts/examples/TestAsyncDecrypt.sol
+++ b/host-contracts/examples/TestAsyncDecrypt.sol
@@ -82,9 +82,9 @@ contract TestAsyncDecrypt {
     function callbackBoolInfinite(
         uint256 requestID,
         bool decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (bool) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         uint256 i = 0;
         while (true) {
             i++;
@@ -109,8 +109,8 @@ contract TestAsyncDecrypt {
     }
 
     /// @notice Callback function for boolean decryption
-    function callbackBool(uint256 requestID, bool decryptedInput, bytes[] memory signatures) public returns (bool) {
-        FHE.checkSignatures(requestID, signatures);
+    function callbackBool(uint256 requestID, bool decryptedInput, bytes memory decryptionProof) public returns (bool) {
+        FHE.checkSignatures(requestID, decryptionProof);
         yBool = decryptedInput;
         return yBool;
     }
@@ -132,9 +132,14 @@ contract TestAsyncDecrypt {
 
     /// @notice Callback function for 8-bit unsigned integer decryption
     /// @param decryptedInput The decrypted 8-bit unsigned integer
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     /// @return The decrypted value
-    function callbackUint8(uint256 requestID, uint8 decryptedInput, bytes[] memory signatures) public returns (uint8) {
-        FHE.checkSignatures(requestID, signatures);
+    function callbackUint8(
+        uint256 requestID,
+        uint8 decryptedInput,
+        bytes memory decryptionProof
+    ) public returns (uint8) {
+        FHE.checkSignatures(requestID, decryptionProof);
         yUint8 = decryptedInput;
         return decryptedInput;
     }
@@ -156,13 +161,14 @@ contract TestAsyncDecrypt {
 
     /// @notice Callback function for 16-bit unsigned integer decryption
     /// @param decryptedInput The decrypted 16-bit unsigned integer
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     /// @return The decrypted value
     function callbackUint16(
         uint256 requestID,
         uint16 decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (uint16) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yUint16 = decryptedInput;
         return decryptedInput;
     }
@@ -189,13 +195,14 @@ contract TestAsyncDecrypt {
     /// @notice Callback function for 32-bit unsigned integer decryption
     /// @param requestID The ID of the decryption request
     /// @param decryptedInput The decrypted 32-bit unsigned integer
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     /// @return The result of the computation
     function callbackUint32(
         uint256 requestID,
         uint32 decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (uint32) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         uint256[] memory params = getParamsUint256(requestID);
         unchecked {
             uint32 result = uint32(uint256(params[0])) + uint32(uint256(params[1])) + decryptedInput;
@@ -231,13 +238,14 @@ contract TestAsyncDecrypt {
 
     /// @notice Callback function for 64-bit unsigned integer decryption
     /// @param decryptedInput The decrypted 64-bit unsigned integer
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     /// @return The decrypted value
     function callbackUint64(
         uint256 requestID,
         uint64 decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (uint64) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yUint64 = decryptedInput;
         return decryptedInput;
     }
@@ -258,9 +266,9 @@ contract TestAsyncDecrypt {
     function callbackUint128(
         uint256 requestID,
         uint128 decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (uint128) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yUint128 = decryptedInput;
         return decryptedInput;
     }
@@ -281,9 +289,9 @@ contract TestAsyncDecrypt {
     function callbackUint256(
         uint256 requestID,
         uint256 decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (uint256) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yUint256 = decryptedInput;
         return decryptedInput;
     }
@@ -306,14 +314,15 @@ contract TestAsyncDecrypt {
     /// @notice Callback function for multiple address decryption
     /// @param decryptedInput1 The first decrypted address
     /// @param decryptedInput2 The second decrypted address
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     /// @return The first decrypted address
     function callbackAddresses(
         uint256 requestID,
         address decryptedInput1,
         address decryptedInput2,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (address) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yAddress = decryptedInput1;
         yAddress2 = decryptedInput2;
         return decryptedInput1;
@@ -329,13 +338,14 @@ contract TestAsyncDecrypt {
 
     /// @notice Callback function for address decryption
     /// @param decryptedInput The decrypted address
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     /// @return The decrypted address
     function callbackAddress(
         uint256 requestID,
         address decryptedInput,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public returns (address) {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yAddress = decryptedInput;
         return decryptedInput;
     }
@@ -360,16 +370,16 @@ contract TestAsyncDecrypt {
     /// @param decAddress Decrypted address
     /// @param decEuint32 Decrypted 32-bit unsigned integer
     /// @param decEuint256 Decrypted 256-bit unsigned integer
-    /// @param signatures Signatures to verify the authenticity of the decryption
+    /// @param decryptionProof The decryption proof containing KMS signatures and extra data
     function callbackMixed(
         uint256 requestID,
         bool decBool,
         address decAddress,
         uint32 decEuint32,
         uint256 decEuint256,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yBool = decBool;
         yAddress = decAddress;
         yUint32 = decEuint32;

--- a/host-contracts/examples/TestInput.sol
+++ b/host-contracts/examples/TestInput.sol
@@ -28,8 +28,8 @@ contract TestInput {
         FHE.requestDecryption(cts, this.callbackUint64.selector);
     }
 
-    function callbackUint64(uint256 requestID, uint64 decryptedInput, bytes[] memory signatures) public {
-        FHE.checkSignatures(requestID, signatures);
+    function callbackUint64(uint256 requestID, uint64 decryptedInput, bytes memory decryptionProof) public {
+        FHE.checkSignatures(requestID, decryptionProof);
         yUint64 = decryptedInput;
     }
 
@@ -54,9 +54,9 @@ contract TestInput {
         bool decryptedBool,
         uint8 decryptedUint8,
         address decryptedAddress,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) public {
-        FHE.checkSignatures(requestID, signatures);
+        FHE.checkSignatures(requestID, decryptionProof);
         yBool = decryptedBool;
         yUint8 = decryptedUint8;
         yAddress = decryptedAddress;

--- a/host-contracts/lib/FHE.sol
+++ b/host-contracts/lib/FHE.sol
@@ -7783,6 +7783,7 @@ library FHE {
     function select(ebool control, ebool a, ebool b) internal returns (ebool) {
         return ebool.wrap(Impl.select(ebool.unwrap(control), ebool.unwrap(a), ebool.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7790,6 +7791,7 @@ library FHE {
     function select(ebool control, euint8 a, euint8 b) internal returns (euint8) {
         return euint8.wrap(Impl.select(ebool.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7797,6 +7799,7 @@ library FHE {
     function select(ebool control, euint16 a, euint16 b) internal returns (euint16) {
         return euint16.wrap(Impl.select(ebool.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7804,6 +7807,7 @@ library FHE {
     function select(ebool control, euint32 a, euint32 b) internal returns (euint32) {
         return euint32.wrap(Impl.select(ebool.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7811,6 +7815,7 @@ library FHE {
     function select(ebool control, euint64 a, euint64 b) internal returns (euint64) {
         return euint64.wrap(Impl.select(ebool.unwrap(control), euint64.unwrap(a), euint64.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7818,6 +7823,7 @@ library FHE {
     function select(ebool control, euint128 a, euint128 b) internal returns (euint128) {
         return euint128.wrap(Impl.select(ebool.unwrap(control), euint128.unwrap(a), euint128.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7825,6 +7831,7 @@ library FHE {
     function select(ebool control, eaddress a, eaddress b) internal returns (eaddress) {
         return eaddress.wrap(Impl.select(ebool.unwrap(control), eaddress.unwrap(a), eaddress.unwrap(b)));
     }
+
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7832,6 +7839,7 @@ library FHE {
     function select(ebool control, euint256 a, euint256 b) internal returns (euint256) {
         return euint256.wrap(Impl.select(ebool.unwrap(control), euint256.unwrap(a), euint256.unwrap(b)));
     }
+
     /**
      * @dev Casts an encrypted integer from 'euint16' to 'euint8'.
      */

--- a/host-contracts/lib/FHE.sol
+++ b/host-contracts/lib/FHE.sol
@@ -14,7 +14,7 @@ interface IKMSVerifier {
     function verifyDecryptionEIP712KMSSignatures(
         bytes32[] memory handlesList,
         bytes memory decryptedResult,
-        bytes[] memory signatures
+        bytes memory decryptionProof
     ) external returns (bool);
 }
 
@@ -7783,7 +7783,6 @@ library FHE {
     function select(ebool control, ebool a, ebool b) internal returns (ebool) {
         return ebool.wrap(Impl.select(ebool.unwrap(control), ebool.unwrap(a), ebool.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7791,7 +7790,6 @@ library FHE {
     function select(ebool control, euint8 a, euint8 b) internal returns (euint8) {
         return euint8.wrap(Impl.select(ebool.unwrap(control), euint8.unwrap(a), euint8.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7799,7 +7797,6 @@ library FHE {
     function select(ebool control, euint16 a, euint16 b) internal returns (euint16) {
         return euint16.wrap(Impl.select(ebool.unwrap(control), euint16.unwrap(a), euint16.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7807,7 +7804,6 @@ library FHE {
     function select(ebool control, euint32 a, euint32 b) internal returns (euint32) {
         return euint32.wrap(Impl.select(ebool.unwrap(control), euint32.unwrap(a), euint32.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7815,7 +7811,6 @@ library FHE {
     function select(ebool control, euint64 a, euint64 b) internal returns (euint64) {
         return euint64.wrap(Impl.select(ebool.unwrap(control), euint64.unwrap(a), euint64.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7823,7 +7818,6 @@ library FHE {
     function select(ebool control, euint128 a, euint128 b) internal returns (euint128) {
         return euint128.wrap(Impl.select(ebool.unwrap(control), euint128.unwrap(a), euint128.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7831,7 +7825,6 @@ library FHE {
     function select(ebool control, eaddress a, eaddress b) internal returns (eaddress) {
         return eaddress.wrap(Impl.select(ebool.unwrap(control), eaddress.unwrap(a), eaddress.unwrap(b)));
     }
-
     /**
      * @dev If 'control's value is 'true', the result has the same value as 'ifTrue'.
      *      If 'control's value is 'false', the result has the same value as 'ifFalse'.
@@ -7839,7 +7832,6 @@ library FHE {
     function select(ebool control, euint256 a, euint256 b) internal returns (euint256) {
         return euint256.wrap(Impl.select(ebool.unwrap(control), euint256.unwrap(a), euint256.unwrap(b)));
     }
-
     /**
      * @dev Casts an encrypted integer from 'euint16' to 'euint8'.
      */
@@ -8924,9 +8916,9 @@ library FHE {
      * @dev     otherwise fake decryption results could be submitted.
      * @notice  Warning: MUST be called directly in the callback function called by the relayer.
      */
-    function checkSignatures(uint256 requestID, bytes[] memory signatures) internal {
+    function checkSignatures(uint256 requestID, bytes memory decryptionProof) internal {
         bytes32[] memory handlesList = loadRequestedHandles(requestID);
-        bool isVerified = verifySignatures(handlesList, signatures);
+        bool isVerified = verifySignatures(handlesList, decryptionProof);
         if (!isVerified) {
             revert InvalidKMSSignatures();
         }
@@ -8948,7 +8940,7 @@ library FHE {
      * @dev Private low-level function used to extract the decryptedResult bytes array and verify the KMS signatures.
      * @notice  Warning: MUST be called directly in the callback function called by the relayer.
      */
-    function verifySignatures(bytes32[] memory handlesList, bytes[] memory signatures) private returns (bool) {
+    function verifySignatures(bytes32[] memory handlesList, bytes memory decryptionProof) private returns (bool) {
         uint256 start = 4 + 32; // start position after skipping the selector (4 bytes) and the first argument (index, 32 bytes)
         uint256 length = getSignedDataLength(handlesList);
         bytes memory decryptedResult = new bytes(length);
@@ -8960,7 +8952,7 @@ library FHE {
             IKMSVerifier($.KMSVerifierAddress).verifyDecryptionEIP712KMSSignatures(
                 handlesList,
                 decryptedResult,
-                signatures
+                decryptionProof
             );
     }
 
@@ -8978,7 +8970,6 @@ library FHE {
                 revert UnsupportedHandleType();
             }
         }
-        signedDataLength += 32; // add offset of signatures
         return signedDataLength;
     }
 

--- a/host-contracts/test/asyncDecrypt.ts
+++ b/host-contracts/test/asyncDecrypt.ts
@@ -1,7 +1,8 @@
+import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import dotenv from 'dotenv';
 import { Signer } from 'ethers';
 import fs from 'fs';
-import { ethers, hardhatArguments as hre, network } from 'hardhat';
+import { ethers, network } from 'hardhat';
 
 import { getRequiredEnvVar } from '../tasks/utils/loadVariables';
 import { DecryptionOracle } from '../types';
@@ -109,7 +110,6 @@ const fulfillAllPastRequestsIds = async (mocked: boolean) => {
     const handles = event.args[2];
     const contractCaller = event.args[3];
     const callbackSelector = event.args[4];
-    const typesList = handles.map((handle) => parseInt(handle.toString(16).slice(-4, -2), 16));
     // if request is not already fulfilled
     if (mocked && !toSkip.includes(requestID)) {
       // in mocked mode, we trigger the decryption fulfillment manually
@@ -124,29 +124,33 @@ const fulfillAllPastRequestsIds = async (mocked: boolean) => {
       if (!allTrue(isAllowedForDec)) {
         throw new Error('Some handle is not authorized for decryption');
       }
-      const values = await Promise.all(handles.map(async (handle: string) => await getClearText(handle)));
 
       const abiCoder = new ethers.AbiCoder();
-      let encodedData;
-      let decryptedResult;
+      const values = await Promise.all(handles.map(async (handle: string) => await getClearText(handle)));
+      const decryptedResult = abiCoder.encode(Array(values.length).fill('uint256'), values); // since ebytesXXX were deprecated, all cleartexts are native static types, i.e encoding works as if they were all uint256 types, and the selector already takes into account correct underlying types
+      const extraDataV0: string = ethers.solidityPacked(['uint8'], [0]);
 
-      encodedData = abiCoder.encode(
-        ['uint256', ...Array(values.length).fill('uint256'), 'bytes[]'],
-        [31, ...values, []],
-      ); // 31 is just a dummy uint256 requestID to get correct abi encoding for the remaining arguments (i.e everything except the requestID)
-      // + adding also a dummy empty array of bytes for correct abi-encoding when used with signatures
-      decryptedResult = '0x' + encodedData.slice(66).slice(0, -64); // we pop the dummy requestID to get the correct value to pass for `decryptedCts` + we also pop the last 32 bytes (empty bytes[])
+      const decryptResultsEIP712signatures: string[] = await computeDecryptSignatures(
+        handles,
+        decryptedResult,
+        extraDataV0,
+      );
 
-      const decryptResultsEIP712signatures = await computeDecryptSignatures(handles, decryptedResult);
+      // Build the decryptionProof as numSigners + KMS signatures + extraData
+      const packedNumSigners = ethers.solidityPacked(['uint8'], [decryptResultsEIP712signatures.length]);
+      const packedSignatures = ethers.solidityPacked(
+        Array(decryptResultsEIP712signatures.length).fill('bytes'),
+        decryptResultsEIP712signatures,
+      );
+      const decryptionProof = ethers.concat([packedNumSigners, packedSignatures, extraDataV0]);
 
       const calldata =
         callbackSelector +
         abiCoder
           .encode(
-            ['uint256', ...Array(values.length).fill('uint256'), 'bytes[]'],
-            [requestID, ...values, decryptResultsEIP712signatures],
+            ['uint256', ...Array(values.length).fill('uint256'), 'bytes'],
+            [requestID, ...values, decryptionProof],
           )
-
           .slice(2);
 
       const txData = {
@@ -169,20 +173,29 @@ const fulfillAllPastRequestsIds = async (mocked: boolean) => {
   }
 };
 
-async function computeDecryptSignatures(handlesList: string[], decryptedResult: string): Promise<string[]> {
+async function computeDecryptSignatures(
+  handlesList: string[],
+  decryptedResult: string,
+  extraData: string,
+): Promise<string[]> {
   const signatures: string[] = [];
 
   let signers = await getKMSSigners();
 
   for (let idx = 0; idx < signers.length; idx++) {
     const kmsSigner = signers[idx];
-    const signature = await kmsSign(handlesList, decryptedResult, kmsSigner);
+    const signature = await kmsSign(handlesList, decryptedResult, extraData, kmsSigner);
     signatures.push(signature);
   }
   return signatures;
 }
 
-async function kmsSign(handlesList: string[], decryptedResult: string, kmsSigner: Wallet) {
+async function kmsSign(
+  handlesList: string[],
+  decryptedResult: string,
+  extraData: string,
+  kmsSigner: HardhatEthersSigner,
+) {
   const decAdd = process.env.DECRYPTION_ADDRESS;
   const chainId = process.env.CHAIN_ID_GATEWAY;
 
@@ -203,11 +216,16 @@ async function kmsSign(handlesList: string[], decryptedResult: string, kmsSigner
         name: 'decryptedResult',
         type: 'bytes',
       },
+      {
+        name: 'extraData',
+        type: 'bytes',
+      },
     ],
   };
   const message = {
     ctHandles: handlesList,
-    decryptedResult: decryptedResult,
+    decryptedResult,
+    extraData,
   };
 
   const signature = await kmsSigner.signTypedData(domain, types, message);

--- a/host-contracts/test/kmsVerifier/kmsVerifier.t.sol
+++ b/host-contracts/test/kmsVerifier/kmsVerifier.t.sol
@@ -426,7 +426,7 @@ contract KMSVerifierTest is Test {
     }
 
     /**
-     * @dev Tests that the verification of EIP-712 KMS signatures fails as expected when invalid signature is added.
+     * @dev Tests that the verification of EIP-712 KMS signatures fails as expected when no signer is added.
      */
     function test_VerifyInputEIP712KMSSignaturesFailAsExpectedIfNoSignerAdded() public {
         _upgradeProxyWithSigners(1);

--- a/host-contracts/test/kmsVerifier/kmsVerifier.t.sol
+++ b/host-contracts/test/kmsVerifier/kmsVerifier.t.sol
@@ -57,13 +57,15 @@ contract KMSVerifierTest is Test {
      */
     function _computeDigest(
         bytes32[] memory handlesList,
-        bytes memory decryptedResult
+        bytes memory decryptedResult,
+        bytes memory extraData
     ) internal view returns (bytes32) {
         bytes32 structHash = keccak256(
             abi.encode(
                 kmsVerifier.DECRYPTION_RESULT_TYPEHASH(),
                 keccak256(abi.encodePacked(handlesList)),
-                keccak256(decryptedResult)
+                keccak256(decryptedResult),
+                keccak256(abi.encodePacked(extraData))
             )
         );
 
@@ -379,13 +381,16 @@ contract KMSVerifierTest is Test {
         bytes32[] memory handlesList = _generateMockHandlesList(3);
 
         bytes memory decryptedResult = abi.encodePacked(keccak256("test"), keccak256("test"), keccak256("test"));
+        bytes memory extraData = abi.encodePacked(uint8(0));
         bytes[] memory signatures = new bytes[](2);
 
-        bytes32 digest = _computeDigest(handlesList, decryptedResult);
+        bytes32 digest = _computeDigest(handlesList, decryptedResult, extraData);
         signatures[0] = _computeSignature(privateKeySigner1, digest);
         signatures[1] = _computeSignature(privateKeySigner2, digest);
 
-        assertTrue(kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures));
+        assertTrue(
+            kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures, extraData)
+        );
     }
 
     /**
@@ -396,6 +401,7 @@ contract KMSVerifierTest is Test {
         bytes32[] memory handlesList = _generateMockHandlesList(3);
 
         bytes memory decryptedResult = abi.encodePacked(keccak256("test"), keccak256("test"), keccak256("test"));
+        bytes memory extraData = abi.encodePacked(uint8(0));
         bytes[] memory signatures = new bytes[](3);
 
         bytes32 invalidDigest = bytes32("420");
@@ -404,7 +410,7 @@ contract KMSVerifierTest is Test {
         signatures[1] = _computeSignature(privateKeySigner2, invalidDigest);
 
         vm.expectPartialRevert(KMSVerifier.KMSInvalidSigner.selector);
-        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures);
+        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures, extraData);
     }
 
     /**
@@ -418,15 +424,16 @@ contract KMSVerifierTest is Test {
         handlesList[2] = bytes32(uint256(323));
 
         bytes memory decryptedResult = abi.encodePacked(keccak256("test"), keccak256("test"), keccak256("test"));
+        bytes memory extraData = abi.encodePacked(uint8(0));
         bytes[] memory signatures = new bytes[](3);
 
-        bytes32 digest = _computeDigest(handlesList, decryptedResult);
+        bytes32 digest = _computeDigest(handlesList, decryptedResult, extraData);
 
         signatures[0] = _computeSignature(privateKeySigner1, digest);
         signatures[1] = _computeSignature(privateKeySigner2, digest);
 
         vm.expectPartialRevert(KMSVerifier.KMSInvalidSigner.selector);
-        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures);
+        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures, extraData);
     }
 
     /**
@@ -438,10 +445,11 @@ contract KMSVerifierTest is Test {
         bytes32[] memory handlesList = _generateMockHandlesList(3);
 
         bytes memory decryptedResult = abi.encodePacked(keccak256("test"), keccak256("test"), keccak256("test"));
+        bytes memory extraData = abi.encodePacked(uint8(0));
         bytes[] memory signatures = new bytes[](0);
 
         vm.expectPartialRevert(KMSVerifier.KMSZeroSignature.selector);
-        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures);
+        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures, extraData);
     }
 
     /**
@@ -458,13 +466,14 @@ contract KMSVerifierTest is Test {
         /// @dev Mock data for testing purposes.
         bytes32[] memory handlesList = _generateMockHandlesList(3);
         bytes memory decryptedResult = abi.encodePacked(keccak256("test"), keccak256("test"), keccak256("test"));
+        bytes memory extraData = abi.encodePacked(uint8(0));
         bytes[] memory signatures = new bytes[](1);
 
-        bytes32 digest = _computeDigest(handlesList, decryptedResult);
+        bytes32 digest = _computeDigest(handlesList, decryptedResult, extraData);
         signatures[0] = _computeSignature(privateKeySigner1, digest);
 
         vm.expectPartialRevert(KMSVerifier.KMSSignatureThresholdNotReached.selector);
-        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures);
+        kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures, extraData);
     }
 
     /**
@@ -481,12 +490,15 @@ contract KMSVerifierTest is Test {
         /// @dev Mock data for testing purposes.
         bytes32[] memory handlesList = _generateMockHandlesList(3);
         bytes memory decryptedResult = abi.encodePacked(keccak256("test"), keccak256("test"), keccak256("test"));
+        bytes memory extraData = abi.encodePacked(uint8(0));
         bytes[] memory signatures = new bytes[](2);
 
-        bytes32 digest = _computeDigest(handlesList, decryptedResult);
+        bytes32 digest = _computeDigest(handlesList, decryptedResult, extraData);
         signatures[0] = _computeSignature(privateKeySigner1, digest);
         signatures[1] = _computeSignature(privateKeySigner1, digest);
 
-        assertFalse(kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures));
+        assertFalse(
+            kmsVerifier.verifyDecryptionEIP712KMSSignatures(handlesList, decryptedResult, signatures, extraData)
+        );
     }
 }


### PR DESCRIPTION
Note that this PR not only introduces the `extraData` field at the `KMSVerifier` but also refactors its `verifyDecryptionEIP712KMSSignatures` method to receive a `bytes decryptionProof` argument containing `number of signers + KMS signatures + extra data`. This refactor is based on the changes requested in the [Add ERC-7995 PR](https://github.com/ethereum/ERCs/pull/1143/files#diff-05bcded41894aaf6a46d15840fd9d378934b820bda8e59c22b0dcfec9fe667a2R342)

Closes https://github.com/zama-ai/fhevm-internal/issues/298