### PR TITLE
docs(gateway-contracts): add example usage for safe deployment command

### DIFF
--- a/gateway-contracts/tasks/safeSmartAccounts.ts
+++ b/gateway-contracts/tasks/safeSmartAccounts.ts
@@ -160,6 +160,13 @@ task(
   console.log(`${SAFE_SMART_ACCOUNT_IMPL_NAME} address ${safeAddress} written successfully!`);
 });
 
+/**
+ * Example usage:
+ * npx hardhat task:deployOwnerSafeSmartAccountProxy \
+ *   --owners '["<address1>","<address2>"]' \
+ *   --threshold 2 \
+ *   --use-internal-safe-impl-address true
+ */
 task("task:deployOwnerSafeSmartAccountProxy", "Deploys the OwnerSafeSmartAccountProxy contract")
   .addParam("owners", "List of addresses that control the OwnerSafeSmartAccount.", undefined, types.json)
   .addParam(


### PR DESCRIPTION
Adds an in-code documentation on how to properly invoke the deployment command, notably on the JSON format expected when feeding the owners addresses, which is not straightforward.