### PR TITLE
ci(common): re-tag docker images when not built

### DIFF
--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -68,6 +68,9 @@ on:
         description: "Enable/disable build for Coprocessor's ZKProof Worker"
         type: boolean
         default: true
+  push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -251,3 +254,93 @@ jobs:
       image-name: "fhevm/coprocessor/zkproof-worker"
       docker-file: "coprocessor/fhevm-engine/zkproof-worker/Dockerfile"
       app-cache-dir: "fhevm-coprocessor-zkproof-worker"
+
+  re-tag-db-migration-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-db-migration != 'true' && github.event_name == 'push'
+    permissions: &re-tag-image-permissions
+      actions: 'read' # Required to read workflow run information
+      contents: 'read' # Required to checkout repository code
+      packages: 'write' # Required to publish Docker images
+      id-token: 'write' # Required for OIDC authentication
+    secrets: &re-tag-image-secrets
+      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
+      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/db-migration"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-gw-listener-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-gw-listener != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/gw-listener"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-host-listener-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-host-listener != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/host-listener"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-sns-worker-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-sns-worker != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/sns-worker"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-tfhe-worker-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-tfhe-worker != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/tfhe-worker"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-tx-sender-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-tx-sender != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/tx-sender"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-zkproof-worker-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-zkproof-worker != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/coprocessor/zkproof-worker"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -264,9 +264,6 @@ jobs:
       contents: 'read' # Required to checkout repository code
       packages: 'write' # Required to publish Docker images
       id-token: 'write' # Required for OIDC authentication
-    secrets: &re-tag-image-secrets
-      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
-      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/db-migration"
@@ -278,7 +275,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-gw-listener != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/gw-listener"
@@ -290,7 +286,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-host-listener != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/host-listener"
@@ -302,7 +297,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-sns-worker != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/sns-worker"
@@ -314,7 +308,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-tfhe-worker != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/tfhe-worker"
@@ -326,7 +319,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-tx-sender != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/tx-sender"
@@ -338,7 +330,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-zkproof-worker != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/coprocessor/zkproof-worker"

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -86,9 +86,6 @@ jobs:
       contents: 'read' # Required to checkout repository code
       packages: 'write' # Required to publish Docker images
       id-token: 'write' # Required for OIDC authentication
-    secrets:
-      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
-      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/gateway-contracts"

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -21,6 +21,9 @@ on:
     types:
       - published
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -73,3 +76,21 @@ jobs:
       image-name: "fhevm/gateway-contracts"
       docker-file: "./gateway-contracts/Dockerfile"
       app-cache-dir: "fhevm-gateway-contracts"
+
+  re-tag-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-gw-contracts != 'true' && github.event_name == 'push'
+    permissions:
+      actions: 'read' # Required to read workflow run information
+      contents: 'read' # Required to checkout repository code
+      packages: 'write' # Required to publish Docker images
+      id-token: 'write' # Required for OIDC authentication
+    secrets:
+      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
+      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/gateway-contracts"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -21,6 +21,9 @@ on:
     types:
       - published
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -62,7 +65,6 @@ jobs:
       BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
       CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
       CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
-
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code
@@ -77,3 +79,21 @@ jobs:
       image-name: "fhevm/host-contracts"
       docker-file: "./host-contracts/Dockerfile"
       app-cache-dir: "fhevm-host-contracts"
+
+  re-tag-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-host-contracts != 'true' && github.event_name == 'push'
+    permissions:
+      actions: 'read' # Required to read workflow run information
+      contents: 'read' # Required to checkout repository code
+      packages: 'write' # Required to publish Docker images
+      id-token: 'write' # Required for OIDC authentication
+    secrets:
+      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
+      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/host-contracts"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -89,9 +89,6 @@ jobs:
       contents: 'read' # Required to checkout repository code
       packages: 'write' # Required to publish Docker images
       id-token: 'write' # Required for OIDC authentication
-    secrets:
-      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
-      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/host-contracts"

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -181,9 +181,6 @@ jobs:
       contents: 'read' # Required to checkout repository code
       packages: 'write' # Required to publish Docker images
       id-token: 'write' # Required for OIDC authentication
-    secrets: &re-tag-image-secrets
-      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
-      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/kms-connector/db-migration"
@@ -195,7 +192,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-gw-listener != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/kms-connector/gw-listener"
@@ -207,7 +203,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-kms-worker != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/kms-connector/kms-worker"
@@ -219,7 +214,6 @@ jobs:
     if: |
       needs.check-changes.outputs.changes-tx-sender != 'true' && github.event_name == 'push'
     permissions: *re-tag-image-permissions
-    secrets: *re-tag-image-secrets
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/kms-connector/tx-sender"

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -47,6 +47,9 @@ on:
         description: "Enable/disable build for KMS Connector's Transaction Sender"
         type: boolean
         default: true
+  push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -168,3 +171,57 @@ jobs:
       image-name: "fhevm/kms-connector/tx-sender"
       docker-file: "./kms-connector/crates/tx-sender/Dockerfile"
       app-cache-dir: "fhevm-kms-connector-tx-sender"
+
+  re-tag-db-migration-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-db-migration != 'true' && github.event_name == 'push'
+    permissions: &re-tag-image-permissions
+      actions: 'read' # Required to read workflow run information
+      contents: 'read' # Required to checkout repository code
+      packages: 'write' # Required to publish Docker images
+      id-token: 'write' # Required for OIDC authentication
+    secrets: &re-tag-image-secrets
+      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
+      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/kms-connector/db-migration"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-gw-listener-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-gw-listener != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/kms-connector/gw-listener"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-kms-worker-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-kms-worker != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/kms-connector/kms-worker"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}
+
+  re-tag-tx-sender-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-tx-sender != 'true' && github.event_name == 'push'
+    permissions: *re-tag-image-permissions
+    secrets: *re-tag-image-secrets
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/kms-connector/tx-sender"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}

--- a/.github/workflows/re-tag-docker-image.yml
+++ b/.github/workflows/re-tag-docker-image.yml
@@ -1,0 +1,94 @@
+name: re-tag-docker-image
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: 'The name of the image to re-tag'
+        type: string
+        required: true
+      previous-tag-or-commit:
+        description: 'Previous tag or commit of the image'
+        type: string
+        required: true
+      new-tag-or-commit:
+        description: 'New tag or commit of the image'
+        type: string
+        required: true
+    secrets:
+      CGR_USERNAME:
+        required: true
+      CGR_PASSWORD:
+        required: true
+
+permissions: {}
+
+jobs:
+  prepare-image-tags:
+    name: prepare-image-tags
+    runs-on: ubuntu-latest
+    permissions:
+      actions: 'read' # Required to read workflow run information
+      contents: 'read' # Required to checkout repository code
+    env:
+      PREVIOUS_TAG_OR_COMMIT: ${{ inputs.previous-tag-or-commit }}
+      NEW_TAG_OR_COMMIT: ${{ inputs.new-tag-or-commit }}
+    outputs:
+      previous-tag: ${{ steps.set-tag.outputs.previous-tag }}
+      new-tag: ${{ steps.set-tag.outputs.new-tag }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+      - id: set-tag
+        run: |
+          # If input is a commit hash (40 chars) shorten it. Otherwise, use as-is.
+          if [[ "$PREVIOUS_TAG_OR_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            PREVIOUS_TAG=$(git rev-parse --short "$PREVIOUS_TAG_OR_COMMIT")
+          else
+            PREVIOUS_TAG="$PREVIOUS_TAG_OR_COMMIT"
+          fi
+
+          if [[ "$NEW_TAG_OR_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            NEW_TAG=$(git rev-parse --short "$NEW_TAG_OR_COMMIT")
+          else
+            NEW_TAG="$NEW_TAG_OR_COMMIT"
+          fi
+
+          echo "previous-tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          echo "new-tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+  re-tag-image:
+    name: re-tag-image
+    needs: prepare-image-tags
+    permissions:
+      actions: 'read' # Required to read workflow run information
+      packages: 'write' # Required to publish Docker images
+      id-token: 'write' # Required for OIDC authentication
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Chainguard Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CGR_USERNAME }}
+          password: ${{ secrets.CGR_PASSWORD }}
+
+      - name: Re-tag docker image
+        env:
+          IMAGE_NAME: ${{ inputs.image-name }}
+          PREVIOUS_TAG: ${{ needs.prepare-image-tags.outputs.previous-tag }}
+          NEW_TAG: ${{ needs.prepare-image-tags.outputs.new-tag }}
+        run: |
+          echo "Creating new tag $NEW_TAG for existing image $IMAGE_NAME:$PREVIOUS_TAG"
+          docker buildx imagetools create "ghcr.io/zama-ai/$IMAGE_NAME:$PREVIOUS_TAG" --tag "ghcr.io/zama-ai/$IMAGE_NAME:$NEW_TAG"

--- a/.github/workflows/re-tag-docker-image.yml
+++ b/.github/workflows/re-tag-docker-image.yml
@@ -15,11 +15,6 @@ on:
         description: 'New tag or commit of the image'
         type: string
         required: true
-    secrets:
-      CGR_USERNAME:
-        required: true
-      CGR_PASSWORD:
-        required: true
 
 permissions: {}
 
@@ -76,13 +71,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Chainguard Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: cgr.dev
-          username: ${{ secrets.CGR_USERNAME }}
-          password: ${{ secrets.CGR_PASSWORD }}
 
       - name: Re-tag docker image
         env:

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -88,9 +88,6 @@ jobs:
       contents: 'read' # Required to checkout repository code
       packages: 'write' # Required to publish Docker images
       id-token: 'write' # Required for OIDC authentication
-    secrets:
-      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
-      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/test-suite/e2e"

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -21,6 +21,9 @@ on:
     types:
       - published
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions: {}
 
@@ -75,3 +78,21 @@ jobs:
       image-name: "fhevm/test-suite/e2e"
       docker-file: "./test-suite/e2e/Dockerfile"
       app-cache-dir: "fhevm-test-suite-e2e"
+
+  re-tag-image:
+    needs: check-changes
+    if: |
+      needs.check-changes.outputs.changes-e2e-docker != 'true' && github.event_name == 'push'
+    permissions:
+      actions: 'read' # Required to read workflow run information
+      contents: 'read' # Required to checkout repository code
+      packages: 'write' # Required to publish Docker images
+      id-token: 'write' # Required for OIDC authentication
+    secrets:
+      CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
+      CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    with:
+      image-name: "fhevm/test-suite/e2e"
+      previous-tag-or-commit: ${{ github.event.before }}
+      new-tag-or-commit: ${{ github.event.after }}


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/803

Now we also run docker build on every push on `main`.
If no changes made in the service, we just re-tag the previous latest image with the new commit being pushed.