### PR TITLE
feat(kms-connector): add db polling backup

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/config/parsed.rs
+++ b/kms-connector/crates/kms-worker/src/core/config/parsed.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub database_url: String,
     /// The size of the database connection pool.
     pub database_pool_size: u32,
+    /// The timeout for polling the database for events.
+    pub database_polling_timeout: Duration,
     /// The Gateway RPC endpoint.
     pub gateway_url: String,
     /// The KMS Core endpoint.
@@ -98,6 +100,8 @@ impl Config {
             return Err(Error::EmptyField("KMS Core endpoint".to_string()));
         }
 
+        let database_polling_timeout =
+            Duration::from_secs(raw_config.database_polling_timeout_secs);
         let public_decryption_timeout =
             Duration::from_secs(raw_config.public_decryption_timeout_secs);
         let user_decryption_timeout = Duration::from_secs(raw_config.user_decryption_timeout_secs);
@@ -108,6 +112,7 @@ impl Config {
         Ok(Self {
             database_url: raw_config.database_url,
             database_pool_size: raw_config.database_pool_size,
+            database_polling_timeout,
             gateway_url: raw_config.gateway_url,
             kms_core_endpoint: raw_config.kms_core_endpoint,
             chain_id: raw_config.chain_id,

--- a/kms-connector/crates/kms-worker/src/core/config/raw.rs
+++ b/kms-connector/crates/kms-worker/src/core/config/raw.rs
@@ -26,6 +26,8 @@ pub struct RawConfig {
     pub database_url: String,
     #[serde(default = "default_database_pool_size")]
     pub database_pool_size: u32,
+    #[serde(default = "default_database_polling_timeout_secs")]
+    pub database_polling_timeout_secs: u64,
     pub gateway_url: String,
     pub kms_core_endpoint: String,
     pub chain_id: u64,
@@ -65,6 +67,10 @@ fn default_service_name() -> String {
 
 fn default_database_pool_size() -> u32 {
     16
+}
+
+fn default_database_polling_timeout_secs() -> u64 {
+    5
 }
 
 fn default_events_batch_size() -> u8 {
@@ -107,6 +113,7 @@ impl Default for RawConfig {
         Self {
             database_url: "postgres://postgres:postgres@localhost".to_string(),
             database_pool_size: 16,
+            database_polling_timeout_secs: default_database_polling_timeout_secs(),
             gateway_url: "ws://localhost:8545".to_string(),
             kms_core_endpoint: "http://localhost:50052".to_string(),
             chain_id: 1,

--- a/kms-connector/crates/kms-worker/src/core/event_picker.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_picker.rs
@@ -1,8 +1,17 @@
-use crate::monitoring::metrics::{EVENT_RECEIVED_COUNTER, EVENT_RECEIVED_ERRORS};
+use std::time::Duration;
+
+use crate::{
+    core::Config,
+    monitoring::metrics::{EVENT_RECEIVED_COUNTER, EVENT_RECEIVED_ERRORS},
+};
 use anyhow::anyhow;
 use connector_utils::types::GatewayEvent;
-use sqlx::{Pool, Postgres, postgres::PgListener};
-use tracing::{debug, info, warn};
+use sqlx::{
+    Pool, Postgres,
+    postgres::{PgListener, PgNotification},
+};
+use tokio::select;
+use tracing::{debug, info};
 
 /// Interface used to pick Gateway's events from some storage.
 pub trait EventPicker {
@@ -30,23 +39,37 @@ pub struct DbEventPicker {
 
     /// The limit number of events to fetch from the database.
     events_batch_size: u8,
+
+    /// The timeout for polling the database for events.
+    polling_timeout: Duration,
 }
 
 impl DbEventPicker {
-    pub fn new(db_pool: Pool<Postgres>, db_listener: PgListener, events_batch_size: u8) -> Self {
+    pub fn new(
+        db_pool: Pool<Postgres>,
+        db_listener: PgListener,
+        events_batch_size: u8,
+        polling_timeout: Duration,
+    ) -> Self {
         Self {
             db_pool,
             db_listener,
             events_batch_size,
+            polling_timeout,
         }
     }
 
-    pub async fn connect(db_pool: Pool<Postgres>, events_batch_size: u8) -> anyhow::Result<Self> {
+    pub async fn connect(db_pool: Pool<Postgres>, config: &Config) -> anyhow::Result<Self> {
         let db_listener = PgListener::connect_with(&db_pool)
             .await
             .map_err(|e| anyhow!("Failed to init Postgres Listener: {e}"))?;
 
-        let mut event_picker = DbEventPicker::new(db_pool, db_listener, events_batch_size);
+        let mut event_picker = DbEventPicker::new(
+            db_pool,
+            db_listener,
+            config.events_batch_size,
+            config.database_polling_timeout,
+        );
         event_picker
             .listen()
             .await
@@ -71,44 +94,63 @@ impl EventPicker for DbEventPicker {
 
     async fn pick_events(&mut self) -> anyhow::Result<Vec<Self::Event>> {
         loop {
-            // Wait for notification
-            let notification = self.db_listener.recv().await?;
-            info!("Received Postgres notification: {}", notification.channel());
-
-            let query_result = match notification.channel() {
-                PUBLIC_DECRYPT_NOTIFICATION => self.pick_public_decryption_requests().await,
-                USER_DECRYPT_NOTIFICATION => self.pick_user_decryption_requests().await,
-                PRE_KEYGEN_NOTIFICATION => self.pick_pre_keygen_requests().await,
-                PRE_KSKGEN_NOTIFICATION => self.pick_pre_kskgen_requests().await,
-                KEYGEN_NOTIFICATION => self.pick_keygen_requests().await,
-                KSKGEN_NOTIFICATION => self.pick_kskgen_requests().await,
-                CRSGEN_NOTIFICATION => self.pick_crsgen_requests().await,
-                channel => {
-                    warn!("Unexpected notification: {channel}");
-                    continue;
-                }
+            let events = select! {
+                notification = self.db_listener.recv() => {
+                    let notification = notification?;
+                    info!("Received Postgres notification: {}", notification.channel());
+                    self.pick_notified_events(notification)
+                        .await
+                        .inspect_err(|_| EVENT_RECEIVED_ERRORS.inc())?
+                },
+                _ = tokio::time::sleep(self.polling_timeout) => {
+                    debug!("Polling timeout, rechecking for events");
+                    self.pick_any_events().await.inspect_err(|_| EVENT_RECEIVED_ERRORS.inc())?
+                },
             };
 
-            match query_result {
-                Ok(events) => {
-                    if events.is_empty() {
-                        debug!("Events have already been picked");
-                        continue;
-                    }
-                    info!("Picked {} events successfully", events.len());
-                    EVENT_RECEIVED_COUNTER.inc_by(events.len() as u64);
-                    return Ok(events);
-                }
-                Err(err) => {
-                    EVENT_RECEIVED_ERRORS.inc();
-                    return Err(err.into());
-                }
+            if events.is_empty() {
+                debug!("Events have already been picked");
+                continue;
+            } else {
+                info!("Picked {} events successfully", events.len());
+                EVENT_RECEIVED_COUNTER.inc_by(events.len() as u64);
+                return Ok(events);
             }
         }
     }
 }
 
 impl DbEventPicker {
+    async fn pick_notified_events(
+        &self,
+        notification: PgNotification,
+    ) -> anyhow::Result<Vec<GatewayEvent>> {
+        match notification.channel() {
+            PUBLIC_DECRYPT_NOTIFICATION => self.pick_public_decryption_requests().await,
+            USER_DECRYPT_NOTIFICATION => self.pick_user_decryption_requests().await,
+            PRE_KEYGEN_NOTIFICATION => self.pick_pre_keygen_requests().await,
+            PRE_KSKGEN_NOTIFICATION => self.pick_pre_kskgen_requests().await,
+            KEYGEN_NOTIFICATION => self.pick_keygen_requests().await,
+            KSKGEN_NOTIFICATION => self.pick_kskgen_requests().await,
+            CRSGEN_NOTIFICATION => self.pick_crsgen_requests().await,
+            channel => return Err(anyhow!("Unexpected notification: {channel}")),
+        }
+        .map_err(anyhow::Error::from)
+    }
+
+    async fn pick_any_events(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+        Ok([
+            self.pick_public_decryption_requests().await?,
+            self.pick_user_decryption_requests().await?,
+            self.pick_pre_keygen_requests().await?,
+            self.pick_pre_kskgen_requests().await?,
+            self.pick_keygen_requests().await?,
+            self.pick_kskgen_requests().await?,
+            self.pick_crsgen_requests().await?,
+        ]
+        .concat())
+    }
+
     async fn pick_public_decryption_requests(&self) -> sqlx::Result<Vec<GatewayEvent>> {
         sqlx::query(
             "

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -100,8 +100,7 @@ impl KmsWorker<DbEventPicker, DbEventProcessor<GatewayProvider>, DbKmsResponsePu
         let kms_client = KmsClient::connect(&config).await?;
         let kms_health_client = KmsHealthClient::connect(&config.kms_core_endpoint).await?;
 
-        let event_picker =
-            DbEventPicker::connect(db_pool.clone(), config.events_batch_size).await?;
+        let event_picker = DbEventPicker::connect(db_pool.clone(), &config).await?;
 
         let s3_service = S3Service::new(&config, provider.clone());
         let decryption_processor = DecryptionProcessor::new(&config, s3_service);

--- a/kms-connector/crates/kms-worker/tests/event_picker/parallel.rs
+++ b/kms-connector/crates/kms-worker/tests/event_picker/parallel.rs
@@ -6,15 +6,16 @@ use connector_utils::{
     types::{GatewayEvent, db::SnsCiphertextMaterialDbItem},
 };
 use fhevm_gateway_rust_bindings::decryption::Decryption::PublicDecryptionRequest;
-use kms_worker::core::{DbEventPicker, EventPicker};
+use kms_worker::core::{Config, DbEventPicker, EventPicker};
 use tokio::time::timeout;
 
 #[tokio::test]
 async fn test_parallel_event_picker_one_events() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker0 = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
-    let mut event_picker1 = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let config = Config::default();
+    let mut event_picker0 = DbEventPicker::connect(test_instance.db().clone(), &config).await?;
+    let mut event_picker1 = DbEventPicker::connect(test_instance.db().clone(), &config).await?;
 
     let id0 = U256::ZERO;
     let sns_ct = vec![rand_sns_ct()];
@@ -56,8 +57,12 @@ async fn test_parallel_event_picker_one_events() -> anyhow::Result<()> {
 async fn test_parallel_event_picker_two_events() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker0 = DbEventPicker::connect(test_instance.db().clone(), 1).await?;
-    let mut event_picker1 = DbEventPicker::connect(test_instance.db().clone(), 1).await?;
+    let config = Config {
+        events_batch_size: 1,
+        ..Default::default()
+    };
+    let mut event_picker0 = DbEventPicker::connect(test_instance.db().clone(), &config).await?;
+    let mut event_picker1 = DbEventPicker::connect(test_instance.db().clone(), &config).await?;
 
     let id0 = U256::ZERO;
     let id1 = U256::ONE;

--- a/kms-connector/crates/kms-worker/tests/event_picker/simple.rs
+++ b/kms-connector/crates/kms-worker/tests/event_picker/simple.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use connector_utils::{
     tests::{
         rand::{rand_address, rand_digest, rand_public_key, rand_sns_ct, rand_u256},
@@ -12,13 +14,14 @@ use fhevm_gateway_rust_bindings::{
         PreprocessKskgenRequest,
     },
 };
-use kms_worker::core::{DbEventPicker, EventPicker};
+use kms_worker::core::{Config, DbEventPicker, EventPicker};
 
 #[tokio::test]
 async fn test_pick_public_decryption() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let decryption_id = rand_u256();
     let sns_ct = vec![rand_sns_ct()];
@@ -55,7 +58,8 @@ async fn test_pick_public_decryption() -> anyhow::Result<()> {
 async fn test_pick_user_decryption() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let decryption_id = rand_u256();
     let sns_ct = vec![rand_sns_ct()];
@@ -98,7 +102,8 @@ async fn test_pick_user_decryption() -> anyhow::Result<()> {
 async fn test_pick_preprocess_keygen() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let pre_keygen_request_id = rand_u256();
     let fhe_params_digest = rand_digest();
@@ -131,7 +136,8 @@ async fn test_pick_preprocess_keygen() -> anyhow::Result<()> {
 async fn test_pick_preprocess_kskgen() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let pre_kskgen_request_id = rand_u256();
     let fhe_params_digest = rand_digest();
@@ -164,7 +170,8 @@ async fn test_pick_preprocess_kskgen() -> anyhow::Result<()> {
 async fn test_pick_keygen() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let pre_key_id = rand_u256();
     let fhe_params_digest = rand_digest();
@@ -197,7 +204,8 @@ async fn test_pick_keygen() -> anyhow::Result<()> {
 async fn test_pick_kskgen() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let pre_ksk_id = rand_u256();
     let source_key_id = rand_u256();
@@ -236,7 +244,8 @@ async fn test_pick_kskgen() -> anyhow::Result<()> {
 async fn test_pick_crsgen() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), 10).await?;
+    let mut event_picker =
+        DbEventPicker::connect(test_instance.db().clone(), &Config::default()).await?;
 
     let crsgen_request_id = rand_u256();
     let fhe_params_digest = rand_digest();
@@ -259,6 +268,46 @@ async fn test_pick_crsgen() -> anyhow::Result<()> {
         vec![GatewayEvent::Crsgen(CrsgenRequest {
             crsgenRequestId: crsgen_request_id,
             fheParamsDigest: fhe_params_digest,
+        })]
+    );
+    println!("Data OK!");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_polling_backup() -> anyhow::Result<()> {
+    let test_instance = TestInstanceBuilder::db_setup().await?;
+
+    let decryption_id = rand_u256();
+    let sns_ct = vec![rand_sns_ct()];
+    let sns_ciphertexts_db = sns_ct
+        .iter()
+        .map(SnsCiphertextMaterialDbItem::from)
+        .collect::<Vec<SnsCiphertextMaterialDbItem>>();
+    println!("Inserting PublicDecryptionRequest before starting the event picker...");
+    sqlx::query!(
+        "INSERT INTO public_decryption_requests VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        decryption_id.as_le_slice(),
+        sns_ciphertexts_db as Vec<SnsCiphertextMaterialDbItem>,
+    )
+    .execute(test_instance.db())
+    .await?;
+
+    let config = Config {
+        database_polling_timeout: Duration::from_millis(500),
+        ..Default::default()
+    };
+    let mut event_picker = DbEventPicker::connect(test_instance.db().clone(), &config).await?;
+
+    println!("Picking PublicDecryptionRequest...");
+    let events = event_picker.pick_events().await?;
+
+    println!("Checking PublicDecryptionRequest data...");
+    assert_eq!(
+        events,
+        vec![GatewayEvent::PublicDecryption(PublicDecryptionRequest {
+            decryptionId: decryption_id,
+            snsCtMaterials: sns_ct,
         })]
     );
     println!("Data OK!");

--- a/kms-connector/crates/tx-sender/src/core/config/parsed.rs
+++ b/kms-connector/crates/tx-sender/src/core/config/parsed.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub database_url: String,
     /// The size of the database connection pool.
     pub database_pool_size: u32,
+    /// The timeout for polling the database for responses.
+    pub database_polling_timeout: Duration,
     /// The Gateway RPC endpoint.
     pub gateway_url: String,
     /// The Chain ID of the Gateway.
@@ -91,12 +93,15 @@ impl Config {
             ));
         }
 
+        let database_polling_timeout =
+            Duration::from_secs(raw_config.database_polling_timeout_secs);
         let tx_retry_interval = Duration::from_millis(raw_config.tx_retry_interval_ms);
         let healthcheck_timeout = Duration::from_secs(raw_config.healthcheck_timeout_secs);
 
         Ok(Self {
             database_url: raw_config.database_url,
             database_pool_size: raw_config.database_pool_size,
+            database_polling_timeout,
             gateway_url: raw_config.gateway_url,
             chain_id: raw_config.chain_id,
             decryption_contract,

--- a/kms-connector/crates/tx-sender/src/core/config/raw.rs
+++ b/kms-connector/crates/tx-sender/src/core/config/raw.rs
@@ -15,6 +15,8 @@ pub struct RawConfig {
     pub database_url: String,
     #[serde(default = "default_database_pool_size")]
     pub database_pool_size: u32,
+    #[serde(default = "default_database_polling_timeout_secs")]
+    pub database_polling_timeout_secs: u64,
     pub gateway_url: String,
     pub chain_id: u64,
     pub decryption_contract: RawContractConfig,
@@ -47,6 +49,10 @@ fn default_database_pool_size() -> u32 {
     16
 }
 
+fn default_database_polling_timeout_secs() -> u64 {
+    5
+}
+
 fn default_tx_retries() -> u8 {
     3
 }
@@ -71,6 +77,7 @@ impl Default for RawConfig {
         Self {
             database_url: "postgres://postgres:postgres@localhost".to_string(),
             database_pool_size: default_database_pool_size(),
+            database_polling_timeout_secs: default_database_polling_timeout_secs(),
             gateway_url: "ws://localhost:8545".to_string(),
             chain_id: 1,
             decryption_contract: RawContractConfig {

--- a/kms-connector/crates/tx-sender/src/core/kms_response_picker.rs
+++ b/kms-connector/crates/tx-sender/src/core/kms_response_picker.rs
@@ -1,9 +1,16 @@
-use crate::monitoring::metrics::{RESPONSE_RECEIVED_COUNTER, RESPONSE_RECEIVED_ERRORS};
+use crate::{
+    core::Config,
+    monitoring::metrics::{RESPONSE_RECEIVED_COUNTER, RESPONSE_RECEIVED_ERRORS},
+};
 use anyhow::anyhow;
 use connector_utils::types::KmsResponse;
-use sqlx::{Pool, Postgres, postgres::PgListener};
-use std::future::Future;
-use tracing::{debug, info, warn};
+use sqlx::{
+    Pool, Postgres,
+    postgres::{PgListener, PgNotification},
+};
+use std::{future::Future, time::Duration};
+use tokio::select;
+use tracing::{debug, info};
 
 /// Interface used to pick KMS Core's responses from some storage.
 pub trait KmsResponsePicker {
@@ -24,24 +31,37 @@ pub struct DbKmsResponsePicker {
 
     /// The maximum number of responses to fetch at once.
     responses_batch_size: u8,
+
+    /// The timeout for polling the database for responses.
+    polling_timeout: Duration,
 }
 
 impl DbKmsResponsePicker {
-    pub fn new(db_pool: Pool<Postgres>, db_listener: PgListener, response_batch_size: u8) -> Self {
+    pub fn new(
+        db_pool: Pool<Postgres>,
+        db_listener: PgListener,
+        response_batch_size: u8,
+        polling_timeout: Duration,
+    ) -> Self {
         Self {
             db_pool,
             db_listener,
             responses_batch_size: response_batch_size,
+            polling_timeout,
         }
     }
 
-    pub async fn connect(db_pool: Pool<Postgres>, response_batch_size: u8) -> anyhow::Result<Self> {
+    pub async fn connect(db_pool: Pool<Postgres>, config: &Config) -> anyhow::Result<Self> {
         let db_listener = PgListener::connect_with(&db_pool)
             .await
             .map_err(|e| anyhow!("Failed to init Postgres Listener: {e}"))?;
 
-        let mut response_picker =
-            DbKmsResponsePicker::new(db_pool, db_listener, response_batch_size);
+        let mut response_picker = DbKmsResponsePicker::new(
+            db_pool,
+            db_listener,
+            config.responses_batch_size,
+            config.database_polling_timeout,
+        );
         response_picker
             .listen()
             .await
@@ -59,39 +79,53 @@ impl DbKmsResponsePicker {
 impl KmsResponsePicker for DbKmsResponsePicker {
     async fn pick_responses(&mut self) -> anyhow::Result<Vec<KmsResponse>> {
         loop {
-            // Wait for notification
-            let notification = self.db_listener.recv().await?;
-            info!("Received Postgres notification: {}", notification.channel());
-
-            let query_result = match notification.channel() {
-                PUBLIC_DECRYPT_NOTIFICATION => self.pick_public_decryption_responses().await,
-                USER_DECRYPT_NOTIFICATION => self.pick_user_decryption_responses().await,
-                channel => {
-                    warn!("Unexpected notification: {channel}");
-                    continue;
-                }
+            let responses = select! {
+                notification = self.db_listener.recv() => {
+                    let notification = notification?;
+                    info!("Received Postgres notification: {}", notification.channel());
+                    self.pick_notified_responses(notification)
+                        .await
+                        .inspect_err(|_| RESPONSE_RECEIVED_ERRORS.inc())?
+                },
+                _ = tokio::time::sleep(self.polling_timeout) => {
+                    debug!("Polling timeout, rechecking for responses");
+                    self.pick_any_responses().await.inspect_err(|_| RESPONSE_RECEIVED_ERRORS.inc())?
+                },
             };
 
-            match query_result {
-                Ok(responses) => {
-                    if responses.is_empty() {
-                        debug!("Responses have already been picked");
-                        continue;
-                    }
-                    info!("Picked {} responses successfully", responses.len());
-                    RESPONSE_RECEIVED_COUNTER.inc_by(responses.len() as u64);
-                    return Ok(responses);
-                }
-                Err(err) => {
-                    RESPONSE_RECEIVED_ERRORS.inc();
-                    return Err(err.into());
-                }
+            if responses.is_empty() {
+                debug!("Responses have already been picked");
+                continue;
+            } else {
+                info!("Picked {} responses successfully", responses.len());
+                RESPONSE_RECEIVED_COUNTER.inc_by(responses.len() as u64);
+                return Ok(responses);
             }
         }
     }
 }
 
 impl DbKmsResponsePicker {
+    async fn pick_notified_responses(
+        &self,
+        notification: PgNotification,
+    ) -> anyhow::Result<Vec<KmsResponse>> {
+        match notification.channel() {
+            PUBLIC_DECRYPT_NOTIFICATION => self.pick_public_decryption_responses().await,
+            USER_DECRYPT_NOTIFICATION => self.pick_user_decryption_responses().await,
+            channel => return Err(anyhow!("Unexpected notification: {channel}")),
+        }
+        .map_err(anyhow::Error::from)
+    }
+
+    async fn pick_any_responses(&self) -> anyhow::Result<Vec<KmsResponse>> {
+        Ok([
+            self.pick_public_decryption_responses().await?,
+            self.pick_user_decryption_responses().await?,
+        ]
+        .concat())
+    }
+
     async fn pick_public_decryption_responses(&self) -> sqlx::Result<Vec<KmsResponse>> {
         sqlx::query(
             "

--- a/kms-connector/crates/tx-sender/src/core/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/core/tx_sender.rs
@@ -102,8 +102,7 @@ impl TransactionSender<DbKmsResponsePicker, WalletGatewayProvider, DbKmsResponse
     /// Creates a new `TransactionSender` instance from a valid `Config`.
     pub async fn from_config(config: Config) -> anyhow::Result<(Self, State)> {
         let db_pool = connect_to_db(&config.database_url, config.database_pool_size).await?;
-        let response_picker =
-            DbKmsResponsePicker::connect(db_pool.clone(), config.responses_batch_size).await?;
+        let response_picker = DbKmsResponsePicker::connect(db_pool.clone(), &config).await?;
         let response_remover = DbKmsResponseRemover::new(db_pool.clone());
 
         let provider = connect_to_gateway_with_wallet(&config.gateway_url, config.wallet).await?;

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -15,7 +15,8 @@ use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tx_sender::core::{
-    DbKmsResponsePicker, DbKmsResponseRemover, TransactionSender, tx_sender::TransactionSenderInner,
+    Config, DbKmsResponsePicker, DbKmsResponseRemover, TransactionSender,
+    tx_sender::TransactionSenderInner,
 };
 
 #[rstest]
@@ -173,7 +174,8 @@ async fn start_test_tx_sender(
     test_instance: &TestInstance,
     cancel_token: CancellationToken,
 ) -> anyhow::Result<JoinHandle<()>> {
-    let response_picker = DbKmsResponsePicker::connect(test_instance.db().clone(), 10).await?;
+    let response_picker =
+        DbKmsResponsePicker::connect(test_instance.db().clone(), &Config::default().await).await?;
     let response_remover = DbKmsResponseRemover::new(test_instance.db().clone());
 
     let tx_sender_inner = TransactionSenderInner::new(

--- a/kms-connector/crates/tx-sender/tests/response_picker.rs
+++ b/kms-connector/crates/tx-sender/tests/response_picker.rs
@@ -1,14 +1,17 @@
 mod common;
 
+use std::time::Duration;
+
 use common::{insert_rand_public_decrypt_response, insert_rand_user_decrypt_response};
 use connector_utils::tests::setup::TestInstanceBuilder;
-use tx_sender::core::{DbKmsResponsePicker, KmsResponsePicker};
+use tx_sender::core::{Config, DbKmsResponsePicker, KmsResponsePicker};
 
 #[tokio::test]
 async fn test_pick_public_decryption() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut response_picker = DbKmsResponsePicker::connect(test_instance.db().clone(), 1).await?;
+    let mut response_picker =
+        DbKmsResponsePicker::connect(test_instance.db().clone(), &Config::default().await).await?;
 
     println!("Triggering Postgres notification with PublicDecryptionResponse insertion...");
     let inserted_response = insert_rand_public_decrypt_response(test_instance.db()).await?;
@@ -26,10 +29,31 @@ async fn test_pick_public_decryption() -> anyhow::Result<()> {
 async fn test_pick_user_decryption() -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    let mut response_picker = DbKmsResponsePicker::connect(test_instance.db().clone(), 1).await?;
+    let mut response_picker =
+        DbKmsResponsePicker::connect(test_instance.db().clone(), &Config::default().await).await?;
 
     println!("Triggering Postgres notification with UserDecryptionResponse insertion...");
     let inserted_response = insert_rand_user_decrypt_response(test_instance.db()).await?;
+    println!("Picking UserDecryptionResponse...");
+    let responses = response_picker.pick_responses().await?;
+
+    println!("Checking UserDecryptionResponse data...");
+    assert_eq!(responses[0], inserted_response);
+    println!("Data OK!");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_polling_backup() -> anyhow::Result<()> {
+    let test_instance = TestInstanceBuilder::db_setup().await?;
+
+    println!("Inserting UserDecryptionResponse before starting the picker...");
+    let inserted_response = insert_rand_user_decrypt_response(test_instance.db()).await?;
+
+    let mut config = Config::default().await;
+    config.database_polling_timeout = Duration::from_millis(500);
+    let mut response_picker =
+        DbKmsResponsePicker::connect(test_instance.db().clone(), &config).await?;
     println!("Picking UserDecryptionResponse...");
     let responses = response_picker.pick_responses().await?;
 


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/341

Note: E2E are passing locally, but I can't show it on CI as the input of the workflow does not allow different versions for the connector services, and only two of them have been modified