### PR TITLE
chore(common): add CI Cargo profile for faster test builds

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -101,3 +101,10 @@ overflow-checks = false
 [profile.release]
 opt-level = 3
 lto = "fat"
+
+# CI profile for faster test/CI builds (30-50% faster link times)
+# Use with: cargo build --profile ci
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -102,9 +102,10 @@ overflow-checks = false
 opt-level = 3
 lto = "fat"
 
-# CI profile for faster test/CI builds (30-50% faster link times)
+# CI profile for faster builds in CI/testing (significantly faster compile+link)
 # Use with: cargo build --profile ci
 [profile.ci]
 inherits = "release"
-lto = "thin"
+opt-level = 2
+lto = false
 codegen-units = 16

--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install && \
 # Stage 1: Build GW Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -29,17 +31,18 @@ COPY .git/HEAD ./coprocessor/fhevm-engine/BUILD_ID
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build gw_listener binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --release -p gw-listener
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/gw_listener /usr/local/bin/gw_listener
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/gw_listener /usr/local/bin/gw_listener
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx ha
 # Stage 1: Build Host Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -28,18 +30,19 @@ COPY .git/HEAD ./coprocessor/fhevm-engine/BUILD_ID
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build host_listener binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --release -p host-listener
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/host_listener /usr/local/bin/host_listener
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/host_listener_poller /usr/local/bin/host_listener_poller
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/host_listener /usr/local/bin/host_listener
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/host_listener_poller /usr/local/bin/host_listener_poller
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/sns-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-worker/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build SNS Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -11,17 +13,18 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build sns_executor binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p sns-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/sns_worker /usr/local/bin/sns_worker
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/sns_worker /usr/local/bin/sns_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
+++ b/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
@@ -21,6 +21,8 @@ RUN cp .env.example .env \
 # Stage 1: Build Stress-Tool
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -33,17 +35,18 @@ COPY --from=contract_builder /app/host-contracts/artifacts/contracts /app/host-c
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build stress_generator binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p stress-test-generator
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p stress-test-generator
 
 # Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/stress_generator /usr/local/bin/stress_generator
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/stress_generator /usr/local/bin/stress_generator
 USER fhevm:fhevm
 
 CMD ["/usr/local/bin/stress_generator"]

--- a/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build TFHE Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -11,17 +13,18 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build tfhe_worker binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p tfhe-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/tfhe_worker /usr/local/bin/tfhe_worker
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/tfhe_worker /usr/local/bin/tfhe_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build Transaction Sender
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -11,17 +13,18 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build transaction_sender binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p transaction-sender
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/transaction_sender /usr/local/bin/transaction_sender
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/transaction_sender /usr/local/bin/transaction_sender
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build ZK Proof Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -11,17 +13,18 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build zkproof_worker binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p zkproof-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/zkproof_worker /usr/local/bin/zkproof_worker
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/zkproof_worker /usr/local/bin/zkproof_worker
 
 USER fhevm:fhevm
 

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -103,10 +103,6 @@ testcontainers = "=0.24.0"
 toml = { version = "=0.9.8", default-features = true }
 tracing-test = { version = "=0.2.5", default-features = false }
 
-[profile.release]
-opt-level = 3
-lto = "fat"
-
 # CI profile for faster builds in CI/testing (significantly faster compile+link)
 # Use with: cargo build --profile ci
 [profile.ci]

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -102,3 +102,14 @@ serial_test = "3.2.0"
 testcontainers = "=0.24.0"
 toml = { version = "=0.9.8", default-features = true }
 tracing-test = { version = "=0.2.5", default-features = false }
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+
+# CI profile for faster test/CI builds (30-50% faster link times)
+# Use with: cargo build --profile ci
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -107,9 +107,10 @@ tracing-test = { version = "=0.2.5", default-features = false }
 opt-level = 3
 lto = "fat"
 
-# CI profile for faster test/CI builds (30-50% faster link times)
+# CI profile for faster builds in CI/testing (significantly faster compile+link)
 # Use with: cargo build --profile ci
 [profile.ci]
 inherits = "release"
-lto = "thin"
+opt-level = 2
+lto = false
 codegen-units = 16

--- a/kms-connector/crates/gw-listener/Dockerfile
+++ b/kms-connector/crates/gw-listener/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
-ARG LTO_RELEASE=release
+ARG CARGO_PROFILE=release
 
 # Use root user for build stage
 USER root
@@ -24,14 +24,16 @@ COPY kms-connector ./kms-connector
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${LTO_RELEASE} -p gw-listener
+    cargo build --profile=${CARGO_PROFILE} -p gw-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/release/gw-listener /app/kms-connector/bin/gw-listener
+COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/gw-listener /app/kms-connector/bin/gw-listener
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/kms-worker/Dockerfile
+++ b/kms-connector/crates/kms-worker/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
-ARG LTO_RELEASE=release
+ARG CARGO_PROFILE=release
 
 # Use root user for build stage
 USER root
@@ -24,14 +24,16 @@ COPY kms-connector ./kms-connector
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${LTO_RELEASE} -p kms-worker
+    cargo build --profile=${CARGO_PROFILE} -p kms-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/release/kms-worker /app/kms-connector/bin/kms-worker
+COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/kms-worker /app/kms-connector/bin/kms-worker
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/tx-sender/Dockerfile
+++ b/kms-connector/crates/tx-sender/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
-ARG LTO_RELEASE=release
+ARG CARGO_PROFILE=release
 
 # Use root user for build stage
 USER root
@@ -24,14 +24,16 @@ COPY kms-connector ./kms-connector
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${LTO_RELEASE} -p tx-sender
+    cargo build --profile=${CARGO_PROFILE} -p tx-sender
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/release/tx-sender /app/kms-connector/bin/tx-sender
+COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/tx-sender /app/kms-connector/bin/tx-sender
 
 USER fhevm:fhevm
 

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/db-migration/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -25,6 +27,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -49,6 +53,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -72,6 +78,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/gw-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -103,6 +111,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -129,6 +139,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -153,6 +165,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/sns-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -190,6 +204,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/transaction-sender/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:

--- a/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
@@ -14,6 +14,8 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/crates/gw-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -30,6 +32,8 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/crates/kms-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:
@@ -46,6 +50,8 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/crates/tx-sender/Dockerfile
+      args:
+        CARGO_PROFILE: ${CARGO_PROFILE:-release}
       cache_from:
         - type=gha
       cache_to:

--- a/test-suite/gateway-stress/Dockerfile
+++ b/test-suite/gateway-stress/Dockerfile
@@ -5,7 +5,8 @@ ARG RUST_IMAGE_VERSION
 # Stage 1: Build gateway-stress tool
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
-ARG LTO_RELEASE=release
+# The profile used to run `cargo build`
+ARG CARGO_PROFILE=release
 
 USER root
 
@@ -16,14 +17,16 @@ COPY test-suite/gateway-stress test-suite/gateway-stress
 # Build with improved caching
 WORKDIR /app/test-suite/gateway-stress
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    cargo build --profile=${LTO_RELEASE}
+    cargo build --profile=${CARGO_PROFILE}
 
 # Stage 2: Runtime image
 FROM cgr.dev/chainguard/busybox:latest-glibc AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/test-suite/gateway-stress/target/release/gateway-stress /bin/gateway-stress
+COPY --from=builder --chown=fhevm:fhevm /app/test-suite/gateway-stress/target/${CARGO_PROFILE}/gateway-stress /bin/gateway-stress
 
 USER fhevm:fhevm
 


### PR DESCRIPTION
## Summary

Add a `[profile.ci]` Cargo profile with optimized settings for CI/test builds to reduce build times without affecting production releases.

Closes #839

## Changes

- Add `[profile.ci]` section to `coprocessor/fhevm-engine/Cargo.toml`
- Add `[profile.ci]` and `[profile.release]` sections to `kms-connector/Cargo.toml`
- Add `CARGO_PROFILE` build arg to all Rust Dockerfiles (11 files)
- Update `COPY` statements to use `${CARGO_PROFILE}` for dynamic output directories
- Add `CARGO_PROFILE` args to `coprocessor-docker-compose.yml` and `kms-connector-docker-compose.yml`

## CI Profile Settings

```toml
[profile.ci]
inherits = "release"
opt-level = 2       # vs 3 in release - faster compilation
lto = false         # vs "fat" in release - eliminates LTO linking
codegen-units = 16  # more parallelism during codegen
```

## Expected Build Time Improvements

| Setting | Release | CI | Impact |
|---------|---------|-----|--------|
| `opt-level` | `3` | `2` | **Faster compilation** - less aggressive optimization passes |
| `lto` | `"fat"` | `false` | **Much faster linking** - eliminates LTO phase entirely |
| `codegen-units` | `1` | `16` | **Faster codegen** - more parallelism |

The trade-off is slightly larger binary size and marginally slower runtime performance, which is acceptable for CI/test builds.

## Usage

```bash
# Build with CI profile (faster)
CARGO_PROFILE=ci ./fhevm-cli deploy --build

# Build with release profile (default, production)
./fhevm-cli deploy --build
```

## Testing

- [x] Verified `cargo check --profile ci` works for both workspaces
- [x] Default behavior unchanged (builds with `release` when no arg passed)
- [x] All Dockerfiles updated with ARG and dynamic COPY paths

## Files Modified (15)

**Cargo.toml files (2):**
- `coprocessor/fhevm-engine/Cargo.toml`
- `kms-connector/Cargo.toml`

**Coprocessor Dockerfiles (7):**
- `coprocessor/fhevm-engine/tfhe-worker/Dockerfile`
- `coprocessor/fhevm-engine/zkproof-worker/Dockerfile`
- `coprocessor/fhevm-engine/transaction-sender/Dockerfile`
- `coprocessor/fhevm-engine/sns-worker/Dockerfile`
- `coprocessor/fhevm-engine/host-listener/Dockerfile`
- `coprocessor/fhevm-engine/gw-listener/Dockerfile`
- `coprocessor/fhevm-engine/stress-test-generator/Dockerfile`

**KMS Connector Dockerfiles (3):**
- `kms-connector/crates/tx-sender/Dockerfile`
- `kms-connector/crates/kms-worker/Dockerfile`
- `kms-connector/crates/gw-listener/Dockerfile`

**Test Suite (1):**
- `test-suite/gateway-stress/Dockerfile`

**Docker Compose (2):**
- `test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml`
- `test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml`