### PR TITLE
refactor: remove unwrap calls, propagate errors, and fix logging levels

### DIFF
--- a/kms-connector/simple-connector/src/core/decryption/handler.rs
+++ b/kms-connector/simple-connector/src/core/decryption/handler.rs
@@ -218,12 +218,15 @@ impl<P: Provider + Clone> DecryptionHandler<P> {
                     .map(|(handle, ciphertext)| {
                         let hexed_handle = hex::encode(handle);
                         let fhe_type = extract_fhe_type_from_handle(handle);
-                        info!(
-                            "UserDecryptionRequest handle: {}, retrieved S3 ciphertext of length: {}, FHE Type: {}",
-                            hexed_handle,
-                            ciphertext.len(),
-                            fhe_type_to_string(fhe_type)
-                        );
+                        if tracing::enabled!(tracing::Level::DEBUG) {
+                            debug!(
+                                "UserDecryptionRequest handle: {}, retrieved S3 ciphertext of length: {}, FHE Type: {}",
+                                hexed_handle,
+                                ciphertext.len(),
+                                fhe_type_to_string(fhe_type)
+                            );
+                        }
+
                         TypedCiphertext {
                             ciphertext: ciphertext.clone(),
                             external_handle: handle.clone(),
@@ -299,7 +302,6 @@ impl<P: Provider + Clone> DecryptionHandler<P> {
                         .unwrap_or_else(|| "unknown".to_string())
                 );
 
-                // TODO: revert to DEBUG
                 // Only log detailed ciphertext info at debug level
                 if tracing::enabled!(tracing::Level::DEBUG) {
                     for (i, ct) in request.get_ref().typed_ciphertexts.iter().enumerate() {


### PR DESCRIPTION
## Summary
This pull request addresses several TODOs across different modules by improving error handling and logging consistency.

`sns-worker/src/executor.rs`
- Removed `unwrap()` from `decompress_ct` call.  
- Added proper error propagation and tracing span completion to prevent panic during ciphertext decompression.

`kms-connector/src/core/decryption/handler.rs`
- Adjusted ciphertext logging level from `info!` to `debug!`.  
- Cleaned up redundant comments and aligned with intended TODO (“revert to DEBUG”).

`host-listener/src/cmd/mod.rs`
- Replaced a `panic!` in `new_log_stream()` with graceful error propagation via `anyhow::Result`.  
- Updated function signature and all call sites to properly handle the returned `Result`.

These changes remove unsafe panic and unwrap calls, ensure consistent logging levels, and make error handling across the FHEVM engine modules more robust and maintainable.

