### PR TITLE
chore(kms-connector): enable tls for sqlx

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -7078,6 +7078,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "sha2",
@@ -7087,6 +7088,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -69,6 +69,7 @@ sqlx = { version = "=0.8.6", default-features = false, features = [
     "macros",
     "postgres",
     "runtime-tokio",
+    "tls-rustls",
 ] }
 thiserror = { version = "=2.0.12", default-features = false }
 tokio = { version = "=1.46.1", default-features = false, features = [


### PR DESCRIPTION
e2e tests are passing: https://github.com/zama-ai/fhevm/actions/runs/17976964176/job/51132743478