### PR TITLE
refactor(coprocessor): remove tenant notion from sns-worker

### DIFF
--- a/coprocessor/fhevm-engine/db-migration/migrations/20260128095635_remove_tenants.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260128095635_remove_tenants.sql
@@ -80,6 +80,12 @@ ALTER TABLE ciphertexts DROP CONSTRAINT ciphertexts_pkey;
 ALTER TABLE ciphertexts DROP COLUMN tenant_id;
 ALTER TABLE ciphertexts ADD PRIMARY KEY (handle, ciphertext_version);
 
+-- ciphertexts128.tenant_id no longer needed.
+ALTER TABLE ciphertexts128 DROP CONSTRAINT ciphertexts128_pkey;
+ALTER TABLE ciphertexts128 DROP COLUMN tenant_id;
+ALTER TABLE ciphertexts128 ADD PRIMARY KEY (handle);
+DROP INDEX IF EXISTS idx_ciphertexts128_handle;
+
 -- computations.tenant_id no longer needed.
 ALTER TABLE computations DROP CONSTRAINT computations_pkey;
 DROP INDEX IF EXISTS idx_computations_pk;
@@ -87,6 +93,10 @@ ALTER TABLE computations DROP COLUMN tenant_id;
 ALTER TABLE computations ADD PRIMARY KEY (output_handle, transaction_id);
 
 -- pbs_computations.tenant_id no longer needed.
+ALTER TABLE pbs_computations ADD COLUMN host_chain_id BIGINT DEFAULT NULL;
+UPDATE pbs_computations SET host_chain_id = (SELECT chain_id FROM keys WHERE tenant_id = pbs_computations.tenant_id);
+ALTER TABLE pbs_computations ALTER COLUMN host_chain_id SET NOT NULL;
+ALTER TABLE pbs_computations ADD CONSTRAINT pbs_computations_host_chain_id_positive CHECK (host_chain_id > 0);
 ALTER TABLE pbs_computations DROP CONSTRAINT pbs_computations_pkey;
 ALTER TABLE pbs_computations DROP COLUMN tenant_id;
 ALTER TABLE pbs_computations ADD PRIMARY KEY (handle);

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -19,7 +19,6 @@ fn construct_config() -> Config {
     let db_url = args.database_url.clone().unwrap_or_default();
 
     Config {
-        tenant_api_key: args.tenant_api_key,
         service_name: args.service_name,
         metrics: SNSMetricsConfig {
             addr: args.metrics_addr,

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
@@ -11,10 +11,6 @@ use tracing::Level;
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Tenant API key
-    #[arg(long)]
-    pub tenant_api_key: String,
-
     /// Work items batch size
     #[arg(long, default_value_t = 4)]
     pub work_items_batch_size: u32,

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -1,5 +1,5 @@
 use crate::aws_upload::check_is_ready;
-use crate::keyset::fetch_keyset;
+use crate::keyset::fetch_latest_keyset;
 use crate::metrics::SNS_LATENCY_OP_HISTOGRAM;
 use crate::metrics::TASK_EXECUTE_FAILURE_COUNTER;
 use crate::metrics::TASK_EXECUTE_SUCCESS_COUNTER;
@@ -13,6 +13,7 @@ use crate::SchedulePolicy;
 use crate::UploadJob;
 use crate::{Config, ExecutionError};
 use aws_sdk_s3::Client;
+use fhevm_engine_common::db_keys::DbKeyId;
 use fhevm_engine_common::healthz_server::{HealthCheckService, HealthStatus, Version};
 use fhevm_engine_common::pg_pool::PostgresPoolManager;
 use fhevm_engine_common::pg_pool::ServiceError;
@@ -142,7 +143,7 @@ impl SwitchNSquashService {
     }
 
     pub async fn run(&self, pool_mngr: &PostgresPoolManager) {
-        let keys_cache: Arc<RwLock<lru::LruCache<String, KeySet>>> = Arc::new(RwLock::new(
+        let keys_cache: Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>> = Arc::new(RwLock::new(
             lru::LruCache::new(NonZeroUsize::new(10).unwrap()),
         ));
 
@@ -174,19 +175,10 @@ impl SwitchNSquashService {
 
 async fn get_keyset(
     pool: PgPool,
-    keys_cache: Arc<RwLock<lru::LruCache<String, KeySet>>>,
-    tenant_api_key: &String,
-) -> Result<Option<KeySet>, ExecutionError> {
+    keys_cache: Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>>,
+) -> Result<Option<(DbKeyId, KeySet)>, ExecutionError> {
     let _t = telemetry::tracer("fetch_keyset", &None);
-    {
-        let mut cache = keys_cache.write().await;
-        if let Some(keys) = cache.get(tenant_api_key) {
-            info!(tenant_api_key = tenant_api_key, "Keyset found in cache");
-            return Ok(Some(keys.clone()));
-        }
-    }
-    let keys: Option<KeySet> = fetch_keyset(&keys_cache, &pool, tenant_api_key).await?;
-    Ok(keys)
+    fetch_latest_keyset(&keys_cache, &pool).await
 }
 
 /// Executes the worker logic for the SnS task.
@@ -196,12 +188,11 @@ pub(crate) async fn run_loop(
     pool: PgPool,
     token: CancellationToken,
     last_active_at: Arc<RwLock<SystemTime>>,
-    keys_cache: Arc<RwLock<lru::LruCache<String, KeySet>>>,
+    keys_cache: Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>>,
     events_tx: InternalEvents,
 ) -> Result<(), ExecutionError> {
     update_last_active(last_active_at.clone()).await;
 
-    let tenant_api_key = &conf.tenant_api_key;
     let mut listener = PgListener::connect_with(&pool).await?;
     info!("Connected to PostgresDB");
 
@@ -209,7 +200,7 @@ pub(crate) async fn run_loop(
         .listen_all(conf.db.listen_channels.iter().map(|v| v.as_str()))
         .await?;
 
-    let mut keys = None;
+    let mut keys: Option<(DbKeyId, KeySet)> = None;
     let mut gc_ticker = interval(conf.db.cleanup_interval);
     let mut gc_timestamp = SystemTime::now();
     let mut polling_ticker = interval(Duration::from_secs(conf.db.polling_interval.into()));
@@ -218,27 +209,30 @@ pub(crate) async fn run_loop(
         // Continue looping until the service is cancelled or a critical error occurs
         update_last_active(last_active_at.clone()).await;
 
-        let Some(keys) = keys.as_ref() else {
-            keys = get_keyset(pool.clone(), keys_cache.clone(), tenant_api_key).await?;
-            if keys.is_some() {
-                info!(tenant_api_key = tenant_api_key, "Fetched keyset");
+        let latest_keys = get_keyset(pool.clone(), keys_cache.clone()).await?;
+        if let Some((key_id, keyset)) = latest_keys {
+            let key_changed = keys
+                .as_ref()
+                .map(|(current_key_id, _)| current_key_id != &key_id)
+                .unwrap_or(true);
+            if key_changed {
+                info!(key_id = hex::encode(&key_id), "Fetched keyset");
                 // Notify that the keys are loaded
                 if let Some(events_tx) = &events_tx {
                     let _ = events_tx.try_send("event_keys_loaded");
                 }
-            } else {
-                warn!(
-                    tenant_api_key = tenant_api_key,
-                    "No keys available, retrying in 5 seconds"
-                );
-                tokio::time::sleep(Duration::from_secs(5)).await;
             }
-
+            keys = Some((key_id, keyset));
+        } else {
+            warn!("No keys available, retrying in 5 seconds");
+            tokio::time::sleep(Duration::from_secs(5)).await;
             if token.is_cancelled() {
                 return Ok(());
             }
             continue;
-        };
+        }
+
+        let (_, keys) = keys.as_ref().expect("keyset should be available");
 
         let (maybe_remaining, _tasks_processed) =
             fetch_and_execute_sns_tasks(&pool, &tx, keys, &conf, &token)
@@ -316,11 +310,10 @@ pub async fn garbage_collect(pool: &PgPool, limit: u32) -> Result<(), ExecutionE
     let rows_affected: u64 = sqlx::query!(
         "
         WITH uploaded_ct128 AS (
-            SELECT c.tenant_id, c.handle
+            SELECT c.handle
             FROM ciphertexts128 c
             JOIN ciphertext_digest d
-            ON d.tenant_id = c.tenant_id
-            AND d.handle = c.handle
+            ON d.handle = c.handle
             WHERE d.ciphertext128 IS NOT NULL
             FOR UPDATE OF c SKIP LOCKED
             LIMIT $1
@@ -328,8 +321,7 @@ pub async fn garbage_collect(pool: &PgPool, limit: u32) -> Result<(), ExecutionE
 
         DELETE FROM ciphertexts128 c
         USING uploaded_ct128 r
-        WHERE c.tenant_id = r.tenant_id
-        AND c.handle = r.handle;
+        WHERE c.handle = r.handle;
         ",
         limit as i32
     )
@@ -375,7 +367,7 @@ async fn fetch_and_execute_sns_tasks(
 
     let mut maybe_remaining = false;
     let tasks_processed;
-    if let Some(mut tasks) = query_sns_tasks(trx, conf.db.batch_limit, order).await? {
+    if let Some(mut tasks) = query_sns_tasks(trx, conf.db.batch_limit, order, &keys.key_id).await? {
         maybe_remaining = conf.db.batch_limit as usize == tasks.len();
         tasks_processed = tasks.len();
 
@@ -423,6 +415,7 @@ pub async fn query_sns_tasks(
     db_txn: &mut Transaction<'_, Postgres>,
     limit: u32,
     order: Order,
+    key_id: &DbKeyId,
 ) -> Result<Option<Vec<HandleItem>>, ExecutionError> {
     let start_time = SystemTime::now();
 
@@ -460,13 +453,16 @@ pub async fn query_sns_tasks(
     let tasks = records
         .into_iter()
         .map(|record| {
-            let tenant_id: i32 = record.try_get("tenant_id")?;
+            let host_chain_id: i64 = record.try_get("host_chain_id")?;
             let handle: Vec<u8> = record.try_get("handle")?;
             let ciphertext: Vec<u8> = record.try_get("ciphertext")?;
             let transaction_id: Option<Vec<u8>> = record.try_get("transaction_id")?;
 
             Ok(HandleItem {
-                tenant_id,
+                // NOTE: Ensure all coprocessors use the same key_id during rotation
+                // to keep ciphertext_digest consensus on the gateway.
+                key_id: key_id.clone(),
+                host_chain_id,
                 handle: handle.clone(),
                 ct64_compressed: Arc::new(ciphertext),
                 ct128: Arc::new(BigCiphertext::default()), // to be computed
@@ -644,12 +640,10 @@ async fn update_ciphertext128(
             let res = sqlx::query!(
                 "
                 INSERT INTO ciphertexts128 (
-                        tenant_id,
                         handle,
                         ciphertext
                 )
-                VALUES ($1, $2, $3)",
-                task.tenant_id,
+                VALUES ($1, $2)",
                 task.handle,
                 ciphertext128,
             )

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -232,6 +232,7 @@ pub(crate) async fn run_loop(
             continue;
         }
 
+        // keys is guaranteed by the branch above; panic here if that invariant ever regresses.
         let (_, keys) = keys.as_ref().expect("keyset should be available");
 
         let (maybe_remaining, _tasks_processed) =
@@ -459,8 +460,8 @@ pub async fn query_sns_tasks(
             let transaction_id: Option<Vec<u8>> = record.try_get("transaction_id")?;
 
             Ok(HandleItem {
-                // NOTE: Ensure all coprocessors use the same key_id during rotation
-                // to keep ciphertext_digest consensus on the gateway.
+                // TODO: During key rotation, ensure all coprocessors pin the same key_id for a batch
+                // (e.g., via gateway coordination) to keep ciphertext_digest consistent.
                 key_id: key_id.clone(),
                 host_chain_id,
                 handle: handle.clone(),

--- a/coprocessor/fhevm-engine/sns-worker/src/keyset.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/keyset.rs
@@ -1,4 +1,7 @@
-use fhevm_engine_common::{db_keys::read_keys_from_large_object, utils::safe_deserialize_sns_key};
+use fhevm_engine_common::{
+    db_keys::{read_keys_from_large_object, DbKeyId},
+    utils::safe_deserialize_sns_key,
+};
 use sqlx::{PgPool, Row};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -8,47 +11,52 @@ use crate::{ExecutionError, KeySet};
 
 const SKS_KEY_WITH_NOISE_SQUASHING_SIZE: usize = 1_150 * 1_000_000; // ~1.1 GB
 
-/// Retrieve the keyset from the database
-pub(crate) async fn fetch_keyset(
-    cache: &Arc<RwLock<lru::LruCache<String, KeySet>>>,
-    pool: &PgPool,
-    tenant_api_key: &String,
-) -> Result<Option<KeySet>, ExecutionError> {
-    let mut cache = cache.write().await;
-    if let Some(keys) = cache.get(tenant_api_key) {
-        info!(tenant_api_key, "Cache hit");
-        return Ok(Some(keys.clone()));
+async fn fetch_latest_key_id(pool: &PgPool) -> Result<Option<(DbKeyId, i64)>, ExecutionError> {
+    let record = sqlx::query(
+        "SELECT key_id, sequence_number FROM keys ORDER BY sequence_number DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    if let Some(record) = record {
+        let key_id: DbKeyId = record.try_get("key_id")?;
+        let sequence_number: i64 = record.try_get("sequence_number")?;
+        Ok(Some((key_id, sequence_number)))
+    } else {
+        Ok(None)
     }
+}
 
-    info!(tenant_api_key, "Cache miss");
-
-    let Some((client_key, server_key)) = fetch_keys(pool, tenant_api_key).await? else {
+pub(crate) async fn fetch_latest_keyset(
+    cache: &Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>>,
+    pool: &PgPool,
+) -> Result<Option<(DbKeyId, KeySet)>, ExecutionError> {
+    let Some((key_id, _sequence_number)) = fetch_latest_key_id(pool).await? else {
         return Ok(None);
     };
 
-    let key_set: KeySet = KeySet {
-        client_key,
-        server_key,
-    };
-
-    cache.push(tenant_api_key.clone(), key_set.clone());
-    Ok(Some(key_set))
+    let keyset = fetch_keyset_by_id(cache, pool, &key_id).await?;
+    Ok(keyset.map(|keys| (key_id, keys)))
 }
 
-/// Retrieve both the ClientKey and ServerKey from the tenants table
-///
-/// The ServerKey is stored in a large object (LOB) in the database.
-/// ServerKey must be generated with enable_noise_squashing option.
-///
-/// The ClientKey is stored in a bytea column and is optional. It's used only
-/// for decrypting on testing.
-pub async fn fetch_keys(
+async fn fetch_keyset_by_id(
+    cache: &Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>>,
     pool: &PgPool,
-    tenant_api_key: &String,
-) -> anyhow::Result<Option<(Option<tfhe::ClientKey>, crate::ServerKey)>> {
+    key_id: &DbKeyId,
+) -> Result<Option<KeySet>, ExecutionError> {
+    {
+        let mut cache = cache.write().await;
+        if let Some(keys) = cache.get(key_id) {
+            info!(key_id = hex::encode(key_id), "Cache hit");
+            return Ok(Some(keys.clone()));
+        }
+    }
+
+    info!(key_id = hex::encode(key_id), "Cache miss");
+
     let blob = read_keys_from_large_object(
         pool,
-        tenant_api_key,
+        key_id.clone(),
         "sns_pk",
         SKS_KEY_WITH_NOISE_SQUASHING_SIZE,
     )
@@ -75,24 +83,29 @@ pub async fn fetch_keys(
     };
 
     // Optionally retrieve the ClientKey for testing purposes
-    let client_key = fetch_client_key(pool, tenant_api_key).await?;
-    Ok(Some((client_key, server_key)))
+    let client_key = fetch_client_key(pool, key_id).await?;
+
+    let key_set = KeySet {
+        key_id: key_id.clone(),
+        client_key,
+        server_key,
+    };
+
+    let mut cache = cache.write().await;
+    cache.put(key_id.clone(), key_set.clone());
+    Ok(Some(key_set))
 }
 
 pub async fn fetch_client_key(
     pool: &PgPool,
-    tenant_api_key: &String,
+    key_id: &DbKeyId,
 ) -> anyhow::Result<Option<tfhe::ClientKey>> {
-    if let Ok(keys) = sqlx::query(
-        "
-                SELECT cks_key FROM tenants
-                WHERE tenant_api_key = $1::uuid
-            ",
-    )
-    .bind(tenant_api_key)
-    .fetch_one(pool)
-    .await
-    {
+    let keys = sqlx::query("SELECT cks_key FROM keys WHERE key_id = $1")
+        .bind(key_id)
+        .fetch_optional(pool)
+        .await?;
+
+    if let Some(keys) = keys {
         if let Ok(cks) = keys.try_get::<Vec<u8>, _>(0) {
             if !cks.is_empty() {
                 info!(bytes_len = cks.len(), "Retrieved cks");

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -19,6 +19,7 @@ use std::{
 use aws_config::{retry::RetryConfig, timeout::TimeoutConfig, BehaviorVersion};
 use aws_sdk_s3::{config::Builder, Client};
 use fhevm_engine_common::{
+    db_keys::DbKeyId,
     healthz_server::{self},
     metrics_server,
     pg_pool::{PostgresPoolManager, ServiceError},
@@ -57,6 +58,7 @@ type ServerKey = tfhe::ServerKey;
 
 #[derive(Clone)]
 pub struct KeySet {
+    pub key_id: DbKeyId,
     /// Optional ClientKey for decrypting on testing
     pub client_key: Option<tfhe::ClientKey>,
     pub server_key: ServerKey,
@@ -110,7 +112,6 @@ pub struct HealthCheckConfig {
 
 #[derive(Clone)]
 pub struct Config {
-    pub tenant_api_key: String,
     pub service_name: String,
     pub db: DBConfig,
     pub s3: S3Config,
@@ -221,7 +222,8 @@ impl std::fmt::Display for Ciphertext128Format {
 
 #[derive(Clone)]
 pub struct HandleItem {
-    pub tenant_id: i32,
+    pub host_chain_id: i64,
+    pub key_id: DbKeyId,
     pub handle: Vec<u8>,
 
     /// Compressed 64-bit ciphertext
@@ -248,9 +250,10 @@ impl HandleItem {
         db_txn: &mut Transaction<'_, Postgres>,
     ) -> Result<(), ExecutionError> {
         sqlx::query!(
-            "INSERT INTO ciphertext_digest (tenant_id, handle, transaction_id)
-            VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-            self.tenant_id,
+            "INSERT INTO ciphertext_digest (host_chain_id, key_id, handle, transaction_id)
+            VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+            self.host_chain_id,
+            &self.key_id,
             self.handle,
             self.transaction_id,
         )

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -249,8 +249,8 @@ async fn test_lifo_mode() {
             host_chain_id,
             &Vec::from([i as u8; 32]),
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
     }
 
     let mut trx = pool.begin().await.unwrap();

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -188,7 +188,6 @@ services:
     command:
       - sns_worker
       - --database-url=${DATABASE_URL}
-      - --tenant-api-key=${TENANT_API_KEY}
       - --pg-listen-channels
       - event_pbs_computations
       - event_ciphertext_computed


### PR DESCRIPTION
## Summary
- Remove tenant_id usage in sns-worker paths; carry host_chain_id and key_id through tasks.
- Load latest SnS key by sequence_number with key-id cache and LOB read.
- Update migrations, tests/harness, and sns-worker docs/compose for new schema.
