### PR TITLE
fix(kms-connector): upgrade slab version for security

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -6383,9 +6383,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Upgrade `slab` due to new CVE being detected (see https://github.com/zama-ai/fhevm/actions/runs/16905409735/job/47893929250?pr=711 for instance)