### PR TITLE
feat(coprocessor): re-randomise ciphertext inputs per FHE operation

### DIFF
--- a/coprocessor/fhevm-engine/scheduler/src/lib.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/lib.rs
@@ -9,7 +9,7 @@ pub static RERAND_LATENCY_BATCH_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|
     register_histogram(
         RERAND_LATENCY_BATCH_HISTOGRAM_CONF.get(),
         "coprocessor_rerand_batch_latency_seconds",
-        "Re-randomization latencies per transaction in seconds",
+        "Re-randomization latencies per operation in seconds",
     )
 });
 


### PR DESCRIPTION
Re-randomisation is moved at operation level to enable coprocessor consensus.

Each operation's inputs re-randomised for every operation using only the hash of the input ciphertext and the operator for seed generation. As the output handle and randomisation use the same source of entropy, this achieves (at least semantically) a dynamic single assignment property.