### PR TITLE
fix(gateway): add file for rust toolchain

### DIFF
--- a/gateway-contracts/rust_bindings/rust-toolchain.toml
+++ b/gateway-contracts/rust_bindings/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.91.0"
+components = ["rustc", "clippy", "rustfmt"]


### PR DESCRIPTION
## Why

The current file (`toolchain.txt`) is not a valid `rust-toolchain.toml` file (nor a valid legacy file), and consequently the version of the Rust toolchain is not set correctly.

## What

~~Update the legacy format used to a `rust-toolchain.toml` file to set the same version.~~
Didn't do this as this file is used in a lot of difference places. So just added yet another `rust-toolchain.toml` file

Note: there are ~3~ 4 "rust-toolchain" files in the repository with all the same version. One could just keep the root one and use it for all the others.
