### PR TITLE
chore(common): add fhevm-devops codeowner of ci workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,7 @@
 # All pull request should be reviewed by at least one of the members of fhevm-devs
 *    @zama-ai/fhevm-devs
 
-# All CI pull request should be reviewed by at least one of the members of fhevm-devops
-/.github/workflows/*release.yml	@zama-ai/fhevm-devops
+/.github/workflows/	@zama-ai/fhevm-devops @zama-ai/fhevm-devs
 
 # Gateway Team ownership
 /gateway-contracts/ @zama-ai/fhevm-gateway


### PR DESCRIPTION
So `fhevm-devops` team can perform review/PR of github workflows of the repo