### PR TITLE
feat(coprocessor): gw-listener, catchup for KMSGeneration contract

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.6.1
+version: 0.6.2
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -244,6 +244,10 @@ gwListener:
     - --get-logs-block-batch-size=100
     # NEW ARG: KMS generation contract address
     - --kms-generation-address=$(KMS_GENERATION_ADDRESS)
+    ### Catchup parameters (optional)
+    # --catchup-kms-generation-from-block BLOCK_NUMBER
+    # To go back in time from latest block
+    # --catchup-kms-generation-from-block -NB_BLOCK
 
   # Service ports configuration
   ports:

--- a/coprocessor/README.md
+++ b/coprocessor/README.md
@@ -160,6 +160,8 @@ Options:
           [default: 1]
       --error-sleep-max-secs <ERROR_SLEEP_MAX_SECS>
           [default: 10]
+      --catchup-kms-generation-from-block <BLOCK_NUMBER OR -BLOCKS_BACK>
+          [default: None]
   -h, --help
           Print help
   -V, --version

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -75,6 +75,9 @@ struct Conf {
     /// gw-listener service name in OTLP traces
     #[arg(long, default_value = "gw-listener")]
     pub service_name: String,
+
+    #[arg(long, default_value = None, help = "Can be negative from last processed block", allow_hyphen_values = true)]
+    pub catchup_kms_generation_from_block: Option<i64>,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -145,7 +148,7 @@ async fn main() -> anyhow::Result<()> {
     let cancel_token = CancellationToken::new();
 
     let Some(host_chain_id) = conf.host_chain_id.or_else(chain_id_from_env) else {
-        anyhow::bail!("--chain-id or CHAIN_ID env var is missing.")
+        anyhow::bail!("--host-chain-id or CHAIN_ID env var is missing.")
     };
     let config = ConfigSettings {
         host_chain_id,
@@ -159,6 +162,7 @@ async fn main() -> anyhow::Result<()> {
         health_check_timeout: conf.health_check_timeout,
         get_logs_poll_interval: conf.get_logs_poll_interval,
         get_logs_block_batch_size: conf.get_logs_block_batch_size,
+        catchup_kms_generation_from_block: conf.catchup_kms_generation_from_block,
     };
 
     let gw_listener = GatewayListener::new(

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -51,6 +51,7 @@ pub struct ConfigSettings {
 
     pub get_logs_poll_interval: Duration,
     pub get_logs_block_batch_size: u64,
+    pub catchup_kms_generation_from_block: Option<i64>,
 }
 
 pub fn chain_id_from_env() -> Option<ChainId> {
@@ -77,6 +78,7 @@ impl Default for ConfigSettings {
             health_check_timeout: Duration::from_secs(4),
             get_logs_poll_interval: Duration::from_secs(1),
             get_logs_block_batch_size: 100,
+            catchup_kms_generation_from_block: None,
         }
     }
 }

--- a/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -461,6 +461,135 @@ async fn keygen_ok() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial(db)]
+async fn keygen_ok_catchup_positive() -> anyhow::Result<()> {
+    keygen_ok_catchup_gen(true).await
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn keygen_ok_catchup_negative() -> anyhow::Result<()> {
+    keygen_ok_catchup_gen(false).await
+}
+
+async fn keygen_ok_catchup_gen(positive: bool) -> anyhow::Result<()> {
+    use aws_sdk_s3::operation::get_object::GetObjectOutput;
+    use aws_sdk_s3::primitives::ByteStream;
+    use aws_sdk_s3::Client;
+    use aws_smithy_mocks::RuleMode;
+    use aws_smithy_mocks::{mock, mock_client};
+    use gw_listener::KeyType;
+
+    // see ../contracts/KMSGeneration.sol
+    let buckets = [
+        "test-bucket1/PUB-P1",
+        "test-bucket2/PUB-P2",
+        "test-bucket3/PUB-P3",
+        "test-bucket4/PUB-P4",
+    ];
+
+    let keys_digests = [KeyType::PublicKey, KeyType::ServerKey];
+
+    let key_id = U256::from(16);
+
+    let mut rules = vec![];
+    for &bucket in &buckets {
+        for key_type in &keys_digests {
+            let key_type_str: &str = to_bucket_key_prefix(*key_type);
+            let key_id_no_0x = key_id_to_key_bucket(key_id);
+            let key = format!("{}/{}", key_type_str, key_id_no_0x);
+            eprintln!("Adding {}/{}", bucket, key);
+            let get_object_rule = mock!(Client::get_object)
+                .match_requests(move |req| req.bucket() == Some(bucket) && req.key() == Some(&key))
+                .then_output(|| {
+                    GetObjectOutput::builder()
+                        .body(ByteStream::from_static(b"key_bytes"))
+                        .build()
+                });
+            rules.push(get_object_rule);
+        }
+    }
+    for &bucket in &buckets {
+        let key_id_no_0x = key_id_to_key_bucket(key_id);
+        let key = format!("PUB/CRS/{key_id_no_0x}");
+        eprintln!("Adding {}/{}", bucket, key);
+        let get_object_rule = mock!(Client::get_object)
+            .match_requests(move |req| req.bucket() == Some(bucket) && req.key() == Some(&key))
+            .then_output(|| {
+                GetObjectOutput::builder()
+                    .body(ByteStream::from_static(b"key_bytes"))
+                    .build()
+            });
+        rules.push(get_object_rule);
+    }
+    let rules_ref: Vec<_> = rules.iter().collect();
+
+    // Create a mocked client with the rule
+    let s3 = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &rules_ref);
+
+    let env = TestEnvironment::new().await?;
+    let provider = ProviderBuilder::new()
+        .wallet(env.wallet)
+        .connect_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let aws_s3_client = AwsS3ClientMocked(s3);
+    let input_verification = InputVerification::deploy(&provider).await?;
+    let kms_generation = KMSGeneration::deploy(&provider).await?;
+
+    assert!(provider.get_block_number().await? > 0);
+
+    let txn_req = kms_generation
+        .keygen_public_key()
+        .into_transaction_request();
+    let pending_txn = provider.send_transaction(txn_req).await?;
+    let receipt = pending_txn.get_receipt().await?;
+    assert!(receipt.status());
+
+    let txn_req = kms_generation
+        .keygen_server_key()
+        .into_transaction_request();
+    let pending_txn = provider.send_transaction(txn_req).await?;
+    let receipt = pending_txn.get_receipt().await?;
+    assert!(receipt.status());
+
+    let txn_req = kms_generation.crsgen().into_transaction_request();
+    let pending_txn = provider.send_transaction(txn_req).await?;
+    let receipt = pending_txn.get_receipt().await?;
+    assert!(receipt.status());
+
+    assert!(has_not_public_key(&env.db_pool.clone()).await?);
+    assert!(has_not_server_key(&env.db_pool.clone()).await?);
+    assert!(has_not_crs(&env.db_pool.clone()).await?);
+
+    let catchup_kms_generation_from_block = if positive {
+        Some(0)
+    } else {
+        Some(-(provider.get_block_number().await? as i64))
+    };
+    let conf = ConfigSettings {
+        catchup_kms_generation_from_block,
+        ..env.conf.clone()
+    };
+    let gw_listener = GatewayListener::new(
+        *input_verification.address(),
+        *kms_generation.address(),
+        conf,
+        env.cancel_token.clone(),
+        provider.clone(),
+        aws_s3_client.clone(),
+    );
+    let listener = tokio::spawn(async move { gw_listener.run().await });
+
+    assert!(has_public_key(&env.db_pool.clone()).await?);
+    assert!(has_server_key(&env.db_pool.clone()).await?);
+    assert!(has_crs(&env.db_pool.clone()).await?);
+
+    env.cancel_token.cancel();
+    listener.abort();
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn keygen_compromised_key() -> anyhow::Result<()> {
     use aws_sdk_s3::operation::get_object::GetObjectOutput;
     use aws_sdk_s3::primitives::ByteStream;


### PR DESCRIPTION
add --catchup-kms-generation-from-block

This is a backport tested on devnet.
The only modification wrt release is that negative catchup completely override last validated block to be more easier to use.
The negative is from now block and not from last processed block.