### PR TITLE
fix(gateway-contracts): add zero address validation in GatewayConfig initialization

### DIFF
--- a/gateway-contracts/contracts/GatewayConfig.sol
+++ b/gateway-contracts/contracts/GatewayConfig.sol
@@ -181,6 +181,12 @@ contract GatewayConfig is IGatewayConfig, Ownable2StepUpgradeable, UUPSUpgradeab
 
         // Register the KMS nodes
         for (uint256 i = 0; i < initialKmsNodes.length; i++) {
+            if (initialKmsNodes[i].txSenderAddress == address(0)) {
+                revert InvalidZeroAddress("KMS txSenderAddress");
+            }
+            if (initialKmsNodes[i].signerAddress == address(0)) {
+                revert InvalidZeroAddress("KMS signerAddress");
+            }
             $.isKmsTxSender[initialKmsNodes[i].txSenderAddress] = true;
             $.kmsNodes[initialKmsNodes[i].txSenderAddress] = initialKmsNodes[i];
             $.kmsTxSenderAddresses.push(initialKmsNodes[i].txSenderAddress);
@@ -197,6 +203,12 @@ contract GatewayConfig is IGatewayConfig, Ownable2StepUpgradeable, UUPSUpgradeab
 
         // Register the coprocessors
         for (uint256 i = 0; i < initialCoprocessors.length; i++) {
+            if (initialCoprocessors[i].txSenderAddress == address(0)) {
+                revert InvalidZeroAddress("Coprocessor txSenderAddress");
+            }
+            if (initialCoprocessors[i].signerAddress == address(0)) {
+                revert InvalidZeroAddress("Coprocessor signerAddress");
+            }
             $.isCoprocessorTxSender[initialCoprocessors[i].txSenderAddress] = true;
             $.coprocessors[initialCoprocessors[i].txSenderAddress] = initialCoprocessors[i];
             $.coprocessorTxSenderAddresses.push(initialCoprocessors[i].txSenderAddress);
@@ -206,6 +218,12 @@ contract GatewayConfig is IGatewayConfig, Ownable2StepUpgradeable, UUPSUpgradeab
 
         // Register the custodians
         for (uint256 i = 0; i < initialCustodians.length; i++) {
+            if (initialCustodians[i].txSenderAddress == address(0)) {
+                revert InvalidZeroAddress("Custodian txSenderAddress");
+            }
+            if (initialCustodians[i].signerAddress == address(0)) {
+                revert InvalidZeroAddress("Custodian signerAddress");
+            }
             $.custodians[initialCustodians[i].txSenderAddress] = initialCustodians[i];
             $.custodianTxSenderAddresses.push(initialCustodians[i].txSenderAddress);
             $.isCustodianTxSender[initialCustodians[i].txSenderAddress] = true;

--- a/gateway-contracts/contracts/interfaces/IGatewayConfig.sol
+++ b/gateway-contracts/contracts/interfaces/IGatewayConfig.sol
@@ -157,6 +157,12 @@ interface IGatewayConfig {
     error ChainIdNotUint64(uint256 chainId);
 
     /**
+     * @notice Error emitted when a zero address is provided.
+     * @param addressType The type of address that was zero.
+     */
+    error InvalidZeroAddress(string addressType);
+
+    /**
      * @notice Add a new host chain metadata to the GatewayConfig contract.
      * @dev The associated chain ID must be non-zero and representable by a uint64.
      * @param hostChain The new host chain metadata to include.


### PR DESCRIPTION
Missing Zero Address Validation:
- Location: initializeFromEmptyProxy() function
- Issue: No validation to prevent zero addresses (address(0))
- Impact: Invalid system configuration, potential fund loss via address(0)