### PR TITLE
chore: update `compute_handle` to include the domain separators

### DIFF
--- a/sdk/rust-sdk/Cargo.toml
+++ b/sdk/rust-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "gateway-sdk"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 
 # Library configuration

--- a/sdk/rust-sdk/src/encryption/input.rs
+++ b/sdk/rust-sdk/src/encryption/input.rs
@@ -12,6 +12,10 @@ use crate::encryption::IntoU256;
 use crate::encryption::primitives::create_encryption_parameters;
 use std::sync::Arc;
 use tfhe::{safe_serialization::safe_serialize, zk::ZkComputeLoad};
+
+const RAW_CT_HASH_DOMAIN_SEPARATOR: &'static str = "ZK-w_rct";
+const HANDLE_HASH_DOMAIN_SEPARATOR: &'static str= "ZK-w_hdl";
+
 /// Struct for building encrypted inputs with verification data
 /// Only constants are used for the builder factory
 pub struct InputBuilderFactory {
@@ -316,7 +320,8 @@ impl EncryptedInputBuilder {
         ciphertext_version: u8,
     ) -> Result<Vec<[u8; 32]>> {
         // Calculate ciphertext hash using keccak256
-        let ciphertext_hash = keccak256(ciphertext);
+        let ciphertext_preimage = [RAW_CT_HASH_DOMAIN_SEPARATOR.as_bytes(), ciphertext].concat();
+        let ciphertext_hash = keccak256(ciphertext_preimage);
 
         // Convert chain_id to bytes (ensuring we only use the last 8 bytes)
         let chain_id_bytes = chain_id_to_bytes(chain_id);
@@ -345,6 +350,7 @@ impl EncryptedInputBuilder {
                 // Create a buffer for the handle using the same scheme as the JavaScript version
                 let index_byte = index as u8;
                 let mut hash_input = Vec::new();
+                hash_input.extend_from_slice(HANDLE_HASH_DOMAIN_SEPARATOR.as_bytes());
                 hash_input.extend_from_slice(ciphertext_hash.as_slice());
                 hash_input.push(index_byte);
                 hash_input.extend_from_slice(acl_contract_address.as_slice());


### PR DESCRIPTION
Add domain separators when computing the handles during encryption