### PR TITLE
fix(kms-connector): use eth_sendRawTransactionSync

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "fhevm_gateway_bindings"
 version = "0.1.0-rc14"
-source = "git+https://github.com/zama-ai/fhevm.git?rev=70ccca7509de4e5ec9eb897943b861c679e56376#70ccca7509de4e5ec9eb897943b861c679e56376"
+source = "git+https://github.com/zama-ai/fhevm.git?tag=v0.9.0#6f108f405b21beed28182a180a039aa77e030b4c"
 dependencies = [
  "alloy",
  "serde",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -18,7 +18,7 @@ gw-listener.path = "crates/gw-listener"
 kms-worker.path = "crates/kms-worker"
 tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
-fhevm_gateway_bindings = { git = "https://github.com/zama-ai/fhevm.git", rev = "70ccca7509de4e5ec9eb897943b861c679e56376", default-features = false }
+fhevm_gateway_bindings = { git = "https://github.com/zama-ai/fhevm.git", tag = "v0.9.0", default-features = false }
 kms-grpc = { git = "https://github.com/zama-ai/kms.git", tag = "v0.12.0", default-features = true }
 bc2wrap = { git = "https://github.com/zama-ai/kms.git", tag = "v0.12.0", default-features = true }
 tfhe = "=1.4.0-alpha.3"

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -274,7 +274,7 @@ async fn test_process_crsgen_response() -> anyhow::Result<()> {
 }
 
 #[rstest]
-#[timeout(Duration::from_secs(20))]
+#[timeout(Duration::from_secs(60))]
 #[tokio::test]
 async fn stress_test() -> anyhow::Result<()> {
     let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;

--- a/kms-connector/crates/tx-sender/tests/integration_tests.rs
+++ b/kms-connector/crates/tx-sender/tests/integration_tests.rs
@@ -274,7 +274,7 @@ async fn test_process_crsgen_response() -> anyhow::Result<()> {
 }
 
 #[rstest]
-#[timeout(Duration::from_secs(60))]
+#[timeout(Duration::from_secs(20))]
 #[tokio::test]
 async fn stress_test() -> anyhow::Result<()> {
     let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -54,14 +54,10 @@ type DefaultFillers = JoinFill<
 pub type GatewayProvider = FillProvider<JoinFill<DefaultFillers, ChainIdFiller>, RootProvider>;
 
 /// The default `alloy::Provider` used to interact with the Gateway using a wallet.
-pub type WalletGatewayProvider = NonceManagedProvider<
-    FillProvider<
-        JoinFill<
-            JoinFill<JoinFill<Identity, ChainIdFiller>, FillersWithoutNonceManagement>,
-            WalletFiller<EthereumWallet>,
-        >,
-        RootProvider,
-    >,
+pub type WalletGatewayProvider = NonceManagedProvider<WalletGatewayProviderFillers, RootProvider>;
+pub type WalletGatewayProviderFillers = JoinFill<
+    JoinFill<JoinFill<Identity, ChainIdFiller>, FillersWithoutNonceManagement>,
+    WalletFiller<EthereumWallet>,
 >;
 
 /// Tries to establish the connection with a RPC node of the Gateway.

--- a/kms-connector/crates/utils/src/provider.rs
+++ b/kms-connector/crates/utils/src/provider.rs
@@ -1,7 +1,7 @@
 use alloy::{
     consensus::Account,
-    eips::{BlockId, BlockNumberOrTag},
-    network::{Network, TransactionBuilder},
+    eips::{BlockId, BlockNumberOrTag, Encodable2718},
+    network::{Ethereum, Network, TransactionBuilder},
     primitives::{
         Address, B256, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, U64, U128,
         U256,
@@ -11,20 +11,21 @@ use alloy::{
         PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig,
         PendingTransactionError, Provider, ProviderCall, RootProvider, RpcWithBlock, SendableTx,
         fillers::{
-            BlobGasFiller, CachedNonceManager, ChainIdFiller, GasFiller, JoinFill, NonceManager,
+            BlobGasFiller, CachedNonceManager, ChainIdFiller, FillProvider, GasFiller, JoinFill,
+            NonceManager, TxFiller,
         },
     },
     rpc::{
         client::NoParams,
         types::{
             AccessListResult, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory,
-            Filter, FilterChanges, Index, Log, SyncStatus,
+            Filter, FilterChanges, Index, Log, SyncStatus, TransactionReceipt, TransactionRequest,
             erc4337::TransactionConditional,
             pubsub::{Params, SubscriptionKind},
             simulate::{SimulatePayload, SimulatedBlock},
         },
     },
-    transports::TransportResult,
+    transports::{TransportError, TransportResult},
 };
 use futures::lock::Mutex;
 use serde_json::value::RawValue;
@@ -38,23 +39,68 @@ pub type FillersWithoutNonceManagement =
 /// Note that the provider given by the user must not have nonce management enabled, as this
 /// is done by the `NonceManagedProvider` itself.
 /// Users can use the default `FillersWithoutNonceManagement` to create a provider.
-pub struct NonceManagedProvider<P> {
-    inner: P,
+pub struct NonceManagedProvider<F, P, N = Ethereum>
+where
+    N: Network,
+    F: TxFiller<N>,
+    P: Provider<N>,
+{
+    inner: FillProvider<F, P, N>,
     signer_address: Address,
     nonce_manager: Arc<Mutex<CachedNonceManager>>,
 }
 
-impl<P> NonceManagedProvider<P> {
-    pub fn new(provider: P, signer_address: Address) -> Self {
+impl<F, P> NonceManagedProvider<F, P>
+where
+    F: TxFiller<Ethereum>,
+    P: Provider<Ethereum>,
+{
+    pub fn new(provider: FillProvider<F, P, Ethereum>, signer_address: Address) -> Self {
         Self {
             inner: provider,
             signer_address,
             nonce_manager: Default::default(),
         }
     }
+
+    pub async fn send_transaction_sync(
+        &self,
+        mut tx: TransactionRequest,
+    ) -> TransportResult<TransactionReceipt> {
+        let nonce = self
+            .nonce_manager
+            .lock()
+            .await
+            .get_next_nonce(&self.inner, self.signer_address)
+            .await?;
+        tx.set_nonce(nonce);
+
+        let mut tx_bytes = Vec::new();
+        self.inner
+            .fill(tx)
+            .await?
+            .try_into_envelope()
+            .map_err(|e| TransportError::LocalUsageError(Box::new(e)))?
+            .encode_2718(&mut tx_bytes);
+
+        let res = self
+            .client()
+            .request("eth_sendRawTransactionSync", (Bytes::from(tx_bytes),))
+            .await;
+        if res.is_err() {
+            // Reset the nonce manager if the transaction sending failed.
+            *self.nonce_manager.lock().await = Default::default();
+        }
+        res
+    }
 }
 
-impl<P: Clone> Clone for NonceManagedProvider<P> {
+impl<F, P, N> Clone for NonceManagedProvider<F, P, N>
+where
+    N: Network,
+    F: TxFiller<N>,
+    P: Provider<N> + Clone,
+{
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -65,8 +111,10 @@ impl<P: Clone> Clone for NonceManagedProvider<P> {
 }
 
 #[async_trait::async_trait]
-impl<N: Network, P> Provider<N> for NonceManagedProvider<P>
+impl<F, P, N> Provider<N> for NonceManagedProvider<F, P, N>
 where
+    N: Network,
+    F: TxFiller<N>,
     P: Provider<N>,
 {
     fn root(&self) -> &RootProvider<N> {

--- a/kms-connector/crates/utils/src/tests/setup/gw.rs
+++ b/kms-connector/crates/utils/src/tests/setup/gw.rs
@@ -3,7 +3,6 @@ use crate::{
     conn::WalletGatewayProvider,
     provider::{FillersWithoutNonceManagement, NonceManagedProvider},
     tests::setup::{ROOT_CARGO_TOML, pick_free_port},
-    // tests::setup::{ROOT_CARGO_TOML, pick_free_port},
 };
 use alloy::{
     primitives::{Address, ChainId, FixedBytes},


### PR DESCRIPTION
e2e tests are passing: https://github.com/zama-ai/fhevm/actions/runs/18306478320/job/52124802024#step:10:11

Btw if you wonder why I had to use concrete `FillProvider` in `NonceManagedProvider`, it is partially explained by this issue I opened on `alloy`'s repo (https://github.com/alloy-rs/alloy/issues/2997)