### PR TITLE
chore(kms-connector): add mpc-devs as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /host-contracts/ @zama-ai/fhevm-gateway
 /protocol-contracts/ @zama-ai/fhevm-gateway
 /library-solidity/ @zama-ai/fhevm-gateway
-/kms-connector/ @zama-ai/fhevm-gateway @dartdart26
+/kms-connector/ @zama-ai/mpc-devs @zama-ai/fhevm-gateway @dartdart26
 
 # Coprocessor Team ownership
 /coprocessor/ @zama-ai/fhevm-coprocessor


### PR DESCRIPTION
Add `zama-ai/mpc-devs` as codeowners, as the ownership of the kms-connector will shift to the mpc team.

Will remove `zama-ai/fhevm-gateway` later once the ownership shift is fully done.