### PR TITLE
feat(coprocessor): gw-listener key activation via getLogs

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3844,6 +3844,7 @@ version = "0.7.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -28,6 +28,7 @@ alloy = { version = "1.0.32", default-features = false, features = [
 ] }
 alloy-provider = "1.0.9"
 alloy-primitives = "1.2.0"
+async-trait = "0.1.88"
 axum = "0.7"
 tower-http = { version = "0.5", features = ["trace"] }
 anyhow = "1.0.98"

--- a/coprocessor/fhevm-engine/gw-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/gw-listener/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 # workspace dependencies
 alloy = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }

--- a/coprocessor/fhevm-engine/gw-listener/src/aws_s3.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/aws_s3.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use async_trait::async_trait;
 use aws_config::{retry::RetryConfig, timeout::TimeoutConfig, BehaviorVersion};
 use aws_sdk_s3::config::{Builder, ProvideCredentials};
 use aws_sdk_s3::Client;
@@ -65,6 +66,7 @@ pub async fn create_s3_client(
 #[derive(Clone)]
 pub struct AwsS3Client {}
 
+#[async_trait]
 impl AwsS3Interface for AwsS3Client {
     async fn get_bucket_key(
         &self,
@@ -86,13 +88,14 @@ impl AwsS3Interface for AwsS3Client {
     }
 }
 
-pub trait AwsS3Interface {
-    fn get_bucket_key(
+#[async_trait]
+pub trait AwsS3Interface: Send + Sync {
+    async fn get_bucket_key(
         &self,
         url: &str,
         bucket: &str,
         key: &str,
-    ) -> impl std::future::Future<Output = anyhow::Result<bytes::Bytes>>;
+    ) -> anyhow::Result<bytes::Bytes>;
 }
 
 fn split_url(s3_bucket_url: &String) -> anyhow::Result<(String, String)> {

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -61,6 +61,12 @@ struct Conf {
 
     #[arg(long)]
     host_chain_id: Option<u64>,
+
+    #[arg(long, default_value = "1s", value_parser = parse_duration)]
+    get_logs_poll_interval: Duration,
+
+    #[arg(long, default_value_t = 100)]
+    get_logs_block_batch_size: u64,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -137,6 +143,8 @@ async fn main() -> anyhow::Result<()> {
         error_sleep_max_secs: conf.error_sleep_max_secs,
         health_check_port: conf.health_check_port,
         health_check_timeout: conf.health_check_timeout,
+        get_logs_poll_interval: conf.get_logs_poll_interval,
+        get_logs_block_batch_size: conf.get_logs_block_batch_size,
     };
 
     let gw_listener = GatewayListener::new(

--- a/coprocessor/fhevm-engine/gw-listener/src/http_server.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/http_server.rs
@@ -100,7 +100,7 @@ impl<
 // Health handler returns appropriate HTTP status code based on health
 async fn health_handler<
     P: Provider<Ethereum> + Clone + Send + Sync + 'static,
-    A: AwsS3Interface,
+    A: AwsS3Interface + Clone + 'static,
 >(
     State(listener): State<Arc<GatewayListener<P, A>>>,
 ) -> impl IntoResponse {
@@ -117,7 +117,7 @@ async fn health_handler<
 
 async fn liveness_handler<
     P: Provider<Ethereum> + Clone + Send + Sync + 'static,
-    A: AwsS3Interface,
+    A: AwsS3Interface + Clone + 'static,
 >(
     State(_listener): State<Arc<GatewayListener<P, A>>>,
 ) -> impl IntoResponse {

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -45,6 +45,9 @@ pub struct ConfigSettings {
     pub error_sleep_max_secs: u16,
     pub health_check_port: u16,
     pub health_check_timeout: Duration,
+
+    pub get_logs_poll_interval: Duration,
+    pub get_logs_block_batch_size: u64,
 }
 
 pub fn chain_id_from_env() -> Option<ChainId> {
@@ -69,6 +72,8 @@ impl Default for ConfigSettings {
             error_sleep_max_secs: 10,
             health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
+            get_logs_poll_interval: Duration::from_secs(1),
+            get_logs_block_batch_size: 100,
         }
     }
 }

--- a/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    sync::{Arc, OnceLock, RwLock},
+    time::Duration,
+};
 
 use alloy::{
     network::EthereumWallet,
@@ -9,6 +12,7 @@ use alloy::{
     sol,
 };
 
+use async_trait::async_trait;
 use aws_sdk_s3::{operation::get_object::GetObjectError, Client};
 use gw_listener::{
     aws_s3::{AwsS3Client, AwsS3Interface},
@@ -22,6 +26,7 @@ use tokio::time::sleep;
 use tokio_util::bytes;
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
+use tracing_subscriber::fmt::{writer::MakeWriterExt, MakeWriter};
 
 sol!(
     #[sol(rpc)]
@@ -35,6 +40,62 @@ sol!(
     "artifacts/KMSGeneration.sol/KMSGeneration.json"
 );
 
+static TEST_LOGS: OnceLock<Arc<RwLock<String>>> = OnceLock::new();
+
+#[derive(Clone)]
+struct TestLogs {
+    logs: Arc<RwLock<String>>,
+}
+
+impl TestLogs {
+    fn new() -> Self {
+        let logs = TEST_LOGS.get_or_init(|| Arc::new(RwLock::new(String::new())));
+        // Flush logs every time a new test starts.
+        logs.write().unwrap().clear();
+        Self { logs: logs.clone() }
+    }
+
+    fn add(&mut self, data: &[u8]) {
+        let data = String::from_utf8_lossy(data).into_owned();
+        *self.logs.write().unwrap() += &data;
+    }
+
+    fn contains(&self, substr: &str) -> bool {
+        self.logs.read().unwrap().contains(substr)
+    }
+}
+
+struct Writer {
+    logs: TestLogs,
+}
+
+impl Writer {
+    fn new(logs: TestLogs) -> Self {
+        Self { logs }
+    }
+}
+
+impl std::io::Write for Writer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.logs.add(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for Writer {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        Self {
+            logs: self.logs.clone(),
+        }
+    }
+}
+
 struct TestEnvironment {
     wallet: EthereumWallet,
     conf: ConfigSettings,
@@ -42,15 +103,19 @@ struct TestEnvironment {
     _test_instance: Option<test_harness::instance::DBInstance>, // maintain db alive
     db_pool: Pool<Postgres>,
     anvil: AnvilInstance,
+    test_logs: TestLogs,
 }
 
 impl TestEnvironment {
     async fn new() -> anyhow::Result<Self> {
+        let test_logs = TestLogs::new();
+        let writer = Writer::new(test_logs.clone());
+
         let _ = tracing_subscriber::fmt()
-            .json()
+            .compact()
+            .with_writer(writer.and(std::io::stdout))
             .with_level(true)
-            .with_max_level(Level::DEBUG)
-            .with_test_writer()
+            .with_max_level(Level::INFO)
             .try_init();
 
         let mut conf = ConfigSettings::default();
@@ -64,6 +129,8 @@ impl TestEnvironment {
             conf.database_url = instance.db_url().to_owned();
             _test_instance = Some(instance);
         };
+        conf.error_sleep_initial_secs = 1;
+        conf.error_sleep_max_secs = 1;
         let db_pool = PgPoolOptions::new()
             .max_connections(16)
             .acquire_timeout(Duration::from_secs(5))
@@ -90,11 +157,23 @@ impl TestEnvironment {
             db_pool,
             _test_instance,
             anvil,
+            test_logs,
         })
+    }
+
+    async fn wait_for_log(&self, log: &str) -> anyhow::Result<()> {
+        for _ in 0..LOG_RETRY_COUNT {
+            if self.test_logs.contains(log) {
+                return Ok(());
+            }
+            sleep(RETRY_DELAY).await;
+        }
+        anyhow::bail!("wait_for_log() didn't find {}", log);
     }
 }
 
 const RETRY_EVENT_TO_DB: u64 = 20;
+const LOG_RETRY_COUNT: u64 = 50;
 const RETRY_DELAY: Duration = Duration::from_millis(500);
 
 #[tokio::test]
@@ -216,6 +295,7 @@ async fn has_crs(db_pool: &Pool<Postgres>) -> anyhow::Result<bool> {
 #[derive(Clone)]
 pub struct AwsS3ClientMocked(Client);
 
+#[async_trait]
 impl AwsS3Interface for AwsS3ClientMocked {
     async fn get_bucket_key(
         &self,
@@ -242,12 +322,6 @@ impl AwsS3Interface for AwsS3ClientMocked {
 #[tokio::test]
 #[serial(db)]
 async fn keygen_ok() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .compact()
-        .try_init()
-        .ok();
-
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::Client;
@@ -355,12 +429,6 @@ async fn keygen_ok() -> anyhow::Result<()> {
 #[tokio::test]
 #[serial(db)]
 async fn keygen_compromised_key() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .compact()
-        .try_init()
-        .ok();
-
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::Client;
@@ -404,7 +472,7 @@ async fn keygen_compromised_key() -> anyhow::Result<()> {
 
     let env = TestEnvironment::new().await?;
     let provider = ProviderBuilder::new()
-        .wallet(env.wallet)
+        .wallet(env.wallet.clone())
         .connect_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
         .await?;
     let aws_s3_client = AwsS3ClientMocked(s3);
@@ -419,10 +487,7 @@ async fn keygen_compromised_key() -> anyhow::Result<()> {
         aws_s3_client.clone(),
     );
 
-    let mut sleep_duration = 6_u64;
-    let db_pool = env.db_pool.clone();
-    let result =
-        tokio::spawn(async move { gw_listener.run_loop(&db_pool, &mut sleep_duration).await });
+    let result = tokio::spawn(async move { gw_listener.run().await });
 
     assert!(!has_public_key(&env.db_pool.clone()).await?);
     assert!(!has_server_key(&env.db_pool.clone()).await?);
@@ -433,30 +498,21 @@ async fn keygen_compromised_key() -> anyhow::Result<()> {
     let pending_txn = provider.send_transaction(txn_req).await?;
     let receipt = pending_txn.get_receipt().await?;
     assert!(receipt.status());
-    assert!(result.is_finished());
-    let result = result.await;
-    assert!(result.is_ok());
-    let result = result.unwrap();
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(err.to_string().contains("Invalid Key digest"));
+
+    env.wait_for_log("Invalid Key digest").await?;
 
     assert!(!has_public_key(&env.db_pool.clone()).await?);
     assert!(!has_server_key(&env.db_pool.clone()).await?);
 
     env.cancel_token.cancel();
+    result.await??;
+
     Ok(())
 }
 
 #[tokio::test]
 #[serial(db)]
 async fn keygen_bad_key_or_bucket() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .compact()
-        .try_init()
-        .ok();
-
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::primitives::ByteStream;
     use aws_sdk_s3::Client;

--- a/coprocessor/fhevm-engine/transaction-sender/Cargo.toml
+++ b/coprocessor/fhevm-engine/transaction-sender/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 # workspace dependencies
 alloy = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-kms = { workspace = true }
 clap = { workspace = true }
@@ -29,7 +30,6 @@ serde_json = { workspace = true }
 humantime = { workspace = true }
 
 # crates.io dependencies
-async-trait = "0.1.88"
 
 # local dependencies
 fhevm-engine-common = { path = "../fhevm-engine-common" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
         "test-suite/e2e",
         "test-suite/benchmarks"
       ],
-      "dependencies": {
-        "relayer-sdk": "^1.0.1"
-      },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "prettier": "^3.5.3",
@@ -21993,125 +21990,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/relayer-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/relayer-sdk/-/relayer-sdk-1.0.1.tgz",
-      "integrity": "sha512-A/KpkwnuWGO42IDpc//v4tWnQZPPJASjTuVHUApOxfHUpHiXwGhYAAeJP+72n7/cHykunsz43Tr2pqdW7UxJvg==",
-      "license": "ISC",
-      "dependencies": {
-        "isomorphic-unfetch": "^4.0.2"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/isomorphic-unfetch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz",
-      "integrity": "sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^3.2.0",
-        "unfetch": "^5.0.0"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/relayer-sdk/node_modules/unfetch": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
-      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg==",
-      "license": "MIT",
-      "workspaces": [
-        "./packages/isomorphic-unfetch"
-      ]
-    },
-    "node_modules/relayer-sdk/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "test-suite/benchmarks": {


### PR DESCRIPTION
Using eth_getLogs ensures we don't miss key activation events. We keep input verification via eth_subscribe as we want less latency and we don't care about missed events that much there.

eth_getLogs is implemented by polling with a configurable period and max batch size.

Also, handle digest mismatch by ignoring such events instead of retry forever. For all other errors, we do retry forever, though maube we want to also not retry forever for missing key.

This commit is not optimal in a number of ways. Also, more importantly, it is not tested enough. Further improvements and tests will be added in a separate one.

Remove unused `relayer-sdk` npm dependency from package-lock.json.