### PR TITLE
feat(coprocessor): add metrics in txn-sender

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -7929,6 +7929,7 @@ dependencies = [
  "foundry-compilers",
  "futures-util",
  "humantime",
+ "prometheus",
  "rand 0.9.1",
  "rstest",
  "semver 1.0.26",

--- a/coprocessor/fhevm-engine/transaction-sender/Cargo.toml
+++ b/coprocessor/fhevm-engine/transaction-sender/Cargo.toml
@@ -13,6 +13,7 @@ aws-config = { workspace = true }
 aws-sdk-kms = { workspace = true }
 clap = { workspace = true }
 futures-util = { workspace = true }
+prometheus = { workspace = true }
 rand = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -107,9 +107,9 @@ struct Conf {
     #[arg(long, default_value = "4s", value_parser = parse_duration)]
     provider_retry_interval: Duration,
 
-    /// HTTP server port for health checks
-    #[arg(long, default_value_t = 8080)]
-    health_check_port: u16,
+    /// HTTP server port
+    #[arg(long, alias = "health-check-port", default_value_t = 8080)]
+    http_server_port: u16,
 
     #[arg(long, default_value = "4s", value_parser = parse_duration)]
     health_check_timeout: Duration,
@@ -229,7 +229,7 @@ async fn main() -> anyhow::Result<()> {
         txn_receipt_timeout_secs: conf.txn_receipt_timeout_secs,
         required_txn_confirmations: conf.required_txn_confirmations,
         review_after_unlimited_retries: conf.review_after_unlimited_retries,
-        health_check_port: conf.health_check_port,
+        http_server_port: conf.http_server_port,
         health_check_timeout: conf.health_check_timeout,
         gas_limit_overprovision_percent: conf.gas_limit_overprovision_percent,
     };
@@ -250,16 +250,16 @@ async fn main() -> anyhow::Result<()> {
 
     let http_server = HttpServer::new(
         transaction_sender.clone(),
-        conf.health_check_port,
+        conf.http_server_port,
         cancel_token.clone(),
     );
 
     install_signal_handlers(cancel_token.clone())?;
 
     info!(
-        health_check_port = conf.health_check_port,
+        http_server_port = conf.http_server_port,
         conf = ?config,
-        "Transaction sender and HTTP health check server starting"
+        "Transaction sender and HTTP server starting"
     );
 
     // Run both services concurrently

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -30,8 +30,8 @@ pub struct ConfigSettings {
 
     pub review_after_unlimited_retries: u16,
 
-    // Health check related settings
-    pub health_check_port: u16,
+    pub http_server_port: u16,
+
     pub health_check_timeout: Duration,
 
     pub gas_limit_overprovision_percent: u32,
@@ -59,7 +59,7 @@ impl Default for ConfigSettings {
             txn_receipt_timeout_secs: 10,
             required_txn_confirmations: 0,
             review_after_unlimited_retries: 30,
-            health_check_port: 8080,
+            http_server_port: 8080,
             health_check_timeout: Duration::from_secs(4),
             gas_limit_overprovision_percent: 120,
         }

--- a/coprocessor/fhevm-engine/transaction-sender/src/http_server.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/http_server.rs
@@ -64,6 +64,7 @@ impl<P: Provider<Ethereum> + Clone + Send + Sync + 'static> HttpServer<P> {
         let app = Router::new()
             .route("/healthz", get(health_handler))
             .route("/liveness", get(liveness_handler))
+            .route("/metrics", get(metrics_handler))
             .with_state(self.sender.clone());
 
         let addr = SocketAddr::from(([0, 0, 0, 0], self.port));
@@ -113,4 +114,13 @@ async fn liveness_handler<P: Provider<Ethereum> + Clone + Send + Sync + 'static>
             "status": "alive"
         })),
     )
+}
+
+async fn metrics_handler() -> impl IntoResponse {
+    let encoder = prometheus::TextEncoder::new();
+    let metric_families = prometheus::gather();
+    match encoder.encode_to_string(&metric_families) {
+        Ok(encoded_metrics) => (StatusCode::OK, encoded_metrics),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod http_server;
+mod metrics;
 mod nonce_managed_provider;
 mod ops;
 pub mod overprovision_gas_limit;

--- a/coprocessor/fhevm-engine/transaction-sender/src/metrics.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/metrics.rs
@@ -1,0 +1,52 @@
+use prometheus::{register_int_counter, IntCounter};
+use std::sync::LazyLock;
+
+pub(crate) static VERIFY_PROOF_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_txn_sender_verify_proof_success_counter",
+        "Number of successful verify or reject proof txns in transaction-sender"
+    )
+    .unwrap()
+});
+
+pub(crate) static VERIFY_PROOF_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_txn_sender_verify_proof_fail_counter",
+        "Number of failed verify or reject proof txns requests in transaction-sender"
+    )
+    .unwrap()
+});
+
+pub(crate) static ADD_CIPHERTEXT_MATERIAL_SUCCESS_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| {
+        register_int_counter!(
+            "coprocessor_txn_sender_add_ciphertext_material_success_counter",
+            "Number of successful add ciphertext material txns in transaction-sender"
+        )
+        .unwrap()
+    });
+
+pub(crate) static ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| {
+        register_int_counter!(
+            "coprocessor_txn_sender_add_ciphertext_material_fail_counter",
+            "Number of failed add ciphertext material txns requests in transaction-sender"
+        )
+        .unwrap()
+    });
+
+pub(crate) static ALLOW_HANDLE_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_txn_sender_allow_handle_success_counter",
+        "Number of successful allow handle txns in transaction-sender"
+    )
+    .unwrap()
+});
+
+pub(crate) static ALLOW_HANDLE_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_txn_sender_allow_handle_fail_counter",
+        "Number of failed allow handle txns requests in transaction-sender"
+    )
+    .unwrap()
+});

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
 use crate::{
+    metrics::{ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER, ADD_CIPHERTEXT_MATERIAL_SUCCESS_COUNTER},
     nonce_managed_provider::NonceManagedProvider,
-    overprovision_gas_limit::try_overprovision_gas_limit, REVIEW,
+    overprovision_gas_limit::try_overprovision_gas_limit,
+    REVIEW,
 };
 
 use super::common::try_into_array;
@@ -77,6 +79,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
                 if matches!(&e, RpcError::Transport(inner) if inner.is_retry_err() || matches!(inner, TransportErrorKind::BackendGone))
                     || matches!(&e, RpcError::LocalUsageError(_)) =>
             {
+                ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER.inc();
                 warn!(
                     transaction_request = ?overprovisioned_txn_req,
                     error = %e,
@@ -95,6 +98,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
                 );
             }
             Err(e) => {
+                ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER.inc();
                 warn!(
                     transaction_request = ?overprovisioned_txn_req,
                     error = %e,
@@ -123,6 +127,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
         {
             Ok(receipt) => receipt,
             Err(e) => {
+                ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER.inc();
                 error!(error = %e, "Getting receipt failed");
                 self.increment_txn_limited_retries_count(
                     handle,
@@ -146,7 +151,9 @@ impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
                 handle = h,
                 "addCiphertext txn succeeded"
             );
+            ADD_CIPHERTEXT_MATERIAL_SUCCESS_COUNTER.inc();
         } else {
+            ADD_CIPHERTEXT_MATERIAL_FAIL_COUNTER.inc();
             error!(
                 transaction_hash = %receipt.transaction_hash,
                 status = receipt.status(),

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -5,8 +5,11 @@ use std::{
 };
 
 use crate::{
-    nonce_managed_provider::NonceManagedProvider, ops::common::try_into_array,
-    overprovision_gas_limit::try_overprovision_gas_limit, REVIEW,
+    metrics::{ALLOW_HANDLE_FAIL_COUNTER, ALLOW_HANDLE_SUCCESS_COUNTER},
+    nonce_managed_provider::NonceManagedProvider,
+    ops::common::try_into_array,
+    overprovision_gas_limit::try_overprovision_gas_limit,
+    REVIEW,
 };
 
 use super::TransactionOperation;
@@ -103,6 +106,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
                 if matches!(&e, RpcError::Transport(inner) if inner.is_retry_err() || matches!(inner, TransportErrorKind::BackendGone))
                     || matches!(&e, RpcError::LocalUsageError(_)) =>
             {
+                ALLOW_HANDLE_FAIL_COUNTER.inc();
                 warn!(
                     transaction_request = ?overprovisioned_txn_req,
                     error = %e,
@@ -121,6 +125,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
                 );
             }
             Err(e) => {
+                ALLOW_HANDLE_FAIL_COUNTER.inc();
                 warn!(
                     transaction_request = ?overprovisioned_txn_req,
                     error = %e,
@@ -149,6 +154,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
         {
             Ok(receipt) => receipt,
             Err(e) => {
+                ALLOW_HANDLE_FAIL_COUNTER.inc();
                 error!(error = %e, "Getting receipt failed");
                 self.increment_txn_limited_retries_count(
                     key,
@@ -173,7 +179,9 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
                 key = %key,
                 "Allow txn succeeded"
             );
+            ALLOW_HANDLE_SUCCESS_COUNTER.inc();
         } else {
+            ALLOW_HANDLE_FAIL_COUNTER.inc();
             error!(
                 transaction_hash = %receipt.transaction_hash,
                 status = receipt.status(),

--- a/test-suite/fhevm/config/prometheus/prometheus.yml
+++ b/test-suite/fhevm/config/prometheus/prometheus.yml
@@ -6,4 +6,4 @@ scrape_configs:
   - job_name: 'kms-connector'
 
     static_configs:
-      - targets: ['kms-connector-gw-listener:9100', 'kms-connector-kms-worker:9100', 'kms-connector-tx-sender:9100']
+      - targets: ['kms-connector-gw-listener:9100', 'kms-connector-kms-worker:9100', 'kms-connector-tx-sender:9100', 'transaction-sender:8080']


### PR DESCRIPTION
Wire the metrics handler into the existing HTTP server under `/metrics`.

Rename the `health-check-port` argument to `http-server-port`, but keep `health-check-port` as an alias for backwards compatibility.