### PR TITLE
chore: Remove erroneous \ forcing line breaks

### DIFF
--- a/docs/protocol/architecture/coprocessor.md
+++ b/docs/protocol/architecture/coprocessor.md
@@ -67,8 +67,7 @@ This is essential for fraud-proof mechanisms and eventual slashing of malicious 
 Coprocessors assist in:
 
 - Bridging encrypted values between host chains by generating new handles and signatures.
-- Preparing ciphertexts for public and user decryption using operations like Switch-n-Squash to normalize ciphertexts\
-  for the KMS.
+- Preparing ciphertexts for public and user decryption using operations like Switch-n-Squash to normalize ciphertexts for the KMS.
 
 These roles help maintain cross-chain interoperability and enable privacy-preserving data access for users and smart contracts .
 
@@ -91,5 +90,4 @@ The coprocessor architecture includes:
 - Worker threads that process tasks in parallel
 - A public storage layer (e.g., S3) for ciphertext availability
 
-This modular setup supports horizontal scaling: adding more workers or machines increases throughput. Symbolic\
-computation and delayed execution also ensure low gas costs on-chain .
+This modular setup supports horizontal scaling: adding more workers or machines increases throughput. Symbolic computation and delayed execution also ensure low gas costs on-chain .

--- a/docs/protocol/architecture/gateway.md
+++ b/docs/protocol/architecture/gateway.md
@@ -22,13 +22,11 @@ The Gateway ensures that encrypted values provided by users are well-formed and 
 
 - Accepting encrypted inputs along with Zero-Knowledge Proofs of Knowledge (ZKPoKs).
 - Emitting verification events for coprocessors to validate.
-- Aggregating signatures from a majority of coprocessors to generate attestations, which can then be used on-chain as\
-  trusted external values.
+- Aggregating signatures from a majority of coprocessors to generate attestations, which can then be used on-chain as trusted external values.
 
 ### Access Control coordination
 
-The Gateway maintains a synchronized copy of Access Control Lists (ACLs) from host chains, enabling it to independently\
-determine if decryption or computation rights should be granted for a ciphertext. This helps enforce:
+The Gateway maintains a synchronized copy of Access Control Lists (ACLs) from host chains, enabling it to independently determine if decryption or computation rights should be granted for a ciphertext. This helps enforce:
 
 - Access permissions (allow)
 - Public decryption permissions (allowForDecryption)
@@ -41,8 +39,7 @@ When a smart contract or user requests the decryption of an encrypted value:
 
 1. The Gateway verifies ACL permissions.
 2. It then triggers the KMS to decrypt (either publicly or privately).
-3. Once the KMS returns signed results, the Gateway emits events that can be picked up by an oracle (for smart contract\
-   decryption) or returned to the user (for private decryption).
+3. Once the KMS returns signed results, the Gateway emits events that can be picked up by an oracle (for smart contract decryption) or returned to the user (for private decryption).
 
 This ensures asynchronous, secure, and auditable decryption without the Gateway itself knowing the plaintext.
 

--- a/docs/protocol/architecture/overview.md
+++ b/docs/protocol/architecture/overview.md
@@ -11,5 +11,4 @@ FHEVM is the core technology that powers the Zama Protocol. It is composed of th
 - [**Coprocessors**](coprocessor.md) – Decentralized services that verify encrypted inputs, run FHE computations, and commit results.
 - [**Gateway**](gateway.md) **–** The central orchestrator of the protocol. It validates encrypted inputs, manages access control lists (ACLs), bridges ciphertexts across chains, and coordinates coprocessors and the KMS.
 - [**Key Management Service (KMS)**](kms.md) – A threshold MPC network that generates and rotates FHE keys, and handles secure, verifiable decryption.&#x20;
-- [**Relayer & oracle**](relayer_oracle.md) – A lightweight off-chain service that helps users interact with the Gateway by\
-  forwarding encryption or decryption requests.
+- [**Relayer & oracle**](relayer_oracle.md) – A lightweight off-chain service that helps users interact with the Gateway by forwarding encryption or decryption requests.

--- a/docs/protocol/architecture/relayer_oracle.md
+++ b/docs/protocol/architecture/relayer_oracle.md
@@ -17,8 +17,7 @@ These components are not part of the trusted base of the protocol; their actions
 - Wait for the KMS to produce signed plaintexts via the Gateway.
 - Call back the contract on the host chain, passing the decrypted result.
 
-Since the decrypted values are signed by the KMS, the receiving smart contract can verify the result, removing any need\
-to trust the oracle itself.
+Since the decrypted values are signed by the KMS, the receiving smart contract can verify the result, removing any needto trust the oracle itself.
 
 ## Security model of the Oracle
 
@@ -31,8 +30,7 @@ Goal: Enable contracts to access decrypted values asynchronously and securely, w
 
 ## What is the Relayer?
 
-The Relayer is a user-facing service that simplifies interaction with the Gateway, particularly for encryption and\
-decryption operations that need to happen off-chain.
+The Relayer is a user-facing service that simplifies interaction with the Gateway, particularly for encryption and decryption operations that need to happen off-chain.
 
 ## Responsibilities of the Relayer
 
@@ -50,13 +48,11 @@ validator, or FHE tooling.
 - All data flows are signed and auditable by the user.
 - Users can always run their own relayer or interact with the Gateway directly if needed.
 
-Goal: Make it easy for users to submit encrypted inputs and retrieve private decrypted results without managing\
-infrastructure.
+Goal: Make it easy for users to submit encrypted inputs and retrieve private decrypted results without managing infrastructure.
 
 ## How they fit in
 
 - Smart contracts use the Oracle to receive plaintext results of encrypted computations via callbacks.
-- Users rely on the Relayer to push encrypted values into the system and fetch personal decrypted results, all backed by\
-  EIP-712 signatures and FHE key re-encryption.
+- Users rely on the Relayer to push encrypted values into the system and fetch personal decrypted results, all backed by EIP-712 signatures and FHE key re-encryption.
 
 Together, Oracles and Relayers help bridge the gap between encrypted execution and application usability—without compromising security or decentralization.

--- a/docs/protocol/roadmap.md
+++ b/docs/protocol/roadmap.md
@@ -22,6 +22,5 @@ This document gives a preview of the upcoming features of FHEVM. In addition to 
 | Set inclusion         | `FHE.isIn()`      | Binary             | -           |
 
 {% hint style="info" %}
-Random encrypted integers that are generated fully on-chain. Currently, implemented as a mockup\
-by using a PRNG in the plain. Not for use in production!
+Random encrypted integers that are generated fully on-chain. Currently, implemented as a mockup by using a PRNG in the plain. Not for use in production!
 {% endhint %}


### PR DESCRIPTION
## Why

The documentation has some extra `\` forcing line breaks.
