### PR TITLE
chore(coprocessor): return error if update cts table fails

### DIFF
--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -634,6 +634,9 @@ async fn update_ciphertext128(
                 Err(err) => {
                     error!( handle = ?task.handle, error = %err, "Failed to insert ct128 in DB");
                     telemetry::end_span_with_err(s, err.to_string());
+                    // Although this is a single error, we drop the entire batch to be on the safe side
+                    // This will ensure we will not mark a task as completed falsely
+                    return Err(err.into());
                 }
             }
 


### PR DESCRIPTION
Just a quick fix/workaround for `Finding ID: TOB-ZGATEWAY-21` 

A more sophisticated error handling is implemented in https://github.com/zama-ai/fhevm/pull/1245