### PR TITLE
chore(coprocessor): Improve usability of DatabaseURL

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/utils.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/utils.rs
@@ -114,32 +114,70 @@ impl Default for HeartBeat {
         Self::new()
     }
 }
-
+/// Simple wrapper around Database URL string to provide
+/// url constraints and masking functionality.
 #[derive(Clone)]
 pub struct DatabaseURL(String);
 
 impl From<&str> for DatabaseURL {
     fn from(s: &str) -> Self {
-        Self(s.to_owned())
+        let url: Self = Self(s.to_owned());
+        url.parse().expect("DatabaseURL is valid");
+        url
     }
 }
 impl From<String> for DatabaseURL {
     fn from(s: String) -> Self {
-        Self(s)
+        let url: Self = Self(s);
+        url.parse().expect("DatabaseURL is valid");
+        url
     }
 }
 
 impl Default for DatabaseURL {
     fn default() -> Self {
-        std::env::var("DATABASE_URL")
-            .unwrap_or("postgres://postgres:postgres@localhost:5432/coprocessor".to_owned())
-            .into()
+        let url = std::env::var("DATABASE_URL")
+            .unwrap_or("postgres://postgres:postgres@localhost:5432/coprocessor".to_owned());
+
+        let app_name = Self::default_app_name();
+        Self::new_with_app_name(&url, &app_name)
     }
 }
 
 impl DatabaseURL {
+    /// Create a new DatabaseURL, appending application_name if not present
+    /// If the base URL already contains an application_name, it will be preserved.
+    ///
+    /// application_name is useful for identifying the source of DB conns
+    pub fn new_with_app_name(base: &str, app_name: &str) -> Self {
+        // Append application_name if not present
+        let mut url = base.to_owned();
+        if !url.contains("application_name=") {
+            if url.contains('?') {
+                url.push_str(&format!("&application_name={}", app_name));
+            } else {
+                url.push_str(&format!("?application_name={}", app_name));
+            }
+        }
+        let url: Self = Self(url);
+        let _ = url.parse().expect("DatabaseURL is valid");
+        url
+    }
+
+    /// Get default app name from the executable name
+    fn default_app_name() -> String {
+        std::env::args()
+            .next()
+            .and_then(|path| {
+                std::path::Path::new(&path)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+            })
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 
     pub fn into_inner(self) -> String {
@@ -148,14 +186,19 @@ impl DatabaseURL {
 
     fn mask_password(options: &PgConnectOptions) -> String {
         let new_url = format!(
-            "postgres://{}:{}@{}:{}/{}",
+            "postgres://{}:{}@{}:{}/{}?application_name={}",
             options.get_username(),
             "*****",
             options.get_host(),
             options.get_port(),
-            options.get_database().unwrap_or_default()
+            options.get_database().unwrap_or_default(),
+            options.get_application_name().unwrap_or_default()
         );
         new_url
+    }
+
+    pub fn parse(&self) -> Result<PgConnectOptions, sqlx::Error> {
+        PgConnectOptions::from_str(self.as_str())
     }
 }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/utils.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/utils.rs
@@ -121,16 +121,16 @@ pub struct DatabaseURL(String);
 
 impl From<&str> for DatabaseURL {
     fn from(s: &str) -> Self {
-        let url: Self = Self(s.to_owned());
-        url.parse().expect("DatabaseURL should be valid");
-        url
+        let url = s.to_owned();
+        let app_name = Self::default_app_name();
+        Self::new_with_app_name(&url, &app_name)
     }
 }
 impl From<String> for DatabaseURL {
     fn from(s: String) -> Self {
-        let url: Self = Self(s);
-        url.parse().expect("DatabaseURL should be valid");
-        url
+        let url = s.to_owned();
+        let app_name = Self::default_app_name();
+        Self::new_with_app_name(&url, &app_name)
     }
 }
 
@@ -150,6 +150,11 @@ impl DatabaseURL {
     ///
     /// application_name is useful for identifying the source of DB conns
     pub fn new_with_app_name(base: &str, app_name: &str) -> Self {
+        let app_name = app_name.trim();
+        if app_name.is_empty() {
+            return Self(base.to_owned());
+        }
+
         // Append application_name if not present
         let mut url = base.to_owned();
         if !url.contains("application_name=") {
@@ -173,7 +178,7 @@ impl DatabaseURL {
                     .file_name()
                     .map(|s| s.to_string_lossy().into_owned())
             })
-            .unwrap_or_else(|| "unknown".to_string())
+            .unwrap_or_default()
     }
 
     pub fn as_str(&self) -> &str {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/utils.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/utils.rs
@@ -122,14 +122,14 @@ pub struct DatabaseURL(String);
 impl From<&str> for DatabaseURL {
     fn from(s: &str) -> Self {
         let url: Self = Self(s.to_owned());
-        url.parse().expect("DatabaseURL is valid");
+        url.parse().expect("DatabaseURL should be valid");
         url
     }
 }
 impl From<String> for DatabaseURL {
     fn from(s: String) -> Self {
         let url: Self = Self(s);
-        url.parse().expect("DatabaseURL is valid");
+        url.parse().expect("DatabaseURL should be valid");
         url
     }
 }
@@ -160,7 +160,7 @@ impl DatabaseURL {
             }
         }
         let url: Self = Self(url);
-        let _ = url.parse().expect("DatabaseURL is valid");
+        let _ = url.parse().expect("DatabaseURL should be valid");
         url
     }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/tests/utils.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/tests/utils.rs
@@ -30,4 +30,9 @@ async fn mask_database_url() {
     );
 
     println!("DatabaseURL: {}", db_url);
+
+    let db_url: DatabaseURL =
+        DatabaseURL::new_with_app_name("postgres://user:secret@dbhost:5432/mydb", " ");
+
+    assert_eq!(db_url.as_str(), "postgres://user:secret@dbhost:5432/mydb");
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/tests/utils.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/tests/utils.rs
@@ -1,0 +1,33 @@
+use fhevm_engine_common::utils::DatabaseURL;
+
+#[tokio::test]
+async fn mask_database_url() {
+    let db_url: DatabaseURL = "postgres://postgres:mypassword@localhost:5432/coprocessor".into();
+
+    let debug_fmt = format!("{:?}", db_url);
+    assert!(!debug_fmt.contains("mypassword"));
+
+    let display_fmt = format!("{}", db_url);
+    assert!(!display_fmt.contains("mypassword"));
+    println!("DatabaseURL: {}", db_url);
+
+    let db_url: DatabaseURL = DatabaseURL::new_with_app_name(
+        "postgres://user:secret@dbhost:5432/mydb?sslmode=require",
+        "tfhe-worker",
+    );
+
+    assert_eq!(
+        db_url.as_str(),
+        "postgres://user:secret@dbhost:5432/mydb?sslmode=require&application_name=tfhe-worker"
+    );
+
+    let db_url: DatabaseURL =
+        DatabaseURL::new_with_app_name("postgres://user:secret@dbhost:5432/mydb", "tfhe-worker");
+
+    assert_eq!(
+        db_url.as_str(),
+        "postgres://user:secret@dbhost:5432/mydb?application_name=tfhe-worker"
+    );
+
+    println!("DatabaseURL: {}", db_url);
+}

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -81,7 +81,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
         );
         let db_pool = PgPoolOptions::new()
             .max_connections(self.conf.database_pool_size)
-            .connect(&self.conf.database_url)
+            .connect(self.conf.database_url.as_str())
             .await?;
 
         let input_verification_handle = {
@@ -549,7 +549,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
         // Check database connection
         let db_pool_result = PgPoolOptions::new()
             .max_connections(self.conf.database_pool_size)
-            .connect(&self.conf.database_url)
+            .connect(self.conf.database_url.as_str())
             .await;
 
         match db_pool_result {

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -1,5 +1,6 @@
 use alloy::primitives::Uint;
 use alloy::transports::http::reqwest::Url;
+use fhevm_engine_common::utils::DatabaseURL;
 use std::time::Duration;
 
 use tracing::error;
@@ -36,7 +37,7 @@ impl TryFrom<u8> for KeyType {
 #[derive(Clone, Debug)]
 pub struct ConfigSettings {
     pub host_chain_id: ChainId,
-    pub database_url: String,
+    pub database_url: DatabaseURL,
     pub database_pool_size: u32,
     pub verify_proof_req_db_channel: String,
 
@@ -67,8 +68,7 @@ impl Default for ConfigSettings {
     fn default() -> Self {
         Self {
             host_chain_id: chain_id_from_env().unwrap_or(12345),
-            database_url: std::env::var("DATABASE_URL")
-                .unwrap_or("postgres://postgres:postgres@localhost/coprocessor".to_owned()),
+            database_url: DatabaseURL::default(),
             database_pool_size: 16,
             verify_proof_req_db_channel: "event_zkpok_new_work".to_owned(),
             gw_url: "ws://127.0.0.1:8546".try_into().expect("Invalid URL"),

--- a/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -132,7 +132,7 @@ impl TestEnvironment {
                 .await
                 .expect("valid db instance");
             eprintln!("New test database on {}", instance.db_url());
-            conf.database_url = instance.db_url().to_owned();
+            conf.database_url = instance.db_url.clone();
             _test_instance = Some(instance);
         };
         conf.error_sleep_initial_secs = 1;
@@ -140,7 +140,7 @@ impl TestEnvironment {
         let db_pool = PgPoolOptions::new()
             .max_connections(16)
             .acquire_timeout(Duration::from_secs(5))
-            .connect(&conf.database_url)
+            .connect(conf.database_url.as_str())
             .await?;
 
         // Delete all proofs from the database.

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 
 use fhevm_engine_common::healthz_server::HttpServer as HealthHttpServer;
 use fhevm_engine_common::types::{BlockchainProvider, Handle};
-use fhevm_engine_common::utils::HeartBeat;
+use fhevm_engine_common::utils::{DatabaseURL, HeartBeat};
 
 use crate::contracts::{AclContract, TfheContract};
 use crate::database::tfhe_event_propagate::{
@@ -58,7 +58,7 @@ pub struct Args {
         long,
         default_value = "postgresql://postgres:postgres@localhost:5432/coprocessor"
     )]
-    pub database_url: String,
+    pub database_url: DatabaseURL,
 
     #[arg(long, default_value = None, help = "Can be negative from last block", allow_hyphen_values = true)]
     pub start_at_block: Option<i64>,
@@ -970,7 +970,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
     let mut log_iter = InfiniteLogIter::new(&args);
     let chain_id = log_iter.get_chain_id().await?;
     info!(chain_id = chain_id, "Chain ID");
-    if args.database_url.is_empty() {
+    if args.database_url.as_str().is_empty() {
         error!("Database URL is required");
         panic!("Database URL is required");
     };

--- a/coprocessor/fhevm-engine/host-listener/tests/integration_test.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/integration_test.rs
@@ -217,7 +217,7 @@ async fn setup(node_chain_id: Option<u64>) -> Result<Setup, anyhow::Error> {
         initial_block_time: 1,
         acl_contract_address: acl_contract.address().to_string(),
         tfhe_contract_address: tfhe_contract.address().to_string(),
-        database_url: test_instance.db_url().to_string(),
+        database_url: test_instance.db_url.clone(),
         coprocessor_api_key: Some(coprocessor_api_key),
         start_at_block: None,
         end_at_block: None,

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -16,10 +16,7 @@ fn handle_sigint(token: CancellationToken) {
 fn construct_config() -> Config {
     let args: utils::daemon_cli::Args = utils::daemon_cli::parse_args();
 
-    let db_url = args
-        .database_url
-        .clone()
-        .unwrap_or_else(|| std::env::var("DATABASE_URL").expect("DATABASE_URL is undefined"));
+    let db_url = args.database_url.clone().unwrap_or_default();
 
     Config {
         tenant_api_key: args.tenant_api_key,

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use clap::{command, Parser};
 use fhevm_engine_common::telemetry::MetricsConfig;
+use fhevm_engine_common::utils::DatabaseURL;
 use humantime::parse_duration;
 use sns_worker::{SchedulePolicy, SNS_LATENCY_OP_HISTOGRAM_CONF};
 use tracing::Level;
@@ -48,7 +49,7 @@ pub struct Args {
     /// Postgres database url. If unspecified DATABASE_URL environment variable
     /// is used
     #[arg(long)]
-    pub database_url: Option<String>,
+    pub database_url: Option<DatabaseURL>,
 
     /// KeySet file. If unspecified the the keys are read from the database
     #[arg(long)]

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -23,7 +23,7 @@ use fhevm_engine_common::{
     telemetry::{self, OtelTracer},
     telemetry::{register_histogram, MetricsConfig},
     types::FhevmError,
-    utils::compact_hex,
+    utils::{compact_hex, DatabaseURL},
 };
 use futures::join;
 use serde::{Deserialize, Serialize};
@@ -60,7 +60,7 @@ pub struct KeySet {
 
 #[derive(Clone)]
 pub struct DBConfig {
-    pub url: String,
+    pub url: DatabaseURL,
     pub listen_channels: Vec<String>,
     pub notify_channel: String,
     pub batch_limit: u32,

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -75,17 +75,6 @@ pub struct DBConfig {
     pub lifo: bool,
 }
 
-impl std::fmt::Debug for DBConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Custom debug impl to avoid printing sensitive information
-        write!(
-            f,
-            "db_listen_channel: {:?}, db_notify_channel: {}, db_batch_limit: {}, db_gc_batch_limit: {}, db_polling_interval: {}, db_cleanup_interval: {:?}, db_max_connections: {}, db_timeout: {:?}, lifo: {}",
-            self.listen_channels, self.notify_channel, self.batch_limit, self.gc_batch_limit, self.polling_interval, self.cleanup_interval, self.max_connections, self.timeout, self.lifo
-        )
-    }
-}
-
 #[derive(Clone, Default, Debug)]
 pub struct S3Config {
     pub bucket_ct128: String,
@@ -109,7 +98,7 @@ pub struct HealthCheckConfig {
     pub port: u16,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Config {
     pub tenant_api_key: String,
     pub service_name: String,
@@ -510,7 +499,7 @@ pub async fn run_all(
         mpsc::channel::<UploadJob>(10 * config.s3.max_concurrent_uploads as usize);
 
     let rayon_threads = rayon::current_num_threads();
-    info!(config = ?config, rayon_threads, "Starting SNS worker");
+    info!(config = %config, rayon_threads, "Starting SNS worker");
 
     if !config.service_name.is_empty() {
         if let Err(err) = telemetry::setup_otlp(&config.service_name) {

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -9,7 +9,6 @@ use aws_config::BehaviorVersion;
 use fhevm_engine_common::utils::{compact_hex, DatabaseURL};
 use serde::{Deserialize, Serialize};
 use serial_test::serial;
-use sqlx::Database;
 use std::{
     fs::File,
     io::{Read, Write},

--- a/coprocessor/fhevm-engine/stress-test-generator/data/json/minitest_002_erc20.json
+++ b/coprocessor/fhevm-engine/stress-test-generator/data/json/minitest_002_erc20.json
@@ -9,8 +9,8 @@
         "user_address": "0xa0534e99d86F081E8D3868A8C4732C8f65dfdB07",
         "scenario": [
             [
-                20.0,
-                120
+                0.1,
+                5
             ]
         ]
     }

--- a/coprocessor/fhevm-engine/stress-test-generator/data/json/minitest_002_erc20.json
+++ b/coprocessor/fhevm-engine/stress-test-generator/data/json/minitest_002_erc20.json
@@ -9,8 +9,8 @@
         "user_address": "0xa0534e99d86F081E8D3868A8C4732C8f65dfdB07",
         "scenario": [
             [
-                0.1,
-                5
+                20.0,
+                120
             ]
         ]
     }

--- a/coprocessor/fhevm-engine/stress-test-generator/src/bin/stress_generator.rs
+++ b/coprocessor/fhevm-engine/stress-test-generator/src/bin/stress_generator.rs
@@ -5,6 +5,7 @@ use axum::{
     Json, Router,
 };
 use chrono::{DateTime, Utc};
+use fhevm_engine_common::utils::DatabaseURL;
 use host_listener::database::tfhe_event_propagate::{Database as ListenerDatabase, Handle};
 
 use sqlx::Postgres;
@@ -416,16 +417,17 @@ async fn generate_transactions_at_rate(
     scenario: &Scenario,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ecfg = EnvConfig::new();
+    let database_url: DatabaseURL = ecfg.evgen_db_url.into();
     let coprocessor_api_key = sqlx::types::Uuid::parse_str(&ecfg.api_key).unwrap();
     let mut listener_event_to_db = ListenerDatabase::new(
-        &ecfg.evgen_db_url,
+        &database_url,
         &coprocessor_api_key,
         default_dependence_cache_size(),
     )
     .await?;
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(2)
-        .connect(&ecfg.evgen_db_url)
+        .connect(database_url.as_str())
         .await
         .unwrap();
     let mut dependence_handle1: Option<Handle> = None;
@@ -497,16 +499,17 @@ async fn generate_transactions_count(
     scenario: &Scenario,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ecfg = ctx.ecfg.clone();
+    let database_url: DatabaseURL = ecfg.evgen_db_url.into();
     let coprocessor_api_key = sqlx::types::Uuid::parse_str(&ecfg.api_key).unwrap();
     let mut listener_event_to_db = ListenerDatabase::new(
-        &ecfg.evgen_db_url,
+        &database_url,
         &coprocessor_api_key,
         default_dependence_cache_size(),
     )
     .await?;
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(2)
-        .connect(&ecfg.evgen_db_url)
+        .connect(database_url.as_str())
         .await
         .unwrap();
 

--- a/coprocessor/fhevm-engine/stress-test-generator/src/utils.rs
+++ b/coprocessor/fhevm-engine/stress-test-generator/src/utils.rs
@@ -346,7 +346,7 @@ impl EnvConfig {
         };
         let acl_contract_address: String = match env::var("ACL_CONTRACT_ADDRESS") {
             Ok(val) => val,
-            Err(_) => "0x617E46088ffe8d0f27A123574119b9C3F3b81073".to_string(),
+            Err(_) => "0x05fD9B5EFE0a996095f42Ed7e77c390810CF660c".to_string(),
         };
         let chain_id: i64 = match env::var("CHAIN_ID") {
             Ok(val) => val.parse::<i64>().unwrap(),

--- a/coprocessor/fhevm-engine/stress-test-generator/src/utils.rs
+++ b/coprocessor/fhevm-engine/stress-test-generator/src/utils.rs
@@ -346,7 +346,7 @@ impl EnvConfig {
         };
         let acl_contract_address: String = match env::var("ACL_CONTRACT_ADDRESS") {
             Ok(val) => val,
-            Err(_) => "0x05fD9B5EFE0a996095f42Ed7e77c390810CF660c".to_string(),
+            Err(_) => "0x617E46088ffe8d0f27A123574119b9C3F3b81073".to_string(),
         };
         let chain_id: i64 = match env::var("CHAIN_ID") {
             Ok(val) => val.parse::<i64>().unwrap(),

--- a/coprocessor/fhevm-engine/tfhe-worker/benches/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/benches/utils.rs
@@ -100,7 +100,7 @@ async fn start_coprocessor(rx: Receiver<bool>, app_port: u16, db_url: &str) {
         pg_pool_max_connections: 2,
         server_addr: format!("127.0.0.1:{app_port}"),
         metrics_addr: None,
-        database_url: Some(db_url.to_string()),
+        database_url: Some(db_url.into()),
         maximum_compact_inputs_upload: 10,
         coprocessor_private_key: "./coprocessor.key".to_string(),
         service_name: "coprocessor".to_string(),

--- a/coprocessor/fhevm-engine/tfhe-worker/src/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/daemon_cli.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use fhevm_engine_common::telemetry::MetricsConfig;
+use fhevm_engine_common::utils::DatabaseURL;
 use tracing::Level;
 
 #[derive(Parser, Debug, Clone)]
@@ -71,7 +72,7 @@ pub struct Args {
 
     /// Postgres database url. If unspecified DATABASE_URL environment variable is used
     #[arg(long)]
-    pub database_url: Option<String>,
+    pub database_url: Option<DatabaseURL>,
 
     /// Coprocessor private key file path.
     /// Private key is in plain text 0x1234.. format.

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -70,11 +70,8 @@ pub async fn async_main(
         }
     }
 
-    let health_check = health_check::HealthCheck::new(
-        args.database_url
-            .clone()
-            .unwrap_or("no_database_url".to_string()),
-    );
+    let database_url = args.database_url.clone().unwrap_or_default();
+    let health_check = health_check::HealthCheck::new(database_url);
 
     let mut set = JoinSet::new();
     if args.run_server {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/server.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/server.rs
@@ -105,17 +105,17 @@ pub async fn run_server_iteration(
         .server_addr
         .parse()
         .expect("Can't parse server address");
-    let db_url = crate::utils::db_url(&args);
 
     let coprocessor_key_file = tokio::fs::read_to_string(&args.coprocessor_private_key).await?;
 
     let signer = PrivateKeySigner::from_str(coprocessor_key_file.trim())?;
     info!(target: "grpc_server", { address = signer.address().to_string() }, "Coprocessor signer initiated");
+    let database_url = args.database_url.clone().unwrap_or_default();
 
     info!("Coprocessor listening on {}", addr);
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(args.pg_pool_max_connections)
-        .connect(&db_url)
+        .connect(database_url.as_str())
         .await?;
 
     let tenant_key_cache: std::sync::Arc<tokio::sync::RwLock<lru::LruCache<i32, TfheTenantKeys>>> =

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/operators_from_events.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/operators_from_events.rs
@@ -258,10 +258,14 @@ fn next_handle() -> Handle {
 
 async fn listener_event_to_db(app: &TestInstance) -> ListenerDatabase {
     let coprocessor_api_key = sqlx::types::Uuid::parse_str(default_api_key()).unwrap();
-    let url = app.db_url().to_string();
-    ListenerDatabase::new(&url, &coprocessor_api_key, default_dependence_cache_size())
-        .await
-        .unwrap()
+
+    ListenerDatabase::new(
+        &app.db_url().into(),
+        &coprocessor_api_key,
+        default_dependence_cache_size(),
+    )
+    .await
+    .unwrap()
 }
 
 #[tokio::test]

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
@@ -109,7 +109,7 @@ async fn start_coprocessor(rx: Receiver<bool>, app_port: u16, db_url: &str) {
         pg_pool_max_connections: 2,
         server_addr: format!("127.0.0.1:{app_port}"),
         metrics_addr: None,
-        database_url: Some(db_url.to_string()),
+        database_url: Some(db_url.into()),
         maximum_compact_inputs_upload: 10,
         coprocessor_private_key: "./coprocessor.key".to_string(),
         service_name: "coprocessor".to_string(),

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -78,10 +78,11 @@ async fn tfhe_worker_cycle(
         std::sync::Arc::new(tokio::sync::RwLock::new(lru::LruCache::new(
             NonZeroUsize::new(args.tenant_key_cache_size as usize).unwrap(),
         )));
-    let db_url = crate::utils::db_url(args);
+    let db_url = args.database_url.clone().unwrap_or_default();
+
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(args.pg_pool_max_connections)
-        .connect(&db_url)
+        .connect(db_url.as_str())
         .await?;
     let mut listener = PgListener::connect_with(&pool).await?;
     listener.listen("work_available").await?;

--- a/coprocessor/fhevm-engine/tfhe-worker/src/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/utils.rs
@@ -168,13 +168,6 @@ pub fn sort_computations_by_dependencies(
     Ok((res, handles_to_check_in_db))
 }
 
-pub fn db_url(args: &crate::daemon_cli::Args) -> String {
-    if let Some(db_url) = &args.database_url {
-        return db_url.clone();
-    }
-    std::env::var("DATABASE_URL").expect("DATABASE_URL is undefined")
-}
-
 #[test]
 fn test_invalid_handle_too_short() {
     let comp = vec![AsyncComputation {

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -20,7 +20,8 @@ use transaction_sender::{
 
 use fhevm_engine_common::{
     metrics_server,
-    telemetry::{self, utils::DatabaseURL, MetricsConfig},
+    telemetry::{self, MetricsConfig},
+    utils::DatabaseURL,
 };
 use humantime::parse_duration;
 
@@ -227,12 +228,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     let wallet = EthereumWallet::new(abstract_signer.clone());
-    let database_url = match conf.database_url.clone() {
-        Some(url) => url,
-        None => std::env::var("DATABASE_URL")
-            .context("DATABASE_URL is undefined")?
-            .into(),
-    };
+    let database_url = conf.database_url.clone();
 
     let provider = loop {
         if cancel_token.is_cancelled() {

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -20,7 +20,7 @@ use transaction_sender::{
 
 use fhevm_engine_common::{
     metrics_server,
-    telemetry::{self, MetricsConfig},
+    telemetry::{self, utils::DatabaseURL, MetricsConfig},
 };
 use humantime::parse_duration;
 
@@ -52,7 +52,7 @@ struct Conf {
     private_key: Option<String>,
 
     #[arg(short, long)]
-    database_url: Option<String>,
+    database_url: Option<DatabaseURL>,
 
     #[arg(long, default_value = "10")]
     database_pool_size: u32,
@@ -229,7 +229,9 @@ async fn main() -> anyhow::Result<()> {
     let wallet = EthereumWallet::new(abstract_signer.clone());
     let database_url = match conf.database_url.clone() {
         Some(url) => url,
-        None => std::env::var("DATABASE_URL").context("DATABASE_URL is undefined")?,
+        None => std::env::var("DATABASE_URL")
+            .context("DATABASE_URL is undefined")?
+            .into(),
     };
 
     let provider = loop {

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
+use fhevm_engine_common::utils::DatabaseURL;
+
 #[derive(Clone, Debug)]
 pub struct ConfigSettings {
-    pub database_url: String,
+    pub database_url: DatabaseURL,
     pub database_pool_size: u32,
 
     pub verify_proof_resp_db_channel: String,
@@ -46,8 +48,7 @@ pub struct ConfigSettings {
 impl Default for ConfigSettings {
     fn default() -> Self {
         Self {
-            database_url: std::env::var("DATABASE_URL")
-                .unwrap_or("postgres://postgres:postgres@localhost/coprocessor".to_owned()),
+            database_url: DatabaseURL::default(),
             database_pool_size: 10,
             verify_proof_resp_db_channel: "event_zkpok_computed".to_owned(),
             add_ciphertexts_db_channel: "event_ciphertexts_uploaded".to_owned(),

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -4,7 +4,7 @@ use fhevm_engine_common::utils::DatabaseURL;
 
 #[derive(Clone, Debug)]
 pub struct ConfigSettings {
-    pub database_url: DatabaseURL,
+    pub database_url: Option<DatabaseURL>,
     pub database_pool_size: u32,
 
     pub verify_proof_resp_db_channel: String,
@@ -48,7 +48,7 @@ pub struct ConfigSettings {
 impl Default for ConfigSettings {
     fn default() -> Self {
         Self {
-            database_url: DatabaseURL::default(),
+            database_url: Some(DatabaseURL::default()),
             database_pool_size: 10,
             verify_proof_resp_db_channel: "event_zkpok_computed".to_owned(),
             add_ciphertexts_db_channel: "event_ciphertexts_uploaded".to_owned(),

--- a/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -37,7 +37,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
     ) -> anyhow::Result<Self> {
         let db_pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(conf.database_pool_size)
-            .connect(&conf.database_url)
+            .connect(conf.database_url.as_str())
             .await?;
 
         let operations: Vec<Arc<dyn ops::TransactionOperation<P>>> = vec![

--- a/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -35,9 +35,11 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
         conf: ConfigSettings,
         gas: Option<u64>,
     ) -> anyhow::Result<Self> {
+        let database_url = conf.database_url.to_owned().unwrap_or_default();
+
         let db_pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(conf.database_pool_size)
-            .connect(conf.database_url.as_str())
+            .connect(database_url.as_str())
             .await?;
 
         let operations: Vec<Arc<dyn ops::TransactionOperation<P>>> = vec![
@@ -81,7 +83,6 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
 
     pub async fn run(&self) -> anyhow::Result<()> {
         info!(
-            conf = ?self.conf,
             input_verification_address = %self.input_verification_address,
             ciphertext_commits_address = %self.ciphertext_commits_address,
             multichain_acl_address = %self.multichain_acl_address,

--- a/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
@@ -81,7 +81,7 @@ impl TestEnvironment {
 
         let db_pool = PgPoolOptions::new()
             .max_connections(1)
-            .connect(&conf.database_url)
+            .connect(conf.database_url.as_str())
             .await?;
 
         Self::truncate_tables(

--- a/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
@@ -78,10 +78,11 @@ impl TestEnvironment {
             .with_max_level(Level::DEBUG)
             .with_test_writer()
             .try_init();
+        let database_url = conf.database_url.to_owned().unwrap_or_default();
 
         let db_pool = PgPoolOptions::new()
             .max_connections(1)
-            .connect(conf.database_url.as_str())
+            .connect(database_url.as_str())
             .await?;
 
         Self::truncate_tables(

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -1,7 +1,9 @@
 use clap::{command, Parser};
+use fhevm_engine_common::telemetry;
 use fhevm_engine_common::telemetry::{self, MetricsConfig};
-use fhevm_engine_common::{healthz_server::HttpServer, metrics_server};
+use fhevm_engine_common::{healthz_server::HttpServer, metrics_server, utils::DatabaseURL};
 use humantime::parse_duration;
+use sqlx::Database;
 use std::{sync::Arc, time::Duration};
 use tokio::{join, task};
 use tokio_util::sync::CancellationToken;
@@ -41,7 +43,7 @@ pub struct Args {
     /// Postgres database url. If unspecified DATABASE_URL environment variable
     /// is used
     #[arg(long)]
-    pub database_url: Option<String>,
+    pub database_url: Option<DatabaseURL>,
 
     /// Number of zkproof workers to process proofs in parallel
     #[arg(long, default_value_t = 8)]
@@ -90,10 +92,7 @@ async fn main() {
         .with_max_level(args.log_level)
         .init();
 
-    let database_url = args
-        .database_url
-        .clone()
-        .unwrap_or_else(|| std::env::var("DATABASE_URL").expect("DATABASE_URL is undefined"));
+    let database_url = args.database_url.clone().unwrap_or_default();
 
     let conf = zkproof_worker::Config {
         database_url,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -1,9 +1,7 @@
 use clap::{command, Parser};
-use fhevm_engine_common::telemetry;
 use fhevm_engine_common::telemetry::{self, MetricsConfig};
 use fhevm_engine_common::{healthz_server::HttpServer, metrics_server, utils::DatabaseURL};
 use humantime::parse_duration;
-use sqlx::Database;
 use std::{sync::Arc, time::Duration};
 use tokio::{join, task};
 use tokio_util::sync::CancellationToken;

--- a/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
@@ -5,6 +5,7 @@ mod tests;
 
 pub mod verifier;
 use std::{
+    fmt::{self, Display},
     io,
     sync::{LazyLock, OnceLock},
     time::Duration,
@@ -16,7 +17,10 @@ use fhevm_engine_common::{
     types::FhevmError,
 };
 use prometheus::Histogram;
+
+use fhevm_engine_common::{pg_pool::ServiceError, types::FhevmError, utils::DatabaseURL};
 use thiserror::Error;
+use tracing_subscriber::registry::Data;
 
 /// The highest index of an input is 254,
 /// cause 255 (0xff) is reserved for handles originating from the FHE operations
@@ -77,7 +81,7 @@ impl From<ExecutionError> for ServiceError {
 
 #[derive(Default, Debug, Clone)]
 pub struct Config {
-    pub database_url: String,
+    pub database_url: DatabaseURL,
     pub listen_database_channel: String,
     pub notify_database_channel: String,
     pub pg_pool_connections: u32,
@@ -96,3 +100,19 @@ pub static ZKVERIFY_OP_LATENCY_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(||
         "ZK verification latencies in seconds",
     )
 });
+impl Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Config {{ database_url: {}, listen_database_channel: {}, notify_database_channel: {}, pg_pool_connections: {}, pg_polling_interval: {}, pg_timeout: {:?}, pg_auto_explain_with_min_duration: {:?}, worker_thread_count: {} }}",
+            self.database_url,
+            self.listen_database_channel,
+            self.notify_database_channel,
+            self.pg_pool_connections,
+            self.pg_polling_interval,
+            self.pg_timeout,
+            self.pg_auto_explain_with_min_duration,
+            self.worker_thread_count
+        )
+    }
+}

--- a/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
@@ -15,12 +15,10 @@ use fhevm_engine_common::{
     pg_pool::ServiceError,
     telemetry::{register_histogram, MetricsConfig},
     types::FhevmError,
+    utils::DatabaseURL,
 };
 use prometheus::Histogram;
-
-use fhevm_engine_common::{pg_pool::ServiceError, types::FhevmError, utils::DatabaseURL};
 use thiserror::Error;
-use tracing_subscriber::registry::Data;
 
 /// The highest index of an input is 254,
 /// cause 255 (0xff) is reserved for handles originating from the FHE operations

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
@@ -15,7 +15,7 @@ pub async fn setup() -> anyhow::Result<(PostgresPoolManager, DBInstance)> {
         .expect("valid db instance");
 
     let conf = crate::Config {
-        database_url: test_instance.db_url().to_owned(),
+        database_url: test_instance.db_url.clone(),
         listen_database_channel: "fhevm".to_string(),
         notify_database_channel: "notify".to_string(),
         pg_pool_connections: 10,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -125,7 +125,7 @@ pub async fn execute_verify_proofs_loop(
     conf: Config,
     last_active_at: Arc<RwLock<SystemTime>>,
 ) -> Result<(), ExecutionError> {
-    info!(conf = ?conf, "Starting with config");
+    info!(conf = %conf, "Starting with config");
 
     // Tenants key cache is shared amongst all workers
     let tenant_key_cache = Arc::new(RwLock::new(LruCache::new(


### PR DESCRIPTION
fixes https://github.com/zama-ai/fhevm-internal/issues/453

Introduces a simple wrapper around database_url string that
 
 - ensures DATABASE_URL env is used when `--database_url` is not present
 - appends default **application_name** to the url for better observability 
 - ensures application_name is the binary name, if not present.
 - Mask password on each display/debug print