### PR TITLE
chore(common): add root .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,139 @@
+# =============================================================================
+# Root .dockerignore for fhevm repository
+# =============================================================================
+# This file reduces Docker build context size when builds use the repo root as
+# context (e.g., test-suite/fhevm/docker-compose/*.yml files).
+#
+# IMPORTANT: Do not exclude paths that Dockerfiles COPY from:
+#   - coprocessor/fhevm-engine/
+#   - coprocessor/proto/
+#   - gateway-contracts/
+#   - kms-connector/
+#   - host-contracts/
+#   - library-solidity/
+#   - test-suite/
+#   - package.json, package-lock.json
+#   - .git/ (used for build metadata in some Dockerfiles)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Rust build artifacts (CRITICAL - can be GB-scale)
+# -----------------------------------------------------------------------------
+**/target/
+
+# -----------------------------------------------------------------------------
+# FHE keys (CRITICAL - can be GB-scale, mounted at runtime)
+# -----------------------------------------------------------------------------
+**/fhevm-keys/
+**/*.fhekey
+
+# -----------------------------------------------------------------------------
+# Node.js dependencies and build artifacts
+# -----------------------------------------------------------------------------
+**/node_modules/
+**/dist/
+**/.next/
+**/.turbo/
+**/.cache/
+
+# -----------------------------------------------------------------------------
+# IDE and OS files
+# -----------------------------------------------------------------------------
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# -----------------------------------------------------------------------------
+# Test artifacts and coverage
+# -----------------------------------------------------------------------------
+**/coverage/
+**/.nyc_output/
+**/junit.xml
+**/*.lcov
+
+# -----------------------------------------------------------------------------
+# Logs
+# -----------------------------------------------------------------------------
+**/*.log
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+
+# -----------------------------------------------------------------------------
+# Documentation (not needed for builds)
+# Large PDF files and markdown docs that aren't required by Dockerfiles
+# -----------------------------------------------------------------------------
+docs/
+charts/
+*.pdf
+**/*.md
+!**/README.md
+
+# Re-include README.md files since some tooling might expect them
+# (though they're generally not needed for Docker builds)
+
+# -----------------------------------------------------------------------------
+# Python artifacts
+# -----------------------------------------------------------------------------
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/.venv/
+**/venv/
+**/.pytest_cache/
+
+# -----------------------------------------------------------------------------
+# Environment files with secrets (local overrides are gitignored)
+# Keep base .env.* templates as they're tracked in git
+# -----------------------------------------------------------------------------
+**/.env
+**/.env.local
+**/.env.*.local
+
+# -----------------------------------------------------------------------------
+# Git-related (keep .git/ for build metadata, exclude others)
+# -----------------------------------------------------------------------------
+.gitignore
+.gitattributes
+**/.gitkeep
+
+# -----------------------------------------------------------------------------
+# CI/CD and config files not needed in builds
+# -----------------------------------------------------------------------------
+.github/
+.devcontainer/
+.mergify.yml
+.commitlintrc.json
+.hadolint.yaml
+.linkspector.yml
+.prettierrc.yml
+.prettierignore
+.slither.config.json
+.npmrc
+CODE_OF_CONDUCT.md
+LICENSE
+SECURITY.md
+
+# -----------------------------------------------------------------------------
+# Golden container images (base image definitions, not needed in app builds)
+# -----------------------------------------------------------------------------
+golden-container-images/
+
+# -----------------------------------------------------------------------------
+# SDK (not used by any Dockerfile)
+# -----------------------------------------------------------------------------
+sdk/
+
+# -----------------------------------------------------------------------------
+# Protocol contracts (not used by any Dockerfile)
+# -----------------------------------------------------------------------------
+protocol-contracts/
+
+# -----------------------------------------------------------------------------
+# CI directory (not used by any Dockerfile)
+# -----------------------------------------------------------------------------
+ci/


### PR DESCRIPTION
## Summary

- Add root `.dockerignore` to dramatically reduce Docker build context size for test-suite compose builds
- Reduces context transfer from **~2.53 GB (without `target` artifacts, ~20Gb with) to ~26 MB** (99% reduction). Even more reduction when the user has a local `target` folder with rust artifacts

## Build Context Size Comparison

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Build context size | 2.53 GB | 25.86 MB | **99% reduction** |

### Test Results

All Dockerfiles successfully build with the new `.dockerignore`:

- ✅ `coprocessor/fhevm-engine/tfhe-worker/Dockerfile` - Context: 10.66 MB
- ✅ `coprocessor/fhevm-engine/gw-listener/Dockerfile` - `.git/HEAD` copied successfully
- ✅ `kms-connector/crates/gw-listener/Dockerfile` - `.git/` directory copied successfully
- ✅ `test-suite/e2e/Dockerfile` - Context: 7.18 MB

## What's Excluded

| Category | Patterns | Impact |
|----------|----------|--------|
| **Rust artifacts** | `**/target/` | **High** - can be GB-scale |
| **FHE keys** | `**/fhevm-keys/`, `**/*.fhekey` | **High** - ~2.3 GB |
| **Node.js** | `**/node_modules/`, `**/dist/` | Medium |
| **Documentation** | `docs/`, `charts/`, `*.pdf`, `**/*.md` | Low |
| **IDE/OS** | `.idea/`, `.vscode/`, `.DS_Store` | Low |
| **Unused dirs** | `protocol-contracts/`, `sdk/`, `ci/`, `golden-container-images/` | Low |

## What's Preserved (Required by Dockerfiles)

All paths used by Dockerfile COPY statements are preserved:
- `coprocessor/fhevm-engine/`, `coprocessor/proto/`
- `gateway-contracts/`, `kms-connector/`
- `host-contracts/`, `library-solidity/`, `test-suite/`
- `.git/` (needed for build metadata in some Dockerfiles)
- `package.json`, `package-lock.json`

## Why This Matters

The test-suite compose files use the repo root as Docker build context:
```yaml
build:
  context: ../../..  # repo root
  dockerfile: coprocessor/fhevm-engine/tfhe-worker/Dockerfile
```

Without a root `.dockerignore`, Docker transfers the entire repo (including `fhevm-keys/` at ~2.3 GB and `target`/. compilation artifacts that can be dozen of GBs) to the daemon for every build. This can take minutes several minutes.

Closes https://github.com/zama-ai/fhevm-internal/issues/837