### PR TITLE
fix(protocol-contracts): wrap permit call with try-catch to prevent frontrun DOS (L-01)

### DIFF
--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -160,7 +160,8 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
         bytes32 r,
         bytes32 s
     ) public virtual returns (uint256) {
-        IERC20Permit(asset()).permit(msg.sender, address(this), assets, deadline, v, r, s);
+        // Use try-catch to prevent frontrun DOS attacks on permit (see ERC-2612)
+        try IERC20Permit(asset()).permit(msg.sender, address(this), assets, deadline, v, r, s) {} catch {}
 
         return deposit(assets, receiver);
     }


### PR DESCRIPTION
Wrap permit call with try-catch to prevent frontrun DOS attacks (L-01).

refs https://github.com/zama-ai/fhevm-internal/issues/826