### PR TITLE
fix(coprocessor): remove redundant npm install in GPU workflows

### DIFF
--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -232,7 +232,7 @@ jobs:
         run: |
           cp ./host-contracts/.env.example ./host-contracts/.env
           npm --workspace=host-contracts ci --include=optional
-          cd host-contracts && npm install && npm run deploy:emptyProxies && npx hardhat compile
+          cd host-contracts && npm run deploy:emptyProxies && npx hardhat compile
 
       - name: Run benchmarks on GPU
         run: |

--- a/.github/workflows/coprocessor-gpu-tests.yml
+++ b/.github/workflows/coprocessor-gpu-tests.yml
@@ -181,7 +181,7 @@ jobs:
 
       - run: cp ./host-contracts/.env.example ./host-contracts/.env
       - run: npm --workspace=host-contracts ci --include=optional
-      - run: "cd host-contracts && npm install && npm run deploy:emptyProxies && npx hardhat compile"
+      - run: "cd host-contracts && npm run deploy:emptyProxies && npx hardhat compile"
         env:
           HARDHAT_NETWORK: hardhat
 


### PR DESCRIPTION
## Summary

Remove redundant `npm install` call after `npm ci` in GPU CI workflows.

`npm ci` already performs a complete clean install from `package-lock.json`. The subsequent `npm install` does nothing useful but wastes a few minutes checking dependencies on each workflow run.

**Files changed:**
- `.github/workflows/coprocessor-benchmark-gpu.yml`
- `.github/workflows/coprocessor-gpu-tests.yml`

Similar fix to #1867 which addressed the same issue in `host-listener/build.rs`.