### PR TITLE
chore(common): enable py typos checks

### DIFF
--- a/library-solidity/ci/tests/ERC20.py
+++ b/library-solidity/ci/tests/ERC20.py
@@ -196,7 +196,7 @@ assert transaction_receipt['status'] == 1
 
 print(f"\n\n======== STEP 2: MINT {initial_mint} TOKENS ========")
 
-# get contract adress and send mint transaction
+# get contract address and send mint transaction
 contract_address = transaction_receipt.contractAddress
 
 # create the contract and make sure we use a middleware to automatically sign calls.

--- a/typos.toml
+++ b/typos.toml
@@ -50,7 +50,6 @@ extend-exclude = [
     "*.sol",
     "*.ts",
     "*.js",
-    "*.py",
     "*.sql",
     "*.toml",
     "*.yaml",


### PR DESCRIPTION
## Summary
- remove `*.py` from `typos.toml` exclude list
- fix the Python typo reported by `typos` in `library-solidity/ci/tests/ERC20.py`

## Testing
- typos

Closes #1912
