### PR TITLE
ci: add additional clippy lints for clone operations

### DIFF
--- a/.github/workflows/coprocessor-cargo-clippy.yml
+++ b/.github/workflows/coprocessor-cargo-clippy.yml
@@ -83,7 +83,7 @@ jobs:
         # For now, only specify the `bench latency throughput` features as the
         # other ones require specific dependencies (e.g. GPU, etc.).
         SQLX_OFFLINE=true cargo clippy -p host-listener --all-targets \
-          -- -W clippy::perf -W clippy::suspicious -W clippy::style -D warnings
+          -- -W clippy::perf -W clippy::suspicious -W clippy::style -W clippy::redundant_clone -W clippy::clone_on_copy -W clippy::unnecessary_to_owned -D warnings
         SQLX_OFFLINE=true cargo clippy --all-targets --features "bench latency throughput" \
-          -- -W clippy::perf -W clippy::suspicious -W clippy::style -D warnings
+          -- -W clippy::perf -W clippy::suspicious -W clippy::style -W clippy::redundant_clone -W clippy::clone_on_copy -W clippy::unnecessary_to_owned -D warnings
       working-directory: coprocessor/fhevm-engine


### PR DESCRIPTION
Adds `clippy::clone_on_copy` and `clippy::unnecessary_to_owned` checks to prevent unnecessary clone operations.

Follow-up to #1169 as suggested  ref : https://github.com/zama-ai/fhevm/pull/1169#discussion_r2489287945