### PR TITLE
feat(protocol-contracts): deployment-cli sets DAO as token INITIAL_ADMIN

### DIFF
--- a/protocol-contracts/deployment-cli/deployment-state/deployment-config.yaml
+++ b/protocol-contracts/deployment-cli/deployment-state/deployment-config.yaml
@@ -33,6 +33,9 @@ wallets:
   deployer:
     description: "Deployer for gateway and host contracts"
     private_key_env: "DEPLOYER_PRIVATE_KEY"
+  governance_deployer:
+    description: "Governance deployer (owns governance until DAO takes over)"
+    private_key_env: "GOVERNANCE_DEPLOYER_PRIVATE_KEY"
 
 operators:
   - name: "Operator 1"

--- a/protocol-contracts/deployment-cli/src/config/env-manager.ts
+++ b/protocol-contracts/deployment-cli/src/config/env-manager.ts
@@ -12,7 +12,7 @@ type WalletKey = keyof DeploymentConfig["wallets"];
 
 interface AddressRecord {
     readonly key: string;
-    readonly value: string;
+    readonly value: `0x${string}`;
     readonly source: string;
 }
 
@@ -48,7 +48,11 @@ export class EnvManager {
         return fromEnv;
     }
 
-    public recordAddress(key: string, value: string, source = "step"): void {
+    public recordAddress(
+        key: string,
+        value: `0x${string}`,
+        source = "step",
+    ): void {
         const normalizedKey = key.toUpperCase();
         this.addresses.set(normalizedKey, {
             key: normalizedKey,
@@ -59,7 +63,7 @@ export class EnvManager {
         this.logger.info(`Recorded address ${normalizedKey}=${value}`);
     }
 
-    public getAddress(key: string): string {
+    public getAddress(key: string): `0x${string}` {
         const normalizedKey = key.toUpperCase();
         const value =
             this.addresses.get(normalizedKey)?.value ??

--- a/protocol-contracts/deployment-cli/src/config/schema.ts
+++ b/protocol-contracts/deployment-cli/src/config/schema.ts
@@ -216,6 +216,7 @@ export const DeploymentConfigSchema = z.object({
     wallets: z.object({
         protocol_deployer: WalletSchema,
         deployer: WalletSchema,
+        governance_deployer: WalletSchema,
     }),
     operators: z.array(OperatorSchema).min(1),
     protocol: ProtocolSchema,

--- a/protocol-contracts/deployment-cli/src/state/state-manager.ts
+++ b/protocol-contracts/deployment-cli/src/state/state-manager.ts
@@ -142,16 +142,16 @@ export class StateManager {
         this.touch();
     }
 
-    public setAddress(key: string, value: string): void {
+    public setAddress(key: string, value: `0x${string}`): void {
         this.data.addresses[key] = value;
         this.touch();
     }
 
-    public getAddress(key: string): string | undefined {
-        return this.data.addresses[key];
+    public getAddress(key: string): `0x${string}` | undefined {
+        return this.data.addresses[key] as `0x${string}` | undefined;
     }
 
-    public getAddresses(): Record<string, string> {
+    public getAddresses(): Record<string, `0x${string}`> {
         return { ...this.data.addresses };
     }
 

--- a/protocol-contracts/deployment-cli/src/state/types.ts
+++ b/protocol-contracts/deployment-cli/src/state/types.ts
@@ -12,7 +12,7 @@ export interface StepTransaction {
 }
 
 export interface StepResultData {
-    readonly addresses?: Record<string, string>;
+    readonly addresses?: Record<string, `0x${string}`>;
     readonly transactions?: StepTransaction[];
     readonly artifacts?: Record<string, unknown>;
     readonly notes?: string[];
@@ -36,5 +36,5 @@ export interface DeploymentStateData {
         updatedAt: string;
     };
     steps: Record<string, StepState>;
-    addresses: Record<string, string>;
+    addresses: Record<string, `0x${string}`>;
 }

--- a/protocol-contracts/deployment-cli/src/steps/step-01-aragon-dao.ts
+++ b/protocol-contracts/deployment-cli/src/steps/step-01-aragon-dao.ts
@@ -49,7 +49,7 @@ export class Step01AragonDao extends BaseStep {
 
         return {
             addresses: {
-                DAO_ADDRESS: getAddress(daoAddress),
+                DAO_ADDRESS: getAddress(daoAddress) as `0x${string}`,
             },
         };
     }

--- a/protocol-contracts/deployment-cli/src/steps/step-02-safe.ts
+++ b/protocol-contracts/deployment-cli/src/steps/step-02-safe.ts
@@ -30,7 +30,7 @@ export class Step02Safe extends BaseStep {
 
         // Check if Safe is already deployed
         const taskOutput = new TaskOutputReader(projectRoot);
-        let safeProxyAddress: string | undefined;
+        let safeProxyAddress: `0x${string}` | undefined;
         try {
             safeProxyAddress = taskOutput.readHardhatDeployment(
                 this.pkgName,

--- a/protocol-contracts/deployment-cli/src/steps/step-04-token.ts
+++ b/protocol-contracts/deployment-cli/src/steps/step-04-token.ts
@@ -55,7 +55,7 @@ export class Step04TokenDeployment extends BaseStep {
         const recipients = ctx.config.protocol.token.recipients;
         const envVars: Record<string, string> = {
             PRIVATE_KEY: protocolPk,
-            INITIAL_ADMIN: ctx.config.wallets.protocol_deployer.address,
+            INITIAL_ADMIN: daoAddress,
             SEPOLIA_RPC_URL: ethereum.rpcUrl,
             RPC_URL_ZAMA_GATEWAY_TESTNET: gateway.rpcUrl,
             DAO_ADDRESS: daoAddress,
@@ -178,7 +178,7 @@ export class Step04TokenDeployment extends BaseStep {
 
         const baseEnv = ctx.env.buildTaskEnv({
             PRIVATE_KEY: protocolPk,
-            INITIAL_ADMIN: ctx.config.wallets.protocol_deployer.address,
+            INITIAL_ADMIN: daoAddress,
             SEPOLIA_RPC_URL: ethereum.rpcUrl,
             RPC_URL_ZAMA_GATEWAY_TESTNET: gateway.rpcUrl,
             DAO_ADDRESS: daoAddress,

--- a/protocol-contracts/deployment-cli/src/steps/step-08-pauser-set-wrapper.ts
+++ b/protocol-contracts/deployment-cli/src/steps/step-08-pauser-set-wrapper.ts
@@ -1,111 +1,122 @@
+import { grantRoleViaDao } from "../tasks/dao-tasks.js";
 import { ValidationError } from "../utils/errors.js";
 import { resolveProjectRoot } from "../utils/project-paths.js";
 import { withRetry } from "../utils/retry.js";
 import { TaskOutputReader } from "../utils/task-output-reader.js";
-import { BaseStep, type DeploymentContext, type StepExecutionResult } from "./base-step.js";
+import {
+    BaseStep,
+    type DeploymentContext,
+    type StepExecutionResult,
+} from "./base-step.js";
 
 export class Step08PauserSetWrapper extends BaseStep {
-  public readonly id = "step-08";
-  public readonly name = "Deploy PauserSetWrapper";
-  public readonly description = "Deploys PauserSetWrapper on Ethereum and grants pauser role via DAO governance.";
-  public readonly dependencies = ["step-04", "step-07"] as const;
-  public readonly pkgName = "protocol-contracts/pauserSetWrapper" as const;
+    public readonly id = "step-08";
+    public readonly name = "Deploy PauserSetWrapper";
+    public readonly description =
+        "Deploys PauserSetWrapper on Ethereum and grants pauser role via DAO governance.";
+    public readonly dependencies = ["step-04", "step-07"] as const;
+    public readonly pkgName = "protocol-contracts/pauserSetWrapper" as const;
 
-  protected async validate(ctx: DeploymentContext): Promise<void> {
-    const pauserSetAddress = ctx.env.getAddress("PAUSER_SET_HOST");
-    const zamaToken = ctx.env.getAddress("ZAMA_TOKEN");
-    if (!pauserSetAddress || !zamaToken) {
-      throw new ValidationError("Pauser set address and Zama token must be available before Step 8.");
-    }
-  }
-
-  protected async execute(ctx: DeploymentContext): Promise<StepExecutionResult> {
-    const ethereum = ctx.networks.getEthereum();
-    const protocolPk = ctx.env.resolveWalletPrivateKey("protocol_deployer");
-
-    const zamaToken = ctx.env.getAddress("ZAMA_TOKEN");
-    const pauserSetAddress = ctx.env.getAddress("PAUSER_SET_HOST");
-
-    const baseEnv = ctx.env.buildTaskEnv({
-      PRIVATE_KEY: protocolPk,
-      SEPOLIA_RPC_URL: ethereum.rpcUrl,
-      CONTRACT_TARGET: zamaToken,
-      FUNCTION_SIGNATURE: "pauseMinting()",
-      PAUSER_SET: pauserSetAddress,
-    });
-
-    await ctx.hardhat.runTask({
-      pkg: this.pkgName,
-      task: "deploy",
-      args: ["--network", ethereum.name],
-      env: baseEnv,
-    });
-
-    const projectRoot = resolveProjectRoot();
-    const reader = new TaskOutputReader(projectRoot);
-    const wrapperAddress = reader.readHardhatDeployment(this.pkgName, ethereum.name, "PauserSetWrapper");
-
-    // Grant MINTING_PAUSER_ROLE to PAUSER_SET_WRAPPER on ZAMA_TOKEN
-    try {
-      await ctx.hardhat.runTask({
-        pkg: "protocol-contracts/token",
-        task: "zama:erc20:grant:minter_role",
-        args: ["--address", wrapperAddress, "--contract-address", zamaToken, "--network", ethereum.name],
-        env: baseEnv,
-      });
-    } catch (error: unknown) {
-      const stderr = ((error as Record<string, unknown>)?.stderr ||
-        (error as Record<string, unknown>)?.message ||
-        "") as string;
-      if (String(stderr).includes("already has MINTER_ROLE on contract")) {
-      } else {
-        throw error;
-      }
+    protected async validate(ctx: DeploymentContext): Promise<void> {
+        const pauserSetAddress = ctx.env.getAddress("PAUSER_SET_HOST");
+        const zamaToken = ctx.env.getAddress("ZAMA_TOKEN");
+        if (!pauserSetAddress || !zamaToken) {
+            throw new ValidationError(
+                "Pauser set address and Zama token must be available before Step 8.",
+            );
+        }
     }
 
-    return {
-      addresses: {
-        PAUSER_SET_WRAPPER: wrapperAddress,
-      },
-    };
-  }
+    protected async execute(
+        ctx: DeploymentContext,
+    ): Promise<StepExecutionResult> {
+        const ethereum = ctx.networks.getEthereum();
+        const protocolPk = ctx.env.resolveWalletPrivateKey("protocol_deployer");
 
-  protected async verifyDeployments(
-    ctx: DeploymentContext,
-    result: StepExecutionResult & {
-      addresses: { PAUSER_SET_WRAPPER: string };
-    },
-  ): Promise<void> {
-    const ethereum = ctx.networks.getEthereum();
-    const protocolPk = ctx.env.resolveWalletPrivateKey("protocol_deployer");
-    const zamaToken = ctx.env.getAddress("ZAMA_TOKEN");
-    const pauserSetAddress = ctx.env.getAddress("PAUSER_SET_HOST");
-    const wrapperAddress = result.addresses.PAUSER_SET_WRAPPER;
+        const zamaToken = ctx.env.getAddress("ZAMA_TOKEN");
+        const pauserSetAddress = ctx.env.getAddress("PAUSER_SET_HOST");
 
-    const baseEnv = ctx.env.buildTaskEnv({
-      PRIVATE_KEY: protocolPk,
-      SEPOLIA_RPC_URL: ethereum.rpcUrl,
-      CONTRACT_TARGET: zamaToken,
-      FUNCTION_SIGNATURE: "pauseMinting()",
-      PAUSER_SET: pauserSetAddress,
-    });
+        const baseEnv = ctx.env.buildTaskEnv({
+            PRIVATE_KEY: protocolPk,
+            SEPOLIA_RPC_URL: ethereum.rpcUrl,
+            CONTRACT_TARGET: zamaToken,
+            FUNCTION_SIGNATURE: "pauseMinting()",
+            PAUSER_SET: pauserSetAddress,
+        });
 
-    await withRetry(
-      () =>
-        ctx.hardhat.runTask({
-          pkg: this.pkgName,
-          task: "task:verifyPauserSetWrapper",
-          args: ["--address", wrapperAddress, "--network", ethereum.name],
-          env: baseEnv,
-        }),
-      {
-        maxAttempts: 3,
-        initialDelayMs: 10000,
-        onRetry: (attempt) => {
-          ctx.logger.warn(`PauserSetWrapper verification failed, retrying (attempt ${attempt}/3)...`);
+        await ctx.hardhat.runTask({
+            pkg: this.pkgName,
+            task: "deploy",
+            args: ["--network", ethereum.name],
+            env: baseEnv,
+        });
+
+        const projectRoot = resolveProjectRoot();
+        const reader = new TaskOutputReader(projectRoot);
+        const wrapperAddress = reader.readHardhatDeployment(
+            this.pkgName,
+            ethereum.name,
+            "PauserSetWrapper",
+        );
+
+        // Grant MINTING_PAUSER_ROLE to PAUSER_SET_WRAPPER on ZAMA_TOKEN via DAO Admin plugin
+        await grantRoleViaDao({
+            ctx,
+            tokenAddress: zamaToken as `0x${string}`,
+            grantee: wrapperAddress as `0x${string}`,
+            role: "MINTING_PAUSER_ROLE",
+        });
+
+        return {
+            addresses: {
+                PAUSER_SET_WRAPPER: wrapperAddress,
+            },
+        };
+    }
+
+    protected async verifyDeployments(
+        ctx: DeploymentContext,
+        result: StepExecutionResult & {
+            addresses: { PAUSER_SET_WRAPPER: string };
         },
-      },
-    );
-    ctx.logger.success(`Verified PauserSetWrapper on ${ethereum.name}`);
-  }
+    ): Promise<void> {
+        const ethereum = ctx.networks.getEthereum();
+        const protocolPk = ctx.env.resolveWalletPrivateKey("protocol_deployer");
+        const zamaToken = ctx.env.getAddress("ZAMA_TOKEN");
+        const pauserSetAddress = ctx.env.getAddress("PAUSER_SET_HOST");
+        const wrapperAddress = result.addresses.PAUSER_SET_WRAPPER;
+
+        const baseEnv = ctx.env.buildTaskEnv({
+            PRIVATE_KEY: protocolPk,
+            SEPOLIA_RPC_URL: ethereum.rpcUrl,
+            CONTRACT_TARGET: zamaToken,
+            FUNCTION_SIGNATURE: "pauseMinting()",
+            PAUSER_SET: pauserSetAddress,
+        });
+
+        await withRetry(
+            () =>
+                ctx.hardhat.runTask({
+                    pkg: this.pkgName,
+                    task: "task:verifyPauserSetWrapper",
+                    args: [
+                        "--address",
+                        wrapperAddress,
+                        "--network",
+                        ethereum.name,
+                    ],
+                    env: baseEnv,
+                }),
+            {
+                maxAttempts: 3,
+                initialDelayMs: 10000,
+                onRetry: (attempt) => {
+                    ctx.logger.warn(
+                        `PauserSetWrapper verification failed, retrying (attempt ${attempt}/3)...`,
+                    );
+                },
+            },
+        );
+        ctx.logger.success(`Verified PauserSetWrapper on ${ethereum.name}`);
+    }
 }

--- a/protocol-contracts/deployment-cli/src/tasks/dao-tasks.ts
+++ b/protocol-contracts/deployment-cli/src/tasks/dao-tasks.ts
@@ -1,0 +1,143 @@
+import { AdminABI } from "@aragon/admin-plugin-artifacts";
+import {
+    type Address,
+    createPublicClient,
+    createWalletClient,
+    defineChain,
+    encodeFunctionData,
+    getAddress,
+    http,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { loadContractABIs } from "../../tests/utils/contract-loader.js";
+import type { DeploymentContext } from "../steps/base-step.js";
+
+export type DaoAction = {
+    to: `0x${string}`;
+    value: bigint;
+    data: `0x${string}`;
+};
+
+export async function executeViaAdminPlugin(
+    ctx: DeploymentContext,
+    actions: DaoAction[],
+): Promise<`0x${string}`> {
+    const ethereum = ctx.networks.getEthereum();
+    const rpcUrl = ethereum.rpcUrl;
+    const chain = defineChain({
+        id: ethereum.chainId,
+        name: ethereum.name,
+        rpcUrls: { default: { http: [rpcUrl] }, public: { http: [rpcUrl] } },
+        nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    });
+
+    const adminPluginAddress = process.env.DAO_ADMIN_PLUGIN;
+    if (!adminPluginAddress) {
+        throw new Error(
+            "DAO_ADMIN_PLUGIN env var is required to execute via Admin plugin.",
+        );
+    }
+
+    const pk = ctx.env.resolveWalletPrivateKey("governance_deployer");
+    const account = privateKeyToAccount(pk as `0x${string}`);
+    const wallet = createWalletClient({
+        account,
+        chain,
+        transport: http(rpcUrl),
+    });
+    const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
+
+    // Write executeProposal on Admin plugin
+    const { writeContract, waitForTransactionReceipt } = {
+        writeContract: wallet.writeContract.bind(wallet),
+        waitForTransactionReceipt:
+            publicClient.waitForTransactionReceipt.bind(publicClient),
+    };
+
+    ctx.logger.info(
+        `Executing ${actions.length} action(s) via Admin plugin ${getAddress(adminPluginAddress)}`,
+    );
+
+    const hash = await writeContract({
+        address: getAddress(adminPluginAddress),
+        abi: AdminABI,
+        functionName: "executeProposal",
+        args: [
+            "0x", // proposalId left empty for direct execution
+            actions.map((a) => ({
+                to: getAddress(a.to),
+                value: a.value,
+                data: a.data,
+            })),
+            0n, // allowFailureMap
+        ],
+    });
+
+    await waitForTransactionReceipt({ hash });
+    ctx.logger.success(`Admin plugin execution tx: ${hash}`);
+    return hash;
+}
+
+export async function grantRoleViaDao(options: {
+    ctx: DeploymentContext;
+    tokenAddress: Address;
+    grantee: Address;
+    role: "MINTING_PAUSER_ROLE" | "MINTER_ROLE";
+}): Promise<`0x${string}` | null> {
+    const { ctx, tokenAddress, grantee, role } = options;
+    const ethereum = ctx.networks.getEthereum();
+    const rpcUrl = ethereum.rpcUrl;
+    const chain = defineChain({
+        id: ethereum.chainId,
+        name: ethereum.name,
+        rpcUrls: { default: { http: [rpcUrl] }, public: { http: [rpcUrl] } },
+        nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    });
+
+    const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
+
+    const { readContract } = {
+        readContract: publicClient.readContract.bind(publicClient),
+    };
+
+    const token = getAddress(tokenAddress);
+    const granteeAddr = getAddress(grantee);
+
+    // Resolve role value from contract
+    const { zamaERC20Abi } = await loadContractABIs();
+    const roleValue = (await readContract({
+        address: token,
+        abi: zamaERC20Abi,
+        functionName: role,
+        args: [],
+    })) as `0x${string}`;
+
+    // Short-circuit if grantee already has the role
+    const alreadyHas = (await readContract({
+        address: token,
+        abi: zamaERC20Abi,
+        functionName: "hasRole",
+        args: [roleValue, granteeAddr],
+    })) as boolean;
+
+    if (alreadyHas) {
+        ctx.logger.info(
+            `${granteeAddr} already has ${role} on ${token}; skipping DAO action`,
+        );
+        return null;
+    }
+
+    const data = encodeFunctionData({
+        abi: zamaERC20Abi,
+        functionName: "grantRole",
+        args: [roleValue, granteeAddr],
+    });
+
+    return executeViaAdminPlugin(ctx, [
+        {
+            to: token,
+            value: 0n,
+            data,
+        },
+    ]);
+}

--- a/protocol-contracts/deployment-cli/src/utils/task-output-reader.ts
+++ b/protocol-contracts/deployment-cli/src/utils/task-output-reader.ts
@@ -39,7 +39,7 @@ export class TaskOutputReader {
         pkgPath: string,
         network: string,
         contractName: string,
-    ): string {
+    ): `0x${string}` {
         const artifactPath = path.join(
             this.projectRoot,
             pkgPath,
@@ -58,7 +58,7 @@ export class TaskOutputReader {
                 );
             }
 
-            return ethers.getAddress(data.address);
+            return ethers.getAddress(data.address) as `0x${string}`;
         } catch (error) {
             if (error instanceof ValidationError) {
                 throw error;
@@ -92,7 +92,7 @@ export class TaskOutputReader {
     public readEnvFile(
         envPath: string,
         fieldMapping?: Record<string, string>,
-    ): Record<string, string> {
+    ): Record<string, `0x${string}`> {
         if (!fs.existsSync(envPath)) {
             throw new ValidationError(`Environment file not found: ${envPath}`);
         }
@@ -101,7 +101,7 @@ export class TaskOutputReader {
             const raw = fs.readFileSync(envPath, "utf8");
             const parsed = dotenv.parse(raw);
 
-            const result: Record<string, string> = {};
+            const result: Record<string, `0x${string}`> = {};
 
             if (fieldMapping) {
                 // Use the provided mapping
@@ -110,14 +110,17 @@ export class TaskOutputReader {
                 )) {
                     const value = parsed[envKey];
                     if (value) {
-                        result[normalizedKey] = value.toLowerCase();
+                        result[normalizedKey] =
+                            value.toLowerCase() as `0x${string}`;
                     }
                 }
             } else {
                 // Return all fields as-is
                 for (const [key, value] of Object.entries(parsed)) {
                     result[key] =
-                        typeof value === "string" ? value.toLowerCase() : value;
+                        typeof value === "string"
+                            ? (value.toLowerCase() as `0x${string}`)
+                            : value;
                 }
             }
 


### PR DESCRIPTION
- The INITIAL_ADMIN of the ZAMA_ERC20 token is now the DAO in the deployment CLI
- This means future role attributions need to be going through DAO. The CLI assumes that the DAO has an admin plugin (default config for Aragon DAO) — we use it to bypass the governance process.

In later steps, will be revoked, but at this point in the deployment it is still accessible.

Closes https://github.com/zama-ai/fhevm-internal/issues/564