### PR TITLE
ci(common): docker build / re-tag on release

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -7,8 +7,8 @@ This directory contains the CI/CD workflows for the fhevm repository.
 The repository uses a set of reusable workflows to build and publish Docker images efficiently. The system is designed to:
 
 1. **Build images only when relevant files change** - avoiding unnecessary builds
-2. **Re-tag existing images when no changes occur** - ensuring every commit on `main` has corresponding Docker image tags without rebuilding
-3. **Deterministic build cancellation** - ensuring that when multiple PRs are merged simultaneously on `main`, only the latest commit's workflow runs (see [Deterministic Build Cancellation](#deterministic-build-cancellation))
+2. **Re-tag existing images when no changes occur** - ensuring every commit on `main`/`release/vx.y.z` has corresponding Docker image tags without rebuilding
+3. **Deterministic build cancellation** - ensuring that when multiple PRs are merged simultaneously on `main`/`release/vx.y.z`, only the latest commit's workflow runs (see [Deterministic Build Cancellation](#deterministic-build-cancellation))
 
 ### Architecture Overview
 
@@ -65,7 +65,7 @@ Determines whether a Docker image needs to be rebuilt by checking if relevant fi
 
 **How it works:**
 
-1. On `push` events to `main`, it searches through recent commits to find the most recent one that has a published Docker image
+1. On `push` events to `main`/`release/vx.y.z`, it searches through recent commits to find the most recent one that has a published Docker image
 2. Uses [dorny/paths-filter](https://github.com/dorny/paths-filter) to check if any relevant files changed between that commit and the current one
 3. Outputs whether changes were detected and the base commit for potential re-tagging
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -8,6 +8,7 @@ The repository uses a set of reusable workflows to build and publish Docker imag
 
 1. **Build images only when relevant files change** - avoiding unnecessary builds
 2. **Re-tag existing images when no changes occur** - ensuring every commit on `main` has corresponding Docker image tags without rebuilding
+3. **Deterministic build cancellation** - ensuring that when multiple PRs are merged simultaneously on `main`, only the latest commit's workflow runs (see [Deterministic Build Cancellation](#deterministic-build-cancellation))
 
 ### Architecture Overview
 
@@ -17,24 +18,46 @@ The repository uses a set of reusable workflows to build and publish Docker imag
 │  - Triggered on push/release        │
 └───────────────┬─────────────────────┘
                 │
-                ▼
-┌─────────────────────────────────────┐
-│  check-changes-for-docker-          │  (reusable workflow)
-│  build.yml                          │
-│  - Detects file changes             │
-│  - Finds previous image base commit │
-│  - Outputs: changes, base-commit    │
-└───────────────┬─────────────────────┘
-                │
-        ┌───────┴──────────────────────┐
-        ▼                              ▼
-┌───────────────────────────┐ ┌─────────────────────────┐
-│ common-docker.yml (build) │ │ re-tag-docker-image.yml │
-│ if changes                │ │ if no changes           │
-└───────────────────────────┘ └─────────────────────────┘
+     ┌──────────┴──────────┐
+     ▼                     ▼
+┌─────────────────┐  ┌─────────────────────────────────────┐
+│ is-latest-      │  │  check-changes-for-docker-          │
+│ commit.yml      │  │  build.yml                          │
+│ (push only)     │  │  - Detects file changes             │
+│ - Checks if     │  │  - Finds previous image base commit │
+│   current SHA   │  │  - Outputs: changes, base-commit    │
+│   is latest on  │  └───────────────┬─────────────────────┘
+│   branch        │                  │
+└────────┬────────┘                  │
+         │                           │
+         └───────────┬───────────────┘
+                     │
+                     ▼
+        ┌─────────────────────────────┐
+        │  build-decisions (optional) │  (job in caller workflow, only for
+        │  - Centralizes build logic  │   multi-image workflows)
+        │  - Outputs: build/retag/skip│
+        └───────────────┬─────────────┘
+                        │
+         ┌──────────────┼──────────────┐
+         ▼              ▼              ▼
+┌────────────────┐ ┌──────────────┐ ┌──────┐
+│ common-docker  │ │ re-tag-docker│ │ skip │
+│ (build)        │ │ -image.yml   │ │      │
+└────────────────┘ └──────────────┘ └──────┘
 ```
 
 ### Reusable Workflows
+
+#### `is-latest-commit.yml`
+
+Checks whether the current commit is the latest on the target branch. This enables deterministic build cancellation by allowing workflows to skip execution if a newer commit has been pushed.
+
+**How it works:**
+
+1. Uses `git ls-remote` to fetch the latest commit SHA from the remote branch
+2. Compares it with the current workflow's commit SHA (`github.sha`)
+3. Outputs `is_latest: true` if they match, `false` otherwise
 
 #### `check-changes-for-docker-build.yml`
 
@@ -50,48 +73,116 @@ Determines whether a Docker image needs to be rebuilt by checking if relevant fi
 
 Creates a new tag for an existing Docker image without rebuilding it.
 
-### Docker Build Workflow Pattern
+### Docker Build Workflow Patterns
 
-Each service has its own docker build workflow (e.g., `coprocessor-docker-build.yml`, `kms-connector-docker-build.yml`) that follows this pattern:
+Each service has its own docker build workflow. There are two patterns depending on the number of images built:
+
+#### Simple Pattern (Single Image)
+
+Used by workflows that build a single image (e.g., `gateway-contracts-docker-build.yml`, `host-contracts-docker-build.yml`, `test-suite-docker-build.yml`). The decision logic is embedded directly in the job `if` conditions:
 
 ```yaml
 jobs:
-  # 1. Check for changes using the reusable workflow
-  check-changes-my-service:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets:
-      GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
-    permissions:
-      actions: 'read'
-      contents: 'read'
-      pull-requests: 'read'
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/my-service
-      filters: |
-        my-service:
-          - .github/workflows/my-service-docker-build.yml
-          - my-service/**
+  # 1. Check if this is the latest commit (push events only)
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
 
-  # 2. Build if changes detected (or on release/workflow_dispatch)
-  build-my-service:
-    needs: check-changes-my-service
+  # 2. Check for changes
+  check-changes:
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    # ... configuration
+
+  # 3. Build with inline decision logic
+  build:
+    needs: [is-latest-commit, check-changes]
+    concurrency:
+      group: my-service-build-${{ github.ref_name }}
+      cancel-in-progress: true
     if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-my-service.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_my_service)
+      always()
+      && (
+        github.event_name == 'release'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
+        || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
+      )
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@<version>
     # ... build configuration
 
-  # 3. Re-tag if no changes detected (push events only)
-  re-tag-my-service-image:
-    needs: check-changes-my-service
+  # 4. Re-tag with inline decision logic
+  re-tag-image:
+    needs: [is-latest-commit, check-changes]
     if: |
-      needs.check-changes-my-service.outputs.changes != 'true' && github.event_name == 'push'
+      always()
+      && (
+        github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes != 'true'
+      )
     uses: ./.github/workflows/re-tag-docker-image.yml
-    with:
-      image-name: "fhevm/my-service"
-      previous-tag-or-commit: ${{ needs.check-changes-my-service.outputs.base-commit }}
-      new-tag-or-commit: ${{ github.event.after }}
+    # ... configuration
 ```
+
+#### Complex Pattern (Multiple Images)
+
+Used by workflows that build multiple images (e.g., `coprocessor-docker-build.yml`, `kms-connector-docker-build.yml`). A centralized `build-decisions` job computes the action for each service to avoid duplicating decision logic:
+
+```yaml
+jobs:
+  # 1. Check if this is the latest commit (push events only)
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
+
+  # 2. Check for changes for each service
+  check-changes-service-a:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    # ... configuration
+
+  check-changes-service-b:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    # ... configuration
+
+  # 3. Centralized decision logic for all services
+  build-decisions:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [is-latest-commit, check-changes-service-a, check-changes-service-b]
+    outputs:
+      service_a: ${{ steps.decide.outputs.service_a }}
+      service_b: ${{ steps.decide.outputs.service_b }}
+    steps:
+      # ... decide which images need to be built
+
+  # 4. Build if decision is "build"
+  build-service-a:
+    needs: build-decisions
+    concurrency:
+      group: service-a-build-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.service_a == 'build'
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@<version>
+    # ... build configuration
+
+  # 5. Re-tag if decision is "retag"
+  re-tag-service-a-image:
+    needs: [build-decisions, check-changes-service-a]
+    if: always() && needs.build-decisions.outputs.service_a == 'retag'
+    uses: ./.github/workflows/re-tag-docker-image.yml
+    # ... configuration
+```
+
+### Deterministic Build Cancellation
+
+When multiple PRs are merged to `main` in quick succession, GitHub's concurrency groups cannot guarantee which workflow will "win" - the ordering is arbitrary. This could result in an older commit's workflow completing while a newer commit's workflow gets cancelled.
+
+To solve this, the workflows now use a **deterministic cancellation** approach:
+
+1. **`is-latest-commit.yml`** checks at runtime if the current commit is still the latest on the branch
+2. If the commit is the latest: proceed with build or retag. If a newer commit exists: skip all work.
+
+This is used only if the docker build workflow is triggered by a push on `main`!
+
+This ensures that only the workflow for the most recent commit on `main` will actually build or retag images, regardless of the order in which GitHub starts the workflows.
+
+**Note:** Concurrency groups are still used on individual build jobs to prevent duplicate builds of the same service, but the `is-latest-commit` check handles the cross-workflow coordination.

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -5,6 +5,12 @@ on:
     types:
       - published
   workflow_call:
+    inputs:
+      is_workflow_call:
+        description: "Indicates if the workflow is called from another workflow"
+        type: boolean
+        default: true
+        required: false
     secrets:
       AWS_ACCESS_KEY_S3_USER:
         required: true
@@ -76,16 +82,17 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: coprocessor-docker-build-${{ github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   ########################################################################
-  #                             DB MIGRATION                             #
+  #                        PRE-BUILD CHECKS                              #
   ########################################################################
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
+
   check-changes-db-migration:
     uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
     secrets: &check_changes_secrets
       GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
     permissions: &check_changes_permissions
@@ -101,12 +108,177 @@ jobs:
           - .github/workflows/coprocessor-docker-build.yml
           - coprocessor/fhevm-engine/db-migration/**
 
+  check-changes-gw-listener:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/coprocessor/gw-listener
+      filters: |
+        gw-listener:
+          - .github/workflows/coprocessor-docker-build.yml
+          - coprocessor/fhevm-engine/gw-listener/**
+          - coprocessor/fhevm-engine/Cargo.*
+
+  check-changes-host-listener:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/coprocessor/host-listener
+      filters: |
+        host-listener:
+          - .github/workflows/coprocessor-docker-build.yml
+          - coprocessor/fhevm-engine/host-listener/**
+          - coprocessor/fhevm-engine/Cargo.*
+          - host-contracts/contracts/*Events.sol
+          - host-contracts/contracts/shared/**
+
+  check-changes-sns-worker:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/coprocessor/sns-worker
+      filters: |
+        sns-worker:
+          - .github/workflows/coprocessor-docker-build.yml
+          - coprocessor/fhevm-engine/sns-worker/**
+          - coprocessor/fhevm-engine/Cargo.*
+
+  check-changes-tfhe-worker:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/coprocessor/tfhe-worker
+      filters: |
+        tfhe-worker:
+          - .github/workflows/coprocessor-docker-build.yml
+          - coprocessor/fhevm-engine/tfhe-worker/**
+          - coprocessor/fhevm-engine/Cargo.*
+
+  check-changes-tx-sender:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/coprocessor/tx-sender
+      filters: |
+        tx-sender:
+          - .github/workflows/coprocessor-docker-build.yml
+          - coprocessor/fhevm-engine/transaction-sender/**
+          - coprocessor/fhevm-engine/Cargo.*
+
+  check-changes-zkproof-worker:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/coprocessor/zkproof-worker
+      filters: |
+        zkproof-worker:
+          - .github/workflows/coprocessor-docker-build.yml
+          - coprocessor/fhevm-engine/zkproof-worker/**
+          - coprocessor/fhevm-engine/Cargo.*
+
+  ########################################################################
+  #                        BUILD DECISIONS                               #
+  # Centralizes all build/re-tag logic in one place for maintainability  #
+  ########################################################################
+  build-decisions:
+    name: build-decisions
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - is-latest-commit
+      - check-changes-db-migration
+      - check-changes-gw-listener
+      - check-changes-host-listener
+      - check-changes-sns-worker
+      - check-changes-tfhe-worker
+      - check-changes-tx-sender
+      - check-changes-zkproof-worker
+    outputs:
+      db_migration: ${{ steps.decide.outputs.db_migration }}
+      gw_listener: ${{ steps.decide.outputs.gw_listener }}
+      host_listener: ${{ steps.decide.outputs.host_listener }}
+      sns_worker: ${{ steps.decide.outputs.sns_worker }}
+      tfhe_worker: ${{ steps.decide.outputs.tfhe_worker }}
+      tx_sender: ${{ steps.decide.outputs.tx_sender }}
+      zkproof_worker: ${{ steps.decide.outputs.zkproof_worker }}
+    steps:
+      - id: decide
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          NEEDS: ${{ toJSON(needs) }}
+          INPUTS: ${{ toJSON(inputs) }}
+        with:
+          script: |
+            // Decision logic (returns: "build", "retag", or "skip"):
+            // - release: always build
+            // - push: only act if latest commit; build if changes, retag otherwise
+            // - workflow_call: build if changes detected, otherwise skip
+            // - workflow_dispatch: build if input is true, otherwise skip
+            const event = process.env.EVENT_NAME;
+            const needs = JSON.parse(process.env.NEEDS);
+            const inputs = JSON.parse(process.env.INPUTS);
+            const isLatestCommit = needs['is-latest-commit'].outputs?.is_latest === 'true';
+            const isWorkflowCall = inputs.is_workflow_call ?? false;
+
+            const decideAction = (changes, manualInput) => {
+              if (event === 'release') return 'build';
+              if (event === 'push') return isLatestCommit ? (changes ? 'build' : 'retag') : 'skip';
+              if (isWorkflowCall) return changes ? 'build' : 'skip';
+              if (!isWorkflowCall && event === 'workflow_dispatch') return manualInput ? 'build' : 'skip';
+              return 'skip';
+            };
+
+            const services = {
+              db_migration: { changes: needs['check-changes-db-migration'].outputs?.changes, build_input: inputs.build_db_migration },
+              gw_listener: { changes: needs['check-changes-gw-listener'].outputs?.changes, build_input: inputs.build_gw_listener },
+              host_listener: { changes: needs['check-changes-host-listener'].outputs?.changes, build_input: inputs.build_host_listener },
+              sns_worker: { changes: needs['check-changes-sns-worker'].outputs?.changes, build_input: inputs.build_sns_worker },
+              tfhe_worker: { changes: needs['check-changes-tfhe-worker'].outputs?.changes, build_input: inputs.build_tfhe_worker },
+              tx_sender: { changes: needs['check-changes-tx-sender'].outputs?.changes, build_input: inputs.build_tx_sender },
+              zkproof_worker: { changes: needs['check-changes-zkproof-worker'].outputs?.changes, build_input: inputs.build_zkproof_worker },
+            };
+
+            core.info(`Event: ${event}, Is latest commit: ${isLatestCommit}, Is workflow call: ${isWorkflowCall}`);
+            for (const [name, { changes, build_input }] of Object.entries(services)) {
+              const action = decideAction(changes === 'true', build_input ?? false);
+              core.setOutput(name, action);
+              core.info(`${name}: ${action} (changes: ${changes}, build_input: ${build_input})`);
+            }
+
+  ########################################################################
+  #                             DB MIGRATION                             #
+  ########################################################################
   build-db-migration:
-    needs: check-changes-db-migration
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-db-migration.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_db_migration)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-db-migration-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.db_migration == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
@@ -130,9 +302,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-db-migration-image:
-    needs: check-changes-db-migration
-    if: |
-      needs.check-changes-db-migration.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-db-migration]
+    if: always() && needs.build-decisions.outputs.db_migration == 'retag'
     permissions: &re-tag-image-permissions
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code
@@ -147,26 +318,12 @@ jobs:
   ########################################################################
   #                           GATEWAY LISTENER                           #
   ########################################################################
-  check-changes-gw-listener:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/coprocessor/gw-listener
-      filters: |
-        gw-listener:
-          - .github/workflows/coprocessor-docker-build.yml
-          - coprocessor/fhevm-engine/gw-listener/**
-          - coprocessor/fhevm-engine/Cargo.*
-
   build-gw-listener:
-    needs: check-changes-gw-listener
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-gw-listener.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_gw_listener)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-gw-listener-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.gw_listener == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -179,9 +336,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-gw-listener-image:
-    needs: check-changes-gw-listener
-    if: |
-      needs.check-changes-gw-listener.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-gw-listener]
+    if: always() && needs.build-decisions.outputs.gw_listener == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -192,28 +348,12 @@ jobs:
   ########################################################################
   #                            HOST LISTENER                             #
   ########################################################################
-  check-changes-host-listener:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/coprocessor/host-listener
-      filters: |
-        host-listener:
-          - .github/workflows/coprocessor-docker-build.yml
-          - coprocessor/fhevm-engine/host-listener/**
-          - coprocessor/fhevm-engine/Cargo.*
-          - host-contracts/contracts/*Events.sol
-          - host-contracts/contracts/shared/**
-
   build-host-listener:
-    needs: check-changes-host-listener
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-host-listener.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_host_listener)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-host-listener-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.host_listener == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -226,9 +366,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-host-listener-image:
-    needs: check-changes-host-listener
-    if: |
-      needs.check-changes-host-listener.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-host-listener]
+    if: always() && needs.build-decisions.outputs.host_listener == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -239,26 +378,12 @@ jobs:
   ########################################################################
   #                              SNS WORKER                              #
   ########################################################################
-  check-changes-sns-worker:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/coprocessor/sns-worker
-      filters: |
-        sns-worker:
-          - .github/workflows/coprocessor-docker-build.yml
-          - coprocessor/fhevm-engine/sns-worker/**
-          - coprocessor/fhevm-engine/Cargo.*
-
   build-sns-worker:
-    needs: check-changes-sns-worker
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-sns-worker.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_sns_worker)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-sns-worker-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.sns_worker == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -271,9 +396,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-sns-worker-image:
-    needs: check-changes-sns-worker
-    if: |
-      needs.check-changes-sns-worker.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-sns-worker]
+    if: always() && needs.build-decisions.outputs.sns_worker == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -284,26 +408,12 @@ jobs:
   ########################################################################
   #                             TFHE WORKER                              #
   ########################################################################
-  check-changes-tfhe-worker:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/coprocessor/tfhe-worker
-      filters: |
-        tfhe-worker:
-          - .github/workflows/coprocessor-docker-build.yml
-          - coprocessor/fhevm-engine/tfhe-worker/**
-          - coprocessor/fhevm-engine/Cargo.*
-
   build-tfhe-worker:
-    needs: check-changes-tfhe-worker
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-tfhe-worker.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_tfhe_worker)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-tfhe-worker-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.tfhe_worker == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -316,9 +426,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-tfhe-worker-image:
-    needs: check-changes-tfhe-worker
-    if: |
-      needs.check-changes-tfhe-worker.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-tfhe-worker]
+    if: always() && needs.build-decisions.outputs.tfhe_worker == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -329,26 +438,12 @@ jobs:
   ########################################################################
   #                          TRANSACTION SENDER                          #
   ########################################################################
-  check-changes-tx-sender:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/coprocessor/tx-sender
-      filters: |
-        tx-sender:
-          - .github/workflows/coprocessor-docker-build.yml
-          - coprocessor/fhevm-engine/transaction-sender/**
-          - coprocessor/fhevm-engine/Cargo.*
-
   build-tx-sender:
-    needs: check-changes-tx-sender
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-tx-sender.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_tx_sender)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-tx-sender-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.tx_sender == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -361,9 +456,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-tx-sender-image:
-    needs: check-changes-tx-sender
-    if: |
-      needs.check-changes-tx-sender.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-tx-sender]
+    if: always() && needs.build-decisions.outputs.tx_sender == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -374,26 +468,12 @@ jobs:
   ########################################################################
   #                            ZKPROOF WORKER                            #
   ########################################################################
-  check-changes-zkproof-worker:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/coprocessor/zkproof-worker
-      filters: |
-        zkproof-worker:
-          - .github/workflows/coprocessor-docker-build.yml
-          - coprocessor/fhevm-engine/zkproof-worker/**
-          - coprocessor/fhevm-engine/Cargo.*
-
   build-zkproof-worker:
-    needs: check-changes-zkproof-worker
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-zkproof-worker.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_zkproof_worker)
+    needs: build-decisions
+    concurrency:
+      group: coprocessor-build-zkproof-worker-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.zkproof_worker == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -406,9 +486,8 @@ jobs:
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
 
   re-tag-zkproof-worker-image:
-    needs: check-changes-zkproof-worker
-    if: |
-      needs.check-changes-zkproof-worker.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-zkproof-worker]
+    if: always() && needs.build-decisions.outputs.zkproof_worker == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -77,8 +77,7 @@ on:
         type: boolean
         default: true
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -2,6 +2,12 @@ name: gateway-contracts-docker-build
 
 on:
   workflow_call:
+    inputs:
+      is_workflow_call:
+        description: "Indicates if the workflow is called from another workflow"
+        type: boolean
+        default: true
+        required: false
     secrets:
       AWS_ACCESS_KEY_S3_USER:
         required: true
@@ -29,12 +35,13 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: gateway-contracts-docker-build-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
+
   check-changes:
+    if: github.event_name == 'push' || inputs.is_workflow_call
     uses: ./.github/workflows/check-changes-for-docker-build.yml
     secrets:
       GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
@@ -52,11 +59,18 @@ jobs:
           - gateway-contracts/**
 
   build:
-    needs: check-changes
+    needs: [is-latest-commit, check-changes]
+    concurrency:
+      group: gateway-contracts-build-${{ github.ref_name }}
+      cancel-in-progress: true
     if: |
-      needs.check-changes.outputs.changes == 'true'
-      || github.event_name == 'release'
-      || github.event_name == 'workflow_dispatch'
+      always()
+      && (
+        github.event_name == 'release'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
+        || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
+      )
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
@@ -78,9 +92,12 @@ jobs:
       app-cache-dir: "fhevm-gateway-contracts"
 
   re-tag-image:
-    needs: check-changes
+    needs: [is-latest-commit, check-changes]
     if: |
-      needs.check-changes.outputs.changes != 'true' && github.event_name == 'push'
+      always()
+      && (
+        github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes != 'true'
+      )
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -30,8 +30,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -2,6 +2,12 @@ name: host-contracts-docker-build
 
 on:
   workflow_call:
+    inputs:
+      is_workflow_call:
+        description: "Indicates if the workflow is called from another workflow"
+        type: boolean
+        default: true
+        required: false
     secrets:
       AWS_ACCESS_KEY_S3_USER:
         required: true
@@ -29,12 +35,13 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: host-contracts-docker-build-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
+
   check-changes:
+    if: github.event_name == 'push' || inputs.is_workflow_call
     uses: ./.github/workflows/check-changes-for-docker-build.yml
     secrets:
       GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
@@ -52,11 +59,18 @@ jobs:
           - host-contracts/**
 
   build:
-    needs: check-changes
+    needs: [is-latest-commit, check-changes]
+    concurrency:
+      group: host-contracts-build-${{ github.ref_name }}
+      cancel-in-progress: true
     if: |
-      needs.check-changes.outputs.changes == 'true'
-      || github.event_name == 'release'
-      || github.event_name == 'workflow_dispatch'
+      always()
+      && (
+        github.event_name == 'release'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
+        || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
+      )
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
@@ -80,9 +94,12 @@ jobs:
       app-cache-dir: "fhevm-host-contracts"
 
   re-tag-image:
-    needs: check-changes
+    needs: [is-latest-commit, check-changes]
     if: |
-      needs.check-changes.outputs.changes != 'true' && github.event_name == 'push'
+      always()
+      && (
+        github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes != 'true'
+      )
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -30,8 +30,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/is-latest-commit.yml
+++ b/.github/workflows/is-latest-commit.yml
@@ -1,0 +1,35 @@
+name: is-latest-commit
+
+on:
+  workflow_call:
+    outputs:
+      is_latest:
+        description: "Whether the current commit is the latest on the target branch"
+        value: ${{ jobs.check.outputs.is_latest }}
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      is_latest: ${{ steps.check.outputs.is_latest }}
+    steps:
+      - name: Check if current commit is latest on target branch
+        id: check
+        env:
+          CURRENT_COMMIT: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          LATEST_COMMIT=$(git ls-remote https://github.com/"$REPOSITORY".git refs/heads/"$REF_NAME" | cut -f1)
+          if [ -z "$LATEST_COMMIT" ]; then
+            echo "::error::Failed to fetch latest commit for $REF_NAME"
+            exit 1
+          elif [ "$LATEST_COMMIT" == "$CURRENT_COMMIT" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            echo "Current commit $CURRENT_COMMIT is the latest on $REF_NAME"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "Current commit $CURRENT_COMMIT is not the latest on $REF_NAME (latest: $LATEST_COMMIT)."
+          fi

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -56,8 +56,7 @@ on:
         type: boolean
         default: true
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -2,6 +2,12 @@ name: kms-connector-docker-build
 
 on:
   workflow_call:
+    inputs:
+      is_workflow_call:
+        description: "Indicates if the workflow is called from another workflow"
+        type: boolean
+        default: true
+        required: false
     secrets:
       AWS_ACCESS_KEY_S3_USER:
         required: true
@@ -55,16 +61,17 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: kms-connector-build-${{ github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   ########################################################################
-  #                             DB MIGRATION                             #
+  #                        PRE-BUILD CHECKS                              #
   ########################################################################
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
+
   check-changes-db-migration:
     uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
     secrets: &check_changes_secrets
       GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
     permissions: &check_changes_permissions
@@ -80,12 +87,128 @@ jobs:
           - .github/workflows/kms-connector-docker-build.yml
           - kms-connector/connector-db/**
 
+  check-changes-gw-listener:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/kms-connector/gw-listener
+      filters: |
+        gw-listener:
+          - .github/workflows/kms-connector-docker-build.yml
+          - kms-connector/crates/gw-listener/**
+          - kms-connector/crates/utils/**
+          - kms-connector/Cargo.*
+          - gateway-contracts/rust-bindings/**
+
+  check-changes-kms-worker:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/kms-connector/kms-worker
+      filters: |
+        kms-worker:
+          - .github/workflows/kms-connector-docker-build.yml
+          - kms-connector/crates/kms-worker/**
+          - kms-connector/crates/utils/**
+          - kms-connector/Cargo.*
+          - gateway-contracts/rust-bindings/**
+          - host-contracts/rust-bindings/**
+
+  check-changes-tx-sender:
+    uses: ./.github/workflows/check-changes-for-docker-build.yml
+    if: github.event_name == 'push' || inputs.is_workflow_call
+    secrets: *check_changes_secrets
+    permissions: *check_changes_permissions
+    with:
+      caller-workflow-event-name: ${{ github.event_name }}
+      caller-workflow-event-before: ${{ github.event.before }}
+      docker-image: fhevm/kms-connector/tx-sender
+      filters: |
+        tx-sender:
+          - .github/workflows/kms-connector-docker-build.yml
+          - kms-connector/crates/tx-sender/**
+          - kms-connector/crates/utils/**
+          - kms-connector/Cargo.*
+          - gateway-contracts/rust-bindings/**
+
+  ########################################################################
+  #                        BUILD DECISIONS                               #
+  # Centralizes all build/re-tag logic in one place for maintainability  #
+  ########################################################################
+  build-decisions:
+    name: build-decisions
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - is-latest-commit
+      - check-changes-db-migration
+      - check-changes-gw-listener
+      - check-changes-kms-worker
+      - check-changes-tx-sender
+    outputs:
+      db_migration: ${{ steps.decide.outputs.db_migration }}
+      gw_listener: ${{ steps.decide.outputs.gw_listener }}
+      kms_worker: ${{ steps.decide.outputs.kms_worker }}
+      tx_sender: ${{ steps.decide.outputs.tx_sender }}
+    steps:
+      - id: decide
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          NEEDS: ${{ toJSON(needs) }}
+          INPUTS: ${{ toJSON(inputs) }}
+        with:
+          script: |
+            // Decision logic (returns: "build", "retag", or "skip"):
+            // - release: always build
+            // - push: only act if latest commit; build if changes, retag otherwise
+            // - workflow_call: build if changes detected, otherwise skip
+            // - workflow_dispatch: build if input is true, otherwise skip
+            const event = process.env.EVENT_NAME;
+            const needs = JSON.parse(process.env.NEEDS);
+            const inputs = JSON.parse(process.env.INPUTS);
+            const isLatestCommit = needs['is-latest-commit'].outputs?.is_latest === 'true';
+            const isWorkflowCall = inputs.is_workflow_call ?? false;
+
+            const decideAction = (changes, manualInput) => {
+              if (event === 'release') return 'build';
+              if (event === 'push') return isLatestCommit ? (changes ? 'build' : 'retag') : 'skip';
+              if (isWorkflowCall) return changes ? 'build' : 'skip';
+              if (!isWorkflowCall && event === 'workflow_dispatch') return manualInput ? 'build' : 'skip';
+              return 'skip';
+            };
+
+            const services = {
+              db_migration: { changes: needs['check-changes-db-migration'].outputs?.changes, build_input: inputs.build_db_migration },
+              gw_listener: { changes: needs['check-changes-gw-listener'].outputs?.changes, build_input: inputs.build_gw_listener },
+              kms_worker: { changes: needs['check-changes-kms-worker'].outputs?.changes, build_input: inputs.build_kms_worker },
+              tx_sender: { changes: needs['check-changes-tx-sender'].outputs?.changes, build_input: inputs.build_tx_sender },
+            };
+
+            core.info(`Event: ${event}, Is latest commit: ${isLatestCommit}, Is workflow call: ${isWorkflowCall}`);
+            for (const [name, { changes, build_input }] of Object.entries(services)) {
+              const action = decideAction(changes === 'true', build_input ?? false);
+              core.setOutput(name, action);
+              core.info(`${name}: ${action} (changes: ${changes}, build_input: ${build_input})`);
+            }
+
+  ########################################################################
+  #                             DB MIGRATION                             #
+  ########################################################################
   build-db-migration:
-    needs: check-changes-db-migration
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-db-migration.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_db_migration)
+    needs: build-decisions
+    concurrency:
+      group: kms-connector-build-db-migration-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.db_migration == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
@@ -109,9 +232,8 @@ jobs:
       rust-toolchain-file-path: kms-connector/rust-toolchain.toml
 
   re-tag-db-migration-image:
-    needs: check-changes-db-migration
-    if: |
-      needs.check-changes-db-migration.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-db-migration]
+    if: always() && needs.build-decisions.outputs.db_migration == 'retag'
     permissions: &re-tag-image-permissions
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code
@@ -126,28 +248,12 @@ jobs:
   ########################################################################
   #                           GATEWAY LISTENER                           #
   ########################################################################
-  check-changes-gw-listener:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/kms-connector/gw-listener
-      filters: |
-        gw-listener:
-          - .github/workflows/kms-connector-docker-build.yml
-          - kms-connector/crates/gw-listener/**
-          - kms-connector/crates/utils/**
-          - kms-connector/Cargo.*
-          - gateway-contracts/rust-bindings/**
-
   build-gw-listener:
-    needs: check-changes-gw-listener
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-gw-listener.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_gw_listener)
+    needs: build-decisions
+    concurrency:
+      group: kms-connector-build-gw-listener-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.gw_listener == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -160,9 +266,8 @@ jobs:
       rust-toolchain-file-path: kms-connector/rust-toolchain.toml
 
   re-tag-gw-listener-image:
-    needs: check-changes-gw-listener
-    if: |
-      needs.check-changes-gw-listener.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-gw-listener]
+    if: always() && needs.build-decisions.outputs.gw_listener == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -173,29 +278,12 @@ jobs:
   ########################################################################
   #                              KMS WORKER                              #
   ########################################################################
-  check-changes-kms-worker:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/kms-connector/kms-worker
-      filters: |
-        kms-worker:
-          - .github/workflows/kms-connector-docker-build.yml
-          - kms-connector/crates/kms-worker/**
-          - kms-connector/crates/utils/**
-          - kms-connector/Cargo.*
-          - gateway-contracts/rust-bindings/**
-          - host-contracts/rust-bindings/**
-
   build-kms-worker:
-    needs: check-changes-kms-worker
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-kms-worker.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_kms_worker)
+    needs: build-decisions
+    concurrency:
+      group: kms-connector-build-kms-worker-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.kms_worker == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -208,9 +296,8 @@ jobs:
       rust-toolchain-file-path: kms-connector/rust-toolchain.toml
 
   re-tag-kms-worker-image:
-    needs: check-changes-kms-worker
-    if: |
-      needs.check-changes-kms-worker.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-kms-worker]
+    if: always() && needs.build-decisions.outputs.kms_worker == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
@@ -221,28 +308,12 @@ jobs:
   ########################################################################
   #                          TRANSACTION SENDER                          #
   ########################################################################
-  check-changes-tx-sender:
-    uses: ./.github/workflows/check-changes-for-docker-build.yml
-    secrets: *check_changes_secrets
-    permissions: *check_changes_permissions
-    with:
-      caller-workflow-event-name: ${{ github.event_name }}
-      caller-workflow-event-before: ${{ github.event.before }}
-      docker-image: fhevm/kms-connector/tx-sender
-      filters: |
-        tx-sender:
-          - .github/workflows/kms-connector-docker-build.yml
-          - kms-connector/crates/tx-sender/**
-          - kms-connector/crates/utils/**
-          - kms-connector/Cargo.*
-          - gateway-contracts/rust-bindings/**
-
   build-tx-sender:
-    needs: check-changes-tx-sender
-    if: |
-      github.event_name == 'release'
-      || (github.event_name != 'workflow_dispatch' && needs.check-changes-tx-sender.outputs.changes == 'true')
-      || (github.event_name == 'workflow_dispatch' && inputs.build_tx_sender)
+    needs: build-decisions
+    concurrency:
+      group: kms-connector-build-tx-sender-${{ github.ref_name }}
+      cancel-in-progress: true
+    if: always() && needs.build-decisions.outputs.tx_sender == 'build'
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     permissions: *docker_permissions
     secrets: *docker_secrets
@@ -255,9 +326,8 @@ jobs:
       rust-toolchain-file-path: kms-connector/rust-toolchain.toml
 
   re-tag-tx-sender-image:
-    needs: check-changes-tx-sender
-    if: |
-      needs.check-changes-tx-sender.outputs.changes != 'true' && github.event_name == 'push'
+    needs: [build-decisions, check-changes-tx-sender]
+    if: always() && needs.build-decisions.outputs.tx_sender == 'retag'
     permissions: *re-tag-image-permissions
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -30,8 +30,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -2,6 +2,12 @@ name: test-suite-docker-build
 
 on:
   workflow_call:
+    inputs:
+      is_workflow_call:
+        description: "Indicates if the workflow is called from another workflow"
+        type: boolean
+        default: true
+        required: false
     secrets:
       AWS_ACCESS_KEY_S3_USER:
         required: true
@@ -29,12 +35,13 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: test-suite-e2e-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
+  is-latest-commit:
+    uses: ./.github/workflows/is-latest-commit.yml
+    if: github.event_name == 'push'
+
   check-changes:
+    if: github.event_name == 'push' || inputs.is_workflow_call
     uses: ./.github/workflows/check-changes-for-docker-build.yml
     secrets:
       GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
@@ -53,11 +60,18 @@ jobs:
           - 'library-solidity/**'
 
   build:
-    needs: check-changes
+    needs: [is-latest-commit, check-changes]
+    concurrency:
+      group: test-suite-e2e-build-${{ github.ref_name }}
+      cancel-in-progress: true
     if: |
-      needs.check-changes.outputs.changes == 'true'
-      || github.event_name == 'release'
-      || github.event_name == 'workflow_dispatch'
+      always()
+      && (
+        github.event_name == 'release'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
+        || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
+      )
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
@@ -79,9 +93,12 @@ jobs:
       app-cache-dir: "fhevm-test-suite-e2e"
 
   re-tag-image:
-    needs: check-changes
+    needs: [is-latest-commit, check-changes]
     if: |
-      needs.check-changes.outputs.changes != 'true' && github.event_name == 'push'
+      always()
+      && (
+        github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes != 'true'
+      )
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/test-suite-orchestrate-e2e-tests.yml
+++ b/.github/workflows/test-suite-orchestrate-e2e-tests.yml
@@ -85,7 +85,7 @@ jobs:
           persist-credentials: 'false'
 
       - id: create-e2e-tests-input
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v0.8.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const previousCommitHash = process.env.PREVIOUS_COMMIT_HASH;


### PR DESCRIPTION
Cherry-pick https://github.com/zama-ai/fhevm/pull/1864 + configured build workflow to be triggered on `push` on release

Unfortunately, the only way to test that it works well is to merge to trigger the `push` event on release...

Ref [PR](https://github.com/zama-ai/fhevm/pull/1919) on main