### PR TITLE
fix(kms-connector): reduce port collision in tests

### DIFF
--- a/kms-connector/crates/gw-listener/tests/common/mod.rs
+++ b/kms-connector/crates/gw-listener/tests/common/mod.rs
@@ -56,7 +56,7 @@ pub async fn start_test_listener(
 
     // Wait for all gw-listener event filters to be ready + 2 anvil blocks
     for _ in 0..NB_EVENT_TYPE {
-        test_instance.wait_for_log("Waiting for next").await;
+        test_instance.wait_for_log("Subscribed to ").await;
     }
     tokio::time::sleep(2 * test_instance.anvil_block_time()).await;
 

--- a/kms-connector/crates/utils/src/tests/setup/db.rs
+++ b/kms-connector/crates/utils/src/tests/setup/db.rs
@@ -2,8 +2,6 @@ use sqlx::{Pool, Postgres};
 use testcontainers::{ContainerAsync, GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
 use tracing::info;
 
-use crate::tests::setup::pick_free_port;
-
 const POSTGRES_PORT: u16 = 5432;
 
 pub struct DbInstance {
@@ -15,13 +13,11 @@ pub struct DbInstance {
 
 impl DbInstance {
     pub async fn setup() -> anyhow::Result<Self> {
-        let host_port = pick_free_port();
         info!("Starting Postgres container...");
         let container = GenericImage::new("postgres", "17.5")
             .with_wait_for(WaitFor::message_on_stderr(
                 "database system is ready to accept connections",
             ))
-            .with_mapped_port(host_port, POSTGRES_PORT.into())
             .with_env_var("POSTGRES_USER", "postgres")
             .with_env_var("POSTGRES_PASSWORD", "postgres")
             .start()
@@ -29,6 +25,7 @@ impl DbInstance {
         info!("Postgres container ready!");
 
         let cont_host = container.get_host().await?;
+        let host_port = container.get_host_port_ipv4(POSTGRES_PORT).await?;
         let admin_db_url =
             format!("postgresql://postgres:postgres@{cont_host}:{host_port}/postgres");
         let db_url =


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/825

I reduce the usage of the `pick_free_port` fn as much as possible, because I suspect it to be responsible for port collisions in integration tests due to race conditions (see our slack discussion for more details).

I still use this fn for healthcheck tests, because it is more convenient this way, and these tests are run "alone", so I think the race condition is less likely to happen.