### PR TITLE
fix(coprocessor): add missing indices for ciphertext_digest table

### DIFF
--- a/coprocessor/fhevm-engine/.sqlx/query-77a440566615702c5cec52195809b5c1e27c3b50bda491f62cd9455c07a582aa.json
+++ b/coprocessor/fhevm-engine/.sqlx/query-77a440566615702c5cec52195809b5c1e27c3b50bda491f62cd9455c07a582aa.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT handle, ciphertext, ciphertext128, tenant_id, txn_limited_retries_count, txn_unlimited_retries_count, transaction_id\n            FROM ciphertext_digest\n            WHERE txn_is_sent = false\n            AND ciphertext IS NOT NULL\n            AND ciphertext128 IS NOT NULL\n            AND txn_limited_retries_count < $1\n            LIMIT $2",
+  "query": "\n            SELECT handle, ciphertext, ciphertext128, tenant_id, txn_limited_retries_count, txn_unlimited_retries_count, transaction_id\n            FROM ciphertext_digest\n            WHERE txn_is_sent = false\n            AND ciphertext IS NOT NULL\n            AND ciphertext128 IS NOT NULL\n            AND txn_limited_retries_count < $1\n            ORDER BY created_at ASC\n            LIMIT $2",
   "describe": {
     "columns": [
       {
@@ -55,5 +55,5 @@
       true
     ]
   },
-  "hash": "a74057b8122baa26cff2f59a9e0e7403bb1abe1881fd3da8757e192da9f84180"
+  "hash": "77a440566615702c5cec52195809b5c1e27c3b50bda491f62cd9455c07a582aa"
 }

--- a/coprocessor/fhevm-engine/.sqlx/query-fd37e7dc679caa21ba22d7724a27409c232cceb719aa41a71e7faf44d2cb8ef9.json
+++ b/coprocessor/fhevm-engine/.sqlx/query-fd37e7dc679caa21ba22d7724a27409c232cceb719aa41a71e7faf44d2cb8ef9.json
@@ -67,6 +67,11 @@
         "ordinal": 12,
         "name": "transaction_id",
         "type_info": "Bytea"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamp"
       }
     ],
     "parameters": {
@@ -88,7 +93,8 @@
       false,
       true,
       true,
-      true
+      true,
+      false
     ]
   },
   "hash": "fd37e7dc679caa21ba22d7724a27409c232cceb719aa41a71e7faf44d2cb8ef9"

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2139,7 +2139,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4274,7 +4274,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4667,7 +4667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5636,7 +5636,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -5673,7 +5673,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6859,7 +6859,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width",
 ]
@@ -7311,9 +7311,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svm-rs"
-version = "0.5.19"
+version = "0.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f15cc0fb280301739995e3b9f0f0dde3aecb876814f4768689f9138570cd3b"
+checksum = "909e8ff825120cd2b34ceb236ab72e2a7f74b1d3a86c247936c8ff7a80c5d408"
 dependencies = [
  "const-hex",
  "dirs",
@@ -7323,16 +7323,16 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.19"
+version = "0.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31affc47068aeef445accc5c3d5f7fd24f9072cae0a651cef564239003c94ff8"
+checksum = "c1ebe77b200f965e8dbec3ef1d8337e974179ca1ecaa9fc28f67288d6b438159"
 dependencies = [
  "const-hex",
  "semver 1.0.27",
@@ -8572,7 +8572,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/db-migration/migrations/20251203140023_ciphertext_digest_idx_sent_and_handle.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20251203140023_ciphertext_digest_idx_sent_and_handle.sql
@@ -1,0 +1,11 @@
+-- Track when entries are created for fair queuing of unsent transactions.
+ALTER TABLE ciphertext_digest
+ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+
+-- Handle SELECTs on handle only by the txn-sender.
+CREATE INDEX IF NOT EXISTS idx_ciphertext_digest_handle
+ON ciphertext_digest (handle);
+
+-- Handle SELECTs on unsent txns with limited retries by the txn-sender.
+CREATE INDEX IF NOT EXISTS idx_ciphertext_digest_unsent
+ON ciphertext_digest (txn_is_sent, created_at);

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -310,6 +310,7 @@ where
             AND ciphertext IS NOT NULL
             AND ciphertext128 IS NOT NULL
             AND txn_limited_retries_count < $1
+            ORDER BY created_at ASC
             LIMIT $2",
             self.conf.add_ciphertexts_max_retries,
             self.conf.add_ciphertexts_batch_limit as i64,


### PR DESCRIPTION
 * `idx_ciphertext_digest_handle` - we want the txn-sender to select by
   handle only
 * `idx_ciphertext_digest_unsent` - we want the txn-sender to
   select unsent txns with ordered limited retries efficiently

Furthermore, add fair ordering of rows in the ciphertext_digest table by
tracking when entries are created and order by that in the txn-sender.

Also, update the `svm-rs-builds` dependency to fix an issue with it
failing to fetch 0.8.31 prerelease version during build time from the
Soliditylang JSON file.