### PR TITLE
Fix typo: Remove extra space in README.md main features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The directories of this repository are organized in the following way:
 - **Privacy by design:** Building decentralized apps with full privacy and confidentiality on Ethereum, leveraging FHE.
 - **Solidity integration:** Write FHEVM contracts like any standard Solidity contract using Solidity. Compatible with existing toolchains — such as Hardhat and Foundry (*coming soon*).
 - **Programmable privacy:**  Define exactly what data is encrypted and write the access control logic directly in your smart contracts.
-- **High precision encrypted integers :** Up to 256 bits of precision for integers.
+- **High precision encrypted integers:** Up to 256 bits of precision for integers.
 - **Full range of operators:** All typical operators are available: `+`, `-`, `*`, `/`, `<`, `>`, `==`, ternary-if, boolean operations…. Consecutive FHE operations are not limited.
 - **Security:** The underlying FHE crypto-scheme of FHEVM is quantum-resistant. Decryption is managed via a key management system (KMS) using multi-party computation (MPC), ensuring security even if some parties are compromised or misbehaving.
 - **Symbolic execution of FHE computations:** All FHE operations are executed symbolically on the host chain, significantly reducing execution time. The actual computations on encrypted data are offloaded asynchronously to our coprocessor, allowing for faster, efficient, and scalable processing.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The directories of this repository are organized in the following way:
 ### Main features
 
 - **Privacy by design:** Building decentralized apps with full privacy and confidentiality on Ethereum, leveraging FHE.
-- **Solidity integration:** Write FHEVM contracts like any standard Solidity contract using Solidity. Compatible with existing toolchains — such as Hardhat and Foundry (*coming soon*).
+- **Solidity integration:** Write FHEVM contracts like any standard Solidity contract using Solidity. Compatible with existing toolchains — such as Hardhat and Foundry.
 - **Programmable privacy:**  Define exactly what data is encrypted and write the access control logic directly in your smart contracts.
 - **High precision encrypted integers:** Up to 256 bits of precision for integers.
 - **Full range of operators:** All typical operators are available: `+`, `-`, `*`, `/`, `<`, `>`, `==`, ternary-if, boolean operations…. Consecutive FHE operations are not limited.

--- a/coprocessor/README.md
+++ b/coprocessor/README.md
@@ -2,7 +2,7 @@
 **FHEVM Coprocessor** provides the execution service for FHE computations.
 
 It includes a **Coprocessor** service [FHEVM-coprocessor](docs/getting_started/fhevm/coprocessor/coprocessor_backend.md). The Coprocessor
-itself consists of multiple microservices, e.g. for FHE compute, input verify, transaction sending, listenting to events, etc.
+itself consists of multiple microservices, e.g. for FHE compute, input verify, transaction sending, listening to events, etc.
 
 ## Main features
 
@@ -19,7 +19,7 @@ _Learn more about FHEVM Coprocessor features in the [documentation](docs)._
 - [Getting Started](#getting-started)
   - [Generating Keys](#generating-keys)
   - [Coprocessor](#coprocessor)
-    - [Dependencies](#dependences)
+    - [Dependencies](#dependencies)
     - [Installation](#installation)
     - [Services Configuration](#services-configuration)
       - [tfhe-worker](#tfhe-worker)
@@ -49,7 +49,7 @@ The keys are stored by default in `fhevm-engine/fhevm-keys`.
 
 ### Coprocessor
 
-#### Dependences
+#### Dependencies
 
 - `docker-compose`
 - `rust`


### PR DESCRIPTION
Removed an unnecessary space after the colon in the 'High precision encrypted integers' bullet point for improved formatting consistency in the README.md file. This ensures cleaner documentation presentation.