### PR TITLE
feat(kms-connector): add ACL verification for decryption requests

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2989,6 +2989,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fhevm_host_bindings"
+version = "0.10.0"
+dependencies = [
+ "alloy",
+ "serde",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,6 +4068,7 @@ dependencies = [
  "connector-utils",
  "dashmap",
  "fhevm_gateway_bindings",
+ "fhevm_host_bindings",
  "humantime-serde",
  "kms-grpc",
  "mocktail",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -19,6 +19,7 @@ kms-worker.path = "crates/kms-worker"
 tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
 fhevm_gateway_bindings = { git = "https://github.com/zama-ai/fhevm.git", tag = "v0.10.3", default-features = false }
+fhevm_host_bindings = { path = "../host-contracts/rust_bindings" }
 kms-grpc = { git = "https://github.com/zama-ai/kms.git", tag = "v0.12.4", default-features = true }
 bc2wrap = { git = "https://github.com/zama-ai/kms.git", tag = "v0.12.4", default-features = true }
 tfhe = "=1.4.0-alpha.3"

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -106,3 +106,17 @@ address = "0x0000000000000000000000000000000000000000"
 # EIP-712 domain version for KMSGeneration contract (optional, defaults to "1")
 # ENV: KMS_CONNECTOR_KMS_GENERATION_CONTRACT__DOMAIN_VERSION
 # domain_version = "1"
+
+# Configuration of the Host Chain for ACL verification (optional, defaults shown below)
+# The KMS Worker will verify decryption authorization by calling view functions on the host chain ACL contract.
+[host_chain]
+# RPC URL of the host chain (required if host_chain section is present)
+# ENV: KMS_CONNECTOR_HOST_CHAIN__RPC_URL
+rpc_url = "http://localhost:8546"
+# Chain ID of the host chain (required if host_chain section is present)
+# ENV: KMS_CONNECTOR_HOST_CHAIN__CHAIN_ID
+chain_id = 1
+# Address of the ACL contract on the host chain (required if host_chain section is present)
+# Format: hex string with 0x prefix
+# ENV: KMS_CONNECTOR_HOST_CHAIN__ACL_CONTRACT_ADDRESS
+acl_contract_address = "0x0000000000000000000000000000000000000000"

--- a/kms-connector/crates/kms-worker/Cargo.toml
+++ b/kms-connector/crates/kms-worker/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 bc2wrap.workspace = true
 connector-utils.workspace = true
 fhevm_gateway_bindings.workspace = true
+fhevm_host_bindings.workspace = true
 
 actix-web.workspace = true
 alloy.workspace = true

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -12,6 +12,7 @@ use connector_utils::types::KmsGrpcRequest;
 use fhevm_gateway_bindings::decryption::Decryption::{
     self, DecryptionInstance, SnsCiphertextMaterial,
 };
+use fhevm_host_bindings::acl::ACL::{self, ACLInstance};
 use kms_grpc::kms::v1::{
     Eip712DomainMsg, PublicDecryptionRequest, RequestId, TypedCiphertext, UserDecryptionRequest,
 };
@@ -19,7 +20,7 @@ use tracing::info;
 
 #[derive(Clone)]
 /// The struct responsible of processing incoming decryption requests.
-pub struct DecryptionProcessor<P: Provider> {
+pub struct DecryptionProcessor<P: Provider, H: Provider = P> {
     /// The EIP712 domain of the `Decryption` contract.
     domain: Eip712DomainMsg,
 
@@ -28,13 +29,22 @@ pub struct DecryptionProcessor<P: Provider> {
 
     /// The entity used to collect ciphertexts from S3 buckets.
     s3_service: S3Service<P>,
+
+    /// The instance of the ACL contract on the host chain used for authorization checks.
+    acl_contract: ACLInstance<H>,
 }
 
-impl<P> DecryptionProcessor<P>
+impl<P, H> DecryptionProcessor<P, H>
 where
     P: Provider,
+    H: Provider,
 {
-    pub fn new(config: &Config, provider: P, s3_service: S3Service<P>) -> Self {
+    pub fn new(
+        config: &Config,
+        gateway_provider: P,
+        host_chain_provider: H,
+        s3_service: S3Service<P>,
+    ) -> Self {
         let domain = Eip712DomainMsg {
             name: config.decryption_contract.domain_name.clone(),
             version: config.decryption_contract.domain_version.clone(),
@@ -42,12 +52,16 @@ where
             verifying_contract: config.decryption_contract.address.to_string(),
             salt: None,
         };
-        let decryption_contract = Decryption::new(config.decryption_contract.address, provider);
+        let decryption_contract =
+            Decryption::new(config.decryption_contract.address, gateway_provider);
+        let acl_contract =
+            ACL::new(config.host_chain.acl_contract_address, host_chain_provider);
 
         Self {
             decryption_contract,
             s3_service,
             domain,
+            acl_contract,
         }
     }
 
@@ -153,6 +167,84 @@ where
 
         Ok(sns_ciphertext_materials)
     }
+
+    /// Checks that all handles are allowed for public decryption on the host chain ACL.
+    ///
+    /// For public decryption, each handle must have been explicitly allowed for decryption
+    /// by calling `allowForDecryption` on the ACL contract.
+    pub async fn check_acl_for_public_decryption(
+        &self,
+        sns_materials: &[SnsCiphertextMaterial],
+    ) -> Result<(), ProcessingError> {
+        for material in sns_materials {
+            let handle = material.ctHandle;
+            let is_allowed: bool = self
+                .acl_contract
+                .isAllowedForDecryption(handle)
+                .call()
+                .await
+                .map_err(|e| {
+                    ProcessingError::Recoverable(anyhow!(
+                        "Failed to check ACL for public decryption: {}",
+                        e
+                    ))
+                })?;
+
+            if !is_allowed {
+                return Err(ProcessingError::Irrecoverable(anyhow!(
+                    "Handle {} is not allowed for public decryption",
+                    handle
+                )));
+            }
+        }
+
+        info!(
+            "ACL check passed for public decryption of {} handles",
+            sns_materials.len()
+        );
+        Ok(())
+    }
+
+    /// Checks that all handles are allowed for user decryption on the host chain ACL.
+    ///
+    /// For user decryption, the user address must be allowed to access each handle.
+    /// This is checked via the `isAllowed` function on the ACL contract.
+    pub async fn check_acl_for_user_decryption(
+        &self,
+        sns_materials: &[SnsCiphertextMaterial],
+        user_address: Address,
+    ) -> Result<(), ProcessingError> {
+        for material in sns_materials {
+            let handle = material.ctHandle;
+            let is_allowed: bool = self
+                .acl_contract
+                .isAllowed(handle, user_address)
+                .call()
+                .await
+                .map_err(|e| {
+                    ProcessingError::Recoverable(anyhow!(
+                        "Failed to check ACL for user decryption: {}",
+                        e
+                    ))
+                })?
+                .into();
+
+            if !is_allowed {
+                return Err(ProcessingError::Irrecoverable(anyhow!(
+                    "User {} is not allowed to decrypt handle {}",
+                    user_address,
+                    handle
+                )));
+            }
+        }
+
+        info!(
+            "ACL check passed for user decryption of {} handles for user {}",
+            sns_materials.len(),
+            user_address
+        );
+        Ok(())
+    }
 }
 
 pub struct UserDecryptionExtraData {
@@ -173,23 +265,46 @@ impl UserDecryptionExtraData {
 mod tests {
     use super::*;
     use alloy::{
+        primitives::FixedBytes,
         providers::{ProviderBuilder, mock::Asserter},
         sol_types::SolValue,
         transports::http::reqwest,
     };
+    use rstest::rstest;
+
+    fn create_test_processor(
+        gateway_asserter: Asserter,
+        host_chain_asserter: Asserter,
+    ) -> DecryptionProcessor<impl Provider + Clone, impl Provider + Clone> {
+        let gateway_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_mocked_client(gateway_asserter);
+        let host_chain_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_mocked_client(host_chain_asserter);
+
+        let config = Config::default();
+        let s3_service = S3Service::new(&config, gateway_provider.clone(), reqwest::Client::new());
+        DecryptionProcessor::new(&config, gateway_provider, host_chain_provider, s3_service)
+    }
+
+    fn create_test_sns_materials() -> Vec<SnsCiphertextMaterial> {
+        vec![SnsCiphertextMaterial {
+            ctHandle: FixedBytes::ZERO,
+            keyId: U256::ZERO,
+            snsCiphertextDigest: FixedBytes::ZERO,
+            coprocessorTxSenderAddresses: vec![],
+        }]
+    }
 
     #[tokio::test]
     async fn check_decryption_not_already_done() {
-        let asserter = Asserter::new();
-        let mock_provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .connect_mocked_client(asserter.clone());
+        let gateway_asserter = Asserter::new();
+        let host_chain_asserter = Asserter::new();
+        let decryption_processor =
+            create_test_processor(gateway_asserter.clone(), host_chain_asserter);
 
-        let config = Config::default();
-        let s3_service = S3Service::new(&config, mock_provider.clone(), reqwest::Client::new());
-        let decryption_processor = DecryptionProcessor::new(&config, mock_provider, s3_service);
-
-        asserter.push_failure_msg("Transport Error");
+        gateway_asserter.push_failure_msg("Transport Error");
         assert!(matches!(
             decryption_processor
                 .check_decryption_not_already_done(U256::ZERO)
@@ -198,13 +313,13 @@ mod tests {
             ProcessingError::Recoverable(_)
         ));
 
-        asserter.push_success(&false.abi_encode());
+        gateway_asserter.push_success(&false.abi_encode());
         decryption_processor
             .check_decryption_not_already_done(U256::ZERO)
             .await
             .unwrap();
 
-        asserter.push_success(&true.abi_encode());
+        gateway_asserter.push_success(&true.abi_encode());
         assert!(matches!(
             decryption_processor
                 .check_decryption_not_already_done(U256::ZERO)
@@ -212,5 +327,78 @@ mod tests {
                 .unwrap_err(),
             ProcessingError::Irrecoverable(_)
         ));
+    }
+
+    /// Tests for ACL checks - parametrized by decryption type and expected result
+    #[derive(Debug, Clone, Copy)]
+    enum AclCheckType {
+        Public,
+        User,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum MockResponse {
+        Allowed,
+        NotAllowed,
+        TransportError,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ExpectedResult {
+        Success,
+        Irrecoverable,
+        Recoverable,
+    }
+
+    #[rstest]
+    #[case::public_allowed(AclCheckType::Public, MockResponse::Allowed, ExpectedResult::Success)]
+    #[case::public_not_allowed(AclCheckType::Public, MockResponse::NotAllowed, ExpectedResult::Irrecoverable)]
+    #[case::public_transport_error(AclCheckType::Public, MockResponse::TransportError, ExpectedResult::Recoverable)]
+    #[case::user_allowed(AclCheckType::User, MockResponse::Allowed, ExpectedResult::Success)]
+    #[case::user_not_allowed(AclCheckType::User, MockResponse::NotAllowed, ExpectedResult::Irrecoverable)]
+    #[case::user_transport_error(AclCheckType::User, MockResponse::TransportError, ExpectedResult::Recoverable)]
+    #[tokio::test]
+    async fn check_acl_authorization(
+        #[case] check_type: AclCheckType,
+        #[case] mock_response: MockResponse,
+        #[case] expected: ExpectedResult,
+    ) {
+        let gateway_asserter = Asserter::new();
+        let host_chain_asserter = Asserter::new();
+        let decryption_processor =
+            create_test_processor(gateway_asserter, host_chain_asserter.clone());
+        let sns_materials = create_test_sns_materials();
+
+        // Setup mock response
+        match mock_response {
+            MockResponse::Allowed => host_chain_asserter.push_success(&true.abi_encode()),
+            MockResponse::NotAllowed => host_chain_asserter.push_success(&false.abi_encode()),
+            MockResponse::TransportError => host_chain_asserter.push_failure_msg("Transport Error"),
+        }
+
+        // Execute the appropriate check
+        let result = match check_type {
+            AclCheckType::Public => {
+                decryption_processor
+                    .check_acl_for_public_decryption(&sns_materials)
+                    .await
+            }
+            AclCheckType::User => {
+                decryption_processor
+                    .check_acl_for_user_decryption(&sns_materials, Address::ZERO)
+                    .await
+            }
+        };
+
+        // Verify expected outcome
+        match expected {
+            ExpectedResult::Success => result.unwrap(),
+            ExpectedResult::Irrecoverable => {
+                assert!(matches!(result.unwrap_err(), ProcessingError::Irrecoverable(_)))
+            }
+            ExpectedResult::Recoverable => {
+                assert!(matches!(result.unwrap_err(), ProcessingError::Recoverable(_)))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add host chain ACL verification to KMS Connector before processing decryption requests
- KMS now independently verifies authorization by calling view functions on the host chain ACL contract

## Changes

### New Features
- **Host chain configuration**: Added `HostChainConfig` struct with RPC URL, chain ID, and ACL contract address
- **Public decryption ACL check**: Calls `isAllowedForDecryption(handle)` for each handle
- **User decryption ACL check**: Calls `isAllowed(handle, userAddress)` for the requester

### Error Handling
- ACL denials → `Irrecoverable` error (immediate failure, no retry)
- Network errors → `Recoverable` error (retry with counter, max 200 attempts)

### Files Modified
| File | Changes |
|------|---------|
| `config.rs` | Added `HostChainConfig` struct |
| `decryption.rs` | Added `check_acl_for_public_decryption()` and `check_acl_for_user_decryption()` |
| `processor.rs` | Integrated ACL checks, fixed error counter increment |
| `kms_worker.rs` | Added host chain provider initialization |
| `kms-worker.toml` | Added `[host_chain]` configuration section |

## Test Plan

- [x] Unit tests for ACL authorization (6 parametrized cases)
- [x] Unit test for decryption-not-already-done check
- [x] Integration tests for ACL denied scenarios
- [x] Integration tests for ACL transport error scenarios
- [x] Config loading tests updated

```
cargo test -p kms-worker --lib
test result: ok. 14 passed; 0 failed
```

## Related Issues

Closes #849