### PR TITLE
feat(protocol-contracts): add mainnet network

### DIFF
--- a/protocol-contracts/feesBurner/.env.example
+++ b/protocol-contracts/feesBurner/.env.example
@@ -1,9 +1,16 @@
+# Deployer account
 PRIVATE_KEY=
+# mainnet
+MAINNET_RPC_URL=
+RPC_URL_ZAMA_GATEWAY_MAINNET=
+# testnet
 SEPOLIA_RPC_URL=
 RPC_URL_ZAMA_GATEWAY_TESTNET=
+# API for contract verification
 ETHERSCAN_API=TA5XXXXXXXXXXXXXXXXXXXXXXXXXXXGX9
-
+BLOCKSCOUT_API=https://explorer-xxxx-xxxxxxx.conduit.xyz/api # don't forget the /api suffix at the end
+# Addresses used as constructor args when deploying ProtocolFeesBurner.sol & FeesSenderToBurner.sol
 ZAMA_OFT_ADDRESS=
 ZAMA_ERC20_ADDRESS=
-
+# Address used as constructor arg when deploying FeesSenderToBurner.sol
 PROTOCOL_FEES_BURNER_ADDRESS=

--- a/protocol-contracts/feesBurner/README.md
+++ b/protocol-contracts/feesBurner/README.md
@@ -1,25 +1,35 @@
 After filling all values of the `.env` file until the `ZAMA_ERC20_ADDRESS` variable (i.e all variables except from `PROTOCOL_FEES_BURNER_ADDRESS`), run this command to deploy first the `ProtocolFeesBurner` contract on Ethereum testnet:
 
+# Deployment
+## Setup
+Copy the environment file: `cp .env.example .env`.
+
+Then fill all the environment variables till `ZAMA_ERC20_ADDRESS` for the wanted networks (`MAINNET` or `TESTNET` RPC urls).
+
+## ProtocolFeesBurner Deployment
+
+Deploy the ProtocolFeesBurner contract on Ethereum
+
 ```bash
 npx hardhat deploy --tags ProtocolFeesBurner --network ethereum-testnet
 ```
 
-Then to verify it on Etherscan: 
+Then fill the `PROTOCOL_FEES_BURNER_ADDRESS` env variable with the address of your deployment.
 
-```bash
-npx hardhat --network ethereum-testnet etherscan-verify --license BSD-3-Clause --force-license --api-key [ETHERSCAN_API]
-```
-
-Then to deploy the `FeesSenderToBurner` on Gateway-testnet, after filling the last missing value in the `.env` file, ie `PROTOCOL_FEES_BURNER_ADDRESS` coming from the first deployment step, run:
+## FeesSenderToBurner Deployment
 
 ```bash
 npx hardhat deploy --tags FeesSenderToBurner --network gateway-testnet
 ```
 
-Then to verify it:
+## Verification
+
+You can verify the contracts on Etherscan with the following tasks:
 
 ```bash
-npx hardhat task:verifyFeesSenderToBurner --network gateway-testnet --fees-sender-to-burner [FEES_SENDER_TO_BURNER_ADDRESS]
+npx hardhat --network ethereum-testnet task:verifyProtocolFeesBurner --protocol-fees-burner <PROCOTOL_FEES_BURNER_ADDRESS>
 ```
 
-Where `FEES_SENDER_TO_BURNER_ADDRESS` value must come from the second deployment step.
+```bash
+npx hardhat --network gateway-testnet task:verifyFeesSenderToBurner --fees-sender-to-burner <FEES_SENDER_TO_BURNER_ADDRESS>
+```

--- a/protocol-contracts/feesBurner/hardhat.config.ts
+++ b/protocol-contracts/feesBurner/hardhat.config.ts
@@ -25,12 +25,20 @@ if (accounts == null) {
 const config: HardhatUserConfig = {
   solidity: "0.8.28",
   networks: {
+    "ethereum-mainnet": {
+      url: process.env.MAINNET_RPC_URL || "",
+      accounts,
+    },
     "ethereum-testnet": {
-      url: process.env.SEPOLIA_RPC_URL,
+      url: process.env.SEPOLIA_RPC_URL || "",
+      accounts,
+    },
+    "gateway-mainnet": {
+      url: process.env.RPC_URL_ZAMA_GATEWAY_MAINNET || "",
       accounts,
     },
     "gateway-testnet": {
-      url: process.env.RPC_URL_ZAMA_GATEWAY_TESTNET,
+      url: process.env.RPC_URL_ZAMA_GATEWAY_TESTNET || "",
       accounts,
     },
     hardhat: {
@@ -43,10 +51,16 @@ const config: HardhatUserConfig = {
     },
   },
   etherscan: {
-    apiKey: {
-      "gateway-testnet": "empty",
-    },
+    apiKey: process.env.ETHERSCAN_API || "",
     customChains: [
+      {
+        network: "gateway-mainnet",
+        chainId: 261131,
+        urls: {
+          apiURL: "https://explorer-zama-gateway-mainnet.t.conduit.xyz/api",
+          browserURL: "https://explorer-zama-gateway-mainnet.t.conduit.xyz",
+        },
+      },
       {
         network: "gateway-testnet",
         chainId: 10901,

--- a/protocol-contracts/feesBurner/tasks/blockExplorerVerify.ts
+++ b/protocol-contracts/feesBurner/tasks/blockExplorerVerify.ts
@@ -5,10 +5,18 @@ import { getRequiredEnvVar } from "../deploy/utils/loadVariables";
 // Verify the ProtocolFeesBurner contract at the given address.
 task("task:verifyProtocolFeesBurner")
   .addParam("protocolFeesBurner", "address of the already deployed ProtocolFeesBurner contract that should be verified")
-  .setAction(async function ({ protocolFeesBurner }, { run }) {
+  .setAction(async function ({ protocolFeesBurner }, hre) {
     const zamaERC20Address = getRequiredEnvVar("ZAMA_ERC20_ADDRESS");
+    const apiKey = getRequiredEnvVar("ETHERSCAN_API");
 
-    await run("verify:verify", {
+    if (typeof hre.config.etherscan.apiKey !== "string") {
+      console.log(
+        "Verification on Ethereum requires using Etherscan API V2, only available when the etherscan.apiKey field is a string.",
+      );
+      hre.config.etherscan.apiKey = apiKey;
+    }
+
+    await hre.run("verify:verify", {
       address: protocolFeesBurner,
       constructorArguments: [zamaERC20Address],
     });
@@ -17,11 +25,18 @@ task("task:verifyProtocolFeesBurner")
 // Verify the FeesSenderToBurner contract at the given address.
 task("task:verifyFeesSenderToBurner")
   .addParam("feesSenderToBurner", "address of the already deployed FeesSenderToBurner contract that should be verified")
-  .setAction(async function ({ feesSenderToBurner }, { run }) {
+  .setAction(async function ({ feesSenderToBurner }, hre) {
     const oftAddress = getRequiredEnvVar("ZAMA_OFT_ADDRESS");
     const protocolFeesBurnerAddress = getRequiredEnvVar("PROTOCOL_FEES_BURNER_ADDRESS");
 
-    await run("verify:verify", {
+    if (typeof hre.config.etherscan.apiKey === "string") {
+      console.log(
+        "Verification on Gateway requires using BlockScout API, only available when the etherscan.apiKey field is not a string.",
+      );
+      hre.config.etherscan.apiKey = { "gateway-testnet": "empty" };
+    }
+
+    await hre.run("verify:verify", {
       address: feesSenderToBurner,
       constructorArguments: [oftAddress, protocolFeesBurnerAddress],
     });

--- a/protocol-contracts/feesBurner/tasks/blockExplorerVerify.ts
+++ b/protocol-contracts/feesBurner/tasks/blockExplorerVerify.ts
@@ -2,6 +2,19 @@ import { task } from "hardhat/config";
 
 import { getRequiredEnvVar } from "../deploy/utils/loadVariables";
 
+// Verify the ProtocolFeesBurner contract at the given address.
+task("task:verifyProtocolFeesBurner")
+  .addParam("protocolFeesBurner", "address of the already deployed ProtocolFeesBurner contract that should be verified")
+  .setAction(async function ({ protocolFeesBurner }, { run }) {
+    const zamaERC20Address = getRequiredEnvVar("ZAMA_ERC20_ADDRESS");
+
+    await run("verify:verify", {
+      address: protocolFeesBurner,
+      constructorArguments: [zamaERC20Address],
+    });
+  });
+
+// Verify the FeesSenderToBurner contract at the given address.
 task("task:verifyFeesSenderToBurner")
   .addParam("feesSenderToBurner", "address of the already deployed FeesSenderToBurner contract that should be verified")
   .setAction(async function ({ feesSenderToBurner }, { run }) {

--- a/protocol-contracts/feesBurner/tasks/blockExplorerVerify.ts
+++ b/protocol-contracts/feesBurner/tasks/blockExplorerVerify.ts
@@ -33,7 +33,7 @@ task("task:verifyFeesSenderToBurner")
       console.log(
         "Verification on Gateway requires using BlockScout API, only available when the etherscan.apiKey field is not a string.",
       );
-      hre.config.etherscan.apiKey = { "gateway-testnet": "empty" };
+      hre.config.etherscan.apiKey = { "gateway-testnet": "empty", "gateway-mainnet": "empty" };
     }
 
     await hre.run("verify:verify", {

--- a/protocol-contracts/token/.env.example
+++ b/protocol-contracts/token/.env.example
@@ -1,9 +1,16 @@
+# Deployer account
 PRIVATE_KEY=
+# mainnet
+MAINNET_RPC_URL=
+RPC_URL_ZAMA_GATEWAY_MAINNET=
+# testnet
 SEPOLIA_RPC_URL=
 RPC_URL_ZAMA_GATEWAY_TESTNET=
 RPC_URL_ARBITRUM_SEPOLIA=
+# API for contract verification
 ETHERSCAN_API=TA5XXXXXXXXXXXXXXXXXXXXXXXXXXXGX9
 BLOCKSCOUT_API=https://explorer-xxxx-xxxxxxx.conduit.xyz/api # don't forget the /api suffix at the end
+# Addresses used as constructor args when deploying ZamaERC20.sol
 INITIAL_SUPPLY_RECEIVER=
 INITIAL_ADMIN=
 

--- a/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_arbitrum_testnet.sh
@@ -13,7 +13,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	-h | --help)
 		cat <<'USAGE'
-Usage: ./scripts/deploy_zama_oft_testnet.sh [--verify]
+Usage: ./deploy_zama_oft_arbitrum_testnet.sh [--verify]
 
 Options:
   --verify   Run the optional Etherscan verification commands.

--- a/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
+++ b/protocol-contracts/token/deploy_zama_oft_gateway_testnet.sh
@@ -13,7 +13,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	-h | --help)
 		cat <<'USAGE'
-Usage: ./scripts/deploy_zama_oft_testnet.sh [--verify]
+Usage: ./deploy_zama_oft_gateway_testnet.sh [--verify]
 
 Options:
   --verify   Run the optional Etherscan verification commands.

--- a/protocol-contracts/token/hardhat.config.ts
+++ b/protocol-contracts/token/hardhat.config.ts
@@ -69,17 +69,31 @@ const config: HardhatUserConfig = {
             url: process.env.RPC_URL_ARBITRUM_SEPOLIA || 'https://sepolia-rollup.arbitrum.io/rpc',
             accounts,
         },
-        'ethereum-testnet': {
-            eid: EndpointId.SEPOLIA_V2_TESTNET,
-            url: process.env.SEPOLIA_RPC_URL,
+        'ethereum-mainnet': {
+            eid: EndpointId.ETHEREUM_V2_MAINNET,
+            url: process.env.MAINNET_RPC_URL || '',
             accounts,
             oftAdapter: {
                 tokenAddress: '0x',
             },
         },
+        'ethereum-testnet': {
+            eid: EndpointId.SEPOLIA_V2_TESTNET,
+            url: process.env.SEPOLIA_RPC_URL!,
+            accounts,
+            oftAdapter: {
+                tokenAddress: '0x',
+            },
+        },
+        // No ZAMA_V2_MAINNET endpoint available yet.
+        // 'gateway-mainnet': {
+        //     eid: EndpointId.ZAMA_V2_MAINNET,
+        //     url: process.env.RPC_URL_ZAMA_GATEWAY_MAINNET || '',
+        //     accounts,
+        // },
         'gateway-testnet': {
             eid: EndpointId.ZAMA_V2_TESTNET,
-            url: process.env.RPC_URL_ZAMA_GATEWAY_TESTNET,
+            url: process.env.RPC_URL_ZAMA_GATEWAY_TESTNET || '',
             accounts,
         },
         hardhat: {

--- a/protocol-contracts/token/package.json
+++ b/protocol-contracts/token/package.json
@@ -16,7 +16,9 @@
     "test:forge": "forge test",
     "test:hardhat": "hardhat test",
     "verify:etherscan:arbitrum:sepolia": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n arbitrum-testnet -u https://api.etherscan.io/v2/api?chainid=421614 -k $ETHERSCAN_API'",
+    "verify:etherscan:ethereum:mainnet": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n ethereum-mainnet -u https://api.etherscan.io/v2/api?chainid=1 -k $ETHERSCAN_API'",
     "verify:etherscan:ethereum:sepolia": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n ethereum-testnet -u https://api.etherscan.io/v2/api?chainid=11155111 -k $ETHERSCAN_API'",
+    "verify:etherscan:gateway:mainnet": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n gateway-mainnet -u $BLOCKSCOUT_API'",
     "verify:etherscan:gateway:testnet": "dotenv -e .env --  bash -c 'npx @layerzerolabs/verify-contract verify-contract -d ./deployments -n gateway-testnet -u $BLOCKSCOUT_API'",
     "zama:oft:send:ethToGateway": "dotenv -e .env -- bash -c 'npx hardhat evm:validate:address --address \"$1\" && npx hardhat lz:oft:send --src-eid 40161 --dst-eid 40424 --amount \"$2\" --to \"$1\" --oapp-config  layerzero.config.gatewaytestnet.ts' --",
     "zama:oft:send:gatewayToEth": "dotenv -e .env -- bash -c 'npx hardhat evm:validate:address --address \"$1\" && npx hardhat lz:oft:send --src-eid 40424 --dst-eid 40161 --amount \"$2\" --to \"$1\" --oapp-config  layerzero.config.gatewaytestnet.ts' --"


### PR DESCRIPTION
Add Ethereum and Gateway mainnet networks to FeesBurner and Token hardhat projects:
- Updates the .env.example
- Add a task to verify `ProtocolFeesBurner` using `hardhat-verify` as `etherscan-verify` is deprecated.
- Gateway Mainnet is commented out as the EndpointId is not available yet.
- Add NPM scripts for token verification

~~FeesBurner known issue:~~
The Etherscan API v1 is deprecated since 05/31/2025, ~~there are issues to verify a contract with `hardhat-verify` using Etherscan API v2 for Ethereum and Blockscout for Gateway using the same hardhat config (`hardhat.config.ts`).~~


To use Etherscan API V2 with `hardhat-verify`, the `etherscan.apiKey` field must be a **string**: otherwise even if overwriting the apiUrl (which defaults to deprecated etherscan API V1 url due to chain descriptors), it misses the mandatory url parameter `chainid`.
However, for the Gateway if `etherscan.apiKey` is a string, `hardhat-verify` recognizes it as using Etherscan API V2, and appends the `chainid` parameter, which is unwanted in this case (using BlockScout), resulting in an error.

To fix this, the hardhat tasks for verifying both contracts of the feesBurner override the apiKey if not in the right configuration for the targeted chain.