### PR TITLE
fix(coprocessor): make ciphertext compression fallible

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
@@ -575,9 +575,6 @@ impl SupportedFheCiphertexts {
             SupportedFheCiphertexts::FheBytes128(c) => builder.push(c.clone()),
             SupportedFheCiphertexts::FheBytes256(c) => builder.push(c.clone()),
         };
-        if !self.clone().to_ciphertext64().block_carries_are_empty() {
-            return Err(FhevmError::CiphertextCompressionRequiresEmptyCarries);
-        }
         let list = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| builder.build()))
         {
             Ok(Ok(list)) => list,

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
@@ -555,8 +555,7 @@ impl SupportedFheCiphertexts {
         }
     }
 
-    pub fn compress(&self) -> std::result::Result<(i16, Vec<u8>), FhevmError> {
-        let type_num = self.type_num();
+    pub fn compress(&self) -> std::result::Result<Vec<u8>, FhevmError> {
         let mut builder = CompressedCiphertextListBuilder::new();
         match self {
             SupportedFheCiphertexts::Scalar(_) => {
@@ -588,7 +587,7 @@ impl SupportedFheCiphertexts {
                 return Err(FhevmError::CiphertextCompressionPanic { message });
             }
         };
-        Ok((type_num, safe_serialize(&list)))
+        Ok(safe_serialize(&list))
     }
 
     #[cfg(feature = "gpu")]

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -554,14 +554,25 @@ fn run_computation(
             compress_span.set_attribute(KeyValue::new("ct_type", inputs[0].type_name()));
             compress_span.set_attribute(KeyValue::new("operation", "FheGetCiphertext"));
 
-            let (ct_type, ct_bytes) = inputs[0].compress();
-            compress_span.set_attribute(KeyValue::new("compressed_size", ct_bytes.len() as i64));
-            compress_span.end();
-
-            (
-                graph_node_index,
-                Ok((inputs[0].clone(), Some((ct_type, ct_bytes)))),
-            )
+            let compressed = inputs[0].compress();
+            match compressed {
+                Ok((ct_type, ct_bytes)) => {
+                    compress_span
+                        .set_attribute(KeyValue::new("compressed_size", ct_bytes.len() as i64));
+                    compress_span.end();
+                    (
+                        graph_node_index,
+                        Ok((inputs[0].clone(), Some((ct_type, ct_bytes)))),
+                    )
+                }
+                Err(error) => {
+                    compress_span.set_status(Status::Error {
+                        description: error.to_string().into(),
+                    });
+                    compress_span.end();
+                    (graph_node_index, Err(error.into()))
+                }
+            }
         }
         Ok(fhe_op) => {
             let op_name = fhe_op.as_str_name();
@@ -586,13 +597,24 @@ fn run_computation(
                         telemetry::set_txn_id(&mut compress_span, transaction_id);
                         compress_span.set_attribute(KeyValue::new("ct_type", result.type_name()));
                         compress_span.set_attribute(KeyValue::new("operation", op_name));
-
-                        let (ct_type, ct_bytes) = result.compress();
-                        compress_span
-                            .set_attribute(KeyValue::new("compressed_size", ct_bytes.len() as i64));
-                        compress_span.end();
-
-                        (graph_node_index, Ok((result, Some((ct_type, ct_bytes)))))
+                        let compressed = result.compress();
+                        match compressed {
+                            Ok((ct_type, ct_bytes)) => {
+                                compress_span.set_attribute(KeyValue::new(
+                                    "compressed_size",
+                                    ct_bytes.len() as i64,
+                                ));
+                                compress_span.end();
+                                (graph_node_index, Ok((result, Some((ct_type, ct_bytes)))))
+                            }
+                            Err(error) => {
+                                compress_span.set_status(Status::Error {
+                                    description: error.to_string().into(),
+                                });
+                                compress_span.end();
+                                (graph_node_index, Err(error.into()))
+                            }
+                        }
                     } else {
                         (graph_node_index, Ok((result, None)))
                     }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -554,9 +554,10 @@ fn run_computation(
             compress_span.set_attribute(KeyValue::new("ct_type", inputs[0].type_name()));
             compress_span.set_attribute(KeyValue::new("operation", "FheGetCiphertext"));
 
+            let ct_type = inputs[0].type_num();
             let compressed = inputs[0].compress();
             match compressed {
-                Ok((ct_type, ct_bytes)) => {
+                Ok(ct_bytes) => {
                     compress_span
                         .set_attribute(KeyValue::new("compressed_size", ct_bytes.len() as i64));
                     compress_span.end();
@@ -597,9 +598,10 @@ fn run_computation(
                         telemetry::set_txn_id(&mut compress_span, transaction_id);
                         compress_span.set_attribute(KeyValue::new("ct_type", result.type_name()));
                         compress_span.set_attribute(KeyValue::new("operation", op_name));
+                        let ct_type = result.type_num();
                         let compressed = result.compress();
                         match compressed {
-                            Ok((ct_type, ct_bytes)) => {
+                            Ok(ct_bytes) => {
                                 compress_span.set_attribute(KeyValue::new(
                                     "compressed_size",
                                     ct_bytes.len() as i64,

--- a/coprocessor/fhevm-engine/tfhe-worker/src/server.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/server.rs
@@ -518,7 +518,8 @@ impl CoprocessorService {
                 let server_key_clone = server_key.clone();
                 let (handle, serialized_ct, serialized_type) = spawn_blocking(move || {
                     tfhe::set_server_key(server_key_clone);
-                    let (serialized_type, serialized_ct) = the_ct.compress().unwrap();
+                    let serialized_type = the_ct.type_num();
+                    let serialized_ct = the_ct.compress().unwrap();
                     let mut handle_hash = Keccak256::new();
                     handle_hash.update(&blob_hash_clone);
                     handle_hash.update([ct_idx as u8]);
@@ -764,7 +765,8 @@ impl CoprocessorService {
                 let ct = trivial_encrypt_be_bytes(v.output_type as i16, &v.be_value);
                 span.end();
                 let mut span = inner_tracer.child_span("compress_ciphertext");
-                let (ct_type, ct_bytes) = ct.compress().unwrap();
+                let ct_type = ct.type_num();
+                let ct_bytes = ct.compress().unwrap();
                 span.end();
                 res.push((v.handle, ct_type, ct_bytes));
             }

--- a/coprocessor/fhevm-engine/tfhe-worker/src/server.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/server.rs
@@ -187,9 +187,6 @@ pub struct GrpcTracer {
     tracer: BoxedTracer,
 }
 
-type StoredCiphertextRow = (Vec<u8>, i16, Vec<u8>);
-type CompressedCiphertextData = (Vec<u8>, Vec<u8>, i16);
-
 impl GrpcTracer {
     pub fn child_span(&self, name: &'static str) -> BoxedSpan {
         self.tracer.start_with_context(name, &self.ctx)
@@ -519,30 +516,26 @@ impl CoprocessorService {
                 // TODO: simplify compress and hash computation async handling
                 let blob_hash_clone = blob_hash.clone();
                 let server_key_clone = server_key.clone();
-                let (handle, serialized_ct, serialized_type) = spawn_blocking(
-                    move || -> std::result::Result<CompressedCiphertextData, FhevmError> {
-                        tfhe::set_server_key(server_key_clone);
-                        let (serialized_type, serialized_ct) = the_ct.compress()?;
-                        let mut handle_hash = Keccak256::new();
-                        handle_hash.update(&blob_hash_clone);
-                        handle_hash.update([ct_idx as u8]);
-                        handle_hash.update(acl_contract_address.as_slice());
-                        handle_hash.update(chain_id_be);
-                        let mut handle = handle_hash.finalize().to_vec();
-                        assert_eq!(handle.len(), 32);
-                        // idx cast to u8 must succeed because we don't allow
-                        // more handles than u8 size
-                        handle[29] = ct_idx as u8;
-                        handle[30] = serialized_type as u8;
-                        handle[31] = ciphertext_version as u8;
+                let (handle, serialized_ct, serialized_type) = spawn_blocking(move || {
+                    tfhe::set_server_key(server_key_clone);
+                    let (serialized_type, serialized_ct) = the_ct.compress().unwrap();
+                    let mut handle_hash = Keccak256::new();
+                    handle_hash.update(&blob_hash_clone);
+                    handle_hash.update([ct_idx as u8]);
+                    handle_hash.update(acl_contract_address.as_slice());
+                    handle_hash.update(chain_id_be);
+                    let mut handle = handle_hash.finalize().to_vec();
+                    assert_eq!(handle.len(), 32);
+                    // idx cast to u8 must succeed because we don't allow
+                    // more handles than u8 size
+                    handle[29] = ct_idx as u8;
+                    handle[30] = serialized_type as u8;
+                    handle[31] = ciphertext_version as u8;
 
-                        Ok((handle, serialized_ct, serialized_type))
-                    },
-                )
+                    (handle, serialized_ct, serialized_type)
+                })
                 .await
-                .map_err(|join_error| tonic::Status::from_error(Box::new(join_error)))?
-                .map_err(CoprocessorError::FhevmError)
-                .map_err(tonic::Status::from)?;
+                .map_err(|e| tonic::Status::from_error(Box::new(e)))?;
 
                 let mut span = tracer.child_span("db_insert_ciphertext");
                 span.set_attributes(vec![
@@ -759,31 +752,27 @@ impl CoprocessorService {
         let cloned = req.values.clone();
         let inner_tracer = tracer.clone();
         let mut outer_span = tracer.child_span("blocking_trivial_encrypt");
-        let out_cts = tokio::task::spawn_blocking(
-            move || -> std::result::Result<Vec<StoredCiphertextRow>, FhevmError> {
-                let mut span = inner_tracer.child_span("set_sks");
-                tfhe::set_server_key(server_key.clone());
+        let out_cts = tokio::task::spawn_blocking(move || {
+            let mut span = inner_tracer.child_span("set_sks");
+            tfhe::set_server_key(server_key.clone());
+            span.end();
+
+            // single threaded implementation, we can optimize later
+            let mut res: Vec<(Vec<u8>, i16, Vec<u8>)> = Vec::with_capacity(cloned.len());
+            for v in cloned {
+                let mut span = inner_tracer.child_span("trivial_encrypt");
+                let ct = trivial_encrypt_be_bytes(v.output_type as i16, &v.be_value);
                 span.end();
+                let mut span = inner_tracer.child_span("compress_ciphertext");
+                let (ct_type, ct_bytes) = ct.compress().unwrap();
+                span.end();
+                res.push((v.handle, ct_type, ct_bytes));
+            }
 
-                // single threaded implementation, we can optimize later
-                let mut res: Vec<StoredCiphertextRow> = Vec::with_capacity(cloned.len());
-                for v in cloned {
-                    let mut span = inner_tracer.child_span("trivial_encrypt");
-                    let ct = trivial_encrypt_be_bytes(v.output_type as i16, &v.be_value);
-                    span.end();
-                    let mut span = inner_tracer.child_span("compress_ciphertext");
-                    let (ct_type, ct_bytes) = ct.compress()?;
-                    span.end();
-                    res.push((v.handle, ct_type, ct_bytes));
-                }
-
-                Ok(res)
-            },
-        )
+            res
+        })
         .await
-        .map_err(|join_error| tonic::Status::from_error(Box::new(join_error)))?
-        .map_err(CoprocessorError::FhevmError)
-        .map_err(tonic::Status::from)?;
+        .unwrap();
         outer_span.end();
 
         let mut tx_span = tracer.child_span("db_transaction_insert_ciphertexts");

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -493,7 +493,7 @@ fn create_ciphertext(
     // Add the full 256bit hash as re-randomization metadata, NOT the
     // truncated hash of the handle
     the_ct.add_re_randomization_metadata(&handle);
-    let (serialized_type, compressed) = the_ct.compress();
+    let (serialized_type, compressed) = the_ct.compress()?;
 
     // idx cast to u8 must succeed because we don't allow
     // more handles than u8 size

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -493,7 +493,8 @@ fn create_ciphertext(
     // Add the full 256bit hash as re-randomization metadata, NOT the
     // truncated hash of the handle
     the_ct.add_re_randomization_metadata(&handle);
-    let (serialized_type, compressed) = the_ct.compress()?;
+    let serialized_type = the_ct.type_num();
+    let compressed = the_ct.compress()?;
 
     // idx cast to u8 must succeed because we don't allow
     // more handles than u8 size


### PR DESCRIPTION
## Summary
This is the standalone fix for `zama-ai/fhevm-internal#1020`.

- Make `SupportedFheCiphertexts::compress()` fallible and remove panic/expect usage.
- Convert TFHE compression failures (including panic payloads from internal asserts) into typed `FhevmError` values.
- Bubble compression errors at caller sites instead of killing execution:
  - scheduler compression paths
  - tfhe-worker server compression paths
  - zkproof-worker handle creation path
- Add a focused unit test for scalar compression error behavior.

## Scope
Compression error propagation only.
No gRPC-refactor changes, no unrelated cleanup.

## Validation
- `cd coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo check -p fhevm-engine-common -p scheduler -p zkproof-worker -p tfhe-worker`
- `cd coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test -p fhevm-engine-common -p scheduler -p zkproof-worker -p tfhe-worker --no-run`
- `cd coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test -p fhevm-engine-common compress_scalar_returns_error -- --nocapture`

closes https://github.com/zama-ai/fhevm-internal/issues/1020