### PR TITLE
docs(common): remove deprecated DecryptionOracle references

### DIFF
--- a/coprocessor/docs/fundamentals/fhevm/contracts.md
+++ b/coprocessor/docs/fundamentals/fhevm/contracts.md
@@ -51,8 +51,3 @@ When using FHE, the `HCULimit` contract tracks the HCU consumed in each transact
 - the limit for sequential FHE operations is exceeded.
 - the limit for non-sequential FHE operations is exceeded.
 
-## Public Decryption
-
-Public decryption in FHEVM uses a self-relaying model. A dApp marks ciphertexts as publicly decryptable on-chain by calling `FHE.makePubliclyDecryptable()`. Any user can then perform the decryption off-chain via the Relayer SDK's `publicDecrypt()` function, which returns both the cleartext value and a cryptographic proof. Finally, the proof is submitted back on-chain and verified using `FHE.checkSignatures()`.
-
-This approach is trustless and permissionless since anyone can perform the off-chain decryption and submit proofs for verification. The KMS signatures ensure authenticity of the decrypted values.

--- a/coprocessor/docs/fundamentals/fhevm/contracts.md
+++ b/coprocessor/docs/fundamentals/fhevm/contracts.md
@@ -51,8 +51,8 @@ When using FHE, the `HCULimit` contract tracks the HCU consumed in each transact
 - the limit for sequential FHE operations is exceeded.
 - the limit for non-sequential FHE operations is exceeded.
 
-## DecryptionOracle Contract
+## Public Decryption
 
-The [DecryptionOracle](../../../contracts/decryptionOracle/DecryptionOracle.sol) is an onchain contract designed to interact with an offchain Gateway component that handles decryption requests. When a dApp calls the `requestDecryption` function, the `DecryptionOracle` contract emits an event that is caught by the Gateway service.
+Public decryption in FHEVM uses a self-relaying model. A dApp marks ciphertexts as publicly decryptable on-chain by calling `FHE.makePubliclyDecryptable()`. Any user can then perform the decryption off-chain via the Relayer SDK's `publicDecrypt()` function, which returns both the cleartext value and a cryptographic proof. Finally, the proof is submitted back on-chain and verified using `FHE.checkSignatures()`.
 
-_Note_: It is possible to have multiple Gateways, so multiple Gateway contracts can also be deployed. This is the only contract from this documentation page that is not strictly part of "core FHEVM" contracts, and as such, it should not be considered as a "trusted" contract. We only trust the KMS and the core FHEVM contracts. The Gateway is only bridging trust from host chain to KMS chain via storage proofs, and from KMS chain to the host chain via the signatures from KMS signers.
+This approach is trustless and permissionless since anyone can perform the off-chain decryption and submit proofs for verification. The KMS signatures ensure authenticity of the decrypted values.

--- a/docs/sdk-guides/public-decryption.md
+++ b/docs/sdk-guides/public-decryption.md
@@ -2,7 +2,7 @@
 
 This document explains how to perform public decryption of FHEVM ciphertexts.
 Public decryption is required when you want everyone to see the value in a ciphertext, for example the result of private auction.
-Public decryption is done using the Relayer SDK, which handles the off-chain decryption and returns both the cleartext values and a cryptographic proof that can be verified on-chain.
+Public decryption is done using the Relayer SDK, which requests the decryption via HTTP endpoint and returns both the cleartext values and a cryptographic proof that can be verified on-chain.
 
 ## HTTP Public Decrypt
 
@@ -27,4 +27,4 @@ const values = instance.publicDecrypt(handles);
 
 ## On-chain Verification
 
-After obtaining decrypted values via the Relayer SDK, you can verify the decryption proof on-chain using `FHE.checkSignatures()`. For the complete workflow including on-chain setup with `FHE.makePubliclyDecryptable()` and verification, please refer to the [Public Decryption Solidity Guide](https://docs.zama.ai/protocol/solidity-guides/smart-contract/decryption/oracle).
+After obtaining decrypted values via the Relayer SDK, you can verify the decryption proof on-chain using `FHE.checkSignatures()`. For the complete workflow including on-chain setup with `FHE.makePubliclyDecryptable()` and verification, please refer to the [Public Decryption Solidity Guide](https://docs.zama.org/protocol/solidity-guides/smart-contract/oracle).

--- a/docs/sdk-guides/public-decryption.md
+++ b/docs/sdk-guides/public-decryption.md
@@ -2,7 +2,7 @@
 
 This document explains how to perform public decryption of FHEVM ciphertexts.
 Public decryption is required when you want everyone to see the value in a ciphertext, for example the result of private auction.
-Public decryption can be done with either the Relayer HTTP endpoint or calling the on-chain decryption oracle.
+Public decryption is done using the Relayer SDK, which handles the off-chain decryption and returns both the cleartext values and a cryptographic proof that can be verified on-chain.
 
 ## HTTP Public Decrypt
 
@@ -25,6 +25,6 @@ const handles = [
 const values = instance.publicDecrypt(handles);
 ```
 
-## Onchain Public Decrypt
+## On-chain Verification
 
-For more details please refer to the on [onchain Oracle public decryption page](https://docs.zama.ai/protocol/solidity-guides/smart-contract/oracle).
+After obtaining decrypted values via the Relayer SDK, you can verify the decryption proof on-chain using `FHE.checkSignatures()`. For the complete workflow including on-chain setup with `FHE.makePubliclyDecryptable()` and verification, please refer to the [Public Decryption Solidity Guide](https://docs.zama.ai/protocol/solidity-guides/smart-contract/decryption/oracle).

--- a/docs/sdk-guides/sdk-overview.md
+++ b/docs/sdk-guides/sdk-overview.md
@@ -19,7 +19,7 @@ Otherwise:
 
 🟨 Go to [**User decryption**](user-decryption.md) to enable users to decrypt data with their own keys, once permissions have been granted via Access Control List(ACL).
 
-🟨 Go to [**Public decryption**](public-decryption.md) to learn how to decrypt outputs that are publicly accessible, either via HTTP or onchain Oracle.
+🟨 Go to [**Public decryption**](public-decryption.md) to learn how to decrypt outputs that are publicly accessible via the Relayer SDK.
 
 🟨 Go to [**Solidity ACL Guide**](https://docs.zama.ai/protocol/solidity-guides/smart-contract/acl) for more detailed instructions about access control.
 

--- a/docs/solidity-guides/configure.md
+++ b/docs/solidity-guides/configure.md
@@ -4,27 +4,26 @@ This document explains how to enable encrypted computations in your smart contra
 
 ## Core configuration setup
 
-To utilize encrypted computations in Solidity contracts, you must configure the **FHE library** and **Oracle addresses**. The `fhevm` package simplifies this process with prebuilt configuration contracts, allowing you to focus on developing your contract’s logic without handling the underlying cryptographic setup.
+To utilize encrypted computations in Solidity contracts, you must configure the **FHE library**. The `fhevm` package simplifies this process with prebuilt configuration contracts, allowing you to focus on developing your contract's logic without handling the underlying cryptographic setup.
 
-This library and its associated contracts provide a standardized way to configure and interact with Zama's FHEVM (Fully Homomorphic Encryption Virtual Machine) infrastructure on different Ethereum networks. It supplies the necessary contract addresses for Zama's FHEVM components (`ACL`, `FHEVMExecutor`, `KMSVerifier`, `InputVerifier`) and the decryption oracle, enabling seamless integration for Solidity contracts that require FHEVM support.
+This library and its associated contracts provide a standardized way to configure and interact with Zama's FHEVM (Fully Homomorphic Encryption Virtual Machine) infrastructure on different Ethereum networks. It supplies the necessary contract addresses for Zama's FHEVM components (`ACL`, `FHEVMExecutor`, `KMSVerifier`, `InputVerifier`), enabling seamless integration for Solidity contracts that require FHEVM support.
 
 ## Key components configured automatically
 
 1. **FHE library**: Sets up encryption parameters and cryptographic keys.
-2. **Oracle**: Manages secure cryptographic operations such as public decryption.
-3. **Network-specific settings**: Adapts to local testing, testnets (Sepolia for example), or mainnet deployment.
+2. **Network-specific settings**: Adapts to local testing, testnets (Sepolia for example), or mainnet deployment.
 
 By inheriting these configuration contracts, you ensure seamless initialization and functionality across environments.
 
 ## ZamaConfig.sol
 
-The `ZamaConfig` library exposes functions to retrieve FHEVM configuration structs and oracle addresses for supported networks (currently only the Sepolia testnet).
+The `ZamaConfig` library exposes functions to retrieve FHEVM configuration structs and contract addresses for supported networks (currently only the Sepolia testnet).
 
 Under the hood, this library encapsulates the network-specific addresses of Zama's FHEVM infrastructure into a single struct (`FHEVMConfigStruct`).
 
 ## ZamaEthereumConfig
 
-The `ZamaEthereumConfig` contract is designed to be inherited by a user contract. The constructor automatically sets up the FHEVM coprocessor and decryption oracle using the configuration provided by the library for the respective network. When a contract inherits from `ZamaEthereumConfig`, the constructor calls `FHE.setCoprocessor` with the appropriate addresses. This ensures that the inheriting contract is automatically wired to the correct FHEVM contracts and oracle for the target network, abstracting away manual address management and reducing the risk of misconfiguration.
+The `ZamaEthereumConfig` contract is designed to be inherited by a user contract. The constructor automatically sets up the FHEVM coprocessor using the configuration provided by the library for the respective network. When a contract inherits from `ZamaEthereumConfig`, the constructor calls `FHE.setCoprocessor` with the appropriate addresses. This ensures that the inheriting contract is automatically wired to the correct FHEVM contracts for the target network, abstracting away manual address management and reducing the risk of misconfiguration.
 
 **Example**
 


### PR DESCRIPTION
  - Remove Oracle references from sdk-guides (public-decryption.md, sdk-overview.md)
  - Remove Oracle references from solidity-guides/configure.md
  - Replace deprecated DecryptionOracle section in coprocessor docs with current Public Decryption flow
  
  There are still references to the old Decryption oracle pattern that I did not address as those were not publicly accessible pages