### PR TITLE
ci(common): docker build / re-tag on release

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -7,8 +7,8 @@ This directory contains the CI/CD workflows for the fhevm repository.
 The repository uses a set of reusable workflows to build and publish Docker images efficiently. The system is designed to:
 
 1. **Build images only when relevant files change** - avoiding unnecessary builds
-2. **Re-tag existing images when no changes occur** - ensuring every commit on `main` has corresponding Docker image tags without rebuilding
-3. **Deterministic build cancellation** - ensuring that when multiple PRs are merged simultaneously on `main`, only the latest commit's workflow runs (see [Deterministic Build Cancellation](#deterministic-build-cancellation))
+2. **Re-tag existing images when no changes occur** - ensuring every commit on `main`/`release/vx.y.z` has corresponding Docker image tags without rebuilding
+3. **Deterministic build cancellation** - ensuring that when multiple PRs are merged simultaneously on `main`/`release/vx.y.z`, only the latest commit's workflow runs (see [Deterministic Build Cancellation](#deterministic-build-cancellation))
 
 ### Architecture Overview
 
@@ -65,7 +65,7 @@ Determines whether a Docker image needs to be rebuilt by checking if relevant fi
 
 **How it works:**
 
-1. On `push` events to `main`, it searches through recent commits to find the most recent one that has a published Docker image
+1. On `push` events to `main`/`release/vx.y.z`, it searches through recent commits to find the most recent one that has a published Docker image
 2. Uses [dorny/paths-filter](https://github.com/dorny/paths-filter) to check if any relevant files changed between that commit and the current one
 3. Outputs whether changes were detected and the base commit for potential re-tagging
 

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -77,8 +77,7 @@ on:
         type: boolean
         default: true
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -30,8 +30,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -30,8 +30,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -56,8 +56,7 @@ on:
         type: boolean
         default: true
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -30,8 +30,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: ['main', 'release/*']
 
 permissions: {}
 


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/1016

[PR](https://github.com/zama-ai/fhevm/pull/1917) on release branch

Docker images successfully built, see CI workflow of commit 667025f5b1b9d6b4f72fbd02067f7cfa63ad9edb on `release/v0.11.x`