### PR TITLE
test(test-suite): e2e for input, compute and decrypt

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -157,6 +157,11 @@ jobs:
         run: |
           ./fhevm-cli test input-proof
 
+      - name: Input proof test with compute and decrypt (uint64)
+        working-directory: test-suite/fhevm
+        run: |
+          ./fhevm-cli test input-proof-compute-decrypt
+
       - name: User Decryption test
         working-directory: test-suite/fhevm
         run: |

--- a/test-suite/e2e/contracts/TestInput.sol
+++ b/test-suite/e2e/contracts/TestInput.sol
@@ -6,10 +6,19 @@ import "@fhevm/solidity/lib/FHE.sol";
 import {E2ECoprocessorConfig} from "./E2ECoprocessorConfigLocal.sol";
 
 contract TestInput is E2ECoprocessorConfig {
-    uint64 public yUint64;
+    euint64 public resUint64;
 
     function requestUint64NonTrivial(externalEuint64 inputHandle, bytes calldata inputProof) public {
-        euint64 inputNonTrivial = FHE.fromExternal(inputHandle, inputProof);
-        FHE.allowThis(inputNonTrivial);
+        resUint64 = FHE.fromExternal(inputHandle, inputProof);
+        FHE.allowThis(resUint64);
+    }
+
+    // Adds a trivially-encrypted 42 to the user-provided encrypted uint64 input.
+    function add42ToInput64(externalEuint64 inputHandle, bytes calldata inputProof) public {
+        euint64 input = FHE.fromExternal(inputHandle, inputProof);
+        euint64 trivial42 = FHE.asEuint64(42);
+        resUint64 = FHE.add(input, trivial42);
+        FHE.allowThis(resUint64);
+        FHE.allow(resUint64, msg.sender);
     }
 }

--- a/test-suite/e2e/test/httpPublicDecrypt/httpPublicDecrypt.ts
+++ b/test-suite/e2e/test/httpPublicDecrypt/httpPublicDecrypt.ts
@@ -23,7 +23,7 @@ describe('HTTPPublicDecrypt', function () {
     const expectedRes = {
       [handleBool]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test HTTPPublicDecrypt mixed', async function () {
@@ -36,6 +36,6 @@ describe('HTTPPublicDecrypt', function () {
       [handle32]: 242n,
       [handleAddress]: '0xfC4382C084fCA3f4fB07c3BCDA906C01797595a8',
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/userInput/inputFlow.ts
+++ b/test-suite/e2e/test/userInput/inputFlow.ts
@@ -3,6 +3,7 @@ import { ethers } from 'hardhat';
 
 import { createInstances } from '../instance';
 import { getSigners, initSigners } from '../signers';
+import { userDecryptSingleHandle } from '../utils';
 
 describe('Input Flow', function () {
   before(async function () {
@@ -11,10 +12,16 @@ describe('Input Flow', function () {
   });
 
   beforeEach(async function () {
+    const envContractAddress = process.env.TEST_INPUT_CONTRACT_ADDRESS;
     const contractFactory = await ethers.getContractFactory('TestInput');
-    this.contract = await contractFactory.connect(this.signers.alice).deploy();
-    this.contractAddress = await this.contract.getAddress();
-    await this.contract.waitForDeployment();
+    if (!envContractAddress) {
+      this.contract = await contractFactory.connect(this.signers.alice).deploy();
+      this.contractAddress = await this.contract.getAddress();
+      await this.contract.waitForDeployment();
+    } else {
+      this.contractAddress = envContractAddress;
+      this.contract = contractFactory.connect(this.signers.alice).attach(this.contractAddress);
+    }
     this.instances = await createInstances(this.signers);
   });
 
@@ -30,5 +37,32 @@ describe('Input Flow', function () {
     const tx = await this.contract.requestUint64NonTrivial(encryptedAmount.handles[0], encryptedAmount.inputProof);
     const receipt = await tx.wait();
     expect(receipt.status).to.equal(1);
+  });
+
+  it('test add 42 to uint64 input and decrypt', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add64(7n);
+    const encryptedInput = await input.encrypt();
+    encryptedInput.handles.forEach((handle: any, index: any) => {
+      // Assuming handle is a Uint8Array or Buffer
+      console.log(`  Handle ${index}: 0x${Buffer.from(handle).toString('hex')}`);
+    });
+    console.log('InputProof: 0x' + Buffer.from(encryptedInput.inputProof).toString('hex'));
+    const tx = await this.contract.add42ToInput64(encryptedInput.handles[0], encryptedInput.inputProof);
+    const receipt = await tx.wait();
+    expect(receipt.status).to.equal(1);
+
+    // User decrypt the result - should be 7 + 42 = 49.
+    const handle = await this.contract.resUint64();
+    const { publicKey, privateKey } = this.instances.alice.generateKeypair();
+    const decryptedValue = await userDecryptSingleHandle(
+      handle,
+      this.contractAddress,
+      this.instances.alice,
+      this.signers.alice,
+      privateKey,
+      publicKey,
+    );
+    expect(decryptedValue).to.equal(49n);
   });
 });

--- a/test-suite/fhevm/fhevm-cli
+++ b/test-suite/fhevm/fhevm-cli
@@ -38,7 +38,7 @@ export HOST_VERSION=${HOST_VERSION:-"v0.10.0-2"}
 # Other services.
 export CORE_VERSION=${CORE_VERSION:-"v0.12.4"}
 export RELAYER_VERSION=${RELAYER_VERSION:-"v0.6.0"}
-export TEST_SUITE_VERSION=${TEST_SUITE_VERSION:-"v0.10.0-2"}
+export TEST_SUITE_VERSION=${TEST_SUITE_VERSION:-"770f756"}
 
 
 function print_logo() {
@@ -172,6 +172,10 @@ case $COMMAND in
         input-proof)
           log_message="${LIGHT_BLUE}${BOLD}[TEST] INPUT PROOF (uint64)${RESET}"
           docker_args+=("-g" "test user input uint64")
+          ;;
+        input-proof-compute-decrypt)
+          log_message="${LIGHT_BLUE}${BOLD}[TEST] INPUT PROOF (uint64)${RESET}"
+          docker_args+=("-g" "test add 42 to uint64 input and decrypt")
           ;;
         user-decryption)
           log_message="${LIGHT_BLUE}${BOLD}[TEST] USER DECRYPTION${RESET}"


### PR DESCRIPTION
Also, add ability to run the tests on the TestInput contract without
deploying it each time via the `TEST_INPUT_CONTRACT_ADDRESS` env var.

Intention is to use this a single entry point for a smoke test.