### PR TITLE
fix(common): try cloning private marketplace before claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,9 +15,8 @@ name: claude-review
 # Secrets required:
 # - CLAUDE_CODE_OAUTH_TOKEN: OAuth token from `claude setup-token`
 #
-# Note: Private marketplaces require git auth in base-action mode.
-# We obtain the Claude GitHub App token and configure git to use it for https clones,
-# so the action can clone marketplaces directly.
+# Note: Private marketplaces are cloned in a separate step using the Claude GitHub App token,
+# then passed as a local path to avoid git auth issues in the action's setup.
 
 on:
   issue_comment:
@@ -74,17 +73,17 @@ jobs:
 
           echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
 
-      - name: Configure git for marketplace
+      - name: Clone private marketplace
         run: |
-          git config --global url."https://x-access-token:${GITHUB_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+          gh repo clone zama-ai/zama-marketplace /tmp/zama-marketplace
         env:
-          GITHUB_APP_TOKEN: ${{ steps.claude-token.outputs.token }}
+          GH_TOKEN: ${{ steps.claude-token.outputs.token }}
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "https://github.com/zama-ai/zama-marketplace.git"
+          plugin_marketplaces: "/tmp/zama-marketplace"
           plugins: |
             project-manager@zama-marketplace
             zama-developer@zama-marketplace


### PR DESCRIPTION
## Problem

The Claude Code action fails to add the private marketplace because the base-action does not configure git auth before running `claude plugin marketplace add <url>`.

## Strategy

Clone the marketplace explicitly using the Claude GitHub App token, then pass the local path to the action. This avoids relying on git auth within the action itself.

## Changes

- Clone `zama-ai/zama-marketplace` to `/tmp/zama-marketplace` using the App token
- Pass the local path via `plugin_marketplaces`
- Update the workflow note to reflect the approach

## Testing

- Not run locally (GitHub Actions only)
