### PR TITLE
fix(protocol-contracts): mitigate ERC4626 inflation attack with decimal offset (L-06)

### DIFF
--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -474,8 +474,12 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
             );
     }
 
+    /**
+     * @dev Returns a decimal offset of 2 to mitigate the ERC4626 inflation attack.
+     * This creates 100 virtual shares per asset unit, making the attack economically unfeasible.
+     */
     function _decimalsOffset() internal view virtual returns (uint8) {
-        return 0;
+        return 2;
     }
 
     function _getOperatorStakingStorage() internal pure returns (OperatorStakingStorage storage $) {

--- a/protocol-contracts/staking/test/OperatorRewarder.test.ts
+++ b/protocol-contracts/staking/test/OperatorRewarder.test.ts
@@ -10,7 +10,7 @@ const timeIncreaseNoMine = (duration: number) =>
 // DECIMAL_OFFSET is used in OperatorStaking to mitigate inflation attacks.
 // This creates 10^DECIMAL_OFFSET virtual shares per asset unit.
 const DECIMAL_OFFSET = 2n;
-const VIRTUAL_SHARES = 10n ** DECIMAL_OFFSET;
+const SHARES_PER_ASSET_UNIT = 10n ** DECIMAL_OFFSET;
 
 describe('OperatorRewarder', function () {
   beforeEach(async function () {
@@ -161,7 +161,7 @@ describe('OperatorRewarder', function () {
       await timeIncreaseNoMine(10);
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
       await this.mock.connect(this.delegator1).claimRewards(this.delegator1); // claims past rewards before not being able to
-      const sharesToTransfer = ethers.parseEther('1') * VIRTUAL_SHARES;
+      const sharesToTransfer = ethers.parseEther('1') * SHARES_PER_ASSET_UNIT;
       await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, sharesToTransfer);
       // delegator1 will be able deposit and claim reward again
       await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
@@ -220,7 +220,7 @@ describe('OperatorRewarder', function () {
       await this.mock.connect(this.delegator1).claimRewards(this.delegator1);
       await this.mock.connect(this.delegator2).claimRewards(this.delegator2);
 
-      const sharesToRedeem = ethers.parseEther('1') * VIRTUAL_SHARES;
+      const sharesToRedeem = ethers.parseEther('1') * SHARES_PER_ASSET_UNIT;
       await this.operatorStaking
         .connect(this.delegator1)
         .requestRedeem(sharesToRedeem, this.delegator1, this.delegator1);
@@ -255,7 +255,7 @@ describe('OperatorRewarder', function () {
 
       await timeIncreaseNoMine(10);
 
-      const sharesToRedeem = ethers.parseEther('2') * VIRTUAL_SHARES;
+      const sharesToRedeem = ethers.parseEther('2') * SHARES_PER_ASSET_UNIT;
       await this.operatorStaking
         .connect(this.delegator1)
         .requestRedeem(sharesToRedeem, this.delegator1, this.delegator1);
@@ -580,7 +580,7 @@ describe('OperatorRewarder', function () {
         await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
         await timeIncreaseNoMine(10);
 
-        const sharesToTransfer = ethers.parseEther('1') * VIRTUAL_SHARES;
+        const sharesToTransfer = ethers.parseEther('1') * SHARES_PER_ASSET_UNIT;
         await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, sharesToTransfer);
         await time.increase(10);
 
@@ -592,7 +592,7 @@ describe('OperatorRewarder', function () {
         await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
         await timeIncreaseNoMine(10);
 
-        const sharesToTransfer = ethers.parseEther('0.5') * VIRTUAL_SHARES;
+        const sharesToTransfer = ethers.parseEther('0.5') * SHARES_PER_ASSET_UNIT;
         await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, sharesToTransfer);
         await time.increase(10);
 

--- a/protocol-contracts/staking/test/OperatorRewarder.test.ts
+++ b/protocol-contracts/staking/test/OperatorRewarder.test.ts
@@ -7,6 +7,11 @@ import hre from 'hardhat';
 const timeIncreaseNoMine = (duration: number) =>
   time.latest().then(clock => time.setNextBlockTimestamp(clock + duration));
 
+// DECIMAL_OFFSET is used in OperatorStaking to mitigate inflation attacks.
+// This creates 10^DECIMAL_OFFSET virtual shares per asset unit.
+const DECIMAL_OFFSET = 2n;
+const VIRTUAL_SHARES = 10n ** DECIMAL_OFFSET;
+
 describe('OperatorRewarder', function () {
   beforeEach(async function () {
     const [delegator1, delegator2, claimer, admin, beneficiary, anyone, ...accounts] = await ethers.getSigners();
@@ -156,7 +161,8 @@ describe('OperatorRewarder', function () {
       await timeIncreaseNoMine(10);
       await this.protocolStaking.connect(this.admin).setRewardRate(0);
       await this.mock.connect(this.delegator1).claimRewards(this.delegator1); // claims past rewards before not being able to
-      await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, ethers.parseEther('1'));
+      const sharesToTransfer = ethers.parseEther('1') * VIRTUAL_SHARES;
+      await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, sharesToTransfer);
       // delegator1 will be able deposit and claim reward again
       await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
       // delegator2 cannot claim any reward
@@ -214,20 +220,17 @@ describe('OperatorRewarder', function () {
       await this.mock.connect(this.delegator1).claimRewards(this.delegator1);
       await this.mock.connect(this.delegator2).claimRewards(this.delegator2);
 
+      const sharesToRedeem = ethers.parseEther('1') * VIRTUAL_SHARES;
       await this.operatorStaking
         .connect(this.delegator1)
-        .requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
+        .requestRedeem(sharesToRedeem, this.delegator1, this.delegator1);
       await this.operatorStaking
         .connect(this.delegator2)
-        .requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
+        .requestRedeem(sharesToRedeem, this.delegator2, this.delegator2);
       await timeIncreaseNoMine(60);
 
-      await this.operatorStaking
-        .connect(this.delegator1)
-        .redeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
-      await this.operatorStaking
-        .connect(this.delegator2)
-        .redeem(ethers.parseEther('1'), this.delegator2, this.delegator2);
+      await this.operatorStaking.connect(this.delegator1).redeem(sharesToRedeem, this.delegator1, this.delegator1);
+      await this.operatorStaking.connect(this.delegator2).redeem(sharesToRedeem, this.delegator2, this.delegator2);
 
       await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
       await expect(this.mock.earned(this.delegator1)).to.eventually.eq(0);
@@ -252,9 +255,10 @@ describe('OperatorRewarder', function () {
 
       await timeIncreaseNoMine(10);
 
+      const sharesToRedeem = ethers.parseEther('2') * VIRTUAL_SHARES;
       await this.operatorStaking
         .connect(this.delegator1)
-        .requestRedeem(ethers.parseEther('2'), this.delegator1, this.delegator1);
+        .requestRedeem(sharesToRedeem, this.delegator1, this.delegator1);
 
       await time.increase(10);
 
@@ -576,7 +580,8 @@ describe('OperatorRewarder', function () {
         await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
         await timeIncreaseNoMine(10);
 
-        await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, ethers.parseEther('1'));
+        const sharesToTransfer = ethers.parseEther('1') * VIRTUAL_SHARES;
+        await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, sharesToTransfer);
         await time.increase(10);
 
         await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('5'));
@@ -587,7 +592,8 @@ describe('OperatorRewarder', function () {
         await this.operatorStaking.connect(this.delegator1).deposit(ethers.parseEther('1'), this.delegator1);
         await timeIncreaseNoMine(10);
 
-        await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, ethers.parseEther('0.5'));
+        const sharesToTransfer = ethers.parseEther('0.5') * VIRTUAL_SHARES;
+        await this.operatorStaking.connect(this.delegator1).transfer(this.delegator2, sharesToTransfer);
         await time.increase(10);
 
         await expect(this.mock.earned(this.delegator1)).to.eventually.eq(ethers.parseEther('7.5'));


### PR DESCRIPTION
## Summary
- Set `_decimalsOffset` to 2 in OperatorStaking vault to mitigate the ERC4626 inflation attack
- This creates 100 virtual shares per asset unit, making the attack economically unfeasible
- Updated tests to account for the new share-to-asset conversion ratio

refs https://github.com/zama-ai/fhevm-internal/issues/826