### PR TITLE
fix(coprocessor): verify input via eth_getLogs

### DIFF
--- a/.github/workflows/coprocessor-dependency-analysis.yml
+++ b/.github/workflows/coprocessor-dependency-analysis.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install cargo tools
         run: |
           cargo binstall --no-confirm --force \
-            cargo-audit@0.21.0 \
+            cargo-audit@0.22.0 \
             cargo-deny@0.16.2
 
       - name: Check that Cargo.lock is the source of truth

--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.7.10
+version: 0.7.11
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.7.11
+version: 0.7.12
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -361,12 +361,13 @@ gwListener:
     - --provider-retry-interval=4s
     - --log-level=INFO
     - --get-logs-poll-interval=500ms
-    - --get-logs-block-batch-size=10
+    - --get-logs-block-batch-size=100
     - --service-name=gw-listener
-    ### Catchup parameters (optional)
-    # --catchup-kms-generation-from-block BLOCK_NUMBER
+    - --log-last-processed-every-number-of-updates=50
+    ### Replay parameters (optional)
+    # --replay-from-block BLOCK_NUMBER
     # To go back in time from latest block
-    # --catchup-kms-generation-from-block -NB_BLOCK
+    # --replay-from-block -NB_BLOCK
 
   # Service ports configuration
   ports:

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -360,8 +360,8 @@ gwListener:
     - --provider-max-retries=4294967295
     - --provider-retry-interval=4s
     - --log-level=INFO
-    - --get-logs-poll-interval=1s
-    - --get-logs-block-batch-size=100
+    - --get-logs-poll-interval=500ms
+    - --get-logs-block-batch-size=10
     - --service-name=gw-listener
     ### Catchup parameters (optional)
     # --catchup-kms-generation-from-block BLOCK_NUMBER

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3096,7 +3096,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3298,7 +3298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6036,13 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.16.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -6056,7 +6057,7 @@ dependencies = [
  "rand 0.9.2",
  "rlp",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]
@@ -6116,7 +6117,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6862,7 +6863,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width",
 ]
@@ -7330,7 +7331,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -7417,7 +7418,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8611,7 +8612,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -69,15 +69,18 @@ struct Conf {
     #[arg(long, default_value = "500ms", value_parser = parse_duration)]
     get_logs_poll_interval: Duration,
 
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 100)]
     get_logs_block_batch_size: u64,
+
+    #[arg(long, default_value_t = 50)]
+    log_last_processed_every_number_of_updates: u64,
 
     /// gw-listener service name in OTLP traces
     #[arg(long, default_value = "gw-listener")]
     pub service_name: String,
 
-    #[arg(long, default_value = None, help = "Can be negative from last processed block", allow_hyphen_values = true)]
-    pub catchup_kms_generation_from_block: Option<i64>,
+    #[arg(long, default_value = None, help = "Can be negative from last processed block", allow_hyphen_values = true, alias = "catchup-kms-generation-from-block")]
+    pub replay_from_block: Option<i64>,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -158,7 +161,8 @@ async fn main() -> anyhow::Result<()> {
         health_check_timeout: conf.health_check_timeout,
         get_logs_poll_interval: conf.get_logs_poll_interval,
         get_logs_block_batch_size: conf.get_logs_block_batch_size,
-        catchup_kms_generation_from_block: conf.catchup_kms_generation_from_block,
+        replay_from_block: conf.replay_from_block,
+        log_last_processed_every_number_of_updates: conf.log_last_processed_every_number_of_updates,
     };
 
     let gw_listener = GatewayListener::new(

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -66,10 +66,10 @@ struct Conf {
     #[arg(long)]
     host_chain_id: Option<u64>,
 
-    #[arg(long, default_value = "1s", value_parser = parse_duration)]
+    #[arg(long, default_value = "500ms", value_parser = parse_duration)]
     get_logs_poll_interval: Duration,
 
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 10)]
     get_logs_block_batch_size: u64,
 
     /// gw-listener service name in OTLP traces

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -4,7 +4,7 @@ use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEventInterface;
 use alloy::{network::Ethereum, primitives::Address, providers::Provider, rpc::types::Log};
 use fhevm_engine_common::telemetry;
-use fhevm_engine_common::utils::to_hex;
+use fhevm_engine_common::utils::compact_hex;
 use futures_util::future::join_all;
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 use tokio_util::sync::CancellationToken;
@@ -88,11 +88,11 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             let s = self.clone();
             let d = db_pool.clone();
             tokio::spawn(async move {
-                let mut catchup_kms_generation_from = s.conf.catchup_kms_generation_from_block;
+                let mut replay_from_block = s.conf.replay_from_block;
                 let mut sleep_duration = s.conf.error_sleep_initial_secs as u64;
                 loop {
                     match s
-                        .run_get_logs(&d, &mut sleep_duration, &mut catchup_kms_generation_from)
+                        .run_get_logs(&d, &mut sleep_duration, &mut replay_from_block)
                         .await
                     {
                         Ok(_) => {
@@ -117,12 +117,13 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
         &self,
         db_pool: &Pool<Postgres>,
         sleep_duration: &mut u64,
-        catchup_kms_generation_from: &mut Option<i64>,
+        replay_from_block: &mut Option<i64>,
     ) -> anyhow::Result<()> {
         let mut ticker = tokio::time::interval(self.conf.get_logs_poll_interval);
         let mut last_processed_block_num = self.get_last_processed_block_num(db_pool).await?;
-        if let Some(from_block) = *catchup_kms_generation_from {
-            info!(from_block, "Catchup on KMSGeneration, start");
+        let mut number_of_last_processed_updates: u64 = 0;
+        if let Some(from_block) = *replay_from_block {
+            info!(from_block, "Replay starts");
             let from_block = if from_block >= 0 {
                 // start from specified block
                 from_block
@@ -132,7 +133,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                 current_block as i64 + from_block
             };
             // clipped to positive block number
-            // note, we cannot catchup block 0
+            // note, we cannot replay block 0
             last_processed_block_num = Some((from_block - 1).try_into().unwrap_or(0));
         }
 
@@ -153,6 +154,10 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
 
                     let from_block = if let Some(last) = last_processed_block_num {
                         if last >= current_block {
+                            if last > current_block {
+                                error!(last_processed_block = last, current_block = current_block,
+                                    "Unexpectedly, last processed is ahead of current block, skipping this iteration");
+                            }
                             continue;
                         }
                         last + 1
@@ -170,6 +175,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                         .from_block(from_block)
                         .to_block(to_block);
 
+                    let mut verify_proof_success = 0;
                     let mut activate_crs_success = 0;
                     let mut crs_digest_mismatch = 0;
                     let mut activate_key_success = 0;
@@ -180,15 +186,21 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                     }).inspect_err(|_| {
                         GET_LOGS_FAIL_COUNTER.inc();
                     })?;
-                    if catchup_kms_generation_from.is_some() && from_block < current_block {
-                        info!(from_block, to_block, nb_events=logs.len(), "Catchup on KMSGeneration, get_logs");
+                    if replay_from_block.is_some() && from_block < current_block {
+                        info!(from_block, to_block, nb_events=logs.len(), "Replay get_logs");
                     }
                     for log in logs {
                         if log.address() == self.input_verification_address {
                             if let Ok(event) = InputVerification::InputVerificationEvents::decode_log(&log.inner) {
                                 match event.data {
                                     InputVerification::InputVerificationEvents::VerifyProofRequest(request) => {
-                                        self.verify_proof_request(db_pool, request, log.clone()).await?;
+                                        self.verify_proof_request(db_pool, request, log.clone()).await.
+                                            inspect(|_| {
+                                                verify_proof_success += 1;
+                                            }).inspect_err(|e| {
+                                                error!(error = %e, "VerifyProofRequest processing failed");
+                                                VERIFY_PROOF_FAIL_COUNTER.inc();
+                                        })?;
                                     },
                                     _ => {
                                         error!(log = ?log, "Unknown InputVerification event");
@@ -247,20 +259,21 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                         }
                     }
                     last_processed_block_num = Some(to_block);
-                    if catchup_kms_generation_from.is_some() {
+                    if replay_from_block.is_some() {
                         if to_block == current_block {
-                            info!("Catchup on KMSGeneration, finished");
-                            *catchup_kms_generation_from = None;
+                            info!("Replay finished");
+                            *replay_from_block = None;
                         } else {
-                            // if an error happens catchup will restart here
-                            *catchup_kms_generation_from = Some(to_block as i64 + 1);
-                            info!(catchup_kms_generation_from, "Catchup on KMSGeneration continue");
+                            // if an error happens replay will restart here
+                            *replay_from_block = Some(to_block as i64 + 1);
+                            info!(replay_from_block, "Replay continues");
                         }
                     }
-                    self.update_last_block_num(db_pool, last_processed_block_num).await?;
+                    self.update_last_block_num(db_pool, last_processed_block_num, &mut number_of_last_processed_updates).await?;
 
                     // Update metrics only after a successful DB update as we don't want to consider events that will be processed again
                     // if the DB update fails.
+                    VERIFY_PROOF_SUCCESS_COUNTER.inc_by(verify_proof_success);
                     ACTIVATE_CRS_SUCCESS_COUNTER.inc_by(activate_crs_success);
                     CRS_DIGEST_MISMATCH_COUNTER.inc_by(crs_digest_mismatch);
                     ACTIVATE_KEY_SUCCESS_COUNTER.inc_by(activate_key_success);
@@ -476,12 +489,9 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
         &self,
         db_pool: &Pool<Postgres>,
         last_block: Option<u64>,
+        number_of_last_processed_updates: &mut u64,
     ) -> anyhow::Result<()> {
         let last_block = last_block.map(i64::try_from).transpose()?;
-        debug!(
-            last_block = last_block,
-            "Updating last processed block number"
-        );
         sqlx::query!(
             "INSERT into gw_listener_last_block (dummy_id, last_block_num)
             VALUES (true, $1)
@@ -490,6 +500,16 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
         )
         .execute(db_pool)
         .await?;
+
+        *number_of_last_processed_updates += 1;
+        if (*number_of_last_processed_updates)
+            .is_multiple_of(self.conf.log_last_processed_every_number_of_updates)
+        {
+            info!(
+                last_block = last_block,
+                "Updated last processed block number"
+            );
+        }
         Ok(())
     }
 
@@ -511,13 +531,16 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                 match sqlx::query("SELECT 1").execute(&pool).await {
                     Ok(_) => {
                         database_connected = true;
+                        info!("Database connection healthy");
                     }
                     Err(e) => {
+                        error!(error = %e, "Database check failed");
                         error_details.push(format!("Database query error: {}", e));
                     }
                 }
             }
             Err(e) => {
+                error!(error = %e, "Database connection error");
                 error_details.push(format!("Database connection error: {}", e));
             }
         }
@@ -538,9 +561,11 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             }
 
             Ok(Err(e)) => {
+                error!(error = %e, "Blockchain connection error");
                 error_details.push(format!("Blockchain connection error: {}", e));
             }
             Err(_) => {
+                error!("Blockchain connection timeout");
                 error_details.push("Blockchain connection timeout".to_string());
             }
         }

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -52,7 +52,9 @@ pub struct ConfigSettings {
 
     pub get_logs_poll_interval: Duration,
     pub get_logs_block_batch_size: u64,
-    pub catchup_kms_generation_from_block: Option<i64>,
+    pub replay_from_block: Option<i64>,
+
+    pub log_last_processed_every_number_of_updates: u64,
 }
 
 pub fn chain_id_from_env() -> Option<ChainId> {
@@ -77,8 +79,9 @@ impl Default for ConfigSettings {
             health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
             get_logs_poll_interval: Duration::from_millis(500),
-            get_logs_block_batch_size: 10,
-            catchup_kms_generation_from_block: None,
+            get_logs_block_batch_size: 100,
+            replay_from_block: None,
+            log_last_processed_every_number_of_updates: 50,
         }
     }
 }

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -76,8 +76,8 @@ impl Default for ConfigSettings {
             error_sleep_max_secs: 10,
             health_check_port: 8080,
             health_check_timeout: Duration::from_secs(4),
-            get_logs_poll_interval: Duration::from_secs(1),
-            get_logs_block_batch_size: 100,
+            get_logs_poll_interval: Duration::from_millis(500),
+            get_logs_block_batch_size: 10,
             catchup_kms_generation_from_block: None,
         }
     }

--- a/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -567,13 +567,13 @@ async fn keygen_ok_catchup_gen(positive: bool) -> anyhow::Result<()> {
     assert!(has_not_server_key(&env.db_pool.clone()).await?);
     assert!(has_not_crs(&env.db_pool.clone()).await?);
 
-    let catchup_kms_generation_from_block = if positive {
+    let replay_from_block = if positive {
         Some(0)
     } else {
         Some(-(provider.get_block_number().await? as i64))
     };
     let conf = ConfigSettings {
-        catchup_kms_generation_from_block,
+        replay_from_block,
         ..env.conf.clone()
     };
     let gw_listener = GatewayListener::new(


### PR DESCRIPTION
Instead of relying on subscriptions that are not reliable in all cases, use eth_getLogs to fetch verify input requests.

Also, change:
 * poll interval from 1 sec to 500 ms to reduce latency
 
Since gw-listener catches up automatically via the last processed block number in the DB, call the manual process "replay" instead of "catchup". Replay is requested via the cmd line. Also, keep the old name as an alias for backward compatibility. Furthermore, replay is not KMS-specific anymore, so remove KMS from the name.

Add more logging in health checks and replay.