### PR TITLE
chore(coprocessor): disable default features for pinned bincode

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -43,7 +43,7 @@ aws-sdk-kms = { version = "1.68.0", default-features = false }
 aws-sdk-s3 = { version = "1.103.0", features = ["test-util"] }
 bigdecimal = "0.4.8"
 # Do not upgrade bincode and replace asap
-bincode = "=1.3.3"
+bincode = { version = "=1.3.3", default-features = false }
 clap = { version = "4.5.38", features = ["derive"] }
 daggy = "0.8.1"
 foundry-compilers = { version = "0.19.1", features = ["svm-solc"] }


### PR DESCRIPTION
Explicitly disables default features for the pinned bincode dependency to avoid potential feature drift.
No version or behavior change intended.
