### PR TITLE
fix: correct broken file paths in documentation

### DIFF
--- a/coprocessor/docs/getting_started/fhevm/native/executor.md
+++ b/coprocessor/docs/getting_started/fhevm/native/executor.md
@@ -6,7 +6,7 @@ An FHEVM-native node consists of the following components:
 
 More detailed description of the architecture and FHE execution can be found in [Architecture](../../../fundamentals/fhevm/native/architecture.md) and [FHE Computation](../../../fundamentals/fhevm/native/fhe_computation.md).
 
-The Executor service is a gRPC server that accepts FHE computation requests from the full node/validator node and executes them. It is implemented in the [executor](../../../../fhevm-engine/executor/README.md) directory of `fhevm-engine`.
+The Executor service is a gRPC server that accepts FHE computation requests from the full node/validator node and executes them. It is implemented in the [sns-worker](../../../../fhevm-engine/sns-worker/README.md) directory of `fhevm-engine`.
 
 At the time of writing, the [geth](geth.md) implementation is not yet implemented.
 

--- a/docs/solidity-guides/mocked.md
+++ b/docs/solidity-guides/mocked.md
@@ -12,11 +12,11 @@ This document provides an overview of mocked mode in the FHEVM framework, explai
 
 Mocked mode is currently supported in the [Zama Hardhat template](https://github.com/zama-ai/fhevm-hardhat-template). Developers can enable mocked mode to simulate encrypted operations while building and testing smart contracts locally. The Hardhat template includes pre-configured scripts and libraries to simplify the setup process for mocked mode.
 
-Refer to the [[Quick start - Hardhat]](../getting-started/overview-1/hardhat/README.md) guide for instructions on using the Hardhat template.
+Refer to the [[Quick start - Hardhat]](./hardhat/README.md) guide for instructions on using the Hardhat template.
 
 ### 2. **Foundry (coming soon)**
 
-Mocked mode support is planned for [Foundry](./write_contract/foundry.md) in future releases.
+Mocked mode support is planned for [Foundry](./foundry.md) in future releases.
 
 ## How mocked mode works
 


### PR DESCRIPTION
Fix broken file paths in executor.md and mocked.md documentation files.
Resolves "Cannot find file" errors by updating links to point to existing files.