### PR TITLE
fix(kms-connector): fix prss init encoding

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
@@ -341,7 +341,7 @@ impl KmsClient {
         request: InitRequest,
     ) -> Result<KmsGrpcResponse, ProcessingError> {
         let inner_client = self.choose_client(RequestId {
-            request_id: hex::encode(PRSS_INIT_ID.as_le_slice()),
+            request_id: hex::encode(PRSS_INIT_ID.to_be_bytes::<32>()),
         });
         send_request_with_retry(
             self.grpc_request_retries,


### PR DESCRIPTION
Made this change in the `hotfix` branch merged in `release/0.9.x`, I report it in `main` now