### PR TITLE
docs(common): changed definitions to public decrypt and user decrypt

### DIFF
--- a/docs/examples/SUMMARY.md
+++ b/docs/examples/SUMMARY.md
@@ -7,12 +7,12 @@
 - Encryption
   - [Encrypt single value](fhe-encrypt-single-value.md)
   - [Encrypt multiple values](fhe-encrypt-multiple-values.md)
-- Decryption
-  - [Decrypt single value](fhe-decrypt-single-value.md)
-  - [Decrypt multiple values](fhe-decrypt-multiple-values.md)
-- Decryption in Solidity
-  - [Decrypt single value in Solidity](fhe-decrypt-single-value-in-solidity.md)
-  - [Decrypt multiple values in Solidity](fhe-decrypt-multiple-values-in-solidity.md)
+- User Decryption
+  - [User decrypt single value](fhe-user-decrypt-single-value.md)
+  - [User decrypt multiple values](fhe-user-decrypt-multiple-values.md)
+- Public Decryption
+  - [Public Decrypt single value](fhe-public-decrypt-single-value.md)
+  - [Public Decrypt multiple values](fhe-public-decrypt-multiple-values.md)
 
 ## Advanced
 

--- a/docs/examples/SUMMARY.md
+++ b/docs/examples/SUMMARY.md
@@ -7,10 +7,9 @@
 - Encryption
   - [Encrypt single value](fhe-encrypt-single-value.md)
   - [Encrypt multiple values](fhe-encrypt-multiple-values.md)
-- User Decryption
+- Decryption
   - [User decrypt single value](fhe-user-decrypt-single-value.md)
   - [User decrypt multiple values](fhe-user-decrypt-multiple-values.md)
-- Public Decryption
   - [Public Decrypt single value](fhe-public-decrypt-single-value.md)
   - [Public Decrypt multiple values](fhe-public-decrypt-multiple-values.md)
 

--- a/docs/examples/fhe-public-decrypt-multiple-values.md
+++ b/docs/examples/fhe-public-decrypt-multiple-values.md
@@ -1,6 +1,6 @@
 This example demonstrates the FHE public decryption mechanism with multiple value.
 
-Public decryption is a mechanism that makes encrypted values visible to everyone once decrypted. Unlike user decryption where values remain private to authorized users, public decryption makes the data permanently visible to all participants. The public decryption call occurs on-chain through smart contracts, making the decrypted value part of the blockchain's public state.
+Public decryption is a mechanism that makes encrypted values visible to everyone once decrypted. Unlike user decryption where values remain private to authorized users, public decryption makes the data permanently visible to all participants. The public decryption call occurs onchain through smart contracts, making the decrypted value part of the blockchain's public state.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:
@@ -163,14 +163,14 @@ describe("PublicDecryptMultipleValues", function () {
 
   // ✅ Test should succeed
   it("public decryption should succeed", async function () {
-    // For simplicity, we create 3 trivialy encrypted values on-chain.
+    // For simplicity, we create 3 trivialy encrypted values onchain.
     let tx = await contract.connect(signers.alice).initialize(true, 123456, 78901234567);
     await tx.wait();
 
     tx = await contract.requestDecryptMultipleValues();
     await tx.wait();
 
-    // We use the FHEVM Hardhat plugin to simulate the asynchronous on-chain
+    // We use the FHEVM Hardhat plugin to simulate the asynchronous onchain
     // public decryption
     const fhevm: HardhatFhevmRuntimeEnvironment = hre.fhevm;
 

--- a/docs/examples/fhe-public-decrypt-multiple-values.md
+++ b/docs/examples/fhe-public-decrypt-multiple-values.md
@@ -1,4 +1,6 @@
-This example demonstrates the FHE decryption mechanism in Solidity with multiple values.
+This example demonstrates the FHE public decryption mechanism with multiple value.
+
+Public decryption is a mechanism that makes encrypted values visible to everyone once decrypted. Unlike user decryption where values remain private to authorized users, public decryption makes the data permanently visible to all participants. The public decryption call occurs on-chain through smart contracts, making the decrypted value part of the blockchain's public state.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:
@@ -11,7 +13,7 @@ This ensures Hardhat can compile and test your contracts as expected.
 
 {% tabs %}
 
-{% tab title="DecryptMultipleValuesInSolidity.sol" %}
+{% tab title="PublicDecryptMultipleValues.sol" %}
 
 ```solidity
 // SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -20,7 +22,7 @@ pragma solidity ^0.8.24;
 import { FHE, ebool, euint32, euint64 } from "@fhevm/solidity/lib/FHE.sol";
 import { SepoliaConfig } from "@fhevm/solidity/config/ZamaConfig.sol";
 
-contract DecryptMultipleValuesInSolidity is SepoliaConfig {
+contract PublicDecryptMultipleValues is SepoliaConfig {
   ebool private _encryptedBool; // = 0 (uninitialized)
   euint32 private _encryptedUint32; // = 0 (uninitialized)
   euint64 private _encryptedUint64; // = 0 (uninitialized)
@@ -45,18 +47,18 @@ contract DecryptMultipleValuesInSolidity is SepoliaConfig {
     _encryptedUint64 = FHE.add(FHE.asEuint64(c), FHE.asEuint64(1));
 
     // see `DecryptSingleValueInSolidity.sol` for more detailed explanations
-    // about FHE permissions and asynchronous decryption requests.
+    // about FHE permissions and asynchronous public decryption requests.
     FHE.allowThis(_encryptedBool);
     FHE.allowThis(_encryptedUint32);
     FHE.allowThis(_encryptedUint64);
   }
 
   function requestDecryptMultipleValues() external {
-    // To decrypt multiple values, we must construct an array of the encrypted values
-    // we want to decrypt.
+    // To public decrypt multiple values, we must construct an array of the encrypted values
+    // we want to public decrypt.
     //
     // ⚠️ Warning: The order of values in the array is critical!
-    // The FHEVM backend will pass the decrypted values to the callback function
+    // The FHEVM backend will pass the public decrypted values to the callback function
     // in the exact same order they appear in this array.
     // Therefore, the order must match the parameter declaration in the callback.
     bytes32[] memory cypherTexts = new bytes32[](3);
@@ -65,7 +67,7 @@ contract DecryptMultipleValuesInSolidity is SepoliaConfig {
     cypherTexts[2] = FHE.toBytes32(_encryptedUint64);
 
     FHE.requestDecryption(
-      // the list of encrypte values we want to decrypt
+      // the list of encrypte values we want to public decrypt
       cypherTexts,
       // Selector of the Solidity callback function that the FHEVM backend will call with
       // the decrypted (clear) values as arguments
@@ -113,10 +115,10 @@ contract DecryptMultipleValuesInSolidity is SepoliaConfig {
 
 {% endtab %}
 
-{% tab title="DecryptMultipleValuesInSolidity.ts" %}
+{% tab title="PublicDecryptMultipleValues.ts" %}
 
 ```ts
-import { DecryptMultipleValuesInSolidity, DecryptMultipleValuesInSolidity__factory } from "../../../types";
+import { PublicDecryptMultipleValues, PublicDecryptMultipleValues__factory } from "../../../types";
 import type { Signers } from "../../types";
 import { HardhatFhevmRuntimeEnvironment } from "@fhevm/hardhat-plugin";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -127,20 +129,20 @@ import * as hre from "hardhat";
 async function deployFixture() {
   // Contracts are deployed using the first signer/account by default
   const factory = (await ethers.getContractFactory(
-    "DecryptMultipleValuesInSolidity",
-  )) as DecryptMultipleValuesInSolidity__factory;
-  const decryptMultipleValuesInSolidity = (await factory.deploy()) as DecryptMultipleValuesInSolidity;
-  const decryptMultipleValuesInSolidity_address = await decryptMultipleValuesInSolidity.getAddress();
+    "PublicDecryptMultipleValues",
+  )) as PublicDecryptMultipleValues__factory;
+  const publicDecryptMultipleValues = (await factory.deploy()) as PublicDecryptMultipleValues;
+  const publicDecryptMultipleValues_address = await publicDecryptMultipleValues.getAddress();
 
-  return { decryptMultipleValuesInSolidity, decryptMultipleValuesInSolidity_address };
+  return { publicDecryptMultipleValues, publicDecryptMultipleValues_address };
 }
 
 /**
- * This trivial example demonstrates the FHE decryption mechanism
+ * This trivial example demonstrates the FHE public decryption mechanism
  * and highlights a common pitfall developers may encounter.
  */
-describe("DecryptMultipleValuesInSolidity", function () {
-  let contract: DecryptMultipleValuesInSolidity;
+describe("PublicDecryptMultipleValues", function () {
+  let contract: PublicDecryptMultipleValues;
   let signers: Signers;
 
   before(async function () {
@@ -156,12 +158,12 @@ describe("DecryptMultipleValuesInSolidity", function () {
   beforeEach(async function () {
     // Deploy a new contract each time we run a new test
     const deployment = await deployFixture();
-    contract = deployment.decryptMultipleValuesInSolidity;
+    contract = deployment.publicDecryptMultipleValues;
   });
 
   // ✅ Test should succeed
-  it("decryption should succeed", async function () {
-    // For simplicity, we create 3 trivially encrypted values on-chain.
+  it("public decryption should succeed", async function () {
+    // For simplicity, we create 3 trivialy encrypted values on-chain.
     let tx = await contract.connect(signers.alice).initialize(true, 123456, 78901234567);
     await tx.wait();
 
@@ -169,15 +171,15 @@ describe("DecryptMultipleValuesInSolidity", function () {
     await tx.wait();
 
     // We use the FHEVM Hardhat plugin to simulate the asynchronous on-chain
-    // decryption
+    // public decryption
     const fhevm: HardhatFhevmRuntimeEnvironment = hre.fhevm;
 
-    // Use the built-in `awaitDecryptionOracle` helper to wait for the FHEVM decryption oracle
-    // to complete all pending Solidity decryption requests.
+    // Use the built-in `awaitDecryptionOracle` helper to wait for the FHEVM public decryption oracle
+    // to complete all pending Solidity public decryption requests.
     await fhevm.awaitDecryptionOracle();
 
     // At this point, the Solidity callback should have been invoked by the FHEVM backend.
-    // We can now retrieve the 3 decrypted (clear) values.
+    // We can now retrieve the 3 publicly decrypted (clear) values.
     const clearBool = await contract.clearBool();
     const clearUint32 = await contract.clearUint32();
     const clearUint64 = await contract.clearUint64();

--- a/docs/examples/fhe-public-decrypt-single-value.md
+++ b/docs/examples/fhe-public-decrypt-single-value.md
@@ -1,4 +1,6 @@
-This example demonstrates the FHE decryption mechanism in Solidity.
+This example demonstrates the FHE public decryption mechanism with a single value.
+
+Public decryption is a mechanism that makes encrypted values visible to everyone once decrypted. Unlike user decryption where values remain private to authorized users, public decryption makes the data permanently visible to all participants. The public decryption call occurs on-chain through smart contracts, making the decrypted value part of the blockchain's public state.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:
@@ -11,7 +13,7 @@ This ensures Hardhat can compile and test your contracts as expected.
 
 {% tabs %}
 
-{% tab title="DecryptSingleValueInSolidity.sol" %}
+{% tab title="PublicDecryptSingleValue.sol" %}
 
 ```solidity
 // SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -20,7 +22,7 @@ pragma solidity ^0.8.24;
 import { FHE, euint32 } from "@fhevm/solidity/lib/FHE.sol";
 import { SepoliaConfig } from "@fhevm/solidity/config/ZamaConfig.sol";
 
-contract DecryptSingleValueInSolidity is SepoliaConfig {
+contract PublicDecryptSingleValue is SepoliaConfig {
   euint32 private _encryptedUint32; // = 0 (uninitizalized)
   uint32 private _clearUint32; // = 0 (uninitizalized)
 
@@ -32,10 +34,10 @@ contract DecryptSingleValueInSolidity is SepoliaConfig {
     _encryptedUint32 = FHE.add(FHE.asEuint32(value), FHE.asEuint32(1));
 
     // Grant FHE permissions to:
-    // ✅ The contract itself (`address(this)`): allows it to request async decryption to the FHEVM backend
+    // ✅ The contract itself (`address(this)`): allows it to request async public decryption to the FHEVM backend
     //
     // Note: If you forget to call `FHE.allowThis(_trivialEuint32)`,
-    //       any async decryption request of `_trivialEuint32`
+    //       any async public decryption request of `_trivialEuint32`
     //       by the contract itself (`address(this)`) will fail!
     FHE.allowThis(_encryptedUint32);
   }
@@ -50,14 +52,14 @@ contract DecryptSingleValueInSolidity is SepoliaConfig {
     cypherTexts[0] = FHE.toBytes32(_encryptedUint32);
 
     // Two possible outcomes:
-    // ✅ If `initializeUint32` was called, the decryption request will succeed.
-    // ❌ If `initializeUint32Wrong` was called, the decryption request will fail 💥
+    // ✅ If `initializeUint32` was called, the public decryption request will succeed.
+    // ❌ If `initializeUint32Wrong` was called, the public decryption request will fail 💥
     //
     // Explanation:
     // The request succeeds only if the contract itself (`address(this)`) was granted
     // the necessary FHE permissions. Missing `FHE.allowThis(...)` will cause failure.
     FHE.requestDecryption(
-      // the list of encrypte values we want to decrypt
+      // the list of encrypte values we want to publc decrypt
       cypherTexts,
       // the function selector the FHEVM backend will callback with the clear values as arguments
       this.callbackDecryptSingleUint32.selector
@@ -101,10 +103,10 @@ contract DecryptSingleValueInSolidity is SepoliaConfig {
 
 {% endtab %}
 
-{% tab title="DecryptSingleValueInSolidity.ts" %}
+{% tab title="PublicDecryptSingleValue.ts" %}
 
 ```ts
-import { DecryptSingleValueInSolidity, DecryptSingleValueInSolidity__factory } from "../../../types";
+import { PublicDecryptSingleValue, PublicDecryptSingleValue__factory } from "../../../types";
 import type { Signers } from "../../types";
 import { HardhatFhevmRuntimeEnvironment } from "@fhevm/hardhat-plugin";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -115,20 +117,20 @@ import * as hre from "hardhat";
 async function deployFixture() {
   // Contracts are deployed using the first signer/account by default
   const factory = (await ethers.getContractFactory(
-    "DecryptSingleValueInSolidity",
-  )) as DecryptSingleValueInSolidity__factory;
-  const decryptSingleValueInSolidity = (await factory.deploy()) as DecryptSingleValueInSolidity;
-  const decryptSingleValueInSolidity_address = await decryptSingleValueInSolidity.getAddress();
+    "PublicDecryptSingleValue",
+  )) as PublicDecryptSingleValue__factory;
+  const publicDecryptSingleValue = (await factory.deploy()) as PublicDecryptSingleValue;
+  const publicDecryptSingleValue_address = await publicDecryptSingleValue.getAddress();
 
-  return { decryptSingleValueInSolidity, decryptSingleValueInSolidity_address };
+  return { publicDecryptSingleValue, publicDecryptSingleValue_address };
 }
 
 /**
- * This trivial example demonstrates the FHE decryption mechanism
+ * This trivial example demonstrates the FHE public decryption mechanism
  * and highlights a common pitfall developers may encounter.
  */
-describe("DecryptSingleValueInSolidity", function () {
-  let contract: DecryptSingleValueInSolidity;
+describe("PublicDecryptSingleValue", function () {
+  let contract: PublicDecryptSingleValue;
   let signers: Signers;
 
   before(async function () {
@@ -144,11 +146,11 @@ describe("DecryptSingleValueInSolidity", function () {
   beforeEach(async function () {
     // Deploy a new contract each time we run a new test
     const deployment = await deployFixture();
-    contract = deployment.decryptSingleValueInSolidity;
+    contract = deployment.publicDecryptSingleValue;
   });
 
   // ✅ Test should succeed
-  it("decryption should succeed", async function () {
+  it("public decryption should succeed", async function () {
     let tx = await contract.connect(signers.alice).initializeUint32(123456);
     await tx.wait();
 
@@ -156,11 +158,11 @@ describe("DecryptSingleValueInSolidity", function () {
     await tx.wait();
 
     // We use the FHEVM Hardhat plugin to simulate the asynchronous on-chain
-    // decryption
+    // public decryption
     const fhevm: HardhatFhevmRuntimeEnvironment = hre.fhevm;
 
-    // Use the built-in `awaitDecryptionOracle` helper to wait for the FHEVM decryption oracle
-    // to complete all pending Solidity decryption requests.
+    // Use the built-in `awaitDecryptionOracle` helper to wait for the FHEVM public decryption oracle
+    // to complete all pending Solidity public decryption requests.
     await fhevm.awaitDecryptionOracle();
 
     // At this point, the Solidity callback should have been invoked by the FHEVM backend.

--- a/docs/examples/fhe-public-decrypt-single-value.md
+++ b/docs/examples/fhe-public-decrypt-single-value.md
@@ -1,6 +1,6 @@
 This example demonstrates the FHE public decryption mechanism with a single value.
 
-Public decryption is a mechanism that makes encrypted values visible to everyone once decrypted. Unlike user decryption where values remain private to authorized users, public decryption makes the data permanently visible to all participants. The public decryption call occurs on-chain through smart contracts, making the decrypted value part of the blockchain's public state.
+Public decryption is a mechanism that makes encrypted values visible to everyone once decrypted. Unlike user decryption where values remain private to authorized users, public decryption makes the data permanently visible to all participants. The public decryption call occurs onchain through smart contracts, making the decrypted value part of the blockchain's public state.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:
@@ -157,7 +157,7 @@ describe("PublicDecryptSingleValue", function () {
     tx = await contract.requestDecryptSingleUint32();
     await tx.wait();
 
-    // We use the FHEVM Hardhat plugin to simulate the asynchronous on-chain
+    // We use the FHEVM Hardhat plugin to simulate the asynchronous onchain
     // public decryption
     const fhevm: HardhatFhevmRuntimeEnvironment = hre.fhevm;
 

--- a/docs/examples/fhe-user-decrypt-multiple-values.md
+++ b/docs/examples/fhe-user-decrypt-multiple-values.md
@@ -1,6 +1,6 @@
 This example demonstrates the FHE user decryption mechanism with multiple values.
 
-User decryption is a mechanism that allows specific users to decrypt encrypted values while keeping them hidden from others. Unlike public decryption where decrypted values become visible to everyone, user decryption maintains privacy by only allowing authorized users with the proper permissions to view the data. While permissions are granted on-chain through smart contracts, the actual **decryption call occurs off-chain in the frontend application**.
+User decryption is a mechanism that allows specific users to decrypt encrypted values while keeping them hidden from others. Unlike public decryption where decrypted values become visible to everyone, user decryption maintains privacy by only allowing authorized users with the proper permissions to view the data. While permissions are granted onchain through smart contracts, the actual **decryption call occurs off-chain in the frontend application**.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:

--- a/docs/examples/fhe-user-decrypt-multiple-values.md
+++ b/docs/examples/fhe-user-decrypt-multiple-values.md
@@ -1,4 +1,6 @@
-This example demonstrates the FHE decryption mechanism with multiple values.
+This example demonstrates the FHE user decryption mechanism with multiple values.
+
+User decryption is a mechanism that allows specific users to decrypt encrypted values while keeping them hidden from others. Unlike public decryption where decrypted values become visible to everyone, user decryption maintains privacy by only allowing authorized users with the proper permissions to view the data. While permissions are granted on-chain through smart contracts, the actual **decryption call occurs off-chain in the frontend application**.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:
@@ -11,7 +13,7 @@ This ensures Hardhat can compile and test your contracts as expected.
 
 {% tabs %}
 
-{% tab title="DecryptMultipleValues.sol" %}
+{% tab title="UserDecryptMultipleValues.sol" %}
 
 ```solidity
 // SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -20,7 +22,7 @@ pragma solidity ^0.8.24;
 import { FHE, ebool, euint32, euint64 } from "@fhevm/solidity/lib/FHE.sol";
 import { SepoliaConfig } from "@fhevm/solidity/config/ZamaConfig.sol";
 
-contract DecryptMultipleValues is SepoliaConfig {
+contract UserDecryptMultipleValues is SepoliaConfig {
   ebool private _encryptedBool; // = 0 (uninitizalized)
   euint32 private _encryptedUint32; // = 0 (uninitizalized)
   euint64 private _encryptedUint64; // = 0 (uninitizalized)
@@ -41,7 +43,7 @@ contract DecryptMultipleValues is SepoliaConfig {
     _encryptedUint64 = FHE.add(FHE.asEuint64(c), FHE.asEuint64(1));
 
     // see `DecryptSingleValue.sol` for more detailed explanations
-    // about FHE permissions and asynchronous decryption requests.
+    // about FHE permissions and asynchronous user decryption requests.
     FHE.allowThis(_encryptedBool);
     FHE.allowThis(_encryptedUint32);
     FHE.allowThis(_encryptedUint64);
@@ -67,10 +69,10 @@ contract DecryptMultipleValues is SepoliaConfig {
 
 {% endtab %}
 
-{% tab title="DecryptMultipleValues.ts" %}
+{% tab title="UserDecryptMultipleValues.ts" %}
 
 ```ts
-import { DecryptMultipleValues, DecryptMultipleValues__factory } from "../../../types";
+import { UserDecryptMultipleValues, UserDecryptMultipleValues__factory } from "../../../types";
 import type { Signers } from "../../types";
 import { HardhatFhevmRuntimeEnvironment } from "@fhevm/hardhat-plugin";
 import { utils as fhevm_utils } from "@fhevm/mock-utils";
@@ -82,19 +84,19 @@ import * as hre from "hardhat";
 
 async function deployFixture() {
   // Contracts are deployed using the first signer/account by default
-  const factory = (await ethers.getContractFactory("DecryptMultipleValues")) as DecryptMultipleValues__factory;
-  const decryptMultipleValues = (await factory.deploy()) as DecryptMultipleValues;
-  const decryptMultipleValues_address = await decryptMultipleValues.getAddress();
+  const factory = (await ethers.getContractFactory("UserDecryptMultipleValues")) as UserDecryptMultipleValues__factory;
+  const userDecryptMultipleValues = (await factory.deploy()) as UserDecryptMultipleValues;
+  const userDecryptMultipleValues_address = await userDecryptMultipleValues.getAddress();
 
-  return { decryptMultipleValues, decryptMultipleValues_address };
+  return { userDecryptMultipleValues, userDecryptMultipleValues_address };
 }
 
 /**
- * This trivial example demonstrates the FHE decryption mechanism
+ * This trivial example demonstrates the FHE user decryption mechanism
  * and highlights a common pitfall developers may encounter.
  */
-describe("DecryptMultipleValues", function () {
-  let contract: DecryptMultipleValues;
+describe("UserDecryptMultipleValues", function () {
+  let contract: UserDecryptMultipleValues;
   let contractAddress: string;
   let signers: Signers;
 
@@ -111,12 +113,12 @@ describe("DecryptMultipleValues", function () {
   beforeEach(async function () {
     // Deploy a new contract each time we run a new test
     const deployment = await deployFixture();
-    contractAddress = deployment.decryptMultipleValues_address;
-    contract = deployment.decryptMultipleValues;
+    contractAddress = deployment.userDecryptMultipleValues_address;
+    contract = deployment.userDecryptMultipleValues;
   });
 
   // ✅ Test should succeed
-  it("decryption should succeed", async function () {
+  it("user decryption should succeed", async function () {
     const tx = await contract.connect(signers.alice).initialize(true, 123456, 78901234567);
     await tx.wait();
 

--- a/docs/examples/fhe-user-decrypt-single-value.md
+++ b/docs/examples/fhe-user-decrypt-single-value.md
@@ -1,6 +1,6 @@
 This example demonstrates the FHE user decryption mechanism with a single value.
 
-User decryption is a mechanism that allows specific users to decrypt encrypted values while keeping them hidden from others. Unlike public decryption where decrypted values become visible to everyone, user decryption maintains privacy by only allowing authorized users with the proper permissions to view the data. While permissions are granted on-chain through smart contracts, the actual **decryption call occurs off-chain in the frontend application**.
+User decryption is a mechanism that allows specific users to decrypt encrypted values while keeping them hidden from others. Unlike public decryption where decrypted values become visible to everyone, user decryption maintains privacy by only allowing authorized users with the proper permissions to view the data. While permissions are granted onchain through smart contracts, the actual **decryption call occurs off-chain in the frontend application**.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:

--- a/docs/examples/fhe-user-decrypt-single-value.md
+++ b/docs/examples/fhe-user-decrypt-single-value.md
@@ -1,4 +1,6 @@
-This example demonstrates the FHE decryption mechanism and highlights a common pitfall developers may encounter.
+This example demonstrates the FHE user decryption mechanism with a single value.
+
+User decryption is a mechanism that allows specific users to decrypt encrypted values while keeping them hidden from others. Unlike public decryption where decrypted values become visible to everyone, user decryption maintains privacy by only allowing authorized users with the proper permissions to view the data. While permissions are granted on-chain through smart contracts, the actual **decryption call occurs off-chain in the frontend application**.
 
 {% hint style="info" %}
 To run this example correctly, make sure the files are placed in the following directories:
@@ -11,7 +13,7 @@ This ensures Hardhat can compile and test your contracts as expected.
 
 {% tabs %}
 
-{% tab title="DecryptSingleValue.sol" %}
+{% tab title="UserDecryptSingleValue.sol" %}
 
 ```solidity
 // SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -22,9 +24,9 @@ import { SepoliaConfig } from "@fhevm/solidity/config/ZamaConfig.sol";
 
 /**
  * This trivial example demonstrates the FHE decryption mechanism
- * and highlights a common pitfall developers may encounter.
+ * and highlights common pitfalls developers may encounter.
  */
-contract DecryptSingleValue is SepoliaConfig {
+contract UserDecryptSingleValue is SepoliaConfig {
   euint32 private _trivialEuint32;
 
   // solhint-disable-next-line no-empty-blocks
@@ -37,11 +39,11 @@ contract DecryptSingleValue is SepoliaConfig {
     // Grant FHE permissions to:
     // ✅ The contract caller (`msg.sender`): allows them to decrypt `_trivialEuint32`.
     // ✅ The contract itself (`address(this)`): allows it to operate on `_trivialEuint32` and
-    //    also enables the caller to perform decryption.
+    //    also enables the caller to perform user decryption.
     //
     // Note: If you forget to call `FHE.allowThis(_trivialEuint32)`, the user will NOT be able
-    //       to decrypt the value! Both the contract and the caller must have FHE permissions
-    //       for decryption to succeed.
+    //       to user decrypt the value! Both the contract and the caller must have FHE permissions
+    //       for user decryption to succeed.
     FHE.allowThis(_trivialEuint32);
     FHE.allow(_trivialEuint32, msg.sender);
   }
@@ -53,12 +55,12 @@ contract DecryptSingleValue is SepoliaConfig {
     // ❌ Common FHE permission mistake:
     // ================================================================
     // We grant FHE permissions to the contract caller (`msg.sender`),
-    // expecting they will be able to decrypt the encrypted value later.
+    // expecting they will be able to user decrypt the encrypted value later.
     //
     // However, this will fail! 💥
-    // The contract itself (`address(this)`) also needs FHE permissions to allow decryption.
+    // The contract itself (`address(this)`) also needs FHE permissions to allow user decryption.
     // Without granting the contract access using `FHE.allowThis(...)`,
-    // the decryption attempt by the user will not succeed.
+    // the user decryption attempt by the user will not succeed.
     FHE.allow(_trivialEuint32, msg.sender);
   }
 
@@ -70,10 +72,10 @@ contract DecryptSingleValue is SepoliaConfig {
 
 {% endtab %}
 
-{% tab title="DecryptSingleValue.ts" %}
+{% tab title="UserDecryptSingleValue.ts" %}
 
 ```ts
-import { DecryptSingleValue, DecryptSingleValue__factory } from "../../../types";
+import { UserDecryptSingleValue, UserDecryptSingleValue__factory } from "../../../types";
 import type { Signers } from "../../types";
 import { FhevmType, HardhatFhevmRuntimeEnvironment } from "@fhevm/hardhat-plugin";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
@@ -83,19 +85,19 @@ import * as hre from "hardhat";
 
 async function deployFixture() {
   // Contracts are deployed using the first signer/account by default
-  const factory = (await ethers.getContractFactory("DecryptSingleValue")) as DecryptSingleValue__factory;
-  const decryptSingleValue = (await factory.deploy()) as DecryptSingleValue;
-  const decryptSingleValue_address = await decryptSingleValue.getAddress();
+  const factory = (await ethers.getContractFactory("UserDecryptSingleValue")) as UserDecryptSingleValue__factory;
+  const userUserDecryptSingleValue = (await factory.deploy()) as UserDecryptSingleValue;
+  const userUserDecryptSingleValue_address = await userUserDecryptSingleValue.getAddress();
 
-  return { decryptSingleValue, decryptSingleValue_address };
+  return { userUserDecryptSingleValue, userUserDecryptSingleValue_address };
 }
 
 /**
- * This trivial example demonstrates the FHE decryption mechanism
+ * This trivial example demonstrates the FHE user decryption mechanism
  * and highlights a common pitfall developers may encounter.
  */
-describe("DecryptSingleValue", function () {
-  let contract: DecryptSingleValue;
+describe("UserDecryptSingleValue", function () {
+  let contract: UserDecryptSingleValue;
   let contractAddress: string;
   let signers: Signers;
 
@@ -112,12 +114,12 @@ describe("DecryptSingleValue", function () {
   beforeEach(async function () {
     // Deploy a new contract each time we run a new test
     const deployment = await deployFixture();
-    contractAddress = deployment.decryptSingleValue_address;
-    contract = deployment.decryptSingleValue;
+    contractAddress = deployment.userUserDecryptSingleValue_address;
+    contract = deployment.userUserDecryptSingleValue;
   });
 
   // ✅ Test should succeed
-  it("decryption should succeed", async function () {
+  it("user decryption should succeed", async function () {
     const tx = await contract.connect(signers.alice).initializeUint32(123456);
     await tx.wait();
 
@@ -138,7 +140,7 @@ describe("DecryptSingleValue", function () {
   });
 
   // ❌ Test should fail
-  it("decryption should fail", async function () {
+  it("user decryption should fail", async function () {
     const tx = await contract.connect(signers.alice).initializeUint32Wrong(123456);
     await tx.wait();
 


### PR DESCRIPTION
It's important that we emphasized in our documentation the differentiation between public decrypt and user decrypt, so that developers know the difference and don't confuse the two concepts together. 