### PR TITLE
fix(coprocessor): remove redundant npm install

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/build.rs
+++ b/coprocessor/fhevm-engine/host-listener/build.rs
@@ -51,17 +51,8 @@ fn build_contracts() {
     }
     println!("Ran npm ci successfully");
 
-    // Step 3: Run `npm install && HARDHAT_NETWORK=hardhat npm run
-    // deploy:emptyProxies && npx hardhat compile` in ../../contracts
-    let npm_install_status = Command::new("npm")
-        .arg("install")
-        .status()
-        .expect("Failed to run npm install");
-    if !npm_install_status.success() {
-        panic!("Error: npm install failed");
-    }
-    println!("Ran npm install successfully");
-
+    // Step 3: Run `HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies
+    // && npx hardhat compile` in ../../contracts
     let npm_run_status = Command::new("npm")
         .env("HARDHAT_NETWORK", "hardhat")
         .args(["run", "deploy:emptyProxies"])


### PR DESCRIPTION
## Summary

Remove redundant `npm install` call after `npm ci` in host-listener build script.

`npm ci` already performs a complete clean install from `package-lock.json`. The subsequent `npm install` does nothing useful but wastes ~100 seconds checking dependencies.

## Benchmark

| Before | After | Improvement |
|--------|-------|-------------|
| 3m 51s | 2m 04s | **-46%** |

## Test plan

- [x] Benchmarked locally with clean builds