### PR TITLE
perf: avoid unnecessary clones in query_ciphertexts

### DIFF
--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -263,11 +263,8 @@ async fn query_ciphertexts<'a>(
     // index ciphertexts in hashmap
     let mut ciphertext_map: HashMap<Vec<u8>, (i16, Vec<u8>)> =
         HashMap::with_capacity(ciphertexts_rows.len());
-    for row in &ciphertexts_rows {
-        let _ = ciphertext_map.insert(
-            row.handle.clone(),
-            (row.ciphertext_type, row.ciphertext.clone()),
-        );
+    for row in ciphertexts_rows {
+        let _ = ciphertext_map.insert(row.handle, (row.ciphertext_type, row.ciphertext));
     }
     Ok(ciphertext_map)
 }


### PR DESCRIPTION
Optimized memory usage by moving row ownership directly into `ciphertext_map` instead of cloning. This eliminates unnecessary double-allocations of ciphertext buffers