### PR TITLE
test(host-contracts): fix edge case in fuzz test

### DIFF
--- a/host-contracts/test/acl/acl.t.sol
+++ b/host-contracts/test/acl/acl.t.sol
@@ -144,6 +144,7 @@ contract ACLTest is Test {
         address account
     ) public {
         _upgradeProxy();
+        vm.assume(sender!=fhevmExecutorAdd); // fhevmExecutor is privileged for transientAllow
         vm.prank(sender);
         vm.expectRevert(abi.encodeWithSelector(ACL.SenderNotAllowed.selector, sender));
         acl.allowTransient(handle, account);


### PR DESCRIPTION
This small PR fixes an edge case in a test that was broken in rare case, since the FHEVMExecutor address is a privileged address for `ACL:transientAllow` method.