### PR TITLE
fix(protocol-contracts): use SafeCast for uint208 conversion in unstake (N-02)

### DIFF
--- a/protocol-contracts/staking/contracts/ProtocolStaking.sol
+++ b/protocol-contracts/staking/contracts/ProtocolStaking.sol
@@ -132,7 +132,7 @@ contract ProtocolStaking is AccessControlDefaultAdminRulesUpgradeable, ERC20Vote
             ._unstakeRequests[msg.sender]
             .latestCheckpoint();
         uint48 releaseTime = SafeCast.toUint48(Math.max(Time.timestamp() + $._unstakeCooldownPeriod, lastReleaseTime));
-        $._unstakeRequests[msg.sender].push(releaseTime, uint208(totalRequestedToWithdraw + amount));
+        $._unstakeRequests[msg.sender].push(releaseTime, SafeCast.toUint208(totalRequestedToWithdraw + amount));
 
         emit TokensUnstaked(msg.sender, amount, releaseTime);
         return releaseTime;


### PR DESCRIPTION
Replace unsafe uint208 cast with SafeCast.toUint208 in ProtocolStaking.unstake function to prevent potential overflow/truncation issues.

refs https://github.com/zama-ai/fhevm-internal/issues/826