### PR TITLE
fix(kms-connector): use numeric for last block

### DIFF
--- a/kms-connector/.sqlx/query-4d560e50c6fda74882a8dafbb767abbbd95e6fa06f732fce2fbf857470c3e4c1.json
+++ b/kms-connector/.sqlx/query-4d560e50c6fda74882a8dafbb767abbbd95e6fa06f732fce2fbf857470c3e4c1.json
@@ -21,7 +21,7 @@
             }
           }
         },
-        "Bytea"
+        "Int8"
       ]
     },
     "nullable": []

--- a/kms-connector/connector-db/migrations/20251104142103_add_last_block_polled.sql
+++ b/kms-connector/connector-db/migrations/20251104142103_add_last_block_polled.sql
@@ -15,7 +15,7 @@ END $$;
 
 CREATE TABLE IF NOT EXISTS last_block_polled (
     event_type event_type NOT NULL,
-    block_number BYTEA,
+    block_number BIGINT,
     update_at TIMESTAMP NOT NULL DEFAULT NOW(),
     PRIMARY KEY (event_type)
 );

--- a/kms-connector/crates/gw-listener/src/core/gw_listener.rs
+++ b/kms-connector/crates/gw-listener/src/core/gw_listener.rs
@@ -251,18 +251,13 @@ where
                 .bind(event_type)
                 .fetch_one(&self.db_pool)
                 .await?
-                .try_get::<Option<Vec<u8>>, _>("block_number")?;
+                .try_get::<Option<i64>, _>("block_number")?;
 
-        let Some(block_number_bytes) = query_result else {
+        let Some(block_number) = query_result else {
             info!("No block number stored in DB yet for {event_type}");
             return Ok(None);
         };
-
-        let block_number = block_number_bytes
-            .try_into()
-            .map(u64::from_le_bytes)
-            .map_err(|b| anyhow!("Couldn't convert {b:?} into u64"))?;
-        Ok(Some(block_number))
+        Ok(Some(block_number as u64))
     }
 }
 

--- a/kms-connector/crates/gw-listener/src/core/publish.rs
+++ b/kms-connector/crates/gw-listener/src/core/publish.rs
@@ -210,7 +210,7 @@ pub async fn update_last_block_polled(
         "UPDATE last_block_polled SET block_number = $2 \
         WHERE event_type = $1 AND (block_number IS NULL OR block_number < $2)",
         event_type as EventType,
-        last_block_polled.map(|n| n.to_le_bytes().to_vec()),
+        last_block_polled.map(|n| n as i64),
     )
     .execute(db_pool)
     .await?;


### PR DESCRIPTION
e2e tests: https://github.com/zama-ai/fhevm/actions/runs/19173431171