### PR TITLE
feat(coprocessor): add metrics for gw-listener (#1140)

### DIFF
--- a/coprocessor/fhevm-engine/.cargo/audit.toml
+++ b/coprocessor/fhevm-engine/.cargo/audit.toml
@@ -3,7 +3,8 @@
 
 [advisories]
 # The ignored vulnerability RUSTSEC-2024-0388 is due to sqlx-mysql which is not used
-ignore = ["RUSTSEC-2023-0071"]
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0111"]
+# RUSTSEC-2025-0111 impacts only testcontainers
 informational_warnings = ["unmaintained"]
 severity_threshold = "medium"
 

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3862,6 +3862,7 @@ dependencies = [
  "foundry-compilers",
  "futures-util",
  "humantime",
+ "prometheus",
  "rustls 0.23.31",
  "semver 1.0.27",
  "serde",

--- a/coprocessor/fhevm-engine/gw-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/gw-listener/Cargo.toml
@@ -17,6 +17,7 @@ aws-sdk-s3 = { workspace = true }
 clap = { workspace = true }
 futures-util = { workspace = true }
 humantime = { workspace = true }
+prometheus = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -13,6 +13,12 @@ use tracing::{debug, error, info};
 use crate::aws_s3::{download_key_from_s3, AwsS3Interface};
 use crate::database::{tenant_id, update_tenant_crs, update_tenant_key};
 use crate::digest::{digest_crs, digest_key};
+use crate::metrics::{
+    ACTIVATE_CRS_FAIL_COUNTER, ACTIVATE_CRS_SUCCESS_COUNTER, ACTIVATE_KEY_FAIL_COUNTER,
+    ACTIVATE_KEY_SUCCESS_COUNTER, CRS_DIGEST_MISMATCH_COUNTER, GET_BLOCK_NUM_FAIL_COUNTER,
+    GET_BLOCK_NUM_SUCCESS_COUNTER, GET_LOGS_FAIL_COUNTER, GET_LOGS_SUCCESS_COUNTER,
+    KEY_DIGEST_MISMATCH_COUNTER, VERIFY_PROOF_FAIL_COUNTER, VERIFY_PROOF_SUCCESS_COUNTER,
+};
 use crate::sks_key::extract_server_key_without_ns;
 use crate::{ChainId, ConfigSettings, HealthStatus, KeyId, KeyType};
 
@@ -216,7 +222,11 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                 }
 
                 _ = ticker.tick() => {
-                    let current_block = self.provider.get_block_number().await?;
+                    let current_block = self.provider.get_block_number().await.inspect(|_| {
+                        GET_BLOCK_NUM_SUCCESS_COUNTER.inc();
+                    }).inspect_err(|_| {
+                        GET_BLOCK_NUM_FAIL_COUNTER.inc();
+                    })?;
 
                     let from_block = if let Some(last) = last_processed_block_num {
                         if last >= current_block {
@@ -237,7 +247,16 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                         .from_block(from_block)
                         .to_block(to_block);
 
-                    let logs = self.provider.get_logs(&filter).await?;
+                    let mut activate_crs_success = 0;
+                    let mut crs_digest_mismatch = 0;
+                    let mut activate_key_success = 0;
+                    let mut key_digest_mismatch = 0;
+
+                    let logs = self.provider.get_logs(&filter).await.inspect(|_| {
+                        GET_LOGS_SUCCESS_COUNTER.inc();
+                    }).inspect_err(|_| {
+                        GET_LOGS_FAIL_COUNTER.inc();
+                    })?;
                     if catchup_kms_generation_from.is_some() && from_block < current_block {
                         info!(from_block, to_block, nb_events=logs.len(), "Catchup on KMSGeneration, get_logs");
                     }
@@ -248,21 +267,35 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                                     // IMPORTANT: If we ignore the event due to digest mismatch, this might lead to inconsistency between coprocessors.
                                     // We choose to ignore the event and then manually fix if it happens.
                                     match self.activate_crs(db_pool, a, &self.aws_s3_client, self.conf.host_chain_id).await {
-                                        Ok(_) => info!("ActivateCrs event successful"),
+                                        Ok(_) => {
+                                            activate_crs_success += 1;
+                                            info!("ActivateCrs event successful");
+                                        },
                                         Err(e) if e.is::<DigestMismatchError>() => {
+                                            crs_digest_mismatch += 1;
                                             error!(error = %e, "CRS digest mismatch, ignoring event");
                                         }
-                                        Err(e) => return Err(e),
+                                        Err(e) => {
+                                            ACTIVATE_CRS_FAIL_COUNTER.inc();
+                                            return Err(e);
+                                        }
                                     }
                                 },
                                 // IMPORTANT: See comment above.
                                 KMSGeneration::KMSGenerationEvents::ActivateKey(a) => {
                                     match self.activate_key(db_pool, a, &self.aws_s3_client, self.conf.host_chain_id).await {
-                                        Ok(_) => info!("ActivateKey event successful"),
+                                        Ok(_) => {
+                                            activate_key_success += 1;
+                                            info!("ActivateKey event successful");
+                                        }
                                         Err(e) if e.is::<DigestMismatchError>() => {
+                                            key_digest_mismatch += 1;
                                             error!(error = %e, "Key digest mismatch, ignoring event");
                                         }
-                                        Err(e) => return Err(e),
+                                        Err(e) => {
+                                            ACTIVATE_KEY_FAIL_COUNTER.inc();
+                                            return Err(e);
+                                        }
                                     };
                                 },
                                 _ => {}
@@ -283,6 +316,14 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                         }
                     }
                     self.update_last_block_num(db_pool, last_processed_block_num).await?;
+
+                    // Update metrics only after a successful DB update as we don't want to consider events that will be processed again
+                    // if the DB update fails.
+                    ACTIVATE_CRS_SUCCESS_COUNTER.inc_by(activate_crs_success);
+                    CRS_DIGEST_MISMATCH_COUNTER.inc_by(crs_digest_mismatch);
+                    ACTIVATE_KEY_SUCCESS_COUNTER.inc_by(activate_key_success);
+                    KEY_DIGEST_MISMATCH_COUNTER.inc_by(key_digest_mismatch);
+
                     if to_block < current_block {
                         debug!(to_block = to_block,
                             current_block = current_block,
@@ -335,7 +376,12 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             self.conf.verify_proof_req_db_channel
         )
         .execute(db_pool)
-        .await?;
+        .await.
+        inspect(|_| {
+            VERIFY_PROOF_SUCCESS_COUNTER.inc();
+        }).inspect_err(|_| {
+            VERIFY_PROOF_FAIL_COUNTER.inc();
+        })?;
         Ok(())
     }
 

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod database;
 pub(crate) mod digest;
 pub mod gw_listener;
 pub mod http_server;
+pub(crate) mod metrics;
 pub(crate) mod sks_key;
 
 pub(crate) type ChainId = u64;
@@ -43,7 +44,9 @@ pub struct ConfigSettings {
 
     pub error_sleep_initial_secs: u16,
     pub error_sleep_max_secs: u16,
+
     pub health_check_port: u16,
+
     pub health_check_timeout: Duration,
 
     pub get_logs_poll_interval: Duration,

--- a/coprocessor/fhevm-engine/gw-listener/src/metrics.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/metrics.rs
@@ -1,0 +1,98 @@
+use prometheus::{register_int_counter, IntCounter};
+use std::sync::LazyLock;
+
+pub(crate) static VERIFY_PROOF_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_verify_proof_success_counter",
+        "Number of successful verify request events in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static VERIFY_PROOF_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_verify_proof_fail_counter",
+        "Number of failed verify request events in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_BLOCK_NUM_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_block_num_success_counter",
+        "Number of successful get block num requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_BLOCK_NUM_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_block_num_fail_counter",
+        "Number of failed get block num requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_LOGS_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_logs_success_counter",
+        "Number of successful get logs requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static GET_LOGS_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_get_logs_fail_counter",
+        "Number of failed get logs requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_CRS_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_crs_success_counter",
+        "Number of successful activate CRS requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_CRS_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_crs_fail_counter",
+        "Number of failed activate CRS requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static CRS_DIGEST_MISMATCH_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_crs_digest_mismatch_counter",
+        "Number of CRS digest mismatches in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_KEY_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_key_success_counter",
+        "Number of successful activate key requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static ACTIVATE_KEY_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_activate_key_fail_counter",
+        "Number of failed activate key requests in GW listener"
+    )
+    .unwrap()
+});
+
+pub(crate) static KEY_DIGEST_MISMATCH_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coprocessor_gw_listener_key_digest_mismatch_counter",
+        "Number of key digest mismatches in GW listener"
+    )
+    .unwrap()
+});

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -30,7 +30,7 @@ pub struct ConfigSettings {
 
     pub review_after_unlimited_retries: u16,
 
-    pub http_server_port: u16,
+    pub health_check_port: u16,
 
     pub health_check_timeout: Duration,
 
@@ -61,7 +61,7 @@ impl Default for ConfigSettings {
             txn_receipt_timeout_secs: 10,
             required_txn_confirmations: 0,
             review_after_unlimited_retries: 30,
-            http_server_port: 8080,
+            health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
             gas_limit_overprovision_percent: 120,
             graceful_shutdown_timeout: Duration::from_secs(8),

--- a/test-suite/fhevm/config/prometheus/prometheus.yml
+++ b/test-suite/fhevm/config/prometheus/prometheus.yml
@@ -11,4 +11,4 @@ scrape_configs:
   # Coprocessor job configuration
   - job_name: 'coprocessor'
     static_configs:
-      - targets: ['coprocessor-transaction-sender:9100', 'coprocessor-tfhe-worker:9100', 'coprocessor-sns-worker:9100', 'coprocessor-zkproof-worker:9100']
+      - targets: ['coprocessor-transaction-sender:9100', 'coprocessor-gw-listener:9100', 'coprocessor-tfhe-worker:9100', 'coprocessor-sns-worker:9100', 'coprocessor-zkproof-worker:9100']


### PR DESCRIPTION
Additionally:
 * use the metrics server from fhevm-engine-common
 * remove the `health_check_port` alias and use it as the name of the config option (as we now only have health check on that port, without metrics) in both txn-sender and gw-listener
 * use 2 spawns instead of tokio::join! in gw-listener such that the 2 tasks can run in parallel
 * ignore RUSTSEC-2025-0111 in cargo-audit - impacts only testcontainers