### PR TITLE
feat(charts): sc-deploy, support extracting multiple contract addresses from env file

### DIFF
--- a/charts/contracts/Chart.yaml
+++ b/charts/contracts/Chart.yaml
@@ -1,6 +1,6 @@
 name: contracts
 description: A helm chart to manage fhevm Smart Contracts Deployment
-version: 0.5.0
+version: 0.6.0
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/contracts/templates/sc-deploy-config.yaml
+++ b/charts/contracts/templates/sc-deploy-config.yaml
@@ -85,10 +85,20 @@ data:
 
     for envfile in /app/addresses/.env.*; do
       echo "---"
-      echo "Updating configmap for ${envfile}"
-      CONTRACT_NAME="$(echo ${envfile} | cut -d'.' -f 3)"
-      CONTRACT_ADDRESS="$(cat ${envfile} | cut -d'=' -f 2)"
-      add_key_to_configmap "${CONFIGMAP_NAME}" "${CONTRACT_NAME}.address" "${CONTRACT_ADDRESS}"
+      echo "Updating configmap: ${CONFIGMAP_NAME} for the following contract addresses:"
+      cat ${envfile}
+
+      while IFS= read -r line; do
+        # Use `cut` to split the line at the first `=`
+        # The first part is the key (CONTRACT_NAME) and the second is the value (CONTRACT_ADDRESS)
+        CONTRACT_NAME=$(echo "$line" | cut -d'=' -f1)
+        CONTRACT_ADDRESS=$(echo "$line" | cut -d'=' -f2)
+
+        # Remove the "_ADDRESS" or  "_CONTRACT_ADDRESS" suffix to get the clean contract name
+        CLEAN_NAME=$(echo "${CONTRACT_NAME}" | sed 's/_CONTRACT_ADDRESS\|_ADDRESS//g' | tr '[:upper:]' '[:lower:]')
+        echo "Adding ${CLEAN_NAME}.address=${CONTRACT_ADDRESS}"
+        add_key_to_configmap "${CONFIGMAP_NAME}" "${CLEAN_NAME}.address" "${CONTRACT_ADDRESS}"
+      done < "${envfile}"
     done;
 
     {{- if .Values.scDeploy.verifyContracts }}


### PR DESCRIPTION
In newer version of the hardhat deploy tasks, we are combining output contract addresses in a single file eg:
```
$ cat addresses/.env.gateway 
MULTICHAIN_ACL_ADDRESS=0x2813eCae2976F28Fbeee3D1453D46F62f7830b0E
CIPHERTEXT_COMMITS_ADDRESS=0xbBD85E0D86F461B8A2fdd13B7323Eda0229e044B
DECRYPTION_ADDRESS=0x562F9456Afe2c92D507E86B0EF7aBc025fE05733
GATEWAY_CONFIG_ADDRESS=0xC1bddF26e1521C8064f998B38Ea180f827bbDaCb
KMS_MANAGEMENT_ADDRESS=0x877CcB61F32fdc06ACe506cd4418a3ED5e8b4d10
INPUT_VERIFICATION_ADDRESS=0xe73e69975c55EB521243eAFD8BA2501E89687677
```

In this PR, we change the script to support this new format.