### PR TITLE
chore(coprocessor): measure both tfhe-per-txn and rerand-per-txn late…

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -6326,6 +6326,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "prometheus",
  "rayon",
  "tfhe",
  "tokio",

--- a/coprocessor/fhevm-engine/scheduler/Cargo.toml
+++ b/coprocessor/fhevm-engine/scheduler/Cargo.toml
@@ -16,6 +16,7 @@ rayon = { workspace = true }
 tfhe = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+prometheus = { workspace = true }
 
 # local dependencies
 fhevm-engine-common = { path = "../fhevm-engine-common" }


### PR DESCRIPTION
Prometheus histogram metrics to track the timings of execution of rerand and tfhe within a transaction.

- coprocessor_rerand_latency_seconds
- coprocessor_fhe_batch_latency_seconds