### PR TITLE
ci(common): configure Claude workflow with Opus model, custom prompt, and tool permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,6 +58,77 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
 
+      - name: Build custom system prompt
+        id: custom_prompt
+        run: |
+          # Extract PR metadata from webhook payload
+          if [[ "${{ github.event_name }}" == "pull_request" ]] || [[ -n "${{ github.event.issue.pull_request }}" ]]; then
+            # For pull_request events
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              PR_TITLE="${{ github.event.pull_request.title }}"
+              PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+              PR_HEAD="${{ github.event.pull_request.head.ref }}"
+              PR_BASE="${{ github.event.pull_request.base.ref }}"
+              PR_STATE="${{ github.event.pull_request.state }}"
+              PR_ADDITIONS="${{ github.event.pull_request.additions }}"
+              PR_DELETIONS="${{ github.event.pull_request.deletions }}"
+              PR_COMMITS="${{ github.event.pull_request.commits }}"
+              PR_FILES="${{ github.event.pull_request.changed_files }}"
+            else
+              # For issue_comment on PRs - need to fetch PR data
+              PR_NUMBER="${{ github.event.issue.number }}"
+              PR_DATA=$(gh pr view "$PR_NUMBER" --json title,author,headRefName,baseRefName,state,additions,deletions,commits)
+              PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+              PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+              PR_HEAD=$(echo "$PR_DATA" | jq -r '.headRefName')
+              PR_BASE=$(echo "$PR_DATA" | jq -r '.baseRefName')
+              PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
+              PR_ADDITIONS=$(echo "$PR_DATA" | jq -r '.additions')
+              PR_DELETIONS=$(echo "$PR_DATA" | jq -r '.deletions')
+              PR_COMMITS=$(echo "$PR_DATA" | jq -r '.commits | length')
+              PR_FILES=$(gh pr view "$PR_NUMBER" --json files | jq '.files | length')
+            fi
+
+            # Build formatted context
+            FORMATTED_CONTEXT="PR Title: ${PR_TITLE}
+          PR Author: ${PR_AUTHOR}
+          PR Branch: ${PR_HEAD} -> ${PR_BASE}
+          PR State: ${PR_STATE^^}
+          PR Additions: ${PR_ADDITIONS}
+          PR Deletions: ${PR_DELETIONS}
+          Total Commits: ${PR_COMMITS}
+          Changed Files: ${PR_FILES} files"
+
+            # Build system prompt
+            SYSTEM_PROMPT="You are Claude, an AI assistant designed to help with GitHub issues and pull requests. Think carefully as you analyze the context and respond appropriately. Here's the context for your current task:
+
+          <formatted_context>
+          ${FORMATTED_CONTEXT}
+          </formatted_context>"
+          else
+            # For issues
+            ISSUE_TITLE="${{ github.event.issue.title }}"
+            ISSUE_AUTHOR="${{ github.event.issue.user.login }}"
+            ISSUE_STATE="${{ github.event.issue.state }}"
+
+            FORMATTED_CONTEXT="Issue Title: ${ISSUE_TITLE}
+          Issue Author: ${ISSUE_AUTHOR}
+          Issue State: ${ISSUE_STATE^^}"
+
+            SYSTEM_PROMPT="You are Claude, an AI assistant designed to help with GitHub issues and pull requests. Think carefully as you analyze the context and respond appropriately. Here's the context for your current task:
+
+          <formatted_context>
+          ${FORMATTED_CONTEXT}
+          </formatted_context>"
+          fi
+
+          # Save to environment file for next step
+          echo "CUSTOM_SYSTEM_PROMPT<<EOF" >> $GITHUB_ENV
+          echo "$SYSTEM_PROMPT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16
         with:
@@ -70,3 +141,5 @@ jobs:
           prompt: ""
           claude_args: |
             --model opus
+            --allowedTools "Bash(uv),Bash(gh),Bash(git),Read,Edit,Write,Glob,Grep,Task"
+            --system-prompt "${{ env.CUSTOM_SYSTEM_PROMPT }}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,3 +68,5 @@ jobs:
             zama-developer@zama-marketplace
           # Prompt: empty string for comments (action extracts text after @claude)
           prompt: ""
+          claude_args: |
+            --model opus

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,21 +62,21 @@ jobs:
         id: custom_prompt
         run: |
           # Extract PR metadata from webhook payload
-          if [[ "${{ github.event_name }}" == "pull_request" ]] || [[ -n "${{ github.event.issue.pull_request }}" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]] || [[ -n "$ISSUE_PR_URL" ]]; then
             # For pull_request events
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              PR_TITLE="${{ github.event.pull_request.title }}"
-              PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-              PR_HEAD="${{ github.event.pull_request.head.ref }}"
-              PR_BASE="${{ github.event.pull_request.base.ref }}"
-              PR_STATE="${{ github.event.pull_request.state }}"
-              PR_ADDITIONS="${{ github.event.pull_request.additions }}"
-              PR_DELETIONS="${{ github.event.pull_request.deletions }}"
-              PR_COMMITS="${{ github.event.pull_request.commits }}"
-              PR_FILES="${{ github.event.pull_request.changed_files }}"
+            if [[ "$EVENT_NAME" == "pull_request" ]]; then
+              PR_TITLE="$PR_TITLE_INPUT"
+              PR_AUTHOR="$PR_AUTHOR_INPUT"
+              PR_HEAD="$PR_HEAD_INPUT"
+              PR_BASE="$PR_BASE_INPUT"
+              PR_STATE="$PR_STATE_INPUT"
+              PR_ADDITIONS="$PR_ADDITIONS_INPUT"
+              PR_DELETIONS="$PR_DELETIONS_INPUT"
+              PR_COMMITS="$PR_COMMITS_INPUT"
+              PR_FILES="$PR_FILES_INPUT"
             else
               # For issue_comment on PRs - need to fetch PR data
-              PR_NUMBER="${{ github.event.issue.number }}"
+              PR_NUMBER="$ISSUE_NUMBER_INPUT"
               PR_DATA=$(gh pr view "$PR_NUMBER" --json title,author,headRefName,baseRefName,state,additions,deletions,commits)
               PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
               PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
@@ -107,9 +107,9 @@ jobs:
           </formatted_context>"
           else
             # For issues
-            ISSUE_TITLE="${{ github.event.issue.title }}"
-            ISSUE_AUTHOR="${{ github.event.issue.user.login }}"
-            ISSUE_STATE="${{ github.event.issue.state }}"
+            ISSUE_TITLE="$ISSUE_TITLE_INPUT"
+            ISSUE_AUTHOR="$ISSUE_AUTHOR_INPUT"
+            ISSUE_STATE="$ISSUE_STATE_INPUT"
 
             FORMATTED_CONTEXT="Issue Title: ${ISSUE_TITLE}
           Issue Author: ${ISSUE_AUTHOR}
@@ -122,12 +122,31 @@ jobs:
           </formatted_context>"
           fi
 
-          # Save to environment file for next step
-          echo "CUSTOM_SYSTEM_PROMPT<<EOF" >> $GITHUB_ENV
-          echo "$SYSTEM_PROMPT" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          # Save to environment file for next step (using block redirect)
+          {
+            echo "CUSTOM_SYSTEM_PROMPT<<EOF"
+            echo "$SYSTEM_PROMPT"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request }}
+          # Pull request event variables
+          PR_TITLE_INPUT: ${{ github.event.pull_request.title }}
+          PR_AUTHOR_INPUT: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_INPUT: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_INPUT: ${{ github.event.pull_request.base.ref }}
+          PR_STATE_INPUT: ${{ github.event.pull_request.state }}
+          PR_ADDITIONS_INPUT: ${{ github.event.pull_request.additions }}
+          PR_DELETIONS_INPUT: ${{ github.event.pull_request.deletions }}
+          PR_COMMITS_INPUT: ${{ github.event.pull_request.commits }}
+          PR_FILES_INPUT: ${{ github.event.pull_request.changed_files }}
+          # Issue event variables
+          ISSUE_NUMBER_INPUT: ${{ github.event.issue.number }}
+          ISSUE_TITLE_INPUT: ${{ github.event.issue.title }}
+          ISSUE_AUTHOR_INPUT: ${{ github.event.issue.user.login }}
+          ISSUE_STATE_INPUT: ${{ github.event.issue.state }}
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # 2026-01-16


### PR DESCRIPTION
## Summary

Configure the Claude Code workflow for optimal PR review capabilities:
1. Use Opus model instead of Sonnet
2. Override system prompt with minimal PR metadata (no verbose body)
3. Enable tool permissions for pr-review skill compatibility

## Changes

### Model Configuration
- Add `--model opus` to use the latest Opus model automatically
- No need to specify full version - alias ensures always-current version

### System Prompt Override
- Build custom system prompt with only PR metadata (`<formatted_context>`)
- Includes: title, author, branches, additions/deletions, commit count, file count
- **Excludes**: verbose PR body that clutters the context
- Handles both `pull_request` and `issue_comment` events

### Tool Permissions
- Enable `Bash(uv)` for running Python scripts via uv
- Enable `Bash(gh)` for GitHub CLI operations (reviews, comments, API calls)
- Enable `Bash(git)` for git operations
- Enable core tools: `Read,Edit,Write,Glob,Grep,Task`

### pr-review Skill Compatibility
The workflow now supports the `pr-review` skill which can:
- Execute `uv run scripts/gh_pr.py` for PR operations
- Post real GitHub reviews with inline comments via `gh api`
- Use `gh pr comment` for additional comments
- Create batched reviews to avoid notification spam

## Motivation

1. **Opus model**: More capable for complex code reviews and analysis
2. **Clean prompt**: Avoid context pollution with verbose PR descriptions
3. **Tool access**: Enable pr-review skill to post professional GitHub reviews

## Technical Details

### Token Usage
- `GITHUB_TOKEN` (auto-injected): Used by `gh_pr.py` to post reviews - has `pull-requests: write`
- `CLAUDE_ACCESS_TOKEN`: Used only to clone private repos (read-only OK)

### Review Workflow
When `@claude` is mentioned in a PR comment:
1. Fetch PR metadata and build minimal system prompt
2. Claude receives clean context with just PR stats
3. pr-review skill can run parallel review agents
4. Post batched inline review via GitHub API

## Test Plan

- [x] Verify workflow syntax is correct
- [x] Confirm tool permissions allow uv/gh/git
- [x] Validate system prompt override works
- [ ] Test `@claude /pr-review` in a real PR after merge
- [ ] Verify inline comments appear correctly on GitHub