### PR TITLE
refactor(protocol-contracts): remove scaling factor from constructor

### DIFF
--- a/protocol-contracts/token/contracts/ZamaERC20.sol
+++ b/protocol-contracts/token/contracts/ZamaERC20.sol
@@ -30,7 +30,7 @@ contract ZamaERC20 is ERC20, ERC20Permit, ERC1363, ERC20Burnable, AccessControl,
      * @param initialReceivers Array of addresses of the receivers of the initial supply.
      * @param initialAmounts Array of amounts to be distributed to each initial receiver.
      * @param initialAdmin Account granted the DEFAULT_ADMIN_ROLE role.
-     * @dev The amounts in initialAmounts are token units, i.e an amount of 1 corresponds to a balance of 1e18
+     * @dev The initialAmounts values are expected to have all decimals accounted for (i.e. 1e18 for 1 token unit).
      */
     constructor(
         string memory name,
@@ -43,7 +43,7 @@ contract ZamaERC20 is ERC20, ERC20Permit, ERC1363, ERC20Burnable, AccessControl,
         if (initialAmounts.length != initialReceiversLen) revert AmountsReceiversLengthMismatch();
 
         for (uint256 i = 0; i < initialReceiversLen; i++) {
-            _mint(initialReceivers[i], initialAmounts[i] * 1e18);
+            _mint(initialReceivers[i], initialAmounts[i]);
         }
 
         _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);

--- a/protocol-contracts/token/deploy/ZamaERC20.ts
+++ b/protocol-contracts/token/deploy/ZamaERC20.ts
@@ -1,13 +1,14 @@
 import assert from 'assert'
 
+import { ethers } from 'hardhat'
 import { type DeployFunction } from 'hardhat-deploy/types'
 
 import { getRequiredEnvVar } from '../tasks/utils/loadVariables'
 
 const contractName = 'ZamaERC20'
 
-function toBigIntWithUnderscores(s: string): bigint {
-    return BigInt(s.replace(/_/g, ''))
+function removeUnderscores(s: string): string {
+    return s.replace(/_/g, '')
 }
 
 const deploy: DeployFunction = async (hre) => {
@@ -31,7 +32,7 @@ const deploy: DeployFunction = async (hre) => {
     const amounts = []
     for (let idx = 0; idx < numReceivers; idx++) {
         receivers.push(getRequiredEnvVar(`INITIAL_RECEIVER_${idx}`))
-        amounts.push(toBigIntWithUnderscores(getRequiredEnvVar(`INITIAL_AMOUNT_${idx}`)))
+        amounts.push(ethers.utils.parseEther(removeUnderscores(getRequiredEnvVar(`INITIAL_AMOUNT_${idx}`))))
     }
 
     const initialAdmin = getRequiredEnvVar('INITIAL_ADMIN')

--- a/protocol-contracts/token/test/MyOFTAdapter.test.ts
+++ b/protocol-contracts/token/test/MyOFTAdapter.test.ts
@@ -64,9 +64,11 @@ describe('Zama Token OFT Transfer', () => {
         mockEndpointV2B = await endpointV2MockFactory.deploy(eidB)
 
         // The INITIAL_RECEIVER_0 and INITIAL_ADMIN can be different from the deployer.
+        const _INITIAL_MINT_AMOUNT = 11_000_000_000n
+        const INITIAL_MINT_AMOUNT = ethers.utils.parseEther(_INITIAL_MINT_AMOUNT.toString())
         zamaERC20 = await zamaERC20Factory
             .connect(deployer)
-            .deploy('ZAMAERC20', 'ZAMA', [owner.address], [11_000_000_000n], admin.address)
+            .deploy('ZAMAERC20', 'ZAMA', [owner.address], [INITIAL_MINT_AMOUNT], admin.address)
         // Grant the admin the MINTER_ROLE & PAUSING_MINTER_ROLE
         zamaERC20.connect(admin).grantRole(MINTER_ROLE, admin.address)
         zamaERC20.connect(admin).grantRole(MINTING_PAUSER_ROLE, admin.address)

--- a/protocol-contracts/token/test/ZamaERC20.test.ts
+++ b/protocol-contracts/token/test/ZamaERC20.test.ts
@@ -28,12 +28,15 @@ describe('ZamaERC20 - Unit Test', () => {
         ;[deployer, owner, admin, alice, bob, charlie] = signers
     })
 
+    const _INITIAL_MINT_AMOUNT = 11_000_000_000n
+    const INITIAL_MINT_AMOUNT = ethers.utils.parseEther(_INITIAL_MINT_AMOUNT.toString())
+
     // beforeEach hook for setup that runs before each test in the block
     beforeEach(async () => {
         // The INITIAL_RECEIVER_0 and INITIAL_ADMIN can be different from the deployer.
         zamaERC20 = await zamaERC20Factory
             .connect(deployer)
-            .deploy('ZAMAERC20', 'ZAMA', [owner.address], [11_000_000_000n], admin.address)
+            .deploy('ZAMAERC20', 'ZAMA', [owner.address], [INITIAL_MINT_AMOUNT], admin.address)
     })
 
     describe('Initialization', () => {
@@ -48,12 +51,11 @@ describe('ZamaERC20 - Unit Test', () => {
             expect(await zamaERC20.symbol()).to.eq('ZAMA')
 
             // Check that owner has the initial supply
-            const expectedTokenAmount = ethers.utils.parseEther('11000000000')
             const ownerBalance = await zamaERC20.balanceOf(owner.address)
-            expect(ownerBalance).eql(expectedTokenAmount)
+            expect(ownerBalance).eql(INITIAL_MINT_AMOUNT)
 
             // Total Supply
-            expect(await zamaERC20.totalSupply()).to.eq(expectedTokenAmount)
+            expect(await zamaERC20.totalSupply()).to.eq(INITIAL_MINT_AMOUNT)
 
             // Check that admin has DEFAULT_ADMIN_ROLE
             const hasAdminRole = await zamaERC20.hasRole(DEFAULT_ADMIN_ROLE, admin.address)

--- a/protocol-contracts/token/test/tasks/oftadapter.test.ts
+++ b/protocol-contracts/token/test/tasks/oftadapter.test.ts
@@ -23,9 +23,11 @@ describe('ZamaOFTAdapter task suite', function () {
 
     beforeEach(async function () {
         endpointStub = await endpointFactory.deploy()
+        const _INITIAL_MINT_AMOUNT = 11_000_000_000n
+        const INITIAL_MINT_AMOUNT = ethers.utils.parseEther(_INITIAL_MINT_AMOUNT.toString())
         zamaERC20 = await zamaERC20Factory
             .connect(deployer)
-            .deploy('ZAMAERC20', 'ZAMA', [deployer.address], [11_000_000_000n], deployer.address)
+            .deploy('ZAMAERC20', 'ZAMA', [deployer.address], [INITIAL_MINT_AMOUNT], deployer.address)
         zamaOFTAdapter = await zamaOFTAdapterFactory
             .connect(deployer)
             .deploy(zamaERC20.address, endpointStub.address, deployer.address)

--- a/protocol-contracts/token/test/tasks/roles.test.ts
+++ b/protocol-contracts/token/test/tasks/roles.test.ts
@@ -20,9 +20,11 @@ describe('ZamaERC20 Role task suite', function () {
     })
 
     beforeEach(async () => {
+        const _INITIAL_MINT_AMOUNT = 11_000_000_000n
+        const INITIAL_MINT_AMOUNT = ethers.utils.parseEther(_INITIAL_MINT_AMOUNT.toString())
         zamaERC20 = await zamaERC20Factory
             .connect(deployer)
-            .deploy('ZAMAERC20', 'ZAMA', [deployer.address], [11_000_000_000n], deployer.address)
+            .deploy('ZAMAERC20', 'ZAMA', [deployer.address], [INITIAL_MINT_AMOUNT], deployer.address)
 
         minterRole = await zamaERC20.MINTER_ROLE()
         pausingRole = await zamaERC20.MINTING_PAUSER_ROLE()


### PR DESCRIPTION
Removes the 1e18 scaling factor from the ZamaERC20 constructor: the arguments are now expected to have all the decimals ; similar behavior to the ERC20 standard

The environment variable stay in token units, the scaling factor from the token units in .env and the constructor arguments is done with ethers in the deployment script.