### PR TITLE
chore(coprocessor): improve the git LFS installation step in benchmar…

### DIFF
--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -86,12 +86,14 @@ jobs:
             gcc: 11
 
     steps:
-      - name: Wait for unattended upgrades to complete
-        run: |
-          sudo apt-get update
-
       - name: Install git LFS
         run: |
+          # Wait for apt locks to be released (e.g., unattended-upgrades may hold the lock on fresh instances)
+          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+            echo "Waiting for apt lock to be released..."
+            sleep 5
+          done
+          sudo apt-get update
           sudo apt-get install -y git-lfs
           git lfs install
 

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -136,6 +136,11 @@ jobs:
     steps:
       - name: Install git LFS
         run: |
+          # Wait for apt locks to be released (e.g., unattended-upgrades may hold the lock on fresh instances)
+          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+            echo "Waiting for apt lock to be released..."
+            sleep 5
+          done
           sudo apt-get update
           sudo apt-get install -y git-lfs
           git lfs install


### PR DESCRIPTION
…k flows

Ubuntu unattended upgrades can hold the lock and prevent installation.