### PR TITLE
test(protocol-contracts): simple 2-steps transfer of safe ownership

### DIFF
--- a/protocol-contracts/safe/package-lock.json
+++ b/protocol-contracts/safe/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^6.1.0",
         "@openzeppelin/contracts": "^5.4.0",
+        "@safe-global/protocol-kit": "^6.1.1",
         "@safe-global/safe-contracts": "^1.4.1-2",
         "hardhat": "^2.26.3",
         "hardhat-dependency-compiler": "^1.2.1"
@@ -1268,6 +1269,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.5.0.tgz",
+      "integrity": "sha512-YM/nFfskFJSlHqv59ed6dZlLZqtZQwjRVJ4bBAiWV08Oc+1rSd5lDZcBEx0lGDHfSoH3UziI2pXt2UM33KerPQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1279,6 +1301,69 @@
         "node": ">=14"
       }
     },
+    "node_modules/@safe-global/protocol-kit": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@safe-global/protocol-kit/-/protocol-kit-6.1.1.tgz",
+      "integrity": "sha512-SlRosKB52h1CV2gMlKG4UOvh2j4tXuzz1GZ/yQ1HD0Zvm5azUlaytFwKzHun9xNVvfe+vvSNHUEGX2Umy+rQ9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@safe-global/safe-deployments": "^1.37.42",
+        "@safe-global/safe-modules-deployments": "^2.2.14",
+        "@safe-global/types-kit": "^3.0.0",
+        "abitype": "^1.0.2",
+        "semver": "^7.7.2",
+        "viem": "^2.21.8"
+      },
+      "optionalDependencies": {
+        "@noble/curves": "^1.6.0",
+        "@peculiar/asn1-schema": "^2.3.13"
+      }
+    },
+    "node_modules/@safe-global/protocol-kit/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@safe-global/protocol-kit/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@safe-global/protocol-kit/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@safe-global/safe-contracts": {
       "version": "1.4.1-2",
       "resolved": "https://registry.npmjs.org/@safe-global/safe-contracts/-/safe-contracts-1.4.1-2.tgz",
@@ -1287,6 +1372,46 @@
       "license": "LGPL-3.0",
       "peerDependencies": {
         "ethers": "5.4.0"
+      }
+    },
+    "node_modules/@safe-global/safe-deployments": {
+      "version": "1.37.47",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-deployments/-/safe-deployments-1.37.47.tgz",
+      "integrity": "sha512-abxu9nmvjfDahCIFdrHw4ENZ1CD60z/bgrv5cV3+sygADU1vuh96jFumebo+6PR/Q5qz5glrQuLwEtZ8K/lvJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.2"
+      }
+    },
+    "node_modules/@safe-global/safe-deployments/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@safe-global/safe-modules-deployments": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-modules-deployments/-/safe-modules-deployments-2.2.18.tgz",
+      "integrity": "sha512-OQwoguGdano/XPMSbzc9cMuRXW84KCSAoG9avKRo5O4AcGLMNDqXTYG993a3k6QeWGpPwpl9LFEpwT0oAZ6UwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@safe-global/types-kit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/types-kit/-/types-kit-3.0.0.tgz",
+      "integrity": "sha512-AZWIlR5MguDPdGiOj7BB4JQPY2afqmWQww1mu8m8Oi16HHBW99G01kFOu4NEHBwEU1cgwWOMY19hsI5KyL4W2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abitype": "^1.0.2"
       }
     },
     "node_modules/@scure/base": {
@@ -1959,6 +2084,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -5613,6 +5762,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6790,6 +6969,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/protocol-contracts/safe/package.json
+++ b/protocol-contracts/safe/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
     "@openzeppelin/contracts": "^5.4.0",
+    "@safe-global/protocol-kit": "^6.1.1",
     "@safe-global/safe-contracts": "^1.4.1-2",
     "hardhat": "^2.26.3",
     "hardhat-dependency-compiler": "^1.2.1"

--- a/protocol-contracts/safe/test/adminModule.ts
+++ b/protocol-contracts/safe/test/adminModule.ts
@@ -1,6 +1,8 @@
+import Safe from "@safe-global/protocol-kit";
+import MultiSendJson from "@safe-global/safe-contracts/build/artifacts/contracts/libraries/MultiSend.sol/MultiSend.json";
 import { expect } from "chai";
-import { Signer, ZeroAddress } from "ethers";
-import { ethers } from "hardhat";
+import { ContractFactory, Signer, ZeroAddress } from "ethers";
+import { ethers, network } from "hardhat";
 
 import { AdminModule, GatewayConfigMock, SafeL2 } from "../typechain-types";
 import { execTransaction } from "./utils/utils";
@@ -12,9 +14,11 @@ describe("AdminModule Tests", function () {
   let bob: Signer;
   let charlie: Signer;
   let masterCopy: any;
+  let proxyFactory: any;
   let safe: SafeL2;
   let safeAddress: string;
   let gatewayConfigMock: GatewayConfigMock;
+  let multiSendAddress: string;
 
   before(async () => {
     [deployer, alice, bob, charlie] = await ethers.getSigners();
@@ -22,7 +26,7 @@ describe("AdminModule Tests", function () {
     const safeFactory = await ethers.getContractFactory("SafeL2", deployer); // L2 version for easier debugging and because gas is cheap on gateway
     masterCopy = await safeFactory.deploy(); // deploys the singleton Safe implementation
 
-    const proxyFactory = await (await ethers.getContractFactory("SafeProxyFactory", deployer)).deploy();
+    proxyFactory = await (await ethers.getContractFactory("SafeProxyFactory", deployer)).deploy();
 
     // Setup the Safe, Step 1, generate transaction data, with one owner, alice, and threshold of 1
     const safeData = masterCopy.interface.encodeFunctionData("setup", [
@@ -48,6 +52,9 @@ describe("AdminModule Tests", function () {
     safe = await ethers.getContractAt("SafeL2", safeAddress);
 
     gatewayConfigMock = await (await ethers.getContractFactory("GatewayConfigMock", deployer)).deploy(safeAddress);
+
+    const multiSend = await new ContractFactory(MultiSendJson.abi, MultiSendJson.bytecode, deployer).deploy();
+    multiSendAddress = await multiSend.getAddress();
   });
 
   // A Safe Module is a smart contract that is allowed to execute transactions on behalf of a Safe Smart Account.
@@ -78,5 +85,55 @@ describe("AdminModule Tests", function () {
     const data = gatewayConfigMock.interface.encodeFunctionData("setByOwner", [42n]);
     await adminModule.connect(charlie).execTransactionFromModuleReturnData(gatewayConfigMockAddress, 0n, data, 0n);
     expect(await gatewayConfigMock.value()).to.equal(42n);
+  });
+
+  it("Transfer ownership in a single step", async function () {
+    let owners = await safe.getOwners();
+    console.log("Current owners: ", owners);
+    let threshold = await safe.getThreshold();
+    console.log("Current threshold: ", threshold);
+
+    const chain = await ethers.provider.getNetwork();
+    const chainIdKey = chain.chainId.toString();
+
+    const contractNetworks = {
+      [chainIdKey]: {
+        multiSendAddress,
+        multiSendCallOnlyAddress: multiSendAddress,
+      },
+    };
+
+    const safeKit = await Safe.init({
+      provider: network.provider,
+      signer: await alice.getAddress(),
+      safeAddress,
+      contractNetworks,
+    });
+    const aliceAddress = await alice.getAddress();
+
+    const newOwners = Array.from({ length: 9 }, (_, i) => "0x" + String(i + 1).repeat(40));
+
+    const txs = [];
+
+    for (const addr of newOwners) {
+      txs.push(await safeKit.createAddOwnerTx({ ownerAddress: addr }));
+    }
+
+    const partials = txs.map((t) => t.data);
+    const batch = await safeKit.createTransaction({ transactions: partials });
+    await safeKit.signTransaction(batch);
+    await safeKit.executeTransaction(batch);
+
+    const txs2 = [];
+    txs2.push(await safeKit.createRemoveOwnerTx({ ownerAddress: aliceAddress, threshold: 6 }));
+    const partials2 = txs2.map((t) => t.data);
+    const batch2 = await safeKit.createTransaction({ transactions: partials2 });
+    await safeKit.signTransaction(batch2);
+    await safeKit.executeTransaction(batch2);
+
+    owners = await safe.getOwners();
+    console.log("Current owners: ", owners);
+    threshold = await safe.getThreshold();
+    console.log("Current threshold: ", threshold);
   });
 });


### PR DESCRIPTION
This is needed for the task to be used by the initial `PROTOCOL_DEPLOYER` account once protocol contracts are deployed.
2 tx are needed and offer best trade-off between security and simplicity.
Requirement: MultiSend contract is deployed on Gateway.
First step: deployer adds in a single tx atomically all the operators cold addresses as owners (but keep threshold to 1).
Then, after checking new owners are added, the deployer does a second tx to atomically remove himself from list of owners and change the threshold to correct value.