### PR TITLE
chore(common): enable sol typos checks

### DIFF
--- a/gateway-contracts/contracts/interfaces/IPauserSet.sol
+++ b/gateway-contracts/contracts/interfaces/IPauserSet.sol
@@ -58,7 +58,7 @@ interface IPauserSet {
     function removePauser(address account) external;
 
     /**
-     * @notice Returns wether specified account is in the set of pausers.
+     * @notice Returns whether specified account is in the set of pausers.
      * @param account The address of the account.
      */
     function isPauser(address account) external view returns (bool);

--- a/host-contracts/contracts/ACL.sol
+++ b/host-contracts/contracts/ACL.sol
@@ -524,7 +524,7 @@ contract ACL is
     }
 
     /**
-     * @notice Returns wether specified account is in the set of pausers.
+     * @notice Returns whether specified account is in the set of pausers.
      * @param account The address of the account.
      */
     function isPauser(address account) external view virtual returns (bool) {

--- a/host-contracts/contracts/interfaces/IPauserSet.sol
+++ b/host-contracts/contracts/interfaces/IPauserSet.sol
@@ -58,7 +58,7 @@ interface IPauserSet {
     function removePauser(address account) external;
 
     /**
-     * @notice Returns wether specified account is in the set of pausers.
+     * @notice Returns whether specified account is in the set of pausers.
      * @param account The address of the account.
      */
     function isPauser(address account) external view returns (bool);

--- a/host-contracts/examples/EncryptedERC20.sol
+++ b/host-contracts/examples/EncryptedERC20.sol
@@ -207,7 +207,7 @@ contract EncryptedERC20 is Ownable2Step {
     /// @param amount The amount to transfer
     /// @param isTransferable Boolean indicating if the transfer is allowed
     function _transfer(address from, address to, euint64 amount, ebool isTransferable) internal virtual {
-        /// @dev Add to the balance of `to` and subract from the balance of `from`.
+        /// @dev Add to the balance of `to` and subtract from the balance of `from`.
         euint64 transferValue = FHE.select(isTransferable, amount, FHE.asEuint64(0));
         euint64 newBalanceTo = FHE.add(balances[to], transferValue);
         balances[to] = newBalanceTo;

--- a/host-contracts/lib/Impl.sol
+++ b/host-contracts/lib/Impl.sol
@@ -327,7 +327,7 @@ interface IACL {
     function allowForDecryption(bytes32[] memory handlesList) external;
 
     /**
-     * @notice                  Returns wether a handle is allowed to be publicly decrypted.
+     * @notice                  Returns whether a handle is allowed to be publicly decrypted.
      * @param handle            Handle.
      * @return isDecryptable    Whether the handle can be publicly decrypted.
      */

--- a/host-contracts/test/hcuLimit/HCULimit.t.sol
+++ b/host-contracts/test/hcuLimit/HCULimit.t.sol
@@ -855,7 +855,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheRem(FheType(resultType), scalarByte, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheAddRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheAddRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -869,7 +869,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheAdd(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheSubRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheSubRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -883,7 +883,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheSub(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheMulRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheMulRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -897,7 +897,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheMul(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheDivRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForFheDivRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheDiv));
 
@@ -908,7 +908,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheDiv(FheType(resultType), 0x01, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheRemRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForFheRemRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheRem));
 
@@ -919,7 +919,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheRem(FheType(resultType), 0x01, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheBitAndRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheBitAndRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -933,7 +933,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheBitAnd(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheBitOrRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheBitOrRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -947,7 +947,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheBitOr(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheBitXorRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheBitXorRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -961,7 +961,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheBitXor(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheShlRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheShlRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -975,7 +975,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheShl(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheShrRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheShrRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -989,7 +989,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheShr(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheRotlRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheRotlRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1003,7 +1003,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheRotl(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheRotrRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheRotrRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1017,7 +1017,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheRotr(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheGeRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheGeRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1031,7 +1031,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheGe(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheGtRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheGtRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1045,7 +1045,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheGt(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheLeRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheLeRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1059,7 +1059,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheLe(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheLtRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheLtRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1073,7 +1073,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheLt(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheMinRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheMinRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1087,7 +1087,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheMin(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheMaxRevertsIfHCUTransationIsAboveHCUTransactionLimit(
+    function test_checkHCUForFheMaxRevertsIfHCUTransactionIsAboveHCUTransactionLimit(
         uint8 resultType,
         bytes1 scalarType
     ) public {
@@ -1101,7 +1101,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheMax(FheType(resultType), scalarType, mockLHS, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheNegRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForFheNegRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheNeg));
 
@@ -1112,7 +1112,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheNeg(FheType(resultType), mockLHS, mockResult);
     }
 
-    function test_checkHCUForFheNotRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForFheNotRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheNot));
 
@@ -1123,7 +1123,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheNot(FheType(resultType), mockLHS, mockResult);
     }
 
-    function test_checkHCUForCastRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForCastRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesInputCast));
 
@@ -1134,7 +1134,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForCast(FheType(resultType), mockLHS, mockResult);
     }
 
-    function test_CheckGasLimitForIfThenElseRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_CheckGasLimitForIfThenElseRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheIfThenElse));
 
@@ -1145,7 +1145,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForIfThenElse(FheType(resultType), mockLHS, mockMiddle, mockRHS, mockResult);
     }
 
-    function test_checkHCUForFheRandRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForFheRandRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheRand));
 
@@ -1156,7 +1156,7 @@ contract HCULimitTest is Test, SupportedTypesConstants {
         hcuLimit.checkHCUForFheRand(FheType(resultType), mockResult);
     }
 
-    function test_checkHCUForFheRandBoundedRevertsIfHCUTransationIsAboveHCUTransactionLimit(uint8 resultType) public {
+    function test_checkHCUForFheRandBoundedRevertsIfHCUTransactionIsAboveHCUTransactionLimit(uint8 resultType) public {
         vm.assume(resultType <= uint8(FheType.Int248));
         vm.assume(_isTypeSupported(FheType(resultType), supportedTypesFheRandBounded));
 

--- a/library-solidity/examples/EncryptedERC20.sol
+++ b/library-solidity/examples/EncryptedERC20.sol
@@ -206,7 +206,7 @@ contract EncryptedERC20 is Ownable2Step {
     /// @param amount The amount to transfer
     /// @param isTransferable Boolean indicating if the transfer is allowed
     function _transfer(address from, address to, euint64 amount, ebool isTransferable) internal virtual {
-        /// @dev Add to the balance of `to` and subract from the balance of `from`.
+        /// @dev Add to the balance of `to` and subtract from the balance of `from`.
         euint64 transferValue = FHE.select(isTransferable, amount, FHE.asEuint64(0));
         euint64 newBalanceTo = FHE.add(balances[to], transferValue);
         balances[to] = newBalanceTo;

--- a/library-solidity/examples/HeadsOrTails.sol
+++ b/library-solidity/examples/HeadsOrTails.sol
@@ -57,12 +57,12 @@ contract HeadsOrTails is ZamaEthereumConfig {
         return games[gameId].encryptedHasHeadWon;
     }
 
-    // This logic was before called through an oracle worklfow after requestDecryption
+    // This logic was before called through an oracle workflow after requestDecryption
     // now used by the enduser directly.
     function checkWinner(
         // pass handles in the right order, or it will fail.
         uint256 gameId,
-        // Thoses two next arguments are provided by calling the endpoint of the relayer or the relayer sdk
+        // Those two next arguments are provided by calling the endpoint of the relayer or the relayer sdk
         // using http public decrypt. There is some changes needed on the relayer sdk returns to fits this
         // new workflow.
         bytes memory clearGameResult,

--- a/library-solidity/lib/Impl.sol
+++ b/library-solidity/lib/Impl.sol
@@ -327,7 +327,7 @@ interface IACL {
     function allowForDecryption(bytes32[] memory handlesList) external;
 
     /**
-     * @notice                  Returns wether a handle is allowed to be publicly decrypted.
+     * @notice                  Returns whether a handle is allowed to be publicly decrypted.
      * @param handle            Handle.
      * @return isDecryptable    Whether the handle can be publicly decrypted.
      */

--- a/test-suite/e2e/contracts/EncryptedERC20.sol
+++ b/test-suite/e2e/contracts/EncryptedERC20.sol
@@ -205,7 +205,7 @@ contract EncryptedERC20 is Ownable2Step, E2ECoprocessorConfig {
     /// @param amount The amount to transfer
     /// @param isTransferable Boolean indicating if the transfer is allowed
     function _transfer(address from, address to, euint64 amount, ebool isTransferable) internal virtual {
-        /// @dev Add to the balance of `to` and subract from the balance of `from`.
+        /// @dev Add to the balance of `to` and subtract from the balance of `from`.
         euint64 transferValue = FHE.select(isTransferable, amount, FHE.asEuint64(0));
         euint64 newBalanceTo = FHE.add(balances[to], transferValue);
         balances[to] = newBalanceTo;

--- a/typos.toml
+++ b/typos.toml
@@ -47,7 +47,6 @@ extend-exclude = [
     "*.min.css",
     # Docs-only scope for now: exclude source/config/test files
     "*.rs",
-    "*.sol",
     "*.js",
     "*.sql",
     "*.toml",

--- a/typos.toml
+++ b/typos.toml
@@ -24,6 +24,13 @@ extend-exclude = [
     # Specific docs with known legacy typos (tracked separately)
     "coprocessor/fhevm-engine/host-listener/README.md",
 
+    # Upgrade-sensitive contracts (exclude from typo edits until infra sign-off)
+    "host-contracts/contracts/ACL.sol",
+    "host-contracts/contracts/FHEVMExecutor.sol",
+    "host-contracts/contracts/InputVerifier.sol",
+    "host-contracts/contracts/KMSVerifier.sol",
+    "host-contracts/contracts/HCULimit.sol",
+
     # Keys and charts (binary/config data)
     "fhevm-keys/",
     "charts/",


### PR DESCRIPTION
## Summary
- remove `*.sol` from `typos.toml` exclude list
- fix Solidity typos reported by `typos` across contracts, examples, and test contracts

## Testing
- typos

Closes #1909
