### PR TITLE
chore(protocol-contracts): reword staking to delegating in OperatorStaking/Rewarder

### DIFF
--- a/protocol-contracts/staking/contracts/OperatorRewarder.sol
+++ b/protocol-contracts/staking/contracts/OperatorRewarder.sol
@@ -14,7 +14,7 @@ import {ProtocolStaking} from "./ProtocolStaking.sol";
 /**
  * @title OperatorRewarder
  * @custom:security-contact security@zama.ai
- * @notice Distributes protocol staking rewards to operator stakers, with optional fee.
+ * @notice Distributes protocol staking rewards to operator delegators, with optional fee.
  * @dev A rewarder contract that works in tandem with `OperatorStaking` and `ProtocolStaking` contracts.
  * This contract receives rewards directly from `ProtocolStaking` and distributes them to `OperatorStaking` staker.
  * The owner of this contract can opt to take a fee on the rewards.
@@ -118,8 +118,8 @@ contract OperatorRewarder is Ownable {
     }
 
     /**
-     * @notice Claims rewards for a staker.
-     * @param account The staker's address.
+     * @notice Claims rewards for a delegator.
+     * @param account The delegator's address.
      */
     function claimRewards(address account) public virtual {
         uint256 earned_ = earned(account);
@@ -256,14 +256,14 @@ contract OperatorRewarder is Ownable {
     }
 
     /**
-     * @notice Returns unpaid reward for a staker.
-     * @param account The staker's address.
+     * @notice Returns unpaid reward for a delegator.
+     * @param account The delegator's address.
      * @return Amount of unpaid reward.
      */
     function earned(address account) public view virtual returns (uint256) {
-        uint256 stakedBalance = operatorStaking().balanceOf(account);
+        uint256 delegatedBalance = operatorStaking().balanceOf(account);
         int256 allocation = SafeCast.toInt256(
-            stakedBalance > 0 ? _allocation(stakedBalance, operatorStaking().totalSupply()) : 0
+            delegatedBalance > 0 ? _allocation(delegatedBalance, operatorStaking().totalSupply()) : 0
         );
         return SafeCast.toUint256(SignedMath.max(0, allocation - _rewardsPaid[account]));
     }

--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -20,12 +20,12 @@ import {ProtocolStaking} from "./ProtocolStaking.sol";
 /**
  * @title OperatorStaking
  * @custom:security-contact security@zama.ai
- * @notice Allows users to stake assets and receive shares, with support for reward distribution.
+ * @notice Allows users to delegate assets to an operator staker and receive shares, with support for reward distribution.
  * @dev Integrates with ProtocolStaking and OperatorRewarder contracts. Inspired by ERC7540 but not fully compliant.
  * Also inherits ERC1363 to ease of users with potential OperatorStaking contract migrations.
  *
  * NOTE: This contract supports slashing on the `ProtocolStaking` level, meaning that the overall stake of this contract
- * may decrease due to slashing. These losses are symmetrically passed to restakers on the `OperatorStaking` level.
+ * may decrease due to slashing. These losses are symmetrically passed to delegators on the `OperatorStaking` level.
  * Slashing must first decrease the `ProtocolStaking` balance of this contract before affecting pending withdrawals.
  */
 contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
@@ -37,7 +37,7 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
     address private _rewarder;
     uint256 private _totalSharesInRedemption;
     mapping(address => uint256) private _sharesReleased;
-    mapping(address => Checkpoints.Trace208) private _unstakeRequests;
+    mapping(address => Checkpoints.Trace208) private _redeemRequests;
     mapping(address => mapping(address => bool)) private _operator;
 
     /// @dev Emitted when an operator is set or unset for a controller.
@@ -144,10 +144,10 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
                 IERC20(asset()).balanceOf(address(this)) + protocolStaking_.awaitingRelease(address(this))
             );
 
-        (, uint48 lastReleaseTime, uint208 controllerSharesRedeemed) = _unstakeRequests[controller].latestCheckpoint();
+        (, uint48 lastReleaseTime, uint208 controllerSharesRedeemed) = _redeemRequests[controller].latestCheckpoint();
         uint48 releaseTime = protocolStaking_.unstake(SafeCast.toUint256(SignedMath.max(assetsToWithdraw, 0)));
         assert(releaseTime >= lastReleaseTime); // should never happen
-        _unstakeRequests[controller].push(releaseTime, controllerSharesRedeemed + shares);
+        _redeemRequests[controller].push(releaseTime, controllerSharesRedeemed + shares);
 
         emit RedeemRequest(controller, owner, 0, msg.sender, shares, releaseTime);
     }
@@ -191,9 +191,10 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
      * accounting for all in-flight redemptions are restaked into the `ProtocolStaking` contract.
      *
      * NOTE: Excess tokens will be in the `OperatorStaking` contract the operator is slashed
-     * during a redemption flow. Anyone can call this function to restake those tokens.
+     * during a redemption flow or if donations are made to it. Anyone can call this function to
+     * restake those tokens.
      */
-    function restake() public virtual {
+    function restakeOperatorExcess() public virtual {
         ProtocolStaking protocolStaking_ = protocolStaking();
         protocolStaking_.release(address(this));
         uint256 amountToRestake = IERC20(asset()).balanceOf(address(this)) - previewRedeem(totalSharesInRedemption());
@@ -268,7 +269,7 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
      * @return Amount of shares pending redeem.
      */
     function pendingRedeemRequest(uint256, address controller) public view virtual returns (uint256) {
-        return _unstakeRequests[controller].latest() - _unstakeRequests[controller].upperLookup(Time.timestamp());
+        return _redeemRequests[controller].latest() - _redeemRequests[controller].upperLookup(Time.timestamp());
     }
 
     /**
@@ -277,7 +278,7 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
      * @return Amount of claimable shares.
      */
     function claimableRedeemRequest(uint256, address controller) public view virtual returns (uint256) {
-        return _unstakeRequests[controller].upperLookup(Time.timestamp()) - _sharesReleased[controller];
+        return _redeemRequests[controller].upperLookup(Time.timestamp()) - _sharesReleased[controller];
     }
 
     /**

--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -194,7 +194,7 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
      * during a redemption flow or if donations are made to it. Anyone can call this function to
      * restake those tokens.
      */
-    function restakeOperatorExcess() public virtual {
+    function restakeExcess() public virtual {
         ProtocolStaking protocolStaking_ = protocolStaking();
         protocolStaking_.release(address(this));
         uint256 amountToRestake = IERC20(asset()).balanceOf(address(this)) - previewRedeem(totalSharesInRedemption());

--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -187,14 +187,14 @@ contract OperatorStaking is ERC1363, Ownable, ReentrancyGuardTransient {
     }
 
     /**
-     * @dev Restake excess tokens held by this contract. Excess tokens held by this contract after
+     * @dev Stake excess tokens held by this contract. Excess tokens held by this contract after
      * accounting for all in-flight redemptions are restaked into the `ProtocolStaking` contract.
      *
      * NOTE: Excess tokens will be in the `OperatorStaking` contract the operator is slashed
      * during a redemption flow or if donations are made to it. Anyone can call this function to
      * restake those tokens.
      */
-    function restakeExcess() public virtual {
+    function stakeExcess() public virtual {
         ProtocolStaking protocolStaking_ = protocolStaking();
         protocolStaking_.release(address(this));
         uint256 amountToRestake = IERC20(asset()).balanceOf(address(this)) - previewRedeem(totalSharesInRedemption());

--- a/protocol-contracts/staking/test/OperatorRewarder.test.ts
+++ b/protocol-contracts/staking/test/OperatorRewarder.test.ts
@@ -316,7 +316,7 @@ describe('OperatorRewarder', function () {
 
     it('should set fee to max fee and claim fees if new max fee lower than current fee', async function () {
       await this.mock.connect(this.beneficiary).setFee(1000);
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
       await timeIncreaseNoMine(10);
 
       // If the new max fee is lower than the current fee:

--- a/protocol-contracts/staking/test/OperatorRewarder.test.ts
+++ b/protocol-contracts/staking/test/OperatorRewarder.test.ts
@@ -9,7 +9,7 @@ const timeIncreaseNoMine = (duration: number) =>
 
 describe('OperatorRewarder', function () {
   beforeEach(async function () {
-    const [staker1, staker2, admin, beneficiary, anyone, ...accounts] = await ethers.getSigners();
+    const [delegator1, delegator2, admin, beneficiary, anyone, ...accounts] = await ethers.getSigners();
 
     const token = await ethers.deployContract('$ERC20Mock', ['StakingToken', 'ST', 18]);
     const protocolStaking = await ethers.getContractFactory('ProtocolStakingSlashingMock').then(factory =>
@@ -38,7 +38,7 @@ describe('OperatorRewarder', function () {
     await expect(mock.token()).to.eventually.eq(token.target);
 
     await Promise.all(
-      [staker1, staker2].flatMap(account => [
+      [delegator1, delegator2].flatMap(account => [
         token.mint(account, ethers.parseEther('1000')),
         token.$_approve(account, operatorStaking, ethers.MaxUint256),
       ]),
@@ -47,8 +47,8 @@ describe('OperatorRewarder', function () {
     await protocolStaking.connect(admin).addEligibleAccount(operatorStaking);
 
     Object.assign(this, {
-      staker1,
-      staker2,
+      delegator1,
+      delegator2,
       admin,
       beneficiary,
       anyone,
@@ -88,59 +88,59 @@ describe('OperatorRewarder', function () {
     });
   });
 
-  describe('View and claim staker reward', async function () {
-    it('should give all to solo staker', async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+  describe('View and claim delegator reward', async function () {
+    it('should give all to solo delegator', async function () {
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await timeIncreaseNoMine(10);
       await this.protocolStaking.connect(this.admin).setRewardRate(ethers.parseEther('0'));
 
       await expect(this.mock.unpaidFee()).to.eventually.eq(0);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('5'));
-      await expect(this.mock.claimRewards(this.staker1))
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
+      await expect(this.mock.claimRewards(this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('5'));
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(0);
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
 
       // Historical reward: 10 (seconds) * 0.5 (reward rate) = 5
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('5'));
     });
 
-    it('should split between two equal stakers', async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.operatorStaking.connect(this.staker2).deposit(ethers.parseEther('1'), this.staker2);
+    it('should split between two equal delegators', async function () {
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.operatorStaking.connect(this.delegator2).deposit(ethers.parseEther('1'), this.delegator2);
 
       await timeIncreaseNoMine(9);
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
 
       await expect(this.mock.unpaidFee()).to.eventually.eq(0);
-      await expect(this.mock.earned(this.staker2)).to.eventually.eq(ethers.parseEther('2.25'));
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('2.75'));
+      await expect(this.mock.earned(this.delegator2)).to.eventually.eq(ethers.parseEther('2.25'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('2.75'));
 
-      await expect(this.mock.claimRewards(this.staker1))
+      await expect(this.mock.claimRewards(this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('2.75'));
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(0);
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('2.75'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
 
-      await expect(this.mock.claimRewards(this.staker2))
+      await expect(this.mock.claimRewards(this.delegator2))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker2, ethers.parseEther('2.25'));
-      await expect(this.mock.earned(this.staker2)).to.eventually.eq(0);
+        .withArgs(this.mock, this.delegator2, ethers.parseEther('2.25'));
+      await expect(this.mock.earned(this.delegator2)).to.eventually.eq(0);
 
       // Historical reward: (1+9) (seconds) * 0.5 (reward rate) = 5
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('5'));
     });
 
     it('should not claim past reward after receiving new shares on transfer', async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
       await timeIncreaseNoMine(10);
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
-      await this.mock.claimRewards(this.staker1); // claims past rewards before not being able to
-      await this.operatorStaking.connect(this.staker1).transfer(this.staker2, ethers.parseEther('1'));
-      // staker1 will be able deposit and claim reward again
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(0);
-      // staker2 cannot claim any reward
-      await expect(this.mock.earned(this.staker2)).to.eventually.eq(0);
+      await this.mock.claimRewards(this.delegator1); // claims past rewards before not being able to
+      await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, ethers.parseEther('1'));
+      // delegator1 will be able deposit and claim reward again
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
+      // delegator2 cannot claim any reward
+      await expect(this.mock.earned(this.delegator2)).to.eventually.eq(0);
 
       // Historical reward: 10 (seconds) * 0.5 (reward rate) = 5
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('5'));
@@ -148,18 +148,18 @@ describe('OperatorRewarder', function () {
 
     it('should decrease rewards appropriately for fee', async function () {
       await this.mock.connect(this.beneficiary).setFee(1000); // 10% fee
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await timeIncreaseNoMine(10);
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
 
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('4.5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('4.5'));
       await expect(this.mock.unpaidFee()).to.eventually.eq(ethers.parseEther('0.5'));
 
-      await expect(this.mock.claimRewards(this.staker1))
+      await expect(this.mock.claimRewards(this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('4.5'));
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(0);
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('4.5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
 
       await expect(this.mock.connect(this.beneficiary).claimFee())
         .to.emit(this.token, 'Transfer')
@@ -170,69 +170,73 @@ describe('OperatorRewarder', function () {
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('4.5'));
     });
 
-    it('should not trigger payment if no staker reward', async function () {
+    it('should not trigger payment if no delegator reward', async function () {
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
       await time.increase(9);
 
-      await expect(this.mock.claimRewards(this.staker1)).to.not.emit(this.token, 'Transfer');
+      await expect(this.mock.claimRewards(this.delegator1)).to.not.emit(this.token, 'Transfer');
 
       // Historical reward: 0 (no reward rate)
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('0'));
     });
 
-    it('should calculate properly after full removal then restake', async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.operatorStaking.connect(this.staker2).deposit(ethers.parseEther('1'), this.staker2);
+    it('should calculate properly after full removal then delegate again', async function () {
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.operatorStaking.connect(this.delegator2).deposit(ethers.parseEther('1'), this.delegator2);
 
       await timeIncreaseNoMine(10);
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
 
-      await this.mock.claimRewards(this.staker1);
-      await this.mock.claimRewards(this.staker2);
+      await this.mock.claimRewards(this.delegator1);
+      await this.mock.claimRewards(this.delegator2);
 
       await this.operatorStaking
-        .connect(this.staker1)
-        .requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+        .connect(this.delegator1)
+        .requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
       await this.operatorStaking
-        .connect(this.staker2)
-        .requestRedeem(ethers.parseEther('1'), this.staker2, this.staker2);
+        .connect(this.delegator2)
+        .requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
       await timeIncreaseNoMine(60);
 
-      await this.operatorStaking.connect(this.staker1).redeem(ethers.parseEther('1'), this.staker1, this.staker1);
-      await this.operatorStaking.connect(this.staker2).redeem(ethers.parseEther('1'), this.staker2, this.staker2);
+      await this.operatorStaking
+        .connect(this.delegator1)
+        .redeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
+      await this.operatorStaking
+        .connect(this.delegator2)
+        .redeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
 
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(0);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
 
       await this.protocolStaking.connect(this.admin).setRewardRate(ethers.parseEther('0.5'));
 
       await time.increase(10);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
 
-      await expect(this.mock.claimRewards(this.staker1))
+      await expect(this.mock.claimRewards(this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('5.5'));
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(0);
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('5.5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
 
       // Historical reward: (1+10+10+1) (seconds) * 0.5 (reward rate) = 11
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('11'));
     });
 
     it("should properly count rewards after pending withdrawal that's not yet redeemed", async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('3'), this.staker1);
-      await this.operatorStaking.connect(this.staker2).deposit(ethers.parseEther('1'), this.staker2);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('3'), this.delegator1);
+      await this.operatorStaking.connect(this.delegator2).deposit(ethers.parseEther('1'), this.delegator2);
 
       await timeIncreaseNoMine(10);
 
       await this.operatorStaking
-        .connect(this.staker1)
-        .requestRedeem(ethers.parseEther('2'), this.staker1, this.staker1);
+        .connect(this.delegator1)
+        .requestRedeem(ethers.parseEther('2'), this.delegator1, this.delegator1);
 
       await time.increase(10);
 
-      expect(await this.mock.earned(this.staker1)).to.be.closeTo(ethers.parseEther('6.75'), 1n);
-      await expect(this.mock.earned(this.staker2)).to.eventually.eq(ethers.parseEther('3.75'));
+      expect(await this.mock.earned(this.delegator1)).to.be.closeTo(ethers.parseEther('6.75'), 1n);
+      await expect(this.mock.earned(this.delegator2)).to.eventually.eq(ethers.parseEther('3.75'));
 
       // Historical reward: (1+10) (seconds) * 0.5 (reward rate) = 10.5
       await expect(this.mock.historicalReward()).to.eventually.eq(ethers.parseEther('10.5'));
@@ -242,14 +246,14 @@ describe('OperatorRewarder', function () {
   describe('View and claim owner reward', async function () {
     beforeEach(async function () {
       await this.mock.connect(this.beneficiary).setFee(1000);
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
     });
 
     it('should send tokens', async function () {
       await time.increase(20);
 
       await expect(this.mock.unpaidFee()).to.eventually.eq(ethers.parseEther('1'));
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('9'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('9'));
 
       // 1 more second goes by
       await expect(this.mock.connect(this.beneficiary).claimFee())
@@ -268,11 +272,11 @@ describe('OperatorRewarder', function () {
       await expect(this.mock.unpaidFee()).to.eventually.eq(0);
     });
 
-    it('should not effect staker earned amount', async function () {
+    it('should not effect delegator earned amount', async function () {
       await timeIncreaseNoMine(10);
       await this.mock.connect(this.beneficiary).claimFee();
 
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('4.5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('4.5'));
     });
 
     it('should not effect historical reward', async function () {
@@ -357,7 +361,7 @@ describe('OperatorRewarder', function () {
 
     it('should send pending fees', async function () {
       await this.mock.connect(this.beneficiary).setFee(1000);
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await timeIncreaseNoMine(10);
       await expect(this.mock.connect(this.beneficiary).setFee(2000))
@@ -367,26 +371,26 @@ describe('OperatorRewarder', function () {
 
     it('should accrue awards accurately after change', async function () {
       await this.mock.connect(this.beneficiary).setFee(1000);
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await timeIncreaseNoMine(10);
       await this.mock.connect(this.beneficiary).setFee(2000);
 
       await time.increase(10);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('8.5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('8.5'));
       await expect(this.mock.unpaidFee()).to.eventually.eq(ethers.parseEther('1')); // 0.5 already sent
     });
 
     it('should not take fees from past rewards', async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await timeIncreaseNoMine(10);
       await this.mock.connect(this.beneficiary).setFee(1000);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
       await expect(this.mock.unpaidFee()).to.eventually.eq(0);
 
       await time.increase(10);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('9.5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('9.5'));
       await expect(this.mock.unpaidFee()).to.eventually.eq(ethers.parseEther('0.5'));
     });
 
@@ -419,7 +423,7 @@ describe('OperatorRewarder', function () {
 
   describe('shutdown', function () {
     beforeEach(async function () {
-      await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
       await timeIncreaseNoMine(9);
 
       const newRewarder = await ethers.deployContract('OperatorRewarder', [
@@ -447,10 +451,10 @@ describe('OperatorRewarder', function () {
     it('should stop accruing rewards after shutdown', async function () {
       await this.tx;
 
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
 
       await timeIncreaseNoMine(10);
-      await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('5'));
+      await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
     });
 
     it('only callable by protocolStaking', async function () {
@@ -468,32 +472,34 @@ describe('OperatorRewarder', function () {
 
   describe('transferHook', function () {
     it('should revert if not called by operatorStaking contract', async function () {
-      await expect(this.mock.connect(this.anyone).transferHook(this.staker1, this.staker1, ethers.parseEther('1')))
+      await expect(
+        this.mock.connect(this.anyone).transferHook(this.delegator1, this.delegator1, ethers.parseEther('1')),
+      )
         .to.be.revertedWithCustomError(this.mock, 'CallerNotOperatorStaking')
         .withArgs(this.anyone);
     });
 
     describe('should handle transfers properly', function () {
-      it('one staker to a new staker full balance', async function () {
-        await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      it('one delegator to a new delegator full balance', async function () {
+        await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
         await timeIncreaseNoMine(10);
 
-        await this.operatorStaking.connect(this.staker1).transfer(this.staker2, ethers.parseEther('1'));
+        await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, ethers.parseEther('1'));
         await time.increase(10);
 
-        await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('5'));
-        await expect(this.mock.earned(this.staker2)).to.eventually.eq(ethers.parseEther('5'));
+        await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
+        await expect(this.mock.earned(this.delegator2)).to.eventually.eq(ethers.parseEther('5'));
       });
 
-      it('one staker to a new staker partial balance', async function () {
-        await this.operatorStaking.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      it('one delegator to a new delegator partial balance', async function () {
+        await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
         await timeIncreaseNoMine(10);
 
-        await this.operatorStaking.connect(this.staker1).transfer(this.staker2, ethers.parseEther('0.5'));
+        await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, ethers.parseEther('0.5'));
         await time.increase(10);
 
-        await expect(this.mock.earned(this.staker1)).to.eventually.eq(ethers.parseEther('7.5'));
-        await expect(this.mock.earned(this.staker2)).to.eventually.eq(ethers.parseEther('2.5'));
+        await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('7.5'));
+        await expect(this.mock.earned(this.delegator2)).to.eventually.eq(ethers.parseEther('2.5'));
       });
     });
   });

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -247,10 +247,10 @@ describe('OperatorStaking', function () {
     });
   });
 
-  describe('restakeOperatorExcess', async function () {
+  describe('restakeExcess', async function () {
     it('should restake in protocol staking', async function () {
       await this.token.connect(this.delegator1).transfer(this.mock, ethers.parseEther('10'));
-      await expect(this.mock.restakeOperatorExcess())
+      await expect(this.mock.restakeExcess())
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, ethers.parseEther('10'));
     });
@@ -267,7 +267,7 @@ describe('OperatorStaking', function () {
       await this.protocolStaking.release(this.mock);
 
       const restakeAmount = BigInt(ethers.parseEther('1')) + 1n;
-      await expect(this.mock.restakeOperatorExcess())
+      await expect(this.mock.restakeExcess())
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, restakeAmount);
     });
@@ -426,7 +426,7 @@ describe('OperatorStaking', function () {
         await time.increase(10);
 
         await expect(this.newRewarder.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('1.25'));
-        await expect(this.newRewarder.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('3.75'));
+        await expect(this.newRewarder.earned(this.delegator2)).to.eventually.eq(ethers.parseEther('3.75'));
         await expect(this.newRewarder.unpaidFee()).to.eventually.eq(0);
 
         await expect(this.newRewarder.claimRewards(this.delegator1))

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -8,7 +8,7 @@ const timeIncreaseNoMine = (duration: number) =>
 
 describe('OperatorStaking', function () {
   beforeEach(async function () {
-    const [staker1, staker2, admin, beneficiary, ...accounts] = await ethers.getSigners();
+    const [delegator1, delegator2, admin, beneficiary, ...accounts] = await ethers.getSigners();
 
     const token = await ethers.deployContract('$ERC20Mock', ['StakingToken', 'ST', 18]);
     const protocolStaking = await ethers.getContractFactory('ProtocolStakingSlashingMock').then(factory =>
@@ -35,122 +35,120 @@ describe('OperatorStaking', function () {
     ]);
 
     await Promise.all(
-      [staker1, staker2].flatMap(account => [
+      [delegator1, delegator2].flatMap(account => [
         token.mint(account, ethers.parseEther('1000')),
         token.$_approve(account, mock, ethers.MaxUint256),
       ]),
     );
 
-    Object.assign(this, { staker1, staker2, admin, beneficiary, accounts, token, protocolStaking, mock });
+    Object.assign(this, { delegator1, delegator2, admin, beneficiary, accounts, token, protocolStaking, mock });
   });
 
   describe('deposit', async function () {
     it('should stake into protocol staking', async function () {
-      await expect(this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1))
+      await expect(this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1))
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, ethers.parseEther('1'));
     });
 
     it('should mint shares', async function () {
-      await expect(this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1))
+      await expect(this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1))
         .to.emit(this.mock, 'Transfer')
-        .withArgs(ethers.ZeroAddress, this.staker1, ethers.parseEther('1'));
+        .withArgs(ethers.ZeroAddress, this.delegator1, ethers.parseEther('1'));
     });
 
     it('should pull tokens', async function () {
-      await expect(this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1))
+      await expect(this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.staker1, this.mock, ethers.parseEther('1'));
+        .withArgs(this.delegator1, this.mock, ethers.parseEther('1'));
     });
   });
 
   describe('redeem', async function () {
     it('simple redemption', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
       await this.mock
-        .connect(this.staker1)
-        .requestRedeem(await this.mock.balanceOf(this.staker1), this.staker1, this.staker1);
+        .connect(this.delegator1)
+        .requestRedeem(await this.mock.balanceOf(this.delegator1), this.delegator1, this.delegator1);
 
-      await expect(this.mock.pendingRedeemRequest(0, this.staker1)).to.eventually.eq(ethers.parseEther('1'));
-      await expect(this.mock.claimableRedeemRequest(0, this.staker1)).to.eventually.eq(0);
+      await expect(this.mock.pendingRedeemRequest(0, this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
+      await expect(this.mock.claimableRedeemRequest(0, this.delegator1)).to.eventually.eq(0);
 
       await time.increase(60);
 
-      await expect(this.mock.pendingRedeemRequest(0, this.staker1)).to.eventually.eq(0);
-      await expect(this.mock.claimableRedeemRequest(0, this.staker1)).to.eventually.eq(ethers.parseEther('1'));
+      await expect(this.mock.pendingRedeemRequest(0, this.delegator1)).to.eventually.eq(0);
+      await expect(this.mock.claimableRedeemRequest(0, this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
 
-      await expect(this.mock.connect(this.staker1).redeem(ethers.parseEther('1'), this.staker1, this.staker1))
+      await expect(this.mock.connect(this.delegator1).redeem(ethers.parseEther('1'), this.delegator1, this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('1'));
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('1'));
       await expect(this.token.balanceOf(this.mock)).to.eventually.be.eq(0);
     });
 
     it('zero redemption should terminate early', async function () {
-      await expect(this.mock.connect(this.staker1).requestRedeem(0, this.staker1, this.staker1)).to.not.emit(
+      await expect(this.mock.connect(this.delegator1).requestRedeem(0, this.delegator1, this.delegator1)).to.not.emit(
         this.mock,
         'RedeemRequest',
       );
     });
 
     it('should not redeem twice', async function () {
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('5'), this.staker2);
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('10'), this.staker1);
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
-      await this.mock.connect(this.staker2).requestRedeem(ethers.parseEther('1'), this.staker2, this.staker2);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('5'), this.delegator2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
+      await this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
 
       await timeIncreaseNoMine(60);
 
-      await expect(this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1))
+      await expect(this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('1'));
-      await expect(this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1)).to.not.emit(
-        this.token,
-        'Transfer',
-      );
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('1'));
+      await expect(
+        this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1),
+      ).to.not.emit(this.token, 'Transfer');
     });
 
     it('should revert on redeem more than available', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('10'), this.staker1);
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
 
       await timeIncreaseNoMine(10);
-      await expect(this.mock.connect(this.staker1).redeem(ethers.parseEther('1'), this.staker1, this.staker1))
+      await expect(this.mock.connect(this.delegator1).redeem(ethers.parseEther('1'), this.delegator1, this.delegator1))
         .to.be.revertedWithCustomError(this.mock, 'ERC4626ExceededMaxRedeem')
-        .withArgs(this.staker1, ethers.parseEther('1'), 0);
+        .withArgs(this.delegator1, ethers.parseEther('1'), 0);
     });
 
     it('should be able to redeem a second time', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('10'), this.staker1);
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
 
       await timeIncreaseNoMine(60);
 
-      await expect(this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1))
+      await expect(this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('1'));
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('1'));
 
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('2'), this.staker1, this.staker1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('2'), this.delegator1, this.delegator1);
 
       await timeIncreaseNoMine(60);
 
-      await expect(this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1))
+      await expect(this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, this.staker1, ethers.parseEther('2'));
+        .withArgs(this.mock, this.delegator1, ethers.parseEther('2'));
     });
 
     it('via separate controller', async function () {
       const controller = this.accounts[0];
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('10'), this.staker1);
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), controller, this.staker1);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), controller, this.delegator1);
 
       await timeIncreaseNoMine(60);
 
-      await expect(this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1)).to.not.emit(
-        this.token,
-        'Transfer',
-      );
       await expect(
-        this.mock.connect(this.staker1).redeem(ethers.MaxUint256, controller, controller),
+        this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1),
+      ).to.not.emit(this.token, 'Transfer');
+      await expect(
+        this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, controller, controller),
       ).to.be.revertedWithCustomError(this.mock, 'Unauthorized');
       await expect(this.mock.connect(controller).redeem(ethers.MaxUint256, controller, controller))
         .to.emit(this.token, 'Transfer')
@@ -158,114 +156,118 @@ describe('OperatorStaking', function () {
     });
 
     it('should fail if controller is zero address', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await expect(
-        this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), ethers.ZeroAddress, this.staker1),
+        this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), ethers.ZeroAddress, this.delegator1),
       ).to.be.revertedWithCustomError(this.mock, 'InvalidController');
     });
 
     it('via approved contract', async function () {
       const approvedActor = this.accounts[0];
 
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker1).approve(approvedActor, ethers.parseEther('1'));
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator1).approve(approvedActor, ethers.parseEther('1'));
 
-      await this.mock.connect(approvedActor).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+      await this.mock.connect(approvedActor).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
     });
 
     it('should fail via unapproved actor', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
 
       await expect(
-        this.mock.connect(this.accounts[0]).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1),
+        this.mock.connect(this.accounts[0]).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1),
       ).to.be.reverted;
     });
 
     it('should handle reduction in cooldown period correctly', async function () {
-      const staker3 = this.accounts[0];
-      await this.token.connect(staker3).approve(this.mock, ethers.MaxUint256);
-      await this.token.connect(this.staker1).transfer(staker3, ethers.parseEther('1'));
+      const delegator3 = this.accounts[0];
+      await this.token.connect(delegator3).approve(this.mock, ethers.MaxUint256);
+      await this.token.connect(this.delegator1).transfer(delegator3, ethers.parseEther('1'));
 
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('1'), this.staker2);
-      await this.mock.connect(staker3).deposit(ethers.parseEther('1'), staker3);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('1'), this.delegator2);
+      await this.mock.connect(delegator3).deposit(ethers.parseEther('1'), delegator3);
 
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
       await timeIncreaseNoMine(30);
 
-      await this.mock.connect(this.staker2).requestRedeem(ethers.parseEther('1'), this.staker2, this.staker2);
+      await this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
 
       await this.protocolStaking.connect(this.admin).setUnstakeCooldownPeriod(30);
-      await this.mock.connect(staker3).requestRedeem(ethers.parseEther('1'), staker3, staker3);
+      await this.mock.connect(delegator3).requestRedeem(ethers.parseEther('1'), delegator3, delegator3);
 
-      // Staker 3 will need to wait 59 seconds
+      // delegator 3 will need to wait 59 seconds
 
       await timeIncreaseNoMine(30);
       await this.protocolStaking.release(this.mock);
 
-      await expect(this.mock.connect(staker3).redeem(ethers.MaxUint256, staker3, staker3)).to.not.emit(
+      await expect(this.mock.connect(delegator3).redeem(ethers.MaxUint256, delegator3, delegator3)).to.not.emit(
         this.token,
         'Transfer',
       );
 
       await timeIncreaseNoMine(29);
 
-      await expect(this.mock.connect(staker3).redeem(ethers.MaxUint256, staker3, staker3))
+      await expect(this.mock.connect(delegator3).redeem(ethers.MaxUint256, delegator3, delegator3))
         .to.emit(this.token, 'Transfer')
-        .withArgs(this.mock, staker3, ethers.parseEther('1'));
+        .withArgs(this.mock, delegator3, ethers.parseEther('1'));
     });
 
     describe('with operator', async function () {
       beforeEach(async function () {
         this.operator = this.accounts[0];
-        await this.mock.connect(this.staker1).setOperator(this.operator, true);
-        await this.mock.connect(this.staker1).deposit(ethers.parseEther('10'), this.staker1);
+        await this.mock.connect(this.delegator1).setOperator(this.operator, true);
+        await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
       });
 
       it('should be allowed to redeem on behalf of authorized controller', async function () {
-        await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+        await this.mock
+          .connect(this.delegator1)
+          .requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
 
         await timeIncreaseNoMine(60);
 
-        await expect(this.mock.connect(this.operator).redeem(ethers.MaxUint256, this.operator, this.staker1))
+        await expect(this.mock.connect(this.operator).redeem(ethers.MaxUint256, this.operator, this.delegator1))
           .to.emit(this.token, 'Transfer')
           .withArgs(this.mock, this.operator, ethers.parseEther('1'));
       });
 
       it('should not be allowed to redeem on behalf of other controller', async function () {
-        await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker2, this.staker1);
+        await this.mock
+          .connect(this.delegator1)
+          .requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator1);
 
         await timeIncreaseNoMine(60);
 
         await expect(
-          this.mock.connect(this.operator).redeem(ethers.MaxUint256, this.operator, this.staker2),
+          this.mock.connect(this.operator).redeem(ethers.MaxUint256, this.operator, this.delegator2),
         ).to.be.revertedWithCustomError(this.mock, 'Unauthorized');
       });
     });
   });
 
-  describe('restake', async function () {
+  describe('restakeOperatorExcess', async function () {
     it('should restake in protocol staking', async function () {
-      await this.token.connect(this.staker1).transfer(this.mock, ethers.parseEther('10'));
-      await expect(this.mock.restake())
+      await this.token.connect(this.delegator1).transfer(this.mock, ethers.parseEther('10'));
+      await expect(this.mock.restakeOperatorExcess())
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, ethers.parseEther('10'));
     });
 
     it('should not transfer required tokens', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('10'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('1'), this.staker2);
-      await this.mock.connect(this.staker2).requestRedeem(ethers.parseEther('1'), this.staker2, this.staker2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('1'), this.delegator2);
+      await this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
 
       // Increase the value of each share by 10%
-      await this.token.connect(this.staker1).transfer(this.mock, ethers.parseEther('1.1'));
+      await this.token.connect(this.delegator1).transfer(this.mock, ethers.parseEther('1.1'));
 
       await timeIncreaseNoMine(60);
       await this.protocolStaking.release(this.mock);
 
       const restakeAmount = BigInt(ethers.parseEther('1')) + 1n;
-      await expect(this.mock.restake())
+      await expect(this.mock.restakeOperatorExcess())
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, restakeAmount);
     });
@@ -273,100 +275,106 @@ describe('OperatorStaking', function () {
 
   describe('slashing', async function () {
     it('symmetrically passes on losses from staked balance without pending withdrawal', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('2'), this.staker2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('2'), this.delegator2);
 
       await this.protocolStaking.slash(this.mock, ethers.parseEther('1.5'));
 
       // Request redemption of all shares and verify actual withdrawal amounts
       await this.mock
-        .connect(this.staker1)
-        .requestRedeem(await this.mock.balanceOf(this.staker1), this.staker1, this.staker1);
+        .connect(this.delegator1)
+        .requestRedeem(await this.mock.balanceOf(this.delegator1), this.delegator1, this.delegator1);
       await this.mock
-        .connect(this.staker2)
-        .requestRedeem(await this.mock.balanceOf(this.staker2), this.staker2, this.staker2);
+        .connect(this.delegator2)
+        .requestRedeem(await this.mock.balanceOf(this.delegator2), this.delegator2, this.delegator2);
 
       await timeIncreaseNoMine(60);
 
       await expect(
-        this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1),
-      ).to.changeTokenBalance(this.token, this.staker1, ethers.parseEther('0.5'));
+        this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1),
+      ).to.changeTokenBalance(this.token, this.delegator1, ethers.parseEther('0.5'));
       await expect(
-        this.mock.connect(this.staker2).redeem(ethers.MaxUint256, this.staker2, this.staker2),
-      ).to.changeTokenBalance(this.token, this.staker2, ethers.parseEther('1'));
+        this.mock.connect(this.delegator2).redeem(ethers.MaxUint256, this.delegator2, this.delegator2),
+      ).to.changeTokenBalance(this.token, this.delegator2, ethers.parseEther('1'));
     });
 
     it('symmetrically passes on losses from staked balance with pending withdrawal', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('2'), this.staker2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('2'), this.delegator2);
 
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('0.5'), this.staker1, this.staker1);
+      await this.mock
+        .connect(this.delegator1)
+        .requestRedeem(ethers.parseEther('0.5'), this.delegator1, this.delegator1);
       // 50% slashing
       await this.protocolStaking.slash(this.mock, ethers.parseEther('1.5'));
 
       await timeIncreaseNoMine(60);
 
       await expect(
-        this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1),
-      ).to.changeTokenBalance(this.token, this.staker1, ethers.parseEther('0.25'));
+        this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1),
+      ).to.changeTokenBalance(this.token, this.delegator1, ethers.parseEther('0.25'));
     });
 
     it('take excess into account on requestRedeem after slashing partially covered', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('2'), this.staker2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('2'), this.delegator2);
 
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
       await this.protocolStaking.slash(this.mock, ethers.parseEther('1.5'));
 
-      await expect(this.mock.connect(this.staker2).requestRedeem(ethers.parseEther('2'), this.staker2, this.staker2))
+      await expect(
+        this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('2'), this.delegator2, this.delegator2),
+      )
         .to.emit(this.protocolStaking, 'TokensUnstaked')
         .withArgs(this.mock, ethers.parseEther('0.5'), anyValue);
     });
 
     it('take excess into account on requestRedeem after slashing fully covered', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('1'), this.staker2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('1'), this.delegator2);
 
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
       await this.protocolStaking.slash(this.mock, ethers.parseEther('1'));
 
       await timeIncreaseNoMine(30);
 
-      await expect(this.mock.connect(this.staker2).requestRedeem(ethers.parseEther('1'), this.staker2, this.staker2))
+      await expect(
+        this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2),
+      )
         .to.emit(this.protocolStaking, 'TokensUnstaked')
         .withArgs(this.mock, 0, anyValue);
 
       await time.increase(30);
-      await expect(this.mock.maxRedeem(this.staker2)).to.eventually.eq(0);
-      await expect(this.mock.maxRedeem(this.staker1)).to.eventually.eq(ethers.parseEther('1'));
+      await expect(this.mock.maxRedeem(this.delegator2)).to.eventually.eq(0);
+      await expect(this.mock.maxRedeem(this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
 
       await time.increase(30);
-      await expect(this.mock.maxRedeem(this.staker2)).to.eventually.eq(ethers.parseEther('1'));
+      await expect(this.mock.maxRedeem(this.delegator2)).to.eventually.eq(ethers.parseEther('1'));
     });
 
     it('symmetrically passes on losses from withdrawal balance', async function () {
-      await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-      await this.mock.connect(this.staker2).deposit(ethers.parseEther('2'), this.staker2);
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+      await this.mock.connect(this.delegator2).deposit(ethers.parseEther('2'), this.delegator2);
 
-      await this.mock.connect(this.staker1).requestRedeem(ethers.parseEther('1'), this.staker1, this.staker1);
-      await this.mock.connect(this.staker2).requestRedeem(ethers.parseEther('2'), this.staker2, this.staker2);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
+      await this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('2'), this.delegator2, this.delegator2);
 
       await this.protocolStaking.slashWithdrawal(this.mock, ethers.parseEther('1.5'));
 
       await timeIncreaseNoMine(60);
 
       await expect(
-        this.mock.connect(this.staker1).redeem(ethers.MaxUint256, this.staker1, this.staker1),
-      ).to.changeTokenBalance(this.token, this.staker1, ethers.parseEther('0.5'));
+        this.mock.connect(this.delegator1).redeem(ethers.MaxUint256, this.delegator1, this.delegator1),
+      ).to.changeTokenBalance(this.token, this.delegator1, ethers.parseEther('0.5'));
       await expect(
-        this.mock.connect(this.staker2).redeem(ethers.MaxUint256, this.staker2, this.staker2),
-      ).to.changeTokenBalance(this.token, this.staker2, ethers.parseEther('1'));
+        this.mock.connect(this.delegator2).redeem(ethers.MaxUint256, this.delegator2, this.delegator2),
+      ).to.changeTokenBalance(this.token, this.delegator2, ethers.parseEther('1'));
     });
   });
 
   describe('setRewarder', async function () {
     it('only owner can set rewarder', async function () {
-      await expect(this.mock.connect(this.staker1).setRewarder(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+      await expect(this.mock.connect(this.delegator1).setRewarder(ethers.ZeroAddress)).to.be.revertedWithCustomError(
         this.mock,
         'OwnableUnauthorizedAccount',
       );
@@ -380,9 +388,9 @@ describe('OperatorStaking', function () {
     });
 
     it('should revert with no code rewarder', async function () {
-      await expect(this.mock.connect(this.admin).setRewarder(this.staker1.address))
+      await expect(this.mock.connect(this.admin).setRewarder(this.delegator1.address))
         .to.be.revertedWithCustomError(this.mock, 'InvalidRewarder')
-        .withArgs(this.staker1);
+        .withArgs(this.delegator1);
     });
 
     describe('with new rewarder', async function () {
@@ -400,8 +408,8 @@ describe('OperatorStaking', function () {
         await this.protocolStaking.connect(this.admin).addEligibleAccount(this.mock);
         await this.protocolStaking.connect(this.admin).setRewardRate(ethers.parseEther('0.5'));
 
-        await this.mock.connect(this.staker1).deposit(ethers.parseEther('1'), this.staker1);
-        await this.mock.connect(this.staker2).deposit(ethers.parseEther('3'), this.staker2);
+        await this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
+        await this.mock.connect(this.delegator2).deposit(ethers.parseEther('3'), this.delegator2);
         await timeIncreaseNoMine(10);
 
         await this.mock.connect(this.admin).setRewarder(newRewarder);
@@ -409,37 +417,37 @@ describe('OperatorStaking', function () {
       });
 
       it('old rewards should remain on old rewarder', async function () {
-        await expect(this.oldRewarder.earned(this.staker1)).to.eventually.eq(ethers.parseEther('1.75'));
-        await expect(this.newRewarder.earned(this.staker1)).to.eventually.eq(0);
+        await expect(this.oldRewarder.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('1.75'));
+        await expect(this.newRewarder.earned(this.delegator1)).to.eventually.eq(0);
         await expect(this.token.balanceOf(this.oldRewarder)).to.eventually.eq(ethers.parseEther('5.5'));
       });
 
       it('new rewarder should start accruing rewards properly', async function () {
         await time.increase(10);
 
-        await expect(this.newRewarder.earned(this.staker1)).to.eventually.eq(ethers.parseEther('1.25'));
-        await expect(this.newRewarder.earned(this.staker2)).to.eventually.eq(ethers.parseEther('3.75'));
+        await expect(this.newRewarder.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('1.25'));
+        await expect(this.newRewarder.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('3.75'));
         await expect(this.newRewarder.unpaidFee()).to.eventually.eq(0);
 
-        await expect(this.newRewarder.claimRewards(this.staker1))
+        await expect(this.newRewarder.claimRewards(this.delegator1))
           .to.emit(this.token, 'Transfer')
-          .withArgs(this.newRewarder, this.staker1, ethers.parseEther('1.375'));
+          .withArgs(this.newRewarder, this.delegator1, ethers.parseEther('1.375'));
       });
     });
   });
 
   describe('setOperator', function () {
     beforeEach(async function () {
-      this.tx = this.mock.connect(this.staker1).setOperator(this.staker2, true);
+      this.tx = this.mock.connect(this.delegator1).setOperator(this.delegator2, true);
     });
 
     it('emits event', async function () {
-      await expect(this.tx).to.emit(this.mock, 'OperatorSet').withArgs(this.staker1, this.staker2, true);
+      await expect(this.tx).to.emit(this.mock, 'OperatorSet').withArgs(this.delegator1, this.delegator2, true);
     });
 
     it('sets operator', async function () {
       await this.tx;
-      await expect(this.mock.isOperator(this.staker1, this.staker2)).to.eventually.eq(true);
+      await expect(this.mock.isOperator(this.delegator1, this.delegator2)).to.eventually.eq(true);
     });
   });
 });

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -247,10 +247,10 @@ describe('OperatorStaking', function () {
     });
   });
 
-  describe('restakeExcess', async function () {
+  describe('stakeExcess', async function () {
     it('should restake in protocol staking', async function () {
       await this.token.connect(this.delegator1).transfer(this.mock, ethers.parseEther('10'));
-      await expect(this.mock.restakeExcess())
+      await expect(this.mock.stakeExcess())
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, ethers.parseEther('10'));
     });
@@ -267,7 +267,7 @@ describe('OperatorStaking', function () {
       await this.protocolStaking.release(this.mock);
 
       const restakeAmount = BigInt(ethers.parseEther('1')) + 1n;
-      await expect(this.mock.restakeExcess())
+      await expect(this.mock.stakeExcess())
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, restakeAmount);
     });


### PR DESCRIPTION
we now want to have users "delegate" rather than "stake" in OperatorStaking (being "delegators" instead of "stakers")

refs https://github.com/zama-ai/fhevm-internal/issues/716