### PR TITLE
docs: restore broken link

### DIFF
--- a/docs/examples/openzeppelin/erc7984-tutorial.md
+++ b/docs/examples/openzeppelin/erc7984-tutorial.md
@@ -20,7 +20,7 @@ Before starting this tutorial, ensure you have:
 2. Set up the OpenZeppelin confidential contracts library 
 
 For help with these steps, refer to the following tutorial:
-- [Setting up OpenZeppelin confidential contracts](./openzeppelin/README.md)
+- [Setting up OpenZeppelin confidential contracts](./README.md)
 
 ## Understanding the architecture
 


### PR DESCRIPTION
## Summary
Update `erc7984-tutorial.md`

**Problem**: 
A link to `./openzeppelin/README.md` is broken

**Solution**: 
restore the link to `./README.md`

**Files changed**:
- `ocs/examples/openzeppelin/erc7984-tutorial.md`


