### PR TITLE
chore(common): remove redundant word in coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs

### DIFF
--- a/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
@@ -51,7 +51,7 @@ pub struct Args {
     #[arg(long)]
     pub database_url: Option<DatabaseURL>,
 
-    /// KeySet file. If unspecified the the keys are read from the database
+    /// KeySet file. If unspecified the keys are read from the database
     #[arg(long)]
     pub keys_file_path: Option<String>,
 


### PR DESCRIPTION


remove redundant word in coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs