### PR TITLE
fix(coprocessor): deploy a s3 emulator as part of the test environment

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1537,7 +1537,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1561,7 +1561,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.78.0"
+version = "1.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038614b6cf7dd68d9a7b5b39563d04337eb3678d1d4173e356e927b0356158a"
+checksum = "d5c82dae9304e7ced2ff6cca43dceb2d6de534c95a506ff0f168a7463c9a885d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1587,7 +1587,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.61.1",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1599,6 +1599,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body 0.4.6",
  "lru 0.12.5",
  "once_cell",
@@ -1618,7 +1619,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1640,7 +1641,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1662,7 +1663,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -1684,7 +1685,7 @@ checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1717,16 +1718,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.0"
+version = "0.63.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2dc8d842d872529355c72632de49ef8c5a2949a4472f10e802f28cf925770c"
+checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
 dependencies = [
- "aws-smithy-http 0.60.12",
+ "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
- "crc32c",
- "crc32fast",
- "crc64fast-nvme",
+ "crc-fast",
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1750,51 +1749,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f276f21c7921fe902826618d1423ae5bf74cf8c1b8472aee8434f3dfd31824"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
 version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1872,7 +1831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -2629,12 +2588,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
+name = "crc-fast"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+checksum = "ec9f79df9b0383475ae6df8fcf35d4e29528441706385339daf0fe3f4cce040b"
 dependencies = [
- "rustc_version 0.4.1",
+ "crc",
+ "digest 0.10.7",
+ "libc",
+ "rand 0.9.1",
+ "regex",
+ "rustversion",
 ]
 
 [[package]]
@@ -2644,15 +2608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crc64fast-nvme"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
-dependencies = [
- "crc",
 ]
 
 [[package]]
@@ -4536,7 +4491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7168,6 +7123,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-kms",
+ "aws-sdk-s3",
  "base64 0.22.1",
  "fhevm-engine-common",
  "hex",
@@ -8341,7 +8297,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "http 1.3.1",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -1464,9 +1464,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a18fd934af6ae7ca52410d4548b98eb895aab0f1ea417d168d85db1434a141"
+checksum = "c478f5b10ce55c9a33f87ca3404ca92768b144fc1bfdede7c0121214a8283a25"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "1541072f81945fa1251f8795ef6c92c4282d74d59f88498ae7d4bf00f0ebdad9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.7"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
+checksum = "c034a1bc1d70e16e7f4e4caf7e9f7693e4c9c24cd91cf17c2a0b21abaebc7c8b"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.85.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c82dae9304e7ced2ff6cca43dceb2d6de534c95a506ff0f168a7463c9a885d"
+checksum = "af040a86ae4378b7ed2f62c83b36be1848709bbbf5757ec850d0e08596a26be9"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1602,7 +1602,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "lru 0.12.5",
- "once_cell",
  "percent-encoding",
  "regex-lite",
  "sha2",
@@ -1612,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.68.0"
+version = "1.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f01ea61fed99b5fe4877abff6c56943342a56ff145e9e0c7e2494419008be"
+checksum = "79ede098271e3471036c46957cba2ba30888f53bda2515bf04b560614a30a36e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1634,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.69.0"
+version = "1.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27454e4c55aaa4ef65647e3a1cf095cb834ca6d54e959e2909f1fef96ad87860"
+checksum = "43326f724ba2cc957e6f3deac0ca1621a3e5d4146f5970c24c8a108dac33070f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1656,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.69.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd6ef5d00c94215960fabcdf2d9fe7c090eed8be482d66d47b92d4aba1dd4aa"
+checksum = "a5468593c47efc31fdbe6c902d1a5fde8d9c82f78a3f8ccfe907b1e9434748cb"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1679,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
+checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1718,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.3"
+version = "0.63.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
+checksum = "4dbef71cd3cf607deb5c407df52f7e589e6849b296874ee448977efbb6d0832b"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1738,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.8"
+version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
+checksum = "182b03393e8c677347fb5705a04a9392695d47d20ef0a2f8cfe28c8e6b9b9778"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1749,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1770,14 +1769,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e44697a9bded898dcd0b1cb997430d949b87f4f8940d91023ae9062bf218250"
+checksum = "4fdbad9bd9dbcc6c5e68c311a841b54b70def3ca3b674c42fbebb265980539f8"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.8",
+ "h2 0.3.26",
+ "h2 0.4.12",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1788,19 +1788,20 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tower 0.5.2",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.3"
+version = "0.61.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92144e45819cae7dc62af23eac5a038a58aa544432d2102609654376a900bd07"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -1826,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "a3d57c8b53a72d15c8e190475743acf34e4996685e346a3448dd54ef696fc6e0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1850,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e5d9e3a80a18afa109391fb5ad09c3daf887b516c6fd805a157c6ea7994a57"
+checksum = "07f5e0fc8a6b3f2303f331b94504bbf754d85488f402d6f1dd7a6080f99afe56"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1867,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1893,18 +1894,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.9"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2196,7 +2197,7 @@ dependencies = [
  "hyperlocal",
  "log",
  "pin-project-lite",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -2589,16 +2590,15 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9f79df9b0383475ae6df8fcf35d4e29528441706385339daf0fe3f4cce040b"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
 dependencies = [
  "crc",
  "digest 0.10.7",
  "libc",
  "rand 0.9.1",
  "regex",
- "rustversion",
 ]
 
 [[package]]
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3846,7 +3846,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "futures-util",
  "lru 0.13.0",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -3966,7 +3966,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -4019,7 +4019,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4491,7 +4491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5489,7 +5489,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -5507,7 +5507,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5724,7 +5724,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -5739,7 +5739,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -5972,16 +5972,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.24"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bf61953b1bc045820a2b947e6e9771c58c8c4b15242425b03f783ede1b34fe"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -6030,11 +6030,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -6049,9 +6050,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7540,7 +7541,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -7579,7 +7580,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -7628,7 +7629,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.8",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -7921,7 +7922,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.1",
- "rustls 0.23.24",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -30,9 +30,9 @@ alloy-primitives = "1.2.0"
 axum = "0.7"
 tower-http = { version = "0.5", features = ["trace"] }
 anyhow = "1.0.98"
-aws-config = "1.6.3"
+aws-config = "1.8.5"
 aws-sdk-kms = { version = "1.68.0", default-features = false }
-aws-sdk-s3 = "1.78.0"
+aws-sdk-s3 = "1.103.0"
 bigdecimal = "0.4.8"
 bincode = "1.3.3"
 clap = { version = "4.5.38", features = ["derive"] }

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -32,6 +32,7 @@ tower-http = { version = "0.5", features = ["trace"] }
 anyhow = "1.0.98"
 aws-config = "1.6.3"
 aws-sdk-kms = { version = "1.68.0", default-features = false }
+aws-sdk-s3 = "1.78.0"
 bigdecimal = "0.4.8"
 bincode = "1.3.3"
 clap = { version = "4.5.38", features = ["derive"] }

--- a/coprocessor/fhevm-engine/sns-worker/Cargo.toml
+++ b/coprocessor/fhevm-engine/sns-worker/Cargo.toml
@@ -50,6 +50,7 @@ path = "src/bin/sns_worker.rs"
 
 [features]
 test_decrypt_128 = []
+test_s3_use_handle_as_key = []
 
 [dev-dependencies]
 test-harness = { path = "../test-harness" }
@@ -57,5 +58,5 @@ test-harness = { path = "../test-harness" }
 
 [dev-dependencies.sns-worker]
 path = "."
-features = ["test_decrypt_128"]
+features = ["test_decrypt_128", "test_s3_use_handle_as_key"]
 

--- a/coprocessor/fhevm-engine/sns-worker/Cargo.toml
+++ b/coprocessor/fhevm-engine/sns-worker/Cargo.toml
@@ -34,11 +34,11 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 humantime = { workspace = true }
 bytesize = { workspace = true}
+aws-sdk-s3 = { workspace = true }
 
 # crates.io dependencies
 aligned-vec = "0.6.4"
 num-traits = "0.2.19"
-aws-sdk-s3 = "1.78.0"
 futures = "0.3.31"
 
 # local dependencies

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -1,12 +1,6 @@
-use std::sync::{atomic::AtomicBool, Arc};
+use sns_worker::{Config, DBConfig, HealthCheckConfig, S3Config, S3RetryPolicy};
 
-use fhevm_engine_common::telemetry;
-use sns_worker::{
-    compute_128bit_ct, create_s3_client, process_s3_uploads, Config, DBConfig, HealthCheckConfig,
-    S3Config, S3RetryPolicy, UploadJob,
-};
-
-use tokio::{signal::unix, spawn, sync::mpsc};
+use tokio::signal::unix;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 mod utils;
@@ -78,35 +72,10 @@ async fn main() {
     // Handle SIGINIT signals
     handle_sigint(parent.clone());
 
-    // Queue of tasks to upload ciphertexts is 10 times the number of concurrent uploads
-    // to avoid blocking the worker
-    // and to allow for some burst of uploads
-    let (uploads_tx, uploads_rx) =
-        mpsc::channel::<UploadJob>(10 * config.s3.max_concurrent_uploads as usize);
-
-    if let Err(err) = telemetry::setup_otlp(&config.service_name) {
-        panic!("Error while initializing tracing: {:?}", err);
-    }
-
-    let conf = config.clone();
-    let token = parent.child_token();
-    let tx = uploads_tx.clone();
-    // Initialize the S3 uploader
-    let (client, is_ready) = create_s3_client(&conf).await;
-    let is_ready = Arc::new(AtomicBool::new(is_ready));
-    let s3 = client.clone();
-
-    spawn(async move {
-        if let Err(err) = process_s3_uploads(&conf, uploads_rx, tx, token, s3, is_ready).await {
-            error!(error = %err, "Failed to run the upload-worker");
-        }
-    });
-
-    // Start the SnS worker
-
-    let conf = config.clone();
-    let token = parent.child_token();
-    if let Err(err) = compute_128bit_ct(conf, uploads_tx, token, client).await {
-        error!(error = %err, "SnS worker failed");
-    }
+    sns_worker::run_all(config, parent)
+        .await
+        .unwrap_or_else(|err| {
+            error!(error = %err, "Error running SNS worker");
+            std::process::exit(1);
+        });
 }

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -438,8 +438,10 @@ pub async fn run_all(
     let (uploads_tx, uploads_rx) =
         mpsc::channel::<UploadJob>(10 * config.s3.max_concurrent_uploads as usize);
 
-    if let Err(err) = telemetry::setup_otlp(&config.service_name) {
-        panic!("Error while initializing tracing: {:?}", err);
+    if !config.service_name.is_empty() {
+        if let Err(err) = telemetry::setup_otlp(&config.service_name) {
+            panic!("Error while initializing tracing: {:?}", err);
+        }
     }
 
     let conf = config.clone();

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -5,14 +5,20 @@ use crate::{
     Config, DBConfig, S3Config, S3RetryPolicy, SchedulePolicy,
 };
 use anyhow::Ok;
+use aws_config::BehaviorVersion;
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
     io::{Read, Write},
+    sync::Arc,
     time::Duration,
 };
 
-use test_harness::instance::{DBInstance, ImportMode};
+use test_harness::{
+    db_utils::truncate_tables,
+    instance::{DBInstance, ImportMode},
+    localstack::LocalstackContainer,
+};
 use tfhe::{
     prelude::FheDecrypt, ClientKey, CompressedSquashedNoiseCiphertextList, SquashedNoiseFheUint,
 };
@@ -26,12 +32,11 @@ const TENANT_API_KEY: &str = "a1503fb6-d79b-4e9e-826d-44cf262f3e05";
 #[ignore = "requires valid SnS keys in CI"]
 async fn test_fhe_ciphertext128_with_compression() {
     const WITH_COMPRESSION: bool = true;
-    let (conn, client_key, _test_instance) = setup(WITH_COMPRESSION).await.expect("valid setup");
+    let test_env = setup(WITH_COMPRESSION).await.expect("valid setup");
     let tf: TestFile = read_test_file("ciphertext64.bin");
 
     test_decryptable(
-        &conn,
-        &client_key,
+        &test_env,
         &tf.handle.into(),
         &tf.ciphertext64.clone(),
         tf.decrypted,
@@ -40,9 +45,9 @@ async fn test_fhe_ciphertext128_with_compression() {
     )
     .await
     .expect("test_fhe_ciphertext128_with_compression, first_fhe_computation = true");
+
     test_decryptable(
-        &conn,
-        &client_key,
+        &test_env,
         &tf.handle.into(),
         &tf.ciphertext64,
         tf.decrypted,
@@ -57,7 +62,7 @@ async fn test_fhe_ciphertext128_with_compression() {
 #[ignore = "requires valid SnS keys in CI"]
 async fn test_batch_execution() {
     const WITH_COMPRESSION: bool = true;
-    let (conn, client_key, _test_instance) = setup(WITH_COMPRESSION).await.expect("valid setup");
+    let test_env = setup(WITH_COMPRESSION).await.expect("valid setup");
     let tf: TestFile = read_test_file("ciphertext64.bin");
 
     let batch_size = std::env::var("BATCH_SIZE")
@@ -68,8 +73,7 @@ async fn test_batch_execution() {
     println!("Batch size: {}", batch_size);
 
     run_batch_computations(
-        &conn,
-        &client_key,
+        &test_env,
         &tf.handle,
         batch_size,
         &tf.ciphertext64.clone(),
@@ -84,12 +88,11 @@ async fn test_batch_execution() {
 #[ignore = "requires valid SnS keys in CI"]
 async fn test_fhe_ciphertext128_no_compression() {
     const NO_COMPRESSION: bool = false;
-    let (conn, client_key, _test_instance) = setup(NO_COMPRESSION).await.expect("valid setup");
+    let test_env = setup(NO_COMPRESSION).await.expect("valid setup");
     let tf: TestFile = read_test_file("ciphertext64.bin");
 
     test_decryptable(
-        &conn,
-        &client_key,
+        &test_env,
         &tf.handle.into(),
         &tf.ciphertext64.clone(),
         tf.decrypted,
@@ -101,15 +104,16 @@ async fn test_fhe_ciphertext128_no_compression() {
 }
 
 async fn test_decryptable(
-    pool: &sqlx::PgPool,
-    client_key: &Option<ClientKey>,
+    test_env: &TestEnvironment,
     handle: &Vec<u8>,
     ciphertext: &Vec<u8>,
     expected_result: i64,
     first_fhe_computation: bool, // first insert ciphertext64 in DB
     with_compression: bool,
 ) -> anyhow::Result<()> {
-    clean_up(pool, handle).await?;
+    let pool = &test_env.pool;
+
+    clean_up(pool).await?;
 
     if first_fhe_computation {
         // insert into ciphertexts
@@ -124,25 +128,34 @@ async fn test_decryptable(
     let tenant_id = get_tenant_id_from_db(pool, TENANT_API_KEY).await;
 
     assert_ciphertext128(
-        pool,
-        client_key,
+        test_env,
         tenant_id,
         with_compression,
         handle,
         expected_result,
     )
-    .await
+    .await?;
+
+    Ok(())
 }
 
 async fn run_batch_computations(
-    pool: &sqlx::PgPool,
-    client_key: &Option<ClientKey>,
+    test_env: &TestEnvironment,
     base_handle: &[u8],
     batch_size: u16,
     ciphertext: &Vec<u8>,
     expected_cleartext: i64,
     with_compression: bool,
 ) -> anyhow::Result<()> {
+    let pool = &test_env.pool;
+    let bucket128 = &test_env.conf.s3.bucket_ct128;
+    let bucket64 = &test_env.conf.s3.bucket_ct64;
+
+    clean_up(pool).await?;
+
+    assert_ciphertext_s3_object_count(test_env, bucket128, 0i64).await;
+    assert_ciphertext_s3_object_count(test_env, bucket64, 0i64).await;
+
     let mut handles = Vec::new();
     let tenant_id = get_tenant_id_from_db(pool, TENANT_API_KEY).await;
     for i in 0..batch_size {
@@ -152,7 +165,6 @@ async fn run_batch_computations(
         // However the ciphertext64 will be the same
         handle[0] = (i >> 8) as u8;
         handle[1] = (i & 0xFF) as u8;
-        clean_up(pool, &handle).await?;
         test_harness::db_utils::insert_ciphertext64(pool, tenant_id, &handle, ciphertext, &[])
             .await?;
         test_harness::db_utils::insert_into_pbs_computations(pool, tenant_id, &handle).await?;
@@ -169,13 +181,11 @@ async fn run_batch_computations(
     let start = std::time::Instant::now();
     let mut set = tokio::task::JoinSet::new();
     for handle in handles.iter() {
-        let pool = pool.clone();
-        let client_key = client_key.clone();
+        let test_env = test_env.clone();
         let handle = handle.clone();
         set.spawn(async move {
             assert_ciphertext128(
-                &pool,
-                &client_key,
+                &test_env,
                 tenant_id,
                 with_compression,
                 &handle,
@@ -191,6 +201,10 @@ async fn run_batch_computations(
 
     let elapsed = start.elapsed();
     println!("Batch execution took: {:?}, batch: {}", elapsed, batch_size);
+
+    // Assert that all ciphertext128 objects are uploaded to S3
+    assert_ciphertext_s3_object_count(test_env, bucket128, batch_size as i64).await;
+    assert_ciphertext_s3_object_count(test_env, bucket64, batch_size as i64).await;
 
     anyhow::Result::<()>::Ok(())
 }
@@ -391,7 +405,7 @@ fn build_test_config(db_url: String, enable_compression: bool) -> Config {
         s3: S3Config {
             bucket_ct128: "ct128".to_owned(),
             bucket_ct64: "ct64".to_owned(),
-            max_concurrent_uploads: 1000,
+            max_concurrent_uploads: 2000,
             retry_policy: S3RetryPolicy {
                 max_retries_per_upload: 100,
                 max_backoff: Duration::from_secs(10),
@@ -400,7 +414,7 @@ fn build_test_config(db_url: String, enable_compression: bool) -> Config {
                 regular_recheck_duration: Duration::from_secs(120),
             },
         },
-        service_name: "test-sns-worker".to_owned(),
+        service_name: "".to_owned(),
         log_level: Level::INFO,
         health_checks: crate::HealthCheckConfig {
             liveness_threshold: Duration::from_secs(10),
@@ -410,33 +424,91 @@ fn build_test_config(db_url: String, enable_compression: bool) -> Config {
         schedule_policy,
     }
 }
-async fn setup(
-    enable_compression: bool,
-) -> anyhow::Result<(sqlx::PgPool, Option<ClientKey>, DBInstance)> {
+
+#[allow(dead_code)]
+#[derive(Clone)]
+struct TestEnvironment {
+    pub pool: sqlx::PgPool,
+    pub client_key: Option<ClientKey>,
+    pub db_instance: DBInstance,
+    pub s3_instance: Option<(Arc<LocalstackContainer>, aws_sdk_s3::Client)>,
+    pub conf: Config,
+}
+
+async fn setup(enable_compression: bool) -> anyhow::Result<TestEnvironment> {
     tracing_subscriber::fmt().json().with_level(true).init();
-    let test_instance = test_harness::instance::setup_test_db(ImportMode::WithAllKeys)
+    let db_instance = test_harness::instance::setup_test_db(ImportMode::WithAllKeys)
         .await
         .expect("valid db instance");
 
-    let conf = build_test_config(test_instance.db_url().to_owned(), enable_compression);
+    let conf = build_test_config(db_instance.db_url().to_owned(), enable_compression);
 
+    // Set up the database connection pool
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(conf.db.max_connections)
         .acquire_timeout(conf.db.timeout)
         .connect(&conf.db.url)
         .await?;
 
-    let token = test_instance.parent_token.child_token();
+    // Set up S3 storage
+    let s3_instance = Some(setup_localstack(&conf).await?);
+
+    let token = db_instance.parent_token.child_token();
+    let config = conf.clone();
     let (client_key, _) = fetch_keys(&pool, &TENANT_API_KEY.to_owned()).await?;
 
     tokio::spawn(async move {
-        crate::run_all(conf, token).await.expect("valid worker run");
+        crate::run_all(config, token)
+            .await
+            .expect("valid worker run");
     });
 
     // TODO: Replace this with notification from the worker when it's in ready-state
     sleep(Duration::from_secs(5)).await;
 
-    Ok((pool, client_key, test_instance))
+    Ok(TestEnvironment {
+        pool,
+        client_key,
+        db_instance,
+        s3_instance,
+        conf,
+    })
+}
+
+async fn setup_localstack(
+    conf: &Config,
+) -> anyhow::Result<(Arc<LocalstackContainer>, aws_sdk_s3::Client)> {
+    let localstack_instance = Arc::new(test_harness::localstack::start_localstack().await?);
+
+    tracing::info!(
+        "LocalStack started on port: {}",
+        localstack_instance.host_port
+    );
+
+    let endpoint_url = format!("http://127.0.0.1:{}", localstack_instance.host_port);
+    std::env::set_var("AWS_ENDPOINT_URL", endpoint_url.clone());
+    std::env::set_var("AWS_REGION", "us-east-1");
+    std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+    std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+
+    let aws_conf = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let client: aws_sdk_s3::Client = aws_sdk_s3::Client::new(&aws_conf);
+
+    client
+        .create_bucket()
+        .set_bucket(Some(conf.s3.bucket_ct128.clone()))
+        .send()
+        .await
+        .expect("Failed to create bucket for ciphertext128");
+
+    client
+        .create_bucket()
+        .set_bucket(Some(conf.s3.bucket_ct64.clone()))
+        .send()
+        .await
+        .expect("Failed to create bucket for ciphertext64");
+
+    Ok((localstack_instance, client))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -518,42 +590,33 @@ async fn insert_into_pbs_computations(
     Ok(())
 }
 
-/// Deletes all records from `pbs_computations` and `ciphertexts` where `handle`
-/// matches.
-async fn clean_up(pool: &sqlx::PgPool, handle: &Vec<u8>) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM pbs_computations WHERE handle = $1")
-        .bind(handle)
-        .execute(pool)
-        .await?;
-
-    sqlx::query("DELETE FROM ciphertexts WHERE handle = $1")
-        .bind(handle)
-        .execute(pool)
-        .await?;
-
-    sqlx::query("DELETE FROM ciphertext_digest WHERE handle = $1")
-        .bind(handle)
-        .execute(pool)
-        .await?;
+/// Cleans up the database by truncating specific tables
+async fn clean_up(pool: &sqlx::PgPool) -> anyhow::Result<()> {
+    truncate_tables(
+        pool,
+        vec!["pbs_computations", "ciphertexts", "ciphertext_digest"],
+    )
+    .await?;
 
     Ok(())
 }
 
 /// Verifies that the ciphertext for the given handle in the database decrypts to the expected value
 async fn assert_ciphertext128(
-    pool: &sqlx::PgPool,
-    client_key: &Option<ClientKey>,
+    test_env: &TestEnvironment,
     tenant_id: i32,
     with_compression: bool,
     handle: &Vec<u8>,
     expected_cleartext: i64,
 ) -> anyhow::Result<()> {
-    let data = test_harness::db_utils::wait_for_ciphertext(pool, tenant_id, handle, 1000).await?;
+    let pool = &test_env.pool;
+    let client_key = &test_env.client_key;
+    let ct = test_harness::db_utils::wait_for_ciphertext(pool, tenant_id, handle, 10000).await?;
 
-    println!("Ciphertext data len: {:?}", data.len());
+    println!("Ciphertext data len: {:?}", ct.len());
 
     let cleartext = if with_compression {
-        let list: CompressedSquashedNoiseCiphertextList = safe_deserialize(&data)?;
+        let list: CompressedSquashedNoiseCiphertextList = safe_deserialize(&ct)?;
         let v: SquashedNoiseFheUint = list
             .get(0)?
             .ok_or_else(|| anyhow::anyhow!("Failed to get the first element from the list"))?;
@@ -564,7 +627,7 @@ async fn assert_ciphertext128(
         );
         r
     } else {
-        let v: SquashedNoiseFheUint = safe_deserialize(&data)?;
+        let v: SquashedNoiseFheUint = safe_deserialize(&ct)?;
         let r: u128 = v.decrypt(client_key.as_ref().unwrap());
         r
     };
@@ -576,5 +639,71 @@ async fn assert_ciphertext128(
         "Cleartext value does not match expected value",
     );
 
+    // Assert that ciphertext128 is uploaded to S3
+    // Note: The tests rely on the `test_s3_use_handle_as_key` feature,
+    // which uses the handle as the key instead of the digest.
+    // This approach allows reusing the same ct128 when uploading a batch of ciphertexts to S3 under different keys.
+
+    #[cfg(feature = "test_s3_use_handle_as_key")]
+    {
+        assert_ciphertext_uploaded(test_env, &test_env.conf.s3.bucket_ct128, handle).await;
+        assert_ciphertext_uploaded(test_env, &test_env.conf.s3.bucket_ct64, handle).await;
+    }
+
     Ok(())
+}
+
+/// Asserts that ciphertext exists in S3
+async fn assert_ciphertext_uploaded(test_env: &TestEnvironment, bucket: &String, handle: &Vec<u8>) {
+    if let Some(client) = test_env.s3_instance.as_ref().map(|(_, c)| c.clone()) {
+        let mut found = false;
+        let retries = 1000;
+        for _i in 0..retries {
+            if client
+                .head_object()
+                .bucket(bucket)
+                .key(hex::encode(handle))
+                .send()
+                .await
+                .is_ok()
+            {
+                found = true;
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        assert!(found, "Failed to find ct in S3 bucket: {}", bucket);
+    }
+}
+
+/// Asserts that the number of ciphertext128 objects in S3 matches the expected count
+async fn assert_ciphertext_s3_object_count(
+    test_env: &TestEnvironment,
+    bucket: &String,
+    expected_count: i64,
+) {
+    if let Some(client) = test_env.s3_instance.as_ref().map(|(_, c)| c.clone()) {
+        let result = client
+            .list_objects()
+            .set_max_keys(Some((expected_count + 1) as i32))
+            .bucket(bucket)
+            .send()
+            .await
+            .expect("Failed to list objects in S3 bucket");
+
+        tracing::info!(
+            "Found {} ct objects in S3 bucket: {}",
+            result.contents().len(),
+            bucket
+        );
+
+        assert_eq!(
+            result.contents().len(),
+            expected_count as usize,
+            "Expected {} ct objects in S3 bucket, found {}",
+            expected_count,
+            result.contents().len()
+        );
+    }
 }

--- a/coprocessor/fhevm-engine/test-harness/Cargo.toml
+++ b/coprocessor/fhevm-engine/test-harness/Cargo.toml
@@ -11,6 +11,7 @@ alloy = { workspace = true }
 anyhow = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-kms = { workspace = true }
+aws-sdk-s3 = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true}
 reqwest = { workspace = true}

--- a/coprocessor/fhevm-engine/test-harness/src/db_utils.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/db_utils.rs
@@ -125,7 +125,7 @@ pub async fn wait_for_ciphertext(
         println!("wait for ciphertext, retry: {}", retry);
 
         // Wait before retrying
-        sleep(Duration::from_millis(500)).await;
+        sleep(Duration::from_millis(300)).await;
     }
 
     Err(sqlx::Error::RowNotFound.into())
@@ -244,4 +244,12 @@ pub async fn insert_random_tenant(pool: &PgPool) -> Result<i32, sqlx::Error> {
     .await?;
 
     Ok(row.tenant_id)
+}
+
+pub async fn truncate_tables(db_pool: &sqlx::PgPool, tables: Vec<&str>) -> Result<(), sqlx::Error> {
+    for table in tables {
+        let query = format!("TRUNCATE {}", table);
+        sqlx::query(&query).execute(db_pool).await?;
+    }
+    Ok(())
 }

--- a/coprocessor/fhevm-engine/test-harness/src/instance.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/instance.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
 pub struct DBInstance {
-    _container: Arc<Option<testcontainers::ContainerAsync<testcontainers::GenericImage>>>,
+    _container: Option<Arc<testcontainers::ContainerAsync<testcontainers::GenericImage>>>,
     db_url: String,
     pub parent_token: CancellationToken,
 }
@@ -64,7 +64,7 @@ async fn setup_test_app_existing_localhost(
     }
 
     Ok(DBInstance {
-        _container: Arc::new(None),
+        _container: None,
         db_url: db_url.to_string(),
         parent_token: CancellationToken::new(),
     })
@@ -93,7 +93,7 @@ async fn setup_test_app_custom_docker(
     create_database(&admin_db_url, &db_url, mode).await?;
 
     Ok(DBInstance {
-        _container: Arc::new(Some(container)),
+        _container: Some(Arc::new(container)),
         db_url,
         parent_token: CancellationToken::new(),
     })

--- a/coprocessor/fhevm-engine/test-harness/src/instance.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/instance.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use crate::db_utils::setup_test_user;
 use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
 
+#[derive(Clone)]
 pub struct DBInstance {
-    _container: Option<testcontainers::ContainerAsync<testcontainers::GenericImage>>,
+    _container: Arc<Option<testcontainers::ContainerAsync<testcontainers::GenericImage>>>,
     db_url: String,
     pub parent_token: CancellationToken,
 }
@@ -12,14 +14,6 @@ pub struct DBInstance {
 impl DBInstance {
     pub fn db_url(&self) -> &str {
         self.db_url.as_str()
-    }
-}
-
-impl Drop for DBInstance {
-    fn drop(&mut self) {
-        warn!("Dropping DBInstance, terminating the database container");
-        drop(self.parent_token.clone());
-        drop(self._container.take());
     }
 }
 
@@ -70,7 +64,7 @@ async fn setup_test_app_existing_localhost(
     }
 
     Ok(DBInstance {
-        _container: None,
+        _container: Arc::new(None),
         db_url: db_url.to_string(),
         parent_token: CancellationToken::new(),
     })
@@ -99,7 +93,7 @@ async fn setup_test_app_custom_docker(
     create_database(&admin_db_url, &db_url, mode).await?;
 
     Ok(DBInstance {
-        _container: Some(container),
+        _container: Arc::new(Some(container)),
         db_url,
         parent_token: CancellationToken::new(),
     })

--- a/coprocessor/fhevm-engine/test-harness/src/lib.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/lib.rs
@@ -2,3 +2,4 @@ pub mod db_utils;
 pub mod health_check;
 pub mod instance;
 pub mod localstack;
+pub mod s3_utils;

--- a/coprocessor/fhevm-engine/test-harness/src/s3_utils.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/s3_utils.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use aws_sdk_s3::Client;
+use tokio::time::sleep;
+
+/// Asserts that a key exists in S3 bucket with an optional expected value length.
+/// If the key is not found, it retries for a specified number of times.
+///# Arguments
+/// * `client` - The S3 client to use for the request.
+/// * `bucket` - The name of the S3 bucket.
+/// * `key` - The key to check in the S3 bucket.
+/// * `expected_value_len` - An optional expected length of the value associated with the key
+pub async fn assert_key_exists(
+    client: Client,
+    bucket: &String,
+    key: &String,
+    expected_value_len: Option<i64>,
+    retries: u64,
+) {
+    let mut key_found = false;
+
+    for _i in 0..retries {
+        if let Result::Ok(output) = client.head_object().bucket(bucket).key(key).send().await {
+            key_found = true;
+
+            if let Some(expected_value_len) = expected_value_len {
+                let content_length = output.content_length().unwrap_or(0);
+                assert!(
+                    content_length == expected_value_len,
+                    "Expected value length: {}, got: {}",
+                    expected_value_len,
+                    content_length
+                );
+            }
+
+            break;
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        key_found,
+        "Failed to find key {} in S3 bucket: {}",
+        key, bucket
+    );
+}
+
+/// Asserts that the number of objects in S3 matches the expected count
+pub async fn assert_object_count(client: Client, bucket: &String, expected_count: i32) {
+    let max_keys = 100_000;
+
+    assert!(
+        expected_count <= max_keys,
+        "Expected count {} exceeds max keys {}",
+        expected_count,
+        max_keys
+    );
+
+    let result = client
+        .list_objects()
+        .set_max_keys(Some(max_keys))
+        .bucket(bucket)
+        .send()
+        .await
+        .expect("Failed to list objects in S3 bucket");
+
+    tracing::info!(
+        "Found {} objects in S3 bucket: {}",
+        result.contents().len(),
+        bucket
+    );
+
+    assert_eq!(
+        result.contents().len(),
+        expected_count as usize,
+        "Expected {} ct objects in S3 bucket, found {}",
+        expected_count,
+        result.contents().len()
+    );
+}


### PR DESCRIPTION
In unit-testing of SnS worker, the localstack container is used as S3 emulator. The required buckets are always created. Additionally, there are new asserts to verify if a S3 upload was successful.

To simplify testing, there is a new feature **test_s3_use_handle_as_key** enabled only in test mode. It allows uploading the same ciphertext multiple times.

fixes: https://github.com/zama-ai/fhevm-internal/issues/351