### PR TITLE
fix(coprocessor): verify input  via eth_getLogs

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.7.10
+version: 0.7.11
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -462,12 +462,13 @@ gwListener:
     - --provider-retry-interval=4s
     - --log-level=INFO
     - --get-logs-poll-interval=500ms
-    - --get-logs-block-batch-size=10
+    - --get-logs-block-batch-size=100
     - --service-name=gw-listener
-    ### Catchup parameters (optional)
-    # --catchup-kms-generation-from-block BLOCK_NUMBER
+    - --log-last-processed-every-number-of-updates=50
+    ### Replay parameters (optional)
+    # --replay-from-block BLOCK_NUMBER
     # To go back in time from latest block
-    # --catchup-kms-generation-from-block -NB_BLOCK
+    # --replay-from-block -NB_BLOCK
 
   # Service ports configuration
   ports:

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -461,8 +461,8 @@ gwListener:
     - --provider-max-retries=4294967295
     - --provider-retry-interval=4s
     - --log-level=INFO
-    - --get-logs-poll-interval=1s
-    - --get-logs-block-batch-size=100
+    - --get-logs-poll-interval=500ms
+    - --get-logs-block-batch-size=10
     - --service-name=gw-listener
     ### Catchup parameters (optional)
     # --catchup-kms-generation-from-block BLOCK_NUMBER

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -69,15 +69,18 @@ struct Conf {
     #[arg(long, default_value = "500ms", value_parser = parse_duration)]
     get_logs_poll_interval: Duration,
 
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 100)]
     get_logs_block_batch_size: u64,
+
+    #[arg(long, default_value_t = 50)]
+    log_last_processed_every_number_of_updates: u64,
 
     /// gw-listener service name in OTLP traces
     #[arg(long, default_value = "gw-listener")]
     pub service_name: String,
 
-    #[arg(long, default_value = None, help = "Can be negative from last processed block", allow_hyphen_values = true)]
-    pub catchup_kms_generation_from_block: Option<i64>,
+    #[arg(long, default_value = None, help = "Can be negative from last processed block", allow_hyphen_values = true, alias = "catchup-kms-generation-from-block")]
+    pub replay_from_block: Option<i64>,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -158,7 +161,8 @@ async fn main() -> anyhow::Result<()> {
         health_check_timeout: conf.health_check_timeout,
         get_logs_poll_interval: conf.get_logs_poll_interval,
         get_logs_block_batch_size: conf.get_logs_block_batch_size,
-        catchup_kms_generation_from_block: conf.catchup_kms_generation_from_block,
+        replay_from_block: conf.replay_from_block,
+        log_last_processed_every_number_of_updates: conf.log_last_processed_every_number_of_updates,
     };
 
     let gw_listener = GatewayListener::new(

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -66,10 +66,10 @@ struct Conf {
     #[arg(long)]
     host_chain_id: Option<u64>,
 
-    #[arg(long, default_value = "1s", value_parser = parse_duration)]
+    #[arg(long, default_value = "500ms", value_parser = parse_duration)]
     get_logs_poll_interval: Duration,
 
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 10)]
     get_logs_block_batch_size: u64,
 
     /// gw-listener service name in OTLP traces

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -5,7 +5,7 @@ use alloy::sol_types::SolEventInterface;
 use alloy::{network::Ethereum, primitives::Address, providers::Provider, rpc::types::Log};
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::utils::to_hex;
-use futures_util::{future::join_all, StreamExt};
+use futures_util::future::join_all;
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
@@ -84,26 +84,6 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             .connect(self.conf.database_url.as_str())
             .await?;
 
-        let input_verification_handle = {
-            let s = self.clone();
-            let d = db_pool.clone();
-            tokio::spawn(async move {
-                let mut sleep_duration = s.conf.error_sleep_initial_secs as u64;
-                loop {
-                    match s.run_input_verification(&d, &mut sleep_duration).await {
-                        Ok(_) => {
-                            info!("run_input_verification() stopped");
-                            break;
-                        }
-                        Err(e) => {
-                            error!(error = %e, "run_input_verification() failed");
-                            s.sleep_with_backoff(&mut sleep_duration).await;
-                        }
-                    }
-                }
-            })
-        };
-
         let get_logs_handle = {
             let s = self.clone();
             let d = db_pool.clone();
@@ -128,54 +108,8 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             })
         };
 
-        input_verification_handle.await?;
         get_logs_handle.await?;
 
-        Ok(())
-    }
-
-    async fn run_input_verification(
-        &self,
-        db_pool: &Pool<Postgres>,
-        sleep_duration: &mut u64,
-    ) -> anyhow::Result<()> {
-        let input_verification =
-            InputVerification::new(self.input_verification_address, &self.provider);
-
-        // We assume that the provider will reconnect internally if the connection is lost and stream.next() will eventually return successfully.
-        // We ensure that by requiring the `provider_max_retries` and `provider_retry_interval` to be set to high enough values in the configuration s.t. retry is essentially infinite.
-        //
-        // That might lead to skipped events, but that is acceptable for input verification requests as the client will eventually retry.
-        // Furthermore, replaying old input verification requests is unnecessary as input verification is a synchronous request/response interaction on the client side.
-        // Finally, no data on the GW will be left in an inconsistent state.
-        let mut verify_proof_request = input_verification
-            .VerifyProofRequest_filter()
-            .subscribe()
-            .await?
-            .into_stream()
-            .fuse();
-        info!("Subscribed to InputVerification.VerifyProofRequest events");
-
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = self.cancel_token.cancelled() => {
-                    break;
-                }
-
-                item = verify_proof_request.next() => {
-                    let Some(item) = item else {
-                        error!("Block stream closed");
-                        return Err(anyhow::anyhow!("Block stream closed"));
-                    };
-                    let (request, log) = item?;
-                    self.verify_proof_request(db_pool, request, log).await?;
-                }
-            }
-            // Reset sleep duration on successful iteration.
-            self.reset_sleep_duration(sleep_duration);
-        }
         Ok(())
     }
 
@@ -232,7 +166,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                     };
 
                     let filter = Filter::new()
-                        .address(self.kms_generation_address)
+                        .address(vec![self.kms_generation_address, self.input_verification_address])
                         .from_block(from_block)
                         .to_block(to_block);
 
@@ -250,47 +184,66 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                         info!(from_block, to_block, nb_events=logs.len(), "Catchup on KMSGeneration, get_logs");
                     }
                     for log in logs {
-                        if let Ok(event) = KMSGeneration::KMSGenerationEvents::decode_log(&log.inner) {
-                            match event.data {
-                                KMSGeneration::KMSGenerationEvents::ActivateCrs(a) => {
-                                    // IMPORTANT: If we ignore the event due to digest mismatch, this might lead to inconsistency between coprocessors.
-                                    // We choose to ignore the event and then manually fix if it happens.
-                                    match self.activate_crs(db_pool, a, &self.aws_s3_client, self.conf.host_chain_id).await {
-                                        Ok(_) => {
-                                            activate_crs_success += 1;
-                                            info!("ActivateCrs event successful");
-                                        },
-                                        Err(e) if e.is::<DigestMismatchError>() => {
-                                            crs_digest_mismatch += 1;
-                                            error!(error = %e, "CRS digest mismatch, ignoring event");
-                                        }
-                                        Err(e) => {
-                                            ACTIVATE_CRS_FAIL_COUNTER.inc();
-                                            return Err(e);
-                                        }
+                        if log.address() == self.input_verification_address {
+                            if let Ok(event) = InputVerification::InputVerificationEvents::decode_log(&log.inner) {
+                                match event.data {
+                                    InputVerification::InputVerificationEvents::VerifyProofRequest(request) => {
+                                        self.verify_proof_request(db_pool, request, log.clone()).await?;
+                                    },
+                                    _ => {
+                                        error!(log = ?log, "Unknown InputVerification event");
                                     }
-                                },
-                                // IMPORTANT: See comment above.
-                                KMSGeneration::KMSGenerationEvents::ActivateKey(a) => {
-                                    match self.activate_key(db_pool, a, &self.aws_s3_client, self.conf.host_chain_id).await {
-                                        Ok(_) => {
-                                            activate_key_success += 1;
-                                            info!("ActivateKey event successful");
+                                }
+                            } else {
+                                error!(log = ?log, "Failed to decode InputVerification event log");
+                            }
+                        } else if log.address() == self.kms_generation_address {
+                            if let Ok(event) = KMSGeneration::KMSGenerationEvents::decode_log(&log.inner) {
+                                match event.data {
+                                    KMSGeneration::KMSGenerationEvents::ActivateCrs(a) => {
+                                        // IMPORTANT: If we ignore the event due to digest mismatch, this might lead to inconsistency between coprocessors.
+                                        // We choose to ignore the event and then manually fix if it happens.
+                                        match self.activate_crs(db_pool, a, &self.aws_s3_client, self.conf.host_chain_id).await {
+                                            Ok(_) => {
+                                                activate_crs_success += 1;
+                                                info!("ActivateCrs event successful");
+                                            },
+                                            Err(e) if e.is::<DigestMismatchError>() => {
+                                                crs_digest_mismatch += 1;
+                                                error!(error = %e, "CRS digest mismatch, ignoring event");
+                                            }
+                                            Err(e) => {
+                                                ACTIVATE_CRS_FAIL_COUNTER.inc();
+                                                return Err(e);
+                                            }
                                         }
-                                        Err(e) if e.is::<DigestMismatchError>() => {
-                                            key_digest_mismatch += 1;
-                                            error!(error = %e, "Key digest mismatch, ignoring event");
-                                        }
-                                        Err(e) => {
-                                            ACTIVATE_KEY_FAIL_COUNTER.inc();
-                                            return Err(e);
-                                        }
-                                    };
-                                },
-                                _ => {}
+                                    },
+                                    // IMPORTANT: See comment above.
+                                    KMSGeneration::KMSGenerationEvents::ActivateKey(a) => {
+                                        match self.activate_key(db_pool, a, &self.aws_s3_client, self.conf.host_chain_id).await {
+                                            Ok(_) => {
+                                                activate_key_success += 1;
+                                                info!("ActivateKey event successful");
+                                            }
+                                            Err(e) if e.is::<DigestMismatchError>() => {
+                                                key_digest_mismatch += 1;
+                                                error!(error = %e, "Key digest mismatch, ignoring event");
+                                            }
+                                            Err(e) => {
+                                                ACTIVATE_KEY_FAIL_COUNTER.inc();
+                                                return Err(e);
+                                            }
+                                        };
+                                    },
+                                    _ => {
+                                        error!(log = ?log, "Unknown KMSGeneration event")
+                                    }
+                                }
+                            } else {
+                                error!(log = ?log, "Failed to decode KMSGeneration event log");
                             }
                         } else {
-                            error!(log = ?log, "Failed to decode KMSGeneration event log");
+                            error!(log = ?log, "Unexpected log address");
                         }
                     }
                     last_processed_block_num = Some(to_block);

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -52,7 +52,9 @@ pub struct ConfigSettings {
 
     pub get_logs_poll_interval: Duration,
     pub get_logs_block_batch_size: u64,
-    pub catchup_kms_generation_from_block: Option<i64>,
+    pub replay_from_block: Option<i64>,
+
+    pub log_last_processed_every_number_of_updates: u64,
 }
 
 pub fn chain_id_from_env() -> Option<ChainId> {
@@ -77,8 +79,9 @@ impl Default for ConfigSettings {
             health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
             get_logs_poll_interval: Duration::from_millis(500),
-            get_logs_block_batch_size: 10,
-            catchup_kms_generation_from_block: None,
+            get_logs_block_batch_size: 100,
+            replay_from_block: None,
+            log_last_processed_every_number_of_updates: 50,
         }
     }
 }

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -76,8 +76,8 @@ impl Default for ConfigSettings {
             error_sleep_max_secs: 10,
             health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
-            get_logs_poll_interval: Duration::from_secs(1),
-            get_logs_block_batch_size: 100,
+            get_logs_poll_interval: Duration::from_millis(500),
+            get_logs_block_batch_size: 10,
             catchup_kms_generation_from_block: None,
         }
     }

--- a/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -567,13 +567,13 @@ async fn keygen_ok_catchup_gen(positive: bool) -> anyhow::Result<()> {
     assert!(has_not_server_key(&env.db_pool.clone()).await?);
     assert!(has_not_crs(&env.db_pool.clone()).await?);
 
-    let catchup_kms_generation_from_block = if positive {
+    let replay_from_block = if positive {
         Some(0)
     } else {
         Some(-(provider.get_block_number().await? as i64))
     };
     let conf = ConfigSettings {
-        catchup_kms_generation_from_block,
+        replay_from_block,
         ..env.conf.clone()
     };
     let gw_listener = GatewayListener::new(


### PR DESCRIPTION
Instead of relying on subscriptions that are not reliable in all cases, use eth_getLogs to fetch verify input requests.

Also, change:
 * poll interval from 1 sec to 500 ms to reduce latency
 
Since gw-listener catches up automatically via the last processed block
number in the DB, call the manual process "replay" instead of "catchup".
Replay is requested via the cmd line. Also, keep the old name as an
alias for backward compatibility. Furthermore, replay is not
KMS-specific anymore, so remove KMS from the name.

Add more logging in health checks and replay.