### PR TITLE
feat(coprocessor): standardize OTLP init + shutdown guard

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3425,6 +3425,8 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/fhevm-engine-common/Cargo.toml
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/Cargo.toml
@@ -23,6 +23,8 @@ tfhe = { workspace = true }
 tonic  = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { workspace = true }
 bytesize = { workspace = true}
 tokio-util = { workspace = true}
 axum = { workspace = true}

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -135,8 +135,6 @@ pub fn init_otel_tracing(
 
     let (tracer, trace_provider) = build_tracer_provider(service_name, tracer_name)?;
     install_global_tracer_provider(trace_provider.clone());
-    // TODO(fhevm-internal#935): remove explicit tracer return once all coprocessor
-    // instrumentation is fully migrated to tracing spans and layer-only wiring.
     Ok(Some((tracer, OtelGuard::new(trace_provider))))
 }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -90,6 +90,8 @@ pub fn init_otel_tracing(
 
     let (tracer, trace_provider) = build_tracer_provider(service_name, tracer_name)?;
     install_global_tracer_provider(trace_provider.clone());
+    // TODO(fhevm-internal#935): remove explicit tracer return once all coprocessor
+    // instrumentation is fully migrated to tracing spans and layer-only wiring.
     Ok(Some((tracer, OtelGuard::new(trace_provider))))
 }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -70,23 +70,6 @@ pub(crate) static ZKPROOF_TXN_LATENCY_HISTOGRAM: LazyLock<Histogram> = LazyLock:
     )
 });
 
-pub fn setup_otlp(
-    service_name: &str,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (_tracer, trace_provider) = build_otlp_tracer_and_provider(service_name, "otlp-layer")?;
-    install_global_otel(trace_provider);
-    Ok(())
-}
-
-pub fn setup_otlp_tracer(
-    service_name: &str,
-    tracer_name: &'static str,
-) -> Result<opentelemetry_sdk::trace::Tracer, Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (tracer, trace_provider) = build_otlp_tracer_and_provider(service_name, tracer_name)?;
-    install_global_otel(trace_provider);
-    Ok(tracer)
-}
-
 pub fn setup_otlp_with_shutdown(
     service_name: &str,
 ) -> Result<OtlpShutdownGuard, Box<dyn std::error::Error + Send + Sync + 'static>> {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -2,15 +2,10 @@ use crate::utils::to_hex;
 use bigdecimal::num_traits::ToPrimitive;
 use opentelemetry::{
     global::{BoxedSpan, BoxedTracer, ObjectSafeSpan},
-    propagation::TextMapCompositePropagator,
     trace::{SpanBuilder, Status, TraceContextExt, Tracer, TracerProvider},
     Context, KeyValue,
 };
-use opentelemetry_sdk::{
-    propagation::{BaggagePropagator, TraceContextPropagator},
-    trace::SdkTracerProvider,
-    Resource,
-};
+use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
 use prometheus::{register_histogram, Histogram};
 use sqlx::PgConnection;
 use std::fmt;
@@ -153,10 +148,6 @@ fn build_otlp_tracer_and_provider(
 
 fn install_global_otel(trace_provider: SdkTracerProvider) {
     opentelemetry::global::set_tracer_provider(trace_provider);
-    opentelemetry::global::set_text_map_propagator(TextMapCompositePropagator::new(vec![
-        Box::new(TraceContextPropagator::new()),
-        Box::new(BaggagePropagator::new()),
-    ]));
 }
 
 #[derive(Clone)]

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -108,15 +108,11 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(conf.log_level)
         .init();
 
-    let _otlp_shutdown_guard = if conf.service_name.is_empty() {
-        None
-    } else {
-        match telemetry::setup_otlp_with_shutdown(&conf.service_name) {
-            Ok(guard) => Some(guard),
-            Err(err) => {
-                error!(error = %err, "Failed to setup OTLP");
-                None
-            }
+    let _otlp_runtime = match telemetry::init_otlp(&conf.service_name) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            error!(error = %err, "Failed to setup OTLP");
+            None
         }
     };
 

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -108,7 +108,7 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(conf.log_level)
         .init();
 
-    let _otlp_runtime = match telemetry::init_otlp(&conf.service_name) {
+    let _otel_guard = match telemetry::init_otel(&conf.service_name) {
         Ok(runtime) => runtime,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -109,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let _otel_guard = match telemetry::init_otel(&conf.service_name) {
-        Ok(runtime) => runtime,
+        Ok(otel_guard) => otel_guard,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");
             None

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -1024,7 +1024,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         )
     };
 
-    let _otlp_runtime = match telemetry::init_otlp(&args.service_name) {
+    let _otel_guard = match telemetry::init_otel(&args.service_name) {
         Ok(runtime) => runtime,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -1025,7 +1025,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
     };
 
     let _otel_guard = match telemetry::init_otel(&args.service_name) {
-        Ok(runtime) => runtime,
+        Ok(otel_guard) => otel_guard,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");
             None

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -1024,15 +1024,11 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         )
     };
 
-    let _otlp_shutdown_guard = if args.service_name.is_empty() {
-        None
-    } else {
-        match telemetry::setup_otlp_with_shutdown(&args.service_name) {
-            Ok(guard) => Some(guard),
-            Err(err) => {
-                error!(error = %err, "Failed to setup OTLP");
-                None
-            }
+    let _otlp_runtime = match telemetry::init_otlp(&args.service_name) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            error!(error = %err, "Failed to setup OTLP");
+            None
         }
     };
 

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -90,7 +90,7 @@ pub struct PollerConfig {
 }
 
 pub async fn run_poller(config: PollerConfig) -> Result<()> {
-    let _otlp_runtime = match telemetry::init_otlp(&config.service_name) {
+    let _otel_guard = match telemetry::init_otel(&config.service_name) {
         Ok(runtime) => runtime,
         Err(err) => {
             warn!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -90,15 +90,11 @@ pub struct PollerConfig {
 }
 
 pub async fn run_poller(config: PollerConfig) -> Result<()> {
-    let _otlp_shutdown_guard = if config.service_name.is_empty() {
-        None
-    } else {
-        match telemetry::setup_otlp_with_shutdown(&config.service_name) {
-            Ok(guard) => Some(guard),
-            Err(err) => {
-                warn!(error = %err, "Failed to setup OTLP");
-                None
-            }
+    let _otlp_runtime = match telemetry::init_otlp(&config.service_name) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            warn!(error = %err, "Failed to setup OTLP");
+            None
         }
     };
 

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -91,7 +91,7 @@ pub struct PollerConfig {
 
 pub async fn run_poller(config: PollerConfig) -> Result<()> {
     let _otel_guard = match telemetry::init_otel(&config.service_name) {
-        Ok(runtime) => runtime,
+        Ok(otel_guard) => otel_guard,
         Err(err) => {
             warn!(error = %err, "Failed to setup OTLP");
             None

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -93,7 +93,7 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
     let _otel_guard = match telemetry::init_otel(&config.service_name) {
         Ok(otel_guard) => otel_guard,
         Err(err) => {
-            warn!(error = %err, "Failed to setup OTLP");
+            error!(error = %err, "Failed to setup OTLP");
             None
         }
     };

--- a/coprocessor/fhevm-engine/host-listener/tests/host_listener_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/host_listener_integration_tests.rs
@@ -316,7 +316,11 @@ async fn test_listener_no_event_loss(
     reorg: bool,
 ) -> Result<(), anyhow::Error> {
     let setup = setup(None).await?;
-    let args = setup.args.clone();
+    let mut args = setup.args.clone();
+    // This test intentionally aborts/restarts the listener many times.
+    // Keep telemetry disabled here to avoid coupling event-loss assertions
+    // with exporter/shutdown timing.
+    args.service_name.clear();
 
     // Start listener in background task
     let listener_handle = tokio::spawn(main(args.clone()));

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -69,14 +69,14 @@ async fn main() {
 
     let mut otlp_setup_error: Option<String> = None;
 
-    let otel_tracer = if config.service_name.is_empty() {
-        None
+    let (otel_tracer, _otlp_shutdown_guard) = if config.service_name.is_empty() {
+        (None, None)
     } else {
-        match telemetry::setup_otlp_tracer(&config.service_name, "otlp-layer") {
-            Ok(tracer) => Some(tracer),
+        match telemetry::setup_otlp_tracer_with_shutdown(&config.service_name, "otlp-layer") {
+            Ok((tracer, guard)) => (Some(tracer), Some(guard)),
             Err(err) => {
                 otlp_setup_error = Some(err.to_string());
-                None
+                (None, None)
             }
         }
     };

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -68,7 +68,7 @@ async fn main() {
 
     let mut otlp_setup_error: Option<String> = None;
 
-    let _otel_guard = match telemetry::init_json_subscriber_with_optional_otel(
+    let _otel_guard = match telemetry::init_json_subscriber_with_otel(
         config.log_level,
         &config.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -68,18 +68,15 @@ async fn main() {
 
     let mut otlp_setup_error: Option<String> = None;
 
-    let _otel_guard = match telemetry::init_json_subscriber_with_otel(
-        config.log_level,
-        &config.service_name,
-        "otlp-layer",
-    ) {
-        Ok(guard) => guard,
-        Err(err) => {
-            otlp_setup_error = Some(err.to_string());
-            telemetry::init_json_subscriber(config.log_level);
-            None
-        }
-    };
+    let _otel_guard =
+        match telemetry::init_json_subscriber(config.log_level, &config.service_name, "otlp-layer")
+        {
+            Ok(guard) => guard,
+            Err(err) => {
+                otlp_setup_error = Some(err.to_string());
+                None
+            }
+        };
 
     if let Some(err) = otlp_setup_error {
         error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -69,7 +69,7 @@ async fn main() {
 
     let mut otlp_setup_error: Option<String> = None;
 
-    let otlp_runtime = match telemetry::init_otlp_tracing(&config.service_name, "otlp-layer") {
+    let otel_guard = match telemetry::init_otel_tracing(&config.service_name, "otlp-layer") {
         Ok(runtime) => runtime,
         Err(err) => {
             otlp_setup_error = Some(err.to_string());
@@ -93,7 +93,7 @@ async fn main() {
         .with(level_filter)
         .with(fmt_layer);
 
-    if let Some(tracer) = otlp_runtime.as_ref().and_then(|runtime| runtime.tracer()) {
+    if let Some(tracer) = otel_guard.as_ref().and_then(|runtime| runtime.tracer()) {
         let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
         base.with(otel_layer).init();
     } else {

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -4,7 +4,6 @@ use fhevm_engine_common::telemetry;
 use tokio::signal::unix;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 mod utils;
 
 fn handle_sigint(token: CancellationToken) {
@@ -69,38 +68,18 @@ async fn main() {
 
     let mut otlp_setup_error: Option<String> = None;
 
-    let (otel_tracer, _otel_guard) =
-        match telemetry::init_otel_tracing(&config.service_name, "otlp-layer") {
-            Ok(Some((tracer, guard))) => (Some(tracer), Some(guard)),
-            Ok(None) => (None, None),
-            Err(err) => {
-                otlp_setup_error = Some(err.to_string());
-                (None, None)
-            }
-        };
-
-    let level_filter = tracing_subscriber::filter::LevelFilter::from_level(config.log_level);
-
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .json()
-        // drop "target" field so the logs are not too verbose. Instead, span names are used.
-        .with_target(false)
-        // keep "span"
-        .with_current_span(true)
-        // drop "spans"
-        .with_span_list(false)
-        .with_level(true);
-
-    let base = tracing_subscriber::registry()
-        .with(level_filter)
-        .with(fmt_layer);
-
-    if let Some(tracer) = otel_tracer {
-        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
-        base.with(otel_layer).init();
-    } else {
-        base.init();
-    }
+    let _otel_guard = match telemetry::init_json_subscriber_with_optional_otel(
+        config.log_level,
+        &config.service_name,
+        "otlp-layer",
+    ) {
+        Ok(guard) => guard,
+        Err(err) => {
+            otlp_setup_error = Some(err.to_string());
+            telemetry::init_json_subscriber(config.log_level);
+            None
+        }
+    };
 
     if let Some(err) = otlp_setup_error {
         error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -66,7 +66,7 @@ pub async fn async_main(
     info!(target: "async_main", args = ?args, "Starting runtime with args");
 
     let _otel_guard = match telemetry::init_otel(&args.service_name) {
-        Ok(runtime) => runtime,
+        Ok(otel_guard) => otel_guard,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");
             None

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -65,15 +65,11 @@ pub async fn async_main(
     let cancel_token = CancellationToken::new();
     info!(target: "async_main", args = ?args, "Starting runtime with args");
 
-    let _otlp_shutdown_guard = if args.service_name.is_empty() {
-        None
-    } else {
-        match telemetry::setup_otlp_with_shutdown(&args.service_name) {
-            Ok(guard) => Some(guard),
-            Err(err) => {
-                error!(error = %err, "Failed to setup OTLP");
-                None
-            }
+    let _otlp_runtime = match telemetry::init_otlp(&args.service_name) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            error!(error = %err, "Failed to setup OTLP");
+            None
         }
     };
 

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -65,7 +65,7 @@ pub async fn async_main(
     let cancel_token = CancellationToken::new();
     info!(target: "async_main", args = ?args, "Starting runtime with args");
 
-    let _otlp_runtime = match telemetry::init_otlp(&args.service_name) {
+    let _otel_guard = match telemetry::init_otel(&args.service_name) {
         Ok(runtime) => runtime,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -309,7 +309,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let _otel_guard = match telemetry::init_otel(&conf.service_name) {
-        Ok(runtime) => runtime,
+        Ok(otel_guard) => otel_guard,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");
             None

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -308,15 +308,11 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let _otlp_shutdown_guard = if conf.service_name.is_empty() {
-        None
-    } else {
-        match telemetry::setup_otlp_with_shutdown(&conf.service_name) {
-            Ok(guard) => Some(guard),
-            Err(err) => {
-                error!(error = %err, "Failed to setup OTLP");
-                None
-            }
+    let _otlp_runtime = match telemetry::init_otlp(&conf.service_name) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            error!(error = %err, "Failed to setup OTLP");
+            None
         }
     };
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -308,7 +308,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let _otlp_runtime = match telemetry::init_otlp(&conf.service_name) {
+    let _otel_guard = match telemetry::init_otel(&conf.service_name) {
         Ok(runtime) => runtime,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -104,7 +104,7 @@ async fn main() {
     };
 
     let _otel_guard = match telemetry::init_otel(&args.service_name) {
-        Ok(runtime) => runtime,
+        Ok(otel_guard) => otel_guard,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");
             None

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -103,7 +103,7 @@ async fn main() {
         pg_auto_explain_with_min_duration: args.pg_auto_explain_with_min_duration,
     };
 
-    let _otlp_runtime = match telemetry::init_otlp(&args.service_name) {
+    let _otel_guard = match telemetry::init_otel(&args.service_name) {
         Ok(runtime) => runtime,
         Err(err) => {
             error!(error = %err, "Failed to setup OTLP");

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -103,15 +103,11 @@ async fn main() {
         pg_auto_explain_with_min_duration: args.pg_auto_explain_with_min_duration,
     };
 
-    let _otlp_shutdown_guard = if args.service_name.is_empty() {
-        None
-    } else {
-        match telemetry::setup_otlp_with_shutdown(&args.service_name) {
-            Ok(guard) => Some(guard),
-            Err(err) => {
-                error!(error = %err, "Failed to setup OTLP");
-                None
-            }
+    let _otlp_runtime = match telemetry::init_otlp(&args.service_name) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            error!(error = %err, "Failed to setup OTLP");
+            None
         }
     };
 


### PR DESCRIPTION
## Summary
- unify coprocessor OTEL init and shutdown lifecycle in `fhevm-engine-common::telemetry`
- centralize `sns-worker` subscriber + optional OTEL layer wiring in common telemetry
- keep behavior minimal: global tracer provider only, no extra propagator config

## Validation
- pre-commit passed (`cargo fmt`, `cargo check`, `clippy`)
- targeted check passed:
  `SQLX_OFFLINE=true cargo check -p fhevm-engine-common -p sns-worker -p gw-listener -p host-listener -p tfhe-worker -p transaction-sender -p zkproof-worker`
- telemetry unit tests pass in `fhevm-engine-common`

## Scope
- no gRPC migration
- no operation-level span migration

Closes https://github.com/zama-ai/fhevm-internal/issues/1006
