### PR TITLE
feat(coprocessor): handle graceful shutdown cases in txn-sender

### DIFF
--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -35,6 +35,8 @@ pub struct ConfigSettings {
     pub health_check_timeout: Duration,
 
     pub gas_limit_overprovision_percent: u32,
+
+    pub graceful_shutdown_timeout: Duration,
 }
 
 impl Default for ConfigSettings {
@@ -62,6 +64,7 @@ impl Default for ConfigSettings {
             http_server_port: 8080,
             health_check_timeout: Duration::from_secs(4),
             gas_limit_overprovision_percent: 120,
+            graceful_shutdown_timeout: Duration::from_secs(8),
         }
     }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/nonce_managed_provider.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/nonce_managed_provider.rs
@@ -67,6 +67,10 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> NonceManagedProv
         self.provider.get_transaction_count(address).await
     }
 
+    pub async fn get_block_number(&self) -> TransportResult<u64> {
+        self.provider.get_block_number().await
+    }
+
     pub fn inner(&self) -> &P {
         &self.provider
     }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -100,7 +100,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
                 self.set_txn_is_sent(key, None, None).await?;
                 return Ok(());
             }
-            // Consider transport errors and local usage errors as something that must be retried infinitely.
+            // Consider transport retryable errors, BackendGone and local usage errors as something that must be retried infinitely.
             // Local usage are included as they might be transient due to external AWS KMS signers.
             Err(e)
                 if matches!(&e, RpcError::Transport(inner) if inner.is_retry_err() || matches!(inner, TransportErrorKind::BackendGone))
@@ -119,10 +119,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
                     current_unlimited_retries_count,
                 )
                 .await?;
-                bail!(
-                    "Transaction sending failed with unlimited retry error: {}",
-                    e
-                );
+                bail!(e);
             }
             Err(e) => {
                 ALLOW_HANDLE_FAIL_COUNTER.inc();
@@ -138,7 +135,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> MultichainAclOperation<P> {
                     current_limited_retries_count,
                 )
                 .await?;
-                bail!("Transaction sending failed with error: {}", e);
+                bail!(e);
             }
         };
 
@@ -485,9 +482,5 @@ where
         }
 
         Ok(maybe_has_more_work)
-    }
-
-    fn provider(&self) -> &P {
-        self.provider.inner()
     }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/mod.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/mod.rs
@@ -9,16 +9,6 @@ where
     fn channel(&self) -> &str;
 
     async fn execute(&self) -> anyhow::Result<bool>;
-
-    /// Get a reference to the provider
-    fn provider(&self) -> &P;
-
-    /// Check if the provider connection is healthy
-    async fn check_provider_connection(&self) -> anyhow::Result<()> {
-        // Default implementation for checking provider connection
-        let _ = self.provider().get_block_number().await?;
-        Ok(())
-    }
 }
 
 pub(crate) mod add_ciphertext;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -366,8 +366,4 @@ where
         }
         Ok(maybe_has_more_work)
     }
-
-    fn provider(&self) -> &P {
-        self.provider.inner()
-    }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -7,7 +7,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use crate::{
-    nonce_managed_provider::NonceManagedProvider, ops, AbstractSigner, ConfigSettings, HealthStatus,
+    is_backend_gone, nonce_managed_provider::NonceManagedProvider, ops, AbstractSigner,
+    ConfigSettings, HealthStatus,
 };
 
 #[derive(Clone)]
@@ -19,6 +20,7 @@ pub struct TransactionSender<P: Provider<Ethereum> + Clone + 'static> {
     ciphertext_commits_address: Address,
     multichain_acl_address: Address,
     db_pool: Pool<Postgres>,
+    provider: NonceManagedProvider<P>,
 }
 
 impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
@@ -73,6 +75,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
             ciphertext_commits_address,
             multichain_acl_address,
             db_pool,
+            provider,
         })
     }
 
@@ -106,6 +109,15 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
 
                         match op.execute().await {
                             Err(e) => {
+                                if is_backend_gone(&e) {
+                                    error!(
+                                        channel = op_channel,
+                                        error = %e,
+                                        "Backend gone error, stopping operation and signalling other operations to stop"
+                                    );
+                                    token.cancel();
+                                    return Err(e);
+                                }
                                 error!(
                                     channel = op_channel,
                                     error = %e,
@@ -173,10 +185,39 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
             });
         }
 
-        while let Some(res) = join_set.join_next().await {
-            res??;
+        self.cancel_token.cancelled().await;
+        info!("Cancellation requested, waiting for operations to stop");
+        // Make sure we don't wait indefinitely.
+        let timeout_future = tokio::time::sleep(self.conf.graceful_shutdown_timeout);
+        tokio::pin!(timeout_future);
+        loop {
+            tokio::select! {
+                _ = &mut timeout_future => {
+                    error!("Graceful shutdown timeout reached, some operations may not have stopped gracefully");
+                    break Err(anyhow::anyhow!("Timeout reached during graceful shutdown"));
+                }
+
+                n = join_set.join_next() => {
+                    match n {
+                        Some(Ok(Ok(_))) => {
+                            info!("An operation stopped gracefully");
+                        }
+                        Some(Ok(Err(e))) => {
+                            error!(error = %e, "An operation returned an error");
+                            break Err(e);
+                        }
+                        Some(Err(e)) => {
+                            error!(error = %e, "Join failed with an error");
+                            break Err(e.into());
+                        }
+                        None => {
+                            info!("All operations stopped");
+                            break Ok(())
+                        }
+                    }
+                }
+            }
         }
-        Ok(())
     }
 
     fn reset_sleep_duration(&self, sleep_duration: &mut u64) {
@@ -203,27 +244,24 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
                 error_details.push(format!("Database query error: {}", e));
             }
         }
-        // Check blockchain connection for at least one operation
-        if let Some(op) = self.operations.first() {
-            // The provider internal retry may last a long time, so we set a timeout
-            match tokio::time::timeout(
-                self.conf.health_check_timeout,
-                op.check_provider_connection(),
-            )
-            .await
-            {
-                Ok(Ok(_)) => {
-                    blockchain_connected = true;
-                }
-                Ok(Err(e)) => {
-                    error_details.push(format!("Blockchain connection error: {}", e));
-                }
-                Err(_) => {
-                    error_details.push("Blockchain connection timeout".to_string());
-                }
+
+        // Check blockchain connection by getting the last block number.
+        // The provider internal retry may last a long time, so we set a timeout.
+        match tokio::time::timeout(
+            self.conf.health_check_timeout,
+            self.provider.get_block_number(),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {
+                blockchain_connected = true;
             }
-        } else {
-            error_details.push("No operations configured".to_string());
+            Ok(Err(e)) => {
+                error_details.push(format!("Blockchain connection error: {}", e));
+            }
+            Err(_) => {
+                error_details.push("Blockchain connection timeout".to_string());
+            }
         }
 
         // Determine overall health status

--- a/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
@@ -13,7 +13,8 @@ use std::time::Duration;
 use test_harness::db_utils::{insert_ciphertext_digest, insert_random_tenant};
 use tokio::time::sleep;
 use transaction_sender::{
-    ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider, TransactionSender,
+    is_backend_gone, ConfigSettings, FillersWithoutNonceManagement, NonceManagedProvider,
+    TransactionSender,
 };
 
 #[rstest]
@@ -307,9 +308,10 @@ async fn recover_from_transport_error(#[case] signer_type: SignerType) -> anyhow
 #[case::aws_kms(SignerType::AwsKms)]
 #[tokio::test]
 #[serial(db)]
-async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Result<()> {
+async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result<()> {
     let conf = ConfigSettings {
         add_ciphertexts_max_retries: 2,
+        graceful_shutdown_timeout: Duration::from_secs(2),
         ..Default::default()
     };
 
@@ -319,7 +321,12 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
             .await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
-        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+        .connect_ws(
+            // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
+            WsConnect::new(env.ws_endpoint_url())
+                .with_max_retries(1)
+                .with_retry_interval(Duration::from_millis(200)),
+        )
         .await?;
     let provider = NonceManagedProvider::new(
         ProviderBuilder::default()
@@ -328,8 +335,8 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
             .connect_ws(
                 // Reduce the retries count and the interval for alloy's internal retry to make this test faster.
                 WsConnect::new(env.ws_endpoint_url())
-                    .with_max_retries(2)
-                    .with_retry_interval(Duration::from_millis(100)),
+                    .with_max_retries(1)
+                    .with_retry_interval(Duration::from_millis(200)),
             )
             .await?,
         Some(env.wallet.default_signer().address()),
@@ -377,7 +384,7 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
     .execute(&env.db_pool)
     .await?;
 
-    // Make sure the digest is not sent, the retry count is 0 and the unlimited retry count is greater than the txn max retry count.
+    // Make sure the digest is not sent, the retry count is 0 and the unlimited retry count is 1.
     loop {
         let rows = sqlx::query!(
             "SELECT txn_is_sent, txn_limited_retries_count, txn_unlimited_retries_count
@@ -389,7 +396,7 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
         .await?;
         if !rows.txn_is_sent
             && rows.txn_limited_retries_count == 0
-            && rows.txn_unlimited_retries_count > conf.add_ciphertexts_max_retries as i32
+            && rows.txn_unlimited_retries_count == 1
         {
             break;
         }
@@ -403,8 +410,9 @@ async fn retry_on_transport_error(#[case] signer_type: SignerType) -> anyhow::Re
     .execute(&env.db_pool)
     .await?;
 
-    env.cancel_token.cancel();
-    run_handle.await??;
+    // Expect that the sender will stop on its own due to BackendGone.
+    let err = run_handle.await?.err().unwrap();
+    assert!(is_backend_gone(&err));
     Ok(())
 }
 

--- a/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
@@ -91,19 +91,15 @@ impl TestEnvironment {
         .await?;
 
         let anvil = Self::new_anvil()?;
-        let chain_id = get_chain_id(
-            anvil.ws_endpoint_url(),
-            std::time::Duration::from_secs(1),
-            CancellationToken::new(),
-        )
-        .await;
+        let chain_id =
+            get_chain_id(anvil.ws_endpoint_url(), std::time::Duration::from_secs(1)).await;
         let abstract_signer;
         let localstack;
         match signer_type {
             SignerType::PrivateKey => {
                 localstack = None;
                 let mut signer = PrivateKeySigner::from_signing_key(anvil.keys()[0].clone().into());
-                signer.set_chain_id(chain_id);
+                signer.set_chain_id(Some(chain_id));
                 abstract_signer = make_abstract_signer(signer);
             }
             SignerType::AwsKms => {
@@ -123,7 +119,7 @@ impl TestEnvironment {
                 let key_id =
                     create_localstack_kms_signing_key(&aws_kms_client, &anvil.keys()[0].to_bytes())
                         .await?;
-                let signer = AwsSigner::new(aws_kms_client, key_id, chain_id).await?;
+                let signer = AwsSigner::new(aws_kms_client, key_id, Some(chain_id)).await?;
                 abstract_signer = make_abstract_signer(signer);
             }
         }


### PR DESCRIPTION
This commit assumes that `provider_max_retries` and `provider_retry_interval` are set such that it would take a long time until the provider stops retrying. If that happens, we consider the provider no longer usable and we shut down the txn-sender. This keeps code simpler and avoids the need to refactor and retest retry behaviour. Reason we do it is that once retries are exhausted, the provider is no longer usable and `BackendGone` is returned.

We could consider using HTTP instead of WS, but that is left for future investigation.

The following other changes are made:
 * propagete errors without converting them to strings, e.g. `bail(a)` instead of `bail("xxx {}", e)`
 * remove the `provider()` and `check_provider_connection()` functions from the `TransactionOperation` trait as they are used for health checking and we do not need the health check to go to just the first operation - instead, we use the provider from the `TransactionSender`
* since the provider can retry for a long time, if a signal to stop the sender is received, we add a graceful timeout such that the sender stops in a timely manner and doesn't wait for a long time for the provider - for that, we introduce the `graceful_shutdown_timeout` config option
* plug the cancellation token to `get_chain_id()` on startup, such that the sender can stop in a timely manner
* use `tokio::spawn()` instead of join! for starting the sender and the HTTP server