### PR TITLE
chore(test-suite): update relayer-sdk for contractsChainId changes

### DIFF
--- a/test-suite/e2e/package-lock.json
+++ b/test-suite/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@fhevm/solidity": "^0.7.0-5",
         "@openzeppelin/contracts": "^5.3.0",
-        "@zama-fhe/relayer-sdk": "^v0.2.0-0",
+        "@zama-fhe/relayer-sdk": "github:zama-ai/relayer-sdk#89d4d733d7ae2a8d2ae825a1b75f706185810e2a",
         "bigint-buffer": "^1.1.5",
         "dotenv": "^16.0.3"
       },
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.2.0-0",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.2.0-0.tgz",
-      "integrity": "sha512-o1bRsllcxhN+mvenC5d8mkbk+E6UgrpWxQHPsBOHuKpZuqOSbw0fiFwq8d4k0VlgtM0jb4AfN/Vu3AMTwi6LDQ==",
+      "version": "0.2.0-3",
+      "resolved": "git+ssh://git@github.com/zama-ai/relayer-sdk.git#89d4d733d7ae2a8d2ae825a1b75f706185810e2a",
+      "integrity": "sha512-fZJntYG/68pxy/KsrjHyWTTc8pfoBEkzfFzg+W85jDl5gJJd+SKCCwKnlMQ8A3S6RCYuKPQmhuA/6aoJ8tgaMw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",
@@ -2097,9 +2097,9 @@
         "fetch-retry": "^6.0.0",
         "keccak": "^3.0.4",
         "node-tfhe": "1.3.0",
-        "node-tkms": "0.11.0-rc20",
+        "node-tkms": "0.11.0-24",
         "tfhe": "1.3.0",
-        "tkms": "0.11.0-rc20",
+        "tkms": "0.11.0-24",
         "wasm-feature-detect": "^1.8.0"
       },
       "bin": {
@@ -5746,9 +5746,9 @@
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/node-tkms": {
-      "version": "0.11.0-rc20",
-      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-rc20.tgz",
-      "integrity": "sha512-Ez9Tnl1WQQ5+3jBTriu9t8K096zgND58R9lH8OSYPGjovNVSmYcvmCawVxz4y1fw2V3Q28JjNnqi6T/I98zeqA==",
+      "version": "0.11.0-24",
+      "resolved": "https://registry.npmjs.org/node-tkms/-/node-tkms-0.11.0-24.tgz",
+      "integrity": "sha512-b2Dn/fwvJJHdLSrbiEB+ljTE9/2rqgS/ky9nlh/v79wRiP15EamozmHIq7P7+4oHCwT7s3lSo6NZgyxu8uEmFw==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/nofilter": {
@@ -7523,9 +7523,9 @@
       }
     },
     "node_modules/tkms": {
-      "version": "0.11.0-rc20",
-      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-rc20.tgz",
-      "integrity": "sha512-TH+D1Oy78qntx2n6DYu1+qt0zl+5o6peL87SZM4xDHFinx8uyeNUNTyFt+ytOlDYF0aaOMumtYp5/6BlrI7AiA==",
+      "version": "0.11.0-24",
+      "resolved": "https://registry.npmjs.org/tkms/-/tkms-0.11.0-24.tgz",
+      "integrity": "sha512-4xAHDgXvDdQmBv2OzFtTGQO+N6+UHCJ2qFST4W20mTz4I6bxcTwxy+bdG4/p+j9dmV6+32M7/C7ihYcJxhG/wA==",
       "license": "BSD-3-Clause-Clear"
     },
     "node_modules/tmp": {

--- a/test-suite/e2e/package.json
+++ b/test-suite/e2e/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@fhevm/solidity": "^0.7.0-5",
     "@openzeppelin/contracts": "^5.3.0",
-    "@zama-fhe/relayer-sdk": "^0.2.0-0",
+    "@zama-fhe/relayer-sdk": "github:zama-ai/relayer-sdk#89d4d733d7ae2a8d2ae825a1b75f706185810e2a",
     "bigint-buffer": "^1.1.5",
     "dotenv": "^16.0.3"
   }


### PR DESCRIPTION
using : 
- relayer-sdk : [this PR](https://github.com/zama-ai/relayer-sdk/pull/299/files) , using commit `89d4d733d7ae2a8d2ae825a1b75f706185810e2a`

Note: for now, relayer-sdk does not have a proper way of handling changes for different fhevm versions, so we include the commit as a dependency for e2e tests to pass, until we have a proper release for fhevm 0.8

e2e tests are green : https://github.com/zama-ai/fhevm/actions/runs/16751676619/job/47423313465

refs https://github.com/zama-ai/fhevm-internal/issues/326