### PR TITLE
fix(coprocessor): use npm ci for deterministic builds

### DIFF
--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -41,9 +41,9 @@ COPY package.json package-lock.json ./
 COPY host-contracts ./host-contracts
 
 # Compile host-contracts
-WORKDIR /app/host-contracts
-RUN cp .env.example .env && \
+RUN cp host-contracts/.env.example host-contracts/.env && \
     npm ci --workspace=host-contracts --include-workspace-root=false && \
+    cd host-contracts && \
     HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
     npx hardhat compile
 

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -40,7 +40,7 @@ COPY host-contracts ./host-contracts
 # Compile host-contracts
 WORKDIR /app/host-contracts
 RUN cp .env.example .env && \
-    npm ci && \
+    npm install && \
     HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
     npx hardhat compile
 
@@ -50,7 +50,7 @@ COPY gateway-contracts ./gateway-contracts
 
 # Compile gateway-contracts
 WORKDIR /app/gateway-contracts
-RUN npm ci && \
+RUN npm install && \
     DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
 
 # =============================================================================

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -40,7 +40,7 @@ COPY host-contracts ./host-contracts
 # Compile host-contracts
 WORKDIR /app/host-contracts
 RUN cp .env.example .env && \
-    npm install && \
+    npm ci && \
     HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
     npx hardhat compile
 
@@ -50,7 +50,7 @@ COPY gateway-contracts ./gateway-contracts
 
 # Compile gateway-contracts
 WORKDIR /app/gateway-contracts
-RUN npm install && \
+RUN npm ci && \
     DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
 
 # =============================================================================

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -34,23 +34,26 @@ FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
 USER root
 WORKDIR /app
 
-# Copy host-contracts for host-listener
+# Copy root package files for workspace resolution
+COPY package.json package-lock.json ./
+
+# Copy host-contracts (workspace member)
 COPY host-contracts ./host-contracts
 
-# Compile host-contracts
+# Compile host-contracts using workspace-aware npm ci
 WORKDIR /app/host-contracts
 RUN cp .env.example .env && \
-    npm install && \
+    npm ci --workspace=host-contracts --include-workspace-root=false && \
     HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
     npx hardhat compile
 
-# Copy gateway-contracts for gw-listener
+# Copy gateway-contracts (standalone, has own lockfile)
 WORKDIR /app
 COPY gateway-contracts ./gateway-contracts
 
 # Compile gateway-contracts
 WORKDIR /app/gateway-contracts
-RUN npm install && \
+RUN npm ci && \
     DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
 
 # =============================================================================

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -34,20 +34,20 @@ FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
 USER root
 WORKDIR /app
 
-# Copy root package files for workspace resolution
+# Copy root lockfile for workspace resolution
 COPY package.json package-lock.json ./
 
-# Copy host-contracts (workspace member)
+# Copy host-contracts for host-listener
 COPY host-contracts ./host-contracts
 
-# Compile host-contracts using workspace-aware npm ci
+# Compile host-contracts
 WORKDIR /app/host-contracts
 RUN cp .env.example .env && \
     npm ci --workspace=host-contracts --include-workspace-root=false && \
     HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
     npx hardhat compile
 
-# Copy gateway-contracts (standalone, has own lockfile)
+# Copy gateway-contracts for gw-listener
 WORKDIR /app
 COPY gateway-contracts ./gateway-contracts
 

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -5,12 +5,18 @@ USER root
 
 WORKDIR /app
 
+# Copy root package files for workspace resolution
+COPY package.json package-lock.json ./
+
+# Copy host-contracts (workspace member)
 COPY host-contracts ./host-contracts
 
 # Compiled host-contracts for listeners
 WORKDIR /app/host-contracts
 RUN cp .env.example .env
-RUN npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile
+RUN npm ci --workspace=host-contracts --include-workspace-root=false && \
+    HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
+    npx hardhat compile
 
 # Stage 1: Build Host Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -10,7 +10,7 @@ COPY host-contracts ./host-contracts
 # Compiled host-contracts for listeners
 WORKDIR /app/host-contracts
 RUN cp .env.example .env
-RUN npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile
+RUN npm ci && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile
 
 # Stage 1: Build Host Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -5,10 +5,9 @@ USER root
 
 WORKDIR /app
 
-# Copy root package files for workspace resolution
+# Copy root lockfile for workspace resolution
 COPY package.json package-lock.json ./
 
-# Copy host-contracts (workspace member)
 COPY host-contracts ./host-contracts
 
 # Compiled host-contracts for listeners

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -11,9 +11,9 @@ COPY package.json package-lock.json ./
 COPY host-contracts ./host-contracts
 
 # Compiled host-contracts for listeners
-WORKDIR /app/host-contracts
-RUN cp .env.example .env
-RUN npm ci --workspace=host-contracts --include-workspace-root=false && \
+RUN cp host-contracts/.env.example host-contracts/.env && \
+    npm ci --workspace=host-contracts --include-workspace-root=false && \
+    cd host-contracts && \
     HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
     npx hardhat compile
 

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -10,7 +10,7 @@ COPY host-contracts ./host-contracts
 # Compiled host-contracts for listeners
 WORKDIR /app/host-contracts
 RUN cp .env.example .env
-RUN npm ci && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile
+RUN npm install && HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && npx hardhat compile
 
 # Stage 1: Build Host Listener
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder


### PR DESCRIPTION
## Summary

Use `npm ci` with proper lockfile access for deterministic Docker builds.

**Problem:** The Dockerfiles were using `npm install` which:
- Can modify `package-lock.json` if versions don't match
- Resolves dependencies at build time (non-deterministic)
- Produces different results depending on npm registry state

**Solution:** Copy the root `package-lock.json` into the build context and use `npm ci`:

**Files changed:**
- `coprocessor/fhevm-engine/host-listener/Dockerfile`
- `coprocessor/fhevm-engine/Dockerfile.workspace`