### PR TITLE
feat(kms-connector): improved nonce manager

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae62e633fa48b4190af5e841eb05179841bb8b713945103291e2c0867037c0d1"
+checksum = "9e15860af634cad451f598712c24ca7fd9b45d84fff68ab8d4967567fa996c64"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b151e38e42f1586a01369ec52a6934702731d07e8509a7307331b09f6c46dc"
+checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -324,6 +324,7 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
@@ -339,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2d5e8668ef6215efdb7dcca6f22277b4e483a5650e05f5de22b2350971f4b8"
+checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -353,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630288cf4f3a34a8c6bc75c03dce1dbd47833138f65f37d53a1661eafc96b83f"
+checksum = "d69af404f1d00ddb42f2419788fa87746a4cd13bab271916d7726fda6c792d94"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -417,32 +418,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5434834adaf64fa20a6fb90877bc1d33214c41b055cc49f82189c98614368cc"
+checksum = "4bd2c7ae05abcab4483ce821f12f285e01c0b33804e6883dd9ca1569a87ee2be"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -451,6 +454,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
@@ -462,14 +466,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919a8471cfbed7bcd8cf1197a57dda583ce0e10c6385f6ff4e8b41304b223392"
+checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
+ "borsh",
  "serde",
  "serde_with",
 ]
@@ -501,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c69f6c9c68a1287c9d5ff903d0010726934de0dac10989be37b75a29190d55"
+checksum = "003f46c54f22854a32b9cc7972660a476968008ad505427eabab49225309ec40"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -516,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf2ae05219e73e0979cb2cf55612aafbab191d130f203079805eaf881cca58"
+checksum = "4f4029954d9406a40979f3a3b46950928a0fdcfe3ea8a9b0c17490d57e8aa0e3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -542,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58f4f345cef483eab7374f2b6056973c7419ffe8ad35e994b7a7f5d8e0c7ba4"
+checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -555,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61321a0dbc084c2c9f2b07aa34f10db7ac80065c01721e567e5426d882c73de6"
+checksum = "b03d35475a02d2a8b76209cb4a1336cb7d85331d10a0f6ec329ee42151695c19"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -603,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2597751539b1cc8fe4204e5325f9a9ed83fcacfb212018dfcfa7877e76de21"
+checksum = "d369e12c92870d069e0c9dc5350377067af8a056e29e3badf8446099d7e00889"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -668,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf8eb8be597cfa8c312934d2566ec4516f066d69164f9212d7a148979fdcfd8"
+checksum = "31c89883fe6b7381744cbe80fef638ac488ead4f1956a4278956a1362c71cd2e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -691,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339af7336571dd39ae3a15bde08ae6a647e62f75350bd415832640268af92c06"
+checksum = "64e279e6d40ee40fe8f76753b678d8d5d260cb276dc6c8a8026099b16d2b43f4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -706,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d98fb386a462e143f5efa64350860af39950c49e7c0cbdba419c16793116ef"
+checksum = "5e176c26fdd87893b6afeb5d92099d8f7e7a1fe11d6f4fe0883d6e33ac5f31ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -718,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbde0801a32d21c5f111f037bee7e22874836fba7add34ed4a6919932dd7cf23"
+checksum = "b43c1622aac2508d528743fd4cfdac1dea92d5a8fa894038488ff7edd0af0b32"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -729,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388cf910e66bd4f309a81ef746dcf8f9bca2226e3577890a8d56c5839225cf46"
+checksum = "1b2ca3a434a6d49910a7e8e51797eb25db42ef8a5578c52d877fcb26d0afe7bc"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -741,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361cd87ead4ba7659bda8127902eda92d17fa7ceb18aba1676f7be10f7222487"
+checksum = "ed5fafb741c19b3cca4cdd04fa215c89413491f9695a3e928dee2ae5657f607e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -762,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4e95fb0572b97b17751d0fdf5cdc42b0050f9dd9459eddd1bf2e2fbfed0a33"
+checksum = "c55324323aa634b01bdecb2d47462a8dce05f5505b14a6e5db361eef16eda476"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -776,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64600fc6c312b7e0ba76f73a381059af044f4f21f43e07f51f1fa76c868fe302"
+checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -787,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5772858492b26f780468ae693405f895d6a27dea6e3eab2c36b6217de47c2647"
+checksum = "ecc39ad2c0a3d2da8891f4081565780703a593f090f768f884049aa3aa929cbc"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -802,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66acf5f8745dd935e94855aada39d83b555112872321d9293748424de144897e"
+checksum = "75411104af460ca0b306ae998f0a00b5159457780487630f4b24722beae6b690"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -821,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4195b803d0a992d8dbaab2ca1986fc86533d4bc80967c0cce7668b26ad99ef9"
+checksum = "930e17cb1e46446a193a593a3bfff8d0ecee4e510b802575ebe300ae2e43ef75"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -910,12 +915,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025a940182bddaeb594c26fe3728525ae262d0806fe6a4befdf5d7bc13d54bce"
+checksum = "cae82426d98f8bc18f53c5223862907cac30ab8fc5e4cd2bb50808e6d3ab43d8"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
  "auto_impl",
  "base64 0.22.1",
  "derive_more",
@@ -934,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5064d1e1e1aabc918b5954e7fb8154c39e77ec6903a581b973198b26628fa"
+checksum = "90aa6825760905898c106aba9c804b131816a15041523e80b6d4fe7af6380ada"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -965,11 +969,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.41"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e52276fdb553d3c11563afad2898f4085165e4093604afe3d78b69afbf408f"
+checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
- "alloy-primitives",
  "darling",
  "proc-macro2",
  "quote",
@@ -2091,6 +2094,29 @@ dependencies = [
  "serde",
  "serde_repr",
  "serde_with",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17c19591d57add4f0c47922877a48aae1f47074e3433436545f8948353b3bbb"
+checksum = "ae62e633fa48b4190af5e841eb05179841bb8b713945103291e2c0867037c0d1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -289,7 +289,6 @@ dependencies = [
  "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",
- "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
@@ -298,7 +297,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws",
  "alloy-trie",
 ]
 
@@ -315,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0dd3ed764953a6b20458b2b7abbfdc93d20d14b38babe1a70fe631a443a9f1"
+checksum = "b9b151e38e42f1586a01369ec52a6934702731d07e8509a7307331b09f6c46dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -341,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9556182afa73cddffa91e64a5aa9508d5e8c912b3a15f26998d2388a824d2c7b"
+checksum = "6e2d5e8668ef6215efdb7dcca6f22277b4e483a5650e05f5de22b2350971f4b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -355,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19d7092c96defc3d132ee0d8969ca1b79ef512b5eda5c66e3065266b253adf2"
+checksum = "630288cf4f3a34a8c6bc75c03dce1dbd47833138f65f37d53a1661eafc96b83f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -366,7 +364,6 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-provider",
- "alloy-pubsub",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
@@ -443,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fa99b538ca7006b0c03cfed24ec6d82beda67aac857ef4714be24231d15e6"
+checksum = "e5434834adaf64fa20a6fb90877bc1d33214c41b055cc49f82189c98614368cc"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -465,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a272533715aefc900f89d51db00c96e6fd4f517ea081a12fea482a352c8c815c"
+checksum = "919a8471cfbed7bcd8cf1197a57dda583ce0e10c6385f6ff4e8b41304b223392"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -504,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91676d242c0ced99c0dd6d0096d7337babe9457cc43407d26aa6367fcf90553"
+checksum = "d7c69f6c9c68a1287c9d5ff903d0010726934de0dac10989be37b75a29190d55"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -519,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f82150116b30ba92f588b87f08fa97a46a1bd5ffc0d0597efdf0843d36bfda"
+checksum = "8eaf2ae05219e73e0979cb2cf55612aafbab191d130f203079805eaf881cca58"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -545,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223612259a080160ce839a4e5df0125ca403a1d5e7206cc911cea54af5d769aa"
+checksum = "e58f4f345cef483eab7374f2b6056973c7419ffe8ad35e994b7a7f5d8e0c7ba4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -558,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3652a65bacfba0a169755090d4ecd7d3c63fa534b21d09b8e604dc2609760da6"
+checksum = "61321a0dbc084c2c9f2b07aa34f10db7ac80065c01721e567e5426d882c73de6"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -606,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7283b81b6f136100b152e699171bc7ed8184a58802accbc91a7df4ebb944445"
+checksum = "de2597751539b1cc8fe4204e5325f9a9ed83fcacfb212018dfcfa7877e76de21"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -618,7 +615,6 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-node-bindings",
  "alloy-primitives",
- "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
@@ -628,7 +624,6 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -646,28 +641,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-pubsub"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee7e3d343814ec0dfea69bd1820042a133a9d0b9ac5faf1e6eb133b43366315"
-dependencies = [
- "alloy-json-rpc",
- "alloy-primitives",
- "alloy-transport",
- "auto_impl",
- "bimap",
- "futures",
- "parking_lot",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
  "wasmtimer",
 ]
 
@@ -695,16 +668,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154b12d470bef59951c62676e106f4ce5de73b987d86b9faa935acebb138ded"
+checksum = "edf8eb8be597cfa8c312934d2566ec4516f066d69164f9212d7a148979fdcfd8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ws",
  "futures",
  "pin-project",
  "reqwest",
@@ -720,11 +691,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ab76bf97648a1c6ad8fb00f0d594618942b5a9e008afbfb5c8a8fca800d574"
+checksum = "339af7336571dd39ae3a15bde08ae6a647e62f75350bd415832640268af92c06"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -734,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456cfc2c1677260edbd7ce3eddb7de419cb46de0e9826c43401f42b0286a779a"
+checksum = "83d98fb386a462e143f5efa64350860af39950c49e7c0cbdba419c16793116ef"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -746,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cc57ee0c1ac9fb14854195fc249494da7416591dc4a4d981ddfd5dd93b9bce"
+checksum = "fbde0801a32d21c5f111f037bee7e22874836fba7add34ed4a6919932dd7cf23"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -757,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ac29dd005c33e3f7e09087accc80843315303685c3f7a1b888002cd27785b"
+checksum = "388cf910e66bd4f309a81ef746dcf8f9bca2226e3577890a8d56c5839225cf46"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -769,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7d47bca1a2a1541e4404aa38b7e262bb4dffd9ac23b4f178729a4ddc5a5caa"
+checksum = "361cd87ead4ba7659bda8127902eda92d17fa7ceb18aba1676f7be10f7222487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -790,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c331c8e48665607682e8a9549a2347c13674d4fbcbdc342e7032834eba2424f4"
+checksum = "de4e95fb0572b97b17751d0fdf5cdc42b0050f9dd9459eddd1bf2e2fbfed0a33"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -804,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8468f1a7f9ee3bae73c24eead0239abea720dbf7779384b9c7e20d51bfb6b0"
+checksum = "64600fc6c312b7e0ba76f73a381059af044f4f21f43e07f51f1fa76c868fe302"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -815,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33387c90b0a5021f45a5a77c2ce6c49b8f6980e66a318181468fb24cea771670"
+checksum = "5772858492b26f780468ae693405f895d6a27dea6e3eab2c36b6217de47c2647"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -830,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bf90f2355769ad93f790b930434b8d3d2948317f3e484de458010409024462"
+checksum = "66acf5f8745dd935e94855aada39d83b555112872321d9293748424de144897e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -849,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55d9e795c85e36dcea08786d2e7ae9b73cb554b6bea6ac4c212def24e1b4d03"
+checksum = "f4195b803d0a992d8dbaab2ca1986fc86533d4bc80967c0cce7668b26ad99ef9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -938,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702002659778d89a94cd4ff2044f6b505460df6c162e2f47d1857573845b0ace"
+checksum = "025a940182bddaeb594c26fe3728525ae262d0806fe6a4befdf5d7bc13d54bce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -962,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6bdc0830e5e8f08a4c70a4c791d400a86679c694a3b4b986caf26fad680438"
+checksum = "e3b5064d1e1e1aabc918b5954e7fb8154c39e77ec6903a581b973198b26628fa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -973,24 +945,6 @@ dependencies = [
  "tower",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-transport-ws"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686219dcef201655763bd3d4eabe42388d9368bfbf6f1c8016d14e739ec53aac"
-dependencies = [
- "alloy-pubsub",
- "alloy-transport",
- "futures",
- "http 1.3.1",
- "rustls 0.23.31",
- "serde_json",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -1011,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.38"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf39928a5e70c9755d6811a2928131b53ba785ad37c8bf85c90175b5d43b818"
+checksum = "f8e52276fdb553d3c11563afad2898f4085165e4093604afe3d78b69afbf408f"
 dependencies = [
  "alloy-primitives",
  "darling",
@@ -1434,17 +1388,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -1958,12 +1901,6 @@ dependencies = [
  "bincode 2.0.1",
  "serde",
 ]
-
-[[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bincode"
@@ -2651,12 +2588,6 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der"
@@ -4756,16 +4687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version 0.4.1",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5856,12 +5777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
 version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6902,22 +6817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.23.31",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.4",
- "tungstenite",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7195,25 +7094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.3.1",
- "httparse",
- "log",
- "rand 0.9.2",
- "rustls 0.23.31",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.12",
- "utf-8",
-]
-
-[[package]]
 name = "tx-sender"
 version = "0.10.0"
 dependencies = [
@@ -7332,12 +7212,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -7909,25 +7783,6 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version 0.4.1",
- "send_wrapper",
- "thiserror 2.0.12",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "wyz"

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -27,7 +27,7 @@ tfhe = "=1.4.0-alpha.3"
 #                       External dependencies                       #
 #####################################################################
 actix-web = "=4.11.0"
-alloy = { version = "=1.0.41", default-features = false, features = [
+alloy = { version = "=1.1.2", default-features = false, features = [
     "essentials",
     "json-rpc",
     "provider-debug-api",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -27,10 +27,10 @@ tfhe = "=1.4.0-alpha.3"
 #                       External dependencies                       #
 #####################################################################
 actix-web = "=4.11.0"
-alloy = { version = "=1.0.38", default-features = false, features = [
+alloy = { version = "=1.0.41", default-features = false, features = [
     "essentials",
+    "json-rpc",
     "provider-debug-api",
-    "provider-ws",
     "reqwest-rustls-tls",
     "signer-aws",
     "std",

--- a/kms-connector/crates/tx-sender/Cargo.toml
+++ b/kms-connector/crates/tx-sender/Cargo.toml
@@ -23,7 +23,6 @@ tracing.workspace = true
 tracing-opentelemetry.workspace = true
 
 [dev-dependencies]
-alloy = { workspace = true, features = ["json-rpc"] }
 bc2wrap.workspace = true
 connector-utils = { workspace = true, features = ["tests"] }
 rstest.workspace = true

--- a/kms-connector/crates/utils/Cargo.toml
+++ b/kms-connector/crates/utils/Cargo.toml
@@ -43,6 +43,7 @@ testcontainers = { workspace = true, optional = true }
 toml = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["provider-anvil-node"] }
 serial_test.workspace = true
 tempfile.workspace = true
 toml.workspace = true

--- a/kms-connector/crates/utils/src/provider/nonce_manager.rs
+++ b/kms-connector/crates/utils/src/provider/nonce_manager.rs
@@ -1,0 +1,518 @@
+use alloy::{
+    network::Network,
+    primitives::Address,
+    providers::{Provider, fillers::NonceManager},
+    transports::TransportResult,
+};
+use async_trait::async_trait;
+use futures::lock::{Mutex, MutexGuard};
+use std::collections::{BTreeSet, HashMap, hash_map::Entry};
+use std::sync::Arc;
+use tracing::debug;
+
+/// A robust, in-memory nonce manager for a scalable transaction engine.
+#[derive(Clone, Debug, Default)]
+pub struct ZamaNonceManager {
+    /// Nonce state for each account, shared across all tasks/threads using the nonce manager.
+    accounts: Arc<Mutex<HashMap<Address, AccountState>>>,
+}
+
+/// Represents the complete nonce state for a single account.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AccountState {
+    /// The "high-water mark" nonce. Used only when no gaps are available.
+    pub next_nonce: u64,
+    /// Nonces that have been dispatched but not yet confirmed or rejected.
+    pub locked_nonces: BTreeSet<u64>,
+    /// Nonces that were previously locked but have been released, creating gaps.
+    pub available_nonces: BTreeSet<u64>,
+}
+
+impl ZamaNonceManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The primary logic for acquiring and locking the next valid nonce.
+    ///
+    /// The logic prioritizes filling gaps from `available_nonces` before
+    /// incrementing the main `next_nonce` counter.
+    pub async fn get_increase_and_lock_nonce<P, N>(
+        &self,
+        provider: &P,
+        address: Address,
+    ) -> TransportResult<u64>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        let mut accounts_guard = self.accounts.lock().await;
+        let account =
+            Self::get_or_init_account_state(&mut accounts_guard, provider, address).await?;
+        let nonce_to_use =
+            if let Some(available_nonce) = account.available_nonces.iter().next().copied() {
+                account.available_nonces.remove(&available_nonce);
+                debug!(%address, nonce = available_nonce, "Reusing available nonce");
+                available_nonce
+            } else {
+                let next = account.next_nonce;
+                account.next_nonce += 1;
+                debug!(%address, nonce = next, "Using next sequential nonce");
+                next
+            };
+
+        account.locked_nonces.insert(nonce_to_use);
+        Ok(nonce_to_use)
+    }
+
+    /// Releases a locked nonce, making it available for reuse.
+    pub async fn release_nonce(&self, address: Address, nonce: u64) {
+        let mut accounts = self.accounts.lock().await;
+        if let Some(account) = accounts.get_mut(&address)
+            && account.locked_nonces.remove(&nonce)
+        {
+            account.available_nonces.insert(nonce);
+        }
+    }
+
+    /// Confirms a nonce has been used on-chain, removing it permanently.
+    pub async fn confirm_nonce(&self, address: Address, nonce: u64) {
+        let mut accounts = self.accounts.lock().await;
+        if let Some(account) = accounts.get_mut(&address) {
+            account.locked_nonces.remove(&nonce);
+        }
+    }
+
+    /// Helper to retrieve or initialize the `AccountState` for an address.
+    async fn get_or_init_account_state<'a, P, N>(
+        accounts_guard: &'a mut MutexGuard<'_, HashMap<Address, AccountState>>,
+        provider: &P,
+        address: Address,
+    ) -> TransportResult<&'a mut AccountState>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        let account = match accounts_guard.entry(address) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let initial_nonce = provider.get_transaction_count(address).await?;
+                entry.insert(AccountState {
+                    next_nonce: initial_nonce,
+                    ..Default::default()
+                })
+            }
+        };
+        Ok(account)
+    }
+}
+
+// Implements the `NonceManager` trait for seamless integration with Alloy's provider stack.
+#[async_trait]
+impl NonceManager for ZamaNonceManager {
+    async fn get_next_nonce<P, N>(&self, provider: &P, address: Address) -> TransportResult<u64>
+    where
+        P: Provider<N>,
+        N: Network,
+    {
+        self.get_increase_and_lock_nonce(provider, address).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::providers::ProviderBuilder;
+    use std::{collections::HashSet, str::FromStr};
+    use tokio::time::{Duration, sleep};
+
+    async fn get_test_address<P: Provider>(provider: &P) -> Address {
+        provider.get_accounts().await.unwrap()[0]
+    }
+
+    #[tokio::test]
+    async fn test_initialization_matches_live_chain_nonce() {
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+        let manager = ZamaNonceManager::new();
+        let address = get_test_address(&provider).await;
+
+        let on_chain_nonce = provider.get_transaction_count(address).await.unwrap();
+
+        // Trigger initialization by getting the first nonce
+        let first_nonce = manager.get_next_nonce(&provider, address).await.unwrap();
+
+        assert_eq!(
+            first_nonce, on_chain_nonce,
+            "First fetched nonce should match the on-chain nonce"
+        );
+
+        let details = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            details.next_nonce,
+            on_chain_nonce + 1,
+            "High-water mark should be incremented"
+        );
+        assert!(details.locked_nonces.contains(&on_chain_nonce));
+    }
+
+    #[tokio::test]
+    async fn test_sequential_nonces_are_dispensed_correctly() {
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+        let manager = ZamaNonceManager::new();
+        let address = get_test_address(&provider).await;
+
+        let nonce0 = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(nonce0, 0);
+        let nonce1 = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(nonce1, 1);
+        let nonce2 = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(nonce2, 2);
+
+        let details = manager.get_account_details(address).await.unwrap();
+        assert_eq!(details.next_nonce, 3);
+        assert_eq!(details.locked_nonces, BTreeSet::from([0, 1, 2]));
+        assert!(details.available_nonces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_next_nonce_prioritizes_available_gaps_over_sequential() {
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+        let manager = ZamaNonceManager::new();
+        let address = get_test_address(&provider).await;
+
+        // Manually set up a state with a high `next_nonce` and some available gaps.
+        let initial_state = AccountState {
+            next_nonce: 100,
+            locked_nonces: BTreeSet::new(),
+            available_nonces: BTreeSet::from([5, 2, 8]), // Intentionally unsorted
+        };
+        manager.accounts.lock().await.insert(address, initial_state);
+
+        // The manager should dispense the LOWEST available nonces first.
+        assert_eq!(manager.get_next_nonce(&provider, address).await.unwrap(), 2);
+        assert_eq!(manager.get_next_nonce(&provider, address).await.unwrap(), 5);
+        assert_eq!(manager.get_next_nonce(&provider, address).await.unwrap(), 8);
+
+        // Now that the available pool is empty, it should use the high-water mark.
+        assert_eq!(
+            manager.get_next_nonce(&provider, address).await.unwrap(),
+            100
+        );
+
+        let details = manager.get_account_details(address).await.unwrap();
+        assert!(details.available_nonces.is_empty());
+        assert_eq!(details.locked_nonces, BTreeSet::from([2, 5, 8, 100]));
+        assert_eq!(details.next_nonce, 101);
+    }
+
+    #[tokio::test]
+    async fn scenario_initialization_and_sequential_dispatch() {
+        println!("SCENARIO: Initialization and Sequential Dispatch");
+
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+        let manager = ZamaNonceManager::new();
+        let address = get_test_address(&provider).await;
+
+        let nonce0 = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(nonce0, 0, "First nonce should be 0 for a new account");
+        let nonce1 = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(nonce1, 1, "Second nonce should be 1");
+        let nonce2 = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(nonce2, 2, "Third nonce should be 2");
+
+        // Final State Verification
+        let details = manager.get_account_details(address).await.unwrap();
+        assert_eq!(details.next_nonce, 3, "High-water mark should now be 3");
+        assert_eq!(
+            details.locked_nonces,
+            BTreeSet::from([0, 1, 2]),
+            "All dispatched nonces should be locked"
+        );
+        assert!(
+            details.available_nonces.is_empty(),
+            "Available pool should be empty"
+        );
+        // Validating transaction:
+        manager.confirm_nonce(address, 0).await;
+        manager.confirm_nonce(address, 1).await;
+        let details1 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            details1.locked_nonces,
+            BTreeSet::from([2]),
+            "Only the transaction with nonce 2 is still pending."
+        );
+
+        manager.confirm_nonce(address, 2).await;
+        let details2 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            details2.locked_nonces,
+            BTreeSet::from([]),
+            "All locked nonce should be released."
+        );
+        assert_eq!(
+            details2.next_nonce, 3,
+            "High-water mark should now still be 3"
+        );
+    }
+
+    #[tokio::test]
+    async fn scenario_stuck_transaction_is_released_and_reused() {
+        println!("SCENARIO: Stuck Transaction is Released and Reused");
+
+        // 1. Arrange: Dispatch 3 nonces (0, 1, 2)
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+        let manager = ZamaNonceManager::new();
+        let address = get_test_address(&provider).await;
+        manager.get_next_nonce(&provider, address).await.unwrap(); // Nonce 0
+        manager.get_next_nonce(&provider, address).await.unwrap(); // Nonce 1
+        manager.get_next_nonce(&provider, address).await.unwrap(); // Nonce 2
+
+        // 2. Act: Simulate nonce 1 getting stuck and being released.
+        println!("Releasing stuck nonce 1...");
+        manager.release_nonce(address, 1).await;
+
+        // 3. Assert Intermediate State
+        let details1 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            details1.locked_nonces,
+            BTreeSet::from([0, 2]),
+            "Nonces 0 and 2 should remain locked"
+        );
+        assert_eq!(
+            details1.available_nonces,
+            BTreeSet::from([1]),
+            "Nonce 1 should now be available"
+        );
+
+        // 4. Act: Request a new nonce.
+        println!("Requesting a new nonce, expecting it to be the released one...");
+        let reused_nonce = manager.get_next_nonce(&provider, address).await.unwrap();
+
+        // 5. Assert Final State
+        assert_eq!(
+            reused_nonce, 1,
+            "The manager MUST reuse the released nonce 1 to fill the gap"
+        );
+        let details2 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            details2.locked_nonces,
+            BTreeSet::from([0, 1, 2]),
+            "All nonces are now locked again"
+        );
+        assert!(
+            details2.available_nonces.is_empty(),
+            "Available pool should be empty after reuse"
+        );
+    }
+
+    #[tokio::test]
+    async fn scenario_concurrent_requests_for_same_address_are_safe() {
+        // This is the most critical test. It proves that the manager is thread-safe
+        // by simulating many concurrent requests for nonces for the SAME address.
+        // It must dispense unique, sequential nonces with no duplicates.
+        println!("SCENARIO: Concurrent Requests are Safe");
+
+        // 1. Arrange
+        let provider = Arc::new(ProviderBuilder::new().connect_anvil_with_wallet());
+        let manager = Arc::new(ZamaNonceManager::new());
+        let address = get_test_address(&provider).await;
+
+        let initial_nonce = provider.get_transaction_count(address).await.unwrap();
+        let num_tasks = 20;
+        let mut tasks = Vec::new();
+
+        // 2. Act: Spawn N tasks that all request a nonce at the same time.
+        for _ in 0..num_tasks {
+            let manager_clone = Arc::clone(&manager);
+            let provider_clone = Arc::clone(&provider);
+            tasks.push(tokio::spawn(async move {
+                manager_clone
+                    .get_next_nonce(&*provider_clone, address)
+                    .await
+            }));
+        }
+        let results = futures::future::join_all(tasks).await;
+
+        // 3. Assert
+        let mut received_nonces = HashSet::new();
+        for res in results {
+            let nonce_result = res.unwrap(); // Panics on task failure
+            assert!(nonce_result.is_ok());
+            let nonce = nonce_result.unwrap();
+            // The core assertion: was this nonce already given to another task?
+            assert!(
+                received_nonces.insert(nonce),
+                "FATAL: Duplicate nonce {nonce} dispensed under contention!",
+            );
+        }
+
+        assert_eq!(
+            received_nonces.len() as u64,
+            num_tasks,
+            "Should have received exactly {num_tasks} unique nonces",
+        );
+        println!("✅ All {num_tasks} dispensed nonces were unique.");
+
+        let final_details = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            final_details.next_nonce,
+            initial_nonce + num_tasks,
+            "High-water mark should be advanced by the number of tasks"
+        );
+    }
+
+    #[tokio::test]
+    async fn scenario_mixed_lifecycle_operations() {
+        // This test simulates a complex, realistic sequence of events.
+        println!("SCENARIO: Mixed Lifecycle Operations");
+
+        // 1. Arrange: Get 5 nonces (0-4)
+        let provider = ProviderBuilder::new().connect_anvil_with_wallet();
+
+        let manager = ZamaNonceManager::new();
+        let address = Address::from_str("0x4444444444444444444444444444444444444444").unwrap();
+        for i in 0..5 {
+            assert_eq!(manager.get_next_nonce(&provider, address).await.unwrap(), i);
+        }
+
+        let details1 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(details1.locked_nonces, BTreeSet::from([0, 1, 2, 3, 4]));
+
+        // 2. Act: A series of events happens out of order.
+        println!("Locked nonce 2, Releasing nonce 1, Confirming nonce 0...");
+        manager.release_nonce(address, 1).await; // Got stuck
+        manager.confirm_nonce(address, 0).await; // Mined successfully
+
+        // 3. Assert Intermediate State
+        let details2 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            details2.locked_nonces,
+            BTreeSet::from([2, 3, 4]),
+            "Only nonces 2, 3 and 4 should be locked"
+        );
+        assert_eq!(
+            details2.available_nonces,
+            BTreeSet::from([1]),
+            "Only nonce 1 should be available"
+        );
+
+        // 4. Act: Get two more nonces.
+        println!("Requesting two more nonces...");
+        let nonce_a = manager.get_next_nonce(&provider, address).await.unwrap();
+        let nonce_b = manager.get_next_nonce(&provider, address).await.unwrap();
+
+        // 5. Assert Final State
+        assert_eq!(nonce_a, 1, "Should have reused the available nonce 1 first");
+        assert_eq!(
+            nonce_b, 5,
+            "Should have used the high-water mark nonce 5 after filling the gap"
+        );
+
+        let details3 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(details3.locked_nonces, BTreeSet::from([1, 2, 3, 4, 5]));
+        assert_eq!(details3.next_nonce, 6);
+
+        // Then txs 1 and 2 passes ! And transaction 4 is dropped by the mempool!
+        manager.confirm_nonce(address, 1).await; // Mined successfully
+        manager.confirm_nonce(address, 2).await; // Mined successfully
+        manager.release_nonce(address, 4).await;
+
+        let details4 = manager.get_account_details(address).await.unwrap();
+
+        assert_eq!(details4.locked_nonces, BTreeSet::from([3, 5]));
+
+        let released = manager.get_next_nonce(&provider, address).await.unwrap();
+        let details5 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            released, 4,
+            "Should have reused the available nonce 1 first"
+        );
+        assert_eq!(details5.locked_nonces, BTreeSet::from([3, 4, 5]));
+        assert_eq!(details5.next_nonce, 6);
+    }
+
+    #[tokio::test]
+    async fn scenario_concurrent_requests_with_mixed_lifecycle() {
+        // This test doesn't care about real scenario.
+        println!("SCENARIO: Concurrent Requests with Mixed Lifecycle ('Chaos Test')");
+
+        // 1. Arrange
+        let provider = Arc::new(ProviderBuilder::new().connect_anvil_with_wallet());
+        let manager = Arc::new(ZamaNonceManager::new());
+        // Use a fresh address for a predictable state.
+        let address = Address::from_str("0x5555555555555555555555555555555555555555").unwrap();
+
+        // Pre-warm the manager: get the first 10 nonces (0-9) and lock them.
+        for i in 0..10 {
+            assert_eq!(
+                manager.get_next_nonce(&*provider, address).await.unwrap(),
+                i
+            );
+        }
+
+        let mut tasks = Vec::new();
+
+        // - Release nonce 2 and 5 (simulating stuck txs)
+        let manager_clone = Arc::clone(&manager);
+        tasks.push(tokio::spawn(async move {
+            println!("Task A: Releasing nonces 2 and 5");
+            manager_clone.release_nonce(address, 2).await;
+            sleep(Duration::from_millis(10)).await; // small delay to allow interleaving
+            manager_clone.release_nonce(address, 5).await;
+        }));
+
+        // - Confirm nonce 3 and 7 (simulating mined txs)
+        let manager_clone = Arc::clone(&manager);
+        tasks.push(tokio::spawn(async move {
+            println!("Task B: Confirming nonces 3 and 7");
+            manager_clone.confirm_nonce(address, 3).await;
+            sleep(Duration::from_millis(5)).await;
+            manager_clone.confirm_nonce(address, 7).await;
+        }));
+
+        // - Request 5 new nonces
+        let mut nonce_requester_tasks = Vec::new();
+        for i in 0..5 {
+            let manager_clone = Arc::clone(&manager);
+            let provider_clone = Arc::clone(&provider);
+            nonce_requester_tasks.push(tokio::spawn(async move {
+                let nonce = manager_clone
+                    .get_next_nonce(&*provider_clone, address)
+                    .await
+                    .unwrap();
+                println!("Task C.{i}: Requested and received nonce {nonce}");
+                nonce
+            }));
+        }
+
+        // Wait for the release/confirm tasks to finish first.
+        futures::future::join_all(tasks).await;
+        // Then get the results from the nonce requesters.
+        futures::future::join_all(nonce_requester_tasks).await;
+        let state1 = manager.get_account_details(address).await.unwrap();
+        assert_eq!(
+            state1.locked_nonces,
+            BTreeSet::from([0, 1, 2, 4, 6, 8, 9, 10, 11, 12, 13])
+        );
+        // Because of milliseconds waiting before release.
+        assert_eq!(state1.available_nonces, BTreeSet::from([5]));
+        assert_eq!(state1.next_nonce, 14);
+        manager.get_next_nonce(&provider, address).await.unwrap();
+        let state2 = manager.get_account_details(address).await.unwrap();
+
+        assert_eq!(
+            state2.locked_nonces,
+            BTreeSet::from([0, 1, 2, 4, 5, 6, 8, 9, 10, 11, 12, 13])
+        );
+        // Because of milliseconds waiting before release.
+        assert_eq!(state2.available_nonces, BTreeSet::from([]));
+        assert_eq!(state2.next_nonce, 14);
+    }
+
+    impl ZamaNonceManager {
+        /// Returns a snapshot of the current nonce state for a given address.
+        async fn get_account_details(&self, address: Address) -> Option<AccountState> {
+            self.accounts.lock().await.get(&address).cloned()
+        }
+    }
+}


### PR DESCRIPTION
Huge kudos to @nboisde for this one :pray: 

Closes https://github.com/zama-ai/fhevm-internal/issues/672
Closes https://github.com/zama-ai/fhevm-internal/issues/671

## Code changes

No longer rely on a `CachedNonceManager` from `alloy`, but from a custom one (also used in the `relayer`) that keeps track of which nonce were successfully used, which are free to be reused in case of failure etc.

This should reduce the number of `nonce too high/low` error caught in our logs.
With the current setup, if the tx-sender get a `nonce too high/low` error, it will reinit the `CachedNonceManager` via RPC call. The problem with that is that in general, there are multiple of these errors, so each task handling a tx will do this RPC call, and the `CachedNonceManager` willl provide the same nonce to all of these tasks (because of the RPC call), instead of an incremented one.
With this new setup, no RPC call is made on error, the failed nonce is just stored in a map to be reused by another tx later on.

## Risk

The main risk I see is that there is that the nonce manager never re-sync with the RPC node on error. So it could result in a dead lock if for some reason, the nonce manager is stuck with too high nonces...