### PR TITLE
chore(common): enable rs typos checks

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/gpu_memory.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/gpu_memory.rs
@@ -85,7 +85,7 @@ pub fn release_memory_on_gpu(amount: u64, idx: usize) {
 pub fn get_op_size_on_gpu(
     fhe_operation_int: i16,
     input_operands: &[SupportedFheCiphertexts],
-    // for deterministc randomness functions
+    // for deterministic randomness functions
 ) -> Result<u64, FhevmError> {
     let fhe_operation: SupportedFheOperations =
         fhe_operation_int.try_into().expect("Invalid operation");

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/tfhe_ops.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/tfhe_ops.rs
@@ -83,7 +83,7 @@ pub fn trivial_encrypt_be_bytes(output_type: i16, input_bytes: &[u8]) -> Support
     };
     match output_type {
         0 => SupportedFheCiphertexts::FheBool(
-            FheBool::try_encrypt_trivial(last_byte > 0).expect("trival encrypt bool"),
+            FheBool::try_encrypt_trivial(last_byte > 0).expect("trivial encrypt bool"),
         ),
         1 => SupportedFheCiphertexts::FheUint4(
             FheUint4::try_encrypt_trivial(last_byte).expect("trivial encrypt 4"),
@@ -740,7 +740,7 @@ pub fn perform_fhe_operation(
     fhe_operation_int: i16,
     input_operands: &[SupportedFheCiphertexts],
     _: usize,
-    // for deterministc randomness functions
+    // for deterministic randomness functions
 ) -> Result<SupportedFheCiphertexts, FhevmError> {
     perform_fhe_operation_impl(fhe_operation_int, input_operands)
 }
@@ -750,7 +750,7 @@ pub fn perform_fhe_operation(
     fhe_operation_int: i16,
     input_operands: &[SupportedFheCiphertexts],
     gpu_idx: usize,
-    // for deterministc randomness functions
+    // for deterministic randomness functions
 ) -> Result<SupportedFheCiphertexts, FhevmError> {
     use crate::gpu_memory::{get_op_size_on_gpu, release_memory_on_gpu, reserve_memory_on_gpu};
 
@@ -767,7 +767,7 @@ pub fn perform_fhe_operation(
 pub fn perform_fhe_operation_impl(
     fhe_operation_int: i16,
     input_operands: &[SupportedFheCiphertexts],
-    // for deterministc randomness functions
+    // for deterministic randomness functions
 ) -> Result<SupportedFheCiphertexts, FhevmError> {
     let fhe_operation: SupportedFheOperations = fhe_operation_int.try_into()?;
     match fhe_operation {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
@@ -22,7 +22,7 @@ pub enum FhevmError {
     UnknownFheType(i32),
     DeserializationError(Box<dyn std::error::Error + Sync + Send>),
     CiphertextExpansionError(tfhe::Error),
-    ReRandomizationError(tfhe::Error),
+    ReRandomisationError(tfhe::Error),
     CiphertextCompressionError(tfhe::Error),
     CiphertextCompressionRequiresEmptyCarries,
     CiphertextCompressionPanic {
@@ -156,8 +156,8 @@ impl std::fmt::Display for FhevmError {
             Self::CiphertextExpansionError(e) => {
                 write!(f, "error expanding compact ciphertext list: {:?}", e)
             }
-            Self::ReRandomizationError(e) => {
-                write!(f, "error re-randomizing ciphertext: {:?}", e)
+            Self::ReRandomisationError(e) => {
+                write!(f, "error re-randomising ciphertext: {:?}", e)
             }
             Self::CiphertextCompressionError(e) => {
                 write!(f, "error compressing ciphertext: {:?}", e)
@@ -780,7 +780,7 @@ impl SupportedFheCiphertexts {
             }
         };
     }
-    pub fn re_randomize(
+    pub fn re_randomise(
         &mut self,
         cpk: &CompactPublicKey,
         seed: ReRandomizationSeed,
@@ -788,51 +788,51 @@ impl SupportedFheCiphertexts {
         match self {
             SupportedFheCiphertexts::FheBool(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint4(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint8(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint16(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint32(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint64(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint128(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint160(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheUint256(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheBytes64(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheBytes128(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::FheBytes256(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomizationError)?;
+                    .map_err(FhevmError::ReRandomisationError)?;
             }
             SupportedFheCiphertexts::Scalar(_s) => {
                 // Do nothing

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
@@ -22,7 +22,7 @@ pub enum FhevmError {
     UnknownFheType(i32),
     DeserializationError(Box<dyn std::error::Error + Sync + Send>),
     CiphertextExpansionError(tfhe::Error),
-    ReRandomisationError(tfhe::Error),
+    ReRandomizationError(tfhe::Error),
     CiphertextCompressionError(tfhe::Error),
     CiphertextCompressionRequiresEmptyCarries,
     CiphertextCompressionPanic {
@@ -156,8 +156,8 @@ impl std::fmt::Display for FhevmError {
             Self::CiphertextExpansionError(e) => {
                 write!(f, "error expanding compact ciphertext list: {:?}", e)
             }
-            Self::ReRandomisationError(e) => {
-                write!(f, "error re-randomising ciphertext: {:?}", e)
+            Self::ReRandomizationError(e) => {
+                write!(f, "error re-randomizing ciphertext: {:?}", e)
             }
             Self::CiphertextCompressionError(e) => {
                 write!(f, "error compressing ciphertext: {:?}", e)
@@ -611,7 +611,7 @@ impl SupportedFheCiphertexts {
     }
 
     // Decompress without checking if enough GPU memory is available -
-    // used when GPU featre is active, but decompressing on CPU
+    // used when GPU feature is active, but decompressing on CPU
     pub fn decompress_no_memcheck(ct_type: i16, list: &[u8]) -> Result<Self> {
         let ctlist: CompressedCiphertextList = safe_deserialize(list)?;
         Self::decompress_impl(ct_type, &ctlist)
@@ -780,7 +780,7 @@ impl SupportedFheCiphertexts {
             }
         };
     }
-    pub fn re_randomise(
+    pub fn re_randomize(
         &mut self,
         cpk: &CompactPublicKey,
         seed: ReRandomizationSeed,
@@ -788,51 +788,51 @@ impl SupportedFheCiphertexts {
         match self {
             SupportedFheCiphertexts::FheBool(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint4(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint8(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint16(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint32(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint64(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint128(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint160(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheUint256(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheBytes64(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheBytes128(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::FheBytes256(c) => {
                 c.re_randomize(cpk, seed)
-                    .map_err(FhevmError::ReRandomisationError)?;
+                    .map_err(FhevmError::ReRandomizationError)?;
             }
             SupportedFheCiphertexts::Scalar(_s) => {
                 // Do nothing

--- a/coprocessor/fhevm-engine/gw-listener/src/sks_key.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/sks_key.rs
@@ -26,7 +26,7 @@ pub fn extract_server_key_without_ns(sns_key: &[u8]) -> anyhow::Result<Vec<u8>> 
         anyhow::bail!("Server key does not have noise squashing");
     }
     if noise_squashing_compression_key.is_none() {
-        anyhow::bail!("Server key does not have noise squashing compresion");
+        anyhow::bail!("Server key does not have noise squashing compression");
     }
     if re_randomization_keyswitching_key.is_none() {
         anyhow::bail!("Server key does not have rerandomisation");

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -656,7 +656,7 @@ impl InfiniteLogIter {
         ))
     }
 
-    async fn get_missings_ancestors(
+    async fn get_missing_ancestors(
         &self,
         mut current_block: BlockSummary,
     ) -> Vec<BlockSummary> {
@@ -730,7 +730,7 @@ impl InfiniteLogIter {
         }
 
         let missing_blocks =
-            self.get_missings_ancestors(current_block_summary).await;
+            self.get_missing_ancestors(current_block_summary).await;
         if missing_blocks.is_empty() {
             // we don't add to history from which we have no event
             // e.g. at timeout, because empty blocks are not get_logs
@@ -762,7 +762,7 @@ impl InfiniteLogIter {
         // note subscribing to real-time before reading catchup
         // events to have the minimal gap between the two
         // TODO: but it does not guarantee no gap for now
-        // (implementation dependant)
+        // (implementation dependent)
         // subscribe_logs does not honor from_block and sometime not to_block
         // so we rely on catchup_blocks and end_at_block_reached
         self.stream = Some(provider.subscribe_blocks().await?.into_stream());
@@ -784,7 +784,7 @@ impl InfiniteLogIter {
         };
         let next_opt_event = stream.next();
         // it assume the eventual discard of next_opt_event is handled correctly
-        // by alloy if not the case, the recheck mecanism ensures it's
+        // by alloy if not the case, the recheck mechanism ensures it's
         // only extra latency
         match tokio::time::timeout(
             Duration::from_secs(self.block_time + 2),

--- a/coprocessor/fhevm-engine/host-listener/src/database/dependence_chains.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/dependence_chains.rs
@@ -33,7 +33,7 @@ impl Transaction {
             allowed_handle: Vec::with_capacity(5),
             input_tx: HashSet::with_capacity(3),
             output_tx: HashSet::with_capacity(3),
-            linear_chain: tx_hash, //  before coallescing linear tx chains
+            linear_chain: tx_hash, //  before coalescing linear tx chains
             size: 0,
             depth_size: 0,
         }

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -684,7 +684,7 @@ impl Database {
         block_number: u64,
         transaction_id: Option<Vec<u8>>,
     ) -> Result<bool, SqlxError> {
-        // ON CONFLIT is done on Unique constraint
+        // ON CONFLICT is done on Unique constraint
         let query = sqlx::query!(
             "INSERT INTO delegate_user_decrypt(
                 delegator, delegate, contract_address, delegation_counter, old_expiration_date, new_expiration_date, host_chain_id, block_number, block_hash, transaction_id, on_gateway, reorg_out)

--- a/coprocessor/fhevm-engine/host-listener/tests/host_listener_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/host_listener_integration_tests.rs
@@ -349,7 +349,7 @@ async fn test_listener_no_event_loss(
     let mut acl_events_count = 0;
     let mut nb_kill = 1;
     let nb_wallets = setup.wallets.len() as i64;
-    // Restart/kill many time until no more events are consumned.
+    // Restart/kill many time until no more events are consumed.
     for _ in 1..120 {
         // 10 mins max to avoid stalled CI
         let listener_handle = tokio::spawn(main(args.clone()));

--- a/coprocessor/fhevm-engine/scheduler/src/dfg.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg.rs
@@ -687,7 +687,7 @@ impl DFGraph {
     }
 }
 
-pub fn add_execution_depedences<TNode, TEdge>(
+pub fn add_execution_dependences<TNode, TEdge>(
     graph: &Dag<TNode, TEdge>,
     execution_graph: &mut Dag<ExecNode, ()>,
     node_map: HashMap<NodeIndex, NodeIndex>,
@@ -759,7 +759,7 @@ pub fn partition_preserving_parallelism<TNode, TEdge>(
             execution_graph[ex_node].df_nodes = df_nodes;
         }
     }
-    add_execution_depedences(graph, execution_graph, node_map)
+    add_execution_dependences(graph, execution_graph, node_map)
 }
 
 pub fn partition_components<TNode, TEdge>(

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
@@ -63,7 +63,7 @@ pub enum SchedulerError {
     DataflowGraphError,
     MissingInputs,
     DecompressionError,
-    ReRandomizationError,
+    ReRandomisationError,
     SchedulerError,
 }
 
@@ -84,8 +84,8 @@ impl std::fmt::Display for SchedulerError {
             Self::DecompressionError => {
                 write!(f, "Decompression error")
             }
-            Self::ReRandomizationError => {
-                write!(f, "Re-randomization error")
+            Self::ReRandomisationError => {
+                write!(f, "Re-randomisation error")
             }
             Self::SchedulerError => {
                 write!(f, "Generic scheduler error")

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
@@ -63,7 +63,7 @@ pub enum SchedulerError {
     DataflowGraphError,
     MissingInputs,
     DecompressionError,
-    ReRandomisationError,
+    ReRandomizationError,
     SchedulerError,
 }
 
@@ -84,8 +84,8 @@ impl std::fmt::Display for SchedulerError {
             Self::DecompressionError => {
                 write!(f, "Decompression error")
             }
-            Self::ReRandomisationError => {
-                write!(f, "Re-randomisation error")
+            Self::ReRandomizationError => {
+                write!(f, "Re-randomization error")
             }
             Self::SchedulerError => {
                 write!(f, "Generic scheduler error")

--- a/coprocessor/fhevm-engine/tfhe-worker/src/dependence_chain.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/dependence_chain.rs
@@ -334,7 +334,7 @@ impl LockMngr {
             }
         };
 
-        // Since UPDATE always aquire a row-level lock internally,
+        // Since UPDATE always acquire a row-level lock internally,
         // this acts as atomic_exchange
         let rows = if let Some(update_at) = update_at {
             sqlx::query!(

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -118,11 +118,11 @@ async fn tfhe_worker_cycle(
             &pool,
         )
         .await?;
-    let mut immedially_poll_more_work = false;
+    let mut immediately_poll_more_work = false;
     let mut no_progress_cycles = 0;
     loop {
         // only if previous iteration had no work done do the wait
-        if !immedially_poll_more_work {
+        if !immediately_poll_more_work {
             tokio::select! {
                 _ = listener.try_recv() => {
                     WORK_ITEMS_NOTIFICATIONS_COUNTER.inc();
@@ -160,7 +160,7 @@ async fn tfhe_worker_cycle(
         if has_more_work {
             // We've fetched work, so we'll poll again without waiting
             // for a notification after this cycle.
-            immedially_poll_more_work = true;
+            immediately_poll_more_work = true;
         } else {
             dcid_mngr.release_current_lock(true, None).await?;
             dcid_mngr.do_cleanup().await?;
@@ -171,7 +171,7 @@ async fn tfhe_worker_cycle(
             let mut s = tracer.start_with_context("query_dependence_chain", &loop_ctx);
 
             let (dependence_chain_id, _) = dcid_mngr.acquire_next_lock().await?;
-            immedially_poll_more_work = dependence_chain_id.is_some();
+            immediately_poll_more_work = dependence_chain_id.is_some();
 
             s.set_attribute(KeyValue::new(
                 "dependence_chain_id",

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -174,7 +174,7 @@ struct Conf {
     #[arg(
         long,
         default_value = "648000", // 3 months assuming 12s block time on host chain
-        help = "Clear delegation entries after N blocks (deault to 3 months)"
+        help = "Clear delegation entries after N blocks (default to 3 months)"
     )]
     pub delegation_clear_after_n_blocks: u64,
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -54,7 +54,7 @@ pub struct DelegationRow {
 
 #[derive(Copy, Clone)]
 enum BlockStatus {
-    Unkown,    // the status could not be determined
+    Unknown,   // the status could not be determined
     Stable,    // block is still valid
     Dismissed, // block has been reorged out
 }
@@ -151,7 +151,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
                 warn!(
                     %error,
                     ?delegation,
-                    "{operation} sending with transient error. Will retry indefinitively"
+                    "{operation} sending with transient error. Will retry indefinitely"
                 );
                 return TxResult::TransientError;
             }
@@ -263,7 +263,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
                             "Cannot get block hash for delegation, will retry next block"
                         );
                         unsure_block.push(delegation.block_number);
-                        BlockStatus::Unkown
+                        BlockStatus::Unknown
                     }
                 };
                 blocks_status.insert(delegation.block_number, status);
@@ -273,7 +273,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
                 BlockStatus::Stable => {
                     stable_delegations.push(delegation.clone());
                 }
-                BlockStatus::Unkown => {
+                BlockStatus::Unknown => {
                     // skip the full block, will retry on the delegation on next call
                     nb_unsure_delegations += 1;
                     continue;
@@ -326,7 +326,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
             let block_number = self.host_chain_provider.get_block_number().await?;
             warn!(
                 block_number,
-                "Delegation notification, based on timeout, use last block nmber"
+                "Delegation notification, based on timeout, use last block number"
             );
             return Ok(block_number);
         };
@@ -401,7 +401,7 @@ where
             all_transaction_id.insert(tx_id);
         }
         // we don't split by transition_id because delegations have an internal order
-        // it's expected that both order are compatible but we don't now the transation_id order
+        // it's expected that both order are compatible but we don't know the transaction_id order
         let ts = all_transaction_id
             .iter()
             .map(|id| telemetry::tracer("prepare_delegate", id))

--- a/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -126,7 +126,7 @@ where
                                     error!(
                                         channel = op_channel,
                                         error = %e,
-                                        "Backend gone error, stopping operation and signalling other operations to stop"
+                                        "Backend gone error, stopping operation and signaling other operations to stop"
                                     );
                                     token.cancel();
                                     return Err(e);

--- a/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
@@ -48,7 +48,7 @@ pub enum ExecutionError {
     InvalidProof(i64, String),
 
     #[error("Fhevm error: {0}")]
-    FaildFhevm(#[from] FhevmError),
+    FailedFhevm(#[from] FhevmError),
 
     #[error("Server keys not found {0}")]
     ServerKeysNotFound(String),

--- a/kms-connector/crates/gw-listener/src/core/gw_listener.rs
+++ b/kms-connector/crates/gw-listener/src/core/gw_listener.rs
@@ -450,7 +450,7 @@ mod tests {
     async fn test_listener_ended_by_end_of_any_task() {
         let (mut test_instance, _asserter, gw_listener) = test_setup(None).await;
 
-        // Will stop because some subcription tasks will not be able to init their event filter
+        // Will stop because some subscription tasks will not be able to init their event filter
         gw_listener.start().await;
 
         test_instance.wait_for_log("Failed to subscribe to").await;

--- a/kms-connector/crates/kms-worker/tests/event_picker/parallel.rs
+++ b/kms-connector/crates/kms-worker/tests/event_picker/parallel.rs
@@ -52,7 +52,7 @@ async fn test_parallel_crsgen_picking() -> anyhow::Result<()> {
 #[rstest]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-#[ignore = "Not possible to have parallel PRSS Init the only ID currenly allowed is 1"]
+#[ignore = "Not possible to have parallel PRSS Init the only ID currently allowed is 1"]
 async fn test_parallel_prss_init_picking() -> anyhow::Result<()> {
     test_parallel_request_picking(EventType::PrssInit).await
 }

--- a/sdk/rust-sdk/examples/minimal-user-decryption-response.rs
+++ b/sdk/rust-sdk/examples/minimal-user-decryption-response.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
         .with_signature("eed514aa094b8a9aff0314a749eef12e2d1d36c44484f1814ae1be9aeb8a9eef41e87d2bde2019131f81a25dcc482bcc0d1ed3cc9f65ebda0a44b9fc42f091621b")
         .with_json_response(json_response)
         .with_verification(true)
-        .with_domain("Authorization token")// Be carefull, domain should be Decryption, but this example has been generated with Authorization token
+        .with_domain("Authorization token")// Be careful, domain should be Decryption, but this example has been generated with Authorization token
         .process();
 
     match result {

--- a/test-suite/gateway-stress/src/blockchain/manager.rs
+++ b/test-suite/gateway-stress/src/blockchain/manager.rs
@@ -290,7 +290,7 @@ impl GatewayTestManager {
 ///
 /// - One is used to track when requests are received by the Gateway (tx receipt was received).
 /// - The other is used to track when responses are received by the Gateway (response event was
-///   catched).
+///   caught).
 fn init_progress_bars(
     config: &Config,
     progress_tracker: &MultiProgress,

--- a/test-suite/gateway-stress/src/decryption/public.rs
+++ b/test-suite/gateway-stress/src/decryption/public.rs
@@ -152,14 +152,14 @@ pub async fn init_public_decryption_response_listener<P: Provider>(
         >,
     >,
 > {
-    debug!("Subcribing to PublicDecryptionResponse events...");
+    debug!("Subscribing to PublicDecryptionResponse events...");
     let mut response_filter = decryption_contract
         .PublicDecryptionResponse_filter()
         .watch()
         .await
         .map_err(|e| anyhow!("Failed to subscribe to PublicDecryptionResponse {e}"))?;
     debug!(
-        "Subcribed to PublicDecryptionResponse events! Can start sending PublicDecryptionRequests..."
+        "Subscribed to PublicDecryptionResponse events! Can start sending PublicDecryptionRequests..."
     );
 
     response_filter.poller = response_filter

--- a/test-suite/gateway-stress/src/decryption/user.rs
+++ b/test-suite/gateway-stress/src/decryption/user.rs
@@ -210,7 +210,7 @@ pub async fn init_user_decryption_response_listener<P: Provider>(
         >,
     >,
 > {
-    debug!("Subcribing to UserDecryptionResponseThresholdReached events...");
+    debug!("Subscribing to UserDecryptionResponseThresholdReached events...");
     let mut response_filter = decryption_contract
         .UserDecryptionResponseThresholdReached_filter()
         .watch()
@@ -219,7 +219,7 @@ pub async fn init_user_decryption_response_listener<P: Provider>(
             anyhow!("Failed to subscribe to UserDecryptionResponseThresholdReached {e}")
         })?;
     debug!(
-        "Subcribed to UserDecryptionResponseThresholdReached events! \
+        "Subscribed to UserDecryptionResponseThresholdReached events! \
         Can start sending UserDecryptionRequests..."
     );
 

--- a/typos.toml
+++ b/typos.toml
@@ -46,7 +46,6 @@ extend-exclude = [
     "*.min.js",
     "*.min.css",
     # Docs-only scope for now: exclude source/config/test files
-    "*.rs",
     "*.sol",
     "*.js",
     "*.sql",

--- a/typos.toml
+++ b/typos.toml
@@ -99,6 +99,14 @@ authorised = "authorised"
 decentralised = "decentralised"
 artefacts = "artefacts"
 misbehaviour = "misbehaviour"
+randomise = "randomise"
+randomised = "randomised"
+randomising = "randomising"
+randomisation = "randomisation"
+rerandomise = "rerandomise"
+rerandomised = "rerandomised"
+rerandomising = "rerandomising"
+rerandomisation = "rerandomisation"
 
 # FHE/TFHE terminology - these are valid domain-specific terms
 euint = "euint"           # encrypted unsigned integer type prefix


### PR DESCRIPTION
## Summary
- remove `*.rs` from `extend-exclude` in `typos.toml`
- fix all Rust typos reported by `typos`
- keep the change scoped to `typos.toml` + `.rs` files only

## Testing
- `typos`
- pre-commit hook checks for coprocessor (auto-run on commit):
  - `cargo fmt --check`
  - `cargo check`
  - `cargo clippy -- -D warnings -D clippy::all -D clippy::pedantic`
- `cargo check` in `test-suite/gateway-stress`
- `cargo check` in `kms-connector`

Closes #1910
