### PR TITLE
fix(protocol-contracts): add named parameters to staking mappings (N-01)

### DIFF
--- a/protocol-contracts/staking/contracts/OperatorRewarder.sol
+++ b/protocol-contracts/staking/contracts/OperatorRewarder.sol
@@ -32,7 +32,7 @@ contract OperatorRewarder {
     uint256 private _lastClaimTotalAssetsPlusPaidRewards;
     uint256 private _totalRewardsPaid;
     int256 private _totalVirtualRewardsPaid;
-    mapping(address account => int256 rewardsPaid) private _rewardsPaid;
+    mapping(address receiver => int256 rewardsPaid) private _rewardsPaid;
     mapping(address receiver => address claimer) private _authorizedClaimers;
 
     /// @notice Emitted when the beneficiary is transferred.
@@ -144,14 +144,14 @@ contract OperatorRewarder {
      * @notice Claims rewards for a delegator. The caller must be authorized to claim rewards on
      * behalf of the delegator. By default, the caller is authorized to claim rewards on behalf of
      * themselves.
-     * @param account The delegator's address.
+     * @param receiver The delegator's address that will receive the rewards.
      */
-    function claimRewards(address account) public virtual onlyClaimer(account) {
-        uint256 earned_ = earned(account);
+    function claimRewards(address receiver) public virtual onlyClaimer(receiver) {
+        uint256 earned_ = earned(receiver);
         if (earned_ > 0) {
-            _rewardsPaid[account] += SafeCast.toInt256(earned_);
+            _rewardsPaid[receiver] += SafeCast.toInt256(earned_);
             _totalRewardsPaid += earned_;
-            _doTransferOut(account, earned_);
+            _doTransferOut(receiver, earned_);
         }
     }
 

--- a/protocol-contracts/staking/contracts/OperatorRewarder.sol
+++ b/protocol-contracts/staking/contracts/OperatorRewarder.sol
@@ -32,8 +32,8 @@ contract OperatorRewarder {
     uint256 private _lastClaimTotalAssetsPlusPaidRewards;
     uint256 private _totalRewardsPaid;
     int256 private _totalVirtualRewardsPaid;
-    mapping(address => int256) private _rewardsPaid;
-    mapping(address => address) private _authorizedClaimers;
+    mapping(address account => int256 rewardsPaid) private _rewardsPaid;
+    mapping(address receiver => address claimer) private _authorizedClaimers;
 
     /// @notice Emitted when the beneficiary is transferred.
     event BeneficiaryTransferred(address oldBeneficiary, address newBeneficiary);

--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -38,9 +38,9 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
         IERC20 _asset;
         address _rewarder;
         uint256 _totalSharesInRedemption;
-        mapping(address => uint256) _sharesReleased;
-        mapping(address => Checkpoints.Trace208) _redeemRequests;
-        mapping(address => mapping(address => bool)) _operator;
+        mapping(address controller => uint256 sharesReleased) _sharesReleased;
+        mapping(address controller => Checkpoints.Trace208 redeemRequests) _redeemRequests;
+        mapping(address controller => mapping(address operator => bool approved)) _operator;
     }
 
     // keccak256(abi.encode(uint256(keccak256("fhevm_protocol.storage.OperatorStaking")) - 1)) & ~bytes32(uint256(0xff))


### PR DESCRIPTION
Add named parameters to mapping declarations in OperatorRewarder and OperatorStaking contracts for improved code readability (Solidity 0.8.18+ feature).

refs https://github.com/zama-ai/fhevm-internal/issues/826