### PR TITLE
chore(test-suite): upgrade relayer-sdk to v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25607,7 +25607,7 @@
       "dependencies": {
         "@fhevm/solidity": "*",
         "@openzeppelin/contracts": "^5.3.0",
-        "@zama-fhe/relayer-sdk": "^0.4.0-5",
+        "@zama-fhe/relayer-sdk": "^0.4.0",
         "bigint-buffer": "^1.1.5",
         "dotenv": "^16.0.3",
         "encrypted-types": "^0.0.4"
@@ -27423,9 +27423,9 @@
       }
     },
     "test-suite/e2e/node_modules/@zama-fhe/relayer-sdk": {
-      "version": "0.4.0-5",
-      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.0-5.tgz",
-      "integrity": "sha512-UraJ8r2rPB6INfRFXXxSgBvkSG4FSuJ3pG0bOAFHN1LOdRiOy0P1tvi9UVbeuOITXUJishAVt+4ft3xxRXt+QA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@zama-fhe/relayer-sdk/-/relayer-sdk-0.4.0.tgz",
+      "integrity": "sha512-gWk9lubkL1UFVuaZcjtKmGUzed9ki+s/lfUpp4MoHDjhmRnpos04fk1xjpEfCTJo9fu4/FpkQ8dw/RqySzotkg==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "commander": "^14.0.0",

--- a/test-suite/e2e/package.json
+++ b/test-suite/e2e/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@fhevm/solidity": "*",
     "@openzeppelin/contracts": "^5.3.0",
-    "@zama-fhe/relayer-sdk": "^0.4.0-5",
+    "@zama-fhe/relayer-sdk": "^0.4.0",
     "bigint-buffer": "^1.1.5",
     "dotenv": "^16.0.3",
     "encrypted-types": "^0.0.4"


### PR DESCRIPTION
Backport commit https://github.com/zama-ai/fhevm/pull/1871/commits/c4d8c7bed155e6a5ba27339effce7564270ce469