### PR TITLE
feat(protocol-contracts): add npm script to send token ethereum <> gateway testnet

### DIFF
--- a/protocol-contracts/token/.gitignore
+++ b/protocol-contracts/token/.gitignore
@@ -8,7 +8,7 @@ typechain-types
 # Hardhat files
 cache
 artifacts
-
+deployments
 
 # LayerZero specific files
 .layerzero

--- a/protocol-contracts/token/README.md
+++ b/protocol-contracts/token/README.md
@@ -109,6 +109,15 @@ And follow straightforward instructions to wire the `ZamaOFTAdapter` contract on
 
 ## Step 7 : Cross-chain transfer
 
+Two NPM scripts are available to send ZAMA tokens between Ethereum Sepolia and Gateway Testnet:
+
+- `npm run zama:oft:send:ethToGateway -- <address> <amount>`
+- `npm run zama:oft:send:gatewayToEth -- <address> <amount>`
+
+The provided address is verified to be a proper Ethereum address, then tokens are sent using `lz:oft:send` task.
+
+If you want to send tokens from/to other chains, you can directly use `lz:oft:send`, as described in the following section.
+
 For example you can send `1.5` ZAMA token from the deployer wallet to a custom receiver address by running this command and following instructions:
 
 ```bash

--- a/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
@@ -143,7 +143,7 @@ for (let i = matches.length - 1; i >= 0; i--) {
 
   const closingIndentMatch = m.closing.match(/\n(\s*)\},/);
   const closingIndent = closingIndentMatch ? closingIndentMatch[1] : '';
-  const innerIndent = `${closingIndent}  `;
+  const innerIndent = `${closingIndent}    `;
 
   const replacement = `${m.opening}\n${innerIndent}tokenAddress: '${address}',${m.closing}`;
 

--- a/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
@@ -145,7 +145,7 @@ for (let i = matches.length - 1; i >= 0; i--) {
   const closingIndent = closingIndentMatch ? closingIndentMatch[1] : '';
   const innerIndent = `${closingIndent}  `;
 
-  const replacement = `${m.opening}\n${innerIndent}tokenAddress: "${address}",${m.closing}`;
+  const replacement = `${m.opening}\n${innerIndent}tokenAddress: '${address}',${m.closing}`;
 
   updated = updated.substring(0, m.index) + replacement + updated.substring(m.index + m.fullMatch.length);
   replacementCount++;

--- a/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
@@ -73,6 +73,7 @@ fi
 
 require_env_value PRIVATE_KEY
 require_env_value SEPOLIA_RPC_URL
+require_env_value RPC_URL_ARBITRUM_SEPOLIA
 require_env_value INITIAL_SUPPLY_RECEIVER
 require_env_value INITIAL_ADMIN
 
@@ -139,13 +140,13 @@ console.log(`Found ${matches.length} oftAdapter block(s)`);
 
 for (let i = matches.length - 1; i >= 0; i--) {
   const m = matches[i];
-  
+
   const closingIndentMatch = m.closing.match(/\n(\s*)\},/);
   const closingIndent = closingIndentMatch ? closingIndentMatch[1] : '';
   const innerIndent = `${closingIndent}  `;
-  
+
   const replacement = `${m.opening}\n${innerIndent}tokenAddress: "${address}",${m.closing}`;
-  
+
   updated = updated.substring(0, m.index) + replacement + updated.substring(m.index + m.fullMatch.length);
   replacementCount++;
 }

--- a/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
@@ -143,7 +143,7 @@ for (let i = matches.length - 1; i >= 0; i--) {
 
   const closingIndentMatch = m.closing.match(/\n(\s*)\},/);
   const closingIndent = closingIndentMatch ? closingIndentMatch[1] : '';
-  const innerIndent = `${closingIndent}  `;
+  const innerIndent = `${closingIndent}    `;
 
   const replacement = `${m.opening}\n${innerIndent}tokenAddress: '${address}',${m.closing}`;
 

--- a/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
@@ -145,7 +145,7 @@ for (let i = matches.length - 1; i >= 0; i--) {
   const closingIndent = closingIndentMatch ? closingIndentMatch[1] : '';
   const innerIndent = `${closingIndent}  `;
 
-  const replacement = `${m.opening}\n${innerIndent}tokenAddress: "${address}",${m.closing}`;
+  const replacement = `${m.opening}\n${innerIndent}tokenAddress: '${address}',${m.closing}`;
 
   updated = updated.substring(0, m.index) + replacement + updated.substring(m.index + m.fullMatch.length);
   replacementCount++;

--- a/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
@@ -73,6 +73,7 @@ fi
 
 require_env_value PRIVATE_KEY
 require_env_value SEPOLIA_RPC_URL
+require_env_value RPC_URL_ZAMA_GATEWAY_TESTNET
 require_env_value INITIAL_SUPPLY_RECEIVER
 require_env_value INITIAL_ADMIN
 
@@ -139,13 +140,13 @@ console.log(`Found ${matches.length} oftAdapter block(s)`);
 
 for (let i = matches.length - 1; i >= 0; i--) {
   const m = matches[i];
-  
+
   const closingIndentMatch = m.closing.match(/\n(\s*)\},/);
   const closingIndent = closingIndentMatch ? closingIndentMatch[1] : '';
   const innerIndent = `${closingIndent}  `;
-  
+
   const replacement = `${m.opening}\n${innerIndent}tokenAddress: "${address}",${m.closing}`;
-  
+
   updated = updated.substring(0, m.index) + replacement + updated.substring(m.index + m.fullMatch.length);
   replacementCount++;
 }
@@ -181,8 +182,6 @@ npx hardhat lz:deploy --ci --networks ethereum-testnet --tags ZamaOFTAdapter
 info "Deploy ZamaOFT on Zama Gateway Testnet"
 note "Running lz:deploy in CI mode for ZamaOFT on gateway-testnet."
 npx hardhat lz:deploy --ci --networks gateway-testnet --tags ZamaOFT
-
-
 
 # Step 5: Wire contracts
 info "Wire ZamaOFTAdapter (Ethereum Sepolia) with ZamaOFT (Gateway Testnet)"

--- a/protocol-contracts/token/hardhat.config.ts
+++ b/protocol-contracts/token/hardhat.config.ts
@@ -15,6 +15,7 @@ import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 import './type-extensions'
 import './tasks/sendOFT'
+import './tasks/validateEVMAddress'
 
 // Set your preferred authentication method
 //

--- a/protocol-contracts/token/package.json
+++ b/protocol-contracts/token/package.json
@@ -15,9 +15,11 @@
     "test": "$npm_execpath run test:forge && $npm_execpath run test:hardhat",
     "test:forge": "forge test",
     "test:hardhat": "hardhat test",
-    "verify:etherscan:ethereum:sepolia": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n ethereum-testnet -u https://api.etherscan.io/v2/api?chainid=11155111 -k $ETHERSCAN_API'",
     "verify:etherscan:arbitrum:sepolia": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n arbitrum-testnet -u https://api.etherscan.io/v2/api?chainid=421614 -k $ETHERSCAN_API'",
-    "verify:etherscan:gateway:testnet": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n gateway-testnet -u $BLOCKSCOUT_API'"
+    "verify:etherscan:ethereum:sepolia": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n ethereum-testnet -u https://api.etherscan.io/v2/api?chainid=11155111 -k $ETHERSCAN_API'",
+    "verify:etherscan:gateway:testnet": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n gateway-testnet -u $BLOCKSCOUT_API'",
+    "zama:oft:send:ethToGateway": "dotenv -e .env -- bash -c 'npx hardhat evm:validate:address --address \"$1\" && npx hardhat lz:oft:send --src-eid 40161 --dst-eid 40424 --amount \"$2\" --to \"$1\" --oapp-config  layerzero.config.gatewaytestnet.ts' --",
+    "zama:oft:send:gatewayToEth": "dotenv -e .env -- bash -c 'npx hardhat evm:validate:address --address \"$1\" && npx hardhat lz:oft:send --src-eid 40424 --dst-eid 40161 --amount \"$2\" --to \"$1\" --oapp-config  layerzero.config.gatewaytestnet.ts' --"
   },
   "resolutions": {
     "ethers": "^5.7.2",
@@ -74,9 +76,5 @@
       "ethers": "^5.7.2",
       "hardhat-deploy": "^0.12.1"
     }
-  },
-  "overrides": {
-    "ethers": "^5.7.2",
-    "hardhat-deploy": "^0.12.1"
   }
 }

--- a/protocol-contracts/token/tasks/validateEVMAddress.ts
+++ b/protocol-contracts/token/tasks/validateEVMAddress.ts
@@ -9,7 +9,7 @@ task('evm:validate:address', 'Sends OFT tokens cross‐chain from EVM chains')
     .addParam('address', 'Address to validate', undefined, types.string)
     .setAction(async (args: MasterArgs) => {
         if (!ethers.utils.isAddress(args.address)) {
-            throw new Error(`The provided adress is not a valid EVM address: ${args.address}`)
+            throw new Error(`The provided address is not a valid EVM address: ${args.address}`)
         }
 
         console.log(`${args.address} is a valid EVM address.`)

--- a/protocol-contracts/token/tasks/validateEVMAddress.ts
+++ b/protocol-contracts/token/tasks/validateEVMAddress.ts
@@ -1,0 +1,16 @@
+import { ethers } from 'ethers'
+import { task, types } from 'hardhat/config'
+
+interface MasterArgs {
+    address: string
+}
+
+task('evm:validate:address', 'Sends OFT tokens cross‐chain from EVM chains')
+    .addParam('address', 'Address to validate', undefined, types.string)
+    .setAction(async (args: MasterArgs) => {
+        if (!ethers.utils.isAddress(args.address)) {
+            throw new Error(`The provided adress is not a valid EVM address: ${args.address}`)
+        }
+
+        console.log(`${args.address} is a valid EVM address.`)
+    })


### PR DESCRIPTION
NPM script are a bit limited for dynamic arguments, proposed usage is:
`npm run zama:oft:send:ethToGateway -- <address> <amount>`
`npm run zama:oft:send:gatewayToEth -- <address> <amount>`

- It will first validate that the provided address (first argument provided) is a valid Ethereum address (checksum with ethers)
- Then call the `lz:oft:send` hardhat task with the right parameters.

Example:
`npm run zama:oft:send:ethToGateway -- 0xAF6556f92E3df28F77dae23F6063f131e05D09bC 12`
`npm run zama:oft:send:gatewayToEth -- 0xAF6556f92E3df28F77dae23F6063f131e05D09bC 12`