### PR TITLE
feat(coprocessor): export squash_noise tracing spans via OTEL

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -6794,6 +6794,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -8182,6 +8183,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -4932,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -7761,29 +7761,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -2378,9 +2378,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -84,7 +84,7 @@ tfhe = { version = "=1.5.1", features = [
 ] }
 tfhe-versionable = "=0.6.2"
 tfhe-zk-pok = "=0.8.0"
-time = "0.3.43"
+time = "0.3.47"
 tokio = { version = "1.45.0", features = ["full"] }
 tokio-util = "0.7.15"
 tonic = { version = "0.12.3", features = ["server"] }

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -90,6 +90,7 @@ tokio-util = "0.7.15"
 tonic = { version = "0.12.3", features = ["server"] }
 tonic-build = "0.12.3"
 tracing = "0.1.41"
+tracing-opentelemetry = "0.30.0"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "json"] }
 tracing-test = "0.2.5"
 union-find = "0.4.3"

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -82,6 +82,10 @@ impl OtelTracer {
         self.tracer.start_with_context(name, &self.ctx)
     }
 
+    pub fn context(&self) -> &Context {
+        &self.ctx
+    }
+
     /// Sets attribute to the root span
     pub fn set_attribute(&self, key: &str, value: String) {
         self.ctx

--- a/coprocessor/fhevm-engine/sns-worker/Cargo.toml
+++ b/coprocessor/fhevm-engine/sns-worker/Cargo.toml
@@ -20,6 +20,7 @@ tfhe = { workspace = true}
 tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
@@ -61,4 +62,3 @@ test-harness = { path = "../test-harness" }
 [dev-dependencies.sns-worker]
 path = "."
 features = ["test_decrypt_128", "test_s3_use_handle_as_key"]
-

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -1,8 +1,10 @@
 use sns_worker::{Config, DBConfig, HealthCheckConfig, S3Config, S3RetryPolicy, SNSMetricsConfig};
 
+use fhevm_engine_common::telemetry;
 use tokio::signal::unix;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 mod utils;
 
 fn handle_sigint(token: CancellationToken) {
@@ -65,14 +67,40 @@ async fn main() {
     let config: Config = construct_config();
     let parent = CancellationToken::new();
 
-    tracing_subscriber::fmt()
+    let otel_tracer = if config.service_name.is_empty() {
+        None
+    } else {
+        match telemetry::setup_otlp_tracer(&config.service_name, "otlp-layer") {
+            Ok(tracer) => Some(tracer),
+            Err(err) => {
+                eprintln!("Failed to setup OTLP: {err}");
+                None
+            }
+        }
+    };
+
+    let level_filter = tracing_subscriber::filter::LevelFilter::from_level(config.log_level);
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .json()
-        .with_target(false) // drop "target" field so the logs are not too verbose. Instead, span names are used.
-        .with_current_span(true) // keep "span"
-        .with_span_list(false) // drop "spans"
-        .with_level(true)
-        .with_max_level(config.log_level)
-        .init();
+        // drop "target" field so the logs are not too verbose. Instead, span names are used.
+        .with_target(false)
+        // keep "span"
+        .with_current_span(true)
+        // drop "spans"
+        .with_span_list(false)
+        .with_level(true);
+
+    let base = tracing_subscriber::registry()
+        .with(level_filter)
+        .with(fmt_layer);
+
+    if let Some(tracer) = otel_tracer {
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        base.with(otel_layer).init();
+    } else {
+        base.init();
+    }
 
     // Handle SIGINIT signals
     handle_sigint(parent.clone());

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -570,12 +570,8 @@ fn compute_task(
     let ct_type = ct.type_name().to_owned();
     info!( { handle, ct_type }, "Converting ciphertext");
 
-    let mut span = task.otel.child_span("squash_noise");
-    telemetry::attribute(&mut span, "ct_type", ct_type);
-
     match ct.squash_noise_and_serialize(enable_compression) {
         Ok(bytes) => {
-            telemetry::end_span(span);
             info!(
                 handle = handle,
                 length = bytes.len(),
@@ -622,7 +618,6 @@ fn compute_task(
             }
         }
         Err(err) => {
-            telemetry::end_span_with_err(span, err.to_string());
             error!({ handle = handle, error = %err }, "Failed to convert ct");
         }
     };

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -22,7 +22,7 @@ use fhevm_engine_common::{
     healthz_server::{self},
     metrics_server,
     pg_pool::{PostgresPoolManager, ServiceError},
-    telemetry::{self, OtelTracer},
+    telemetry::OtelTracer,
     types::FhevmError,
     utils::{to_hex, DatabaseURL},
 };
@@ -508,12 +508,6 @@ pub async fn run_all(
     let rayon_threads = rayon::current_num_threads();
     let gpu_enabled = fhevm_engine_common::utils::log_backend();
     info!(gpu_enabled, rayon_threads, config = %config, "Starting SNS worker");
-
-    if !config.service_name.is_empty() {
-        if let Err(err) = telemetry::setup_otlp(&config.service_name) {
-            error!(error = %err, "Failed to setup OTLP");
-        }
-    }
 
     let conf = config.clone();
     let token = parent_token.child_token();

--- a/coprocessor/fhevm-engine/sns-worker/src/squash_noise.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/squash_noise.rs
@@ -11,19 +11,49 @@ use tfhe::Versionize;
 use fhevm_engine_common::types::SupportedFheCiphertexts;
 
 macro_rules! squash_and_serialize_with_error {
-    ($value:expr, $target_ty:ty, $enable_compression:expr) => {{
-        let squashed: $target_ty = $value
-            .squash_noise()
-            .map_err(ExecutionError::SquashedNoiseError)?;
+    ($value:expr, $target_ty:ty, $enable_compression:expr, $ct_type:expr) => {{
+        let ct_type = $ct_type;
+
+        let squashed: $target_ty = {
+            let span = tracing::info_span!(
+                "squash_noise_fhe",
+                ct_type = %ct_type,
+                operation = "squash_noise_fhe"
+            );
+            let _enter = span.enter();
+            $value
+                .squash_noise()
+                .map_err(ExecutionError::SquashedNoiseError)?
+        };
 
         if !$enable_compression {
+            let span = tracing::info_span!(
+                "serialize",
+                ct_type = %ct_type,
+                operation = "serialize"
+            );
+            let _enter = span.enter();
             return safe_serialize(&squashed);
         }
 
-        let mut builder = CompressedSquashedNoiseCiphertextListBuilder::new();
-        builder.push(squashed);
-        let list = builder.build()?;
+        let list = {
+            let span = tracing::info_span!(
+                "compress",
+                ct_type = %ct_type,
+                operation = "compress"
+            );
+            let _enter = span.enter();
+            let mut builder = CompressedSquashedNoiseCiphertextListBuilder::new();
+            builder.push(squashed);
+            builder.build()?
+        };
 
+        let span = tracing::info_span!(
+            "serialize",
+            ct_type = %ct_type,
+            operation = "serialize"
+        );
+        let _enter = span.enter();
         Ok(safe_serialize(&list)?)
     }};
 }
@@ -59,43 +89,104 @@ impl SquashNoiseCiphertext for SupportedFheCiphertexts {
         &self,
         enable_compression: bool,
     ) -> Result<Vec<u8>, ExecutionError> {
+        let ct_type = self.type_name();
         match self {
             SupportedFheCiphertexts::FheBool(v) => {
-                squash_and_serialize_with_error!(v, tfhe::SquashedNoiseFheBool, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    tfhe::SquashedNoiseFheBool,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint4(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
 
             SupportedFheCiphertexts::FheUint8(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint16(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint32(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint64(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint128(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint160(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheUint256(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheBytes64(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheBytes128(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::FheBytes256(v) => {
-                squash_and_serialize_with_error!(v, SquashedNoiseFheUint, enable_compression)
+                squash_and_serialize_with_error!(
+                    v,
+                    SquashedNoiseFheUint,
+                    enable_compression,
+                    ct_type
+                )
             }
             SupportedFheCiphertexts::Scalar(_) => {
                 panic!("we should never need to serialize scalar")

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -509,7 +509,7 @@ fn create_ciphertext(
     telemetry::attribute(t, "chain_id", aux_data.chain_id.to_string());
     telemetry::attribute(t, "ct_idx", ct_idx.to_string());
     telemetry::attribute(t, "user_address", aux_data.user_address.clone());
-    telemetry::attribute(t, "contract_address", aux_data.user_address.clone());
+    telemetry::attribute(t, "contract_address", aux_data.contract_address.clone());
     telemetry::attribute(t, "version", current_ciphertext_version().to_string());
     telemetry::attribute(t, "type", serialized_type.to_string());
     telemetry::attribute(


### PR DESCRIPTION
## Summary
- Fix zkproof-worker telemetry attribute: `contract_address` now uses `aux_data.contract_address`.
- Add `tracing-opentelemetry` bridge in sns-worker so `tracing` spans export to the existing OTEL collector.
- Split `squash_noise` into `squash_noise_fhe`, `compress`, `serialize` spans with `ct_type` and `operation` attributes.

## Verification
- Pre-commit hook passed locally (fmt/check/clippy).
- Manual: run sns-worker with `OTEL_EXPORTER_OTLP_ENDPOINT` configured and verify spans/attributes in Grafana/Tempo.

Closes [#1851](https://github.com/zama-ai/fhevm-internal/issues/934)
Tracking: zama-ai/fhevm-internal#935