### PR TITLE
ci(common): setup git token to clone marketplace in claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,25 +63,31 @@ jobs:
           # Get OIDC token
           OIDC_RESPONSE=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=claude-code-github-action")
-          echo "OIDC response: $OIDC_RESPONSE"
           OIDC_TOKEN=$(echo "$OIDC_RESPONSE" | jq -r '.value')
 
           if [ -z "$OIDC_TOKEN" ] || [ "$OIDC_TOKEN" = "null" ]; then
             echo "❌ Failed to get OIDC token"
+            echo "Response: $OIDC_RESPONSE"
             exit 1
           fi
+
+          # Mask the OIDC token
+          echo "::add-mask::$OIDC_TOKEN"
+          echo "✓ OIDC token obtained"
 
           # Exchange for GitHub App token
           APP_RESPONSE=$(curl -s -X POST https://api.anthropic.com/api/github/github-app-token-exchange \
             -H "Authorization: Bearer $OIDC_TOKEN")
-          echo "App token response: $APP_RESPONSE"
           APP_TOKEN=$(echo "$APP_RESPONSE" | jq -r '.token // .app_token')
 
           if [ -z "$APP_TOKEN" ] || [ "$APP_TOKEN" = "null" ]; then
             echo "❌ Failed to exchange for App token"
+            echo "Response (check for error): $(echo "$APP_RESPONSE" | jq -c '.error // .message // .')"
             exit 1
           fi
 
+          # Mask the App token
+          echo "::add-mask::$APP_TOKEN"
           echo "token=$APP_TOKEN" >> $GITHUB_OUTPUT
           echo "✓ Claude App token obtained"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -72,7 +72,7 @@ jobs:
             exit 1
           fi
 
-          echo "token=$APP_TOKEN" >> $GITHUB_OUTPUT
+          echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Configure git for marketplace
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,11 +15,9 @@ name: claude-review
 # Secrets required:
 # - CLAUDE_CODE_OAUTH_TOKEN: OAuth token from `claude setup-token`
 #
-# Note: Private marketplaces are cloned in a separate step using the Claude GitHub App token:
-# 1. Get OIDC token (requires id-token: write permission)
-# 2. Exchange OIDC token for Claude App token via Anthropic API
-# 3. Use App token to clone marketplace (has access to all repos where app is installed)
-# 4. Pass local path to action to avoid git authentication issues in the action's setup
+# Note: Private marketplaces require git auth in base-action mode.
+# We obtain the Claude GitHub App token and configure git to use it for https clones,
+# so the action can clone marketplaces directly.
 
 on:
   issue_comment:
@@ -91,18 +89,15 @@ jobs:
           echo "token=$APP_TOKEN" >> $GITHUB_OUTPUT
           echo "✓ Claude App token obtained"
 
-      - name: Clone private marketplace
+      - name: Configure git for marketplace
         run: |
-          gh repo clone zama-ai/zama-marketplace /tmp/zama-marketplace
-          echo "✓ Marketplace cloned to /tmp/zama-marketplace"
-        env:
-          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
+          git config --global url."https://x-access-token:${{ steps.claude-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "/tmp/zama-marketplace"
+          plugin_marketplaces: "https://github.com/zama-ai/zama-marketplace.git"
           plugins: |
             project-manager@zama-marketplace
             zama-developer@zama-marketplace

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,13 +59,8 @@ jobs:
 
           if [ -z "$OIDC_TOKEN" ] || [ "$OIDC_TOKEN" = "null" ]; then
             echo "❌ Failed to get OIDC token"
-            echo "Response: $OIDC_RESPONSE"
             exit 1
           fi
-
-          # Mask the OIDC token
-          echo "::add-mask::$OIDC_TOKEN"
-          echo "✓ OIDC token obtained"
 
           # Exchange for GitHub App token
           APP_RESPONSE=$(curl -s -X POST https://api.anthropic.com/api/github/github-app-token-exchange \
@@ -74,14 +69,10 @@ jobs:
 
           if [ -z "$APP_TOKEN" ] || [ "$APP_TOKEN" = "null" ]; then
             echo "❌ Failed to exchange for App token"
-            echo "Response (check for error): $(echo "$APP_RESPONSE" | jq -c '.error // .message // .')"
             exit 1
           fi
 
-          # Mask the App token
-          echo "::add-mask::$APP_TOKEN"
           echo "token=$APP_TOKEN" >> $GITHUB_OUTPUT
-          echo "✓ Claude App token obtained"
 
       - name: Configure git for marketplace
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,12 +11,23 @@ name: claude-review
 # Security: Only users with write/admin permissions can trigger Claude.
 # External contributors (fork PRs) are automatically blocked by the action.
 # See: https://github.com/anthropics/claude-code-action/blob/main/src/github/validation/permissions.ts
+#
+# Secrets required:
+# - CLAUDE_CODE_OAUTH_TOKEN: OAuth token from `claude setup-token`
+#
+# Note: Private marketplaces are cloned in a separate step using the default GITHUB_TOKEN,
+# then passed to the action as local paths to avoid authentication issues with the action's git setup
 
 on:
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  # TEMPORARY: For testing marketplace cloning fix
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
 
 permissions: {}
 
@@ -24,8 +35,9 @@ jobs:
   claude-review:
     name: claude-review/respond
     if: |
-      contains(github.event.comment.body, '@claude') &&
-      (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment')
+      github.event_name == 'pull_request' ||
+      (contains(github.event.comment.body, '@claude') &&
+       (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment'))
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for checkout
@@ -42,12 +54,21 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b
 
+      - name: Clone private marketplace
+        run: |
+          git clone https://github.com/zama-ai/zama-marketplace.git /tmp/zama-marketplace
+          echo "✓ Marketplace cloned to /tmp/zama-marketplace"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "https://github.com/zama-ai/zama-marketplace.git"
+          plugin_marketplaces: "/tmp/zama-marketplace"
           plugins: |
             project-manager@zama-marketplace
             zama-developer@zama-marketplace
-          # Prompt: empty string → action extracts text after @claude automatically
+          # Prompt: empty string for comments (action extracts text after @claude)
+          # For pull_request trigger: explicit prompt to test marketplace fix
+          prompt: ${{ github.event_name == 'pull_request' && '/pr-review this PR thoroughly' || '' }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,11 +24,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  # TEMPORARY: For testing marketplace cloning fix
-  pull_request:
-    types: [opened, synchronize]
-    branches:
-      - main
 
 permissions: {}
 
@@ -36,9 +31,8 @@ jobs:
   claude-review:
     name: claude-review/respond
     if: |
-      github.event_name == 'pull_request' ||
-      (contains(github.event.comment.body, '@claude') &&
-       (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment'))
+      contains(github.event.comment.body, '@claude') &&
+      (github.event.issue.pull_request || github.event_name == 'pull_request_review_comment')
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for checkout
@@ -102,5 +96,4 @@ jobs:
             project-manager@zama-marketplace
             zama-developer@zama-marketplace
           # Prompt: empty string for comments (action extracts text after @claude)
-          # For pull_request trigger: explicit prompt to test marketplace fix
-          prompt: ${{ github.event_name == 'pull_request' && '/pr-review this PR thoroughly' || '' }}
+          prompt: ""

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,12 +61,26 @@ jobs:
         id: claude-token
         run: |
           # Get OIDC token
-          OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=claude-code-github-action" | jq -r '.value')
+          OIDC_RESPONSE=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=claude-code-github-action")
+          echo "OIDC response: $OIDC_RESPONSE"
+          OIDC_TOKEN=$(echo "$OIDC_RESPONSE" | jq -r '.value')
+
+          if [ -z "$OIDC_TOKEN" ] || [ "$OIDC_TOKEN" = "null" ]; then
+            echo "❌ Failed to get OIDC token"
+            exit 1
+          fi
 
           # Exchange for GitHub App token
-          APP_TOKEN=$(curl -s -X POST https://api.anthropic.com/api/github/github-app-token-exchange \
-            -H "Authorization: Bearer $OIDC_TOKEN" | jq -r '.token // .app_token')
+          APP_RESPONSE=$(curl -s -X POST https://api.anthropic.com/api/github/github-app-token-exchange \
+            -H "Authorization: Bearer $OIDC_TOKEN")
+          echo "App token response: $APP_RESPONSE"
+          APP_TOKEN=$(echo "$APP_RESPONSE" | jq -r '.token // .app_token')
+
+          if [ -z "$APP_TOKEN" ] || [ "$APP_TOKEN" = "null" ]; then
+            echo "❌ Failed to exchange for App token"
+            exit 1
+          fi
 
           echo "token=$APP_TOKEN" >> $GITHUB_OUTPUT
           echo "✓ Claude App token obtained"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,8 +15,11 @@ name: claude-review
 # Secrets required:
 # - CLAUDE_CODE_OAUTH_TOKEN: OAuth token from `claude setup-token`
 #
-# Note: Private marketplaces are cloned in a separate step using the default GITHUB_TOKEN,
-# then passed to the action as local paths to avoid authentication issues with the action's git setup
+# Note: Private marketplaces are cloned in a separate step using the Claude GitHub App token:
+# 1. Get OIDC token (requires id-token: write permission)
+# 2. Exchange OIDC token for Claude App token via Anthropic API
+# 3. Use App token to clone marketplace (has access to all repos where app is installed)
+# 4. Pass local path to action to avoid git authentication issues in the action's setup
 
 on:
   issue_comment:
@@ -54,12 +57,26 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b
 
+      - name: Get Claude App token
+        id: claude-token
+        run: |
+          # Get OIDC token
+          OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=claude-code-github-action" | jq -r '.value')
+
+          # Exchange for GitHub App token
+          APP_TOKEN=$(curl -s -X POST https://api.anthropic.com/api/github/github-app-token-exchange \
+            -H "Authorization: Bearer $OIDC_TOKEN" | jq -r '.token // .app_token')
+
+          echo "token=$APP_TOKEN" >> $GITHUB_OUTPUT
+          echo "✓ Claude App token obtained"
+
       - name: Clone private marketplace
         run: |
           gh repo clone zama-ai/zama-marketplace /tmp/zama-marketplace
           echo "✓ Marketplace cloned to /tmp/zama-marketplace"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: Configure git for marketplace
         run: |
-          git config --global url."https://x-access-token:${{ steps.claude-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://x-access-token:${GITHUB_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_APP_TOKEN: ${{ steps.claude-token.outputs.token }}
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Clone private marketplace
         run: |
-          git clone https://github.com/zama-ai/zama-marketplace.git /tmp/zama-marketplace
+          gh repo clone zama-ai/zama-marketplace /tmp/zama-marketplace
           echo "✓ Marketplace cloned to /tmp/zama-marketplace"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The Claude Code action fails to clone private/internal marketplaces because git auth is not configured in base‑action mode when the action runs `claude plugin marketplace add <url>`.

**Error:**
```
✘ Failed to add marketplace: Failed to clone marketplace repository
remote: Repository not found.
fatal: repository 'https://github.com/zama-ai/zama-marketplace.git/' not found
```

## Root Cause

- `configureGitAuth()` is only called in agent/tag modes, not in base‑action mode
- Marketplace cloning happens before any git credentials are configured
- Our marketplace is internal → requires authenticated HTTPS

## Strategy (current workaround)

Use the Claude GitHub App token + git URL rewriting so the action can clone marketplaces itself:

1. Get GitHub Actions OIDC token
2. Exchange it with Anthropic for the Claude GitHub App token
3. Configure git:
   `url."https://x-access-token:<token>@github.com/".insteadOf "https://github.com/"`
4. Keep `plugin_marketplaces` as the remote HTTPS URL

This avoids PATs and works for cross‑repo access wherever the Claude App is installed.

## Changes

- Add OIDC → Anthropic token exchange step
- Configure git to rewrite `https://github.com/` with the App token
- Keep marketplace as a remote URL (no local pre‑clone)
- Restore comment‑only trigger (remove temporary PR trigger)

## Notes

- The OIDC exchange fails on PR runs when the workflow file differs from `main` (expected)
- Once this PR is merged to `main`, the exchange should succeed
