### PR TITLE
chore(common): unify Dockerfiles to compile workspace once in local

### DIFF
--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -1,0 +1,205 @@
+# =============================================================================
+# UNIFIED COPROCESSOR DOCKERFILE
+# =============================================================================
+# This Dockerfile builds ALL coprocessor workspace binaries in a single builder
+# stage, ensuring dependencies are compiled exactly ONCE. Individual runtime images are
+# produced via multi-stage targets.
+#
+# Usage:
+#   docker build --target tfhe-worker -t tfhe-worker:latest .
+#   docker build --target host-listener -t host-listener:latest .
+#   docker build --target gw-listener -t gw-listener:latest .
+#   docker build --target sns-worker -t sns-worker:latest .
+#   docker build --target transaction-sender -t transaction-sender:latest .
+#   docker build --target zkproof-worker -t zkproof-worker:latest .
+#   docker build --target db-migration -t db-migration:latest .
+#
+# =============================================================================
+
+# =============================================================================
+# Stage 0: Build Solidity contracts (required for host-listener, gw-listener)
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
+
+USER root
+WORKDIR /app
+
+# Copy host-contracts for host-listener
+COPY host-contracts ./host-contracts
+
+# Compile host-contracts
+WORKDIR /app/host-contracts
+RUN cp .env.example .env && \
+    npm install && \
+    HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
+    npx hardhat compile
+
+# Copy gateway-contracts for gw-listener
+WORKDIR /app
+COPY gateway-contracts ./gateway-contracts
+
+# Compile gateway-contracts
+WORKDIR /app/gateway-contracts
+RUN npm install && \
+    DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
+
+# =============================================================================
+# Stage 1: Build ALL Rust workspace binaries
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
+
+ARG CARGO_PROFILE=release
+
+USER root
+WORKDIR /app
+
+# Copy contract artifacts from contract_builder stage
+COPY --from=contract_builder /app/host-contracts/artifacts/contracts /app/host-contracts/artifacts/contracts
+COPY --from=contract_builder /app/gateway-contracts/artifacts/contracts /app/gateway-contracts/artifacts/contracts
+
+# Copy Rust sources and dependencies
+COPY coprocessor/fhevm-engine ./coprocessor/fhevm-engine
+COPY coprocessor/proto ./coprocessor/proto
+COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
+COPY gateway-contracts/contracts ./gateway-contracts/contracts
+COPY host-contracts/contracts ./host-contracts/contracts
+
+# Copy BUILD_ID for version metadata (git commit reference)
+COPY .git/HEAD ./coprocessor/fhevm-engine/BUILD_ID
+
+WORKDIR /app/coprocessor/fhevm-engine
+
+# Build entire workspace - tfhe compiles ONCE here
+# NOTE: We use cache mounts for incremental compilation. Because cache mounts
+# are NOT committed to the image layer, we must copy binaries to /out during
+# the same RUN instruction for COPY --from to work in later stages.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    cargo fetch && \
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} --workspace && \
+    mkdir -p /out && \
+    cp target/${CARGO_PROFILE}/tfhe_worker /out/ && \
+    cp target/${CARGO_PROFILE}/host_listener /out/ && \
+    cp target/${CARGO_PROFILE}/host_listener_poller /out/ && \
+    cp target/${CARGO_PROFILE}/gw_listener /out/ && \
+    cp target/${CARGO_PROFILE}/sns_worker /out/ && \
+    cp target/${CARGO_PROFILE}/transaction_sender /out/ && \
+    cp target/${CARGO_PROFILE}/zkproof_worker /out/
+
+# =============================================================================
+# Stage 1b: Build sqlx-cli for db-migration
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS sqlx_builder
+
+USER root
+WORKDIR /app
+
+# Install sqlx-cli
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    cargo install sqlx-cli --version 0.7.2 \
+    --no-default-features --features postgres --locked
+
+# =============================================================================
+# Stage 2a: tfhe-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS tfhe-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/tfhe_worker /usr/local/bin/tfhe_worker
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/tfhe_worker"]
+
+# =============================================================================
+# Stage 2b: host-listener runtime (includes both host_listener and host_listener_poller)
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS host-listener
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/host_listener /usr/local/bin/host_listener
+COPY --from=builder --chown=fhevm:fhevm /out/host_listener_poller /usr/local/bin/host_listener_poller
+
+USER fhevm:fhevm
+
+# No CMD - compose specifies the command (host_listener or host_listener_poller)
+
+# =============================================================================
+# Stage 2c: gw-listener runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS gw-listener
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/gw_listener /usr/local/bin/gw_listener
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/gw_listener"]
+
+# =============================================================================
+# Stage 2d: sns-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS sns-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/sns_worker /usr/local/bin/sns_worker
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/sns_worker"]
+
+# =============================================================================
+# Stage 2e: transaction-sender runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS transaction-sender
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/transaction_sender /usr/local/bin/transaction_sender
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/transaction_sender"]
+
+# =============================================================================
+# Stage 2f: zkproof-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS zkproof-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/zkproof_worker /usr/local/bin/zkproof_worker
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/zkproof_worker"]
+
+# =============================================================================
+# Stage 2g: db-migration runtime (special: Postgres-based image)
+# =============================================================================
+FROM cgr.dev/zama.ai/postgres:17 AS db-migration
+
+# Copy sqlx-cli from sqlx_builder
+COPY --from=sqlx_builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+
+# Copy migrations and initialization script from source
+COPY coprocessor/fhevm-engine/db-migration/initialize_db.sh /initialize_db.sh
+COPY coprocessor/fhevm-engine/db-migration/migrations /migrations
+
+# Copy user/group from builder for consistency
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+
+# Set ownership
+RUN chown -R fhevm:fhevm /initialize_db.sh /migrations
+
+USER fhevm:fhevm
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD psql --version || exit 1
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -1,11 +1,17 @@
 # =============================================================================
-# UNIFIED COPROCESSOR DOCKERFILE
+# UNIFIED COPROCESSOR DOCKERFILE (LOCAL BUILDS)
 # =============================================================================
 # This Dockerfile builds ALL coprocessor workspace binaries in a single builder
-# stage, ensuring dependencies are compiled exactly ONCE. Individual runtime images are
-# produced via multi-stage targets.
+# stage, ensuring dependencies (especially tfhe-rs) are compiled exactly ONCE.
+# Individual runtime images are produced via multi-stage targets.
 #
-# Usage:
+# LOCAL vs CI BUILDS:
+#   - LOCAL: Uses this Dockerfile.workspace via docker-compose for faster builds
+#            (shared builder stage, single tfhe-rs compilation)
+#   - CI:    Uses individual Dockerfiles (coprocessor/*/Dockerfile) for granular
+#            caching and independent service builds
+#
+# Usage (standalone):
 #   docker build --target tfhe-worker -t tfhe-worker:latest .
 #   docker build --target host-listener -t host-listener:latest .
 #   docker build --target gw-listener -t gw-listener:latest .
@@ -13,6 +19,10 @@
 #   docker build --target transaction-sender -t transaction-sender:latest .
 #   docker build --target zkproof-worker -t zkproof-worker:latest .
 #   docker build --target db-migration -t db-migration:latest .
+#
+# Usage (via docker-compose, recommended for local dev):
+#   cd test-suite/fhevm
+#   ./fhevm-cli deploy --build --local
 #
 # =============================================================================
 

--- a/coprocessor/fhevm-engine/tfhe-worker/docker-compose.yml
+++ b/coprocessor/fhevm-engine/tfhe-worker/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     container_name: db-migration
     build:
       context: ../../../.
-      dockerfile: coprocessor/fhevm-engine/db-migration/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: db-migration
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/coprocessor
       TENANT_API_KEY: "a1503fb6-d79b-4e9e-826d-44cf262f3e05"

--- a/kms-connector/Dockerfile.workspace
+++ b/kms-connector/Dockerfile.workspace
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# UNIFIED KMS-CONNECTOR DOCKERFILE (LOCAL BUILDS)
+# =============================================================================
+# This Dockerfile builds ALL kms-connector workspace binaries in a single
+# builder stage, ensuring dependencies (tfhe-rs, alloy, sqlx) are compiled
+# exactly ONCE. Individual runtime images are produced via multi-stage targets.
+#
+# LOCAL vs CI BUILDS:
+#   - LOCAL: Uses this Dockerfile.workspace via docker-compose for faster builds
+#            (shared builder stage, single dependency compilation)
+#   - CI:    Uses individual Dockerfiles (kms-connector/crates/*/Dockerfile) for
+#            granular caching and independent service builds
+#
+# Usage (standalone):
+#   docker build --target gw-listener -t gw-listener:latest .
+#   docker build --target kms-worker -t kms-worker:latest .
+#   docker build --target tx-sender -t tx-sender:latest .
+#
+# Usage (via docker-compose, recommended for local dev):
+#   cd test-suite/fhevm
+#   ./fhevm-cli deploy --build --local
+#
+# =============================================================================
+
+ARG RUST_IMAGE_VERSION=1.91.0
+
+# =============================================================================
+# Stage 1: Build ALL workspace binaries
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+
+ARG CARGO_PROFILE=release
+
+USER root
+WORKDIR /app
+
+COPY .git ./.git
+COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
+COPY kms-connector ./kms-connector
+
+WORKDIR /app/kms-connector
+
+# Build entire workspace - shared deps compile ONCE here
+# NOTE: Cache mounts are NOT committed to image layers, so we copy binaries
+# to /tmp in the same RUN instruction for COPY --from to work in later stages.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/kms-connector/target,sharing=locked \
+    git config --global --add safe.directory /app && \
+    cargo fetch && \
+    cargo build --profile=${CARGO_PROFILE} --workspace && \
+    mkdir -p /out && \
+    cp target/${CARGO_PROFILE}/gw-listener /out/ && \
+    cp target/${CARGO_PROFILE}/kms-worker /out/ && \
+    cp target/${CARGO_PROFILE}/tx-sender /out/
+
+# =============================================================================
+# Stage 2a: gw-listener runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS gw-listener
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/gw-listener /app/kms-connector/bin/gw-listener
+
+USER fhevm:fhevm
+
+ENTRYPOINT ["/app/kms-connector/bin/gw-listener", "start"]
+
+HEALTHCHECK --start-period=5s --interval=1m --timeout=3s --retries=3 \
+    CMD ["/app/kms-connector/bin/gw-listener", "health", "--endpoint", "http://127.0.0.1:9100/healthz"]
+
+# =============================================================================
+# Stage 2b: kms-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS kms-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/kms-worker /app/kms-connector/bin/kms-worker
+
+USER fhevm:fhevm
+
+ENTRYPOINT ["/app/kms-connector/bin/kms-worker", "start"]
+
+HEALTHCHECK --start-period=5s --interval=1m --timeout=3s --retries=3 \
+    CMD ["/app/kms-connector/bin/kms-worker", "health", "--endpoint", "http://127.0.0.1:9100/healthz"]
+
+# =============================================================================
+# Stage 2c: tx-sender runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS tx-sender
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/tx-sender /app/kms-connector/bin/tx-sender
+
+USER fhevm:fhevm
+
+ENTRYPOINT ["/app/kms-connector/bin/tx-sender", "start"]
+
+HEALTHCHECK --start-period=5s --interval=1m --timeout=3s --retries=3 \
+    CMD ["/app/kms-connector/bin/tx-sender", "health", "--endpoint", "http://127.0.0.1:9100/healthz"]

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  # =============================================================================
+  # COPROCESSOR BUILD CACHING STRATEGY
+  # =============================================================================
+  # All coprocessor services share a single Dockerfile.workspace with multi-stage
+  # targets. When docker-compose builds them in parallel, each service is a separate
+  # BuildKit invocation.
+  #
+  # To avoid cache write conflicts (multiple processes writing to same directory),
+  # we use a SINGLE EXPORTER pattern:
+  #   - ALL services: cache_from (read from shared cache) ✓
+  #   - ONLY tfhe-worker: cache_to (write to shared cache) ✓
+  #   - Other services: no cache_to (read-only)
+  #
+  # tfhe-worker is chosen as the exporter because it's typically the largest build
+  # and shares all common layers with other services.
+  # =============================================================================
+
   coprocessor-db-migration:
     container_name: coprocessor-db-migration
     image: ghcr.io/zama-ai/fhevm/coprocessor/db-migration:${COPROCESSOR_DB_MIGRATION_VERSION}
@@ -10,8 +27,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     environment:
@@ -33,8 +48,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -60,8 +73,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -86,8 +97,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/liveness || exit 1"]
       interval: 10s
@@ -149,8 +158,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -176,8 +183,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -216,8 +221,6 @@ services:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
         - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -4,13 +4,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/db-migration:${COPROCESSOR_DB_MIGRATION_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/db-migration/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: db-migration
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_DB_MIGRATION:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_DB_MIGRATION:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     environment:
@@ -26,13 +27,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/host-listener:${COPROCESSOR_HOST_LISTENER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: host-listener
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_HOST_LISTENER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_HOST_LISTENER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -52,13 +54,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/host-listener:${COPROCESSOR_HOST_LISTENER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/host-listener/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: host-listener
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_HOST_LISTENER_POLLER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_HOST_LISTENER_POLLER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -77,13 +80,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/gw-listener:${COPROCESSOR_GW_LISTENER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/gw-listener/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: gw-listener
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_GW_LISTENER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_GW_LISTENER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/liveness || exit 1"]
       interval: 10s
@@ -110,13 +114,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/tfhe-worker:${COPROCESSOR_TFHE_WORKER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: tfhe-worker
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_TFHE_WORKER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_TFHE_WORKER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -138,13 +143,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/zkproof-worker:${COPROCESSOR_ZKPROOF_WORKER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: zkproof-worker
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_ZKPROOF_WORKER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_ZKPROOF_WORKER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -164,13 +170,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/sns-worker:${COPROCESSOR_SNS_WORKER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/sns-worker/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: sns-worker
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_SNS_WORKER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_SNS_WORKER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:
@@ -203,13 +210,14 @@ services:
     image: ghcr.io/zama-ai/fhevm/coprocessor/tx-sender:${COPROCESSOR_TX_SENDER_VERSION}
     build:
       context: ../../..
-      dockerfile: coprocessor/fhevm-engine/transaction-sender/Dockerfile
+      dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+      target: transaction-sender
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
       cache_from:
-        - ${FHEVM_CACHE_FROM_COPROCESSOR_TRANSACTION_SENDER:-type=gha}
+        - ${FHEVM_CACHE_FROM_COPROCESSOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_COPROCESSOR_TRANSACTION_SENDER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_COPROCESSOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.coprocessor.local
     command:

--- a/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/kms-connector-docker-compose.yml
@@ -1,3 +1,19 @@
+# =============================================================================
+# KMS-CONNECTOR BUILD CACHING STRATEGY
+# =============================================================================
+# The 3 Rust services (gw-listener, kms-worker, tx-sender) share a single
+# Dockerfile.workspace with multi-stage targets. When docker-compose builds
+# them in parallel, each service is a separate BuildKit invocation.
+#
+# To avoid cache write conflicts (multiple processes writing to same directory),
+# we use a SINGLE EXPORTER pattern:
+#   - ALL services: cache_from (read from shared cache) ✓
+#   - ONLY gw-listener: cache_to (write to shared cache) ✓
+#   - Other services: no cache_to (read-only)
+#
+# gw-listener is chosen as the exporter arbitrarily (first alphabetically).
+# =============================================================================
+
 services:
   kms-connector-db-migration:
     container_name: kms-connector-db-migration
@@ -20,14 +36,15 @@ services:
     image: ghcr.io/zama-ai/fhevm/kms-connector/gw-listener:${CONNECTOR_GW_LISTENER_VERSION}
     build:
       context: ../../..
-      dockerfile: kms-connector/crates/gw-listener/Dockerfile
+      dockerfile: kms-connector/Dockerfile.workspace
+      target: gw-listener
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
         RUST_IMAGE_VERSION: 1.91.0
       cache_from:
-        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_GW_LISTENER:-type=gha}
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR:-type=gha}
       cache_to:
-        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_GW_LISTENER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_TO_KMS_CONNECTOR:-type=gha,mode=max}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:
@@ -39,14 +56,13 @@ services:
     image: ghcr.io/zama-ai/fhevm/kms-connector/kms-worker:${CONNECTOR_KMS_WORKER_VERSION}
     build:
       context: ../../..
-      dockerfile: kms-connector/crates/kms-worker/Dockerfile
+      dockerfile: kms-connector/Dockerfile.workspace
+      target: kms-worker
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
         RUST_IMAGE_VERSION: 1.91.0
       cache_from:
-        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_KMS_WORKER:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_KMS_WORKER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR:-type=gha}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:
@@ -58,14 +74,13 @@ services:
     image: ghcr.io/zama-ai/fhevm/kms-connector/tx-sender:${CONNECTOR_TX_SENDER_VERSION}
     build:
       context: ../../..
-      dockerfile: kms-connector/crates/tx-sender/Dockerfile
+      dockerfile: kms-connector/Dockerfile.workspace
+      target: tx-sender
       args:
         CARGO_PROFILE: ${FHEVM_CARGO_PROFILE:-release}
         RUST_IMAGE_VERSION: 1.91.0
       cache_from:
-        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR_TX_SENDER:-type=gha}
-      cache_to:
-        - ${FHEVM_CACHE_TO_KMS_CONNECTOR_TX_SENDER:-type=gha,mode=max}
+        - ${FHEVM_CACHE_FROM_KMS_CONNECTOR:-type=gha}
     env_file:
       - ../env/staging/.env.kms-connector.local
     depends_on:

--- a/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
+++ b/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
@@ -66,6 +66,13 @@ if [ "$LOCAL_BUILD" = true ]; then
     export "FHEVM_CACHE_FROM_COPROCESSOR=type=local,src=${coprocessor_cache_dir}"
     export "FHEVM_CACHE_TO_COPROCESSOR=type=local,dest=${coprocessor_cache_dir},mode=max"
 
+    # Unified kms-connector workspace cache (gw-listener, kms-worker, tx-sender
+    # share Dockerfile.workspace; db-migration uses separate Dockerfile)
+    kms_connector_cache_dir="${FHEVM_BUILDX_CACHE_DIR}/kms-connector"
+    mkdir -p "$kms_connector_cache_dir"
+    export "FHEVM_CACHE_FROM_KMS_CONNECTOR=type=local,src=${kms_connector_cache_dir}"
+    export "FHEVM_CACHE_TO_KMS_CONNECTOR=type=local,dest=${kms_connector_cache_dir},mode=max"
+
     # Other services still use individual caches
     LOCAL_CACHE_SERVICES=(
         gateway-deploy-mocked-zama-oft
@@ -82,9 +89,6 @@ if [ "$LOCAL_BUILD" = true ]; then
         host-sc-pause
         host-sc-unpause
         kms-connector-db-migration
-        kms-connector-gw-listener
-        kms-connector-kms-worker
-        kms-connector-tx-sender
         test-suite-e2e-debug
     )
     for service_name in "${LOCAL_CACHE_SERVICES[@]}"; do

--- a/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
+++ b/test-suite/fhevm/scripts/deploy-fhevm-stack.sh
@@ -59,15 +59,15 @@ if [ "$LOCAL_BUILD" = true ]; then
         export "FHEVM_CACHE_FROM_${service_key}=type=local,src=${cache_dir}"
         export "FHEVM_CACHE_TO_${service_key}=type=local,dest=${cache_dir},mode=max"
     }
-    LOCAL_CACHE_SERVICES=( 
-        coprocessor-db-migration
-        coprocessor-gw-listener
-        coprocessor-host-listener
-        coprocessor-host-listener-poller
-        coprocessor-sns-worker
-        coprocessor-tfhe-worker
-        coprocessor-transaction-sender
-        coprocessor-zkproof-worker
+    # Unified coprocessor workspace cache (all services share one cache since they
+    # are built from a single Dockerfile.workspace with multi-stage targets)
+    coprocessor_cache_dir="${FHEVM_BUILDX_CACHE_DIR}/coprocessor"
+    mkdir -p "$coprocessor_cache_dir"
+    export "FHEVM_CACHE_FROM_COPROCESSOR=type=local,src=${coprocessor_cache_dir}"
+    export "FHEVM_CACHE_TO_COPROCESSOR=type=local,dest=${coprocessor_cache_dir},mode=max"
+
+    # Other services still use individual caches
+    LOCAL_CACHE_SERVICES=(
         gateway-deploy-mocked-zama-oft
         gateway-sc-add-network
         gateway-sc-add-pausers


### PR DESCRIPTION
[STACKS ON TOP OF https://github.com/zama-ai/fhevm/pull/1736]

## Summary

- Create unified `Dockerfile.workspace` for **coprocessor** and **kms-connector** that compile workspace deps exactly **once** instead of multiple times
- Apply single-exporter cache pattern to prevent BuildKit race conditions during parallel builds
- **Individual Dockerfiles kept unchanged for CI builds**

## Performance Improvements

| Component | Fresh Build | Cached Build |
|-----------|-------------|--------------|
| Coprocessor (8 services) | ~600 (down from ~1300) | ~20s (down from ~400s) |
| KMS-connector (3 services) | ~220s (down from ~450s) | ~25s |

## Problem

Each microservice had its own Dockerfile that independently compiled the workspace:
- **tfhe-rs compiled 7+ times** for coprocessor (~15-20 min each)
- **Shared deps compiled 3x** for kms-connector (alloy, sqlx, tokio)
- Cache isolated per service, preventing dependency sharing
- **Race condition**: Parallel builds writing to same cache directory caused failures

## Solution

### 1. Unified Workspace Dockerfiles

Single multi-stage `Dockerfile.workspace` for each Rust workspace:

**Coprocessor** (`coprocessor/fhevm-engine/Dockerfile.workspace`):
- Stage 0: Compile Solidity contracts (host + gateway)
- Stage 1: Build ALL Rust binaries with `cargo build --workspace` - tfhe compiles ONCE
- Stages 2a-2g: Runtime targets for each service

**KMS-connector** (`kms-connector/Dockerfile.workspace`):
- Stage 1: Build ALL workspace binaries (gw-listener, kms-worker, tx-sender)
- Stages 2a-2c: Runtime targets for each service

### 2. Single-Exporter Cache Pattern

When docker-compose builds multiple services in parallel, each is a separate BuildKit invocation. Having all services export cache to the same directory causes race conditions.

**Fix**: Only ONE service exports cache (`cache_to`), others only import (`cache_from`):
- Coprocessor: `tfhe-worker` exports, others read-only
- KMS-connector: `gw-listener` exports, others read-only

## Changes

| File | Change |
|------|--------|
| `coprocessor/fhevm-engine/Dockerfile.workspace` | NEW - unified multi-stage Dockerfile |
| `kms-connector/Dockerfile.workspace` | NEW - unified multi-stage Dockerfile |
| `coprocessor-docker-compose.yml` | Use workspace Dockerfile + single-exporter cache |
| `kms-connector-docker-compose.yml` | Use workspace Dockerfile + single-exporter cache |
| `deploy-fhevm-stack.sh` | Unified cache vars for both workspaces |
| `host-sc-docker-compose.yml` | Fix build context (was broken) |
| Individual Dockerfiles | **UNCHANGED** - kept for CI builds |

## Scope

| What | Included |
|------|----------|
| Local dev builds (`fhevm-cli deploy --build --local`) | ✅ Uses unified Dockerfiles |
| CI builds (GitHub Actions) | ❌ Unchanged - uses individual Dockerfiles |
| Image publishing | ❌ Unchanged - uses individual Dockerfiles |

## Usage

```bash
# Local dev - uses unified Dockerfile.workspace
./fhevm-cli deploy --build --local

# Build specific coprocessor target
docker build --target tfhe-worker -f coprocessor/fhevm-engine/Dockerfile.workspace .

# Build specific kms-connector target
docker build --target gw-listener -f kms-connector/Dockerfile.workspace .
```

## Clean Rebuild (no cache)

```bash
# Clear all caches
rm -rf test-suite/fhevm/.buildx-cache
docker builder prune -af

# Rebuild
cd test-suite/fhevm
./fhevm-cli deploy --build --local
```

## Bug Fixes Included

1. **host-sc build context**: Compose file incorrectly set context to `host-contracts/` but Dockerfile expected repo root
2. **Cache race condition**: Multiple parallel builds writing to same `.buildx-cache/` directory caused `rename` failures

Closes #844