### PR TITLE
fix(coprocessor): re-add trigger on insertion to computations

### DIFF
--- a/coprocessor/fhevm-engine/db-migration/migrations/20251006080000_computations_auto_notify.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20251006080000_computations_auto_notify.sql
@@ -1,0 +1,16 @@
+-- Create function to notify on work updates
+CREATE OR REPLACE FUNCTION notify_work_available()
+    RETURNS trigger AS $$
+BEGIN
+    -- Notify all listeners of work_updated channel
+    NOTIFY work_available;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to fire once per statement on computations inserts
+CREATE TRIGGER work_updated_trigger_from_computations_insertions
+    AFTER INSERT
+    ON computations
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION notify_work_available();


### PR DESCRIPTION
commit was[ included in the v0.9.0 tag](https://github.com/zama-ai/fhevm/compare/v0.8.0...v0.9.0) by mistake. Thanks @antoniupop for pointing this out