### PR TITLE
chore(common): implement NO TYPO POLICY with typos spell checker

### DIFF
--- a/.github/workflows/common-typos-check.yml
+++ b/.github/workflows/common-typos-check.yml
@@ -1,0 +1,18 @@
+name: common-typos-check
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  typos-check:
+    name: common-typos-check/typos (bpr)
+    permissions:
+      contents: 'read'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+      - uses: crate-ci/typos@93cbdb2d23269548cf0db0f74d0bc6a09a3f0d5c # v1.43.0

--- a/coprocessor/README.md
+++ b/coprocessor/README.md
@@ -2,7 +2,7 @@
 **FHEVM Coprocessor** provides the execution service for FHE computations.
 
 It includes a **Coprocessor** service [FHEVM-coprocessor](docs/getting_started/fhevm/coprocessor/coprocessor_backend.md). The Coprocessor
-itself consists of multiple microservices, e.g. for FHE compute, input verify, transaction sending, listenting to events, etc.
+itself consists of multiple microservices, e.g. for FHE compute, input verify, transaction sending, listening to events, etc.
 
 ## Main features
 
@@ -86,7 +86,7 @@ Options:
           Work items batch size [default: 10]
       --tenant-key-cache-size <TENANT_KEY_CACHE_SIZE>
           Tenant key cache size [default: 32]
-      --maximimum-compact-inputs-upload <MAXIMIMUM_COMPACT_INPUTS_UPLOAD>
+      --maximum-compact-inputs-upload <MAXIMUM_COMPACT_INPUTS_UPLOAD>
           Maximum compact inputs to upload [default: 10]
       --maximum-handles-per-input <MAXIMUM_HANDLES_PER_INPUT>
           Maximum compact inputs to upload [default: 255]

--- a/coprocessor/docs/fundamentals/fhevm/contracts.md
+++ b/coprocessor/docs/fundamentals/fhevm/contracts.md
@@ -12,7 +12,7 @@ _Note_: All those contracts are initially deployed behind UUPS proxies, so could
 
 ## FHEVMExecutor Contract
 
-Symbolic execution on the blockchain is implemented via the [FHEVMExecutor](../../../contracts/contracts/FHEVMExecutor.sol) contract. One of its main responsibilites is to deterministically generate ciphertext handles. For this, we hash the FHE operation requested and the inputs to produce the result handle H:
+Symbolic execution on the blockchain is implemented via the [FHEVMExecutor](../../../contracts/contracts/FHEVMExecutor.sol) contract. One of its main responsibilities is to deterministically generate ciphertext handles. For this, we hash the FHE operation requested and the inputs to produce the result handle H:
 
 ```
 H = keccak256(fheOperation, input1, input2, ..., inputN)
@@ -24,7 +24,7 @@ Inputs can either be other handles or plaintext values.
 
 The [ACL](../../../contracts/contracts/ACL.sol) contract enforces access control for ciphertexts. The model we adopt is very simple - a ciphertext is either allowed for an address or not. An address can be any address - either an EOA address or a contract address. Essentially, it is a mapping from handle to a set of addresses that are allowed to use the handle.
 
-Access control applies to transfering ciphertexts from one contract to another, for FHE computation on ciphertexts, for decryption and for reencryption of a ciphertext to a user-provided key.
+Access control applies to transferring ciphertexts from one contract to another, for FHE computation on ciphertexts, for decryption and for reencryption of a ciphertext to a user-provided key.
 
 ### Garbage Collection of Allowed Ciphertexts Data
 

--- a/coprocessor/docs/fundamentals/fhevm/symbolic_execution.md
+++ b/coprocessor/docs/fundamentals/fhevm/symbolic_execution.md
@@ -2,7 +2,7 @@
 
 Symbolic execution is a method of constructing a computational graph of FHE operations without actually doing the FHE computation. It works by utilizing what we call a ciphertext **handle**. The handle could be thought of as an unique "pointer" to a given FHE ciphertext.and is implemented as a 32-byte value that is a result of applying a hash function to either an FHE ciphertext or other handles. Symbolic execution also checks constraints on input handles (e.g. the access control list, whether types match, etc.).
 
-Symbolic execution onchain is implemented via the [FHEVMExecutor](../../../contracts/contracts/FHEVMExecutor.sol) contract. One of its main responsibilites is to deterministically generate ciphertext handles. For this, we hash the FHE operation requested and the inputs to produce the result handle H:
+Symbolic execution onchain is implemented via the [FHEVMExecutor](../../../contracts/contracts/FHEVMExecutor.sol) contract. One of its main responsibilities is to deterministically generate ciphertext handles. For this, we hash the FHE operation requested and the inputs to produce the result handle H:
 
 ```
 H = keccak256(fheOperation, input1, input2, ..., inputN)
@@ -12,7 +12,7 @@ Inputs can either be other handles or plaintext values.
 
 ## FHE Computation Data Dependencies
 
-Note that FHEVM-native and FHEVM-coprocessor send both input handles and result handles for FHE computation. It is able to do that, because result handles are computed symbolically in the FHEVMExecutor contract. That allows for parallel FHE computation by analysing which computations are independent.
+Note that FHEVM-native and FHEVM-coprocessor send both input handles and result handles for FHE computation. It is able to do that, because result handles are computed symbolically in the FHEVMExecutor contract. That allows for parallel FHE computation by analyzing which computations are independent.
 
 The Executor or Coprocessor can detect a conflict if an output of computation A (or the output of another computation depending on the output of A) is also used as an input in a subsequent computation B. We call these computations `dependent` and we need to execute them in order.
 

--- a/coprocessor/docs/fundamentals/gateway/decryption.md
+++ b/coprocessor/docs/fundamentals/gateway/decryption.md
@@ -1,6 +1,6 @@
 # Decryption
 
-Everything in FHEVM is encrypted, at some point one could need to decrypt somes values. Let's give as illustration a blind auction application.
+Everything in FHEVM is encrypted, at some point one could need to decrypt some values. Let's give as illustration a blind auction application.
 After reaching the end of the auction, one need to discover (only) the winner, here is where a asynchronous decrypt could appear. 
 
 
@@ -9,7 +9,7 @@ After reaching the end of the auction, one need to discover (only) the winner, h
 ## How it's working
 
 The Gateway acts as an oracle service: it will listen to decryption request events and return the decrypted value through a callback function.
-The responsabilities of the Gateway are:
+The responsibilities of the Gateway are:
 - Listening decryption request from FHEVM that contains a handle `h` that corresponds to a  ciphertext `C`
 - Computing a storage proof `P` to attest h (i.e. C)  is decryptable
 - Retrieve C from FHEVM using `h` as key

--- a/coprocessor/docs/fundamentals/glossary.md
+++ b/coprocessor/docs/fundamentals/glossary.md
@@ -6,7 +6,7 @@
 
 - _FheLib_: A precompiled contract on FHEVM-native that is available on nodes/validators. Exposes functions such as reading FHE ciphertexts from the on-chain storage in FHEVM-native, etc. At the time of writing, it exists at address **0x000000000000000000000000000000000000005d**.
 
-- _fhEVM-coprocessor_: An FHEVM configuration where an off-chain Coprocessor component does the actual FHE computation. FHE ciphertexts are stored in an off-chain database local to the Coprocessor and in an off-chain public Data Availablility (DA) layer. No modifications the validator software of the existing chain is required (except for the full-node running for the Coprocessor).
+- _fhEVM-coprocessor_: An FHEVM configuration where an off-chain Coprocessor component does the actual FHE computation. FHE ciphertexts are stored in an off-chain database local to the Coprocessor and in an off-chain public Data Availability (DA) layer. No modifications the validator software of the existing chain is required (except for the full-node running for the Coprocessor).
 
 - _fhEVM-native_: An FHEVM configuration where each validator is paired with an Executor. FHE ciphertexts are stored on-chain. FHEVM-native requires modifications to the validator software of an existing chain.
 

--- a/coprocessor/docs/fundamentals/tkms/blockchain.md
+++ b/coprocessor/docs/fundamentals/tkms/blockchain.md
@@ -14,4 +14,4 @@ The blockchain handles all decryption, reencryption, and key management operatio
 All operations must be paid for with tokens. Currently the tokenomics is not implemented and hence tokens can be constructed freely using a focet.
 
 ## Deployment
-The KMS blockchain is deployed using `n` servers where `n` is the number of MPC parties. Each run their own validator docker image but is depoyed on the same machine as each of the MPC parties.
+The KMS blockchain is deployed using `n` servers where `n` is the number of MPC parties. Each run their own validator docker image but is deployed on the same machine as each of the MPC parties.

--- a/coprocessor/docs/fundamentals/tkms/threshold.md
+++ b/coprocessor/docs/fundamentals/tkms/threshold.md
@@ -10,6 +10,6 @@ The cryptographic operations carried out by the threshold back=end are fulfilled
 The underlying MPC protocol is what is known as a _statistically maliciously robust_ and _proactively_ secure MPC protocol. Specifically this implies the following:
 - Statistically: the underlying protocols cannot be “broken” by an adversary regardless of the amount of computation power. This also means that they do not rely on any exotic cryptographic assumptions. (For practical reasons standard security of hash functions is still required.)
 - Maliciously Robust: the protocol can finish execution _correctly_ with up to `t` parties misbehaving by running rogue software or not participating.
-- Proactive: it is possible to "undo" a leakage of key material of at most `t` parties byt refreshing their key shares. That is, if a few servers are compromised it is possible to make the stolen material 100% useless without the need to regenerate a new public key.
+- Proactive: it is possible to "undo" a leakage of key material of at most `t` parties by refreshing their key shares. That is, if a few servers are compromised it is possible to make the stolen material 100% useless without the need to regenerate a new public key.
 
 The MPC protocol is based on peer-reviewed cryptographic core protocols and peer reviewed modifications. For more modifications see [this paper](https://eprint.iacr.org/2023/815).

--- a/coprocessor/docs/getting_started/fhevm/coprocessor/configuration.md
+++ b/coprocessor/docs/getting_started/fhevm/coprocessor/configuration.md
@@ -46,7 +46,7 @@ Options:
           Work items batch size [default: 10]
       --tenant-key-cache-size <TENANT_KEY_CACHE_SIZE>
           Tenant key cache size [default: 32]
-      --maximimum-compact-inputs-upload <MAXIMIMUM_COMPACT_INPUTS_UPLOAD>
+      --maximum-compact-inputs-upload <MAXIMUM_COMPACT_INPUTS_UPLOAD>
           Maximum compact inputs to upload [default: 10]
       --maximum-handles-per-input <MAXIMUM_HANDLES_PER_INPUT>
           Maximum compact inputs to upload [default: 255]

--- a/coprocessor/docs/getting_started/fhevm/coprocessor/coprocessor_backend.md
+++ b/coprocessor/docs/getting_started/fhevm/coprocessor/coprocessor_backend.md
@@ -1,6 +1,6 @@
 # Coprocessor Backend
 
-A Coprocesor backend is needed to run alongside the geth node. The Coprocessor backend executes the actual FHE computation. Please look at [FHE Computation](../../../fundamentals/fhevm/coprocessor/fhe_computation.md) for more info.
+A Coprocessor backend is needed to run alongside the geth node. The Coprocessor backend executes the actual FHE computation. Please look at [FHE Computation](../../../fundamentals/fhevm/coprocessor/fhe_computation.md) for more info.
 
 The coprocessor backend is implemented in the [Coprocessor](../../../../fhevm-engine/coprocessor/README.md) directory of `fhevm-engine`.
 

--- a/docs/examples/fheadd.md
+++ b/docs/examples/fheadd.md
@@ -46,11 +46,11 @@ contract FHEAdd is ZamaEthereumConfig {
     // It does not matter if the contract caller (`msg.sender`) has FHE permission or not.
     _a_plus_b = FHE.add(_a, _b);
 
-    // At this point the contract ifself (`address(this)`) has been granted ephemeral FHE permission
+    // At this point the contract itself (`address(this)`) has been granted ephemeral FHE permission
     // over `_a_plus_b`. This FHE permission will be revoked when the function exits.
     //
     // Now, to make sure `_a_plus_b` can be decrypted by the contract caller (`msg.sender`),
-    // we need to grant permanent FHE permissions to both the contract ifself (`address(this)`)
+    // we need to grant permanent FHE permissions to both the contract itself (`address(this)`)
     // and the contract caller (`msg.sender`)
     FHE.allowThis(_a_plus_b);
     FHE.allow(_a_plus_b, msg.sender);

--- a/docs/examples/wallet-guide.md
+++ b/docs/examples/wallet-guide.md
@@ -22,8 +22,8 @@ While building support for ERC-7984 confidential tokens in your wallet/app, you 
 
 At a high-level, to integrate Zama Protocol into a wallet, you do **not** need to run FHE infrastructure. You can interact with the Zama Protocol using [Relayer SDK](https://docs.zama.org/protocol/relayer-sdk-guides) in your wallet or app. These are the steps at a high-level:
 
-1. **Relayer SDK initialisation** in web app, browser extension, or mobile app. Follow the [setup guide for Relayer SDK](https://docs.zama.org/protocol/relayer-sdk-guides/development-guide/webapp). In browser contexts, importing the library via the CDN links is easiest. Alternatively, do this by importing the `@zama-fhe/relayer-sdk` NPM package.
-2. [Configure and initialise settings](https://docs.zama.org/protocol/relayer-sdk-guides/fhevm-relayer/initialization) for the library.
+1. **Relayer SDK initialization** in web app, browser extension, or mobile app. Follow the [setup guide for Relayer SDK](https://docs.zama.org/protocol/relayer-sdk-guides/development-guide/webapp). In browser contexts, importing the library via the CDN links is easiest. Alternatively, do this by importing the `@zama-fhe/relayer-sdk` NPM package.
+2. [Configure and initialize settings](https://docs.zama.org/protocol/relayer-sdk-guides/fhevm-relayer/initialization) for the library.
 3. **Confidential token (ERC-7984) basics**:
     - Show encrypted balances using **user decryption**.
     - Build **transfers** using encrypted inputs. Refer to [OpenZeppelin’s ERC-7984 token guide](https://docs.openzeppelin.com/confidential-contracts/token).
@@ -73,7 +73,7 @@ pnpm run start
 
 ![Connect wallet to demo app](../.gitbook/assets/wallet-guide-1.png)
 
-**Step 2**: User can now sign and fetch their decrypted ERC-7984 confidential token balance. Balances are stored as ciphertext handles. To display a user’s balance, read the balance handle from your token and [perform **user decryption**](https://docs.zama.ai/protocol/relayer-sdk-guides/v0.1/fhevm-relayer/decryption/user-decryption) with an EIP-712-authorised session in the wallet. Ensure the token grants ACL permission to the user before decrypting.
+**Step 2**: User can now sign and fetch their decrypted ERC-7984 confidential token balance. Balances are stored as ciphertext handles. To display a user’s balance, read the balance handle from your token and [perform **user decryption**](https://docs.zama.ai/protocol/relayer-sdk-guides/v0.1/fhevm-relayer/decryption/user-decryption) with an EIP-712-authorized session in the wallet. Ensure the token grants ACL permission to the user before decrypting.
 
 ![Sign user decryption request](../.gitbook/assets/wallet-guide-2.png)
 

--- a/docs/solidity-guides/decryption/oracle.md
+++ b/docs/solidity-guides/decryption/oracle.md
@@ -125,7 +125,7 @@ contract FooBarContract is ZamaEthereumConfig {
 
   function _runFooBarClearBusinessLogicFinalization() private {
     // Business logic starts here.
-    // Transfer ERC20, releave price or winner etc.
+    // Transfer ERC20, reveal price or winner etc.
   }
 }
 ```

--- a/docs/solidity-guides/functions.md
+++ b/docs/solidity-guides/functions.md
@@ -168,7 +168,7 @@ function max(uint32 a, euint8 b) internal view returns (euint32)
 There are two unary operators: `neg` (`-`) and `not` (`!`). Note that since we work with unsigned integers, the result of negation is interpreted as the modular opposite. The `not` operator returns the value obtained after flipping all the bits of the operand.
 
 {% hint style="info" %}
-More information about the behavior of these operators can be found at the [TFHE-rs docs](https://docs.zama.ai/tfhe-rs/fhe-computation/operations/arithmetic-operations).
+More information about the behaviour of these operators can be found at the [TFHE-rs docs](https://docs.zama.ai/tfhe-rs/fhe-computation/operations/arithmetic-operations).
 {% endhint %}
 
 ### Bitwise operations
@@ -177,7 +177,7 @@ More information about the behavior of these operators can be found at the [TFHE
 
 #### Bitwise operations (`AND`, `OR`, `XOR`)
 
-Unlike other binary operations, bitwise operations do not natively accept a mix of ciphertext and plaintext inputs. To ease developer experience, the `FHE` library adds function overloads for these operations. Such overloads implicitely do a trivial encryption before actually calling the operation function, as shown in the examples below.
+Unlike other binary operations, bitwise operations do not natively accept a mix of ciphertext and plaintext inputs. To ease developer experience, the `FHE` library adds function overloads for these operations. Such overloads implicitly do a trivial encryption before actually calling the operation function, as shown in the examples below.
 
 Available for euint\* types:
 
@@ -227,7 +227,7 @@ function rotr(euint32 a, euint16 b) internal view returns (euint32)
 **Note** that in the case of ciphertext-plaintext operations, since our backend only accepts plaintext right operands, calling the operation with a plaintext left operand will actually invert the operand order and call the _opposite_ comparison.
 {% endhint %}
 
-The result of comparison operations is an encrypted boolean (`ebool`). In the backend, the boolean is represented by an encrypted unsinged integer of bit width 8, but this is abstracted away by the Solidity library.
+The result of comparison operations is an encrypted boolean (`ebool`). In the backend, the boolean is represented by an encrypted unsigned integer of bit width 8, but this is abstracted away by the Solidity library.
 
 Available for all encrypted types:
 

--- a/docs/solidity-guides/getting-started/quick-start-tutorial/write_a_simple_contract.md
+++ b/docs/solidity-guides/getting-started/quick-start-tutorial/write_a_simple_contract.md
@@ -6,8 +6,8 @@ In the [next tutorial](turn_it_into_fhevm.md), you'll learn how to convert this 
 
 ## Prerequisite
 
-- [Set up your Hardhat envrionment](setup.md).
-- Make sure that you Hardhat project is clean and ready to start. See the instructions [here](setup.md#rest-set-the-hardhat-envrionment).
+- [Set up your Hardhat environment](setup.md).
+- Make sure that you Hardhat project is clean and ready to start. See the instructions [here](setup.md#rest-set-the-hardhat-environment).
 
 ## What you'll learn
 

--- a/docs/solidity-guides/hardhat/write_task.md
+++ b/docs/solidity-guides/hardhat/write_task.md
@@ -23,12 +23,12 @@ task("task:get-count", "Calls the getCount() function of Counter Contract")
   .setAction(async function (taskArguments: TaskArguments, hre) {
     const { ethers, deployments } = hre;
 
-    const CounterDeployement = taskArguments.address
+    const CounterDeployment = taskArguments.address
       ? { address: taskArguments.address }
       : await deployments.get("Counter");
-    console.log(`Counter: ${CounterDeployement.address}`);
+    console.log(`Counter: ${CounterDeployment.address}`);
 
-    const counterContract = await ethers.getContractAt("Counter", CounterDeployement.address);
+    const counterContract = await ethers.getContractAt("Counter", CounterDeployment.address);
 
     const clearCount = await counterContract.getCount();
 
@@ -51,12 +51,12 @@ task("task:get-count", "Calls the getCount() function of Counter Contract")
   .setAction(async function (taskArguments: TaskArguments, hre) {
     // const { ethers, deployments } = hre;
 
-    // const CounterDeployement = taskArguments.address
+    // const CounterDeployment = taskArguments.address
     //   ? { address: taskArguments.address }
     //   : await deployments.get("Counter");
-    // console.log(`Counter: ${CounterDeployement.address}`);
+    // console.log(`Counter: ${CounterDeployment.address}`);
 
-    // const counterContract = await ethers.getContractAt("Counter", CounterDeployement.address);
+    // const counterContract = await ethers.getContractAt("Counter", CounterDeployment.address);
 
     // const clearCount = await counterContract.getCount();
 
@@ -110,12 +110,12 @@ Calling `initializeCLIApi()` is essential. Unlike built-in Hardhat tasks like `t
 Replace the following commented-out lines:
 
 ```ts
-    // const CounterDeployement = taskArguments.address
+    // const CounterDeployment = taskArguments.address
     //   ? { address: taskArguments.address }
     //   : await deployments.get("Counter");
-    // console.log(`Counter: ${CounterDeployement.address}`);
+    // console.log(`Counter: ${CounterDeployment.address}`);
 
-    // const counterContract = await ethers.getContractAt("Counter", CounterDeployement.address);
+    // const counterContract = await ethers.getContractAt("Counter", CounterDeployment.address);
 
     // const clearCount = await counterContract.getCount();
 ```
@@ -123,12 +123,12 @@ Replace the following commented-out lines:
 With the FHEVM equivalent:
 
 ```ts
-    const FHECounterDeployement = taskArguments.address
+    const FHECounterDeployment = taskArguments.address
       ? { address: taskArguments.address }
       : await deployments.get("FHECounter");
-    console.log(`FHECounter: ${FHECounterDeployement.address}`);
+    console.log(`FHECounter: ${FHECounterDeployment.address}`);
 
-    const fheCounterContract = await ethers.getContractAt("FHECounter", FHECounterDeployement.address);
+    const fheCounterContract = await ethers.getContractAt("FHECounter", FHECounterDeployment.address);
 
     const encryptedCount = await fheCounterContract.getCount();
     if (encryptedCount === ethers.ZeroHash) {
@@ -158,7 +158,7 @@ With the decryption logic:
     const clearCount = await fhevm.userDecryptEuint(
       FhevmType.euint32,
       encryptedCount,
-      FHECounterDeployement.address,
+      FHECounterDeployment.address,
       signers[0],
     );
     console.log(`Encrypted count: ${encryptedCount}`);

--- a/docs/solidity-guides/hardhat/write_test.md
+++ b/docs/solidity-guides/hardhat/write_test.md
@@ -52,7 +52,7 @@ To compute these arguments in TypeScript, you need:
 
 {% step %}
 
-#### Create a new encryted input
+#### Create a new encrypted input
 
 ```ts
 // use the `fhevm` API module from the Hardhat Runtime Environment

--- a/docs/solidity-guides/transform_smart_contract_with_fhevm.md
+++ b/docs/solidity-guides/transform_smart_contract_with_fhevm.md
@@ -130,7 +130,7 @@ Adjust your contract’s code to accept and return encrypted data where necessar
 
 However, it is far from being the main change. As this example illustrates, working with FHEVM often requires re-architecting the original logic to support privacy. 
 
-In the updated code, the logic becomes async; results are hidden until a request (to the oracle) explicitely has to be made to decrypt publically the vote results.
+In the updated code, the logic becomes async; results are hidden until a request (to the oracle) explicitly has to be made to decrypt publicly the vote results.
 
 ## Conclusion
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,154 @@
+# typos configuration for FHEVM monorepo
+# https://github.com/crate-ci/typos
+
+[files]
+# Directories to exclude from checking
+extend-exclude = [
+    # Dependencies and build artifacts
+    "node_modules/",
+    "target/",
+    "dist/",
+    "build/",
+    "artifacts/",
+    "cache/",
+
+    # Generated code
+    "rust_bindings/",
+    "typechain-types/",
+    "codegen/",
+
+    # External libraries
+    "lib/forge-std/",
+    "lib/openzeppelin-contracts/",
+    "lib/openzeppelin-contracts-upgradeable/",
+    # Specific docs with known legacy typos (tracked separately)
+    "coprocessor/fhevm-engine/host-listener/README.md",
+
+    # Keys and charts (binary/config data)
+    "fhevm-keys/",
+    "charts/",
+
+    # Protocol buffers (generated)
+    "proto/",
+
+    # Lock files and binaries
+    "*.lock",
+    "*.pdf",
+    "*.png",
+    "*.jpg",
+    "*.jpeg",
+    "*.gif",
+    "*.ico",
+    "*.woff",
+    "*.woff2",
+    "*.ttf",
+    "*.eot",
+    "*.min.js",
+    "*.min.css",
+    # Docs-only scope for now: exclude source/config/test files
+    "*.rs",
+    "*.sol",
+    "*.ts",
+    "*.js",
+    "*.py",
+    "*.sql",
+    "*.toml",
+    "*.yaml",
+    "*.yml",
+    "*.sh",
+    "*.bash",
+    "*.zsh",
+    "*.txt",
+]
+
+[default]
+# Locale for spell checking
+locale = "en-us"
+
+[default.extend-words]
+# British English variants accepted
+behaviour = "behaviour"
+behaviours = "behaviours"
+colour = "colour"
+colours = "colours"
+centre = "centre"
+centres = "centres"
+analyse = "analyse"
+analysed = "analysed"
+analysing = "analysing"
+apologise = "apologise"
+apologised = "apologised"
+apologising = "apologising"
+finalise = "finalise"
+finalised = "finalised"
+finalising = "finalising"
+initialise = "initialise"
+initialised = "initialised"
+initialising = "initialising"
+initialisation = "initialisation"
+serialise = "serialise"
+serialised = "serialised"
+serialising = "serialising"
+serialisation = "serialisation"
+optimise = "optimise"
+optimised = "optimised"
+optimiser = "optimiser"
+organisation = "organisation"
+uncomplete = "uncomplete" # metric identifiers in docs/code
+organised = "organised"
+customise = "customise"
+authorise = "authorise"
+authorised = "authorised"
+decentralised = "decentralised"
+artefacts = "artefacts"
+misbehaviour = "misbehaviour"
+
+# FHE/TFHE terminology - these are valid domain-specific terms
+euint = "euint"           # encrypted unsigned integer type prefix
+ebool = "ebool"           # encrypted boolean
+eaddress = "eaddress"     # encrypted address
+ebytes = "ebytes"         # encrypted bytes
+einput = "einput"         # encrypted input
+
+# Common abbreviations and technical terms
+reencrypt = "reencrypt"   # re-encryption operation
+reencryption = "reencryption"
+decryptor = "decryptor"   # entity that decrypts
+ciphertext = "ciphertext" # encrypted data
+ciphertexts = "ciphertexts"
+plaintext = "plaintext"   # unencrypted data
+plaintexts = "plaintexts"
+
+# Project-specific identifiers
+fhevm = "fhevm"           # FHE Virtual Machine
+tfhe = "tfhe"             # TFHE library
+kms = "kms"               # Key Management Service
+acl = "acl"               # Access Control List
+
+# Crypto/blockchain terms
+uint = "uint"             # unsigned integer (Solidity)
+abi = "abi"               # Application Binary Interface
+eip = "eip"               # Ethereum Improvement Proposal
+calldata = "calldata"     # Solidity calldata keyword
+bytecode = "bytecode"     # compiled contract code
+hardhat = "hardhat"       # Ethereum dev framework
+
+# Common variable/function name patterns that might be flagged
+noop = "noop"             # no operation
+keypair = "keypair"       # cryptographic key pair
+keygen = "keygen"         # key generation
+pubkey = "pubkey"         # public key
+privkey = "privkey"       # private key
+
+# Rust module/variable naming conventions
+consts = "consts"         # common Rust module name for constants
+dbe = "dbe"               # variable name (DbError)
+
+# External project/service names
+Hashi = "Hashi"           # HashiCorp (Hashi bridge project)
+
+# AWS AMI IDs contain random hex strings
+caf = "caf"               # appears in AWS AMI IDs
+
+# Test variable naming patterns
+BA = "BA"                 # used in test variable names (e.g., wrongOrderBAInsteadOfAB)


### PR DESCRIPTION
## Summary

- Add automated typo detection via CI workflow that blocks PRs with typos
- Add `typos.toml` configuration with FHE/crypto terminology whitelist
- Add optional pre-commit hook for local typo checking
- Fix 80+ existing typos across 67 files

## Test plan

- [x] Run `typos` locally - passes with no errors
- [x] Verify FHE terms (`euint256`, `ebool`, `tfhe`, `fhevm`) are NOT flagged as typos
- [ ] CI workflow blocks PRs with typos
- [ ] Pre-commit hook catches typos in staged files (optional, requires `typos` installed)

Closes zama-ai/fhevm-internal#948