### PR TITLE
fix(protocol-contracts): remove unused function parameters in staking (N-04)

### DIFF
--- a/protocol-contracts/staking/contracts/OperatorStaking.sol
+++ b/protocol-contracts/staking/contracts/OperatorStaking.sol
@@ -323,7 +323,7 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
      * @param controller The controller address.
      * @return Amount of shares pending redeem.
      */
-    function pendingRedeemRequest(uint256, address controller) public view virtual returns (uint256) {
+    function pendingRedeemRequest(address controller) public view virtual returns (uint256) {
         OperatorStakingStorage storage $ = _getOperatorStakingStorage();
         return $._redeemRequests[controller].latest() - $._redeemRequests[controller].upperLookup(Time.timestamp());
     }
@@ -333,7 +333,7 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
      * @param controller The controller address.
      * @return Amount of claimable shares.
      */
-    function claimableRedeemRequest(uint256, address controller) public view virtual returns (uint256) {
+    function claimableRedeemRequest(address controller) public view virtual returns (uint256) {
         OperatorStakingStorage storage $ = _getOperatorStakingStorage();
         return $._redeemRequests[controller].upperLookup(Time.timestamp()) - $._sharesReleased[controller];
     }
@@ -360,7 +360,7 @@ contract OperatorStaking is ERC1363Upgradeable, ReentrancyGuardTransient, UUPSUp
      * @return The maximum redeemable shares.
      */
     function maxRedeem(address ownerRedeem) public view virtual returns (uint256) {
-        return claimableRedeemRequest(0, ownerRedeem);
+        return claimableRedeemRequest(ownerRedeem);
     }
 
     /**

--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -214,13 +214,13 @@ describe('OperatorStaking', function () {
         .connect(this.delegator1)
         .requestRedeem(await this.mock.balanceOf(this.delegator1), this.delegator1, this.delegator1);
 
-      await expect(this.mock.pendingRedeemRequest(0, this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
-      await expect(this.mock.claimableRedeemRequest(0, this.delegator1)).to.eventually.eq(0);
+      await expect(this.mock.pendingRedeemRequest(this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
+      await expect(this.mock.claimableRedeemRequest(this.delegator1)).to.eventually.eq(0);
 
       await time.increase(60);
 
-      await expect(this.mock.pendingRedeemRequest(0, this.delegator1)).to.eventually.eq(0);
-      await expect(this.mock.claimableRedeemRequest(0, this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
+      await expect(this.mock.pendingRedeemRequest(this.delegator1)).to.eventually.eq(0);
+      await expect(this.mock.claimableRedeemRequest(this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
 
       await expect(this.mock.connect(this.delegator1).redeem(ethers.parseEther('1'), this.delegator1, this.delegator1))
         .to.emit(this.token, 'Transfer')


### PR DESCRIPTION
Remove unused first parameter from `pendingRedeemRequest` and `claimableRedeemRequest` functions in OperatorStaking contract.

refs https://github.com/zama-ai/fhevm-internal/issues/826