### PR TITLE
feat(gw-listener): add InputVerification catchup on startup

### DIFF
--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -34,6 +34,13 @@ struct Conf {
     )]
     catchup_input_verification_from_block: Option<i64>,
 
+    #[arg(
+        long,
+        default_value_t = 0,
+        help = "Finalization margin (in blocks) used to bound InputVerification catchup"
+    )]
+    catchup_finalization_in_blocks: u64,
+
     #[arg(long)]
     gw_url: Url,
 
@@ -160,6 +167,7 @@ async fn main() -> anyhow::Result<()> {
         database_pool_size: conf.database_pool_size,
         verify_proof_req_db_channel: conf.verify_proof_req_database_channel,
         catchup_input_verification_from_block: conf.catchup_input_verification_from_block,
+        catchup_finalization_in_blocks: conf.catchup_finalization_in_blocks,
         gw_url: conf.gw_url,
         error_sleep_initial_secs: conf.error_sleep_initial_secs,
         error_sleep_max_secs: conf.error_sleep_max_secs,

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -26,6 +26,14 @@ struct Conf {
     #[arg(long, default_value = "event_zkpok_new_work")]
     verify_proof_req_database_channel: String,
 
+    #[arg(
+        long,
+        default_value = None,
+        help = "Replay InputVerification events from block (can be negative from latest)",
+        allow_hyphen_values = true
+    )]
+    catchup_input_verification_from_block: Option<i64>,
+
     #[arg(long)]
     gw_url: Url,
 
@@ -151,6 +159,7 @@ async fn main() -> anyhow::Result<()> {
         database_url: conf.database_url.clone().unwrap_or_default(),
         database_pool_size: conf.database_pool_size,
         verify_proof_req_db_channel: conf.verify_proof_req_database_channel,
+        catchup_input_verification_from_block: conf.catchup_input_verification_from_block,
         gw_url: conf.gw_url,
         error_sleep_initial_secs: conf.error_sleep_initial_secs,
         error_sleep_max_secs: conf.error_sleep_max_secs,

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -40,6 +40,7 @@ pub struct ConfigSettings {
     pub database_url: DatabaseURL,
     pub database_pool_size: u32,
     pub verify_proof_req_db_channel: String,
+    pub catchup_input_verification_from_block: Option<i64>,
 
     pub gw_url: Url,
 
@@ -71,6 +72,7 @@ impl Default for ConfigSettings {
             database_url: DatabaseURL::default(),
             database_pool_size: 16,
             verify_proof_req_db_channel: "event_zkpok_new_work".to_owned(),
+            catchup_input_verification_from_block: None,
             gw_url: "ws://127.0.0.1:8546".try_into().expect("Invalid URL"),
             error_sleep_initial_secs: 1,
             error_sleep_max_secs: 10,

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -41,6 +41,7 @@ pub struct ConfigSettings {
     pub database_pool_size: u32,
     pub verify_proof_req_db_channel: String,
     pub catchup_input_verification_from_block: Option<i64>,
+    pub catchup_finalization_in_blocks: u64,
 
     pub gw_url: Url,
 
@@ -73,6 +74,7 @@ impl Default for ConfigSettings {
             database_pool_size: 16,
             verify_proof_req_db_channel: "event_zkpok_new_work".to_owned(),
             catchup_input_verification_from_block: None,
+            catchup_finalization_in_blocks: 0,
             gw_url: "ws://127.0.0.1:8546".try_into().expect("Invalid URL"),
             error_sleep_initial_secs: 1,
             error_sleep_max_secs: 10,


### PR DESCRIPTION
## Summary
- add InputVerification catchup on startup with a bounded head and gap close
- add `--catchup-finalization-in-blocks` to control the replay window

## Incident
- backfill missed InputVerification events after gw-listener restart (mainnet incident Jan 15)

## Testing
- cargo test -p gw-listener
