### PR TITLE
feat(protocol-contracts): add depositWithPermit function in OperatorStaking

### DIFF
--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.27;
 
-import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
-import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {ERC1363Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC1363Upgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {ERC4626, IERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";

--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {ERC1363Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC1363Upgradeable.sol";
 import {ERC4626, IERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -139,6 +140,29 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
         _deposit(msg.sender, receiver, assets, shares);
 
         return shares;
+    }
+
+    /**
+     * @notice Deposit assets and receive shares with ERC-20 Permit extension (ERC-2612).
+     * @param assets Amount of assets to deposit.
+     * @param receiver Address to receive the minted shares.
+     * @param deadline Timestamp in the future until which the permit is valid.
+     * @param v `secp256k1` signature parameter.
+     * @param r `secp256k1` signature parameter.
+     * @param s `secp256k1` signature parameter.
+     * @return shares Amount of shares minted.
+     */
+    function depositWithPermit(
+        uint256 assets,
+        address receiver,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual returns (uint256) {
+        IERC20Permit(asset()).permit(msg.sender, address(this), assets, deadline, v, r, s);
+
+        return deposit(assets, receiver);
     }
 
     /**

--- a/protocol-contracts/staking/contracts/mocks/ERC20Mock.sol
+++ b/protocol-contracts/staking/contracts/mocks/ERC20Mock.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.20;
 
 import {ERC20, ERC1363} from "@openzeppelin/contracts/token/ERC20/extensions/ERC1363.sol";
+import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
-contract ERC20Mock is ERC1363 {
+contract ERC20Mock is ERC1363, ERC20Permit {
     uint8 private immutable _decimals;
 
-    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) ERC20Permit(name_) {
         _decimals = decimals_;
     }
 

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -8,7 +8,8 @@ const timeIncreaseNoMine = (duration: number) =>
 
 describe('OperatorStaking', function () {
   beforeEach(async function () {
-    const [delegator1, delegator2, admin, beneficiary, anyone, ...accounts] = await ethers.getSigners();
+    const [delegator1, delegator2, delegatorNoApproval, admin, beneficiary, anyone, ...accounts] =
+      await ethers.getSigners();
 
     const token = await ethers.deployContract('$ERC20Mock', ['StakingToken', 'ST', 18]);
     const protocolStaking = await ethers.getContractFactory('ProtocolStakingSlashingMock').then(factory =>
@@ -34,6 +35,7 @@ describe('OperatorStaking', function () {
       ]),
     );
 
+    // Mint tokens and approve mock contract
     await Promise.all(
       [delegator1, delegator2].flatMap(account => [
         token.mint(account, ethers.parseEther('1000')),
@@ -41,7 +43,21 @@ describe('OperatorStaking', function () {
       ]),
     );
 
-    Object.assign(this, { delegator1, delegator2, admin, beneficiary, anyone, accounts, token, protocolStaking, mock });
+    // Mint tokens but don't approve mock contract
+    await Promise.all([delegatorNoApproval].flatMap(account => [token.mint(account, ethers.parseEther('1000'))]));
+
+    Object.assign(this, {
+      delegator1,
+      delegator2,
+      delegatorNoApproval,
+      admin,
+      beneficiary,
+      anyone,
+      accounts,
+      token,
+      protocolStaking,
+      mock,
+    });
   });
 
   describe('Access Control', function () {
@@ -86,6 +102,96 @@ describe('OperatorStaking', function () {
       await expect(this.mock.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1))
         .to.emit(this.token, 'Transfer')
         .withArgs(this.delegator1, this.mock, ethers.parseEther('1'));
+    });
+  });
+
+  describe('depositWithPermit', async function () {
+    beforeEach(async function () {
+      // Get deposit with permit inputs
+      const owner = this.delegatorNoApproval.address;
+      const spender = this.mock.target;
+      const value = ethers.parseEther('1');
+      const deadline = ethers.MaxUint256;
+
+      // Get permit parameters from the token
+      const tokenAddress = this.token.target;
+      const nonce = await this.token.nonces(owner);
+      const name = await this.token.name();
+
+      // Get chain ID
+      const { chainId } = await ethers.provider.getNetwork();
+
+      // Define EIP-712 domain
+      const domain = {
+        name: name,
+        version: '1',
+        chainId: chainId,
+        verifyingContract: tokenAddress,
+      };
+
+      // Define EIP-712 Permit type
+      const types = {
+        Permit: [
+          { name: 'owner', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      };
+
+      // Define EIP-712 Permit message
+      const message = {
+        owner: owner,
+        spender: spender,
+        value: value,
+        nonce: nonce,
+        deadline: deadline,
+      };
+
+      // Sign EIP-712 Permit message
+      const flatSig = await this.delegatorNoApproval.signTypedData(domain, types, message);
+
+      // Split into v, r, s
+      const sig = ethers.Signature.from(flatSig);
+
+      Object.assign(this, {
+        permitValue: value,
+        permitDeadline: deadline,
+        v: sig.v,
+        r: sig.r,
+        s: sig.s,
+      });
+    });
+
+    it('should stake into protocol staking with permit', async function () {
+      await expect(
+        this.mock
+          .connect(this.delegatorNoApproval)
+          .depositWithPermit(this.permitValue, this.delegatorNoApproval, this.permitDeadline, this.v, this.r, this.s),
+      )
+        .to.emit(this.token, 'Transfer')
+        .withArgs(this.mock, this.protocolStaking, this.permitValue);
+    });
+
+    it('should mint shares with permit', async function () {
+      await expect(
+        this.mock
+          .connect(this.delegatorNoApproval)
+          .depositWithPermit(this.permitValue, this.delegatorNoApproval, this.permitDeadline, this.v, this.r, this.s),
+      )
+        .to.emit(this.mock, 'Transfer')
+        .withArgs(ethers.ZeroAddress, this.delegatorNoApproval, this.permitValue);
+    });
+
+    it('should pull tokens with permit', async function () {
+      await expect(
+        this.mock
+          .connect(this.delegatorNoApproval)
+          .depositWithPermit(this.permitValue, this.delegatorNoApproval, this.permitDeadline, this.v, this.r, this.s),
+      )
+        .to.emit(this.token, 'Transfer')
+        .withArgs(this.delegatorNoApproval, this.mock, this.permitValue);
     });
   });
 

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -157,37 +157,31 @@ describe('OperatorStaking', function () {
       const sig = ethers.Signature.from(flatSig);
 
       // Deposit with permit
-      const depositWithPermitTx = await this.mock
+      const depositWithPermitTx = this.mock
         .connect(delegatorNoApproval)
         .depositWithPermit(value, delegatorNoApproval, deadline, sig.v, sig.r, sig.s);
 
-      const depositWithPermitReceipt = await depositWithPermitTx.wait();
-
-      if (depositWithPermitReceipt?.status !== 1) {
-        throw new Error('Deposit with permit failed');
-      }
-
       Object.assign(this, {
-        depositWithPermitReceipt: depositWithPermitReceipt,
+        depositWithPermitTx,
         permitValue: value,
         delegatorNoApproval: delegatorNoApproval,
       });
     });
 
     it('should stake into protocol staking with permit', async function () {
-      expect(this.depositWithPermitReceipt)
+      await expect(this.depositWithPermitTx)
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, this.permitValue);
     });
 
     it('should mint shares with permit', async function () {
-      expect(this.depositWithPermitReceipt)
+      await expect(this.depositWithPermitTx)
         .to.emit(this.mock, 'Transfer')
         .withArgs(ethers.ZeroAddress, this.delegatorNoApproval, this.permitValue);
     });
 
     it('should pull tokens with permit', async function () {
-      expect(this.depositWithPermitReceipt)
+      await expect(this.depositWithPermitTx)
         .to.emit(this.token, 'Transfer')
         .withArgs(this.delegatorNoApproval, this.mock, this.permitValue);
     });

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -165,6 +165,10 @@ describe('OperatorStaking', function () {
         depositWithPermitTx,
         permitValue: value,
         delegatorNoApproval: delegatorNoApproval,
+        permitDeadline: deadline,
+        v: sig.v,
+        r: sig.r,
+        s: sig.s,
       });
     });
 
@@ -184,6 +188,22 @@ describe('OperatorStaking', function () {
       await expect(this.depositWithPermitTx)
         .to.emit(this.token, 'Transfer')
         .withArgs(this.delegatorNoApproval, this.mock, this.permitValue);
+    });
+
+    it('should revert if signature is invalid', async function () {
+      await expect(
+        this.mock
+          .connect(this.delegatorNoApproval)
+          .depositWithPermit(this.permitValue, this.delegatorNoApproval, this.permitDeadline, 0, this.r, this.s),
+      ).to.be.revertedWithCustomError(this.token, 'ECDSAInvalidSignature');
+    });
+
+    it('should revert if signer is invalid', async function () {
+      await expect(
+        this.mock
+          .connect(this.delegator1)
+          .depositWithPermit(this.permitValue, this.delegator1, this.permitDeadline, this.v, this.r, this.s),
+      ).to.be.revertedWithCustomError(this.token, 'ERC2612InvalidSigner');
     });
   });
 


### PR DESCRIPTION
to benefit from the token's ERC 2612 and allow approval + deposit in a single tx  for EOA accounts

refs https://github.com/zama-ai/protocol-apps-internal/issues/22
closes https://github.com/zama-ai/fhevm-internal/issues/716
