### PR TITLE
docs(common): update sdk docs for user and public decryption

### DIFF
--- a/docs/sdk-guides/public-decryption.md
+++ b/docs/sdk-guides/public-decryption.md
@@ -25,6 +25,10 @@ const handles = [
 const values = instance.publicDecrypt(handles);
 ```
 
+{% hint style="info" %}
+The total bit length of all ciphertexts being decrypted in a single request must not exceed 2048 bits. Each encrypted type has a specific bit length, for instance `euint8` uses 8 bits and `euint16` uses 16 bits. For the full list of encrypted types and their corresponding bit lengths, refer to the [encrypted types documentation](../solidity-guides/types.md#list-of-encrypted-types).
+{% endhint %}
+
 ## Onchain Public Decrypt
 
 For more details please refer to the on [onchain Oracle public decryption page](https://docs.zama.ai/protocol/solidity-guides/smart-contract/oracle).

--- a/docs/sdk-guides/user-decryption.md
+++ b/docs/sdk-guides/user-decryption.md
@@ -48,7 +48,8 @@ For more details on the topic please refer to [the ACL documentation](../solidit
 
 ## Step 2: decrypt the ciphertext
 
-Using that ciphertext handle user decryption is performed client-side using the `@zama-fhe/relayer-sdk` library.
+Using those ciphertext handles, user decryption is performed client-side using the `@zama-fhe/relayer-sdk` library.
+The `userDecrypt` function takes a **list of handles**, allowing you to decrypt multiple ciphertexts in a single request. In this example, provide just one handle.
 The user needs to have created an instance object prior to that (for more context see [the relayer-sdk setup page](./initialization.md)).
 
 ```ts
@@ -58,6 +59,8 @@ The user needs to have created an instance object prior to that (for more contex
 // contractAddress: [`string`]
 
 const keypair = instance.generateKeypair();
+// userDecrypt can take a batch of handles (with their corresponding contract addresses).
+// In this example we only pass one handle.
 const handleContractPairs = [
   {
     handle: ciphertextHandle,
@@ -89,5 +92,10 @@ const result = await instance.userDecrypt(
   durationDays,
 );
 
+// result maps each handle to its decrypted value
 const decryptedValue = result[ciphertextHandle];
 ```
+
+{% hint style="info" %}
+The total bit length of all ciphertexts being decrypted in a single request must not exceed 2048 bits. Each encrypted type has a specific bit length, for instance `euint8` uses 8 bits and `euint16` uses 16 bits. For the full list of encrypted types and their corresponding bit lengths, refer to the [encrypted types documentation](../solidity-guides/types.md#list-of-encrypted-types).
+{% endhint %}


### PR DESCRIPTION
- In both cases, add an info banner that the total bit length of ciphertexts being decrypted should not exceed 2048 bits.

- In user decrypt, emphasize that API supports batch decryption.