### PR TITLE
fix(protocol-contracts): skip zero-amount stake/unstake operations (N-08)

### DIFF
--- a/protocol-contracts/staking/test/OperatorStaking.test.ts
+++ b/protocol-contracts/staking/test/OperatorStaking.test.ts
@@ -479,20 +479,15 @@ describe('OperatorStaking', function () {
       await this.mock.connect(this.delegator1).requestRedeem(ethers.parseEther('1'), this.delegator1, this.delegator1);
       await this.protocolStaking.slash(this.mock, ethers.parseEther('1'));
 
-      await timeIncreaseNoMine(30);
-
+      // Should revert when there are no assets to withdraw from ProtocolStaking.
       await expect(
         this.mock.connect(this.delegator2).requestRedeem(ethers.parseEther('1'), this.delegator2, this.delegator2),
-      )
-        .to.emit(this.protocolStaking, 'TokensUnstaked')
-        .withArgs(this.mock, 0, anyValue);
+      ).to.be.revertedWithCustomError(this.mock, 'NoAssetsToWithdraw');
 
-      await time.increase(30);
+      // Cooldown period is completed, only delegator1 can redeem now.
+      await time.increase(60);
       await expect(this.mock.maxRedeem(this.delegator2)).to.eventually.eq(0);
       await expect(this.mock.maxRedeem(this.delegator1)).to.eventually.eq(ethers.parseEther('1'));
-
-      await time.increase(30);
-      await expect(this.mock.maxRedeem(this.delegator2)).to.eventually.eq(ethers.parseEther('1'));
     });
 
     it('symmetrically passes on losses from withdrawal balance', async function () {

--- a/protocol-contracts/staking/test/ProtocolStaking.test.ts
+++ b/protocol-contracts/staking/test/ProtocolStaking.test.ts
@@ -117,6 +117,11 @@ describe('Protocol Staking', function () {
       await expect(this.mock.balanceOf(this.staker1)).to.eventually.equal(ethers.parseEther('100'));
     });
 
+    it('zero stake should return early without state changes', async function () {
+      await expect(this.mock.connect(this.staker1).stake(0)).to.not.emit(this.mock, 'TokensStaked');
+      await expect(this.mock.balanceOf(this.staker1)).to.eventually.equal(0);
+    });
+
     it("should not reward accounts that aren't eligible", async function () {
       await this.mock.connect(this.staker1).stake(ethers.parseEther('100'));
 
@@ -211,6 +216,13 @@ describe('Protocol Staking', function () {
         .to.emit(this.mock, 'TokensUnstaked')
         .withArgs(this.staker1, ethers.parseEther('50'), anyValue)
         .to.not.emit(this.token, 'Transfer');
+    });
+
+    it('zero unstake should revert', async function () {
+      await expect(this.mock.connect(this.staker1).unstake(0)).to.be.revertedWithCustomError(
+        this.mock,
+        'ZeroUnstakeAmount',
+      );
     });
 
     describe('Release', function () {


### PR DESCRIPTION
NOTE: as opposed to the audit report, I introduced a revert in `unstake` instead of an early return like in `stake` because it is unclear what releaseTime we should consider then. We'll first need to confirm this with auditors

- Add early return for zero-amount stake in ProtocolStaking
- Add revert with ZeroUnstakeAmount error for zero-amount unstake in ProtocolStaking  
- Add revert with NoAssetsToWithdraw error in OperatorStaking.requestRedeem when no assets to withdraw
- Add tests for new behaviors

refs https://github.com/zama-ai/fhevm-internal/issues/826