### PR TITLE
fix(coprocessor): gate test bypass behind feature flag

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3888,6 +3888,7 @@ dependencies = [
  "fhevm_gateway_bindings",
  "foundry-compilers",
  "futures-util",
+ "gw-listener",
  "humantime",
  "prometheus",
  "rustls 0.23.31",

--- a/coprocessor/fhevm-engine/gw-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/gw-listener/Cargo.toml
@@ -5,6 +5,10 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+test_bypass_key_extraction = []
+
 [dependencies]
 # workspace dependencies
 alloy = { workspace = true }
@@ -43,3 +47,8 @@ alloy = { workspace = true, features = ["node-bindings"] }
 aws-smithy-mocks = "0.1.1"
 serial_test = { workspace = true }
 test-harness = { path = "../test-harness" }
+
+# Enable test bypass features for integration tests
+[dev-dependencies.gw-listener]
+path = "."
+features = ["test_bypass_key_extraction"]

--- a/coprocessor/fhevm-engine/gw-listener/src/sks_key.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/sks_key.rs
@@ -3,9 +3,10 @@ use tfhe::ServerKey;
 use fhevm_engine_common::utils::{safe_deserialize_sns_key, safe_serialize_key};
 
 pub fn extract_server_key_without_ns(sns_key: &[u8]) -> anyhow::Result<Vec<u8>> {
-    // for integration tests
-    if sns_key == "key_bytes".as_bytes() {
-        return Ok("key_bytes".as_bytes().to_vec());
+    // Bypass for integration tests
+    #[cfg(feature = "test_bypass_key_extraction")]
+    if sns_key == b"key_bytes" {
+        return Ok(b"key_bytes".to_vec());
     }
 
     let server_key: ServerKey = safe_deserialize_sns_key(sns_key)?;


### PR DESCRIPTION
The `extract_server_key_without_ns` function had a hardcoded bypass for `"key_bytes"` that was part of production code

Wrap the bypass in `#[cfg(feature = "test_bypass_key_extraction")]` and enable it only for dev builds via self-referential dev-dependency (already done in other parts of the codebase)