### PR TITLE
feat(coprocessor): group dependency graph via SCC

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/database/dependence_chains.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/dependence_chains.rs
@@ -115,7 +115,7 @@ fn tx_of_handle(
     (handle_creator, handle_consumer)
 }
 
-async fn fill_tx_dependence_maps(
+async fn populate_tx_dependencies(
     txs: &mut HashMap<TransactionHash, Transaction>,
     past_chains: &ChainCache,
 ) {
@@ -721,7 +721,7 @@ pub async fn dependence_chains(
     across_blocks: bool,
 ) -> OrderedChains {
     let (ordered_hash, mut txs) = scan_transactions(logs);
-    fill_tx_dependence_maps(&mut txs, past_chains).await;
+    populate_tx_dependencies(&mut txs, past_chains).await;
     debug!("Transactions: {:?}", txs.values());
     let GroupBuild {
         ordered_groups,

--- a/coprocessor/fhevm-engine/host-listener/src/database/dependence_chains.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/dependence_chains.rs
@@ -306,6 +306,12 @@ fn build_group_nodes(
     let mut edges = Vec::new();
     for (group_id, group_tx) in group_txs.iter() {
         for dep in group_tx.input_tx.iter() {
+            used_groups_chains
+                .entry(*dep)
+                .and_modify(|v| {
+                    v.insert(*group_id);
+                })
+                .or_insert_with(|| HashSet::from([*group_id]));
             if group_ids.contains(dep) {
                 edges.push((*dep, *group_id));
             }
@@ -315,12 +321,6 @@ fn build_group_nodes(
         if let Some(dep_tx) = group_txs.get_mut(&dep) {
             dep_tx.output_tx.insert(child);
         }
-        used_groups_chains
-            .entry(dep)
-            .and_modify(|v| {
-                v.insert(child);
-            })
-            .or_insert_with(|| HashSet::from([child]));
     }
 
     GroupBuild {


### PR DESCRIPTION
## Summary
- Collapse per-block dependency graph into SCC groups before ordering
- Compute group-level depth_size and propagate deterministic per-tx offsets
- Add cycle grouping tests (simple cycle, cycle with two parents)

## Testing
- cargo test -p host-listener --manifest-path coprocessor/fhevm-engine/Cargo.toml dependence_chains_cycle
- cargo test -p host-listener --manifest-path coprocessor/fhevm-engine/Cargo.toml test_past_chain_fork
- cargo test --manifest-path coprocessor/fhevm-engine/Cargo.toml (fails in sns-worker: tests::test_batch_execution, error deserializing ciphertext: "the size limit has been reached")