### PR TITLE
ci(gateway-contracts): remove docker cp in upgrade workflow

### DIFF
--- a/.github/workflows/gateway-contracts-upgrade-tests.yml
+++ b/.github/workflows/gateway-contracts-upgrade-tests.yml
@@ -113,15 +113,12 @@ jobs:
 
       # Executing task:deployEmptyUUPSProxies is required to generate the proxy contract addresses, which are then used
       # for compiling the current and new implementations during the upgrade task.
-      # The docker cp command is required until previous-contracts uses separated .env and addresses files,
-      # see https://github.com/zama-ai/fhevm-internal/issues/217.
       - name: Prepare and copy previous contract into current directory
         working-directory: current-fhevm/gateway-contracts
         run: |
           cp .env.example .env
           cp -r ../../previous-fhevm/gateway-contracts/contracts ./previous-contracts
           npx hardhat task:deployEmptyUUPSProxies
-          docker cp deploy-gateway-contracts:/app/addresses ./
 
       # TODO: We should instead automatically detect if the contract needs to be upgraded
       #  See https://github.com/zama-ai/fhevm-internal/issues/379


### PR DESCRIPTION
this was a workaround in order to compare with fhevm 0.7, not needed anymore (+ it creates an issue when introducing new contracts)

closes https://github.com/zama-ai/fhevm-internal/issues/217