### PR TITLE
chore(kms-connector): remove verify_coprocessor config

### DIFF
--- a/charts/kms-connector/Chart.yaml
+++ b/charts/kms-connector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-connector
 description: A helm chart to distribute and deploy the Zama KMS Connector services
-version: 0.6.2
+version: 0.6.3
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/kms-connector/values.yaml
+++ b/charts/kms-connector/values.yaml
@@ -159,8 +159,6 @@ kmsConnectorKmsWorker:
     #   value: "3"
     # - name: KMS_CONNECTOR_S3_CONNECT_TIMEOUT
     #   value: "2"
-    # - name: KMS_CONNECTOR_VERIFY_COPROCESSORS
-    #   value: "true"
     # - name: KMS_CONNECTOR_S3_CONFIG__REGION
     #   value: "us-east-1"
     # - name: KMS_CONNECTOR_S3_CONFIG__BUCKET

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -86,10 +86,6 @@ address = "0x5ffdaAB0373E62E2ea2944776209aEf29E631A64"
 # ENV: KMS_CONNECTOR_S3_CONNECT_TIMEOUT
 # s3_connect_timeout = 2
 
-# Whether to verify coprocessors against the GatewayConfig contract (optional, defaults to false)
-# ENV: KMS_CONNECTOR_VERIFY_COPROCESSORS
-# verify_coprocessors = true
-
 # S3 configuration for ciphertext storage (optional)
 # This is used for fallback ciphertext retrieval when coprocessor URLs are unavailable
 # [s3_config]

--- a/kms-connector/crates/kms-worker/src/core/config/parsed.rs
+++ b/kms-connector/crates/kms-worker/src/core/config/parsed.rs
@@ -53,10 +53,6 @@ pub struct Config {
     /// The maximum number of tasks that can be executed concurrently.
     pub task_limit: usize,
 
-    // TODO: implement to increase security
-    /// Whether to verify coprocessors against the `GatewayConfig` contract (defaults to false).
-    pub verify_coprocessors: bool,
-
     /// The monitoring server endpoint of the `KmsWorker`.
     pub monitoring_endpoint: SocketAddr,
     /// The timeout to perform each external service connection healthcheck.
@@ -136,7 +132,6 @@ impl Config {
             s3_ciphertext_retrieval_retries: raw_config.s3_ciphertext_retrieval_retries,
             s3_connect_timeout: s3_ciphertext_retrieval_timeout,
             task_limit: raw_config.task_limit,
-            verify_coprocessors: raw_config.verify_coprocessors,
             monitoring_endpoint,
             healthcheck_timeout,
         })
@@ -233,7 +228,6 @@ mod tests {
             config.gateway_config_contract.domain_version,
         );
         assert_eq!(raw_config.s3_config, config.s3_config);
-        assert_eq!(raw_config.verify_coprocessors, config.verify_coprocessors);
     }
 
     #[test]

--- a/kms-connector/crates/kms-worker/src/core/config/raw.rs
+++ b/kms-connector/crates/kms-worker/src/core/config/raw.rs
@@ -57,8 +57,6 @@ pub struct RawConfig {
     pub s3_connect_timeout: u64,
     #[serde(default = "default_task_limit")]
     pub task_limit: usize,
-    #[serde(default = "default_verify_coprocessors")]
-    pub verify_coprocessors: bool,
     #[serde(default = "default_monitoring_endpoint")]
     pub monitoring_endpoint: String,
     #[serde(default = "default_healthcheck_timeout_secs")]
@@ -99,10 +97,6 @@ fn default_s3_ciphertext_retrieval_retries() -> u8 {
 
 fn default_s3_connect_timeout() -> u64 {
     2 // 2 seconds
-}
-
-fn default_verify_coprocessors() -> bool {
-    false
 }
 
 impl DeserializeRawConfig for RawConfig {
@@ -167,7 +161,6 @@ impl Default for RawConfig {
             s3_connect_timeout: 2,
             s3_config: None,
             task_limit: default_task_limit(),
-            verify_coprocessors: false,
             monitoring_endpoint: default_monitoring_endpoint(),
             healthcheck_timeout_secs: default_healthcheck_timeout_secs(),
         }


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/347

@piizama regarding our earlier discussion, here the config field that was removed was an optional one that was not used by the connector, and that should not have been configured either by infra team. So I guess it is fine to remove it, right? Plus, even if this field stay configured, it will just be ignored by the connector, so really no impact I would say