### PR TITLE
fix(coprocessor): fix typos in docs

### DIFF
--- a/coprocessor/docs/fundamentals/gateway/decryption.md
+++ b/coprocessor/docs/fundamentals/gateway/decryption.md
@@ -9,13 +9,13 @@ After reaching the end of the auction, one need to discover (only) the winner, h
 ## How it's working
 
 The Gateway acts as an oracle service: it will listen to decryption request events and return the decrypted value through a callback function.
-The responsabilities of the Gateway are:
+The responsibilities of the Gateway are:
 - Listening decryption request from FHEVM that contains a handle `h` that corresponds to a  ciphertext `C`
 - Computing a storage proof `P` to attest h (i.e. C)  is decryptable
 - Retrieve C from FHEVM using `h` as key
-- Send a decyption request to TKMS which in turn is running an internal blockchain aka `KMS BC`
-- Wait and listen for `decyptionResponse` (containing the plaitext and a few signatures from KMS to attest the integrity of the palintext) event from `KMS BC`
-- Return `decyptionResponse` through the callback function
+- Send a decryption request to TKMS which in turn is running an internal blockchain aka `KMS BC`
+- Wait and listen for `decryptionResponse` (containing the plaintext and a few signatures from KMS to attest the integrity of the plaintext) event from `KMS BC`
+- Return `decryptionResponse` through the callback function
 
 ## High level overview of the decryption flow 
 


### PR DESCRIPTION
Fix typos and improve grammar
Summary

This pull request fixes multiple typos, grammatical errors,
and minor style issues in the Decryption documentation page. 
The goal is to improve readability and maintain a consistent, 
professional tone across the technical docs.