### PR TITLE
fix(protocol-contracts): fix deployment script error

### DIFF
--- a/protocol-contracts/token/deploy/ZamaERC20.ts
+++ b/protocol-contracts/token/deploy/ZamaERC20.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 
 import { type DeployFunction } from 'hardhat-deploy/types'
-import { getRequiredEnvVar } from './utils/loadVariables'
+import { getRequiredEnvVar } from '../tasks/utils/loadVariables'
 
 const contractName = 'ZamaERC20'
 

--- a/protocol-contracts/token/deploy/utils/loadVariables.ts
+++ b/protocol-contracts/token/deploy/utils/loadVariables.ts
@@ -1,8 +1,0 @@
-// Get the required environment variable, throw an error if it's not set
-// We only check if the variable is set, not if it's empty
-export function getRequiredEnvVar(name: string): string {
-  if (!(name in process.env)) {
-    throw new Error(`"${name}" env variable is not set`);
-  }
-  return process.env[name]!;
-}


### PR DESCRIPTION
The file `deploy/utils/loadVariables.ts` is located in the `deploy/` directory, which `hardhat-deploy` automatically scans for deployment scripts. However, this file is a utility file, not a deployment script, so it doesn't export a `DeployFunction` as its default export.

Hardhat-deploy expects every `.ts` file in the `deploy/` directory to:
  1. Export a DeployFunction as the default export
  2. Have a .func property (which is the deployment function itself)

The file loadVariables.ts only exports a helper function getRequiredEnvVar, causing the error: `deployScript.func is not a function.`

This PR deletes the `loadVariables.ts` file from the `deploy/` directory, using the existing util from the `tasks/` folder instead.