### PR TITLE
chore(common): enable ts typos checks

### DIFF
--- a/library-solidity/examples/tests/FHEVMManualTestSuite.sol
+++ b/library-solidity/examples/tests/FHEVMManualTestSuite.sol
@@ -211,21 +211,21 @@ contract FHEVMManualTestSuite {
         resEbool = FHE.xor(FHE.asEbool(a), b);
     }
 
-    function test_ebool_select_unitialized() public {
+    function test_ebool_select_uninitialized() public {
         ebool a_;
         ebool b_;
         ebool c_;
         resEbool = FHE.select(a_, b_, c_);
     }
 
-    function test_ebaddress_select_unitialized() public {
+    function test_ebaddress_select_uninitialized() public {
         ebool a_;
         eaddress b_;
         eaddress c_;
         resAdd = FHE.select(a_, b_, c_);
     }
 
-    function test_euint64_select_unitialized() public {
+    function test_euint64_select_uninitialized() public {
         ebool a_;
         euint64 b_;
         euint64 c_;

--- a/library-solidity/test/fhevmOperations/manual.ts
+++ b/library-solidity/test/fhevmOperations/manual.ts
@@ -742,7 +742,7 @@ describe('FHEVM manual operations', function () {
 
   it('select ebool - uninitialized', async function () {
     expect(await this.contract.resEbool()).to.equal(0n);
-    const tx = await this.contract.test_ebool_select_unitialized();
+    const tx = await this.contract.test_ebool_select_uninitialized();
     await tx.wait();
     expect(await this.contract.resEbool()).not.to.equal(0n);
     const res = await decryptBool(await this.contract.resEbool());
@@ -751,7 +751,7 @@ describe('FHEVM manual operations', function () {
 
   it('select address - uninitialized', async function () {
     expect(await this.contract.resAdd()).to.equal(0n);
-    const tx = await this.contract.test_ebaddress_select_unitialized();
+    const tx = await this.contract.test_ebaddress_select_uninitialized();
     await tx.wait();
     expect(await this.contract.resAdd()).not.to.equal(0n);
     const res = await decryptAddress(await this.contract.resAdd());
@@ -760,7 +760,7 @@ describe('FHEVM manual operations', function () {
 
   it('select euint64 - uninitialized', async function () {
     expect(await this.contract.resEuint64()).to.equal(0n);
-    const tx = await this.contract.test_euint64_select_unitialized();
+    const tx = await this.contract.test_euint64_select_uninitialized();
     await tx.wait();
     expect(await this.contract.resEuint64()).not.to.equal(0n);
     const res = await decrypt64(await this.contract.resEuint64());

--- a/typos.toml
+++ b/typos.toml
@@ -48,7 +48,6 @@ extend-exclude = [
     # Docs-only scope for now: exclude source/config/test files
     "*.rs",
     "*.sol",
-    "*.ts",
     "*.js",
     "*.py",
     "*.sql",


### PR DESCRIPTION
## Summary
- remove `*.ts` from `typos.toml` exclude list
- fix `uninitialized` misspellings in TS tests and matching Solidity test helpers

## Testing
- typos

Closes #1913
