### PR TITLE
fix(test-suite): relayer-sdk v0.3.0-6 and Rand

### DIFF
--- a/library-solidity/codegen/src/testgen.ts
+++ b/library-solidity/codegen/src/testgen.ts
@@ -505,7 +505,7 @@ export function generateTypeScriptTestCode(
                     const expectedRes = {
                       [handle]: ${expectedOutput},
                     };
-                    assert.deepEqual(res, expectedRes);
+                    assert.deepEqual(res.clearValues, expectedRes);
                 });
             `);
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25607,7 +25607,7 @@
       "dependencies": {
         "@fhevm/solidity": "*",
         "@openzeppelin/contracts": "^5.3.0",
-        "@zama-fhe/relayer-sdk": "^0.3.0-2",
+        "@zama-fhe/relayer-sdk": "^0.3.0-6",
         "bigint-buffer": "^1.1.5",
         "dotenv": "^16.0.3",
         "encrypted-types": "^0.0.4"
@@ -27423,9 +27423,9 @@
       }
     },
     "test-suite/e2e/node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.3.0-5",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.3.0-5.tgz",
-      "integrity": "sha512-DIPlN9z5tfSCXqUlhQN2MEv57HmAUHSGV9LPtGs6LWmM7POj6WsMd1hU7Qci4AWPsor7k3IqMfqGGthIvot/DQ==",
+      "version": "0.3.0-6",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.3.0-6.tgz",
+      "integrity": "sha512-lrnor1yIsC2ePHWo5XCxSsFkBr8JuaI7FvRk1azpglxkBVNECvuMD23ky04A8F6k53NDBvlh71MvHI+qvAOaQQ==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",

--- a/test-suite/e2e/package.json
+++ b/test-suite/e2e/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@fhevm/solidity": "*",
     "@openzeppelin/contracts": "^5.3.0",
-    "@zama-fhe/relayer-sdk": "^0.3.0-2",
+    "@zama-fhe/relayer-sdk": "^0.3.0-6",
     "bigint-buffer": "^1.1.5",
     "dotenv": "^16.0.3",
     "encrypted-types": "^0.0.4"

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations1.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations1.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 203n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint8, euint8) => euint8 test 2 (4, 8)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint8, euint8) => euint8 test 3 (8, 8)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint8, euint8) => euint8 test 4 (8, 4)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint64) => euint64 test 1 (1488611147, 1488611147)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint64) => euint64 test 2 (1488611147, 1488611143)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint8) => euint16 test 1 (167, 2)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 169n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint8) => euint16 test 2 (96, 100)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint8) => euint16 test 3 (100, 100)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 200n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint8) => euint16 test 4 (100, 96)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint16, uint16) => euint16 test 1 (61612, 47173)', async function () {
@@ -304,7 +304,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint16, uint16) => euint16 test 2 (61310, 61314)', async function () {
@@ -319,7 +319,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint16, uint16) => euint16 test 3 (61314, 61314)', async function () {
@@ -334,7 +334,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint16, uint16) => euint16 test 4 (61314, 61310)', async function () {
@@ -349,7 +349,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, uint8) => ebool test 1 (181, 142)', async function () {
@@ -364,7 +364,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, uint8) => ebool test 2 (5, 9)', async function () {
@@ -379,7 +379,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, uint8) => ebool test 3 (9, 9)', async function () {
@@ -394,7 +394,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, uint8) => ebool test 4 (9, 5)', async function () {
@@ -409,7 +409,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint128) => euint128 test 1 (2, 2147483649)', async function () {
@@ -428,7 +428,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 2147483651n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint128) => euint128 test 2 (1607734426, 1607734428)', async function () {
@@ -447,7 +447,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 3215468854n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint128) => euint128 test 3 (1607734428, 1607734428)', async function () {
@@ -466,7 +466,7 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 3215468856n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint128) => euint128 test 4 (1607734428, 1607734426)', async function () {
@@ -485,6 +485,6 @@ describe('FHEVM operations 1', function () {
     const expectedRes = {
       [handle]: 3215468854n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations10.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations10.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, uint128) => ebool test 2 (340282366920938463463367329768413053355, 340282366920938463463367329768413053359)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, uint128) => ebool test 3 (340282366920938463463367329768413053359, 340282366920938463463367329768413053359)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, uint128) => ebool test 4 (340282366920938463463367329768413053359, 340282366920938463463367329768413053355)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint8) => euint32 test 1 (4253082714, 41)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 41n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint8) => euint32 test 2 (37, 41)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 37n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint8) => euint32 test 3 (41, 41)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 41n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint8) => euint32 test 4 (41, 37)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 37n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint8) => euint16 test 1 (49382, 103)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 49281n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint8) => euint16 test 2 (99, 103)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint8) => euint16 test 3 (103, 103)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint8) => euint16 test 4 (103, 99)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint8) => euint8 test 1 (17, 7)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 119n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint8) => euint8 test 2 (12, 13)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint8) => euint8 test 3 (13, 13)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 169n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint8) => euint8 test 4 (13, 12)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint64, euint64) => ebool test 1 (18445616084724927657, 18445436475565736521)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint64, euint64) => ebool test 2 (18441120945513043029, 18441120945513043033)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint64, euint64) => ebool test 3 (18441120945513043033, 18441120945513043033)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint64, euint64) => ebool test 4 (18441120945513043033, 18441120945513043029)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "neg" overload (euint32) => euint32 test 1 (3613399747)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 10', function () {
     const expectedRes = {
       [handle]: 681567549n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations100.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations100.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, uint64) => ebool test 2 (18439679158105806075, 18439679158105806079)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, uint64) => ebool test 3 (18439679158105806079, 18439679158105806079)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, uint64) => ebool test 4 (18439679158105806079, 18439679158105806075)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint128) => euint128 test 1 (2, 16385)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 32770n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint128) => euint128 test 2 (151, 151)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 22801n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint128) => euint128 test 3 (151, 151)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 22801n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint128) => euint128 test 4 (151, 151)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 22801n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint256) => ebool test 1 (340282366920938463463374435064805796961, 115792089237316195423570985008687907853269984665640564039457577359288559120777)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint256) => ebool test 2 (340282366920938463463374435064805796957, 340282366920938463463374435064805796961)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint256) => ebool test 3 (340282366920938463463374435064805796961, 340282366920938463463374435064805796961)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint256) => ebool test 4 (340282366920938463463374435064805796961, 340282366920938463463374435064805796957)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, euint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457576848855753045347, 10)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 40255843523910708565225850256926655464613393106414102341842675683259782007053n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, euint8) => euint256 test 2 (6, 10)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 678469272874899582559986240285280710077753816400237679918696781296365993984n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, euint8) => euint256 test 3 (10, 10)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 1130782121458165970933310400475467850129589694000396133197827968827276656640n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, euint8) => euint256 test 4 (10, 6)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 18092513943330655534932966407607485602073435104006338131165247501236426506240n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint32, euint32) => euint32 test 1 (4192633711, 1756703468)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 2438179203n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint32, euint32) => euint32 test 2 (640520663, 640520667)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint32, euint32) => euint32 test 3 (640520667, 640520667)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint32, euint32) => euint32 test 4 (640520667, 640520663)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint128) => ebool test 1 (340282366920938463463370396677631502123, 340282366920938463463374167249469603277)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint128) => ebool test 2 (340282366920938463463370396677631502119, 340282366920938463463370396677631502123)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint128) => ebool test 3 (340282366920938463463370396677631502123, 340282366920938463463370396677631502123)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint128) => ebool test 4 (340282366920938463463370396677631502123, 340282366920938463463370396677631502119)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 100', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations101.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations101.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint64, euint64) => ebool test 2 (18441518909520051971, 18441518909520051975)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint64, euint64) => ebool test 3 (18441518909520051975, 18441518909520051975)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint64, euint64) => ebool test 4 (18441518909520051975, 18441518909520051971)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint8) => euint32 test 1 (60, 60)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint8) => euint32 test 2 (60, 56)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint64) => euint64 test 1 (9219094923281824695, 9219147465732255085)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18438242389014079780n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint64) => euint64 test 2 (9219094923281824693, 9219094923281824695)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18438189846563649388n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint64) => euint64 test 3 (9219094923281824695, 9219094923281824695)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18438189846563649390n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint64) => euint64 test 4 (9219094923281824695, 9219094923281824693)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18438189846563649388n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, uint16) => ebool test 1 (59316, 17374)', async function () {
@@ -320,7 +320,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, uint16) => ebool test 2 (27980, 27984)', async function () {
@@ -335,7 +335,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, uint16) => ebool test 3 (27984, 27984)', async function () {
@@ -350,7 +350,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, uint16) => ebool test 4 (27984, 27980)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint256) => euint256 test 1 (18444907664988717009, 115792089237316195423570985008687907853269984665640564039457581041562398124193)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457583304087827283953n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint256) => euint256 test 2 (18444907664988717005, 18444907664988717009)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18444907664988717021n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint256) => euint256 test 3 (18444907664988717009, 18444907664988717009)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18444907664988717009n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint256) => euint256 test 4 (18444907664988717009, 18444907664988717005)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 18444907664988717021n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint8) => euint16 test 1 (64994, 227)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 227n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint8) => euint16 test 2 (223, 227)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint8) => euint16 test 3 (227, 227)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 227n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint8) => euint16 test 4 (227, 223)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 101', function () {
     const expectedRes = {
       [handle]: 223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations102.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations102.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039439142068790649117992n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint256) => euint256 test 2 (18443357991836925999, 18443357991836926003)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint256) => euint256 test 3 (18443357991836926003, 18443357991836926003)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint256) => euint256 test 4 (18443357991836926003, 18443357991836925999)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint128) => ebool test 1 (18439095146183369197, 340282366920938463463372031592158684153)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint128) => ebool test 2 (18439095146183369193, 18439095146183369197)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint128) => ebool test 3 (18439095146183369197, 18439095146183369197)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint128) => ebool test 4 (18439095146183369197, 18439095146183369193)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint8) => euint32 test 1 (710719662, 181)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 710719679n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint8) => euint32 test 2 (177, 181)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 181n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint8) => euint32 test 3 (181, 181)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 181n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint8) => euint32 test 4 (181, 177)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 181n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint64, euint64) => ebool test 1 (18446607332850591667, 18444669461336692671)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint64, euint64) => ebool test 2 (18438850655314522435, 18438850655314522439)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint64, euint64) => ebool test 3 (18438850655314522439, 18438850655314522439)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint64, euint64) => ebool test 4 (18438850655314522439, 18438850655314522435)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 1 (28986, 730827779)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 2n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 2 (28982, 28986)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 28978n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 3 (28986, 28986)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 28986n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint32) => euint32 test 4 (28986, 28982)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 28978n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, uint32) => euint32 test 1 (2056964365, 2047425512)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 4104389877n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, uint32) => euint32 test 2 (2056964361, 2056964365)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 4113928726n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, uint32) => euint32 test 3 (2056964365, 2056964365)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 4113928730n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, uint32) => euint32 test 4 (2056964365, 2056964361)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 102', function () {
     const expectedRes = {
       [handle]: 4113928726n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations103.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations103.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint8, euint8) => ebool test 2 (5, 9)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint8, euint8) => ebool test 3 (9, 9)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint8, euint8) => ebool test 4 (9, 5)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint128) => ebool test 1 (340282366920938463463371440762151696387, 340282366920938463463373147805312009399)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint128) => ebool test 2 (340282366920938463463371440762151696383, 340282366920938463463371440762151696387)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint128) => ebool test 3 (340282366920938463463371440762151696387, 340282366920938463463371440762151696387)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint128) => ebool test 4 (340282366920938463463371440762151696387, 340282366920938463463371440762151696383)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint16) => ebool test 1 (18444392995773358061, 622)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint16) => ebool test 2 (618, 622)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint16) => ebool test 3 (622, 622)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint16) => ebool test 4 (622, 618)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint128) => euint128 test 1 (170141183460469231731687272015842765950, 170141183460469231731686444035462849345)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373716051305615295n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint128) => euint128 test 2 (170141183460469231731686444035462849343, 170141183460469231731686444035462849345)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698688n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint128) => euint128 test 3 (170141183460469231731686444035462849345, 170141183460469231731686444035462849345)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698690n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint128) => euint128 test 4 (170141183460469231731686444035462849345, 170141183460469231731686444035462849343)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698688n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint16) => euint16 test 1 (140, 63165)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 63165n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint16) => euint16 test 2 (136, 140)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 140n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint16) => euint16 test 3 (140, 140)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 140n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint16) => euint16 test 4 (140, 136)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 140n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, uint8) => euint32 test 1 (3796021550, 7)', async function () {
@@ -494,7 +494,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 29656418n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, uint8) => euint32 test 2 (3, 7)', async function () {
@@ -509,7 +509,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, uint8) => euint32 test 3 (7, 7)', async function () {
@@ -524,7 +524,7 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, uint8) => euint32 test 4 (7, 3)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 103', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations104.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations104.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 57106n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint16, euint16) => euint16 test 2 (34851, 34855)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint16, euint16) => euint16 test 3 (34855, 34855)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint16, euint16) => euint16 test 4 (34855, 34851)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint128) => euint128 test 1 (340282366920938463463374432859434778255, 340282366920938463463371780590875218175)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218175n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint128) => euint128 test 2 (340282366920938463463371780590875218171, 340282366920938463463371780590875218175)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218171n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint128) => euint128 test 3 (340282366920938463463371780590875218175, 340282366920938463463371780590875218175)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218175n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint128) => euint128 test 4 (340282366920938463463371780590875218175, 340282366920938463463371780590875218171)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218171n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint128) => ebool test 1 (18441663534855542253, 340282366920938463463368870415596936955)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint128) => ebool test 2 (18441663534855542249, 18441663534855542253)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint128) => ebool test 3 (18441663534855542253, 18441663534855542253)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint128) => ebool test 4 (18441663534855542253, 18441663534855542249)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint8) => ebool test 1 (340282366920938463463369088048016042715, 65)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint8) => ebool test 2 (61, 65)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint8) => ebool test 3 (65, 65)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint8) => ebool test 4 (65, 61)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint128) => euint128 test 1 (18444531246149492859, 340282366920938463463370297997556003923)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 340282366920938463463370297997556003923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint128) => euint128 test 2 (18444531246149492855, 18444531246149492859)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 18444531246149492859n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint128) => euint128 test 3 (18444531246149492859, 18444531246149492859)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 18444531246149492859n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint128) => euint128 test 4 (18444531246149492859, 18444531246149492855)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 18444531246149492859n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint32, euint32) => euint32 test 1 (2271219408, 2271219408)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint32, euint32) => euint32 test 2 (2271219408, 2271219404)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 104', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations105.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations105.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 105', function () {
     const expectedRes = {
       [handle]: 8n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint8) => euint128 test 2 (4, 8)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 105', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint8) => euint128 test 3 (8, 8)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 105', function () {
     const expectedRes = {
       [handle]: 8n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint8) => euint128 test 4 (8, 4)', async function () {
@@ -191,6 +191,6 @@ describe('FHEVM operations 105', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations11.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations11.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 200n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint32) => euint32 test 2 (11, 12)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 132n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint32) => euint32 test 3 (12, 12)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint32) => euint32 test 4 (12, 11)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 132n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, uint64) => ebool test 1 (18446128337109479365, 18445436475565736521)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, uint64) => ebool test 2 (18441120945513043029, 18441120945513043033)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, uint64) => ebool test 3 (18441120945513043033, 18441120945513043033)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, uint64) => ebool test 4 (18441120945513043033, 18441120945513043029)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, uint8) => ebool test 1 (113, 248)', async function () {
@@ -282,7 +282,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, uint8) => ebool test 2 (12, 16)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, uint8) => ebool test 3 (16, 16)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, uint8) => ebool test 4 (16, 12)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint128, euint128) => euint128 test 1 (340282366920938463463373007535719097705, 340282366920938463463368463750923395115)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373007535719097705n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint128, euint128) => euint128 test 2 (340282366920938463463367382444010695717, 340282366920938463463367382444010695721)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint128, euint128) => euint128 test 3 (340282366920938463463367382444010695721, 340282366920938463463367382444010695721)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint128, euint128) => euint128 test 4 (340282366920938463463367382444010695721, 340282366920938463463367382444010695717)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint256) => euint256 test 1 (83, 115792089237316195423570985008687907853269984665640564039457579408559270284265)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 65n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint256) => euint256 test 2 (79, 83)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 67n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint256) => euint256 test 3 (83, 83)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 83n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint256) => euint256 test 4 (83, 79)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 67n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint32) => euint128 test 1 (340282366920938463463365891557340185027, 821014539)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 340282366920938463463365891557340185027n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint32) => euint128 test 2 (821014535, 821014539)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 821014539n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint32) => euint128 test 3 (821014539, 821014539)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 821014539n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint32) => euint128 test 4 (821014539, 821014535)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 11', function () {
     const expectedRes = {
       [handle]: 821014539n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations12.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations12.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 2 (953438493, 953438497)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 3 (953438497, 953438497)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint32, euint32) => ebool test 4 (953438497, 953438493)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint8) => ebool test 1 (41304, 235)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint8) => ebool test 2 (231, 235)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint8) => ebool test 3 (235, 235)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint8) => ebool test 4 (235, 231)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint64) => ebool test 1 (340282366920938463463370752221919344885, 18442321567388496519)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint64) => ebool test 2 (18442321567388496515, 18442321567388496519)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint64) => ebool test 3 (18442321567388496519, 18442321567388496519)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint64) => ebool test 4 (18442321567388496519, 18442321567388496515)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint8) => euint16 test 1 (45661, 80)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: 80n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint8) => euint16 test 2 (76, 80)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: 64n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint8) => euint16 test 3 (80, 80)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: 80n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint8) => euint16 test 4 (80, 76)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: 64n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint256) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457577479120936889355)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint256) => ebool test 2 (115792089237316195423570985008687907853269984665640564039457576299642184965501, 115792089237316195423570985008687907853269984665640564039457576299642184965505)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint256) => ebool test 3 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457576299642184965505)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint256) => ebool test 4 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457576299642184965501)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint64) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457580793699504277477, 18439638370960042927)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint64) => ebool test 2 (18439638370960042923, 18439638370960042927)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint64) => ebool test 3 (18439638370960042927, 18439638370960042927)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint64) => ebool test 4 (18439638370960042927, 18439638370960042923)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 12', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations13.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations13.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 65530n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint64) => euint64 test 2 (150, 150)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 22500n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint64) => euint64 test 3 (150, 150)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 22500n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint64) => euint64 test 4 (150, 150)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 22500n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint128) => ebool test 1 (3349058566, 340282366920938463463366038125678950263)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint128) => ebool test 2 (3349058562, 3349058566)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint128) => ebool test 3 (3349058566, 3349058566)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint128) => ebool test 4 (3349058566, 3349058562)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint8, uint8) => euint8 test 1 (109, 28)', async function () {
@@ -282,7 +282,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 25n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint8, uint8) => euint8 test 2 (40, 44)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 40n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint8, uint8) => euint8 test 3 (44, 44)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint8, uint8) => euint8 test 4 (44, 40)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint8) => euint8 test 1 (122, 122)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint8) => euint8 test 2 (122, 118)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint32) => euint64 test 1 (931283036, 931283036)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint32) => euint64 test 2 (931283036, 931283032)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, uint8) => ebool test 1 (250, 72)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, uint8) => ebool test 2 (67, 71)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, uint8) => ebool test 3 (71, 71)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, uint8) => ebool test 4 (71, 67)', async function () {
@@ -463,6 +463,6 @@ describe('FHEVM operations 13', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations14.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations14.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint32) => ebool test 2 (432148045, 432148049)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint32) => ebool test 3 (432148049, 432148049)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint32) => ebool test 4 (432148049, 432148045)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint16) => ebool test 1 (109, 49209)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint16) => ebool test 2 (105, 109)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint16) => ebool test 3 (109, 109)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint16) => ebool test 4 (109, 105)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457581512116079752891)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580630218897388731n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457580727388371776951, 115792089237316195423570985008687907853269984665640564039457580727388371776955)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776947n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457580727388371776955)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776955n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457580727388371776951)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776947n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 1 (5506, 42837)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 2 (5502, 5506)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 3 (5506, 5506)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint16) => ebool test 4 (5506, 5502)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, uint16) => euint16 test 1 (560, 560)', async function () {
@@ -434,7 +434,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, uint16) => euint16 test 2 (560, 556)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint256) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457579420698410212099)', async function () {
@@ -468,7 +468,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint256) => ebool test 2 (115792089237316195423570985008687907853269984665640564039457575496626475170537, 115792089237316195423570985008687907853269984665640564039457575496626475170541)', async function () {
@@ -487,7 +487,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint256) => ebool test 3 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457575496626475170541)', async function () {
@@ -506,7 +506,7 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint256) => ebool test 4 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457575496626475170537)', async function () {
@@ -525,6 +525,6 @@ describe('FHEVM operations 14', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations15.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations15.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 5n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, uint8) => euint8 test 2 (105, 109)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 105n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, uint8) => euint8 test 3 (109, 109)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 109n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, uint8) => euint8 test 4 (109, 105)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 105n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint64) => ebool test 1 (340282366920938463463366157507106496505, 18444099712193091937)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint64) => ebool test 2 (18444099712193091933, 18444099712193091937)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint64) => ebool test 3 (18444099712193091937, 18444099712193091937)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint64) => ebool test 4 (18444099712193091937, 18444099712193091933)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, uint32) => euint32 test 1 (3255063189, 2466881813)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 3540906901n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, uint32) => euint32 test 2 (3255063185, 3255063189)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, uint32) => euint32 test 3 (3255063189, 3255063189)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, uint32) => euint32 test 4 (3255063189, 3255063185)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint8, euint8) => euint8 test 1 (103, 58)', async function () {
@@ -342,7 +342,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 161n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint8, euint8) => euint8 test 2 (55, 59)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint8, euint8) => euint8 test 3 (59, 59)', async function () {
@@ -372,7 +372,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 118n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint8, euint8) => euint8 test 4 (59, 55)', async function () {
@@ -387,7 +387,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint8, euint8) => euint8 test 1 (9, 9)', async function () {
@@ -402,7 +402,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 81n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint8, euint8) => euint8 test 2 (12, 13)', async function () {
@@ -417,7 +417,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint8, euint8) => euint8 test 3 (13, 13)', async function () {
@@ -432,7 +432,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 169n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint8, euint8) => euint8 test 4 (13, 12)', async function () {
@@ -447,7 +447,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint8) => ebool test 1 (250, 71)', async function () {
@@ -466,7 +466,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint8) => ebool test 2 (67, 71)', async function () {
@@ -485,7 +485,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint8) => ebool test 3 (71, 71)', async function () {
@@ -504,7 +504,7 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint8) => ebool test 4 (71, 67)', async function () {
@@ -523,6 +523,6 @@ describe('FHEVM operations 15', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations16.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations16.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 18442779447269556522n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint64, euint64) => euint64 test 2 (4293270308, 4293270308)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint64, euint64) => euint64 test 3 (4293270308, 4293270308)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint64, euint64) => euint64 test 4 (4293270308, 4293270308)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint64) => euint64 test 1 (101, 18442938135063635285)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 101n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint64) => euint64 test 2 (97, 101)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 97n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint64) => euint64 test 3 (101, 101)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 101n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint64) => euint64 test 4 (101, 97)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 97n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, uint128) => euint128 test 1 (9223372036854775809, 9223372036854775809)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, uint128) => euint128 test 2 (9223372036854775809, 9223372036854775809)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, uint128) => euint128 test 3 (9223372036854775809, 9223372036854775809)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, uint128) => euint128 test 4 (9223372036854775809, 9223372036854775809)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "neg" overload (euint16) => euint16 test 1 (7689)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: 57847n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, uint128) => ebool test 1 (340282366920938463463371647940600324849, 340282366920938463463374407153810090079)', async function () {
@@ -376,7 +376,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, uint128) => ebool test 2 (340282366920938463463371647940600324845, 340282366920938463463371647940600324849)', async function () {
@@ -395,7 +395,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, uint128) => ebool test 3 (340282366920938463463371647940600324849, 340282366920938463463371647940600324849)', async function () {
@@ -414,7 +414,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, uint128) => ebool test 4 (340282366920938463463371647940600324849, 340282366920938463463371647940600324845)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint256) => ebool test 1 (4032139557, 115792089237316195423570985008687907853269984665640564039457581774706644990007)', async function () {
@@ -452,7 +452,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint256) => ebool test 2 (4032139553, 4032139557)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint256) => ebool test 3 (4032139557, 4032139557)', async function () {
@@ -490,7 +490,7 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint256) => ebool test 4 (4032139557, 4032139553)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 16', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations17.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations17.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, uint128) => euint128 test 2 (340282366920938463463365918437382145247, 340282366920938463463365918437382145243)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457579078708043990465)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457579503211574231019n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457576582324561149927, 115792089237316195423570985008687907853269984665640564039457576582324561149931)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149935n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457576582324561149931)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149931n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457576582324561149927)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149935n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint32) => euint32 test 1 (8250, 1102903824)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 8250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint32) => euint32 test 2 (8246, 8250)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 8246n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint32) => euint32 test 3 (8250, 8250)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 8250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint32) => euint32 test 4 (8250, 8246)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: 8246n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, uint16) => ebool test 1 (343, 59905)', async function () {
@@ -320,7 +320,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, uint16) => ebool test 2 (339, 343)', async function () {
@@ -335,7 +335,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, uint16) => ebool test 3 (343, 343)', async function () {
@@ -350,7 +350,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, uint16) => ebool test 4 (343, 339)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint8) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457580594863844092825, 91)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint8) => ebool test 2 (87, 91)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint8) => ebool test 3 (91, 91)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint8) => ebool test 4 (91, 87)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint64) => ebool test 1 (35, 18437783948050928013)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint64) => ebool test 2 (31, 35)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint64) => ebool test 3 (35, 35)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint64) => ebool test 4 (35, 31)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 17', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations18.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations18.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, uint8) => euint8 test 2 (122, 118)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint32) => ebool test 1 (1781953635, 953438497)', async function () {
@@ -164,7 +164,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint32) => ebool test 2 (953438493, 953438497)', async function () {
@@ -183,7 +183,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint32) => ebool test 3 (953438497, 953438497)', async function () {
@@ -202,7 +202,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint32) => ebool test 4 (953438497, 953438493)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint16) => euint32 test 1 (39211, 2)', async function () {
@@ -240,7 +240,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 39213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint16) => euint32 test 2 (26100, 26104)', async function () {
@@ -259,7 +259,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 52204n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint16) => euint32 test 3 (26104, 26104)', async function () {
@@ -278,7 +278,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 52208n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint16) => euint32 test 4 (26104, 26100)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 52204n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint64, uint64) => euint64 test 1 (18445728778359647479, 18445392814158246849)', async function () {
@@ -316,7 +316,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint64, uint64) => euint64 test 2 (18440111143651751757, 18440111143651751761)', async function () {
@@ -335,7 +335,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint64, uint64) => euint64 test 3 (18440111143651751761, 18440111143651751761)', async function () {
@@ -354,7 +354,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint64, uint64) => euint64 test 4 (18440111143651751761, 18440111143651751757)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint16) => ebool test 1 (553680951, 54026)', async function () {
@@ -392,7 +392,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint16) => ebool test 2 (54022, 54026)', async function () {
@@ -411,7 +411,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint16) => ebool test 3 (54026, 54026)', async function () {
@@ -430,7 +430,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint16) => ebool test 4 (54026, 54022)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint32) => euint32 test 1 (2271219408, 2271219408)', async function () {
@@ -468,7 +468,7 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint32) => euint32 test 2 (2271219408, 2271219404)', async function () {
@@ -487,6 +487,6 @@ describe('FHEVM operations 18', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations19.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations19.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint128) => ebool test 2 (194, 198)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint128) => ebool test 3 (198, 198)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint128) => ebool test 4 (198, 194)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, uint8) => euint8 test 1 (121, 7)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, uint8) => euint8 test 2 (3, 7)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, uint8) => euint8 test 3 (7, 7)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, uint8) => euint8 test 4 (7, 3)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 1 (1008, 1894332575)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 1894333439n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 2 (1004, 1008)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 1020n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 3 (1008, 1008)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 1008n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint32) => euint32 test 4 (1008, 1004)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 1020n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint128) => ebool test 1 (43, 340282366920938463463366686290379287993)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint128) => ebool test 2 (39, 43)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint128) => ebool test 3 (43, 43)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint128) => ebool test 4 (43, 39)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, uint8) => euint16 test 1 (43264, 7)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 338n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, uint8) => euint16 test 2 (3, 7)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 1536n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, uint8) => euint16 test 3 (7, 7)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 3584n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, uint8) => euint16 test 4 (7, 3)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 57344n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "neg" overload (euint64) => euint64 test 1 (18446585455408671667)', async function () {
@@ -477,6 +477,6 @@ describe('FHEVM operations 19', function () {
     const expectedRes = {
       [handle]: 158618300879949n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations2.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations2.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint8) => ebool test 2 (12, 16)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint8) => ebool test 3 (16, 16)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint8) => ebool test 4 (16, 12)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint16) => ebool test 1 (340282366920938463463370460778833589529, 53631)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint16) => ebool test 2 (53627, 53631)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint16) => ebool test 3 (53631, 53631)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint16) => ebool test 4 (53631, 53627)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint32) => euint32 test 1 (31, 2627028589)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 31n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint32) => euint32 test 2 (27, 31)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 27n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint32) => euint32 test 3 (31, 31)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 31n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint32) => euint32 test 4 (31, 27)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 27n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, uint64) => euint64 test 1 (18438676246625478911, 18445725819605010405)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 18438676246625478911n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, uint64) => euint64 test 2 (18438248006307692213, 18438248006307692217)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 18438248006307692213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, uint64) => euint64 test 3 (18438248006307692217, 18438248006307692217)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 18438248006307692217n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, uint64) => euint64 test 4 (18438248006307692217, 18438248006307692213)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 18438248006307692213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint32) => euint32 test 1 (2, 20459)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 40918n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint32) => euint32 test 2 (215, 215)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 46225n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint32) => euint32 test 3 (215, 215)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 46225n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint32) => euint32 test 4 (215, 215)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: 46225n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint128) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457579665304002193723, 340282366920938463463366269938851658819)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint128) => ebool test 2 (340282366920938463463366269938851658815, 340282366920938463463366269938851658819)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint128) => ebool test 3 (340282366920938463463366269938851658819, 340282366920938463463366269938851658819)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint128) => ebool test 4 (340282366920938463463366269938851658819, 340282366920938463463366269938851658815)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 2', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations20.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations20.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039456924011684088236799n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, euint8) => euint256 test 2 (3, 7)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, euint8) => euint256 test 3 (7, 7)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, euint8) => euint256 test 4 (7, 3)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, uint8) => euint16 test 1 (48753, 6)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 40000n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, uint8) => euint16 test 2 (2, 6)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, uint8) => euint16 test 3 (6, 6)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, uint8) => euint16 test 4 (6, 2)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 24n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint64) => ebool test 1 (17, 18439452102095684221)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint64) => ebool test 2 (13, 17)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint64) => ebool test 3 (17, 17)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint64) => ebool test 4 (17, 13)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint64) => euint64 test 1 (2, 4292880998)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 4292881000n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint64) => euint64 test 2 (632497413, 632497417)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 1264994830n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint64) => euint64 test 3 (632497417, 632497417)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 1264994834n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint64) => euint64 test 4 (632497417, 632497413)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 1264994830n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint8, euint8) => ebool test 1 (223, 248)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint8, euint8) => ebool test 2 (12, 16)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint8, euint8) => ebool test 3 (16, 16)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint8, euint8) => ebool test 4 (16, 12)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint16) => euint16 test 1 (14010, 31549)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 32703n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint16) => euint16 test 2 (14006, 14010)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 14014n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint16) => euint16 test 3 (14010, 14010)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 14010n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint16) => euint16 test 4 (14010, 14006)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 20', function () {
     const expectedRes = {
       [handle]: 14014n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations21.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations21.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 10871169355528435712n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, uint8) => euint64 test 2 (7, 11)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 14336n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, uint8) => euint64 test 3 (11, 11)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 22528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, uint8) => euint64 test 4 (11, 7)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 1408n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint256) => euint256 test 1 (138, 115792089237316195423570985008687907853269984665640564039457582022149830655347)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457582022149830655483n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint256) => euint256 test 2 (134, 138)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 142n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint256) => euint256 test 3 (138, 138)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 138n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint256) => euint256 test 4 (138, 134)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 142n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 1 (1993066230, 4102504073)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 2 (1993066226, 1993066230)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 3 (1993066230, 1993066230)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, uint32) => ebool test 4 (1993066230, 1993066226)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint128, euint128) => ebool test 1 (340282366920938463463370980851997949775, 340282366920938463463369900732334670961)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint128, euint128) => ebool test 2 (340282366920938463463369402042742166607, 340282366920938463463369402042742166611)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint128, euint128) => ebool test 3 (340282366920938463463369402042742166611, 340282366920938463463369402042742166611)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint128, euint128) => ebool test 4 (340282366920938463463369402042742166611, 340282366920938463463369402042742166607)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint8) => euint64 test 1 (129, 2)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint8) => euint64 test 2 (1, 5)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 6n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint8) => euint64 test 3 (5, 5)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 10n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint8) => euint64 test 4 (5, 1)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 6n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint8, uint8) => euint8 test 1 (181, 154)', async function () {
@@ -494,7 +494,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint8, uint8) => euint8 test 2 (177, 181)', async function () {
@@ -509,7 +509,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint8, uint8) => euint8 test 3 (181, 181)', async function () {
@@ -524,7 +524,7 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint8, uint8) => euint8 test 4 (181, 177)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 21', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations22.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations22.ts
@@ -129,7 +129,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 88n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint8) => euint64 test 1 (18440274106947621563, 178)', async function () {
@@ -148,7 +148,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 18440274106947621385n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint8) => euint64 test 2 (174, 178)', async function () {
@@ -167,7 +167,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint8) => euint64 test 3 (178, 178)', async function () {
@@ -186,7 +186,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint8) => euint64 test 4 (178, 174)', async function () {
@@ -205,7 +205,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint8) => ebool test 1 (4054356723, 142)', async function () {
@@ -224,7 +224,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint8) => ebool test 2 (138, 142)', async function () {
@@ -243,7 +243,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint8) => ebool test 3 (142, 142)', async function () {
@@ -262,7 +262,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint8) => ebool test 4 (142, 138)', async function () {
@@ -281,7 +281,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, euint8) => euint32 test 1 (14421585, 11)', async function () {
@@ -300,7 +300,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 3391101825n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, euint8) => euint32 test 2 (7, 11)', async function () {
@@ -319,7 +319,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 14680064n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, euint8) => euint32 test 3 (11, 11)', async function () {
@@ -338,7 +338,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 23068672n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, euint8) => euint32 test 4 (11, 7)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 369098752n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint32) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457580312633437710753, 3927831061)', async function () {
@@ -376,7 +376,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580312634645674933n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint32) => euint256 test 2 (3927831057, 3927831061)', async function () {
@@ -395,7 +395,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 3927831061n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint32) => euint256 test 3 (3927831061, 3927831061)', async function () {
@@ -414,7 +414,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 3927831061n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint32) => euint256 test 4 (3927831061, 3927831057)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 3927831061n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint16) => euint16 test 1 (194, 29358)', async function () {
@@ -452,7 +452,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 29358n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint16) => euint16 test 2 (190, 194)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 194n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint16) => euint16 test 3 (194, 194)', async function () {
@@ -490,7 +490,7 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 194n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint16) => euint16 test 4 (194, 190)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 22', function () {
     const expectedRes = {
       [handle]: 194n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations23.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations23.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint128) => ebool test 2 (154, 158)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint128) => ebool test 3 (158, 158)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint128) => ebool test 4 (158, 154)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, uint8) => euint8 test 1 (109, 7)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 218n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, uint8) => euint8 test 2 (3, 7)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 6n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, uint8) => euint8 test 3 (7, 7)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 14n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, uint8) => euint8 test 4 (7, 3)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 224n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, uint8) => ebool test 1 (52, 97)', async function () {
@@ -266,7 +266,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, uint8) => ebool test 2 (48, 52)', async function () {
@@ -281,7 +281,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, uint8) => ebool test 3 (52, 52)', async function () {
@@ -296,7 +296,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, uint8) => ebool test 4 (52, 48)', async function () {
@@ -311,7 +311,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, uint64) => euint64 test 1 (18444237080447470479, 18443180247415512627)', async function () {
@@ -330,7 +330,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18444237080447470479n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, uint64) => euint64 test 2 (18439875117400843375, 18439875117400843379)', async function () {
@@ -349,7 +349,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, uint64) => euint64 test 3 (18439875117400843379, 18439875117400843379)', async function () {
@@ -368,7 +368,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, uint64) => euint64 test 4 (18439875117400843379, 18439875117400843375)', async function () {
@@ -387,7 +387,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint16) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457579311607985811765, 30219)', async function () {
@@ -406,7 +406,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457579311607985829695n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint16) => euint256 test 2 (30215, 30219)', async function () {
@@ -425,7 +425,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 30223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint16) => euint256 test 3 (30219, 30219)', async function () {
@@ -444,7 +444,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 30219n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint16) => euint256 test 4 (30219, 30215)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 30223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint64) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457577215480610259831, 18441662610641197675)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457579502663142185855n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint64) => euint256 test 2 (18441662610641197671, 18441662610641197675)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18441662610641197679n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint64) => euint256 test 3 (18441662610641197675, 18441662610641197675)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18441662610641197675n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint64) => euint256 test 4 (18441662610641197675, 18441662610641197671)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 23', function () {
     const expectedRes = {
       [handle]: 18441662610641197679n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations24.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations24.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint128) => ebool test 2 (41, 45)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint128) => ebool test 3 (45, 45)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint128) => ebool test 4 (45, 41)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, euint8) => euint64 test 1 (18440947267520683999, 10)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 18008737565938167n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, euint8) => euint64 test 2 (6, 10)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, euint8) => euint64 test 3 (10, 10)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, euint8) => euint64 test 4 (10, 6)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint64) => ebool test 1 (4116801001, 18440333254436216765)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint64) => ebool test 2 (4116800997, 4116801001)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint64) => ebool test 3 (4116801001, 4116801001)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint64) => ebool test 4 (4116801001, 4116800997)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, euint8) => euint8 test 1 (51, 7)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, euint8) => euint8 test 2 (3, 7)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, euint8) => euint8 test 3 (7, 7)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, euint8) => euint8 test 4 (7, 3)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint32) => ebool test 1 (30305, 3068076784)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint32) => ebool test 2 (30301, 30305)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint32) => ebool test 3 (30305, 30305)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint32) => ebool test 4 (30305, 30301)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint8) => euint16 test 1 (58083, 134)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 58083n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint8) => euint16 test 2 (130, 134)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 134n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint8) => euint16 test 3 (134, 134)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 134n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint8) => euint16 test 4 (134, 130)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 24', function () {
     const expectedRes = {
       [handle]: 134n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations25.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations25.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 163n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint8) => euint8 test 2 (110, 114)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint8) => euint8 test 3 (114, 114)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint8) => euint8 test 4 (114, 110)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint32) => euint128 test 1 (340282366920938463463369548480073312465, 2620915545)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369548482626977753n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint32) => euint128 test 2 (2620915541, 2620915545)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 2620915549n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint32) => euint128 test 3 (2620915545, 2620915545)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 2620915545n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint32) => euint128 test 4 (2620915545, 2620915541)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 2620915549n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint32) => euint32 test 1 (3255063189, 3680535027)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 3680818167n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint32) => euint32 test 2 (3255063185, 3255063189)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint32) => euint32 test 3 (3255063189, 3255063189)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint32) => euint32 test 4 (3255063189, 3255063185)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint128, euint128) => ebool test 1 (340282366920938463463367335436832144223, 340282366920938463463367507822160253739)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint128, euint128) => ebool test 2 (340282366920938463463370396677631502119, 340282366920938463463370396677631502123)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint128, euint128) => ebool test 3 (340282366920938463463370396677631502123, 340282366920938463463370396677631502123)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint128, euint128) => ebool test 4 (340282366920938463463370396677631502123, 340282366920938463463370396677631502119)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint32) => ebool test 1 (135, 1934578914)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint32) => ebool test 2 (131, 135)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint32) => ebool test 3 (135, 135)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint32) => ebool test 4 (135, 131)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint64) => euint64 test 1 (1962491324, 18443279805502846233)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 18443279806590746045n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint64) => euint64 test 2 (1962491320, 1962491324)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 1962491324n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint64) => euint64 test 3 (1962491324, 1962491324)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 1962491324n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint64) => euint64 test 4 (1962491324, 1962491320)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 25', function () {
     const expectedRes = {
       [handle]: 1962491324n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations26.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations26.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint128) => ebool test 2 (340282366920938463463369926229248711471, 340282366920938463463369926229248711475)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint128) => ebool test 3 (340282366920938463463369926229248711475, 340282366920938463463369926229248711475)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint128) => ebool test 4 (340282366920938463463369926229248711475, 340282366920938463463369926229248711471)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint16) => euint32 test 1 (2321629392, 21828)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 21828n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint16) => euint32 test 2 (21824, 21828)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 21824n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint16) => euint32 test 3 (21828, 21828)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 21828n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint16) => euint32 test 4 (21828, 21824)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 21824n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint128) => euint128 test 1 (83, 340282366920938463463372481355988654629)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint128) => euint128 test 2 (79, 83)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 67n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint128) => euint128 test 3 (83, 83)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 83n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint128) => euint128 test 4 (83, 79)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: 67n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, uint256) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457578709698494561291)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, uint256) => ebool test 2 (115792089237316195423570985008687907853269984665640564039457575496626475170537, 115792089237316195423570985008687907853269984665640564039457575496626475170541)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, uint256) => ebool test 3 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457575496626475170541)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, uint256) => ebool test 4 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457575496626475170537)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, uint256) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457583034685916919557)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, uint256) => ebool test 2 (115792089237316195423570985008687907853269984665640564039457576299642184965501, 115792089237316195423570985008687907853269984665640564039457576299642184965505)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, uint256) => ebool test 3 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457576299642184965505)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, uint256) => ebool test 4 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457576299642184965501)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint8) => ebool test 1 (4070953825, 200)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint8) => ebool test 2 (196, 200)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint8) => ebool test 3 (200, 200)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint8) => ebool test 4 (200, 196)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 26', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations27.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations27.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 41000n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint16, euint16) => euint16 test 2 (26704, 26708)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 53412n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint16, euint16) => euint16 test 3 (26708, 26708)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 53416n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint16, euint16) => euint16 test 4 (26708, 26704)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 53412n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457579784451205796137, 30)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457579784451205796151n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint8) => euint256 test 2 (26, 30)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint8) => euint256 test 3 (30, 30)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint8) => euint256 test 4 (30, 26)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, uint8) => euint32 test 1 (1808540925, 10)', async function () {
@@ -266,7 +266,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 815003055n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, uint8) => euint32 test 2 (6, 10)', async function () {
@@ -281,7 +281,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 6144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, uint8) => euint32 test 3 (10, 10)', async function () {
@@ -296,7 +296,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 10240n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, uint8) => euint32 test 4 (10, 6)', async function () {
@@ -311,7 +311,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 640n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint16, euint16) => ebool test 1 (956, 1886)', async function () {
@@ -326,7 +326,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint16, euint16) => ebool test 2 (40292, 40296)', async function () {
@@ -341,7 +341,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint16, euint16) => ebool test 3 (40296, 40296)', async function () {
@@ -356,7 +356,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint16, euint16) => ebool test 4 (40296, 40292)', async function () {
@@ -371,7 +371,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint32) => ebool test 1 (2055001263, 3533790669)', async function () {
@@ -390,7 +390,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint32) => ebool test 2 (2055001259, 2055001263)', async function () {
@@ -409,7 +409,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint32) => ebool test 3 (2055001263, 2055001263)', async function () {
@@ -428,7 +428,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint32) => ebool test 4 (2055001263, 2055001259)', async function () {
@@ -447,7 +447,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint256, euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457582635183639760315, 115792089237316195423570985008687907853269984665640564039457579406779472183961)', async function () {
@@ -466,7 +466,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 5832675456356130n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint256, euint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457579868021624684047, 115792089237316195423570985008687907853269984665640564039457579868021624684051)', async function () {
@@ -485,7 +485,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint256, euint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579868021624684051)', async function () {
@@ -504,7 +504,7 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint256, euint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579868021624684047)', async function () {
@@ -523,6 +523,6 @@ describe('FHEVM operations 27', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations28.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations28.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint16, euint16) => ebool test 2 (339, 343)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint16, euint16) => ebool test 3 (343, 343)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint16, euint16) => ebool test 4 (343, 339)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint16, euint16) => euint16 test 1 (15445, 21508)', async function () {
@@ -190,7 +190,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 31829n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint16, euint16) => euint16 test 2 (14006, 14010)', async function () {
@@ -205,7 +205,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 14014n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint16, euint16) => euint16 test 3 (14010, 14010)', async function () {
@@ -220,7 +220,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 14010n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint16, euint16) => euint16 test 4 (14010, 14006)', async function () {
@@ -235,7 +235,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 14014n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint16) => ebool test 1 (2638127792, 35811)', async function () {
@@ -254,7 +254,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint16) => ebool test 2 (35807, 35811)', async function () {
@@ -273,7 +273,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint16) => ebool test 3 (35811, 35811)', async function () {
@@ -292,7 +292,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint16) => ebool test 4 (35811, 35807)', async function () {
@@ -311,7 +311,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint128) => euint128 test 1 (1955717294, 340282366920938463463373077736107427779)', async function () {
@@ -330,7 +330,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373077736107427779n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint128) => euint128 test 2 (1955717290, 1955717294)', async function () {
@@ -349,7 +349,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 1955717294n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint128) => euint128 test 3 (1955717294, 1955717294)', async function () {
@@ -368,7 +368,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 1955717294n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint128) => euint128 test 4 (1955717294, 1955717290)', async function () {
@@ -387,7 +387,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 1955717294n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint64) => euint64 test 1 (2, 2147282837)', async function () {
@@ -406,7 +406,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 4294565674n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint64) => euint64 test 2 (51395, 51395)', async function () {
@@ -425,7 +425,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 2641446025n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint64) => euint64 test 3 (51395, 51395)', async function () {
@@ -444,7 +444,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 2641446025n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint64) => euint64 test 4 (51395, 51395)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: 2641446025n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint128) => ebool test 1 (826899508, 340282366920938463463368547529794967735)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint128) => ebool test 2 (826899504, 826899508)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint128) => ebool test 3 (826899508, 826899508)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint128) => ebool test 4 (826899508, 826899504)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 28', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations29.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations29.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228752n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint32) => euint32 test 2 (122228748, 122228752)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228748n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint32) => euint32 test 3 (122228752, 122228752)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228752n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint32) => euint32 test 4 (122228752, 122228748)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228748n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint256) => euint256 test 1 (1277117352, 115792089237316195423570985008687907853269984665640564039457579905215275436293)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457579905216484985773n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint256) => euint256 test 2 (1277117348, 1277117352)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 1277117356n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint256) => euint256 test 3 (1277117352, 1277117352)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 1277117352n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint256) => euint256 test 4 (1277117352, 1277117348)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 1277117356n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint32) => euint128 test 1 (340282366920938463463370051199076222007, 1774132872)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 340282366920938463463370051197339589311n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint32) => euint128 test 2 (1774132868, 1774132872)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint32) => euint128 test 3 (1774132872, 1774132872)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint32) => euint128 test 4 (1774132872, 1774132868)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 1 (1441663254, 422146200)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 422146200n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 2 (122228748, 122228752)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228748n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 3 (122228752, 122228752)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228752n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, uint32) => euint32 test 4 (122228752, 122228748)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 122228748n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, uint64) => euint64 test 1 (18443816109613900561, 18437955621632859185)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 18443894119169261361n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, uint64) => euint64 test 2 (18442438487998006519, 18442438487998006523)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 18442438487998006527n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, uint64) => euint64 test 3 (18442438487998006523, 18442438487998006523)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 18442438487998006523n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, uint64) => euint64 test 4 (18442438487998006523, 18442438487998006519)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: 18442438487998006527n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint16) => ebool test 1 (1668873362, 20146)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint16) => ebool test 2 (20142, 20146)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint16) => ebool test 3 (20146, 20146)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint16) => ebool test 4 (20146, 20142)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 29', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations3.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations3.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint32) => ebool test 2 (1412, 1416)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint32) => ebool test 3 (1416, 1416)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint32) => ebool test 4 (1416, 1412)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, uint128) => euint128 test 1 (340282366920938463463370663230474381789, 340282366920938463463368162365024047043)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 7009368991884830n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, uint128) => euint128 test 2 (340282366920938463463366711241836032013, 340282366920938463463366711241836032017)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, uint128) => euint128 test 3 (340282366920938463463366711241836032017, 340282366920938463463366711241836032017)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, uint128) => euint128 test 4 (340282366920938463463366711241836032017, 340282366920938463463366711241836032013)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint16) => ebool test 1 (340282366920938463463373061358223662361, 20178)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint16) => ebool test 2 (20174, 20178)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint16) => ebool test 3 (20178, 20178)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint16) => ebool test 4 (20178, 20174)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint32) => euint32 test 1 (152, 1436102497)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 1436102497n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint32) => euint32 test 2 (148, 152)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 152n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint32) => euint32 test 3 (152, 152)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 152n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint32) => euint32 test 4 (152, 148)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 152n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint64) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457575420275373658947, 18440351101654254241)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint64) => ebool test 2 (18440351101654254237, 18440351101654254241)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint64) => ebool test 3 (18440351101654254241, 18440351101654254241)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint64) => ebool test 4 (18440351101654254241, 18440351101654254237)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint64) => euint64 test 1 (43322, 18442679401548286127)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 2090n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint64) => euint64 test 2 (43318, 43322)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 43314n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint64) => euint64 test 3 (43322, 43322)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 43322n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint64) => euint64 test 4 (43322, 43318)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 3', function () {
     const expectedRes = {
       [handle]: 43314n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations30.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations30.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 220n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint16) => euint16 test 2 (10, 10)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 100n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint16) => euint16 test 3 (10, 10)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 100n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint16) => euint16 test 4 (10, 10)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 100n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint32) => euint32 test 1 (241, 1712999619)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 1712999667n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint32) => euint32 test 2 (237, 241)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 253n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint32) => euint32 test 3 (241, 241)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 241n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint32) => euint32 test 4 (241, 237)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 253n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint8) => ebool test 1 (53755, 122)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint8) => ebool test 2 (118, 122)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint8) => ebool test 3 (122, 122)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint8) => ebool test 4 (122, 118)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint128, euint128) => ebool test 1 (340282366920938463463366301134497944171, 340282366920938463463372126018431653325)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint128, euint128) => ebool test 2 (340282366920938463463369926229248711471, 340282366920938463463369926229248711475)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint128, euint128) => ebool test 3 (340282366920938463463369926229248711475, 340282366920938463463369926229248711475)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint128, euint128) => ebool test 4 (340282366920938463463369926229248711475, 340282366920938463463369926229248711471)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint128) => euint128 test 1 (2, 1073741825)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 2147483650n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint128) => euint128 test 2 (45558, 45558)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 2075531364n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint128) => euint128 test 3 (45558, 45558)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 2075531364n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint128) => euint128 test 4 (45558, 45558)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 2075531364n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint32) => euint32 test 1 (2203566275, 242006180)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 2203566275n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint32) => euint32 test 2 (242006176, 242006180)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint32) => euint32 test 3 (242006180, 242006180)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint32) => euint32 test 4 (242006180, 242006176)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 30', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations31.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations31.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 1809251394333065553493296640760748560207343510400633813116524727616435418608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, uint8) => euint256 test 2 (2, 6)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, uint8) => euint256 test 3 (6, 6)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, uint8) => euint256 test 4 (6, 2)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, uint8) => euint8 test 1 (59, 114)', async function () {
@@ -190,7 +190,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 173n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, uint8) => euint8 test 2 (55, 59)', async function () {
@@ -205,7 +205,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, uint8) => euint8 test 3 (59, 59)', async function () {
@@ -220,7 +220,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 118n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, uint8) => euint8 test 4 (59, 55)', async function () {
@@ -235,7 +235,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint32) => ebool test 1 (965, 394880461)', async function () {
@@ -254,7 +254,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint32) => ebool test 2 (961, 965)', async function () {
@@ -273,7 +273,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint32) => ebool test 3 (965, 965)', async function () {
@@ -292,7 +292,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint32) => ebool test 4 (965, 961)', async function () {
@@ -311,7 +311,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, uint32) => ebool test 1 (3612466835, 1900346676)', async function () {
@@ -330,7 +330,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, uint32) => ebool test 2 (1070970940, 1070970944)', async function () {
@@ -349,7 +349,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, uint32) => ebool test 3 (1070970944, 1070970944)', async function () {
@@ -368,7 +368,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, uint32) => ebool test 4 (1070970944, 1070970940)', async function () {
@@ -387,7 +387,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint32) => ebool test 1 (18441815682018588575, 316906102)', async function () {
@@ -406,7 +406,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint32) => ebool test 2 (316906098, 316906102)', async function () {
@@ -425,7 +425,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint32) => ebool test 3 (316906102, 316906102)', async function () {
@@ -444,7 +444,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint32) => ebool test 4 (316906102, 316906098)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint32) => euint32 test 1 (948248716, 640520667)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 514371927n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint32) => euint32 test 2 (640520663, 640520667)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint32) => euint32 test 3 (640520667, 640520667)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint32) => euint32 test 4 (640520667, 640520663)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 31', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations32.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations32.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457582393614541182916n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint16) => euint256 test 2 (14773, 14777)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint16) => euint256 test 3 (14777, 14777)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint16) => euint256 test 4 (14777, 14773)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, uint8) => ebool test 1 (139, 223)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, uint8) => ebool test 2 (94, 98)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, uint8) => ebool test 3 (98, 98)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, uint8) => ebool test 4 (98, 94)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint8) => euint32 test 1 (2298989665, 184)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 2298989665n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint8) => euint32 test 2 (180, 184)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 184n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint8) => euint32 test 3 (184, 184)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 184n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint8) => euint32 test 4 (184, 180)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 184n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint128) => euint128 test 1 (340282366920938463463370663230474381789, 340282366920938463463366711241836032017)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 5082699043051980n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint128) => euint128 test 2 (340282366920938463463366711241836032013, 340282366920938463463366711241836032017)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint128) => euint128 test 3 (340282366920938463463366711241836032017, 340282366920938463463366711241836032017)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint128) => euint128 test 4 (340282366920938463463366711241836032017, 340282366920938463463366711241836032013)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint128) => euint128 test 1 (43277, 340282366920938463463366028728426237263)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366028728426278223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint128) => euint128 test 2 (43273, 43277)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 43277n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint128) => euint128 test 3 (43277, 43277)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 43277n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint128) => euint128 test 4 (43277, 43273)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: 43277n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, uint128) => ebool test 1 (340282366920938463463369926229248711475, 340282366920938463463372126018431653325)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, uint128) => ebool test 2 (340282366920938463463369926229248711471, 340282366920938463463369926229248711475)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, uint128) => ebool test 3 (340282366920938463463369926229248711475, 340282366920938463463369926229248711475)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, uint128) => ebool test 4 (340282366920938463463369926229248711475, 340282366920938463463369926229248711471)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 32', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations33.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations33.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint256, euint256) => ebool test 2 (115792089237316195423570985008687907853269984665640564039457575496626475170537, 115792089237316195423570985008687907853269984665640564039457575496626475170541)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint256, euint256) => ebool test 3 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457575496626475170541)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint256, euint256) => ebool test 4 (115792089237316195423570985008687907853269984665640564039457575496626475170541, 115792089237316195423570985008687907853269984665640564039457575496626475170537)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "not" overload (euint8) => euint8 test 1 (109)', async function () {
@@ -205,7 +205,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 146n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint64) => euint128 test 1 (340282366920938463463367468006661140089, 18438522459626149825)', async function () {
@@ -224,7 +224,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 18438522459626149825n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint64) => euint128 test 2 (18438522459626149821, 18438522459626149825)', async function () {
@@ -243,7 +243,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 18438522459626149821n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint64) => euint128 test 3 (18438522459626149825, 18438522459626149825)', async function () {
@@ -262,7 +262,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 18438522459626149825n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint64) => euint128 test 4 (18438522459626149825, 18438522459626149821)', async function () {
@@ -281,7 +281,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 18438522459626149821n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint16) => euint64 test 1 (32754, 2)', async function () {
@@ -300,7 +300,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 65508n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint16) => euint64 test 2 (212, 212)', async function () {
@@ -319,7 +319,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 44944n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint16) => euint64 test 3 (212, 212)', async function () {
@@ -338,7 +338,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 44944n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint16) => euint64 test 4 (212, 212)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: 44944n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint8) => ebool test 1 (52, 166)', async function () {
@@ -376,7 +376,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint8) => ebool test 2 (48, 52)', async function () {
@@ -395,7 +395,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint8) => ebool test 3 (52, 52)', async function () {
@@ -414,7 +414,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint8) => ebool test 4 (52, 48)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint8) => ebool test 1 (43195, 201)', async function () {
@@ -452,7 +452,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint8) => ebool test 2 (197, 201)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint8) => ebool test 3 (201, 201)', async function () {
@@ -490,7 +490,7 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint8) => ebool test 4 (201, 197)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 33', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations34.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations34.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 18443024959750531909n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint8) => euint64 test 2 (175, 179)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 179n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint8) => euint64 test 3 (179, 179)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 179n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint8) => euint64 test 4 (179, 175)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 179n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint64) => euint64 test 1 (4294910698, 4293270308)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 18439212575234954984n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint64) => euint64 test 2 (4293270308, 4293270308)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint64) => euint64 test 3 (4293270308, 4293270308)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint64) => euint64 test 4 (4293270308, 4293270308)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint8) => ebool test 1 (33110, 91)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint8) => ebool test 2 (87, 91)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint8) => ebool test 3 (91, 91)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint8) => ebool test 4 (91, 87)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint16) => euint16 test 1 (26708, 35931)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 62639n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint16) => euint16 test 2 (26704, 26708)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 53412n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint16) => euint16 test 3 (26708, 26708)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 53416n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint16) => euint16 test 4 (26708, 26704)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 53412n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, uint16) => euint16 test 1 (5514, 51030)', async function () {
@@ -434,7 +434,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 51030n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, uint16) => euint16 test 2 (5510, 5514)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, uint16) => euint16 test 3 (5514, 5514)', async function () {
@@ -464,7 +464,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, uint16) => euint16 test 4 (5514, 5510)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint16) => euint128 test 1 (26648, 26648)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint16) => euint128 test 2 (26648, 26644)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 34', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations35.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations35.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 170141183460469231731687261769499047604n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, euint8) => euint128 test 2 (2, 6)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 10633823966279326983230456482242756608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, euint8) => euint128 test 3 (6, 6)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 31901471898837980949691369446728269824n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, euint8) => euint128 test 4 (6, 2)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 170141183460469231731687303715884105729n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint32) => ebool test 1 (39088, 2074460100)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint32) => ebool test 2 (39084, 39088)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint32) => ebool test 3 (39088, 39088)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint32) => ebool test 4 (39088, 39084)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint32) => ebool test 1 (340282366920938463463370218243556235431, 4084356301)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint32) => ebool test 2 (4084356297, 4084356301)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint32) => ebool test 3 (4084356301, 4084356301)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint32) => ebool test 4 (4084356301, 4084356297)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint8) => euint128 test 1 (104, 104)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint8) => euint128 test 2 (104, 100)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint32) => ebool test 1 (2247755504, 1603469843)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint32) => ebool test 2 (1603469839, 1603469843)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint32) => ebool test 3 (1603469843, 1603469843)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint32) => ebool test 4 (1603469843, 1603469839)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, uint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457577185211424459481, 7)', async function () {
@@ -472,7 +472,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039456710702094866541696n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, uint8) => euint256 test 2 (3, 7)', async function () {
@@ -487,7 +487,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, uint8) => euint256 test 3 (7, 7)', async function () {
@@ -502,7 +502,7 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, uint8) => euint256 test 4 (7, 3)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 35', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations36.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations36.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint64) => ebool test 2 (3, 7)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint64) => ebool test 3 (7, 7)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint64) => ebool test 4 (7, 3)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint128) => euint128 test 1 (20785, 340282366920938463463370165118407004449)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 20785n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint128) => euint128 test 2 (20781, 20785)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 20781n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint128) => euint128 test 3 (20785, 20785)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 20785n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint128) => euint128 test 4 (20785, 20781)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 20781n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 1 (2761556437, 1083505052)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 2761556437n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 2 (242006176, 242006180)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 3 (242006180, 242006180)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint32, euint32) => euint32 test 4 (242006180, 242006176)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint32) => ebool test 1 (1993066230, 3336778048)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint32) => ebool test 2 (1993066226, 1993066230)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint32) => ebool test 3 (1993066230, 1993066230)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint32) => ebool test 4 (1993066230, 1993066226)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, uint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579406779472183961)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 8705389549370506n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, uint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457579868021624684047, 115792089237316195423570985008687907853269984665640564039457579868021624684051)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, uint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579868021624684051)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, uint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579868021624684047)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint64) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457575486637890877703, 18443967652537936061)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039439143908386058113466n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint64) => euint256 test 2 (18443967652537936057, 18443967652537936061)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint64) => euint256 test 3 (18443967652537936061, 18443967652537936061)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint64) => euint256 test 4 (18443967652537936061, 18443967652537936057)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 36', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations37.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations37.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint64, euint64) => ebool test 2 (18441516720181759759, 18441516720181759763)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint64, euint64) => ebool test 3 (18441516720181759763, 18441516720181759763)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint64, euint64) => ebool test 4 (18441516720181759763, 18441516720181759759)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint32) => euint32 test 1 (77, 4208934522)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 72n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint32) => euint32 test 2 (73, 77)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 73n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint32) => euint32 test 3 (77, 77)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 77n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint32) => euint32 test 4 (77, 73)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 73n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint32) => ebool test 1 (82, 3078038606)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint32) => ebool test 2 (78, 82)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint32) => ebool test 3 (82, 82)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint32) => ebool test 4 (82, 78)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint128) => euint128 test 1 (2334444195, 2334444195)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint128) => euint128 test 2 (2334444195, 2334444191)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint16, euint16) => euint16 test 1 (27034, 54305)', async function () {
@@ -396,7 +396,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 27034n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint16, euint16) => euint16 test 2 (41764, 41768)', async function () {
@@ -411,7 +411,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 41764n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint16, euint16) => euint16 test 3 (41768, 41768)', async function () {
@@ -426,7 +426,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 41768n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint16, euint16) => euint16 test 4 (41768, 41764)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 41764n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, uint8) => euint8 test 1 (194, 5)', async function () {
@@ -456,7 +456,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 88n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, uint8) => euint8 test 2 (1, 5)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 32n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, uint8) => euint8 test 3 (5, 5)', async function () {
@@ -486,7 +486,7 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 160n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, uint8) => euint8 test 4 (5, 1)', async function () {
@@ -501,6 +501,6 @@ describe('FHEVM operations 37', function () {
     const expectedRes = {
       [handle]: 10n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations38.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations38.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 272367873n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint128) => euint128 test 2 (1350314269, 1350314273)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 1350314241n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint128) => euint128 test 3 (1350314273, 1350314273)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 1350314273n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint128) => euint128 test 4 (1350314273, 1350314269)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 1350314241n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 1 (1348456077, 2401584102)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 2 (742459884, 742459888)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 3 (742459888, 742459888)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, uint32) => ebool test 4 (742459888, 742459884)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint64, euint64) => euint64 test 1 (18440829243277354959, 18437858841139870577)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 18437856085838570305n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint64, euint64) => euint64 test 2 (18443935695415273509, 18443935695415273513)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 18443935695415273505n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint64, euint64) => euint64 test 3 (18443935695415273513, 18443935695415273513)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 18443935695415273513n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint64, euint64) => euint64 test 4 (18443935695415273513, 18443935695415273509)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 18443935695415273505n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint8) => euint128 test 1 (340282366920938463463371748264174849215, 200)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 200n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint8) => euint128 test 2 (196, 200)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint8) => euint128 test 3 (200, 200)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 200n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint8) => euint128 test 4 (200, 196)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint128) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457578004725577418833, 340282366920938463463368237915469516165)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907852929702298719625575994210511901084747220n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint128) => euint256 test 2 (340282366920938463463368237915469516161, 340282366920938463463368237915469516165)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint128) => euint256 test 3 (340282366920938463463368237915469516165, 340282366920938463463368237915469516165)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint128) => euint256 test 4 (340282366920938463463368237915469516165, 340282366920938463463368237915469516161)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint64) => ebool test 1 (18446128337109479365, 18441120945513043033)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint64) => ebool test 2 (18441120945513043029, 18441120945513043033)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint64) => ebool test 3 (18441120945513043033, 18441120945513043033)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint64) => ebool test 4 (18441120945513043033, 18441120945513043029)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 38', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations39.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations39.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint64) => ebool test 2 (18443626937865458459, 18443626937865458463)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint64) => ebool test 3 (18443626937865458463, 18443626937865458463)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint64) => ebool test 4 (18443626937865458463, 18443626937865458459)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint64) => euint64 test 1 (15, 18439609981023544053)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 18439609981023544053n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint64) => euint64 test 2 (11, 15)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 15n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint64) => euint64 test 3 (15, 15)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 15n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint64) => euint64 test 4 (15, 11)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 15n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint16) => euint128 test 1 (16385, 2)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 32770n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint16) => euint128 test 2 (199, 199)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 39601n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint16) => euint128 test 3 (199, 199)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 39601n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint16) => euint128 test 4 (199, 199)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 39601n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint32) => euint128 test 1 (2147483649, 2)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 2147483651n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint32) => euint128 test 2 (468914479, 468914483)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 937828962n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint32) => euint128 test 3 (468914483, 468914483)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 937828966n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint32) => euint128 test 4 (468914483, 468914479)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 937828962n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint16) => euint16 test 1 (42893, 26118)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 9732n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint16) => euint16 test 2 (26114, 26118)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 26114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint16) => euint16 test 3 (26118, 26118)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 26118n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint16) => euint16 test 4 (26118, 26114)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 26114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, uint8) => euint32 test 1 (14421585, 11)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 3391101825n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, uint8) => euint32 test 2 (7, 11)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 14680064n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, uint8) => euint32 test 3 (11, 11)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 23068672n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint32, uint8) => euint32 test 4 (11, 7)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 39', function () {
     const expectedRes = {
       [handle]: 369098752n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations4.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations4.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 18439082174920877421n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, uint64) => euint64 test 2 (9219094923281824693, 9219094923281824695)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 18438189846563649388n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, uint64) => euint64 test 3 (9219094923281824695, 9219094923281824695)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 18438189846563649390n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, uint64) => euint64 test 4 (9219094923281824695, 9219094923281824693)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 18438189846563649388n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint16) => euint32 test 1 (1036813849, 57146)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 1036813849n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint16) => euint32 test 2 (57142, 57146)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 57146n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint16) => euint32 test 3 (57146, 57146)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 57146n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint16) => euint32 test 4 (57146, 57142)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 57146n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint64) => euint64 test 1 (1684651265, 18440201580658536803)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 18440201580658536803n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint64) => euint64 test 2 (1684651261, 1684651265)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 1684651265n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint64) => euint64 test 3 (1684651265, 1684651265)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 1684651265n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, euint64) => euint64 test 4 (1684651265, 1684651261)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 1684651265n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint128) => euint128 test 1 (2, 129)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint128) => euint128 test 2 (83, 85)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 168n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint128) => euint128 test 3 (85, 85)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 170n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint128) => euint128 test 4 (85, 83)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 168n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint16) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457575838439338352731, 22223)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint16) => ebool test 2 (22219, 22223)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint16) => ebool test 3 (22223, 22223)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint16) => ebool test 4 (22223, 22219)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, uint16) => euint16 test 1 (51782, 54305)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 51782n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, uint16) => euint16 test 2 (41764, 41768)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 41764n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, uint16) => euint16 test 3 (41768, 41768)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 41768n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, uint16) => euint16 test 4 (41768, 41764)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 4', function () {
     const expectedRes = {
       [handle]: 41764n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations40.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations40.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint8) => euint8 test 2 (105, 109)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 105n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint8) => euint8 test 3 (109, 109)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 109n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint8) => euint8 test 4 (109, 105)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 105n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, euint8) => euint16 test 1 (7904, 9)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 49213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, euint8) => euint16 test 2 (5, 9)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 2560n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, euint8) => euint16 test 3 (9, 9)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 4608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, euint8) => euint16 test 4 (9, 5)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 288n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint8) => euint64 test 1 (18443658458842342439, 77)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 77n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint8) => euint64 test 2 (73, 77)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 73n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint8) => euint64 test 3 (77, 77)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 77n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint8) => euint64 test 4 (77, 73)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 73n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint8, euint8) => euint8 test 1 (14, 42)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 42n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint8, euint8) => euint8 test 2 (110, 114)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint8, euint8) => euint8 test 3 (114, 114)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint8, euint8) => euint8 test 4 (114, 110)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, uint64) => ebool test 1 (18437759487138436563, 18443248756432934313)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, uint64) => ebool test 2 (18437759487138436559, 18437759487138436563)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, uint64) => ebool test 3 (18437759487138436563, 18437759487138436563)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, uint64) => ebool test 4 (18437759487138436563, 18437759487138436559)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint128, euint128) => euint128 test 1 (340282366920938463463365988352988897707, 340282366920938463463368162365024047043)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 2386767570824808n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint128, euint128) => euint128 test 2 (340282366920938463463366711241836032013, 340282366920938463463366711241836032017)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint128, euint128) => euint128 test 3 (340282366920938463463366711241836032017, 340282366920938463463366711241836032017)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint128, euint128) => euint128 test 4 (340282366920938463463366711241836032017, 340282366920938463463366711241836032013)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 40', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations41.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations41.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint8) => ebool test 2 (236, 240)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint8) => ebool test 3 (240, 240)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint8) => ebool test 4 (240, 236)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint64) => ebool test 1 (1607505328, 18439061763696634815)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint64) => ebool test 2 (1607505324, 1607505328)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint64) => ebool test 3 (1607505328, 1607505328)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint64) => ebool test 4 (1607505328, 1607505324)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint8) => euint128 test 1 (65, 2)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 130n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint8) => euint128 test 2 (11, 11)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint8) => euint128 test 3 (11, 11)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint8) => euint128 test 4 (11, 11)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint16, euint16) => euint16 test 1 (138, 296)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 40848n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint16, euint16) => euint16 test 2 (246, 246)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint16, euint16) => euint16 test 3 (246, 246)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint16, euint16) => euint16 test 4 (246, 246)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint128) => ebool test 1 (3132633856, 340282366920938463463373827233209083743)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint128) => ebool test 2 (3132633852, 3132633856)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint128) => ebool test 3 (3132633856, 3132633856)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint128) => ebool test 4 (3132633856, 3132633852)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint32) => ebool test 1 (340282366920938463463371824839409858059, 3617325420)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint32) => ebool test 2 (3617325416, 3617325420)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint32) => ebool test 3 (3617325420, 3617325420)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint32) => ebool test 4 (3617325420, 3617325416)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 41', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations42.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations42.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 159n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint8) => euint64 test 2 (219, 223)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 219n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint8) => euint64 test 3 (223, 223)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint8) => euint64 test 4 (223, 219)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 219n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint64) => ebool test 1 (244, 18445824787124991399)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint64) => ebool test 2 (240, 244)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint64) => ebool test 3 (244, 244)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint64) => ebool test 4 (244, 240)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint8) => ebool test 1 (340282366920938463463371695963490850451, 250)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint8) => ebool test 2 (246, 250)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint8) => ebool test 3 (250, 250)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint8) => ebool test 4 (250, 246)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint64) => euint128 test 1 (340282366920938463463368003169355132215, 18442257005065484651)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 340282366920938463444934766632145671260n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint64) => euint128 test 2 (18442257005065484647, 18442257005065484651)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint64) => euint128 test 3 (18442257005065484651, 18442257005065484651)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint64) => euint128 test 4 (18442257005065484651, 18442257005065484647)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint16) => ebool test 1 (340282366920938463463366240074400215665, 46240)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint16) => ebool test 2 (46236, 46240)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint16) => ebool test 3 (46240, 46240)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint16) => ebool test 4 (46240, 46236)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, euint8) => euint128 test 1 (340282366920938463463367825108556783067, 11)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 340282366920938463449484409494762870784n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, euint8) => euint128 test 2 (7, 11)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 14336n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, euint8) => euint128 test 3 (11, 11)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 22528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, euint8) => euint128 test 4 (11, 7)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 42', function () {
     const expectedRes = {
       [handle]: 1408n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations43.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations43.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint32) => ebool test 2 (48, 52)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint32) => ebool test 3 (52, 52)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint32) => ebool test 4 (52, 48)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint64) => ebool test 1 (44133, 18442008324483527921)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint64) => ebool test 2 (44129, 44133)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint64) => ebool test 3 (44133, 44133)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint64) => ebool test 4 (44133, 44129)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint32) => euint32 test 1 (62163, 28758)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 1787683554n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint32) => euint32 test 2 (57514, 57514)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint32) => euint32 test 3 (57514, 57514)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint32) => euint32 test 4 (57514, 57514)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint128) => euint128 test 1 (221, 221)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint128) => euint128 test 2 (221, 217)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint128) => ebool test 1 (655662779, 340282366920938463463369996699006268013)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint128) => ebool test 2 (655662775, 655662779)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint128) => ebool test 3 (655662779, 655662779)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, euint128) => ebool test 4 (655662779, 655662775)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, euint8) => euint8 test 1 (194, 5)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 88n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, euint8) => euint8 test 2 (1, 5)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 32n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, euint8) => euint8 test 3 (5, 5)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 160n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint8, euint8) => euint8 test 4 (5, 1)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 43', function () {
     const expectedRes = {
       [handle]: 10n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations44.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations44.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, euint16) => euint32 test 2 (19540, 19536)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint16) => euint32 test 1 (4269728288, 49414)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 49152n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint16) => euint32 test 2 (49410, 49414)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 49410n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint16) => euint32 test 3 (49414, 49414)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 49414n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint16) => euint32 test 4 (49414, 49410)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 49410n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint32) => ebool test 1 (1348456077, 742459888)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint32) => ebool test 2 (742459884, 742459888)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint32) => ebool test 3 (742459888, 742459888)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint32) => ebool test 4 (742459888, 742459884)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 1 (3892520086, 2401584102)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 2 (742459884, 742459888)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 3 (742459888, 742459888)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint32, euint32) => ebool test 4 (742459888, 742459884)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint64) => euint64 test 1 (23121, 18443118401380936881)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 23121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint64) => euint64 test 2 (23117, 23121)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 23117n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint64) => euint64 test 3 (23121, 23121)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 23121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint64) => euint64 test 4 (23121, 23117)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 23117n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint8) => euint64 test 1 (65, 2)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 130n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint8) => euint64 test 2 (14, 16)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 224n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint8) => euint64 test 3 (9, 9)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 81n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint8) => euint64 test 4 (16, 14)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 44', function () {
     const expectedRes = {
       [handle]: 224n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations45.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations45.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 16143n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint16, uint16) => euint16 test 2 (16139, 16143)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 16139n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint16, uint16) => euint16 test 3 (16143, 16143)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint16, uint16) => euint16 test 4 (16143, 16139)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint16) => euint64 test 1 (18438052288501675415, 62963)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 18438052288501708279n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint16) => euint64 test 2 (62959, 62963)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 62975n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint16) => euint64 test 3 (62963, 62963)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 62963n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint16) => euint64 test 4 (62963, 62959)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 62975n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint128) => euint128 test 1 (59, 340282366920938463463372716713489912695)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 59n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint128) => euint128 test 2 (55, 59)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 55n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint128) => euint128 test 3 (59, 59)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 59n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint128) => euint128 test 4 (59, 55)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 55n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint64) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457576029112850821961, 18439189234875686269)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 18438053817315529033n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint64) => euint256 test 2 (18439189234875686265, 18439189234875686269)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 18439189234875686265n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint64) => euint256 test 3 (18439189234875686269, 18439189234875686269)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 18439189234875686269n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint64) => euint256 test 4 (18439189234875686269, 18439189234875686265)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 18439189234875686265n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint256) => ebool test 1 (18440606695145923623, 115792089237316195423570985008687907853269984665640564039457578475027787545985)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint256) => ebool test 2 (18440606695145923619, 18440606695145923623)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint256) => ebool test 3 (18440606695145923623, 18440606695145923623)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint256) => ebool test 4 (18440606695145923623, 18440606695145923619)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint32) => euint128 test 1 (3806541193, 3806541193)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint32) => euint128 test 2 (3806541193, 3806541189)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 45', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations46.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations46.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint128) => ebool test 2 (164, 168)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint128) => ebool test 3 (168, 168)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint128) => ebool test 4 (168, 164)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint16) => ebool test 1 (18444516960769536337, 19791)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint16) => ebool test 2 (19787, 19791)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint16) => ebool test 3 (19791, 19791)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint16) => ebool test 4 (19791, 19787)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, uint64) => ebool test 1 (18441793874479678031, 18444669461336692671)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, uint64) => ebool test 2 (18438850655314522435, 18438850655314522439)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, uint64) => ebool test 3 (18438850655314522439, 18438850655314522439)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, uint64) => ebool test 4 (18438850655314522439, 18438850655314522435)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint128) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457578104479961759913, 340282366920938463463372582172919627471)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367858670350123145n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint128) => euint256 test 2 (340282366920938463463372582172919627467, 340282366920938463463372582172919627471)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372582172919627467n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint128) => euint256 test 3 (340282366920938463463372582172919627471, 340282366920938463463372582172919627471)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372582172919627471n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint128) => euint256 test 4 (340282366920938463463372582172919627471, 340282366920938463463372582172919627467)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372582172919627467n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint16) => ebool test 1 (43, 34333)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint16) => ebool test 2 (39, 43)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint16) => ebool test 3 (43, 43)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint16) => ebool test 4 (43, 39)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint16) => euint16 test 1 (2, 146)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 148n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint16) => euint16 test 2 (124, 126)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint16) => euint16 test 3 (126, 126)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 252n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint16) => euint16 test 4 (126, 124)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 46', function () {
     const expectedRes = {
       [handle]: 250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations47.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations47.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 7183n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint16) => euint64 test 2 (7467, 7471)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 7467n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint16) => euint64 test 3 (7471, 7471)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 7471n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint16) => euint64 test 4 (7471, 7467)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 7467n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint8) => euint32 test 1 (2799313384, 73)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 72n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint8) => euint32 test 2 (69, 73)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 65n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint8) => euint32 test 3 (73, 73)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 73n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint8) => euint32 test 4 (73, 69)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 65n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint64) => ebool test 1 (2619423717, 18443770521708734573)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint64) => ebool test 2 (2619423713, 2619423717)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint64) => ebool test 3 (2619423717, 2619423717)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint64) => ebool test 4 (2619423717, 2619423713)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, euint8) => euint16 test 1 (41810, 8)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 163n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, euint8) => euint16 test 2 (4, 8)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, euint8) => euint16 test 3 (8, 8)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, euint8) => euint16 test 4 (8, 4)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint8) => ebool test 1 (146, 45)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint8) => ebool test 2 (41, 45)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint8) => ebool test 3 (45, 45)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint8) => ebool test 4 (45, 41)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint16) => euint128 test 1 (340282366920938463463370597811751712575, 21263)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 340282366920938463463370597811751691312n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint16) => euint128 test 2 (21259, 21263)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint16) => euint128 test 3 (21263, 21263)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint16) => euint128 test 4 (21263, 21259)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 47', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations48.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations48.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 18439210315411832290n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint16) => euint64 test 2 (40141, 40145)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint16) => euint64 test 3 (40145, 40145)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint16) => euint64 test 4 (40145, 40141)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint16) => euint64 test 1 (39826, 39826)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint16) => euint64 test 2 (39826, 39822)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint32) => euint32 test 1 (2802423601, 722020506)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 587792400n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint32) => euint32 test 2 (722020502, 722020506)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 722020498n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint32) => euint32 test 3 (722020506, 722020506)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 722020506n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint32) => euint32 test 4 (722020506, 722020502)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 722020498n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint16) => euint32 test 1 (2392629459, 62449)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 2392609570n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint16) => euint32 test 2 (62445, 62449)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint16) => euint32 test 3 (62449, 62449)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint16) => euint32 test 4 (62449, 62445)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint64) => ebool test 1 (880458574, 18438740505656892795)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint64) => ebool test 2 (880458570, 880458574)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint64) => ebool test 3 (880458574, 880458574)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint64) => ebool test 4 (880458574, 880458570)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, uint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457576848855753045347, 10)', async function () {
@@ -472,7 +472,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 40255843523910708565225850256926655464613393106414102341842675683259782007053n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, uint8) => euint256 test 2 (6, 10)', async function () {
@@ -487,7 +487,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 678469272874899582559986240285280710077753816400237679918696781296365993984n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, uint8) => euint256 test 3 (10, 10)', async function () {
@@ -502,7 +502,7 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 1130782121458165970933310400475467850129589694000396133197827968827276656640n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint256, uint8) => euint256 test 4 (10, 6)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 48', function () {
     const expectedRes = {
       [handle]: 18092513943330655534932966407607485602073435104006338131165247501236426506240n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations49.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations49.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint8, euint8) => euint8 test 2 (105, 109)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 105n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint8, euint8) => euint8 test 3 (109, 109)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 109n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint8, euint8) => euint8 test 4 (109, 105)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 105n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint128) => euint128 test 1 (1262547131, 340282366920938463463373084761551004803)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1262547131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint128) => euint128 test 2 (1262547127, 1262547131)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1262547127n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint128) => euint128 test 3 (1262547131, 1262547131)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1262547131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint128) => euint128 test 4 (1262547131, 1262547127)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1262547127n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint16) => ebool test 1 (193, 12824)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint16) => ebool test 2 (189, 193)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint16) => ebool test 3 (193, 193)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint16) => ebool test 4 (193, 189)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint32) => euint64 test 1 (2147091039, 2)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 4294182078n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint32) => euint64 test 2 (39512, 39512)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1561198144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint32) => euint64 test 3 (39512, 39512)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1561198144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint32) => euint64 test 4 (39512, 39512)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 1561198144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, uint8) => euint8 test 1 (213, 151)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 215n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, uint8) => euint8 test 2 (22, 26)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 30n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, uint8) => euint8 test 3 (26, 26)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 26n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, uint8) => euint8 test 4 (26, 22)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: 30n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint32) => ebool test 1 (18446116136947405035, 729196943)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint32) => ebool test 2 (729196939, 729196943)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint32) => ebool test 3 (729196943, 729196943)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint32) => ebool test 4 (729196943, 729196939)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 49', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations5.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations5.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, uint8) => euint8 test 2 (78, 82)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 78n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, uint8) => euint8 test 3 (82, 82)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, uint8) => euint8 test 4 (82, 78)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 78n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint16) => ebool test 1 (1450084384, 51351)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint16) => ebool test 2 (51347, 51351)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint16) => ebool test 3 (51351, 51351)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint16) => ebool test 4 (51351, 51347)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint32) => ebool test 1 (58105, 2380872833)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint32) => ebool test 2 (58101, 58105)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint32) => ebool test 3 (58105, 58105)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint32) => ebool test 4 (58105, 58101)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint32, uint32) => euint32 test 1 (1691714054, 2857364901)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint32, uint32) => euint32 test 2 (486270740, 486270744)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint32, uint32) => euint32 test 3 (486270744, 486270744)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint32, uint32) => euint32 test 4 (486270744, 486270740)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint64) => euint64 test 1 (53, 18445287305732048029)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 21n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint64) => euint64 test 2 (49, 53)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 49n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint64) => euint64 test 3 (53, 53)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 53n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint64) => euint64 test 4 (53, 49)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: 49n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint64) => ebool test 1 (340282366920938463463366987195931318507, 18439531046471582951)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint64) => ebool test 2 (18439531046471582947, 18439531046471582951)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint64) => ebool test 3 (18439531046471582951, 18439531046471582951)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint64) => ebool test 4 (18439531046471582951, 18439531046471582947)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 5', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations50.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations50.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 18534n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint16) => euint128 test 2 (19682, 19686)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 19682n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint16) => euint128 test 3 (19686, 19686)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 19686n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint16) => euint128 test 4 (19686, 19682)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 19682n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint128) => euint128 test 1 (18440059244970865611, 340282366920938463463368278292102642789)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 18439988871906553921n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint128) => euint128 test 2 (18440059244970865607, 18440059244970865611)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 18440059244970865603n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint128) => euint128 test 3 (18440059244970865611, 18440059244970865611)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 18440059244970865611n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint128) => euint128 test 4 (18440059244970865611, 18440059244970865607)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 18440059244970865603n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, euint8) => euint16 test 1 (43264, 7)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 338n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, euint8) => euint16 test 2 (3, 7)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 1536n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, euint8) => euint16 test 3 (7, 7)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 3584n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint16, euint8) => euint16 test 4 (7, 3)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 57344n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, uint32) => euint32 test 1 (62163, 40446)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 2514244698n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, uint32) => euint32 test 2 (57514, 57514)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, uint32) => euint32 test 3 (57514, 57514)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, uint32) => euint32 test 4 (57514, 57514)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint16, euint16) => ebool test 1 (46926, 12867)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint16, euint16) => ebool test 2 (60961, 60965)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint16, euint16) => ebool test 3 (60965, 60965)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint16, euint16) => ebool test 4 (60965, 60961)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint32, uint32) => euint32 test 1 (924792227, 1960452484)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 924792227n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint32, uint32) => euint32 test 2 (924792223, 924792227)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 924792223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint32, uint32) => euint32 test 3 (924792227, 924792227)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint32, uint32) => euint32 test 4 (924792227, 924792223)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 50', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations51.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations51.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371720113554110409n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint64) => euint128 test 2 (18439325388598280773, 18439325388598280777)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 18439325388598280781n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint64) => euint128 test 3 (18439325388598280777, 18439325388598280777)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 18439325388598280777n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint64) => euint128 test 4 (18439325388598280777, 18439325388598280773)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 18439325388598280781n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint16) => euint16 test 1 (416, 124)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 51584n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint16) => euint16 test 2 (246, 246)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint16) => euint16 test 3 (246, 246)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint16) => euint16 test 4 (246, 246)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, uint16) => ebool test 1 (5506, 5519)', async function () {
@@ -282,7 +282,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, uint16) => ebool test 2 (5502, 5506)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, uint16) => ebool test 3 (5506, 5506)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, uint16) => ebool test 4 (5506, 5502)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint8) => ebool test 1 (3031508215, 244)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint8) => ebool test 2 (240, 244)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint8) => ebool test 3 (244, 244)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint8) => ebool test 4 (244, 240)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint32) => ebool test 1 (340282366920938463463373145318921841867, 1419678105)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint32) => ebool test 2 (1419678101, 1419678105)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint32) => ebool test 3 (1419678105, 1419678105)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint32) => ebool test 4 (1419678105, 1419678101)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint16) => euint128 test 1 (340282366920938463463368659222487539321, 15753)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368659222487539321n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint16) => euint128 test 2 (15749, 15753)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 15753n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint16) => euint128 test 3 (15753, 15753)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 15753n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint16) => euint128 test 4 (15753, 15749)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 51', function () {
     const expectedRes = {
       [handle]: 15753n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations52.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations52.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 9223372036854775810n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint128) => euint128 test 2 (4294329502, 4294329502)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 18441265871747568004n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint128) => euint128 test 3 (4294329502, 4294329502)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 18441265871747568004n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, euint128) => euint128 test 4 (4294329502, 4294329502)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 18441265871747568004n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint64) => euint128 test 1 (4611686018427387905, 2)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 9223372036854775810n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint64) => euint128 test 2 (4293885382, 4293885382)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 18437451673753285924n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint64) => euint128 test 3 (4293885382, 4293885382)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 18437451673753285924n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint64) => euint128 test 4 (4293885382, 4293885382)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 18437451673753285924n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, uint128) => ebool test 1 (340282366920938463463371440762151696387, 340282366920938463463368779850662320005)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, uint128) => ebool test 2 (340282366920938463463371440762151696383, 340282366920938463463371440762151696387)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, uint128) => ebool test 3 (340282366920938463463371440762151696387, 340282366920938463463371440762151696387)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, uint128) => ebool test 4 (340282366920938463463371440762151696387, 340282366920938463463371440762151696383)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457580874640192203921, 195)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 129n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint8) => euint256 test 2 (191, 195)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint8) => euint256 test 3 (195, 195)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 195n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint8) => euint256 test 4 (195, 191)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, euint8) => euint8 test 1 (121, 7)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, euint8) => euint8 test 2 (3, 7)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, euint8) => euint8 test 3 (7, 7)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint8, euint8) => euint8 test 4 (7, 3)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint8, euint8) => euint8 test 1 (132, 151)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 151n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint8, euint8) => euint8 test 2 (22, 26)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 30n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint8, euint8) => euint8 test 3 (26, 26)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 26n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint8, euint8) => euint8 test 4 (26, 22)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 52', function () {
     const expectedRes = {
       [handle]: 30n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations53.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations53.ts
@@ -129,7 +129,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 7056363790535127n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, uint8) => euint64 test 1 (18440947267520683999, 10)', async function () {
@@ -144,7 +144,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 18008737565938167n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, uint8) => euint64 test 2 (6, 10)', async function () {
@@ -159,7 +159,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, uint8) => euint64 test 3 (10, 10)', async function () {
@@ -174,7 +174,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint64, uint8) => euint64 test 4 (10, 6)', async function () {
@@ -189,7 +189,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint64) => euint64 test 1 (63, 18444391301252604423)', async function () {
@@ -208,7 +208,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 18444391301252604479n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint64) => euint64 test 2 (59, 63)', async function () {
@@ -227,7 +227,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 63n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint64) => euint64 test 3 (63, 63)', async function () {
@@ -246,7 +246,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 63n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint64) => euint64 test 4 (63, 59)', async function () {
@@ -265,7 +265,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 63n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint8) => euint32 test 1 (1288312961, 171)', async function () {
@@ -284,7 +284,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 1288312874n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint8) => euint32 test 2 (167, 171)', async function () {
@@ -303,7 +303,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint8) => euint32 test 3 (171, 171)', async function () {
@@ -322,7 +322,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint8) => euint32 test 4 (171, 167)', async function () {
@@ -341,7 +341,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint128) => ebool test 1 (18440506458988889109, 340282366920938463463373149845816753237)', async function () {
@@ -360,7 +360,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint128) => ebool test 2 (18440506458988889105, 18440506458988889109)', async function () {
@@ -379,7 +379,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint128) => ebool test 3 (18440506458988889109, 18440506458988889109)', async function () {
@@ -398,7 +398,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint128) => ebool test 4 (18440506458988889109, 18440506458988889105)', async function () {
@@ -417,7 +417,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint256) => euint256 test 1 (2813540609, 115792089237316195423570985008687907853269984665640564039457575366704679618391)', async function () {
@@ -436,7 +436,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457575366702942338646n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint256) => euint256 test 2 (2813540605, 2813540609)', async function () {
@@ -455,7 +455,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 508n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint256) => euint256 test 3 (2813540609, 2813540609)', async function () {
@@ -474,7 +474,7 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint256) => euint256 test 4 (2813540609, 2813540605)', async function () {
@@ -493,6 +493,6 @@ describe('FHEVM operations 53', function () {
     const expectedRes = {
       [handle]: 508n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations54.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations54.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 18446307955039574325n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint16) => euint64 test 2 (45267, 45271)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 45271n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint16) => euint64 test 3 (45271, 45271)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 45271n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint16) => euint64 test 4 (45271, 45267)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 45271n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint8) => euint8 test 1 (213, 26)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 223n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint8) => euint8 test 2 (22, 26)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 30n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint8) => euint8 test 3 (26, 26)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 26n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint8) => euint8 test 4 (26, 22)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 30n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, uint8) => euint16 test 1 (41810, 8)', async function () {
@@ -282,7 +282,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 163n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, uint8) => euint16 test 2 (4, 8)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, uint8) => euint16 test 3 (8, 8)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint16, uint8) => euint16 test 4 (8, 4)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint64, euint64) => euint64 test 1 (18445863906332305427, 18443180247415512627)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 18445863906332305427n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint64, euint64) => euint64 test 2 (18439875117400843375, 18439875117400843379)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint64, euint64) => euint64 test 3 (18439875117400843379, 18439875117400843379)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint64, euint64) => euint64 test 4 (18439875117400843379, 18439875117400843375)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint256) => ebool test 1 (34, 115792089237316195423570985008687907853269984665640564039457577752723022763875)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint256) => ebool test 2 (30, 34)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint256) => ebool test 3 (34, 34)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint256) => ebool test 4 (34, 30)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint8) => euint16 test 1 (91, 2)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 182n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint8) => euint16 test 2 (14, 16)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 224n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint8) => euint16 test 3 (9, 9)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 81n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, euint8) => euint16 test 4 (16, 14)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 54', function () {
     const expectedRes = {
       [handle]: 224n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations55.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations55.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint8) => ebool test 2 (79, 83)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint8) => ebool test 3 (83, 83)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint8) => ebool test 4 (83, 79)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint32) => ebool test 1 (3612466835, 1070970944)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint32) => ebool test 2 (1070970940, 1070970944)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint32) => ebool test 3 (1070970944, 1070970944)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint32) => ebool test 4 (1070970944, 1070970940)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint16) => ebool test 1 (343, 65371)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint16) => ebool test 2 (339, 343)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint16) => ebool test 3 (343, 343)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint16) => ebool test 4 (343, 339)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint16, euint16) => euint16 test 1 (560, 560)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint16, euint16) => euint16 test 2 (560, 556)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint64) => euint128 test 1 (18439407006649749035, 18439407006649749035)', async function () {
@@ -392,7 +392,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint64) => euint128 test 2 (18439407006649749035, 18439407006649749031)', async function () {
@@ -411,7 +411,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint32) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457575429918769641315, 1067360973)', async function () {
@@ -430,7 +430,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 218636865n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint32) => euint256 test 2 (1067360969, 1067360973)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 1067360969n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint32) => euint256 test 3 (1067360973, 1067360973)', async function () {
@@ -468,7 +468,7 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 1067360973n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint32) => euint256 test 4 (1067360973, 1067360969)', async function () {
@@ -487,6 +487,6 @@ describe('FHEVM operations 55', function () {
     const expectedRes = {
       [handle]: 1067360969n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations56.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations56.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint8) => ebool test 2 (31, 35)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint8) => ebool test 3 (35, 35)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint8) => ebool test 4 (35, 31)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint16) => ebool test 1 (471619784, 4203)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint16) => ebool test 2 (4199, 4203)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint16) => ebool test 3 (4203, 4203)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint32, euint16) => ebool test 4 (4203, 4199)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457582945728811208267, 156)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457582945728811208415n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint8) => euint256 test 2 (152, 156)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint8) => euint256 test 3 (156, 156)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint8) => euint256 test 4 (156, 152)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint64) => euint64 test 1 (11399, 11399)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint64) => euint64 test 2 (11399, 11395)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, uint8) => euint8 test 1 (9, 16)', async function () {
@@ -396,7 +396,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, uint8) => euint8 test 2 (12, 13)', async function () {
@@ -411,7 +411,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, uint8) => euint8 test 3 (13, 13)', async function () {
@@ -426,7 +426,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 169n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, uint8) => euint8 test 4 (13, 12)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 156n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint32) => euint64 test 1 (18437881774083556195, 3048678233)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 279315265n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint32) => euint64 test 2 (3048678229, 3048678233)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 3048678225n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint32) => euint64 test 3 (3048678233, 3048678233)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 3048678233n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint32) => euint64 test 4 (3048678233, 3048678229)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 56', function () {
     const expectedRes = {
       [handle]: 3048678225n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations57.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations57.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 387347926n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint32) => euint128 test 2 (387347922, 387347926)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 387347922n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint32) => euint128 test 3 (387347926, 387347926)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 387347926n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint32) => euint128 test 4 (387347926, 387347922)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 387347922n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint128) => ebool test 1 (18440680620149749757, 340282366920938463463372682460644576311)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint128) => ebool test 2 (18440680620149749753, 18440680620149749757)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint128) => ebool test 3 (18440680620149749757, 18440680620149749757)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint128) => ebool test 4 (18440680620149749757, 18440680620149749753)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint16, euint16) => euint16 test 1 (10738, 51030)', async function () {
@@ -282,7 +282,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 51030n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint16, euint16) => euint16 test 2 (5510, 5514)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint16, euint16) => euint16 test 3 (5514, 5514)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (uint16, euint16) => euint16 test 4 (5514, 5510)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint128) => ebool test 1 (5200, 340282366920938463463373312071413378857)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint128) => ebool test 2 (5196, 5200)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint128) => ebool test 3 (5200, 5200)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint128) => ebool test 4 (5200, 5196)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint128, uint128) => euint128 test 1 (340282366920938463463366055630084189643, 340282366920938463463371120280108078603)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint128, uint128) => euint128 test 2 (340282366920938463463366055630084189639, 340282366920938463463366055630084189643)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint128, uint128) => euint128 test 3 (340282366920938463463366055630084189643, 340282366920938463463366055630084189643)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "div" overload (euint128, uint128) => euint128 test 4 (340282366920938463463366055630084189643, 340282366920938463463366055630084189639)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint8) => euint128 test 1 (340282366920938463463372853748599498619, 29)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372853748599498598n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint8) => euint128 test 2 (25, 29)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint8) => euint128 test 3 (29, 29)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint8) => euint128 test 4 (29, 25)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 57', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations58.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations58.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint256) => ebool test 2 (18438194940858619429, 18438194940858619433)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint256) => ebool test 3 (18438194940858619433, 18438194940858619433)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint256) => ebool test 4 (18438194940858619433, 18438194940858619429)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint8) => euint32 test 1 (83, 2)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 166n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint8) => euint32 test 2 (14, 14)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint8) => euint32 test 3 (14, 14)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint8) => euint32 test 4 (14, 14)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint128) => ebool test 1 (2865527099, 340282366920938463463370518279885807053)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint128) => ebool test 2 (2865527095, 2865527099)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint128) => ebool test 3 (2865527099, 2865527099)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint128) => ebool test 4 (2865527099, 2865527095)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint16, euint16) => ebool test 1 (22031, 35423)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint16, euint16) => ebool test 2 (38999, 39003)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint16, euint16) => ebool test 3 (39003, 39003)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint16, euint16) => ebool test 4 (39003, 38999)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, uint8) => euint128 test 1 (340282366920938463463371083077227253107, 7)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 340282366920938463462923490050525542911n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, uint8) => euint128 test 2 (3, 7)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, uint8) => euint128 test 3 (7, 7)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, uint8) => euint128 test 4 (7, 3)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint256) => euint256 test 1 (3181123601, 115792089237316195423570985008687907853269984665640564039457582018793112267197)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 2777679889n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint256) => euint256 test 2 (3181123597, 3181123601)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 3181123585n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint256) => euint256 test 3 (3181123601, 3181123601)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 3181123601n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint256) => euint256 test 4 (3181123601, 3181123597)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 58', function () {
     const expectedRes = {
       [handle]: 3181123585n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations59.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations59.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373117718404727163n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint128) => euint128 test 2 (172, 176)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 176n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint128) => euint128 test 3 (176, 176)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 176n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, euint128) => euint128 test 4 (176, 172)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 176n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint32) => euint64 test 1 (4293378971, 2)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 4293378973n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint32) => euint64 test 2 (340578119, 340578123)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 681156242n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint32) => euint64 test 3 (340578123, 340578123)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 681156246n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint32) => euint64 test 4 (340578123, 340578119)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 681156242n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint32) => ebool test 1 (115, 2300692216)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint32) => ebool test 2 (111, 115)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint32) => ebool test 3 (115, 115)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint32) => ebool test 4 (115, 111)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint256) => euint256 test 1 (47777, 115792089237316195423570985008687907853269984665640564039457581413711189525205)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457581413711189571700n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint256) => euint256 test 2 (47773, 47777)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 60n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint256) => euint256 test 3 (47777, 47777)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint256) => euint256 test 4 (47777, 47773)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: 60n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 1 (1869741124, 1900346676)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 2 (1070970940, 1070970944)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 3 (1070970944, 1070970944)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint32, euint32) => ebool test 4 (1070970944, 1070970940)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint128, euint128) => ebool test 1 (340282366920938463463369012527038577031, 340282366920938463463368779850662320005)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint128, euint128) => ebool test 2 (340282366920938463463371440762151696383, 340282366920938463463371440762151696387)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint128, euint128) => ebool test 3 (340282366920938463463371440762151696387, 340282366920938463463371440762151696387)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint128, euint128) => ebool test 4 (340282366920938463463371440762151696387, 340282366920938463463371440762151696383)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 59', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations6.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations6.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 18438032856796632073n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint64) => euint128 test 2 (18438032874052408327, 18438032874052408331)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 18438032874052408323n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint64) => euint128 test 3 (18438032874052408331, 18438032874052408331)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 18438032874052408331n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint64) => euint128 test 4 (18438032874052408331, 18438032874052408327)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 18438032874052408323n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint64) => euint64 test 1 (2, 65528)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 65530n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint64) => euint64 test 2 (17052, 17056)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 34108n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint64) => euint64 test 3 (17056, 17056)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 34112n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint64) => euint64 test 4 (17056, 17052)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 34108n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 1 (955768418, 2968171169)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 2 (1603469839, 1603469843)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 3 (1603469843, 1603469843)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint32, euint32) => ebool test 4 (1603469843, 1603469839)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint128) => euint128 test 1 (2279469277, 340282366920938463463366458639718848533)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366458639841622237n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint128) => euint128 test 2 (2279469273, 2279469277)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 2279469277n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint128) => euint128 test 3 (2279469277, 2279469277)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 2279469277n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint128) => euint128 test 4 (2279469277, 2279469273)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 2279469277n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 1 (10810, 3270996750)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 3270990132n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 2 (10806, 10810)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 3 (10810, 10810)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint32) => euint32 test 4 (10810, 10806)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint8) => euint8 test 1 (82, 233)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint8) => euint8 test 2 (78, 82)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 78n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint8) => euint8 test 3 (82, 82)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint8) => euint8 test 4 (82, 78)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 6', function () {
     const expectedRes = {
       [handle]: 78n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations60.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations60.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint8, euint8) => euint8 test 2 (122, 118)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint16) => ebool test 1 (340282366920938463463369916195363392109, 5886)', async function () {
@@ -164,7 +164,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint16) => ebool test 2 (5882, 5886)', async function () {
@@ -183,7 +183,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint16) => ebool test 3 (5886, 5886)', async function () {
@@ -202,7 +202,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint16) => ebool test 4 (5886, 5882)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint32) => ebool test 1 (156, 2424056435)', async function () {
@@ -240,7 +240,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint32) => ebool test 2 (152, 156)', async function () {
@@ -259,7 +259,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint32) => ebool test 3 (156, 156)', async function () {
@@ -278,7 +278,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint8, euint32) => ebool test 4 (156, 152)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint32, euint32) => euint32 test 1 (45685, 40446)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 1847775510n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint32, euint32) => euint32 test 2 (57514, 57514)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint32, euint32) => euint32 test 3 (57514, 57514)', async function () {
@@ -342,7 +342,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint32, euint32) => euint32 test 4 (57514, 57514)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 3307860196n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, euint8) => euint32 test 1 (2285223005, 11)', async function () {
@@ -376,7 +376,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 2917328896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, euint8) => euint32 test 2 (7, 11)', async function () {
@@ -395,7 +395,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 14336n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, euint8) => euint32 test 3 (11, 11)', async function () {
@@ -414,7 +414,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 22528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, euint8) => euint32 test 4 (11, 7)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: 1408n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint64) => ebool test 1 (18437759487138436563, 18442290317833527107)', async function () {
@@ -452,7 +452,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint64) => ebool test 2 (18437759487138436559, 18437759487138436563)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint64) => ebool test 3 (18437759487138436563, 18437759487138436563)', async function () {
@@ -490,7 +490,7 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint64) => ebool test 4 (18437759487138436563, 18437759487138436559)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 60', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations61.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations61.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint128) => ebool test 2 (1895989662, 1895989666)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint128) => ebool test 3 (1895989666, 1895989666)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint128) => ebool test 4 (1895989666, 1895989662)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, euint8) => euint32 test 1 (1808540925, 10)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 815003055n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, euint8) => euint32 test 2 (6, 10)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 6144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, euint8) => euint32 test 3 (10, 10)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 10240n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint32, euint8) => euint32 test 4 (10, 6)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 640n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint128) => euint128 test 1 (18439176389615904441, 340282366920938463463374362111861801331)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 340282366920938463463374394106109192187n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint128) => euint128 test 2 (18439176389615904437, 18439176389615904441)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18439176389615904445n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint128) => euint128 test 3 (18439176389615904441, 18439176389615904441)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18439176389615904441n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint128) => euint128 test 4 (18439176389615904441, 18439176389615904437)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18439176389615904445n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, uint8) => euint8 test 1 (51, 7)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, uint8) => euint8 test 2 (3, 7)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, uint8) => euint8 test 3 (7, 7)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint8, uint8) => euint8 test 4 (7, 3)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint64) => euint64 test 1 (18438676246625478911, 18438248006307692217)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18438248006307692217n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint64) => euint64 test 2 (18438248006307692213, 18438248006307692217)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18438248006307692213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint64) => euint64 test 3 (18438248006307692217, 18438248006307692217)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18438248006307692217n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint64) => euint64 test 4 (18438248006307692217, 18438248006307692213)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 18438248006307692213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, uint128) => euint128 test 1 (340282366920938463463372632433264727071, 340282366920938463463368998126415641363)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373758608049569567n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, uint128) => euint128 test 2 (340282366920938463463372632433264727067, 340282366920938463463372632433264727071)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, uint128) => euint128 test 3 (340282366920938463463372632433264727071, 340282366920938463463372632433264727071)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, uint128) => euint128 test 4 (340282366920938463463372632433264727071, 340282366920938463463372632433264727067)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 61', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations62.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations62.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint128, euint128) => euint128 test 2 (340282366920938463463365918437382145247, 340282366920938463463365918437382145243)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint128) => euint128 test 1 (102, 340282366920938463463372208229959107927)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372208229959107889n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint128) => euint128 test 2 (98, 102)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint128) => euint128 test 3 (102, 102)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint128) => euint128 test 4 (102, 98)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint8) => ebool test 1 (34416, 159)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint8) => ebool test 2 (155, 159)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint8) => ebool test 3 (159, 159)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint8) => ebool test 4 (159, 155)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 1 (51782, 41768)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 41768n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 2 (41764, 41768)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 41764n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 3 (41768, 41768)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 41768n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint16, euint16) => euint16 test 4 (41768, 41764)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 41764n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint32) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457582969101886579889, 207571826)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint32) => ebool test 2 (207571822, 207571826)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint32) => ebool test 3 (207571826, 207571826)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint32) => ebool test 4 (207571826, 207571822)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint64) => euint128 test 1 (340282366920938463463373186356942280159, 18444886943995068945)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373186356942280159n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint64) => euint128 test 2 (18444886943995068941, 18444886943995068945)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 18444886943995068945n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint64) => euint128 test 3 (18444886943995068945, 18444886943995068945)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 18444886943995068945n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint64) => euint128 test 4 (18444886943995068945, 18444886943995068941)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 62', function () {
     const expectedRes = {
       [handle]: 18444886943995068945n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations63.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations63.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 18443861395374125701n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint128) => euint128 test 2 (18443861395374125697, 18443861395374125701)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 18443861395374125697n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint128) => euint128 test 3 (18443861395374125701, 18443861395374125701)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 18443861395374125701n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint128) => euint128 test 4 (18443861395374125701, 18443861395374125697)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 18443861395374125697n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 1 (1781953635, 3170827740)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 2 (953438493, 953438497)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 3 (953438497, 953438497)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, uint32) => ebool test 4 (953438497, 953438493)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint8) => euint8 test 1 (227, 8)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 235n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint8) => euint8 test 2 (4, 8)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint8) => euint8 test 3 (8, 8)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint8) => euint8 test 4 (8, 4)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint256) => ebool test 1 (6132, 115792089237316195423570985008687907853269984665640564039457575985609570325583)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint256) => ebool test 2 (6128, 6132)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint256) => ebool test 3 (6132, 6132)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint256) => ebool test 4 (6132, 6128)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint32) => euint64 test 1 (18442044070392415023, 469081595)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 18442044070196109012n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint32) => euint64 test 2 (469081591, 469081595)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint32) => euint64 test 3 (469081595, 469081595)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint32) => euint64 test 4 (469081595, 469081591)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint64, euint64) => ebool test 1 (18445219802570391153, 18437852794148046425)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint64, euint64) => ebool test 2 (18439679158105806075, 18439679158105806079)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint64, euint64) => ebool test 3 (18439679158105806079, 18439679158105806079)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint64, euint64) => ebool test 4 (18439679158105806079, 18439679158105806075)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 63', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations64.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations64.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457582617005150293175n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint128) => euint256 test 2 (340282366920938463463368712644988520605, 340282366920938463463368712644988520609)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368712644988520637n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint128) => euint256 test 3 (340282366920938463463368712644988520609, 340282366920938463463368712644988520609)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368712644988520609n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, euint128) => euint256 test 4 (340282366920938463463368712644988520609, 340282366920938463463368712644988520605)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368712644988520637n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, euint8) => euint64 test 1 (18443045062616689743, 11)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 10871169355528435712n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, euint8) => euint64 test 2 (7, 11)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 14336n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, euint8) => euint64 test 3 (11, 11)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 22528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint64, euint8) => euint64 test 4 (11, 7)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 1408n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint128, euint128) => euint128 test 1 (170141183460469231731686785650767026796, 170141183460469231731685762323310324907)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372547974077351703n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint128, euint128) => euint128 test 2 (170141183460469231731686444035462849343, 170141183460469231731686444035462849345)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698688n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint128, euint128) => euint128 test 3 (170141183460469231731686444035462849345, 170141183460469231731686444035462849345)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698690n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint128, euint128) => euint128 test 4 (170141183460469231731686444035462849345, 170141183460469231731686444035462849343)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698688n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint128) => euint128 test 1 (242, 340282366920938463463370174735395035729)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 340282366920938463463370174735395035891n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint128) => euint128 test 2 (238, 242)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 254n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint128) => euint128 test 3 (242, 242)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 242n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint8, euint128) => euint128 test 4 (242, 238)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 254n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint64) => euint64 test 1 (2475880453, 18438042163292291237)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 18438042160917164192n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint64) => euint64 test 2 (2475880449, 2475880453)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint64) => euint64 test 3 (2475880453, 2475880453)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint64) => euint64 test 4 (2475880453, 2475880449)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint16) => euint128 test 1 (32769, 2)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 32771n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint16) => euint128 test 2 (12812, 12816)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 25628n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint16) => euint128 test 3 (12816, 12816)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 25632n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint16) => euint128 test 4 (12816, 12812)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 64', function () {
     const expectedRes = {
       [handle]: 25628n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations65.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations65.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 2 (40292, 40296)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 3 (40296, 40296)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint16) => ebool test 4 (40296, 40292)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint64) => ebool test 1 (40449, 18442021680198298403)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint64) => ebool test 2 (40445, 40449)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint64) => ebool test 3 (40449, 40449)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint64) => ebool test 4 (40449, 40445)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint128) => euint128 test 1 (9223372036854775809, 9223372036854775809)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint128) => euint128 test 2 (9223372036854775809, 9223372036854775809)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint128) => euint128 test 3 (9223372036854775809, 9223372036854775809)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint128) => euint128 test 4 (9223372036854775809, 9223372036854775809)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 1 (1306038916, 3736754924)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 2 (2055001259, 2055001263)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 3 (2055001263, 2055001263)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint32, euint32) => ebool test 4 (2055001263, 2055001259)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint256, euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457582926221166663333, 115792089237316195423570985008687907853269984665640564039457577588921391832383)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457583227221083873215n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint256, euint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457576582324561149927, 115792089237316195423570985008687907853269984665640564039457576582324561149931)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149935n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint256, euint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457576582324561149931)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149931n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint256, euint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457576582324561149927)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149935n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint64) => euint64 test 1 (2985316024, 18441735215330138173)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 26216504n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint64) => euint64 test 2 (2985316020, 2985316024)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 2985316016n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint64) => euint64 test 3 (2985316024, 2985316024)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 2985316024n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, euint64) => euint64 test 4 (2985316024, 2985316020)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 65', function () {
     const expectedRes = {
       [handle]: 2985316016n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations66.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations66.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint32) => ebool test 2 (496066040, 496066044)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint32) => ebool test 3 (496066044, 496066044)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint32) => ebool test 4 (496066044, 496066040)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint8) => ebool test 1 (18440507586243272477, 248)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint8) => ebool test 2 (244, 248)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint8) => ebool test 3 (248, 248)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint8) => ebool test 4 (248, 244)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint64) => ebool test 1 (1472580706, 18446395480514774125)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint64) => ebool test 2 (1472580702, 1472580706)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint64) => ebool test 3 (1472580706, 1472580706)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint32, euint64) => ebool test 4 (1472580706, 1472580702)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint8) => ebool test 1 (18440850220626744297, 185)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint8) => ebool test 2 (181, 185)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint8) => ebool test 3 (185, 185)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint8) => ebool test 4 (185, 181)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, uint16) => ebool test 1 (43453, 1886)', async function () {
@@ -434,7 +434,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, uint16) => ebool test 2 (40292, 40296)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, uint16) => ebool test 3 (40296, 40296)', async function () {
@@ -464,7 +464,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, uint16) => ebool test 4 (40296, 40292)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint256) => ebool test 1 (1040742380, 115792089237316195423570985008687907853269984665640564039457579645106516821897)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint256) => ebool test 2 (1040742376, 1040742380)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint256) => ebool test 3 (1040742380, 1040742380)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint256) => ebool test 4 (1040742380, 1040742376)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 66', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations67.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations67.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 340282366920938463463370053804352864031n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint128, euint128) => euint128 test 2 (340282366920938463463372632433264727067, 340282366920938463463372632433264727071)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint128, euint128) => euint128 test 3 (340282366920938463463372632433264727071, 340282366920938463463372632433264727071)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint128, euint128) => euint128 test 4 (340282366920938463463372632433264727071, 340282366920938463463372632433264727067)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, uint8) => euint128 test 1 (340282366920938463463371922863124491551, 6)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 170141183460469231731687261769499047604n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, uint8) => euint128 test 2 (2, 6)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 10633823966279326983230456482242756608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, uint8) => euint128 test 3 (6, 6)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 31901471898837980949691369446728269824n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint128, uint8) => euint128 test 4 (6, 2)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 170141183460469231731687303715884105729n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint32) => euint32 test 1 (45948, 2872927331)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 2872927331n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint32) => euint32 test 2 (45944, 45948)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 45948n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint32) => euint32 test 3 (45948, 45948)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 45948n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint32) => euint32 test 4 (45948, 45944)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 45948n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint32) => euint32 test 1 (2, 61819)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 61821n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint32) => euint32 test 2 (10080, 10084)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 20164n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint32) => euint32 test 3 (10084, 10084)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 20168n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint32) => euint32 test 4 (10084, 10080)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 20164n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint64) => euint64 test 1 (230, 18446051285262524211)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 18446051285262524373n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint64) => euint64 test 2 (226, 230)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint64) => euint64 test 3 (230, 230)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint64) => euint64 test 4 (230, 226)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, uint64) => ebool test 1 (18445582886082735021, 18446444903748302489)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, uint64) => ebool test 2 (18441516720181759759, 18441516720181759763)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, uint64) => ebool test 3 (18441516720181759763, 18441516720181759763)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, uint64) => ebool test 4 (18441516720181759763, 18441516720181759759)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 67', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations68.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations68.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint128) => ebool test 2 (340282366920938463463367329768413053355, 340282366920938463463367329768413053359)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint128) => ebool test 3 (340282366920938463463367329768413053359, 340282366920938463463367329768413053359)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint128) => ebool test 4 (340282366920938463463367329768413053359, 340282366920938463463367329768413053355)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint8, euint8) => euint8 test 1 (37, 210)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 37n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint8, euint8) => euint8 test 2 (78, 82)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 78n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint8, euint8) => euint8 test 3 (82, 82)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint8, euint8) => euint8 test 4 (82, 78)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 78n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint64, euint64) => euint64 test 1 (18438880122339881845, 18441931867559509173)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 3070480001224640n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint64, euint64) => euint64 test 2 (18441939623530402989, 18441939623530402993)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint64, euint64) => euint64 test 3 (18441939623530402993, 18441939623530402993)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (uint64, euint64) => euint64 test 4 (18441939623530402993, 18441939623530402989)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint64) => euint64 test 1 (18443816109613900561, 18442438487998006523)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 18443855792982321147n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint64) => euint64 test 2 (18442438487998006519, 18442438487998006523)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 18442438487998006527n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint64) => euint64 test 3 (18442438487998006523, 18442438487998006523)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 18442438487998006523n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint64) => euint64 test 4 (18442438487998006523, 18442438487998006519)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 18442438487998006527n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint128) => euint128 test 1 (340282366920938463463367474228925970149, 340282366920938463463367382444010695721)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367474228925970149n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint128) => euint128 test 2 (340282366920938463463367382444010695717, 340282366920938463463367382444010695721)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint128) => euint128 test 3 (340282366920938463463367382444010695721, 340282366920938463463367382444010695721)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint128) => euint128 test 4 (340282366920938463463367382444010695721, 340282366920938463463367382444010695717)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint8) => euint128 test 1 (340282366920938463463366521389578999607, 40)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366521389578999607n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint8) => euint128 test 2 (36, 40)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 40n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint8) => euint128 test 3 (40, 40)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 40n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, euint8) => euint128 test 4 (40, 36)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 68', function () {
     const expectedRes = {
       [handle]: 40n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations69.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations69.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint64) => ebool test 2 (18441516720181759759, 18441516720181759763)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint64) => ebool test 3 (18441516720181759763, 18441516720181759763)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint64) => ebool test 4 (18441516720181759763, 18441516720181759759)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint32) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457580506387910376933, 2415329255)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint32) => ebool test 2 (2415329251, 2415329255)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint32) => ebool test 3 (2415329255, 2415329255)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint32) => ebool test 4 (2415329255, 2415329251)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint256) => euint256 test 1 (340282366920938463463369773824201675833, 115792089237316195423570985008687907853269984665640564039457577934122967382619)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457579218438582402683n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint256) => euint256 test 2 (340282366920938463463369773824201675829, 340282366920938463463369773824201675833)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369773824201675837n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint256) => euint256 test 3 (340282366920938463463369773824201675833, 340282366920938463463369773824201675833)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369773824201675833n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint256) => euint256 test 4 (340282366920938463463369773824201675833, 340282366920938463463369773824201675829)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369773824201675837n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint64, euint64) => ebool test 1 (18445167072108074139, 18443248756432934313)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint64, euint64) => ebool test 2 (18437759487138436559, 18437759487138436563)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint64, euint64) => ebool test 3 (18437759487138436563, 18437759487138436563)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint64, euint64) => ebool test 4 (18437759487138436563, 18437759487138436559)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, uint64) => ebool test 1 (18441518909520051975, 18441730793496746391)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, uint64) => ebool test 2 (18441518909520051971, 18441518909520051975)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, uint64) => ebool test 3 (18441518909520051975, 18441518909520051975)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, uint64) => ebool test 4 (18441518909520051975, 18441518909520051971)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint32, euint32) => euint32 test 1 (3725712269, 872226176)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 303110528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint32, euint32) => euint32 test 2 (722020502, 722020506)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 722020498n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint32, euint32) => euint32 test 3 (722020506, 722020506)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 722020506n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint32, euint32) => euint32 test 4 (722020506, 722020502)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 69', function () {
     const expectedRes = {
       [handle]: 722020498n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations7.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations7.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 43515n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint8) => euint16 test 2 (223, 227)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 255n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint8) => euint16 test 3 (227, 227)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 227n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint8) => euint16 test 4 (227, 223)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 255n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, uint16) => euint16 test 1 (42686, 45262)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 5744n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, uint16) => euint16 test 2 (34851, 34855)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, uint16) => euint16 test 3 (34855, 34855)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, uint16) => euint16 test 4 (34855, 34851)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint64) => ebool test 1 (85, 18437797983105660815)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint64) => ebool test 2 (81, 85)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint64) => ebool test 3 (85, 85)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint64) => ebool test 4 (85, 81)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint128) => euint128 test 1 (340282366920938463463372632433264727071, 340282366920938463463373880780216870387)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 340282366920938463463374039808150910463n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint128) => euint128 test 2 (340282366920938463463372632433264727067, 340282366920938463463372632433264727071)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint128) => euint128 test 3 (340282366920938463463372632433264727071, 340282366920938463463372632433264727071)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint128) => euint128 test 4 (340282366920938463463372632433264727071, 340282366920938463463372632433264727067)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372632433264727071n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, uint64) => euint64 test 1 (18443553360840341423, 18443553360840341423)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, uint64) => euint64 test 2 (18443553360840341423, 18443553360840341419)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 1 (39003, 56037)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 2 (38999, 39003)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 3 (39003, 39003)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint16) => ebool test 4 (39003, 38999)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 7', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations70.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations70.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint32) => euint32 test 2 (27746, 27742)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint128, euint128) => ebool test 1 (340282366920938463463373443996970921113, 340282366920938463463374407153810090079)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint128, euint128) => ebool test 2 (340282366920938463463371647940600324845, 340282366920938463463371647940600324849)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint128, euint128) => ebool test 3 (340282366920938463463371647940600324849, 340282366920938463463371647940600324849)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint128, euint128) => ebool test 4 (340282366920938463463371647940600324849, 340282366920938463463371647940600324845)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint128, uint128) => euint128 test 1 (340282366920938463463368815224796447321, 340282366920938463463371207577031220403)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368815224796447321n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint128, uint128) => euint128 test 2 (340282366920938463463368284493474699013, 340282366920938463463368284493474699017)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368284493474699013n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint128, uint128) => euint128 test 3 (340282366920938463463368284493474699017, 340282366920938463463368284493474699017)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint128, uint128) => euint128 test 4 (340282366920938463463368284493474699017, 340282366920938463463368284493474699013)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, euint8) => euint16 test 1 (48753, 6)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 40000n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, euint8) => euint16 test 2 (2, 6)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, euint8) => euint16 test 3 (6, 6)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint16, euint8) => euint16 test 4 (6, 2)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 24n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint32) => ebool test 1 (18439982608232376383, 1259976018)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint32) => ebool test 2 (1259976014, 1259976018)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint32) => ebool test 3 (1259976018, 1259976018)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint32) => ebool test 4 (1259976018, 1259976014)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint128, euint128) => euint128 test 1 (340282366920938463463365918437382145247, 340282366920938463463365918437382145247)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint128, euint128) => euint128 test 2 (340282366920938463463365918437382145247, 340282366920938463463365918437382145243)', async function () {
@@ -495,6 +495,6 @@ describe('FHEVM operations 70', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations71.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations71.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint16) => ebool test 2 (42090, 42094)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint16) => ebool test 3 (42094, 42094)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint16) => ebool test 4 (42094, 42090)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "not" overload (euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457582667778252467021)', async function () {
@@ -205,7 +205,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 1340134877172914n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, euint8) => euint32 test 1 (3796021550, 7)', async function () {
@@ -224,7 +224,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 29656418n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, euint8) => euint32 test 2 (3, 7)', async function () {
@@ -243,7 +243,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, euint8) => euint32 test 3 (7, 7)', async function () {
@@ -262,7 +262,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint32, euint8) => euint32 test 4 (7, 3)', async function () {
@@ -281,7 +281,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint64, euint64) => euint64 test 1 (18445392183738577967, 18437955621632859185)', async function () {
@@ -300,7 +300,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18445608242225085503n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint64, euint64) => euint64 test 2 (18442438487998006519, 18442438487998006523)', async function () {
@@ -319,7 +319,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18442438487998006527n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint64, euint64) => euint64 test 3 (18442438487998006523, 18442438487998006523)', async function () {
@@ -338,7 +338,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18442438487998006523n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint64, euint64) => euint64 test 4 (18442438487998006523, 18442438487998006519)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18442438487998006527n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint64) => euint64 test 1 (18445649915025813613, 18443935695415273513)', async function () {
@@ -376,7 +376,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18443371640966602793n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint64) => euint64 test 2 (18443935695415273509, 18443935695415273513)', async function () {
@@ -395,7 +395,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18443935695415273505n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint64) => euint64 test 3 (18443935695415273513, 18443935695415273513)', async function () {
@@ -414,7 +414,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18443935695415273513n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint64) => euint64 test 4 (18443935695415273513, 18443935695415273509)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: 18443935695415273505n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint256) => ebool test 1 (12594, 115792089237316195423570985008687907853269984665640564039457583629524059178847)', async function () {
@@ -452,7 +452,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint256) => ebool test 2 (12590, 12594)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint256) => ebool test 3 (12594, 12594)', async function () {
@@ -490,7 +490,7 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint256) => ebool test 4 (12594, 12590)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 71', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations72.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations72.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 49188n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint16) => euint256 test 2 (59488, 59492)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 59488n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint16) => euint256 test 3 (59492, 59492)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 59492n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, euint16) => euint256 test 4 (59492, 59488)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 59488n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, euint8) => euint8 test 1 (109, 7)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 218n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, euint8) => euint8 test 2 (3, 7)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 6n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, euint8) => euint8 test 3 (7, 7)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 14n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint8, euint8) => euint8 test 4 (7, 3)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 224n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, euint8) => euint128 test 1 (340282366920938463463371083077227253107, 7)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 340282366920938463462923490050525542911n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, euint8) => euint128 test 2 (3, 7)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, euint8) => euint128 test 3 (7, 7)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint128, euint8) => euint128 test 4 (7, 3)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint16) => ebool test 1 (2567525298, 49779)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint16) => ebool test 2 (49775, 49779)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint16) => ebool test 3 (49779, 49779)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint32, euint16) => ebool test 4 (49779, 49775)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, uint128) => euint128 test 1 (170141183460469231731687272015842765950, 170141183460469231731685762323310324907)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373034339153090857n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, uint128) => euint128 test 2 (170141183460469231731686444035462849343, 170141183460469231731686444035462849345)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698688n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, uint128) => euint128 test 3 (170141183460469231731686444035462849345, 170141183460469231731686444035462849345)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698690n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, uint128) => euint128 test 4 (170141183460469231731686444035462849345, 170141183460469231731686444035462849343)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: 340282366920938463463372888070925698688n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint8) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457583971924612876299, 76)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint8) => ebool test 2 (72, 76)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint8) => ebool test 3 (76, 76)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint256, euint8) => ebool test 4 (76, 72)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 72', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations73.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations73.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 18440149341511828991n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint32) => euint64 test 2 (1754071862, 1754071866)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 1754071866n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint32) => euint64 test 3 (1754071866, 1754071866)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 1754071866n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint32) => euint64 test 4 (1754071866, 1754071862)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 1754071866n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint16) => euint16 test 1 (42686, 34855)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 11929n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint16) => euint16 test 2 (34851, 34855)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint16) => euint16 test 3 (34855, 34855)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint16) => euint16 test 4 (34855, 34851)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint8) => euint16 test 1 (137, 137)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint8) => euint16 test 2 (137, 133)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint64) => euint64 test 1 (18444237080447470479, 18439875117400843379)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 18444237080447470479n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint64) => euint64 test 2 (18439875117400843375, 18439875117400843379)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint64) => euint64 test 3 (18439875117400843379, 18439875117400843379)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint64, euint64) => euint64 test 4 (18439875117400843379, 18439875117400843375)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: 18439875117400843379n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint32) => ebool test 1 (340282366920938463463370565926781235887, 385755231)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint32) => ebool test 2 (385755227, 385755231)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint32) => ebool test 3 (385755231, 385755231)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint128, euint32) => ebool test 4 (385755231, 385755227)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint8) => ebool test 1 (18442457919507223175, 56)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint8) => ebool test 2 (52, 56)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint8) => ebool test 3 (56, 56)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint8) => ebool test 4 (56, 52)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 73', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations74.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations74.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint8) => ebool test 2 (86, 90)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint8) => ebool test 3 (90, 90)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint8) => ebool test 4 (90, 86)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, euint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457577185211424459481, 7)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039456710702094866541696n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, euint8) => euint256 test 2 (3, 7)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, euint8) => euint256 test 3 (7, 7)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint256, euint8) => euint256 test 4 (7, 3)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint128, euint128) => euint128 test 1 (9223372036854775809, 9223372036854775809)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint128, euint128) => euint128 test 2 (9223372036854775809, 9223372036854775809)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint128, euint128) => euint128 test 3 (9223372036854775809, 9223372036854775809)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (uint128, euint128) => euint128 test 4 (9223372036854775809, 9223372036854775809)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 85070591730234615884290395931651604481n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint16) => euint16 test 1 (560, 560)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint16) => euint16 test 2 (560, 556)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, uint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457581513258294236641)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580630218914157985n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, uint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457580727388371776951, 115792089237316195423570985008687907853269984665640564039457580727388371776955)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776947n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, uint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457580727388371776955)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776955n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint256, uint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457580727388371776951)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776947n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint8) => ebool test 1 (340282366920938463463369880057141224403, 209)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint8) => ebool test 2 (205, 209)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint8) => ebool test 3 (209, 209)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint8) => ebool test 4 (209, 205)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 74', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations75.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations75.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 203n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint8) => euint32 test 2 (95, 97)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 192n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint8) => euint32 test 3 (97, 97)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 194n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint8) => euint32 test 4 (97, 95)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 192n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint8) => ebool test 1 (49392, 167)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint8) => ebool test 2 (163, 167)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint8) => ebool test 3 (167, 167)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint8) => ebool test 4 (167, 163)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint8) => euint64 test 1 (236, 236)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint8) => euint64 test 2 (236, 232)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, uint32) => euint32 test 1 (2802423601, 872226176)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 587797760n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, uint32) => euint32 test 2 (722020502, 722020506)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 722020498n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, uint32) => euint32 test 3 (722020506, 722020506)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 722020506n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint32, uint32) => euint32 test 4 (722020506, 722020502)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 722020498n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, uint16) => euint16 test 1 (42893, 49271)', async function () {
@@ -396,7 +396,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 32773n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, uint16) => euint16 test 2 (26114, 26118)', async function () {
@@ -411,7 +411,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 26114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, uint16) => euint16 test 3 (26118, 26118)', async function () {
@@ -426,7 +426,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 26118n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, uint16) => euint16 test 4 (26118, 26114)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 26114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint64) => euint64 test 1 (47227, 18440501421641543975)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 18440501421641501020n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint64) => euint64 test 2 (47223, 47227)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint64) => euint64 test 3 (47227, 47227)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint64) => euint64 test 4 (47227, 47223)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 75', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations76.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations76.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint64) => ebool test 2 (18441518909520051971, 18441518909520051975)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint64) => ebool test 3 (18441518909520051975, 18441518909520051975)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint64, euint64) => ebool test 4 (18441518909520051975, 18441518909520051971)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, uint32) => euint32 test 1 (948248716, 1756703468)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 1345325664n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, uint32) => euint32 test 2 (640520663, 640520667)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, uint32) => euint32 test 3 (640520667, 640520667)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, uint32) => euint32 test 4 (640520667, 640520663)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint32) => ebool test 1 (18729, 1591888937)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint32) => ebool test 2 (18725, 18729)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint32) => ebool test 3 (18729, 18729)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint32) => ebool test 4 (18729, 18725)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, uint16) => euint16 test 1 (209, 149)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 31141n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, uint16) => euint16 test 2 (246, 246)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, uint16) => euint16 test 3 (246, 246)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint16, uint16) => euint16 test 4 (246, 246)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 60516n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint64) => euint64 test 1 (18443553360840341423, 18443553360840341423)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint64) => euint64 test 2 (18443553360840341423, 18443553360840341419)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint8, euint8) => ebool test 1 (195, 97)', async function () {
@@ -456,7 +456,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint8, euint8) => ebool test 2 (48, 52)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint8, euint8) => ebool test 3 (52, 52)', async function () {
@@ -486,7 +486,7 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint8, euint8) => ebool test 4 (52, 48)', async function () {
@@ -501,6 +501,6 @@ describe('FHEVM operations 76', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations77.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations77.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 16336113777889491455n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, uint8) => euint64 test 2 (4, 8)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 1024n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, uint8) => euint64 test 3 (8, 8)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 2048n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, uint8) => euint64 test 4 (8, 4)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint8) => euint64 test 1 (18442111662355596597, 76)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 18442111662355596669n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint8) => euint64 test 2 (72, 76)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 76n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint8) => euint64 test 3 (76, 76)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 76n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint8) => euint64 test 4 (76, 72)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 76n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, uint128) => ebool test 1 (340282366920938463463369402042742166611, 340282366920938463463369900732334670961)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, uint128) => ebool test 2 (340282366920938463463369402042742166607, 340282366920938463463369402042742166611)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, uint128) => ebool test 3 (340282366920938463463369402042742166611, 340282366920938463463369402042742166611)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, uint128) => ebool test 4 (340282366920938463463369402042742166611, 340282366920938463463369402042742166607)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 1 (1066396740, 422146200)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 422146200n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 2 (122228748, 122228752)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 122228748n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 3 (122228752, 122228752)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 122228752n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint32, euint32) => euint32 test 4 (122228752, 122228748)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 122228748n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint32) => euint128 test 1 (1073741825, 2)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 2147483650n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint32) => euint128 test 2 (35025, 35025)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 1226750625n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint32) => euint128 test 3 (35025, 35025)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 1226750625n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint128, euint32) => euint128 test 4 (35025, 35025)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: 1226750625n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint128) => ebool test 1 (60876, 340282366920938463463371785142095910535)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint128) => ebool test 2 (60872, 60876)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint128) => ebool test 3 (60876, 60876)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint128) => ebool test 4 (60876, 60872)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 77', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations78.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations78.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint64) => ebool test 2 (4449, 4453)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint64) => ebool test 3 (4453, 4453)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint16, euint64) => ebool test 4 (4453, 4449)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint16) => euint64 test 1 (65519, 2)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 65521n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint16) => euint64 test 2 (18303, 18305)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 36608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint16) => euint64 test 3 (18305, 18305)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 36610n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint16) => euint64 test 4 (18305, 18303)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 36608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint8) => euint128 test 1 (129, 2)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint8) => euint128 test 2 (124, 126)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint8) => euint128 test 3 (126, 126)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 252n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint8) => euint128 test 4 (126, 124)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint128) => ebool test 1 (16402, 340282366920938463463370817610820899629)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint128) => ebool test 2 (16398, 16402)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint128) => ebool test 3 (16402, 16402)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint128) => ebool test 4 (16402, 16398)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, uint128) => ebool test 1 (340282366920938463463370396677631502123, 340282366920938463463367507822160253739)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, uint128) => ebool test 2 (340282366920938463463370396677631502119, 340282366920938463463370396677631502123)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, uint128) => ebool test 3 (340282366920938463463370396677631502123, 340282366920938463463370396677631502123)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, uint128) => ebool test 4 (340282366920938463463370396677631502123, 340282366920938463463370396677631502119)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint8) => euint128 test 1 (340282366920938463463370989293308019257, 14)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 340282366920938463463370989293308019263n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint8) => euint128 test 2 (10, 14)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 14n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint8) => euint128 test 3 (14, 14)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 14n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint8) => euint128 test 4 (14, 10)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 78', function () {
     const expectedRes = {
       [handle]: 14n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations79.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations79.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 204556561n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint32) => euint128 test 2 (2625202577, 2625202581)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 2625202577n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint32) => euint128 test 3 (2625202581, 2625202581)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 2625202581n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint32) => euint128 test 4 (2625202581, 2625202577)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 2625202577n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint64, euint64) => euint64 test 1 (18445419736884143619, 18445725819605010405)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18445419736884143619n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint64, euint64) => euint64 test 2 (18438248006307692213, 18438248006307692217)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18438248006307692213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint64, euint64) => euint64 test 3 (18438248006307692217, 18438248006307692217)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18438248006307692217n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint64, euint64) => euint64 test 4 (18438248006307692217, 18438248006307692213)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18438248006307692213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint16) => euint32 test 1 (1754647918, 57569)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 1754656239n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint16) => euint32 test 2 (57565, 57569)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 57597n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint16) => euint32 test 3 (57569, 57569)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 57569n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint32, euint16) => euint32 test 4 (57569, 57565)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 57597n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint64, euint64) => euint64 test 1 (9221529251422891363, 9219987251639052726)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18441516503061944089n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint64, euint64) => euint64 test 2 (9219094923281824693, 9219094923281824695)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18438189846563649388n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint64, euint64) => euint64 test 3 (9219094923281824695, 9219094923281824695)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18438189846563649390n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint64, euint64) => euint64 test 4 (9219094923281824695, 9219094923281824693)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 18438189846563649388n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint128) => ebool test 1 (13011, 340282366920938463463366754428009894483)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint128) => ebool test 2 (13007, 13011)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint128) => ebool test 3 (13011, 13011)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint128) => ebool test 4 (13011, 13007)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint128) => euint128 test 1 (4111211228, 340282366920938463463373005160059319335)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373005164136443643n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint128) => euint128 test 2 (4111211224, 4111211228)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint128) => euint128 test 3 (4111211228, 4111211228)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint32, euint128) => euint128 test 4 (4111211228, 4111211224)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 79', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations8.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations8.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 130n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint64) => euint64 test 2 (11, 11)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint64) => euint64 test 3 (11, 11)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint64) => euint64 test 4 (11, 11)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 121n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, uint128) => euint128 test 1 (340282366920938463463369620863023408927, 340282366920938463463369517417588913885)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369057821717980701n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, uint128) => euint128 test 2 (340282366920938463463369620863023408923, 340282366920938463463369620863023408927)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, uint128) => euint128 test 3 (340282366920938463463369620863023408927, 340282366920938463463369620863023408927)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408927n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, uint128) => euint128 test 4 (340282366920938463463369620863023408927, 340282366920938463463369620863023408923)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint64) => ebool test 1 (3308622774, 18437794494309581285)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint64) => ebool test 2 (3308622770, 3308622774)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint64) => ebool test 3 (3308622774, 3308622774)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint64) => ebool test 4 (3308622774, 3308622770)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint8) => euint8 test 1 (59, 81)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 140n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint8) => euint8 test 2 (55, 59)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint8) => euint8 test 3 (59, 59)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 118n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint8) => euint8 test 4 (59, 55)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint8, euint8) => ebool test 1 (40, 72)', async function () {
@@ -434,7 +434,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint8, euint8) => ebool test 2 (67, 71)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint8, euint8) => ebool test 3 (71, 71)', async function () {
@@ -464,7 +464,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint8, euint8) => ebool test 4 (71, 67)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint128) => ebool test 1 (124, 340282366920938463463369290823911112265)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint128) => ebool test 2 (120, 124)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint128) => ebool test 3 (124, 124)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, euint128) => ebool test 4 (124, 120)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 8', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations80.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations80.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint64) => ebool test 2 (18438850655314522435, 18438850655314522439)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint64) => ebool test 3 (18438850655314522439, 18438850655314522439)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint64) => ebool test 4 (18438850655314522439, 18438850655314522435)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint16) => ebool test 1 (18443638241183480427, 23456)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint16) => ebool test 2 (23452, 23456)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint16) => ebool test 3 (23456, 23456)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint64, euint16) => ebool test 4 (23456, 23452)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint256) => euint256 test 1 (340282366920938463463367108430047407109, 115792089237316195423570985008687907853269984665640564039457577114197613017637)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907852929702298719625575994210202580952290848n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint256) => euint256 test 2 (340282366920938463463367108430047407105, 340282366920938463463367108430047407109)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint256) => euint256 test 3 (340282366920938463463367108430047407109, 340282366920938463463367108430047407109)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint128, euint256) => euint256 test 4 (340282366920938463463367108430047407109, 340282366920938463463367108430047407105)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 1 (2247755504, 2968171169)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 2 (1603469839, 1603469843)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 3 (1603469843, 1603469843)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint32, uint32) => ebool test 4 (1603469843, 1603469839)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 1 (2055001263, 3736754924)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 2 (2055001259, 2055001263)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 3 (2055001263, 2055001263)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, uint32) => ebool test 4 (2055001263, 2055001259)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, uint16) => ebool test 1 (39003, 35423)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, uint16) => ebool test 2 (38999, 39003)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, uint16) => ebool test 3 (39003, 39003)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, uint16) => ebool test 4 (39003, 38999)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 80', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations81.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations81.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457583766138435535323n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint32) => euint256 test 2 (4120882790, 4120882794)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint32) => euint256 test 3 (4120882794, 4120882794)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint32) => euint256 test 4 (4120882794, 4120882790)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, uint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457577588921391832383)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457578870958023180287n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, uint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457576582324561149927, 115792089237316195423570985008687907853269984665640564039457576582324561149931)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149935n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, uint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457576582324561149931)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149931n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint256, uint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457576582324561149931, 115792089237316195423570985008687907853269984665640564039457576582324561149927)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576582324561149935n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint8) => ebool test 1 (340282366920938463463367361794982947599, 41)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint8) => ebool test 2 (37, 41)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint8) => ebool test 3 (41, 41)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint8) => ebool test 4 (41, 37)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, euint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457582567451866790913, 6)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 1809251394333065553493296640760748560207343510400633813116524727616435418608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, euint8) => euint256 test 2 (2, 6)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, euint8) => euint256 test 3 (6, 6)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint256, euint8) => euint256 test 4 (6, 2)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "neg" overload (euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457575632604353170041)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 8375308776469895n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "not" overload (euint64) => euint64 test 1 (18441871104838442411)', async function () {
@@ -447,6 +447,6 @@ describe('FHEVM operations 81', function () {
     const expectedRes = {
       [handle]: 4872968871109204n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations82.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations82.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 17798220883680519720n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, euint8) => euint64 test 2 (5, 9)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 180143985094819840n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, euint8) => euint64 test 3 (9, 9)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 324259173170675712n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, euint8) => euint64 test 4 (9, 5)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 5188146770730811392n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint16) => ebool test 1 (18446261592890407429, 62081)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint16) => ebool test 2 (62077, 62081)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint16) => ebool test 3 (62081, 62081)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint16) => ebool test 4 (62081, 62077)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint256) => euint256 test 1 (101, 115792089237316195423570985008687907853269984665640564039457575515923998138179)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457575515923998138150n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint256) => euint256 test 2 (97, 101)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint256) => euint256 test 3 (101, 101)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint256) => euint256 test 4 (101, 97)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint32) => euint32 test 1 (138, 1882102599)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 1882102733n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint32) => euint32 test 2 (134, 138)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint32) => euint32 test 3 (138, 138)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint32) => euint32 test 4 (138, 134)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint256) => ebool test 1 (80, 115792089237316195423570985008687907853269984665640564039457577237607794223383)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint256) => ebool test 2 (76, 80)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint256) => ebool test 3 (80, 80)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint256) => ebool test 4 (80, 76)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, uint8) => euint64 test 1 (18444264105617150445, 9)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 17798220883680519720n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, uint8) => euint64 test 2 (5, 9)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 180143985094819840n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, uint8) => euint64 test 3 (9, 9)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 324259173170675712n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotr" overload (euint64, uint8) => euint64 test 4 (9, 5)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 82', function () {
     const expectedRes = {
       [handle]: 5188146770730811392n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations83.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations83.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint16) => euint16 test 2 (127, 131)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 127n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint16) => euint16 test 3 (131, 131)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint8, euint16) => euint16 test 4 (131, 127)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 127n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint128, euint128) => euint128 test 1 (340282366920938463463366529078120732589, 340282366920938463463368561917409048927)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366529078120732589n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint128, euint128) => euint128 test 2 (340282366920938463463371780590875218171, 340282366920938463463371780590875218175)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218171n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint128, euint128) => euint128 test 3 (340282366920938463463371780590875218175, 340282366920938463463371780590875218175)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218175n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (uint128, euint128) => euint128 test 4 (340282366920938463463371780590875218175, 340282366920938463463371780590875218171)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218171n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint128) => euint128 test 1 (2, 65)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 130n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint128) => euint128 test 2 (12, 12)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint128) => euint128 test 3 (12, 12)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint8, euint128) => euint128 test 4 (12, 12)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 144n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, uint64) => euint64 test 1 (18445649915025813613, 18437858841139870577)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 18437750945107669089n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, uint64) => euint64 test 2 (18443935695415273509, 18443935695415273513)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 18443935695415273505n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, uint64) => euint64 test 3 (18443935695415273513, 18443935695415273513)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 18443935695415273513n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, uint64) => euint64 test 4 (18443935695415273513, 18443935695415273509)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 18443935695415273505n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint8) => ebool test 1 (2056911597, 35)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint8) => ebool test 2 (31, 35)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint8) => ebool test 3 (35, 35)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint32, euint8) => ebool test 4 (35, 31)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, uint8) => euint16 test 1 (7904, 9)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 49213n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, uint8) => euint16 test 2 (5, 9)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 2560n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, uint8) => euint16 test 3 (9, 9)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 4608n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint16, uint8) => euint16 test 4 (9, 5)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 83', function () {
     const expectedRes = {
       [handle]: 288n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations84.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations84.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 35358n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, uint16) => euint16 test 2 (26704, 26708)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 53412n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, uint16) => euint16 test 3 (26708, 26708)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 53416n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, uint16) => euint16 test 4 (26708, 26704)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 53412n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint64) => euint64 test 1 (47038, 18439142016204617673)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 18439142016204617673n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint64) => euint64 test 2 (47034, 47038)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 47038n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint64) => euint64 test 3 (47038, 47038)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 47038n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint64) => euint64 test 4 (47038, 47034)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 47038n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint64) => euint64 test 1 (1399102700, 18440187475592957867)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 1399102700n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint64) => euint64 test 2 (1399102696, 1399102700)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 1399102696n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint64) => euint64 test 3 (1399102700, 1399102700)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 1399102700n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint32, euint64) => euint64 test 4 (1399102700, 1399102696)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 1399102696n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint128) => euint128 test 1 (340282366920938463463369620863023408927, 340282366920938463463374566092192076539)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620205419446811n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint128) => euint128 test 2 (340282366920938463463369620863023408923, 340282366920938463463369620863023408927)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint128) => euint128 test 3 (340282366920938463463369620863023408927, 340282366920938463463369620863023408927)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408927n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint128) => euint128 test 4 (340282366920938463463369620863023408927, 340282366920938463463369620863023408923)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint16) => ebool test 1 (18443280838227813917, 49759)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint16) => ebool test 2 (49755, 49759)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint16) => ebool test 3 (49759, 49759)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint16) => ebool test 4 (49759, 49755)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint64) => euint64 test 1 (18441939623530402993, 18444741482576668091)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 6206501267960074n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint64) => euint64 test 2 (18441939623530402989, 18441939623530402993)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint64) => euint64 test 3 (18441939623530402993, 18441939623530402993)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint64) => euint64 test 4 (18441939623530402993, 18441939623530402989)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 84', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations85.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations85.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 202n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint16) => euint16 test 2 (246, 250)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 242n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint16) => euint16 test 3 (250, 250)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 250n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint8, euint16) => euint16 test 4 (250, 246)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 242n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 1 (4115873166, 4102504073)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 2 (1993066226, 1993066230)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 3 (1993066230, 1993066230)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (uint32, euint32) => ebool test 4 (1993066230, 1993066226)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, uint128) => euint128 test 1 (340282366920938463463374432859434778255, 340282366920938463463368561917409048927)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368561917409048927n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, uint128) => euint128 test 2 (340282366920938463463371780590875218171, 340282366920938463463371780590875218175)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218171n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, uint128) => euint128 test 3 (340282366920938463463371780590875218175, 340282366920938463463371780590875218175)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218175n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, uint128) => euint128 test 4 (340282366920938463463371780590875218175, 340282366920938463463371780590875218171)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 340282366920938463463371780590875218171n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, uint8) => euint8 test 1 (163, 42)', async function () {
@@ -358,7 +358,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 163n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, uint8) => euint8 test 2 (110, 114)', async function () {
@@ -373,7 +373,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, uint8) => euint8 test 3 (114, 114)', async function () {
@@ -388,7 +388,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint8, uint8) => euint8 test 4 (114, 110)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint16, euint16) => euint16 test 1 (23488, 49271)', async function () {
@@ -418,7 +418,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 16448n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint16, euint16) => euint16 test 2 (26114, 26118)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 26114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint16, euint16) => euint16 test 3 (26118, 26118)', async function () {
@@ -448,7 +448,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 26118n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint16, euint16) => euint16 test 4 (26118, 26114)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 26114n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint256) => euint256 test 1 (18439250860245970943, 115792089237316195423570985008687907853269984665640564039457583351897183488535)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 18439179786971515415n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint256) => euint256 test 2 (18439250860245970939, 18439250860245970943)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 18439250860245970939n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint256) => euint256 test 3 (18439250860245970943, 18439250860245970943)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 18439250860245970943n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint64, euint256) => euint256 test 4 (18439250860245970943, 18439250860245970939)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 85', function () {
     const expectedRes = {
       [handle]: 18439250860245970939n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations86.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations86.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint16) => ebool test 2 (57376, 57380)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint16) => ebool test 3 (57380, 57380)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint16) => ebool test 4 (57380, 57376)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, uint8) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457578851692590253973, 7)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039456924011684088236799n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, uint8) => euint256 test 2 (3, 7)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 384n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, uint8) => euint256 test 3 (7, 7)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint256, uint8) => euint256 test 4 (7, 3)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 56n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint128) => euint128 test 1 (44836, 340282366920938463463366391934626299471)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366391934626299471n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint128) => euint128 test 2 (44832, 44836)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 44836n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint128) => euint128 test 3 (44836, 44836)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 44836n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint128) => euint128 test 4 (44836, 44832)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 44836n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint64) => ebool test 1 (47018, 18440001367559116187)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint64) => ebool test 2 (47014, 47018)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint64) => ebool test 3 (47018, 47018)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint16, euint64) => ebool test 4 (47018, 47014)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint64) => euint64 test 1 (2, 129)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 131n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint64) => euint64 test 2 (39, 43)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint64) => euint64 test 3 (43, 43)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 86n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint64) => euint64 test 4 (43, 39)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 82n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint128) => euint128 test 1 (2, 32769)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 32771n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint128) => euint128 test 2 (26358, 26360)', async function () {
@@ -517,7 +517,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 52718n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint128) => euint128 test 3 (26360, 26360)', async function () {
@@ -536,7 +536,7 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 52720n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint16, euint128) => euint128 test 4 (26360, 26358)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 86', function () {
     const expectedRes = {
       [handle]: 52718n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations87.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations87.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457576161828362440737n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint256, euint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457580727388371776951, 115792089237316195423570985008687907853269984665640564039457580727388371776955)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776947n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint256, euint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457580727388371776955)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776955n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint256, euint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457580727388371776955, 115792089237316195423570985008687907853269984665640564039457580727388371776951)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580727388371776947n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint64, uint64) => euint64 test 1 (18446460825824914497, 18439563228988831505)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 6897596836082992n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint64, uint64) => euint64 test 2 (18446214760006990733, 18446214760006990737)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 18446214760006990733n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint64, uint64) => euint64 test 3 (18446214760006990737, 18446214760006990737)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rem" overload (euint64, uint64) => euint64 test 4 (18446214760006990737, 18446214760006990733)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint64) => ebool test 1 (18442977952698121359, 18439679158105806079)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint64) => ebool test 2 (18439679158105806075, 18439679158105806079)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint64) => ebool test 3 (18439679158105806079, 18439679158105806079)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint64) => ebool test 4 (18439679158105806079, 18439679158105806075)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint16) => ebool test 1 (250, 22310)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint16) => ebool test 2 (246, 250)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint16) => ebool test 3 (250, 250)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint16) => ebool test 4 (250, 246)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint16) => ebool test 1 (96, 53828)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint16) => ebool test 2 (92, 96)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint16) => ebool test 3 (96, 96)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint8, euint16) => ebool test 4 (96, 92)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, uint8) => euint128 test 1 (340282366920938463463369869815014359481, 6)', async function () {
@@ -510,7 +510,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 5316911983139663491615154215859599366n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, uint8) => euint128 test 2 (2, 6)', async function () {
@@ -525,7 +525,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, uint8) => euint128 test 3 (6, 6)', async function () {
@@ -540,7 +540,7 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, uint8) => euint128 test 4 (6, 2)', async function () {
@@ -555,6 +555,6 @@ describe('FHEVM operations 87', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations88.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations88.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint16) => ebool test 2 (56784, 56788)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint16) => ebool test 3 (56788, 56788)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint16) => ebool test 4 (56788, 56784)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint64) => ebool test 1 (340282366920938463463366770577467978207, 18443268473052051343)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint64) => ebool test 2 (18443268473052051339, 18443268473052051343)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint64) => ebool test 3 (18443268473052051343, 18443268473052051343)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint128, euint64) => ebool test 4 (18443268473052051343, 18443268473052051339)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint128) => euint128 test 1 (18443836511821893045, 340282366920938463463367317904548486733)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 340282366920938463444933406686891922424n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint128) => euint128 test 2 (18443836511821893041, 18443836511821893045)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint128) => euint128 test 3 (18443836511821893045, 18443836511821893045)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, euint128) => euint128 test 4 (18443836511821893045, 18443836511821893041)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint128) => ebool test 1 (18437922239114402241, 340282366920938463463371221821026982055)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint128) => ebool test 2 (18437922239114402237, 18437922239114402241)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint128) => ebool test 3 (18437922239114402241, 18437922239114402241)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint64, euint128) => ebool test 4 (18437922239114402241, 18437922239114402237)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, uint8) => euint32 test 1 (2285223005, 11)', async function () {
@@ -434,7 +434,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 2917328896n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, uint8) => euint32 test 2 (7, 11)', async function () {
@@ -449,7 +449,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 14336n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, uint8) => euint32 test 3 (11, 11)', async function () {
@@ -464,7 +464,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 22528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint32, uint8) => euint32 test 4 (11, 7)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 1408n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, uint8) => euint128 test 1 (340282366920938463463367825108556783067, 11)', async function () {
@@ -494,7 +494,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 340282366920938463449484409494762870784n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, uint8) => euint128 test 2 (7, 11)', async function () {
@@ -509,7 +509,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 14336n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, uint8) => euint128 test 3 (11, 11)', async function () {
@@ -524,7 +524,7 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 22528n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shl" overload (euint128, uint8) => euint128 test 4 (11, 7)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 88', function () {
     const expectedRes = {
       [handle]: 1408n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations89.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations89.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369122578360959217n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint256) => euint256 test 2 (340282366920938463463373907793626314227, 340282366920938463463373907793626314231)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373907793626314227n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint256) => euint256 test 3 (340282366920938463463373907793626314231, 340282366920938463463373907793626314231)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373907793626314231n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint128, euint256) => euint256 test 4 (340282366920938463463373907793626314231, 340282366920938463463373907793626314227)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 340282366920938463463373907793626314227n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, uint8) => euint8 test 1 (227, 102)', async function () {
@@ -206,7 +206,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 133n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, uint8) => euint8 test 2 (4, 8)', async function () {
@@ -221,7 +221,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, uint8) => euint8 test 3 (8, 8)', async function () {
@@ -236,7 +236,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, uint8) => euint8 test 4 (8, 4)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint16) => euint16 test 1 (125, 125)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint16) => euint16 test 2 (125, 121)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint64) => ebool test 1 (39, 18444513820741033899)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint64) => ebool test 2 (35, 39)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint64) => ebool test 3 (39, 39)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint64) => ebool test 4 (39, 35)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint16) => euint128 test 1 (340282366920938463463366916509737526713, 16503)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366916509737543167n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint16) => euint128 test 2 (16499, 16503)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 16503n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint16) => euint128 test 3 (16503, 16503)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 16503n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint128, euint16) => euint128 test 4 (16503, 16499)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: 16503n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint16) => ebool test 1 (340282366920938463463371461895392466955, 50860)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint16) => ebool test 2 (50856, 50860)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint16) => ebool test 3 (50860, 50860)', async function () {
@@ -498,7 +498,7 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint16) => ebool test 4 (50860, 50856)', async function () {
@@ -517,6 +517,6 @@ describe('FHEVM operations 89', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations9.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations9.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint64) => euint64 test 2 (127, 123)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint16) => euint128 test 1 (340282366920938463463366145918203138607, 58861)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 58861n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint16) => euint128 test 2 (58857, 58861)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 58857n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint16) => euint128 test 3 (58861, 58861)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 58861n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint128, euint16) => euint128 test 4 (58861, 58857)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 58857n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint64) => euint128 test 1 (9223372036854775809, 2)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 9223372036854775811n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint64) => euint128 test 2 (9220555637265783960, 9220555637265783962)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 18441111274531567922n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint64) => euint128 test 3 (9220555637265783962, 9220555637265783962)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 18441111274531567924n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint128, euint64) => euint128 test 4 (9220555637265783962, 9220555637265783960)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 18441111274531567922n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint16) => euint32 test 1 (28540, 2)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 57080n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint16) => euint32 test 2 (166, 166)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 27556n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint16) => euint32 test 3 (166, 166)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 27556n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint32, euint16) => euint32 test 4 (166, 166)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 27556n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 1 (59316, 27984)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 2 (27980, 27984)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 3 (27984, 27984)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint16) => ebool test 4 (27984, 27980)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint32) => euint32 test 1 (1028482183, 2052334060)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 3080816243n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint32) => euint32 test 2 (2056964361, 2056964365)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 4113928726n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint32) => euint32 test 3 (2056964365, 2056964365)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 4113928730n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint32, euint32) => euint32 test 4 (2056964365, 2056964361)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 9', function () {
     const expectedRes = {
       [handle]: 4113928726n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations90.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations90.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 2 (60961, 60965)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 3 (60965, 60965)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint16) => ebool test 4 (60965, 60961)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint8) => ebool test 1 (2780893891, 144)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint8) => ebool test 2 (140, 144)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint8) => ebool test 3 (144, 144)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint32, euint8) => ebool test 4 (144, 140)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint64, euint64) => euint64 test 1 (18443553360840341423, 18443553360840341423)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (uint64, euint64) => euint64 test 2 (18443553360840341423, 18443553360840341419)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint32) => euint64 test 1 (18443417383555926477, 4246521683)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 18443417385300774879n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint32) => euint64 test 2 (4246521679, 4246521683)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 4246521695n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint32) => euint64 test 3 (4246521683, 4246521683)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 4246521683n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint64, euint32) => euint64 test 4 (4246521683, 4246521679)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 4246521695n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint64) => ebool test 1 (340282366920938463463371874412211957777, 18442746425963659289)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint64) => ebool test 2 (18442746425963659285, 18442746425963659289)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint64) => ebool test 3 (18442746425963659289, 18442746425963659289)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint128, euint64) => ebool test 4 (18442746425963659289, 18442746425963659285)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint128, euint128) => euint128 test 1 (340282366920938463463372042619194911899, 340282366920938463463369517417588913885)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366974622192903321n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint128, euint128) => euint128 test 2 (340282366920938463463369620863023408923, 340282366920938463463369620863023408927)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint128, euint128) => euint128 test 3 (340282366920938463463369620863023408927, 340282366920938463463369620863023408927)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408927n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (uint128, euint128) => euint128 test 4 (340282366920938463463369620863023408927, 340282366920938463463369620863023408923)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 90', function () {
     const expectedRes = {
       [handle]: 340282366920938463463369620863023408923n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations91.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations91.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint8) => ebool test 2 (239, 243)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint8) => ebool test 3 (243, 243)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint8) => ebool test 4 (243, 239)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, uint64) => euint64 test 1 (18441939623530402993, 18441931867559509173)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 10111232518148n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, uint64) => euint64 test 2 (18441939623530402989, 18441939623530402993)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, uint64) => euint64 test 3 (18441939623530402993, 18441939623530402993)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint64, uint64) => euint64 test 4 (18441939623530402993, 18441939623530402989)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint128) => euint128 test 1 (24669, 340282366920938463463366292722973600473)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 24665n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint128) => euint128 test 2 (24665, 24669)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 24665n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint128) => euint128 test 3 (24669, 24669)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 24669n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint128) => euint128 test 4 (24669, 24665)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 24665n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint256) => euint256 test 1 (57124, 115792089237316195423570985008687907853269984665640564039457580716762844836757)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 115792089237316195423570985008687907853269984665640564039457580716762844889013n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint256) => euint256 test 2 (57120, 57124)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 57124n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint256) => euint256 test 3 (57124, 57124)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 57124n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint256) => euint256 test 4 (57124, 57120)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 57124n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint128) => euint128 test 1 (2, 9223372036854775809)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 9223372036854775811n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint128) => euint128 test 2 (9221670991015262434, 9221670991015262436)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 18443341982030524870n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint128) => euint128 test 3 (9221670991015262436, 9221670991015262436)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 18443341982030524872n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint64, euint128) => euint128 test 4 (9221670991015262436, 9221670991015262434)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 18443341982030524870n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint128) => euint128 test 1 (18440098425586971115, 18440098425586971115)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint64, euint128) => euint128 test 2 (18440098425586971115, 18440098425586971111)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 91', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations92.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations92.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint128) => ebool test 2 (340282366920938463463366189235925904095, 340282366920938463463366189235925904099)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint128) => ebool test 3 (340282366920938463463366189235925904099, 340282366920938463463366189235925904099)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint256, euint128) => ebool test 4 (340282366920938463463366189235925904099, 340282366920938463463366189235925904095)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, uint64) => euint64 test 1 (4294910698, 4294140114)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 18442948314329539572n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, uint64) => euint64 test 2 (4293270308, 4293270308)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, uint64) => euint64 test 3 (4293270308, 4293270308)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "mul" overload (euint64, uint64) => euint64 test 4 (4293270308, 4293270308)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 18432169937554414864n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint32) => ebool test 1 (18445081815493340105, 1066279837)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint32) => ebool test 2 (1066279833, 1066279837)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint32) => ebool test 3 (1066279837, 1066279837)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint64, euint32) => ebool test 4 (1066279837, 1066279833)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 1 (5514, 51325)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 51325n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 2 (5510, 5514)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 3 (5514, 5514)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint16, euint16) => euint16 test 4 (5514, 5510)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: 5514n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint8) => ebool test 1 (181, 9)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint8) => ebool test 2 (5, 9)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint8) => ebool test 3 (9, 9)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint8) => ebool test 4 (9, 5)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint128) => ebool test 1 (37042, 340282366920938463463368751685907364015)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint128) => ebool test 2 (37038, 37042)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint128) => ebool test 3 (37042, 37042)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint16, euint128) => ebool test 4 (37042, 37038)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 92', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations93.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations93.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: 61009n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint16) => euint64 test 2 (61005, 61009)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: 61005n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint16) => euint64 test 3 (61009, 61009)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: 61009n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint16) => euint64 test 4 (61009, 61005)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: 61005n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint16) => ebool test 1 (64, 34280)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint16) => ebool test 2 (60, 64)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint16) => ebool test 3 (64, 64)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (euint8, euint16) => ebool test 4 (64, 60)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint8) => ebool test 1 (139, 98)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint8) => ebool test 2 (94, 98)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint8) => ebool test 3 (98, 98)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint8, euint8) => ebool test 4 (98, 94)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint256, euint256) => ebool test 1 (115792089237316195423570985008687907853269984665640564039457577072369442341493, 115792089237316195423570985008687907853269984665640564039457583034685916919557)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint256, euint256) => ebool test 2 (115792089237316195423570985008687907853269984665640564039457576299642184965501, 115792089237316195423570985008687907853269984665640564039457576299642184965505)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint256, euint256) => ebool test 3 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457576299642184965505)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ne" overload (uint256, euint256) => ebool test 4 (115792089237316195423570985008687907853269984665640564039457576299642184965505, 115792089237316195423570985008687907853269984665640564039457576299642184965501)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "not" overload (euint16) => euint16 test 1 (65228)', async function () {
@@ -433,7 +433,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: 307n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint256) => ebool test 1 (340282366920938463463366316422565428191, 115792089237316195423570985008687907853269984665640564039457583949710362396523)', async function () {
@@ -452,7 +452,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint256) => ebool test 2 (340282366920938463463366316422565428187, 340282366920938463463366316422565428191)', async function () {
@@ -471,7 +471,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint256) => ebool test 3 (340282366920938463463366316422565428191, 340282366920938463463366316422565428191)', async function () {
@@ -490,7 +490,7 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint256) => ebool test 4 (340282366920938463463366316422565428191, 340282366920938463463366316422565428187)', async function () {
@@ -509,6 +509,6 @@ describe('FHEVM operations 93', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations94.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations94.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint16, euint16) => ebool test 2 (5502, 5506)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint16, euint16) => ebool test 3 (5506, 5506)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (uint16, euint16) => ebool test 4 (5506, 5502)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint32) => ebool test 1 (75, 4137192407)', async function () {
@@ -194,7 +194,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint32) => ebool test 2 (71, 75)', async function () {
@@ -213,7 +213,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint32) => ebool test 3 (75, 75)', async function () {
@@ -232,7 +232,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint8, euint32) => ebool test 4 (75, 71)', async function () {
@@ -251,7 +251,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint128) => ebool test 1 (18440269862836516641, 340282366920938463463370704732463452831)', async function () {
@@ -270,7 +270,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint128) => ebool test 2 (18440269862836516637, 18440269862836516641)', async function () {
@@ -289,7 +289,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint128) => ebool test 3 (18440269862836516641, 18440269862836516641)', async function () {
@@ -308,7 +308,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (euint64, euint128) => ebool test 4 (18440269862836516641, 18440269862836516637)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, uint16) => ebool test 1 (60965, 12867)', async function () {
@@ -342,7 +342,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, uint16) => ebool test 2 (60961, 60965)', async function () {
@@ -357,7 +357,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, uint16) => ebool test 3 (60965, 60965)', async function () {
@@ -372,7 +372,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, uint16) => ebool test 4 (60965, 60961)', async function () {
@@ -387,7 +387,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint64) => euint64 test 1 (35521, 18440535816282915013)', async function () {
@@ -406,7 +406,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: 18440535816282950341n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint64) => euint64 test 2 (35517, 35521)', async function () {
@@ -425,7 +425,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: 35581n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint64) => euint64 test 3 (35521, 35521)', async function () {
@@ -444,7 +444,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: 35521n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, euint64) => euint64 test 4 (35521, 35517)', async function () {
@@ -463,7 +463,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: 35581n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint128) => ebool test 1 (340282366920938463463369402042742166611, 340282366920938463463370349561503835803)', async function () {
@@ -482,7 +482,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint128) => ebool test 2 (340282366920938463463369402042742166607, 340282366920938463463369402042742166611)', async function () {
@@ -501,7 +501,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint128) => ebool test 3 (340282366920938463463369402042742166611, 340282366920938463463369402042742166611)', async function () {
@@ -520,7 +520,7 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint128) => ebool test 4 (340282366920938463463369402042742166611, 340282366920938463463369402042742166607)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 94', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations95.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations95.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 2862902091n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint32, euint32) => euint32 test 2 (2056964361, 2056964365)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 4113928726n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint32, euint32) => euint32 test 3 (2056964365, 2056964365)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 4113928730n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (uint32, euint32) => euint32 test 4 (2056964365, 2056964361)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 4113928726n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint256) => euint256 test 1 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457581063156233134779)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 1340340079156392n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint256) => euint256 test 2 (115792089237316195423570985008687907853269984665640564039457579868021624684047, 115792089237316195423570985008687907853269984665640564039457579868021624684051)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint256) => euint256 test 3 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579868021624684051)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint256, euint256) => euint256 test 4 (115792089237316195423570985008687907853269984665640564039457579868021624684051, 115792089237316195423570985008687907853269984665640564039457579868021624684047)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 28n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint16, euint16) => ebool test 1 (62043, 17374)', async function () {
@@ -282,7 +282,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint16, euint16) => ebool test 2 (27980, 27984)', async function () {
@@ -297,7 +297,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint16, euint16) => ebool test 3 (27984, 27984)', async function () {
@@ -312,7 +312,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint16, euint16) => ebool test 4 (27984, 27980)', async function () {
@@ -327,7 +327,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint32, euint32) => euint32 test 1 (972353252, 2466881813)', async function () {
@@ -346,7 +346,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 3153981429n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint32, euint32) => euint32 test 2 (3255063185, 3255063189)', async function () {
@@ -365,7 +365,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint32, euint32) => euint32 test 3 (3255063189, 3255063189)', async function () {
@@ -384,7 +384,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (uint32, euint32) => euint32 test 4 (3255063189, 3255063185)', async function () {
@@ -403,7 +403,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 3255063189n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint32) => ebool test 1 (340282366920938463463370700084132980427, 3651136799)', async function () {
@@ -422,7 +422,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint32) => ebool test 2 (3651136795, 3651136799)', async function () {
@@ -441,7 +441,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint32) => ebool test 3 (3651136799, 3651136799)', async function () {
@@ -460,7 +460,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint128, euint32) => ebool test 4 (3651136799, 3651136795)', async function () {
@@ -479,7 +479,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, uint16) => euint16 test 1 (14010, 21508)', async function () {
@@ -494,7 +494,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 30398n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, uint16) => euint16 test 2 (14006, 14010)', async function () {
@@ -509,7 +509,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 14014n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, uint16) => euint16 test 3 (14010, 14010)', async function () {
@@ -524,7 +524,7 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 14010n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "or" overload (euint16, uint16) => euint16 test 4 (14010, 14006)', async function () {
@@ -539,6 +539,6 @@ describe('FHEVM operations 95', function () {
     const expectedRes = {
       [handle]: 14014n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations96.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations96.ts
@@ -130,7 +130,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint8, euint8) => ebool test 2 (41, 45)', async function () {
@@ -145,7 +145,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint8, euint8) => ebool test 3 (45, 45)', async function () {
@@ -160,7 +160,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (uint8, euint8) => ebool test 4 (45, 41)', async function () {
@@ -175,7 +175,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "not" overload (euint128) => euint128 test 1 (340282366920938463463370620405464634587)', async function () {
@@ -189,7 +189,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 3987026303576868n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, uint32) => euint32 test 1 (2271219408, 2271219408)', async function () {
@@ -208,7 +208,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint32, uint32) => euint32 test 2 (2271219408, 2271219404)', async function () {
@@ -227,7 +227,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, euint8) => euint64 test 1 (18438499424116504505, 8)', async function () {
@@ -246,7 +246,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 16336113777889491455n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, euint8) => euint64 test 2 (4, 8)', async function () {
@@ -265,7 +265,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 1024n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, euint8) => euint64 test 3 (8, 8)', async function () {
@@ -284,7 +284,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 2048n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "rotl" overload (euint64, euint8) => euint64 test 4 (8, 4)', async function () {
@@ -303,7 +303,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 128n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint32) => ebool test 1 (18445934740504335419, 787068425)', async function () {
@@ -322,7 +322,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint32) => ebool test 2 (787068421, 787068425)', async function () {
@@ -341,7 +341,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint32) => ebool test 3 (787068425, 787068425)', async function () {
@@ -360,7 +360,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint64, euint32) => ebool test 4 (787068425, 787068421)', async function () {
@@ -379,7 +379,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint16) => euint16 test 1 (123, 22976)', async function () {
@@ -398,7 +398,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 22971n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint16) => euint16 test 2 (119, 123)', async function () {
@@ -417,7 +417,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint16) => euint16 test 3 (123, 123)', async function () {
@@ -436,7 +436,7 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint8, euint16) => euint16 test 4 (123, 119)', async function () {
@@ -455,6 +455,6 @@ describe('FHEVM operations 96', function () {
     const expectedRes = {
       [handle]: 12n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations97.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations97.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint8, euint32) => euint32 test 2 (28, 24)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint128) => ebool test 1 (64218, 340282366920938463463369642978869850431)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint128) => ebool test 2 (64214, 64218)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint128) => ebool test 3 (64218, 64218)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint16, euint128) => ebool test 4 (64218, 64214)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint64) => ebool test 1 (42868, 18441383776112538717)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint64) => ebool test 2 (42864, 42868)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint64) => ebool test 3 (42868, 42868)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint16, euint64) => ebool test 4 (42868, 42864)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "not" overload (euint32) => euint32 test 1 (2666711578)', async function () {
@@ -319,7 +319,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: 1628255717n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, uint8) => ebool test 1 (146, 102)', async function () {
@@ -334,7 +334,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, uint8) => ebool test 2 (41, 45)', async function () {
@@ -349,7 +349,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, uint8) => ebool test 3 (45, 45)', async function () {
@@ -364,7 +364,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "gt" overload (euint8, uint8) => ebool test 4 (45, 41)', async function () {
@@ -379,7 +379,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint8, euint8) => ebool test 1 (213, 223)', async function () {
@@ -394,7 +394,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint8, euint8) => ebool test 2 (94, 98)', async function () {
@@ -409,7 +409,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint8, euint8) => ebool test 3 (98, 98)', async function () {
@@ -424,7 +424,7 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (uint8, euint8) => ebool test 4 (98, 94)', async function () {
@@ -439,6 +439,6 @@ describe('FHEVM operations 97', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations98.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations98.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint128) => ebool test 2 (340282366920938463463371647940600324845, 340282366920938463463371647940600324849)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint128) => ebool test 3 (340282366920938463463371647940600324849, 340282366920938463463371647940600324849)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "lt" overload (euint128, euint128) => ebool test 4 (340282366920938463463371647940600324849, 340282366920938463463371647940600324845)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint128, euint128) => ebool test 1 (340282366920938463463374517032478155835, 340282366920938463463373127578809249203)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint128, euint128) => ebool test 2 (340282366920938463463367329768413053355, 340282366920938463463367329768413053359)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint128, euint128) => ebool test 3 (340282366920938463463367329768413053359, 340282366920938463463367329768413053359)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "le" overload (uint128, euint128) => ebool test 4 (340282366920938463463367329768413053359, 340282366920938463463367329768413053355)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint32) => euint64 test 1 (18439380057149500047, 3056369901)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 3056369901n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint32) => euint64 test 2 (3056369897, 3056369901)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 3056369897n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint32) => euint64 test 3 (3056369901, 3056369901)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 3056369901n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "min" overload (euint64, euint32) => euint64 test 4 (3056369901, 3056369897)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 3056369897n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint128) => euint128 test 1 (63714, 340282366920938463463366987378709700637)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 340282366920938463463366987378709747967n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint128) => euint128 test 2 (63710, 63714)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 60n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint128) => euint128 test 3 (63714, 63714)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "xor" overload (euint16, euint128) => euint128 test 4 (63714, 63710)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 60n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, uint128) => euint128 test 1 (340282366920938463463367474228925970149, 340282366920938463463368463750923395115)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 340282366920938463463368463750923395115n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, uint128) => euint128 test 2 (340282366920938463463367382444010695717, 340282366920938463463367382444010695721)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, uint128) => euint128 test 3 (340282366920938463463367382444010695721, 340282366920938463463367382444010695721)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint128, uint128) => euint128 test 4 (340282366920938463463367382444010695721, 340282366920938463463367382444010695717)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: 340282366920938463463367382444010695721n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint64) => ebool test 1 (7070, 18445861434780263909)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint64) => ebool test 2 (7066, 7070)', async function () {
@@ -533,7 +533,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint64) => ebool test 3 (7070, 7070)', async function () {
@@ -552,7 +552,7 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "eq" overload (euint16, euint64) => ebool test 4 (7070, 7066)', async function () {
@@ -571,6 +571,6 @@ describe('FHEVM operations 98', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/fhevmOperations99.ts
+++ b/test-suite/e2e/test/fhevmOperations/fhevmOperations99.ts
@@ -134,7 +134,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint8) => ebool test 2 (95, 99)', async function () {
@@ -153,7 +153,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: false,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint8) => ebool test 3 (99, 99)', async function () {
@@ -172,7 +172,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "ge" overload (euint128, euint8) => ebool test 4 (99, 95)', async function () {
@@ -191,7 +191,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: true,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 1 (2203566275, 1083505052)', async function () {
@@ -210,7 +210,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 2203566275n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 2 (242006176, 242006180)', async function () {
@@ -229,7 +229,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 3 (242006180, 242006180)', async function () {
@@ -248,7 +248,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "max" overload (euint32, uint32) => euint32 test 4 (242006180, 242006176)', async function () {
@@ -267,7 +267,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 242006180n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint32) => euint32 test 1 (2, 172)', async function () {
@@ -286,7 +286,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 174n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint32) => euint32 test 2 (68, 70)', async function () {
@@ -305,7 +305,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 138n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint32) => euint32 test 3 (70, 70)', async function () {
@@ -324,7 +324,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 140n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "add" overload (euint8, euint32) => euint32 test 4 (70, 68)', async function () {
@@ -343,7 +343,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 138n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint128) => euint128 test 1 (5031, 5031)', async function () {
@@ -362,7 +362,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "sub" overload (euint16, euint128) => euint128 test 2 (5031, 5027)', async function () {
@@ -381,7 +381,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 4n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, euint8) => euint128 test 1 (340282366920938463463369869815014359481, 6)', async function () {
@@ -400,7 +400,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 5316911983139663491615154215859599366n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, euint8) => euint128 test 2 (2, 6)', async function () {
@@ -419,7 +419,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, euint8) => euint128 test 3 (6, 6)', async function () {
@@ -438,7 +438,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 0n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "shr" overload (euint128, euint8) => euint128 test 4 (6, 2)', async function () {
@@ -457,7 +457,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 1n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint256) => euint256 test 1 (65456, 115792089237316195423570985008687907853269984665640564039457581000826433146139)', async function () {
@@ -476,7 +476,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 36112n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint256) => euint256 test 2 (65452, 65456)', async function () {
@@ -495,7 +495,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 65440n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint256) => euint256 test 3 (65456, 65456)', async function () {
@@ -514,7 +514,7 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 65456n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 
   it('test operator "and" overload (euint16, euint256) => euint256 test 4 (65456, 65452)', async function () {
@@ -533,6 +533,6 @@ describe('FHEVM operations 99', function () {
     const expectedRes = {
       [handle]: 65440n,
     };
-    assert.deepEqual(res, expectedRes);
+    assert.deepEqual(res.clearValues, expectedRes);
   });
 });

--- a/test-suite/e2e/test/fhevmjsTest/fhevmjsTest.ts
+++ b/test-suite/e2e/test/fhevmjsTest/fhevmjsTest.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import { createInstances } from '../instance';
 import { getSigners, initSigners } from '../signers';
-import { bigIntToBytes64, bigIntToBytes128 } from '../utils';
 
 describe('Testing fhevmjs/fhevmjsMocked', function () {
   before(async function () {

--- a/test-suite/e2e/test/rand/Rand.ts
+++ b/test-suite/e2e/test/rand/Rand.ts
@@ -1,3 +1,4 @@
+import type { PublicDecryptResults } from '@zama-fhe/relayer-sdk/node';
 import { expect } from 'chai';
 import { ethers, network } from 'hardhat';
 
@@ -23,10 +24,11 @@ describe('Rand', function () {
     for (let i = 0; i < 15; i++) {
       const txn = await this.rand.generateBool();
       await txn.wait();
-      const valueHandle = await this.rand.valueb();
-      const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      values.push(value);
+      const valueHandle = (await this.rand.valueb()) as `0x${string}`;
+      const res: PublicDecryptResults = await this.instances.alice.publicDecrypt([valueHandle]);
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('boolean');
+      values.push(value as boolean);
     }
     // Expect at least two different generated values.
     const unique = new Set(values);
@@ -38,11 +40,13 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate8();
       await txn.wait();
-      const valueHandle = await this.rand.value8();
+      const valueHandle = (await this.rand.value8()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      expect(value).to.be.lessThanOrEqual(0xff);
-      values.push(value);
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(0xff);
+      values.push(valueNum);
     }
     // Expect at least two different generated values.
     const unique = new Set(values);
@@ -54,11 +58,13 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate8UpperBound(128);
       await txn.wait();
-      const valueHandle = await this.rand.value8();
+      const valueHandle = (await this.rand.value8()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      expect(value).to.be.lessThanOrEqual(127);
-      values.push(value);
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(127);
+      values.push(valueNum);
     }
     // Expect at least two different generated values.
     const unique = new Set(values);
@@ -71,14 +77,16 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate16();
       await txn.wait();
-      const valueHandle = await this.rand.value16();
+      const valueHandle = (await this.rand.value16()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      expect(value).to.be.lessThanOrEqual(0xffff);
-      if (value > 0xff) {
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(0xffff);
+      if (valueNum > 0xff) {
         has16bit = true;
       }
-      values.push(value);
+      values.push(valueNum);
     }
     // Make sure we actually generate 16 bit integers.
     expect(has16bit).to.be.true;
@@ -92,11 +100,13 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate16UpperBound(8192);
       await txn.wait();
-      const valueHandle = await this.rand.value16();
+      const valueHandle = (await this.rand.value16()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      expect(value).to.be.lessThanOrEqual(8191);
-      values.push(value);
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(8191);
+      values.push(valueNum);
     }
     // Expect at least two different generated values.
     const unique = new Set(values);
@@ -109,14 +119,16 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate32();
       await txn.wait();
-      const valueHandle = await this.rand.value32();
+      const valueHandle = (await this.rand.value32()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      expect(value).to.be.lessThanOrEqual(0xffffffff);
-      if (value > 0xffff) {
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(0xffffffff);
+      if (valueNum > 0xffff) {
         has32bit = true;
       }
-      values.push(value);
+      values.push(valueNum);
     }
     // Make sure we actually generate 32 bit integers.
     expect(has32bit).to.be.true;
@@ -130,11 +142,13 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate32UpperBound(262144);
       await txn.wait();
-      const valueHandle = await this.rand.value32();
+      const valueHandle = (await this.rand.value32()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
-      expect(value).to.be.lessThanOrEqual(262141);
-      values.push(value);
+      const value = res.clearValues[valueHandle];
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(262141);
+      values.push(valueNum);
     }
     // Expect at least two different generated values.
     const unique = new Set(values);
@@ -147,9 +161,10 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate64();
       await txn.wait();
-      const valueHandle = await this.rand.value64();
+      const valueHandle = (await this.rand.value64()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
       expect(value).to.be.lessThanOrEqual(BigInt('0xffffffffffffffff'));
       if (value > BigInt('0xffffffff')) {
         has64bit = true;
@@ -169,9 +184,10 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate64UpperBound(262144);
       await txn.wait();
-      const valueHandle = await this.rand.value64();
+      const valueHandle = (await this.rand.value64()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
       expect(value).to.be.lessThanOrEqual(262141);
       values.push(value);
     }
@@ -186,9 +202,10 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate128();
       await txn.wait();
-      const valueHandle = await this.rand.value128();
+      const valueHandle = (await this.rand.value128()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
       expect(value).to.be.lessThanOrEqual(BigInt('0xffffffffffffffffffffffffffffffff'));
       if (value > BigInt('0xffffffffffffffff')) {
         has128bit = true;
@@ -207,9 +224,10 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate128UpperBound(2n ** 100n);
       await txn.wait();
-      const valueHandle = await this.rand.value128();
+      const valueHandle = (await this.rand.value128()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
       expect(value).to.be.lessThanOrEqual(2n ** 100n);
       values.push(value);
     }
@@ -224,9 +242,10 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate256();
       await txn.wait();
-      const valueHandle = await this.rand.value256();
+      const valueHandle = (await this.rand.value256()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
       expect(value).to.be.lessThanOrEqual(BigInt('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'));
       if (value > BigInt('0xffffffffffffffffffffffffffffffff')) {
         has256bit = true;
@@ -245,9 +264,10 @@ describe('Rand', function () {
     for (let i = 0; i < 5; i++) {
       const txn = await this.rand.generate256UpperBound(2n ** 200n);
       await txn.wait();
-      const valueHandle = await this.rand.value256();
+      const valueHandle = (await this.rand.value256()) as `0x${string}`;
       const res = await this.instances.alice.publicDecrypt([valueHandle]);
-      const value = res[valueHandle];
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
       expect(value).to.be.lessThanOrEqual(2n ** 200n);
       values.push(value);
     }
@@ -264,11 +284,13 @@ describe('Rand', function () {
       for (let i = 0; i < 5; i++) {
         const txn = await this.rand.generate8();
         await txn.wait();
-        const valueHandle = await this.rand.value8();
+        const valueHandle = (await this.rand.value8()) as `0x${string}`;
         const res = await this.instances.alice.publicDecrypt([valueHandle]);
-        const value = res[valueHandle];
-        expect(value).to.be.lessThanOrEqual(0xff);
-        values.push(value);
+        const value = res.clearValues[valueHandle] as bigint;
+        expect(typeof value).to.eq('bigint');
+        const valueNum = Number(value);
+        expect(valueNum).to.be.lessThanOrEqual(0xff);
+        values.push(valueNum);
       }
       // Expect at least two different generated values.
       const unique = new Set(values);
@@ -281,11 +303,13 @@ describe('Rand', function () {
       for (let i = 0; i < 5; i++) {
         const txn = await this.rand.generate8();
         await txn.wait();
-        const valueHandle = await this.rand.value8();
+        const valueHandle = (await this.rand.value8()) as `0x${string}`;
         const res = await this.instances.alice.publicDecrypt([valueHandle]);
-        const value = res[valueHandle];
-        expect(value).to.be.lessThanOrEqual(0xff);
-        values2.push(value);
+        const value = res.clearValues[valueHandle] as bigint;
+        expect(typeof value).to.eq('bigint');
+        const valueNum = Number(value);
+        expect(valueNum).to.be.lessThanOrEqual(0xff);
+        values2.push(valueNum);
       }
       // Expect at least two different generated values.
       const unique2 = new Set(values2);
@@ -297,14 +321,16 @@ describe('Rand', function () {
       for (let i = 0; i < 5; i++) {
         const txn = await this.rand.generate16();
         await txn.wait();
-        const valueHandle = await this.rand.value16();
+        const valueHandle = (await this.rand.value16()) as `0x${string}`;
         const res = await this.instances.alice.publicDecrypt([valueHandle]);
-        const value = res[valueHandle];
-        expect(value).to.be.lessThanOrEqual(0xffff);
-        if (value > 0xff) {
+        const value = res.clearValues[valueHandle] as bigint;
+        expect(typeof value).to.eq('bigint');
+        const valueNum = Number(value);
+        expect(valueNum).to.be.lessThanOrEqual(0xffff);
+        if (valueNum > 0xff) {
           has16bit = true;
         }
-        values3.push(value);
+        values3.push(valueNum);
       }
       // Make sure we actually generate 16 bit integers.
       expect(has16bit).to.be.true;
@@ -317,9 +343,11 @@ describe('Rand', function () {
   it('generating rand in reverting sub-call', async function () {
     const txn = await this.rand.generate64Reverting();
     await txn.wait();
-    const valueHandle = await this.rand.value64Bounded();
+    const valueHandle = (await this.rand.value64Bounded()) as `0x${string}`;
     const res = await this.instances.alice.publicDecrypt([valueHandle]);
-    const value = res[valueHandle];
-    expect(value).to.be.lessThan(1024);
+    const value = res.clearValues[valueHandle] as bigint;
+    expect(typeof value).to.eq('bigint');
+    const valueNum = Number(value);
+    expect(valueNum).to.be.lessThan(1024);
   });
 });

--- a/test-suite/fhevm/fhevm-cli
+++ b/test-suite/fhevm/fhevm-cli
@@ -38,7 +38,7 @@ export HOST_VERSION=${HOST_VERSION:-"v0.10.0-3"}
 # Other services.
 export CORE_VERSION=${CORE_VERSION:-"v0.12.4"}
 export RELAYER_VERSION=${RELAYER_VERSION:-"v0.6.0"}
-export TEST_SUITE_VERSION=${TEST_SUITE_VERSION:-"bd5dcc1"}
+export TEST_SUITE_VERSION=${TEST_SUITE_VERSION:-"d60af28"}
 
 
 function print_logo() {


### PR DESCRIPTION
- Tests are now running relayer-sdk 0.3.0-6
- Fix Rand tests
- Fix fhevmOperationsXX tests
- updated codegen to support new publicDecrypt return values

refs https://github.com/zama-ai/fhevm-internal/issues/674