### PR TITLE
fix(coprocessor): do not expand  an empty compact ct list

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -8776,6 +8776,7 @@ dependencies = [
  "hex",
  "lru 0.13.0",
  "rand 0.9.1",
+ "serial_test",
  "sha3",
  "sqlx",
  "test-harness",

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -256,10 +256,10 @@ where
                     let handles = row
                         .handles
                         .ok_or(anyhow::anyhow!("handles field is None"))?;
-                    if handles.is_empty() || handles.len() % 32 != 0 {
+                    if handles.len() % 32 != 0 {
                         error!(
                             handles_len = handles.len(),
-                            "Bad handles field, len is 0 or not divisible by 32"
+                            "Bad handles field, len is not divisible by 32"
                         );
                         self.remove_proof_by_id(row.zk_proof_id).await?;
                         continue;

--- a/coprocessor/fhevm-engine/zkproof-worker/Cargo.toml
+++ b/coprocessor/fhevm-engine/zkproof-worker/Cargo.toml
@@ -31,6 +31,7 @@ fhevm-engine-common = { path = "../fhevm-engine-common" }
 nightly-avx512 = ["tfhe/nightly-avx512"]
 
 [dev-dependencies]
+serial_test = { workspace = true }
 test-harness = { path = "../test-harness" }
 
 [[bin]]

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -372,6 +372,12 @@ fn try_verify_and_expand_ciphertext_list(
             keys.pks.parameters(), &keys.public_params,
         ))?;
 
+    // TODO: Make sure we don't try to verify and expand an empty list as it would panic with the current version of tfhe-rs.
+    // Could be removed in the future if tfhe-rs is updated to handle empty lists gracefully.
+    if the_list.is_empty() {
+        return Ok(vec![]);
+    }
+
     let expanded: tfhe::CompactCiphertextListExpander = the_list
         .verify_and_expand(&keys.public_params, &keys.pks, &aux_data_bytes)
         .map_err(|err| ExecutionError::InvalidProof(request_id, err.to_string()))?;


### PR DESCRIPTION
Current version of tfhe-rs panics when trying to expand and verify an empty compact ciphertext list. We add a check to avoid this if the list is empty.

We consider an empty list to be a valid empty input (with the ZK proof verified in the future when tfhe-rs is updated).

Future versions of tfhe-rs may handle this gracefully, in which case we can remove this check.

Add a test to verify that an empty compact ciphertext list does not cause a panic.

Thanks to @IceTDrinker for proposing this fix.