### PR TITLE
fix(kms-connector): gw-listener catchup fix

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "fhevm_gateway_bindings"
 version = "0.1.0-rc14"
-source = "git+https://github.com/zama-ai/fhevm.git?tag=v0.10.0#df9e61f99f957b76130651f9deebd45e186ba356"
+source = "git+https://github.com/zama-ai/fhevm.git?tag=v0.10.3#edb4c81c4d45f557faab569055957dd21991223d"
 dependencies = [
  "alloy",
  "serde",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -18,7 +18,7 @@ gw-listener.path = "crates/gw-listener"
 kms-worker.path = "crates/kms-worker"
 tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
-fhevm_gateway_bindings = { git = "https://github.com/zama-ai/fhevm.git", tag = "v0.10.0", default-features = false }
+fhevm_gateway_bindings = { git = "https://github.com/zama-ai/fhevm.git", tag = "v0.10.3", default-features = false }
 kms-grpc = { git = "https://github.com/zama-ai/kms.git", tag = "v0.12.4", default-features = true }
 bc2wrap = { git = "https://github.com/zama-ai/kms.git", tag = "v0.12.4", default-features = true }
 tfhe = "=1.4.0-alpha.3"


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/786

## Code changes

For the catchup mechanism of the kms-connector, I replaced the use of the `from_block` option of the  `eth_newFilter` by using `eth_newFilter` + [eth_getFilterLogs](https://www.quicknode.com/docs/ethereum/eth_getFilterLogs).
Then, `eth_newFilter` + `eth_getFilterChanges` to subscribe to new events (as it was already the case).

## Testing

I tested the catchup (using a real `gw-listener` against both Conduit RPC, and our full node to ensure it is fully functional with a consistent behavior no matter which one we use