### PR TITLE
ci(common): bump actionlint action version

### DIFF
--- a/.github/workflows/common-pull-request-lint.yml
+++ b/.github/workflows/common-pull-request-lint.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: actionlint
-        uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc # v2.0.1
+        uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
         with:
             version: ${{ env.ACTIONLINT_VERSION }}
 


### PR DESCRIPTION
Bump actionlint version that fixes this [issue](https://github.com/raven-actions/actionlint/issues/51), faced this morning in copro CI ([ex](https://github.com/zama-ai/fhevm/actions/runs/21490148801/job/61910184804#step:3:281))