### PR TITLE
chore(sdk): remove contractsChainId from user decrypt

### DIFF
--- a/sdk/rust-sdk/Cargo.lock
+++ b/sdk/rust-sdk/Cargo.lock
@@ -1157,7 +1157,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "bc2wrap"
 version = "2.0.1"
-source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0-26#5618c3d8131a994980c560fa5c508e258025605c"
+source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0#acf9f0c76b2e3e91d3e9e389d731d815c3cc2073"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -1973,7 +1973,7 @@ dependencies = [
 [[package]]
 name = "fhevm_gateway_bindings"
 version = "0.1.0-rc14"
-source = "git+https://git@github.com/zama-ai/fhevm.git?rev=2c9fb79fa557feb4c113f1482f0a4805e9d6acac#2c9fb79fa557feb4c113f1482f0a4805e9d6acac"
+source = "git+https://git@github.com/zama-ai/fhevm.git?tag=v0.9.0-1#bf397ab8138e1f1d6df7e2a79182c8d93b59a722"
 dependencies = [
  "alloy",
  "serde",
@@ -2630,8 +2630,8 @@ dependencies = [
 
 [[package]]
 name = "kms"
-version = "0.11.0-26"
-source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0-26#5618c3d8131a994980c560fa5c508e258025605c"
+version = "0.11.0"
+source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0#acf9f0c76b2e3e91d3e9e389d731d815c3cc2073"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2689,8 +2689,8 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.11.0-26"
-source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0-26#5618c3d8131a994980c560fa5c508e258025605c"
+version = "0.11.0"
+source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0#acf9f0c76b2e3e91d3e9e389d731d815c3cc2073"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4498,8 +4498,8 @@ dependencies = [
 
 [[package]]
 name = "threshold-fhe"
-version = "0.11.0-26"
-source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0-26#5618c3d8131a994980c560fa5c508e258025605c"
+version = "0.11.0"
+source = "git+https://git@github.com/zama-ai/kms.git?tag=v0.11.0#acf9f0c76b2e3e91d3e9e389d731d815c3cc2073"
 dependencies = [
  "aes",
  "aes-prng",

--- a/sdk/rust-sdk/Cargo.toml
+++ b/sdk/rust-sdk/Cargo.toml
@@ -16,10 +16,10 @@ name = "fhevm-demo"
 path = "src/main.rs"
 
 [dependencies]
-fhevm_gateway_bindings = { git = "https://git@github.com/zama-ai/fhevm.git", rev = "2c9fb79fa557feb4c113f1482f0a4805e9d6acac", default-features = false }
-kms = { git = "https://git@github.com/zama-ai/kms.git", tag = "v0.11.0-26", default-features = false }
-kms-grpc = { git = "https://git@github.com/zama-ai/kms.git", tag = "v0.11.0-26", default-features = false }
-bc2wrap = { git = "https://git@github.com/zama-ai/kms.git", tag = "v0.11.0-26", default-features = false }
+fhevm_gateway_bindings = { git = "https://git@github.com/zama-ai/fhevm.git", tag = "v0.9.0-1", default-features = false }
+kms = { git = "https://git@github.com/zama-ai/kms.git", tag = "v0.11.0", default-features = false }
+kms-grpc = { git = "https://git@github.com/zama-ai/kms.git", tag = "v0.11.0", default-features = false }
+bc2wrap = { git = "https://git@github.com/zama-ai/kms.git", tag = "v0.11.0", default-features = false }
 
 alloy = { version = "1.0", default-features = false, features = [
     "essentials",

--- a/sdk/rust-sdk/examples/user-decryption.rs
+++ b/sdk/rust-sdk/examples/user-decryption.rs
@@ -235,7 +235,6 @@ fn prepare_relayer_curl_command(
             "startTimestamp": "1748252823",
             "durationDays": "10"
         },
-        "contractsChainId": "11155111", // Ethereum Sepolia
         "contractAddresses": [
             "0x56a24bcaE11890353726596fD6f5cABb5a126Df9",
             "0x7777777777777777777777777777777777777777"

--- a/sdk/rust-sdk/src/blockchain/calldata.rs
+++ b/sdk/rust-sdk/src/blockchain/calldata.rs
@@ -18,8 +18,11 @@ pub fn public_decryption_req(handles: Vec<FixedBytes<32>>) -> Result<Bytes> {
     Ok(Bytes::from(calldata))
 }
 
-/// Generate calldata for user decryptÒ
-pub fn user_decryption_req(user_decrypt_request: UserDecryptRequest) -> Result<Bytes> {
+/// Generates calldata for user decryption.
+pub fn user_decryption_req(
+    user_decrypt_request: UserDecryptRequest,
+    contracts_chain_id: u64,
+) -> Result<Bytes> {
     info!("Generating user decryption request calldata");
 
     let extra_data = Bytes::new(); // Empty extra_data for now
@@ -27,7 +30,7 @@ pub fn user_decryption_req(user_decrypt_request: UserDecryptRequest) -> Result<B
         user_decrypt_request.ct_handle_contract_pairs,
         user_decrypt_request.request_validity,
         ContractsInfo {
-            chainId: U256::from(user_decrypt_request.contracts_chain_id),
+            chainId: U256::from(contracts_chain_id),
             addresses: user_decrypt_request.contract_addresses,
         },
         user_decrypt_request.user_address,

--- a/sdk/rust-sdk/src/decryption/user/request.rs
+++ b/sdk/rust-sdk/src/decryption/user/request.rs
@@ -175,8 +175,11 @@ impl UserDecryptRequestBuilder {
     ///
     /// This is the final step that creates transaction calldata ready to send.
     pub fn build_and_generate_calldata(self) -> Result<Vec<u8>> {
+        let contracts_chain_id = self.contracts_chain_id.ok_or_else(|| {
+            FhevmError::InvalidParams("contracts_chain_id was not configured".to_string())
+        })?;
         let request = self.build()?;
-        let calldata = user_decryption_req(request)?;
+        let calldata = user_decryption_req(request, contracts_chain_id)?;
         Ok(calldata.to_vec())
     }
 
@@ -256,7 +259,6 @@ impl UserDecryptRequestBuilder {
         let public_key = self.public_key.unwrap();
         let start_timestamp = self.start_timestamp.unwrap();
         let duration_days = self.duration_days.unwrap();
-        let contracts_chain_id = self.contracts_chain_id.unwrap_or(1);
 
         debug!("✅ UserDecryptRequest built successfully");
         debug!("   📊 Handles: {}", self.ct_handle_contract_pairs.len());
@@ -270,7 +272,6 @@ impl UserDecryptRequestBuilder {
                 startTimestamp: U256::from(start_timestamp),
                 durationDays: U256::from(duration_days),
             },
-            contracts_chain_id,
             contract_addresses: self.contract_addresses,
             user_address,
             signature,

--- a/sdk/rust-sdk/src/decryption/user/types.rs
+++ b/sdk/rust-sdk/src/decryption/user/types.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 pub struct UserDecryptRequest {
     pub ct_handle_contract_pairs: Vec<CtHandleContractPair>,
     pub request_validity: RequestValidity,
-    pub contracts_chain_id: u64,
     pub contract_addresses: Vec<Address>,
     pub user_address: Address,
     pub signature: Bytes,

--- a/sdk/rust-sdk/src/signature/eip712/builder.rs
+++ b/sdk/rust-sdk/src/signature/eip712/builder.rs
@@ -283,7 +283,6 @@ impl Eip712SignatureBuilder {
                 publicKey: Bytes::from(public_key_bytes.to_vec()),
                 contractAddresses: self.contract_addresses.clone(),
                 delegatorAddress: delegated_account,
-                contractsChainId: alloy::primitives::U256::from(self.config.contracts_chain_id),
                 startTimestamp: alloy::primitives::U256::from(start_timestamp),
                 durationDays: alloy::primitives::U256::from(duration_days),
                 extraData: self.extra_data.clone().into(),
@@ -293,7 +292,6 @@ impl Eip712SignatureBuilder {
             let message = super::types::UserDecryptRequestVerification {
                 publicKey: Bytes::from(public_key_bytes.to_vec()),
                 contractAddresses: self.contract_addresses.clone(),
-                contractsChainId: alloy::primitives::U256::from(self.config.contracts_chain_id),
                 startTimestamp: alloy::primitives::U256::from(start_timestamp),
                 durationDays: alloy::primitives::U256::from(duration_days),
                 extraData: self.extra_data.clone().into(),

--- a/sdk/rust-sdk/src/signature/eip712/types.rs
+++ b/sdk/rust-sdk/src/signature/eip712/types.rs
@@ -81,7 +81,6 @@ alloy::sol! {
     struct UserDecryptRequestVerification {
         bytes publicKey;
         address[] contractAddresses;
-        uint256 contractsChainId;
         uint256 startTimestamp;
         uint256 durationDays;
         bytes extraData;
@@ -92,7 +91,6 @@ alloy::sol! {
         bytes publicKey;
         address[] contractAddresses;
         address delegatorAddress;
-        uint256 contractsChainId;
         uint256 startTimestamp;
         uint256 durationDays;
         bytes extraData;


### PR DESCRIPTION
Needed for the stress testing tool to work with updated bindings (since this [PR](https://github.com/zama-ai/fhevm/pull/678) was merged)