### PR TITLE
fix(coprocessor): transaction-sender, dedup check_provider_connection

### DIFF
--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -481,10 +481,4 @@ where
     fn provider(&self) -> &P {
         self.provider.inner()
     }
-
-    async fn check_provider_connection(&self) -> anyhow::Result<()> {
-        // Simple check to verify the provider is connected
-        let _ = self.provider.get_block_number().await?;
-        Ok(())
-    }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -355,10 +355,4 @@ where
     fn provider(&self) -> &P {
         self.provider.inner()
     }
-
-    async fn check_provider_connection(&self) -> anyhow::Result<()> {
-        // Simple check to verify the provider is connected
-        let _ = self.provider.get_block_number().await?;
-        Ok(())
-    }
 }


### PR DESCRIPTION
use the trait default implementation