### PR TITLE
fix(protocol-contracts): add explicit error for stakeExcess underflow (L-04)

### DIFF
--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -488,19 +488,19 @@ describe('OperatorStaking', function () {
         .withArgs(this.mock, this.protocolStaking, restakeAmount);
     });
 
-    it('should revert with InsufficientLiquidBalance when liquid balance is less than pending redemptions', async function () {
+    it('should revert with NoExcessBalance when liquid balance is less than pending redemptions', async function () {
       // Deposit and request redemption
       await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
       await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('5'), this.delegator1, this.delegator1);
 
-      // Slash staked balance to reduce available funds (slash remaining 5 ETH staked)
+      // Slash staked balance to reduce available funds (slash 3 assets)
       await this.protocolStaking.slashWithdrawal(this.mock, ethers.parseEther('3'));
 
       await timeIncreaseNoMine(60);
 
       // Now liquid balance (after release) will be less than assets pending redemption
       // since slashing reduced the staked balance but pending redemption still expects original value
-      await expect(this.mock.stakeExcess()).to.be.revertedWithCustomError(this.mock, 'InsufficientLiquidBalance');
+      await expect(this.mock.stakeExcess()).to.be.revertedWithCustomError(this.mock, 'NoExcessBalance');
     });
   });
 

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -487,6 +487,21 @@ describe('OperatorStaking', function () {
         .to.emit(this.token, 'Transfer')
         .withArgs(this.mock, this.protocolStaking, restakeAmount);
     });
+
+    it('should revert with InsufficientLiquidBalance when liquid balance is less than pending redemptions', async function () {
+      // Deposit and request redemption
+      await this.mock.connect(this.delegator1).deposit(ethers.parseEther('10'), this.delegator1);
+      await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('5'), this.delegator1, this.delegator1);
+
+      // Slash staked balance to reduce available funds (slash remaining 5 ETH staked)
+      await this.protocolStaking.slashWithdrawal(this.mock, ethers.parseEther('3'));
+
+      await timeIncreaseNoMine(60);
+
+      // Now liquid balance (after release) will be less than assets pending redemption
+      // since slashing reduced the staked balance but pending redemption still expects original value
+      await expect(this.mock.stakeExcess()).to.be.revertedWithCustomError(this.mock, 'InsufficientLiquidBalance');
+    });
   });
 
   describe('slashing', async function () {


### PR DESCRIPTION
Note: we decided to also revert if there the excess token is exactly null (as we don't see the point of allowing this)

refs https://github.com/zama-ai/fhevm-internal/issues/826