### PR TITLE
chore(test-suite): speed up local build/test iterations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,139 @@
+# =============================================================================
+# Root .dockerignore for fhevm repository
+# =============================================================================
+# This file reduces Docker build context size when builds use the repo root as
+# context (e.g., test-suite/fhevm/docker-compose/*.yml files).
+#
+# IMPORTANT: Do not exclude paths that Dockerfiles COPY from:
+#   - coprocessor/fhevm-engine/
+#   - coprocessor/proto/
+#   - gateway-contracts/
+#   - kms-connector/
+#   - host-contracts/
+#   - library-solidity/
+#   - test-suite/
+#   - package.json, package-lock.json
+#   - .git/ (used for build metadata in some Dockerfiles)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Rust build artifacts (CRITICAL - can be GB-scale)
+# -----------------------------------------------------------------------------
+**/target/
+
+# -----------------------------------------------------------------------------
+# FHE keys (CRITICAL - can be GB-scale, mounted at runtime)
+# -----------------------------------------------------------------------------
+**/fhevm-keys/
+**/*.fhekey
+
+# -----------------------------------------------------------------------------
+# Node.js dependencies and build artifacts
+# -----------------------------------------------------------------------------
+**/node_modules/
+**/dist/
+**/.next/
+**/.turbo/
+**/.cache/
+
+# -----------------------------------------------------------------------------
+# IDE and OS files
+# -----------------------------------------------------------------------------
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# -----------------------------------------------------------------------------
+# Test artifacts and coverage
+# -----------------------------------------------------------------------------
+**/coverage/
+**/.nyc_output/
+**/junit.xml
+**/*.lcov
+
+# -----------------------------------------------------------------------------
+# Logs
+# -----------------------------------------------------------------------------
+**/*.log
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+
+# -----------------------------------------------------------------------------
+# Documentation (not needed for builds)
+# Large PDF files and markdown docs that aren't required by Dockerfiles
+# -----------------------------------------------------------------------------
+docs/
+charts/
+*.pdf
+**/*.md
+!**/README.md
+
+# Re-include README.md files since some tooling might expect them
+# (though they're generally not needed for Docker builds)
+
+# -----------------------------------------------------------------------------
+# Python artifacts
+# -----------------------------------------------------------------------------
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/.venv/
+**/venv/
+**/.pytest_cache/
+
+# -----------------------------------------------------------------------------
+# Environment files with secrets (local overrides are gitignored)
+# Keep base .env.* templates as they're tracked in git
+# -----------------------------------------------------------------------------
+**/.env
+**/.env.local
+**/.env.*.local
+
+# -----------------------------------------------------------------------------
+# Git-related (keep .git/ for build metadata, exclude others)
+# -----------------------------------------------------------------------------
+.gitignore
+.gitattributes
+**/.gitkeep
+
+# -----------------------------------------------------------------------------
+# CI/CD and config files not needed in builds
+# -----------------------------------------------------------------------------
+.github/
+.devcontainer/
+.mergify.yml
+.commitlintrc.json
+.hadolint.yaml
+.linkspector.yml
+.prettierrc.yml
+.prettierignore
+.slither.config.json
+.npmrc
+CODE_OF_CONDUCT.md
+LICENSE
+SECURITY.md
+
+# -----------------------------------------------------------------------------
+# Golden container images (base image definitions, not needed in app builds)
+# -----------------------------------------------------------------------------
+golden-container-images/
+
+# -----------------------------------------------------------------------------
+# SDK (not used by any Dockerfile)
+# -----------------------------------------------------------------------------
+sdk/
+
+# -----------------------------------------------------------------------------
+# Protocol contracts (not used by any Dockerfile)
+# -----------------------------------------------------------------------------
+protocol-contracts/
+
+# -----------------------------------------------------------------------------
+# CI directory (not used by any Dockerfile)
+# -----------------------------------------------------------------------------
+ci/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ logs/
 
 # Build output & temporary directories (generic)
 .cache/
+.buildx-cache/
 temp/
 tmp/
 

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -101,3 +101,9 @@ overflow-checks = false
 [profile.release]
 opt-level = 3
 lto = "fat"
+
+[profile.local]
+inherits = "release"
+opt-level = 1
+lto = false
+codegen-units = 16

--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -32,18 +32,21 @@ COPY .git/HEAD ./coprocessor/fhevm-engine/BUILD_ID
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build gw_listener binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener && \
+    cp target/${CARGO_PROFILE}/gw_listener /tmp/gw_listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/gw_listener /usr/local/bin/gw_listener
+COPY --from=builder --chown=fhevm:fhevm /tmp/gw_listener /usr/local/bin/gw_listener
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install && \
 # Stage 1: Build GW Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -32,14 +34,16 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build gw_listener binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --release -p gw-listener
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/gw_listener /usr/local/bin/gw_listener
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/gw_listener /usr/local/bin/gw_listener
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx ha
 # Stage 1: Build Host Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -31,15 +33,17 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build host_listener binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --release -p host-listener
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/host_listener /usr/local/bin/host_listener
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/host_listener_poller /usr/local/bin/host_listener_poller
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/host_listener /usr/local/bin/host_listener
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/host_listener_poller /usr/local/bin/host_listener_poller
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -31,19 +31,23 @@ COPY .git/HEAD ./coprocessor/fhevm-engine/BUILD_ID
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build host_listener binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener && \
+    cp target/${CARGO_PROFILE}/host_listener /tmp/host_listener && \
+    cp target/${CARGO_PROFILE}/host_listener_poller /tmp/host_listener_poller
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/host_listener /usr/local/bin/host_listener
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/host_listener_poller /usr/local/bin/host_listener_poller
+COPY --from=builder --chown=fhevm:fhevm /tmp/host_listener /usr/local/bin/host_listener
+COPY --from=builder --chown=fhevm:fhevm /tmp/host_listener_poller /usr/local/bin/host_listener_poller
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/sns-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-worker/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build SNS Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -14,14 +16,16 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build sns_executor binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p sns-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/sns_worker /usr/local/bin/sns_worker
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/sns_worker /usr/local/bin/sns_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/sns-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-worker/Dockerfile
@@ -14,18 +14,21 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build sns_executor binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker && \
+    cp target/${CARGO_PROFILE}/sns_worker /tmp/sns_worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/sns_worker /usr/local/bin/sns_worker
+COPY --from=builder --chown=fhevm:fhevm /tmp/sns_worker /usr/local/bin/sns_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
+++ b/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
@@ -36,18 +36,21 @@ COPY --from=contract_builder /app/host-contracts/artifacts/contracts /app/host-c
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build stress_generator binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p stress-test-generator
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p stress-test-generator && \
+    cp target/${CARGO_PROFILE}/stress_generator /tmp/stress_generator
 
 # Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/stress_generator /usr/local/bin/stress_generator
+COPY --from=builder --chown=fhevm:fhevm /tmp/stress_generator /usr/local/bin/stress_generator
 USER fhevm:fhevm
 
 CMD ["/usr/local/bin/stress_generator"]

--- a/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
+++ b/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
@@ -21,6 +21,8 @@ RUN cp .env.example .env \
 # Stage 1: Build Stress-Tool
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -36,14 +38,16 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build stress_generator binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p stress-test-generator
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p stress-test-generator
 
 # Stage 2: Runtime image
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/stress_generator /usr/local/bin/stress_generator
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/stress_generator /usr/local/bin/stress_generator
 USER fhevm:fhevm
 
 CMD ["/usr/local/bin/stress_generator"]

--- a/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
@@ -14,18 +14,21 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build tfhe_worker binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker && \
+    cp target/${CARGO_PROFILE}/tfhe_worker /tmp/tfhe_worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/tfhe_worker /usr/local/bin/tfhe_worker
+COPY --from=builder --chown=fhevm:fhevm /tmp/tfhe_worker /usr/local/bin/tfhe_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build TFHE Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -14,14 +16,16 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build tfhe_worker binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p tfhe-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/tfhe_worker /usr/local/bin/tfhe_worker
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/tfhe_worker /usr/local/bin/tfhe_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build Transaction Sender
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -14,14 +16,16 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build transaction_sender binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p transaction-sender
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/transaction_sender /usr/local/bin/transaction_sender
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/transaction_sender /usr/local/bin/transaction_sender
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -14,18 +14,21 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build transaction_sender binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender && \
+    cp target/${CARGO_PROFILE}/transaction_sender /tmp/transaction_sender
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/transaction_sender /usr/local/bin/transaction_sender
+COPY --from=builder --chown=fhevm:fhevm /tmp/transaction_sender /usr/local/bin/transaction_sender
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build ZK Proof Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
+ARG CARGO_PROFILE=release
+
 USER root
 
 WORKDIR /app
@@ -14,14 +16,16 @@ WORKDIR /app/coprocessor/fhevm-engine
 # Build zkproof_worker binary
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --release -p zkproof-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/release/zkproof_worker /usr/local/bin/zkproof_worker
+COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/zkproof_worker /usr/local/bin/zkproof_worker
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -14,18 +14,21 @@ COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 WORKDIR /app/coprocessor/fhevm-engine
 
 # Build zkproof_worker binary
+# NOTE: We use a cache mount for the target directory to enable incremental compilation.
+# Because cache mounts are NOT committed to the image layer, we must copy the binary
+# to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker && \
+    cp target/${CARGO_PROFILE}/zkproof_worker /tmp/zkproof_worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/target/${CARGO_PROFILE}/zkproof_worker /usr/local/bin/zkproof_worker
+COPY --from=builder --chown=fhevm:fhevm /tmp/zkproof_worker /usr/local/bin/zkproof_worker
 
 USER fhevm:fhevm
 

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -102,3 +102,9 @@ serial_test = "3.2.0"
 testcontainers = "=0.24.0"
 toml = { version = "=0.9.8", default-features = true }
 tracing-test = { version = "=0.2.5", default-features = false }
+
+[profile.local]
+inherits = "release"
+opt-level = 1
+lto = false
+codegen-units = 16

--- a/kms-connector/crates/gw-listener/Dockerfile
+++ b/kms-connector/crates/gw-listener/Dockerfile
@@ -32,8 +32,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder --chown=fhevm:fhevm /tmp/gw-listener /app/kms-connector/bin/gw-listener

--- a/kms-connector/crates/gw-listener/Dockerfile
+++ b/kms-connector/crates/gw-listener/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
-ARG LTO_RELEASE=release
+ARG CARGO_PROFILE=release
 
 # Use root user for build stage
 USER root
@@ -24,14 +24,16 @@ COPY kms-connector ./kms-connector
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${LTO_RELEASE} -p gw-listener
+    cargo build --profile=${CARGO_PROFILE} -p gw-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/release/gw-listener /app/kms-connector/bin/gw-listener
+COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/gw-listener /app/kms-connector/bin/gw-listener
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/gw-listener/Dockerfile
+++ b/kms-connector/crates/gw-listener/Dockerfile
@@ -23,8 +23,11 @@ COPY kms-connector ./kms-connector
 # Build with improved caching
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/kms-connector/target,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${CARGO_PROFILE} -p gw-listener
+    cargo fetch && \
+    cargo build --profile=${CARGO_PROFILE} -p gw-listener && \
+    cp target/${CARGO_PROFILE}/gw-listener /tmp/gw-listener
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
@@ -33,7 +36,7 @@ ARG CARGO_PROFILE=release
 
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/gw-listener /app/kms-connector/bin/gw-listener
+COPY --from=builder --chown=fhevm:fhevm /tmp/gw-listener /app/kms-connector/bin/gw-listener
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/kms-worker/Dockerfile
+++ b/kms-connector/crates/kms-worker/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
-ARG LTO_RELEASE=release
+ARG CARGO_PROFILE=release
 
 # Use root user for build stage
 USER root
@@ -24,14 +24,16 @@ COPY kms-connector ./kms-connector
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${LTO_RELEASE} -p kms-worker
+    cargo build --profile=${CARGO_PROFILE} -p kms-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/release/kms-worker /app/kms-connector/bin/kms-worker
+COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/kms-worker /app/kms-connector/bin/kms-worker
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/kms-worker/Dockerfile
+++ b/kms-connector/crates/kms-worker/Dockerfile
@@ -32,8 +32,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder --chown=fhevm:fhevm /tmp/kms-worker /app/kms-connector/bin/kms-worker

--- a/kms-connector/crates/kms-worker/Dockerfile
+++ b/kms-connector/crates/kms-worker/Dockerfile
@@ -23,8 +23,11 @@ COPY kms-connector ./kms-connector
 # Build with improved caching
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/kms-connector/target,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${CARGO_PROFILE} -p kms-worker
+    cargo fetch && \
+    cargo build --profile=${CARGO_PROFILE} -p kms-worker && \
+    cp target/${CARGO_PROFILE}/kms-worker /tmp/kms-worker
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
@@ -33,7 +36,7 @@ ARG CARGO_PROFILE=release
 
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/kms-worker /app/kms-connector/bin/kms-worker
+COPY --from=builder --chown=fhevm:fhevm /tmp/kms-worker /app/kms-connector/bin/kms-worker
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/tx-sender/Dockerfile
+++ b/kms-connector/crates/tx-sender/Dockerfile
@@ -32,8 +32,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
-ARG CARGO_PROFILE=release
-
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder --chown=fhevm:fhevm /tmp/tx-sender /app/kms-connector/bin/tx-sender

--- a/kms-connector/crates/tx-sender/Dockerfile
+++ b/kms-connector/crates/tx-sender/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
-ARG LTO_RELEASE=release
+ARG CARGO_PROFILE=release
 
 # Use root user for build stage
 USER root
@@ -24,14 +24,16 @@ COPY kms-connector ./kms-connector
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${LTO_RELEASE} -p tx-sender
+    cargo build --profile=${CARGO_PROFILE} -p tx-sender
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
 
+ARG CARGO_PROFILE=release
+
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/release/tx-sender /app/kms-connector/bin/tx-sender
+COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/tx-sender /app/kms-connector/bin/tx-sender
 
 USER fhevm:fhevm
 

--- a/kms-connector/crates/tx-sender/Dockerfile
+++ b/kms-connector/crates/tx-sender/Dockerfile
@@ -23,8 +23,11 @@ COPY kms-connector ./kms-connector
 # Build with improved caching
 WORKDIR /app/kms-connector
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/kms-connector/target,sharing=locked \
     git config --global --add safe.directory /app && \
-    cargo build --profile=${CARGO_PROFILE} -p tx-sender
+    cargo fetch && \
+    cargo build --profile=${CARGO_PROFILE} -p tx-sender && \
+    cp target/${CARGO_PROFILE}/tx-sender /tmp/tx-sender
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod
@@ -33,7 +36,7 @@ ARG CARGO_PROFILE=release
 
 COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder --chown=fhevm:fhevm /app/kms-connector/target/${CARGO_PROFILE}/tx-sender /app/kms-connector/bin/tx-sender
+COPY --from=builder --chown=fhevm:fhevm /tmp/tx-sender /app/kms-connector/bin/tx-sender
 
 USER fhevm:fhevm
 

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -41,7 +41,7 @@ cd test-suite/fhevm
 # Run specific tests
 ./fhevm-cli test input-proof
 # Skip Hardhat compile when artifacts are already up to date
-./fhevm-cli test input-proof --no-compile
+./fhevm-cli test input-proof --no-hardhat-compile
 # Trivial
 ./fhevm-cli test user-decryption
 # Trivial
@@ -98,7 +98,7 @@ For faster local iteration, use `--local` to enable a local BuildKit cache (stor
 When running tests and you know your Hardhat artifacts are already up to date, you can skip compilation:
 
 ```sh
-./fhevm-cli test input-proof --no-compile
+./fhevm-cli test input-proof --no-hardhat-compile
 ```
 
 ## Security policy

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -35,9 +35,13 @@ The test suite offers a unified CLI for all operations:
 cd test-suite/fhevm
 # Deploy the entire stack
 ./fhevm-cli deploy
+# Deploy with local BuildKit cache (disables provenance attestations)
+./fhevm-cli deploy --local
 
 # Run specific tests
 ./fhevm-cli test input-proof
+# Skip Hardhat compile when artifacts are already up to date
+./fhevm-cli test input-proof --no-compile
 # Trivial
 ./fhevm-cli test user-decryption
 # Trivial
@@ -82,6 +86,20 @@ This command instructs Docker Compose to:
 - **Ensuring Correct Setup:** It guarantees that you are running with images built directly from the provided source, eliminating discrepancies that could arise from attempting to pull non-existent or inaccessible public images.
 
 🚧 **In summary:** Until public images are made available, external users should always use `./fhevm-cli deploy --build` to ensure a successful deployment.
+
+### Local developer optimizations
+
+For faster local iteration, use `--local` to enable a local BuildKit cache (stored under `.buildx-cache/`) and disable default provenance attestations:
+
+```sh
+./fhevm-cli deploy --local
+```
+
+When running tests and you know your Hardhat artifacts are already up to date, you can skip compilation:
+
+```sh
+./fhevm-cli test input-proof --no-compile
+```
 
 ## Security policy
 

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -17,14 +17,18 @@ RUN addgroup -g 10001 fhevm && \
     adduser -D -u 10000 -G fhevm fhevm && \
     mkdir -p /app /home/fhevm
 
-# Copy only necessary files
+# Copy only dependency manifests first for better cache reuse
 COPY package.json package-lock.json ./
-COPY library-solidity ./library-solidity
-COPY test-suite/e2e ./test-suite/e2e
+COPY library-solidity/package.json ./library-solidity/package.json
+COPY test-suite/e2e/package.json ./test-suite/e2e/
 
 # Install dependencies
 RUN npm ci && \
     npm prune
+
+# Copy sources after deps are cached
+COPY library-solidity ./library-solidity
+COPY test-suite/e2e ./test-suite/e2e
 
 WORKDIR /app/test-suite/e2e
 

--- a/test-suite/e2e/run-tests.sh
+++ b/test-suite/e2e/run-tests.sh
@@ -9,6 +9,7 @@ RESET='\033[0m'
 DEFAULT_GREP="test user input uint64"
 DEFAULT_NETWORK="staging"
 VERBOSE=false
+NO_COMPILE=false
 
 show_help() {
   echo -e "${BLUE}============================================================${RESET}"
@@ -21,6 +22,7 @@ show_help() {
   echo -e "  -g, --grep PATTERN  Specify test grep pattern (default: ${DEFAULT_GREP})"
   echo -e "  -n, --network NAME  Specify network (default: ${DEFAULT_NETWORK})"
   echo -e "  -v, --verbose       Enable verbose output"
+  echo -e "  --no-compile        Skip Hardhat compilation step"
   echo -e "  -r, --no-relayer    Disable Rust relayer"
   echo -e ""
   echo -e "${YELLOW}Examples:${RESET}"
@@ -67,6 +69,10 @@ while (( "$#" )); do
       VERBOSE=true
       shift
       ;;
+    --no-compile)
+      NO_COMPILE=true
+      shift
+      ;;
     *)
       PARAMS="$PARAMS $1"
       shift
@@ -92,6 +98,9 @@ echo -e "  Network:     ${YELLOW}$NETWORK${RESET}"
 if [ "$VERBOSE" = true ]; then
   echo -e "  Verbose:     ${YELLOW}Enabled${RESET}"
 fi
+if [ "$NO_COMPILE" = true ]; then
+  echo -e "  Compile:     ${YELLOW}Disabled${RESET}"
+fi
 echo -e "${BLUE}============================================================${RESET}"
 
 trap cleanup SIGINT SIGTERM
@@ -101,6 +110,9 @@ echo -e "\n${GREEN}Running tests...${RESET}"
 HARDHAT_OPTS="${HARDHAT_PARALLEL} "
 if [ "$VERBOSE" = true ]; then
   HARDHAT_OPTS+=" --verbose "
+fi
+if [ "$NO_COMPILE" = true ]; then
+  HARDHAT_OPTS+=" --no-compile "
 fi
 
 echo hardhat test ${HARDHAT_OPTS} --grep "$GREP_TEXT" --network "$NETWORK"

--- a/test-suite/e2e/run-tests.sh
+++ b/test-suite/e2e/run-tests.sh
@@ -22,7 +22,7 @@ show_help() {
   echo -e "  -g, --grep PATTERN  Specify test grep pattern (default: ${DEFAULT_GREP})"
   echo -e "  -n, --network NAME  Specify network (default: ${DEFAULT_NETWORK})"
   echo -e "  -v, --verbose       Enable verbose output"
-  echo -e "  --no-compile        Skip Hardhat compilation step"
+  echo -e "  --no-hardhat-compile        Skip Hardhat compilation step"
   echo -e "  -r, --no-relayer    Disable Rust relayer"
   echo -e ""
   echo -e "${YELLOW}Examples:${RESET}"
@@ -69,7 +69,7 @@ while (( "$#" )); do
       VERBOSE=true
       shift
       ;;
-    --no-compile)
+    --no-hardhat-compile)
       NO_COMPILE=true
       shift
       ;;
@@ -112,7 +112,7 @@ if [ "$VERBOSE" = true ]; then
   HARDHAT_OPTS+=" --verbose "
 fi
 if [ "$NO_COMPILE" = true ]; then
-  HARDHAT_OPTS+=" --no-compile "
+  HARDHAT_OPTS+=" --no-hardhat-compile "
 fi
 
 echo hardhat test ${HARDHAT_OPTS} --grep "$GREP_TEXT" --network "$NETWORK"

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/db-migration/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_DB_MIGRATION:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_DB_MIGRATION:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     environment:
@@ -26,9 +26,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_HOST_LISTENER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_HOST_LISTENER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -50,9 +50,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_HOST_LISTENER_POLLER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_HOST_LISTENER_POLLER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -73,9 +73,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/gw-listener/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_GW_LISTENER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_GW_LISTENER:-type=gha,mode=max}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/liveness || exit 1"]
       interval: 10s
@@ -104,9 +104,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/tfhe-worker/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_TFHE_WORKER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_TFHE_WORKER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -130,9 +130,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/zkproof-worker/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_ZKPROOF_WORKER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_ZKPROOF_WORKER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -154,9 +154,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/sns-worker/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_SNS_WORKER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_SNS_WORKER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -191,9 +191,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/transaction-sender/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR_TRANSACTION_SENDER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR_TRANSACTION_SENDER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/db-migration/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_DB_MIGRATION:-type=gha}
       cache_to:
@@ -25,6 +27,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_HOST_LISTENER:-type=gha}
       cache_to:
@@ -49,6 +53,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_HOST_LISTENER_POLLER:-type=gha}
       cache_to:
@@ -72,6 +78,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/gw-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_GW_LISTENER:-type=gha}
       cache_to:
@@ -103,6 +111,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_TFHE_WORKER:-type=gha}
       cache_to:
@@ -129,6 +139,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_ZKPROOF_WORKER:-type=gha}
       cache_to:
@@ -153,6 +165,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/sns-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_SNS_WORKER:-type=gha}
       cache_to:
@@ -190,6 +204,8 @@ services:
     build:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/transaction-sender/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR_TRANSACTION_SENDER:-type=gha}
       cache_to:

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/db-migration/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     environment:
@@ -26,9 +26,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -50,9 +50,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -73,9 +73,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/gw-listener/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/liveness || exit 1"]
       interval: 10s
@@ -104,9 +104,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/tfhe-worker/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -130,9 +130,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/zkproof-worker/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -154,9 +154,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/sns-worker/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -191,9 +191,9 @@ services:
       context: ../../..
       dockerfile: coprocessor/fhevm-engine/transaction-sender/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:

--- a/test-suite/fhevm/docker-compose/gateway-mocked-payment-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-mocked-payment-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_DEPLOY_MOCKED_ZAMA_OFT:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_DEPLOY_MOCKED_ZAMA_OFT:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-mocked-payment.local
     command:
@@ -22,9 +22,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SET_RELAYER_MOCKED_PAYMENT:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SET_RELAYER_MOCKED_PAYMENT:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-mocked-payment.local
     command:

--- a/test-suite/fhevm/docker-compose/gateway-mocked-payment-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-mocked-payment-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-mocked-payment.local
     command:
@@ -22,9 +22,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-mocked-payment.local
     command:

--- a/test-suite/fhevm/docker-compose/gateway-pause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-pause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_PAUSE:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_PAUSE:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/gateway-pause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-pause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/gateway-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-sc-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_DEPLOY:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_DEPLOY:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:
@@ -23,9 +23,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_ADD_NETWORK:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_ADD_NETWORK:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:
@@ -45,9 +45,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_ADD_PAUSERS:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_ADD_PAUSERS:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:
@@ -67,9 +67,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_TRIGGER_KEYGEN:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_TRIGGER_KEYGEN:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     # Using test parameters (--params-type 1) is currently not possible at it can make the random
@@ -92,9 +92,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_TRIGGER_CRSGEN:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_TRIGGER_CRSGEN:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     # Using test parameters (--params-type 1) is currently not possible for keygen (see above), and

--- a/test-suite/fhevm/docker-compose/gateway-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-sc-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:
@@ -23,9 +23,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:
@@ -45,9 +45,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:
@@ -67,9 +67,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     # Using test parameters (--params-type 1) is currently not possible at it can make the random
@@ -92,9 +92,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     # Using test parameters (--params-type 1) is currently not possible for keygen (see above), and

--- a/test-suite/fhevm/docker-compose/gateway-unpause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-unpause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_GATEWAY_SC_UNPAUSE:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_GATEWAY_SC_UNPAUSE:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/gateway-unpause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/gateway-unpause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../gateway-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.gateway-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/host-pause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-pause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_HOST_SC_PAUSE:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_HOST_SC_PAUSE:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/host-pause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-pause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:
@@ -23,9 +23,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
@@ -3,8 +3,8 @@ services:
     container_name: host-sc-deploy
     image: ghcr.io/zama-ai/fhevm/host-contracts:${HOST_VERSION}
     build:
-      context: ../../../host-contracts
-      dockerfile: Dockerfile
+      context: ../../..
+      dockerfile: host-contracts/Dockerfile
       cache_from:
         - ${FHEVM_CACHE_FROM_HOST_SC_DEPLOY:-type=gha}
       cache_to:
@@ -20,8 +20,8 @@ services:
     container_name: host-sc-add-pausers
     image: ghcr.io/zama-ai/fhevm/host-contracts:${HOST_VERSION}
     build:
-      context: ../../../host-contracts
-      dockerfile: Dockerfile
+      context: ../../..
+      dockerfile: host-contracts/Dockerfile
       cache_from:
         - ${FHEVM_CACHE_FROM_HOST_SC_ADD_PAUSERS:-type=gha}
       cache_to:

--- a/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_HOST_SC_DEPLOY:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_HOST_SC_DEPLOY:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:
@@ -23,9 +23,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_HOST_SC_ADD_PAUSERS:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_HOST_SC_ADD_PAUSERS:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/host-unpause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-unpause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_HOST_SC_UNPAUSE:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_HOST_SC_UNPAUSE:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/host-unpause-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-unpause-docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ../../../host-contracts
       dockerfile: Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.host-sc.local
     command:

--- a/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
@@ -15,9 +15,9 @@ services:
       context: ../../..
       dockerfile: kms-connector/crates/gw-listener/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_GW_LISTENER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_GW_LISTENER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:
@@ -31,9 +31,9 @@ services:
       context: ../../..
       dockerfile: kms-connector/crates/kms-worker/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_KMS_WORKER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_KMS_WORKER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:
@@ -47,9 +47,9 @@ services:
       context: ../../..
       dockerfile: kms-connector/crates/tx-sender/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_TX_SENDER:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_TX_SENDER:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:

--- a/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
@@ -15,9 +15,9 @@ services:
       context: ../../..
       dockerfile: kms-connector/crates/gw-listener/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:
@@ -31,9 +31,9 @@ services:
       context: ../../..
       dockerfile: kms-connector/crates/kms-worker/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:
@@ -47,9 +47,9 @@ services:
       context: ../../..
       dockerfile: kms-connector/crates/tx-sender/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:

--- a/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
@@ -5,6 +5,13 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/connector-db/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
+        RUST_IMAGE_VERSION: 1.91.0
+      cache_from:
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_DB_MIGRATION:-type=gha}
+      cache_to:
+        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_DB_MIGRATION:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
 
@@ -14,6 +21,9 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/crates/gw-listener/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
+        RUST_IMAGE_VERSION: 1.91.0
       cache_from:
         - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_GW_LISTENER:-type=gha}
       cache_to:
@@ -30,6 +40,9 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/crates/kms-worker/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
+        RUST_IMAGE_VERSION: 1.91.0
       cache_from:
         - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_KMS_WORKER:-type=gha}
       cache_to:
@@ -46,6 +59,9 @@ services:
     build:
       context: ../../..
       dockerfile: kms-connector/crates/tx-sender/Dockerfile
+      args:
+        CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
+        RUST_IMAGE_VERSION: 1.91.0
       cache_from:
         - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_TX_SENDER:-type=gha}
       cache_to:

--- a/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
@@ -7,9 +7,9 @@ services:
       context: ../../.. # root directory of the repository
       dockerfile: test-suite/e2e/Dockerfile
       cache_from:
-        - type=gha
+        - ${FHEVM_CACHE_FROM:-type=gha}
       cache_to:
-        - type=gha,mode=max
+        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.test-suite.local
     command:

--- a/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
@@ -7,9 +7,9 @@ services:
       context: ../../.. # root directory of the repository
       dockerfile: test-suite/e2e/Dockerfile
       cache_from:
-        - ${FHEVM_CACHE_FROM:-type=gha}
+        - ${FHEVM_CACHE_FROM_TEST_SUITE_E2E_DEBUG:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_TEST_SUITE_E2E_DEBUG:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.test-suite.local
     command:

--- a/test-suite/fhevm/fhevm-cli
+++ b/test-suite/fhevm/fhevm-cli
@@ -73,14 +73,14 @@ function usage {
   echo -e "  ${CYAN}-n, --network NAME${RESET}  Specify network (default: ${GREEN}staging${RESET})"
   echo -e "  ${CYAN}-g, --grep PATTERN${RESET}  Override default test pattern"
   echo -e "  ${CYAN}-r, --no-relayer${RESET}    Disable Rust relayer"
-  echo -e "  ${CYAN}--no-compile${RESET}        Skip Hardhat compilation step"
+  echo -e "  ${CYAN}--no-hardhat-compile${RESET}        Skip Hardhat compilation step"
   echo
   echo -e "${BOLD}${LIGHT_BLUE}Examples:${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli deploy${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli deploy --build${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli deploy --local${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test input-proof${RESET}"
-  echo -e "  ${PURPLE}./fhevm-cli test input-proof --no-compile${RESET}"
+  echo -e "  ${PURPLE}./fhevm-cli test input-proof --no-hardhat-compile${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test user-decryption ${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test public-decrypt-http-ebool ${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test public-decrypt-http-mixed -n staging${RESET}"
@@ -199,8 +199,8 @@ case $COMMAND in
           NO_RELAYER="-r"
           shift
           ;;
-        --no-compile)
-          NO_COMPILE="--no-compile"
+        --no-hardhat-compile)
+          NO_COMPILE="--no-hardhat-compile"
           shift
           ;;
         *)
@@ -220,7 +220,7 @@ case $COMMAND in
       docker_args+=("-r")
     fi
     if [ -n "$NO_COMPILE" ]; then
-      docker_args+=("--no-compile")
+      docker_args+=("--no-hardhat-compile")
     fi
 
     if [ -n "$GREP" ]; then

--- a/test-suite/fhevm/fhevm-cli
+++ b/test-suite/fhevm/fhevm-cli
@@ -59,7 +59,7 @@ function usage {
   echo -e "${BOLD}Usage:${RESET} ${YELLOW}fhevm-cli${RESET} ${CYAN}COMMAND [OPTIONS]${RESET}"
   echo
   echo -e "${BOLD}${LIGHT_BLUE}Commands:${RESET}"
-  echo -e "  ${YELLOW}deploy${RESET} ${CYAN}[--build]${RESET}    WIP: Deploy the full fhevm stack (optionally rebuild images)"
+  echo -e "  ${YELLOW}deploy${RESET} ${CYAN}[--build] [--local]${RESET}    WIP: Deploy the full fhevm stack (optionally rebuild images)"
   echo -e "  ${YELLOW}pause${RESET} ${CYAN}[CONTRACTS]${RESET}     Pause specific contracts (host|gateway)"
   echo -e "  ${YELLOW}unpause${RESET} ${CYAN}[CONTRACTS]${RESET}     Unpause specific contracts (host|gateway)"
   echo -e "  ${YELLOW}test${RESET} ${CYAN}[TYPE]${RESET}         Run tests (input-proof|user-decryption|public-decryption|delegate-user-decryption|random|random-subset|operators|erc20|debug)"
@@ -73,11 +73,14 @@ function usage {
   echo -e "  ${CYAN}-n, --network NAME${RESET}  Specify network (default: ${GREEN}staging${RESET})"
   echo -e "  ${CYAN}-g, --grep PATTERN${RESET}  Override default test pattern"
   echo -e "  ${CYAN}-r, --no-relayer${RESET}    Disable Rust relayer"
+  echo -e "  ${CYAN}--no-compile${RESET}        Skip Hardhat compilation step"
   echo
   echo -e "${BOLD}${LIGHT_BLUE}Examples:${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli deploy${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli deploy --build${RESET}"
+  echo -e "  ${PURPLE}./fhevm-cli deploy --local${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test input-proof${RESET}"
+  echo -e "  ${PURPLE}./fhevm-cli test input-proof --no-compile${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test user-decryption ${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test public-decrypt-http-ebool ${RESET}"
   echo -e "  ${PURPLE}./fhevm-cli test public-decrypt-http-mixed -n staging${RESET}"
@@ -99,16 +102,25 @@ case $COMMAND in
   deploy)
     print_logo
     echo -e "${LIGHT_BLUE}${BOLD}[DEPLOY] Deploying fhevm stack...${RESET}"
-    BUILD_ARG=""
-    if [[ "$1" == "--build" ]]; then
-      BUILD_ARG="--build"
-      shift
-    elif [[ -n "$1" ]]; then
-      echo -e "${RED}[ERROR]${RESET} ${BOLD}Unknown argument for deploy: $1${RESET}"
-      usage
-      exit 1
-    fi
-    "${SCRIPT_DIR}/scripts/deploy-fhevm-stack.sh" $BUILD_ARG
+    DEPLOY_ARGS=()
+    while (( "$#" )); do
+      case "$1" in
+        --build)
+          DEPLOY_ARGS+=("--build")
+          shift
+          ;;
+        --local|--dev)
+          DEPLOY_ARGS+=("--local")
+          shift
+          ;;
+        *)
+          echo -e "${RED}[ERROR]${RESET} ${BOLD}Unknown argument for deploy: $1${RESET}"
+          usage
+          exit 1
+          ;;
+      esac
+    done
+    "${SCRIPT_DIR}/scripts/deploy-fhevm-stack.sh" "${DEPLOY_ARGS[@]}"
     echo -e "${GREEN}${BOLD} [SUCCESS] fhevm stack deployment complete!${RESET}"
     ;;
 
@@ -155,6 +167,7 @@ case $COMMAND in
     NETWORK="staging"
     GREP=""
     NO_RELAYER=""
+    NO_COMPILE=""
 
     while (( "$#" )); do
       case "$1" in
@@ -186,6 +199,10 @@ case $COMMAND in
           NO_RELAYER="-r"
           shift
           ;;
+        --no-compile)
+          NO_COMPILE="--no-compile"
+          shift
+          ;;
         *)
           echo -e "${RED}[ERROR]${RESET} ${BOLD}Unknown option: $1${RESET}"
           usage
@@ -201,6 +218,9 @@ case $COMMAND in
     docker_args+=("-n" "$NETWORK")
     if [ -n "$NO_RELAYER" ]; then
       docker_args+=("-r")
+    fi
+    if [ -n "$NO_COMPILE" ]; then
+      docker_args+=("--no-compile")
     fi
 
     if [ -n "$GREP" ]; then

--- a/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
+++ b/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
@@ -46,12 +46,14 @@ if [ "$LOCAL_BUILD" = true ]; then
     export DOCKER_BUILDKIT=1
     export COMPOSE_DOCKER_CLI_BUILD=1
     export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+    export DOCKER_BUILD_PROVENANCE=false
+    export FHEVM_CARGO_PROFILE=local
     FHEVM_BUILDX_CACHE_DIR="${FHEVM_BUILDX_CACHE_DIR:-.buildx-cache}"
     mkdir -p "$FHEVM_BUILDX_CACHE_DIR"
     set_local_cache_vars() {
         local service_name="$1"
-        local service_key="${service_name//-/_}"
-        service_key="${service_key^^}"
+        local service_key
+        service_key=$(echo "${service_name//-/_}" | tr '[:lower:]' '[:upper:]')
         local cache_dir="${FHEVM_BUILDX_CACHE_DIR}/${service_name}"
         mkdir -p "$cache_dir"
         export "FHEVM_CACHE_FROM_${service_key}=type=local,src=${cache_dir}"
@@ -79,6 +81,7 @@ if [ "$LOCAL_BUILD" = true ]; then
         host-sc-deploy
         host-sc-pause
         host-sc-unpause
+        kms-connector-db-migration
         kms-connector-gw-listener
         kms-connector-kms-worker
         kms-connector-tx-sender

--- a/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
+++ b/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
@@ -48,8 +48,45 @@ if [ "$LOCAL_BUILD" = true ]; then
     export BUILDX_NO_DEFAULT_ATTESTATIONS=1
     FHEVM_BUILDX_CACHE_DIR="${FHEVM_BUILDX_CACHE_DIR:-.buildx-cache}"
     mkdir -p "$FHEVM_BUILDX_CACHE_DIR"
-    export FHEVM_CACHE_FROM="type=local,src=${FHEVM_BUILDX_CACHE_DIR}"
-    export FHEVM_CACHE_TO="type=local,dest=${FHEVM_BUILDX_CACHE_DIR},mode=max"
+    set_local_cache_vars() {
+        local service_name="$1"
+        local service_key="${service_name//-/_}"
+        service_key="${service_key^^}"
+        local cache_dir="${FHEVM_BUILDX_CACHE_DIR}/${service_name}"
+        mkdir -p "$cache_dir"
+        export "FHEVM_CACHE_FROM_${service_key}=type=local,src=${cache_dir}"
+        export "FHEVM_CACHE_TO_${service_key}=type=local,dest=${cache_dir},mode=max"
+    }
+    LOCAL_CACHE_SERVICES=( 
+        coprocessor-db-migration
+        coprocessor-gw-listener
+        coprocessor-host-listener
+        coprocessor-host-listener-poller
+        coprocessor-sns-worker
+        coprocessor-tfhe-worker
+        coprocessor-transaction-sender
+        coprocessor-zkproof-worker
+        gateway-deploy-mocked-zama-oft
+        gateway-sc-add-network
+        gateway-sc-add-pausers
+        gateway-sc-deploy
+        gateway-sc-pause
+        gateway-sc-trigger-crsgen
+        gateway-sc-trigger-keygen
+        gateway-sc-unpause
+        gateway-set-relayer-mocked-payment
+        host-sc-add-pausers
+        host-sc-deploy
+        host-sc-pause
+        host-sc-unpause
+        kms-connector-gw-listener
+        kms-connector-kms-worker
+        kms-connector-tx-sender
+        test-suite-e2e-debug
+    )
+    for service_name in "${LOCAL_CACHE_SERVICES[@]}"; do
+        set_local_cache_vars "$service_name"
+    done
 fi
 
 # Function to check if services are ready based on expected state


### PR DESCRIPTION
## Summary

This PR optimizes local Docker build and test iterations for developers:

- **Local BuildKit cache**: Add `--local` flag to enable per-service local BuildKit caches + disable provenance attestations
- **Per-service cache splitting**: Separate cache directories per service to avoid concurrent cache export collisions
- **Configurable cache backend**: Make build cache backend configurable via env interpolation for all test-suite compose files
- **E2E Dockerfile optimization**: Reorder layers to keep `npm ci` cached when only sources change
- **Test runner optimization**: Add `--no-compile` passthrough for test runner when artifacts are up to date
- **Incremental Rust compilation**: Add BuildKit target cache mounts to all coprocessor and kms-connector Dockerfiles for faster rebuilds
- **Faster local Cargo profile**: Add `[profile.local]` with reduced optimization for faster compilation

## Changes

### New CLI flags
- `./fhevm-cli deploy --local` - Uses local BuildKit cache instead of GHA cache
- `./fhevm-cli test <name> --no-compile` - Skips Hardhat compilation when artifacts are current

### Dockerfile improvements
All Rust service Dockerfiles now use:
```dockerfile
RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
    --mount=type=cache,target=/app/.../target,sharing=locked \
    cargo build ... && \
    cp target/${CARGO_PROFILE}/binary /tmp/binary

COPY --from=builder /tmp/binary /usr/local/bin/binary
```

The target cache mount enables incremental compilation. We copy to `/tmp` because cache mounts are not committed to image layers.

### New files
- `.dockerignore` - Excludes large directories (target/, node_modules/, fhevm-keys/) from build context

## Build Time Metrics

Measured on the `coprocessor` portion of the deployment build:

| Scenario | Time | Improvement |
|----------|------|-------------|
| Before (cold) | 2135s | - |
| After (cold) | 1336s | **37% faster** |
| After (warm, with cache) | 397s | **81% faster** |

## Non-impact

- CI behavior remains default (`type=gha` cache) unless overridden
- Runtime behavior of services unchanged
- Deploy/test defaults unchanged unless new flags are passed

## Test Plan

Manual testing:
- `./test-suite/fhevm/fhevm-cli deploy --build --local`
- `./test-suite/fhevm/fhevm-cli test input-proof --no-compile`

---
Closes zama-ai/fhevm-internal#841