### PR TITLE
ci(common): e2e tests for pr on release branch

### DIFF
--- a/.github/workflows/test-suite-orchestrate-e2e-tests.yml
+++ b/.github/workflows/test-suite-orchestrate-e2e-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - release/*
 
 permissions: {}
 
@@ -13,7 +14,8 @@ concurrency:
 
 jobs:
   coprocessor-docker-build:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    if: &build-trigger-condition |
+      startsWith(github.head_ref, 'mergify/merge-queue/') || startsWith(github.base_ref, 'release/')
     uses: ./.github/workflows/coprocessor-docker-build.yml
     permissions: &docker_permissions
       actions: 'read' # Required to read workflow run information
@@ -30,22 +32,22 @@ jobs:
       CGR_USERNAME: ${{ secrets.CGR_USERNAME }}
       CGR_PASSWORD: ${{ secrets.CGR_PASSWORD }}
   gateway-contracts-docker-build:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    if: *build-trigger-condition
     uses: ./.github/workflows/gateway-contracts-docker-build.yml
     permissions: *docker_permissions
     secrets: *docker_secrets
   host-contracts-docker-build:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    if: *build-trigger-condition
     uses: ./.github/workflows/host-contracts-docker-build.yml
     permissions: *docker_permissions
     secrets: *docker_secrets
   kms-connector-docker-build:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    if: *build-trigger-condition
     uses: ./.github/workflows/kms-connector-docker-build.yml
     permissions: *docker_permissions
     secrets: *docker_secrets
   test-suite-docker-build:
-    if: startsWith(github.head_ref, 'mergify/merge-queue/')
+    if: *build-trigger-condition
     uses: ./.github/workflows/test-suite-docker-build.yml
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -85,7 +87,7 @@ jobs:
           persist-credentials: 'false'
 
       - id: create-e2e-tests-input
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v0.8.0
         with:
           script: |
             const previousCommitHash = process.env.PREVIOUS_COMMIT_HASH;


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/1015

[PR](https://github.com/zama-ai/fhevm/pull/1915) on `release/v0.11.x` showing the e2e tests CI run as expected.