### PR TITLE
ci(kms-connector): upgrade cargo-audit

### DIFF
--- a/.github/workflows/kms-connector-dependency-analysis.yml
+++ b/.github/workflows/kms-connector-dependency-analysis.yml
@@ -30,6 +30,7 @@ jobs:
             rust-files:
               - .github/workflows/kms-connector-dependency-analysis.yml
               - kms-connector/**
+
   dependencies-check:
     name: kms-connector-dependency-analysis/dependencies-check (bpr)
     needs: check-changes
@@ -50,13 +51,13 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@84ca29d5c1719e79e23b6af147555a8f4dac79d6 # v1.10.14
+        uses: cargo-bins/cargo-binstall@80aaafe04903087c333980fa2686259ddd34b2d9 # v1.16.6
 
       - name: Install cargo tools
         run: |
           cargo binstall --no-confirm --force \
-            cargo-audit@0.21.2 \
-            cargo-deny@0.16.2
+            cargo-audit@0.22.0 \
+            cargo-deny@0.18.9
 
       - name: Check that Cargo.lock is the source of truth
         run: |
@@ -72,4 +73,3 @@ jobs:
         run: |
           cd kms-connector
           cargo-audit audit
-

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2905,7 +2905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3873,7 +3873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -4377,7 +4377,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5470,9 +5470,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68df0380e5c9d20ce49534f292a36a7514ae21350726efe1865bdb1fa91d278"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -5557,7 +5557,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6507,7 +6507,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/820

PR mainly started to upgrade `cargo-audit` in CI, but took the time to also upgrade `cargo-binstall`, `cargo-deny` and `ruint` (https://rustsec.org/advisories/RUSTSEC-2025-0137)