### PR TITLE
chore(coprocessor): remove Deref in NonceManagedProvider

### DIFF
--- a/coprocessor/fhevm-engine/transaction-sender/src/nonce_managed_provider.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/nonce_managed_provider.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use alloy::{
     network::Ethereum,
@@ -68,17 +68,6 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> NonceManagedProv
     }
 
     pub fn inner(&self) -> &P {
-        &self.provider
-    }
-}
-
-impl<P> Deref for NonceManagedProvider<P>
-where
-    P: alloy::providers::Provider<Ethereum> + Clone + 'static,
-{
-    type Target = P;
-
-    fn deref(&self) -> &Self::Target {
         &self.provider
     }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -54,7 +54,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
 
         let overprovisioned_txn_req = try_overprovision_gas_limit(
             txn_request,
-            &*self.provider,
+            self.provider.inner(),
             self.conf.gas_limit_overprovision_percent,
         )
         .await;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -81,7 +81,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
 
         let overprovisioned_txn_req = try_overprovision_gas_limit(
             txn_request,
-            &*self.provider,
+            self.provider.inner(),
             self.conf.gas_limit_overprovision_percent,
         )
         .await;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -122,7 +122,7 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOpera
         info!(zk_proof_id = txn_request.0, "Processing proof");
         let overprovisioned_txn_req = try_overprovision_gas_limit(
             txn_request.1,
-            &*self.provider,
+            self.provider.inner(),
             self.conf.gas_limit_overprovision_percent,
         )
         .await;


### PR DESCRIPTION
We don't actually need the Deref implementation, as we can just call `self.provider.inner()` directly. That way we don't introduce unclear semantics.