### PR TITLE
feat(coprocessor): add metrics for gw-listener

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3862,6 +3862,7 @@ dependencies = [
  "foundry-compilers",
  "futures-util",
  "humantime",
+ "prometheus",
  "rustls 0.23.31",
  "semver 1.0.27",
  "serde",

--- a/coprocessor/fhevm-engine/gw-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/gw-listener/Cargo.toml
@@ -17,6 +17,7 @@ aws-sdk-s3 = { workspace = true }
 clap = { workspace = true }
 futures-util = { workspace = true }
 humantime = { workspace = true }
+prometheus = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::{primitives::Address, transports::http::reqwest::Url};
 use clap::Parser;
-use fhevm_engine_common::telemetry;
+use fhevm_engine_common::{metrics_server, telemetry};
 use gw_listener::aws_s3::AwsS3Client;
 use gw_listener::chain_id_from_env;
 use gw_listener::gw_listener::GatewayListener;
@@ -41,9 +41,12 @@ struct Conf {
     #[arg(long, default_value = "10")]
     error_sleep_max_secs: u16,
 
-    /// HTTP server port for health checks
     #[arg(long, default_value_t = 8080)]
     health_check_port: u16,
+
+    /// Prometheus metrics server address
+    #[arg(long, default_value = "0.0.0.0:9100")]
+    metrics_addr: Option<String>,
 
     #[arg(long, default_value = "4s", value_parser = parse_duration)]
     health_check_timeout: Duration,
@@ -170,14 +173,12 @@ async fn main() -> anyhow::Result<()> {
     // Wrap the GatewayListener in an Arc
     let gw_listener = std::sync::Arc::new(gw_listener);
 
-    // Create HTTP server with the Arc-wrapped listener
     let http_server = HttpServer::new(
         gw_listener.clone(),
         conf.health_check_port,
         cancel_token.clone(),
     );
 
-    // Install signal handlers
     install_signal_handlers(cancel_token.clone())?;
 
     info!(
@@ -185,20 +186,26 @@ async fn main() -> anyhow::Result<()> {
         "Starting HTTP health check server"
     );
 
-    // Run both services concurrently - note we now have to deref the Arc for run()
-    let (listener_result, http_result) = tokio::join!(gw_listener.run(), http_server.start());
+    // Run both services in parallel. Here we assume that if gw listener stops without an error, HTTP server should also stop.
+    let gw_listener_fut = tokio::spawn(async move { gw_listener.run().await });
+    let http_server_fut = tokio::spawn(async move { http_server.start().await });
 
-    // Check results
-    if let Err(e) = listener_result {
-        error!(error = %e, "Gateway listener error");
-        return Err(e);
-    }
+    // Start the metrics server.
+    metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
 
-    if let Err(e) = http_result {
-        error!(error = %e, "HTTP server error");
-        return Err(e);
-    }
+    let gw_listener_res = gw_listener_fut.await;
+    let http_server_res = http_server_fut.await;
 
-    info!("Gateway listener and HTTP server stopped gracefully");
+    info!(
+        gw_listener_res = ?gw_listener_res,
+        http_server_res = ?http_server_res,
+        "Gateway listener and HTTP health check server tasks have stopped"
+    );
+
+    gw_listener_res??;
+    http_server_res??;
+
+    info!("Gateway listener and HTTP health check server stopped gracefully");
+
     Ok(())
 }

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod database;
 pub(crate) mod digest;
 pub mod gw_listener;
 pub mod http_server;
+pub(crate) mod metrics;
 pub(crate) mod sks_key;
 
 pub(crate) type ChainId = u64;
@@ -43,7 +44,9 @@ pub struct ConfigSettings {
 
     pub error_sleep_initial_secs: u16,
     pub error_sleep_max_secs: u16,
+
     pub health_check_port: u16,
+
     pub health_check_timeout: Duration,
 
     pub get_logs_poll_interval: Duration,

--- a/coprocessor/fhevm-engine/gw-listener/src/metrics.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/metrics.rs
@@ -1,0 +1,98 @@
+use prometheus::{register_int_counter, IntCounter};
+use std::sync::LazyLock;
+
+pub(crate) static VERIFY_PROOF_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_verify_proof_success_counter",
+        "Number of successful verify request events in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static VERIFY_PROOF_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_verify_proof_fail_counter",
+        "Number of failed verify request events in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_BLOCK_NUM_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_block_num_success_counter",
+        "Number of successful get block num requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_BLOCK_NUM_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_block_num_fail_counter",
+        "Number of failed get block num requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_LOGS_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_logs_success_counter",
+        "Number of successful get logs requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_LOGS_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_logs_fail_counter",
+        "Number of failed get logs requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_CRS_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_crs_success_counter",
+        "Number of successful activate CRS requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_CRS_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_crs_fail_counter",
+        "Number of failed activate CRS requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static CRS_DIGEST_MISMATCH_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_crs_digest_mismatch_counter",
+        "Number of CRS digest mismatches in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_KEY_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_key_success_counter",
+        "Number of successful activate key requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_KEY_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_key_fail_counter",
+        "Number of failed activate key requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static KEY_DIGEST_MISMATCH_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_key_digest_mismatch_counter",
+        "Number of key digest mismatches in GW listener"
+    )
+    .unwrap()
+});

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -30,7 +30,7 @@ pub struct ConfigSettings {
 
     pub review_after_unlimited_retries: u16,
 
-    pub http_server_port: u16,
+    pub health_check_port: u16,
 
     pub health_check_timeout: Duration,
 
@@ -61,7 +61,7 @@ impl Default for ConfigSettings {
             txn_receipt_timeout_secs: 10,
             required_txn_confirmations: 0,
             review_after_unlimited_retries: 30,
-            http_server_port: 8080,
+            health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
             gas_limit_overprovision_percent: 120,
             graceful_shutdown_timeout: Duration::from_secs(8),

--- a/test-suite/fhevm/config/prometheus/prometheus.yml
+++ b/test-suite/fhevm/config/prometheus/prometheus.yml
@@ -11,4 +11,4 @@ scrape_configs:
   # Coprocessor job configuration
   - job_name: 'coprocessor'
     static_configs:
-      - targets: ['coprocessor-transaction-sender:9100', 'coprocessor-tfhe-worker:9100', 'coprocessor-sns-worker:9100', 'coprocessor-zkproof-worker:9100']
+      - targets: ['coprocessor-transaction-sender:9100', 'coprocessor-gw-listener:9100', 'coprocessor-tfhe-worker:9100', 'coprocessor-sns-worker:9100', 'coprocessor-zkproof-worker:9100']


### PR DESCRIPTION
Additionally:
 * use the metrics server from fhevm-engine-common
 * remove the `health_check_port` alias and use it as the name of the
   config option (as we now only have health check on that port, without
   metrics) in both txn-sender and gw-listener
 * use 2 spawns instead of tokio::join! in gw-listener such that the 2
   tasks can run in parallel