### PR TITLE
chore(common): add initial devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
     "features": {
         "ghcr.io/devcontainers/features/rust:1": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/common-utils:2": {}
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/node:1": {}
     },
     "postCreateCommand": "./.devcontainer/post_create_command.sh",
     "customizations": {
@@ -13,7 +14,19 @@
                 "vadimcn.vscode-lldb",
                 "juanblanco.solidity",
                 "eamodio.gitlens"
-            ]
+            ],
+            "settings": {
+                "git.allowForcePush": true,
+                "diffEditor.ignoreTrimWhitespace": false,
+                "editor.formatOnSave": true,
+                "rust-analyzer.linkedProjects": [
+                    "coprocessor/fhevm-engine/Cargo.toml",
+                    "kms-connector/Cargo.toml"
+                ],
+                "rust-analyzer.cargo.extraEnv": {
+                    "SQLX_OFFLINE": "true"
+                }
+            }
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {}
+    },
+    "postCreateCommand": "./.devcontainer/post_create_command.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer",
+                "vadimcn.vscode-lldb",
+                "juanblanco.solidity",
+                "eamodio.gitlens"
+            ]
+        }
+    }
+}

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Package manager dependencies.
+sudo apt update
+sudo apt install -y protobuf-compiler build-essential libssl-dev pkg-config openssl
+
+# Cargo dependencies.
+cargo install sqlx-cli
+
+# Foundry.
+curl --proto '=https' --tlsv1.2 -sSfL https://foundry.paradigm.xyz | bash
+$HOME/.foundry/bin/foundryup -i v1.3.2

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Package manager dependencies.
 sudo apt update
-sudo apt install -y protobuf-compiler build-essential libssl-dev pkg-config openssl
+sudo apt install -y protobuf-compiler build-essential libssl-dev pkg-config openssl vim
 
 # Cargo dependencies.
 cargo install sqlx-cli

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Package manager dependencies.
 sudo apt update
 sudo apt install -y protobuf-compiler build-essential libssl-dev pkg-config openssl
 
 # Cargo dependencies.
 cargo install sqlx-cli
+
+# Install the correct Rust toolchain version.
+rustup toolchain install ${cat toolchain.txt}
 
 # Foundry.
 curl --proto '=https' --tlsv1.2 -sSfL https://foundry.paradigm.xyz | bash

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -10,7 +10,7 @@ sudo apt install -y protobuf-compiler build-essential libssl-dev pkg-config open
 cargo install sqlx-cli
 
 # Install the correct Rust toolchain version.
-rustup toolchain install ${cat toolchain.txt}
+rustup toolchain install $(cat toolchain.txt)
 
 # Foundry.
 curl --proto '=https' --tlsv1.2 -sSfL https://foundry.paradigm.xyz | bash


### PR DESCRIPTION
This initial version makes sure we can work on the coprocessor, mostly.

We could have separate files (say for coprocessor, for contracts, etc), but I figured most of the time people work cross-components, so it would be nice to have one unified environment.

I've tried to keep things minimal, but I get that there could be discussions about what extensions to include. At the end of the day, people can always add more extensions later if they want to. Still, I am open to adding more default extensions.

We have:
 * docker support via docker-in-docker
 * rust
 * sqlx
 * foundry
 * node/npm