### PR TITLE
feat(coprocessor): unsent txn counts as gauges in txn-sender

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.7.1
+version: 0.7.2
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -757,6 +757,7 @@ txSender:
     - --service-name=txn-sender
     - --metric-host-txn-latency=0.1:60.0:0.1
     - --metric-zkproof-txn-latency=0.1:60.0:0.1
+    - --gauge-update-interval-secs=10
 
   # Service ports configuration
   ports:

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -14,7 +14,8 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
 use transaction_sender::{
-    get_chain_id, http_server::HttpServer, make_abstract_signer, AbstractSigner, ConfigSettings,
+    get_chain_id, http_server::HttpServer, make_abstract_signer,
+    metrics::spawn_gauge_update_routine, AbstractSigner, ConfigSettings,
     FillersWithoutNonceManagement, NonceManagedProvider, TransactionSender,
 };
 
@@ -52,6 +53,11 @@ struct Conf {
     #[arg(short, long)]
     private_key: Option<String>,
 
+    /// An optional DB URL.
+    ///
+    /// If not provided, falls back to the DATABASE_URL env var, if it is set.
+    ///
+    /// If not provided and DATABASE_URL is not set, then defaults to a local Postgres URL.
     #[arg(short, long)]
     database_url: Option<DatabaseURL>,
 
@@ -130,7 +136,7 @@ struct Conf {
         default_value_t = Level::INFO)]
     log_level: Level,
 
-    #[arg(long, default_value = "120", value_parser = clap::value_parser!(u32).range(100..))]
+    #[arg(long, default_value_t = 120, value_parser = clap::value_parser!(u32).range(100..))]
     gas_limit_overprovision_percent: u32,
 
     #[arg(long, default_value = "8s", value_parser = parse_duration)]
@@ -147,6 +153,9 @@ struct Conf {
     /// Prometheus metrics: coprocessor_zkproof_txn_latency_seconds
     #[arg(long, default_value = "0.1:60.0:0.1", value_parser = clap::value_parser!(MetricsConfig))]
     pub metric_zkproof_txn_latency: MetricsConfig,
+
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..))]
+    pub gauge_update_interval_secs: u64,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -228,7 +237,6 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     let wallet = EthereumWallet::new(abstract_signer.clone());
-    let database_url = conf.database_url.clone();
 
     let provider = loop {
         if cancel_token.is_cancelled() {
@@ -270,9 +278,12 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
+    let db_pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(conf.database_pool_size)
+        .connect(conf.database_url.unwrap_or_default().as_str())
+        .await?;
+
     let config = ConfigSettings {
-        database_url,
-        database_pool_size: conf.database_pool_size,
         verify_proof_resp_db_channel: conf.verify_proof_resp_database_channel,
         add_ciphertexts_db_channel: conf.add_ciphertexts_database_channel,
         allow_handle_db_channel: conf.allow_handle_database_channel,
@@ -297,6 +308,7 @@ async fn main() -> anyhow::Result<()> {
 
     let transaction_sender = std::sync::Arc::new(
         TransactionSender::new(
+            db_pool.clone(),
             conf.input_verification_address,
             conf.ciphertext_commits_address,
             conf.multichain_acl_address,
@@ -325,8 +337,14 @@ async fn main() -> anyhow::Result<()> {
     let transaction_sender_fut = tokio::spawn(async move { transaction_sender.run().await });
     let http_server_fut = tokio::spawn(async move { http_server.start().await });
 
-    // Start metrics server
+    // Start metrics server.
     metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
+
+    // Start gauge update routine.
+    spawn_gauge_update_routine(
+        Duration::from_secs(conf.gauge_update_interval_secs),
+        db_pool.clone(),
+    );
 
     let transaction_sender_res = transaction_sender_fut.await;
     let http_server_res = http_server_fut.await;

--- a/coprocessor/fhevm-engine/transaction-sender/src/config.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/config.rs
@@ -1,12 +1,7 @@
 use std::time::Duration;
 
-use fhevm_engine_common::utils::DatabaseURL;
-
 #[derive(Clone, Debug)]
 pub struct ConfigSettings {
-    pub database_url: Option<DatabaseURL>,
-    pub database_pool_size: u32,
-
     pub verify_proof_resp_db_channel: String,
     pub add_ciphertexts_db_channel: String,
     pub allow_handle_db_channel: String,
@@ -48,8 +43,6 @@ pub struct ConfigSettings {
 impl Default for ConfigSettings {
     fn default() -> Self {
         Self {
-            database_url: Some(DatabaseURL::default()),
-            database_pool_size: 10,
             verify_proof_resp_db_channel: "event_zkpok_computed".to_owned(),
             add_ciphertexts_db_channel: "event_ciphertexts_uploaded".to_owned(),
             allow_handle_db_channel: "event_allowed_handle".to_owned(),

--- a/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod config;
 pub mod http_server;
-mod metrics;
+pub mod metrics;
 mod nonce_managed_provider;
 mod ops;
 pub mod overprovision_gas_limit;

--- a/coprocessor/fhevm-engine/transaction-sender/src/metrics.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/metrics.rs
@@ -1,5 +1,8 @@
-use prometheus::{register_int_counter, IntCounter};
+use prometheus::{register_int_counter, register_int_gauge, IntCounter, IntGauge};
+use sqlx::PgPool;
 use std::sync::LazyLock;
+use tokio::{task::JoinHandle, time::sleep};
+use tracing::{error, info};
 
 pub(crate) static VERIFY_PROOF_SUCCESS_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
     register_int_counter!(
@@ -50,3 +53,57 @@ pub(crate) static ALLOW_HANDLE_FAIL_COUNTER: LazyLock<IntCounter> = LazyLock::ne
     )
     .unwrap()
 });
+
+pub(crate) static ALLOW_HANDLE_UNSENT: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(
+        "coprocessor_allow_handle_unsent_gauge",
+        "Number of unsent allow handle transactions"
+    )
+    .unwrap()
+});
+
+pub(crate) static ADD_CIPHERTEXT_MATERIAL_UNSENT: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(
+        "coprocessor_add_ciphertext_material_unsent_gauge",
+        "Number of unsent add ciphertext material transactions"
+    )
+    .unwrap()
+});
+
+pub fn spawn_gauge_update_routine(period: std::time::Duration, db_pool: PgPool) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match sqlx::query_scalar(
+                "SELECT COUNT(*) FROM allowed_handles WHERE txn_is_sent = FALSE",
+            )
+            .fetch_one(&db_pool)
+            .await
+            {
+                Ok(count) => {
+                    info!(unsent_allow_handle_count = %count, "Fetched unsent allow handle count");
+                    ALLOW_HANDLE_UNSENT.set(count);
+                }
+                Err(e) => {
+                    error!(error = %e, "Failed to fetch unsent allow handle count");
+                }
+            }
+
+            match sqlx::query_scalar(
+                "SELECT COUNT(*) FROM ciphertext_digest WHERE txn_is_sent = FALSE",
+            )
+            .fetch_one(&db_pool)
+            .await
+            {
+                Ok(count) => {
+                    info!(unsent_add_ciphertext_material_count = %count, "Fetched unsent add ciphertext material count");
+                    ADD_CIPHERTEXT_MATERIAL_UNSENT.set(count);
+                }
+                Err(e) => {
+                    error!(error = %e, "Failed to fetch unsent add ciphertext material count");
+                }
+            }
+
+            sleep(period).await;
+        }
+    })
+}

--- a/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -26,6 +26,7 @@ pub struct TransactionSender<P: Provider<Ethereum> + Clone + 'static> {
 impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
     #[expect(clippy::too_many_arguments)]
     pub async fn new(
+        db_pool: Pool<Postgres>,
         input_verification_address: Address,
         ciphertext_commits_address: Address,
         multichain_acl_address: Address,
@@ -35,13 +36,6 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
         conf: ConfigSettings,
         gas: Option<u64>,
     ) -> anyhow::Result<Self> {
-        let database_url = conf.database_url.to_owned().unwrap_or_default();
-
-        let db_pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(conf.database_pool_size)
-            .connect(database_url.as_str())
-            .await?;
-
         let operations: Vec<Arc<dyn ops::TransactionOperation<P>>> = vec![
             Arc::new(
                 ops::verify_proof::VerifyProofOperation::new(

--- a/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/add_ciphertext_tests.rs
@@ -43,6 +43,7 @@ async fn add_ciphertext_digests(#[case] signer_type: SignerType) -> anyhow::Resu
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -145,6 +146,7 @@ async fn ciphertext_digest_already_added(#[case] signer_type: SignerType) -> any
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -234,6 +236,7 @@ async fn recover_from_transport_error(#[case] signer_type: SignerType) -> anyhow
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -346,6 +349,7 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -445,6 +449,7 @@ async fn retry_mechanism(#[case] signer_type: SignerType) -> anyhow::Result<()> 
     );
 
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         PrivateKeySigner::random().address(),
         PrivateKeySigner::random().address(),
@@ -556,6 +561,7 @@ async fn retry_on_aws_kms_error(#[case] signer_type: SignerType) -> anyhow::Resu
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),

--- a/coprocessor/fhevm-engine/transaction-sender/tests/allow_handle_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/allow_handle_tests.rs
@@ -110,6 +110,7 @@ async fn allow_call(
     let multichain_acl = MultichainACL::deploy(&provider_deploy, already_allowed_revert).await?;
 
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         PrivateKeySigner::random().address(),
         *multichain_acl.address(),
@@ -230,6 +231,7 @@ async fn stop_on_backend_gone(#[case] signer_type: SignerType) -> anyhow::Result
     let multichain_acl = MultichainACL::deploy(&provider_deploy, already_allowed_revert).await?;
 
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         PrivateKeySigner::random().address(),
         *multichain_acl.address(),
@@ -329,6 +331,7 @@ async fn retry_on_aws_kms_error(#[case] signer_type: SignerType) -> anyhow::Resu
     let multichain_acl = MultichainACL::deploy(&provider_deploy, already_allowed_revert).await?;
 
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         PrivateKeySigner::random().address(),
         PrivateKeySigner::random().address(),
         *multichain_acl.address(),

--- a/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/common.rs
@@ -11,6 +11,7 @@ use alloy::{
     sol,
     transports::http::reqwest::Url,
 };
+use fhevm_engine_common::utils::DatabaseURL;
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 use test_harness::localstack::{
     create_aws_aws_kms_client, create_localstack_kms_signing_key, start_localstack,
@@ -78,11 +79,10 @@ impl TestEnvironment {
             .with_max_level(Level::DEBUG)
             .with_test_writer()
             .try_init();
-        let database_url = conf.database_url.to_owned().unwrap_or_default();
 
         let db_pool = PgPoolOptions::new()
-            .max_connections(1)
-            .connect(database_url.as_str())
+            .max_connections(10)
+            .connect(DatabaseURL::default().as_str())
             .await?;
 
         Self::truncate_tables(

--- a/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
@@ -60,6 +60,7 @@ async fn verify_proof_response_success(#[case] signer_type: SignerType) -> anyho
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -176,6 +177,7 @@ async fn verify_proof_response_empty_handles_success(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -295,6 +297,7 @@ async fn verify_proof_response_concurrent_success(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -412,6 +415,7 @@ async fn reject_proof_response_success(#[case] signer_type: SignerType) -> anyho
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -522,6 +526,7 @@ async fn verify_proof_response_reversal_already_verified(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -624,6 +629,7 @@ async fn reject_proof_response_reversal_already_rejected(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -726,6 +732,7 @@ async fn verify_proof_response_other_reversal(
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     // Create the sender with a gas limit such that no gas estimation is done, forcing failure at receipt (after the txn has been sent).
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -825,6 +832,7 @@ async fn reject_proof_response_other_reversal(
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     // Create the sender with a gas limit such that no gas estimation is done, forcing failure at receipt (after the txn has been sent).
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -919,6 +927,7 @@ async fn verify_proof_response_other_reversal_gas_estimation(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -1017,6 +1026,7 @@ async fn reject_proof_response_other_reversal_gas_estimation(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -1117,6 +1127,7 @@ async fn verify_proof_max_retries_remove_entry(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),
@@ -1207,6 +1218,7 @@ async fn verify_proof_max_retries_do_not_remove_entry(
     let ciphertext_commits =
         CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
     let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
         *input_verification.address(),
         *ciphertext_commits.address(),
         PrivateKeySigner::random().address(),


### PR DESCRIPTION
Add the `ALLOW_HANDLE_UNSENT_GAUGE` and
`ADD_CIPHERTEXT_MATERIAL_UNSENT_GAUGE` gauges to track amount of unsent txns in the transaction-sender. They are filled in by querying the DB periodically in a separate tokio task.

We have the existing `ALLOW_HANDLE_SUCCESS_COUNTER` and `ADD_CIPHERTEXT_MATERIAL_SUCCESS_COUNTER` metrics for the sent ones.

Also introduce the `--gauge-update-interval-secs` cmd line argument with a default value of 10 seconds.