### PR TITLE
fix(coprocessor): limit the count of inputs in a single zkproof batch

### DIFF
--- a/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
@@ -9,6 +9,10 @@ use std::io;
 use fhevm_engine_common::types::FhevmError;
 use thiserror::Error;
 
+/// The highest index of an input is 254,
+/// cause 255 (0xff) is reserved for handles originating from the FHE operations
+pub const MAX_INPUT_INDEX: u8 = u8::MAX - 1;
+
 #[derive(Error, Debug)]
 pub enum ExecutionError {
     #[error("Database error: {0}")]
@@ -46,6 +50,9 @@ pub enum ExecutionError {
 
     #[error("JoinError error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+
+    #[error("Too many inputs: {0}")]
+    TooManyInputs(usize),
 }
 
 #[derive(Default, Debug, Clone)]

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -1,6 +1,8 @@
 use serial_test::serial;
 use test_harness::db_utils::ACL_CONTRACT_ADDR;
 
+use crate::MAX_INPUT_INDEX;
+
 mod utils;
 
 #[tokio::test]
@@ -11,7 +13,7 @@ async fn test_verify_proof() {
     // Generate Valid ZkPok
     let aux: (crate::auxiliary::ZkData, [u8; 92]) =
         utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
-    let zk_pok = utils::generate_zk_pok(&pool, &aux.1).await;
+    let zk_pok = utils::generate_sample_zk_pok(&pool, &aux.1).await;
     // Insert ZkPok into database
     let request_id_valid = utils::insert_proof(&pool, 101, &zk_pok, &aux.0)
         .await
@@ -54,4 +56,48 @@ async fn test_verify_empty_input_list() {
     assert!(utils::is_valid(&pool, request_id, max_retries)
         .await
         .unwrap());
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_max_input_index() {
+    let (db, _instance) = utils::setup().await.expect("valid setup");
+
+    let aux: (crate::auxiliary::ZkData, [u8; 92]) =
+        utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
+
+    // Ensure this fails because we exceed the MAX_INPUT_INDEX constraint
+    let inputs = vec![utils::ZkInput::U8(1); MAX_INPUT_INDEX as usize + 2];
+
+    assert!(!utils::is_valid(
+        &db,
+        utils::insert_proof(
+            &db,
+            101,
+            &utils::generate_zk_pok_with_inputs(&db, &aux.1, &inputs).await,
+            &aux.0
+        )
+        .await
+        .expect("valid db insert"),
+        50
+    )
+    .await
+    .expect("non-expired db query"));
+
+    // Test with highest number of inputs - 255
+    let inputs = vec![utils::ZkInput::U64(2); MAX_INPUT_INDEX as usize + 1];
+    assert!(utils::is_valid(
+        &db,
+        utils::insert_proof(
+            &db,
+            102,
+            &utils::generate_zk_pok_with_inputs(&db, &aux.1, &inputs).await,
+            &aux.0
+        )
+        .await
+        .expect("valid db insert"),
+        500
+    )
+    .await
+    .expect("non-expired db query"));
 }

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
@@ -45,6 +45,7 @@ pub async fn setup() -> anyhow::Result<(sqlx::PgPool, DBInstance)> {
     Ok((pool, test_instance))
 }
 
+/// Checks if the proof is valid by querying the database continuously.
 pub(crate) async fn is_valid(
     pool: &sqlx::PgPool,
     zk_proof_id: i64,
@@ -68,7 +69,20 @@ pub(crate) async fn is_valid(
     Ok(false)
 }
 
-pub(crate) async fn generate_zk_pok(pool: &sqlx::PgPool, aux_data: &[u8]) -> Vec<u8> {
+#[derive(Debug, Clone)]
+pub(crate) enum ZkInput {
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+}
+
+pub(crate) async fn generate_zk_pok_with_inputs(
+    pool: &sqlx::PgPool,
+    aux_data: &[u8],
+    inputs: &[ZkInput],
+) -> Vec<u8> {
     let keys: Vec<tenant_keys::TfheTenantKeys> =
         tenant_keys::query_tenant_keys(vec![1], pool, true)
             .await
@@ -79,15 +93,18 @@ pub(crate) async fn generate_zk_pok(pool: &sqlx::PgPool, aux_data: &[u8]) -> Vec
             .unwrap();
     let keys = &keys[0];
 
-    println!("Building list");
     let mut builder = tfhe::ProvenCompactCiphertextList::builder(&keys.pks);
+    for v in inputs {
+        match *v {
+            ZkInput::Bool(b) => builder.push(b),
+            ZkInput::U8(x) => builder.push(x),
+            ZkInput::U16(x) => builder.push(x),
+            ZkInput::U32(x) => builder.push(x),
+            ZkInput::U64(x) => builder.push(x),
+        };
+    }
+
     let the_list = builder
-        .push(false)
-        .push(1u8)
-        .push(2u16)
-        .push(3u32)
-        .push(4u64)
-        .push(5u64)
         .build_with_proof_packed(
             &keys.public_params,
             aux_data,
@@ -98,27 +115,20 @@ pub(crate) async fn generate_zk_pok(pool: &sqlx::PgPool, aux_data: &[u8]) -> Vec
     safe_serialize(&the_list)
 }
 
+pub(crate) async fn generate_sample_zk_pok(pool: &sqlx::PgPool, aux_data: &[u8]) -> Vec<u8> {
+    let inputs = vec![
+        ZkInput::Bool(true),
+        ZkInput::U8(42),
+        ZkInput::U16(12345),
+        ZkInput::U32(67890),
+        ZkInput::U64(1234567890),
+    ];
+    generate_zk_pok_with_inputs(pool, aux_data, &inputs).await
+}
+
 pub(crate) async fn generate_empty_input_list(pool: &sqlx::PgPool, aux_data: &[u8]) -> Vec<u8> {
-    let keys: Vec<tenant_keys::TfheTenantKeys> =
-        tenant_keys::query_tenant_keys(vec![1], pool, true)
-            .await
-            .map_err(|e| {
-                let e: Box<dyn std::error::Error> = e;
-                e
-            })
-            .unwrap();
-    let keys = &keys[0];
-
-    let builder = tfhe::ProvenCompactCiphertextList::builder(&keys.pks);
-    let the_list = builder
-        .build_with_proof_packed(
-            &keys.public_params,
-            aux_data,
-            tfhe::zk::ZkComputeLoad::Proof,
-        )
-        .unwrap();
-
-    safe_serialize(&the_list)
+    let inputs = Vec::new();
+    generate_zk_pok_with_inputs(pool, aux_data, &inputs).await
 }
 
 pub(crate) async fn insert_proof(


### PR DESCRIPTION
Since the input index is stored as a u8 in the handle bytes, and we reserve 0xFF to mark handles originating from a FHE operation, the maximum valid input index is 254. This means a single batch can contain up to 255 inputs.

ref: https://github.com/zama-ai/fhevm-internal/issues/266