### PR TITLE
feat(coprocessor): migrate sns-worker Phase B spans to tracing

### DIFF
--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -188,6 +188,7 @@ async fn run_uploader_loop(
                             AWS_UPLOAD_FAILURE_COUNTER.inc();
                         }
                     }
+                    drop(upload_span);
                     drop(permit);
                 });
 
@@ -274,6 +275,7 @@ async fn upload_ciphertexts(
             }
         };
         ct128_check_span.record("exists", tracing::field::display(exists));
+        drop(ct128_check_span);
 
         if !exists {
             let ct128_upload_span = tracing::info_span!(
@@ -347,6 +349,7 @@ async fn upload_ciphertexts(
             }
         };
         ct64_check_span.record("exists", tracing::field::display(exists));
+        drop(ct64_check_span);
 
         if !exists {
             let ct64_upload_span = tracing::info_span!(
@@ -401,8 +404,10 @@ async fn upload_ciphertexts(
                     span.context()
                         .span()
                         .set_status(Status::error(err.to_string()));
+                    drop(span);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
+                    drop(span);
                     task.update_ct128_uploaded(&mut trx, digest).await?;
                 }
             }
@@ -417,8 +422,10 @@ async fn upload_ciphertexts(
                     span.context()
                         .span()
                         .set_status(Status::error(err.to_string()));
+                    drop(span);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
+                    drop(span);
                     task.update_ct64_uploaded(&mut trx, digest).await?;
                 }
             }

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -260,7 +260,6 @@ async fn upload_ciphertexts(
             ct_type = "ct128",
             exists = tracing::field::Empty,
         );
-        ct128_check_span.set_parent(task.otel.context().clone());
         let exists = match check_object_exists(client, &conf.bucket_ct128, &key)
             .instrument(ct128_check_span.clone())
             .await
@@ -284,7 +283,6 @@ async fn upload_ciphertexts(
                 format = %format_as_str,
                 len = ct128_bytes.len(),
             );
-            ct128_upload_span.set_parent(task.otel.context().clone());
 
             jobs.push((
                 client
@@ -335,7 +333,6 @@ async fn upload_ciphertexts(
             ct_type = "ct64",
             exists = tracing::field::Empty,
         );
-        ct64_check_span.set_parent(task.otel.context().clone());
         let exists = match check_object_exists(client, &conf.bucket_ct64, &key)
             .instrument(ct64_check_span.clone())
             .await
@@ -358,7 +355,6 @@ async fn upload_ciphertexts(
                 ct_type = "ct64",
                 len = ct64_compressed.len(),
             );
-            ct64_upload_span.set_parent(task.otel.context().clone());
 
             jobs.push((
                 client

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -188,6 +188,7 @@ async fn run_uploader_loop(
                             AWS_UPLOAD_FAILURE_COUNTER.inc();
                         }
                     }
+                    drop(upload_span);
                     drop(permit);
                 });
 

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -274,6 +274,7 @@ async fn upload_ciphertexts(
             }
         };
         ct128_check_span.record("exists", tracing::field::display(exists));
+        drop(ct128_check_span);
 
         if !exists {
             let ct128_upload_span = tracing::info_span!(
@@ -347,6 +348,7 @@ async fn upload_ciphertexts(
             }
         };
         ct64_check_span.record("exists", tracing::field::display(exists));
+        drop(ct64_check_span);
 
         if !exists {
             let ct64_upload_span = tracing::info_span!(
@@ -401,8 +403,10 @@ async fn upload_ciphertexts(
                     span.context()
                         .span()
                         .set_status(Status::error(err.to_string()));
+                    drop(span);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
+                    drop(span);
                     task.update_ct128_uploaded(&mut trx, digest).await?;
                 }
             }
@@ -417,8 +421,10 @@ async fn upload_ciphertexts(
                     span.context()
                         .span()
                         .set_status(Status::error(err.to_string()));
+                    drop(span);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
+                    drop(span);
                     task.update_ct64_uploaded(&mut trx, digest).await?;
                 }
             }

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -282,6 +282,7 @@ async fn upload_ciphertexts(
                 operation = "ct128_upload_s3",
                 ct_type = "ct128",
                 format = %format_as_str,
+                len = ct128_bytes.len(),
             );
             ct128_upload_span.set_parent(task.otel.context().clone());
 
@@ -354,7 +355,8 @@ async fn upload_ciphertexts(
             let ct64_upload_span = tracing::info_span!(
                 "ct64_upload_s3",
                 operation = "ct64_upload_s3",
-                ct_type = "ct64"
+                ct_type = "ct64",
+                len = ct64_compressed.len(),
             );
             ct64_upload_span.set_parent(task.otel.context().clone());
 

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -188,7 +188,6 @@ async fn run_uploader_loop(
                             AWS_UPLOAD_FAILURE_COUNTER.inc();
                         }
                     }
-                    drop(upload_span);
                     drop(permit);
                 });
 
@@ -275,7 +274,6 @@ async fn upload_ciphertexts(
             }
         };
         ct128_check_span.record("exists", tracing::field::display(exists));
-        drop(ct128_check_span);
 
         if !exists {
             let ct128_upload_span = tracing::info_span!(
@@ -349,7 +347,6 @@ async fn upload_ciphertexts(
             }
         };
         ct64_check_span.record("exists", tracing::field::display(exists));
-        drop(ct64_check_span);
 
         if !exists {
             let ct64_upload_span = tracing::info_span!(
@@ -404,10 +401,8 @@ async fn upload_ciphertexts(
                     span.context()
                         .span()
                         .set_status(Status::error(err.to_string()));
-                    drop(span);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
-                    drop(span);
                     task.update_ct128_uploaded(&mut trx, digest).await?;
                 }
             }
@@ -422,10 +417,8 @@ async fn upload_ciphertexts(
                     span.context()
                         .span()
                         .set_status(Status::error(err.to_string()));
-                    drop(span);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
-                    drop(span);
                     task.update_ct64_uploaded(&mut trx, digest).await?;
                 }
             }

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -9,21 +9,21 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use bytesize::ByteSize;
 use fhevm_engine_common::pg_pool::{PostgresPoolManager, ServiceError};
-use fhevm_engine_common::telemetry::{self};
+use fhevm_engine_common::telemetry;
 use fhevm_engine_common::utils::to_hex;
 use futures::future::join_all;
-use opentelemetry::global::BoxedSpan;
+use opentelemetry::trace::{Status, TraceContextExt};
 use sha3::{Digest, Keccak256};
 use sqlx::{PgPool, Pool, Postgres, Transaction};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::SystemTime;
 use tokio::select;
 use tokio::sync::{mpsc, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, error_span, info, warn, Instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 // TODO: Use a config TOML to set these values
 pub const EVENT_CIPHERTEXTS_UPLOADED: &str = "event_ciphertexts_uploaded";
@@ -32,6 +32,12 @@ pub const EVENT_CIPHERTEXTS_UPLOADED: &str = "event_ciphertexts_uploaded";
 // There might be pending uploads in the database
 // with sizes of 32MiB so the batch size is set to 10
 const DEFAULT_BATCH_SIZE: usize = 10;
+
+fn set_span_error(span: &tracing::Span, err: &impl std::fmt::Display) {
+    span.context()
+        .span()
+        .set_status(Status::error(err.to_string()));
+}
 
 pub(crate) async fn spawn_resubmit_task(
     pool_mngr: &PostgresPoolManager,
@@ -165,10 +171,13 @@ async fn run_uploader_loop(
 
                 // Spawn a new task to upload the ciphertexts
                 let h = tokio::spawn(async move {
-                    let s = item.otel.child_span("upload_s3");
-                    match upload_ciphertexts(trx, item, &client, &conf).instrument(error_span!("upload_s3")).await {
+                    let upload_span = error_span!("upload_s3", operation = "upload_s3");
+                    upload_span.set_parent(item.otel.context().clone());
+                    match upload_ciphertexts(trx, item, &client, &conf)
+                        .instrument(upload_span.clone())
+                        .await
+                    {
                         Ok(()) => {
-                            telemetry::end_span(s);
                             AWS_UPLOAD_SUCCESS_COUNTER.inc();
                         }
                         Err(err) => {
@@ -178,7 +187,7 @@ async fn run_uploader_loop(
                             } else {
                                 error!(error = %err, "Failed to upload ciphertexts");
                             }
-                            telemetry::end_span_with_err(s, err.to_string());
+                            set_span_error(&upload_span, &err);
                             AWS_UPLOAD_FAILURE_COUNTER.inc();
                         }
                     }
@@ -205,8 +214,8 @@ async fn run_uploader_loop(
 }
 
 enum UploadResult {
-    CtType128((Vec<u8>, BoxedSpan)),
-    CtType64((Vec<u8>, BoxedSpan)),
+    CtType128((Vec<u8>, tracing::Span)),
+    CtType64((Vec<u8>, tracing::Span)),
 }
 
 /// Uploads both 128-bit bootstrapped ciphertext and regular ciphertext to S3
@@ -248,15 +257,33 @@ async fn upload_ciphertexts(
             hex::encode(&ct128_digest)
         };
 
-        let mut s = task.otel.child_span("ct128_check_s3");
-        let exists = check_object_exists(client, &conf.bucket_ct128, &key).await?;
-        telemetry::attribute(&mut s, "exists", exists.to_string());
-        telemetry::end_span(s);
+        let ct128_check_span = tracing::info_span!(
+            "ct128_check_s3",
+            operation = "ct128_check_s3",
+            ct_type = "ct128",
+            exists = tracing::field::Empty,
+        );
+        ct128_check_span.set_parent(task.otel.context().clone());
+        let exists = match check_object_exists(client, &conf.bucket_ct128, &key)
+            .instrument(ct128_check_span.clone())
+            .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                set_span_error(&ct128_check_span, &err);
+                return Err(err);
+            }
+        };
+        ct128_check_span.record("exists", tracing::field::display(exists));
 
         if !exists {
-            let mut span: BoxedSpan = task.otel.child_span("ct128_upload_s3");
-            telemetry::attribute(&mut span, "len", ct128_bytes.len().to_string());
-            telemetry::attribute(&mut span, "format", format_as_str.to_owned());
+            let ct128_upload_span = tracing::info_span!(
+                "ct128_upload_s3",
+                operation = "ct128_upload_s3",
+                ct_type = "ct128",
+                format = %format_as_str,
+            );
+            ct128_upload_span.set_parent(task.otel.context().clone());
 
             jobs.push((
                 client
@@ -265,8 +292,9 @@ async fn upload_ciphertexts(
                     .metadata("Ct-Format", format_as_str)
                     .key(key)
                     .body(ByteStream::from(ct128_bytes.to_vec()))
-                    .send(),
-                UploadResult::CtType128((ct128_digest.clone(), span)),
+                    .send()
+                    .instrument(ct128_upload_span.clone()),
+                UploadResult::CtType128((ct128_digest.clone(), ct128_upload_span)),
             ));
         } else {
             info!(
@@ -300,14 +328,32 @@ async fn upload_ciphertexts(
             hex::encode(&ct64_digest)
         };
 
-        let mut s = task.otel.child_span("ct64_check_s3");
-        let exists = check_object_exists(client, &conf.bucket_ct64, &key).await?;
-        telemetry::attribute(&mut s, "exists", exists.to_string());
-        telemetry::end_span(s);
+        let ct64_check_span = tracing::info_span!(
+            "ct64_check_s3",
+            operation = "ct64_check_s3",
+            ct_type = "ct64",
+            exists = tracing::field::Empty,
+        );
+        ct64_check_span.set_parent(task.otel.context().clone());
+        let exists = match check_object_exists(client, &conf.bucket_ct64, &key)
+            .instrument(ct64_check_span.clone())
+            .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                set_span_error(&ct64_check_span, &err);
+                return Err(err);
+            }
+        };
+        ct64_check_span.record("exists", tracing::field::display(exists));
 
         if !exists {
-            let mut span = task.otel.child_span("ct64_upload_s3");
-            telemetry::attribute(&mut span, "len", ct64_compressed.len().to_string());
+            let ct64_upload_span = tracing::info_span!(
+                "ct64_upload_s3",
+                operation = "ct64_upload_s3",
+                ct_type = "ct64"
+            );
+            ct64_upload_span.set_parent(task.otel.context().clone());
 
             jobs.push((
                 client
@@ -315,8 +361,9 @@ async fn upload_ciphertexts(
                     .bucket(conf.bucket_ct64.clone())
                     .key(key)
                     .body(ByteStream::from(ct64_compressed.clone()))
-                    .send(),
-                UploadResult::CtType64((ct64_digest.clone(), span)),
+                    .send()
+                    .instrument(ct64_upload_span.clone()),
+                UploadResult::CtType64((ct64_digest.clone(), ct64_upload_span)),
             ));
         } else {
             info!(
@@ -332,15 +379,15 @@ async fn upload_ciphertexts(
     }
 
     // Execute all uploads and collect results with their IDs
-    let results: Vec<(Result<_, _>, UploadResult, SystemTime)> = join_all(
+    let results: Vec<(Result<_, _>, UploadResult)> = join_all(
         jobs.into_iter()
-            .map(|(fut, upload)| async move { (fut.await, upload, SystemTime::now()) }),
+            .map(|(fut, upload)| async move { (fut.await, upload) }),
     )
     .await;
 
     let mut transient_error: Option<ExecutionError> = None;
 
-    for (ct_variant, result, finish_time) in results {
+    for (ct_variant, result) in results {
         match result {
             UploadResult::CtType128((digest, span)) => {
                 if let Err(err) = ct_variant {
@@ -350,11 +397,10 @@ async fn upload_ciphertexts(
                         "Failed to upload ct128",
                     );
 
-                    telemetry::end_span_with_err(span, err.to_string());
+                    set_span_error(&span, &err);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
                     task.update_ct128_uploaded(&mut trx, digest).await?;
-                    telemetry::end_span_with_timestamp(span, finish_time);
                 }
             }
             UploadResult::CtType64((digest, span)) => {
@@ -365,11 +411,10 @@ async fn upload_ciphertexts(
                         "Failed to upload ct64"
                     );
 
-                    telemetry::end_span_with_err(span, err.to_string());
+                    set_span_error(&span, &err);
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
                     task.update_ct64_uploaded(&mut trx, digest).await?;
-                    telemetry::end_span_with_timestamp(span, finish_time);
                 }
             }
         }

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -11,7 +11,7 @@ use bytesize::ByteSize;
 use fhevm_engine_common::pg_pool::{PostgresPoolManager, ServiceError};
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::utils::to_hex;
-use futures::future::{join_all, BoxFuture, FutureExt};
+use futures::future::join_all;
 use opentelemetry::trace::{Status, TraceContextExt};
 use sha3::{Digest, Keccak256};
 use sqlx::{PgPool, Pool, Postgres, Transaction};
@@ -210,13 +210,10 @@ async fn run_uploader_loop(
     }
 }
 
-enum UploadKind {
-    CtType128,
-    CtType64,
+enum UploadResult {
+    CtType128((Vec<u8>, tracing::Span)),
+    CtType64((Vec<u8>, tracing::Span)),
 }
-
-type UploadJobResult = (UploadKind, Vec<u8>, Result<(), ExecutionError>);
-type UploadJobFuture<'a> = BoxFuture<'a, UploadJobResult>;
 
 /// Uploads both 128-bit bootstrapped ciphertext and regular ciphertext to S3
 /// buckets. If successful, it stores their digests in the database.
@@ -235,7 +232,7 @@ async fn upload_ciphertexts(
     let handle_as_hex: String = to_hex(&task.handle);
     info!(handle = handle_as_hex, "Received task");
 
-    let mut jobs: Vec<UploadJobFuture<'_>> = vec![];
+    let mut jobs = vec![];
 
     if !task.ct128.is_empty() && task.ct128.format() != Ciphertext128Format::Unknown {
         let ct128_bytes = task.ct128.bytes();
@@ -257,63 +254,47 @@ async fn upload_ciphertexts(
             hex::encode(&ct128_digest)
         };
 
-        let exists = async {
-            match check_object_exists(client, &conf.bucket_ct128, &key).await {
-                Ok(v) => {
-                    tracing::Span::current().record("exists", tracing::field::display(v));
-                    Ok(v)
-                }
-                Err(err) => {
-                    tracing::Span::current()
-                        .context()
-                        .span()
-                        .set_status(Status::error(err.to_string()));
-                    Err(err)
-                }
-            }
-        }
-        .instrument(tracing::info_span!(
+        let ct128_check_span = tracing::info_span!(
             "ct128_check_s3",
             operation = "ct128_check_s3",
             ct_type = "ct128",
             exists = tracing::field::Empty,
-        ))
-        .await?;
+        );
+        let exists = match check_object_exists(client, &conf.bucket_ct128, &key)
+            .instrument(ct128_check_span.clone())
+            .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                ct128_check_span
+                    .context()
+                    .span()
+                    .set_status(Status::error(err.to_string()));
+                return Err(err);
+            }
+        };
+        ct128_check_span.record("exists", tracing::field::display(exists));
 
         if !exists {
-            let format_span_attr = format_as_str.clone();
-            jobs.push(
-                async move {
-                    let upload_result = async {
-                        client
-                            .put_object()
-                            .bucket(conf.bucket_ct128.clone())
-                            .metadata("Ct-Format", format_as_str)
-                            .key(key)
-                            .body(ByteStream::from(ct128_bytes.to_vec()))
-                            .send()
-                            .await
-                            .map(|_| ())
-                            .map_err(|err| {
-                                tracing::Span::current()
-                                    .context()
-                                    .span()
-                                    .set_status(Status::error(err.to_string()));
-                                ExecutionError::S3TransientError(err.to_string())
-                            })
-                    }
-                    .instrument(tracing::info_span!(
-                        "ct128_upload_s3",
-                        operation = "ct128_upload_s3",
-                        ct_type = "ct128",
-                        format = %format_span_attr,
-                        len = ct128_bytes.len(),
-                    ))
-                    .await;
-                    (UploadKind::CtType128, ct128_digest, upload_result)
-                }
-                .boxed(),
+            let ct128_upload_span = tracing::info_span!(
+                "ct128_upload_s3",
+                operation = "ct128_upload_s3",
+                ct_type = "ct128",
+                format = %format_as_str,
+                len = ct128_bytes.len(),
             );
+
+            jobs.push((
+                client
+                    .put_object()
+                    .bucket(conf.bucket_ct128.clone())
+                    .metadata("Ct-Format", format_as_str)
+                    .key(key)
+                    .body(ByteStream::from(ct128_bytes.to_vec()))
+                    .send()
+                    .instrument(ct128_upload_span.clone()),
+                UploadResult::CtType128((ct128_digest.clone(), ct128_upload_span)),
+            ));
         } else {
             info!(
                 handle = handle_as_hex,
@@ -346,60 +327,45 @@ async fn upload_ciphertexts(
             hex::encode(&ct64_digest)
         };
 
-        let exists = async {
-            match check_object_exists(client, &conf.bucket_ct64, &key).await {
-                Ok(v) => {
-                    tracing::Span::current().record("exists", tracing::field::display(v));
-                    Ok(v)
-                }
-                Err(err) => {
-                    tracing::Span::current()
-                        .context()
-                        .span()
-                        .set_status(Status::error(err.to_string()));
-                    Err(err)
-                }
-            }
-        }
-        .instrument(tracing::info_span!(
+        let ct64_check_span = tracing::info_span!(
             "ct64_check_s3",
             operation = "ct64_check_s3",
             ct_type = "ct64",
             exists = tracing::field::Empty,
-        ))
-        .await?;
+        );
+        let exists = match check_object_exists(client, &conf.bucket_ct64, &key)
+            .instrument(ct64_check_span.clone())
+            .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                ct64_check_span
+                    .context()
+                    .span()
+                    .set_status(Status::error(err.to_string()));
+                return Err(err);
+            }
+        };
+        ct64_check_span.record("exists", tracing::field::display(exists));
 
         if !exists {
-            jobs.push(
-                async move {
-                    let upload_result = async {
-                        client
-                            .put_object()
-                            .bucket(conf.bucket_ct64.clone())
-                            .key(key)
-                            .body(ByteStream::from(ct64_compressed.clone()))
-                            .send()
-                            .await
-                            .map(|_| ())
-                            .map_err(|err| {
-                                tracing::Span::current()
-                                    .context()
-                                    .span()
-                                    .set_status(Status::error(err.to_string()));
-                                ExecutionError::S3TransientError(err.to_string())
-                            })
-                    }
-                    .instrument(tracing::info_span!(
-                        "ct64_upload_s3",
-                        operation = "ct64_upload_s3",
-                        ct_type = "ct64",
-                        len = ct64_compressed.len(),
-                    ))
-                    .await;
-                    (UploadKind::CtType64, ct64_digest, upload_result)
-                }
-                .boxed(),
+            let ct64_upload_span = tracing::info_span!(
+                "ct64_upload_s3",
+                operation = "ct64_upload_s3",
+                ct_type = "ct64",
+                len = ct64_compressed.len(),
             );
+
+            jobs.push((
+                client
+                    .put_object()
+                    .bucket(conf.bucket_ct64.clone())
+                    .key(key)
+                    .body(ByteStream::from(ct64_compressed.clone()))
+                    .send()
+                    .instrument(ct64_upload_span.clone()),
+                UploadResult::CtType64((ct64_digest.clone(), ct64_upload_span)),
+            ));
         } else {
             info!(
                 handle = handle_as_hex,
@@ -414,31 +380,43 @@ async fn upload_ciphertexts(
     }
 
     // Execute all uploads and collect results with their IDs
-    let results = join_all(jobs).await;
+    let results: Vec<(Result<_, _>, UploadResult)> = join_all(
+        jobs.into_iter()
+            .map(|(fut, upload)| async move { (fut.await, upload) }),
+    )
+    .await;
 
     let mut transient_error: Option<ExecutionError> = None;
 
-    for (upload_kind, digest, upload_result) in results {
-        match upload_kind {
-            UploadKind::CtType128 => {
-                if let Err(err) = upload_result {
+    for (ct_variant, result) in results {
+        match result {
+            UploadResult::CtType128((digest, span)) => {
+                if let Err(err) = ct_variant {
                     error!(
                         error = %err,
                         handle = handle_as_hex,
                         "Failed to upload ct128",
                     );
+
+                    span.context()
+                        .span()
+                        .set_status(Status::error(err.to_string()));
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
                     task.update_ct128_uploaded(&mut trx, digest).await?;
                 }
             }
-            UploadKind::CtType64 => {
-                if let Err(err) = upload_result {
+            UploadResult::CtType64((digest, span)) => {
+                if let Err(err) = ct_variant {
                     error!(
                         error = %err,
                         handle = handle_as_hex,
                         "Failed to upload ct64"
                     );
+
+                    span.context()
+                        .span()
+                        .set_status(Status::error(err.to_string()));
                     transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
                 } else {
                     task.update_ct64_uploaded(&mut trx, digest).await?;

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -416,6 +416,7 @@ async fn fetch_and_execute_sns_tasks(
                 .set_status(Status::error(err.to_string()));
             return Err(err);
         }
+        drop(batch_store_span);
 
         db_txn.commit().await?;
 
@@ -693,6 +694,7 @@ async fn update_ciphertext128(
 
             match res {
                 Ok(val) => {
+                    drop(persist_span);
                     info!(
                         handle = to_hex(&task.handle),
                         query_res = format!("{:?}", val),
@@ -705,6 +707,7 @@ async fn update_ciphertext128(
                         .context()
                         .span()
                         .set_status(Status::error(err.to_string()));
+                    drop(persist_span);
                     error!( handle = to_hex(&task.handle), error = %err, "Failed to persist ct128");
                     // Although this is a single error, we drop the entire batch to be on the safe side
                     // This will ensure we will not mark a task as completed falsely

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -416,6 +416,7 @@ async fn fetch_and_execute_sns_tasks(
                 .set_status(Status::error(err.to_string()));
             return Err(err);
         }
+        drop(batch_store_span);
 
         db_txn.commit().await?;
 
@@ -693,6 +694,7 @@ async fn update_ciphertext128(
 
             match res {
                 Ok(val) => {
+                    drop(persist_span);
                     info!(
                         handle = to_hex(&task.handle),
                         query_res = format!("{:?}", val),
@@ -701,11 +703,12 @@ async fn update_ciphertext128(
                     );
                 }
                 Err(err) => {
-                    error!( handle = to_hex(&task.handle), error = %err, "Failed to persist ct128");
                     persist_span
                         .context()
                         .span()
                         .set_status(Status::error(err.to_string()));
+                    drop(persist_span);
+                    error!( handle = to_hex(&task.handle), error = %err, "Failed to persist ct128");
                     // Although this is a single error, we drop the entire batch to be on the safe side
                     // This will ensure we will not mark a task as completed falsely
                     return Err(err.into());

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -578,7 +578,6 @@ fn compute_task(
     }
 
     let decompress_span = tracing::info_span!("decompress_ct64", operation = "decompress_ct64");
-    decompress_span.set_parent(task.otel.context().clone());
     let ct = match decompress_span.in_scope(|| decompress_ct(&task.handle, ct64_compressed)) {
         Ok(ct) => ct,
         Err(err) => {
@@ -599,7 +598,6 @@ fn compute_task(
         ct_type = %ct_type,
         operation = "squash_noise"
     );
-    squash_span.set_parent(task.otel.context().clone());
     let _squash_enter = squash_span.enter();
 
     match ct.squash_noise_and_serialize(enable_compression) {
@@ -631,7 +629,6 @@ fn compute_task(
                 .map_err(|err| ExecutionError::InternalSendError(err.to_string()))
             {
                 let send_task_span = tracing::error_span!("send_task", operation = "send_task");
-                send_task_span.set_parent(task.otel.context().clone());
                 let _send_task_enter = send_task_span.enter();
                 send_task_span
                     .context()
@@ -678,7 +675,6 @@ async fn update_ciphertext128(
             let ciphertext128 = task.ct128.bytes();
             let persist_span =
                 tracing::info_span!("ciphertexts128_insert", operation = "ciphertexts128_insert");
-            persist_span.set_parent(task.otel.context().clone());
             let res = sqlx::query!(
                 "
                 INSERT INTO ciphertexts128 (

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -416,7 +416,6 @@ async fn fetch_and_execute_sns_tasks(
                 .set_status(Status::error(err.to_string()));
             return Err(err);
         }
-        drop(batch_store_span);
 
         db_txn.commit().await?;
 
@@ -694,7 +693,6 @@ async fn update_ciphertext128(
 
             match res {
                 Ok(val) => {
-                    drop(persist_span);
                     info!(
                         handle = to_hex(&task.handle),
                         query_res = format!("{:?}", val),
@@ -707,7 +705,6 @@ async fn update_ciphertext128(
                         .context()
                         .span()
                         .set_status(Status::error(err.to_string()));
-                    drop(persist_span);
                     error!( handle = to_hex(&task.handle), error = %err, "Failed to persist ct128");
                     // Although this is a single error, we drop the entire batch to be on the safe side
                     // This will ensure we will not mark a task as completed falsely


### PR DESCRIPTION
## Summary
This PR migrates the remaining Phase B sns-worker spans from manual `task.otel.child_span(...)` usage to `tracing` spans wired through `tracing-opentelemetry`.

## What
- Replace manual OTEL spans in sns-worker hot paths with `tracing` spans:
  - `batch_store_ciphertext128`
  - `decompress_ct64`
  - `ciphertexts128_insert`
  - `upload_s3`
  - `ct128_check_s3`, `ct128_upload_s3`
  - `ct64_check_s3`, `ct64_upload_s3`
- Preserve parent context by explicitly setting span parent from task OTEL context.
- Map errors to OTEL span status on tracing spans.

## Why
- Continue the migration away from dual instrumentation.
- Keep one instrumentation path per operation.
- Improve no-regression confidence before Phase C/D by keeping the same operational boundaries while changing only instrumentation plumbing.

## Validation
- `SQLX_OFFLINE=true cargo check -p sns-worker -p fhevm-engine-common`
- `SQLX_OFFLINE=true cargo clippy -p sns-worker --all-targets -- -D warnings`
- `BATCH_SIZE=8 cargo test -p sns-worker test_batch_execution -- --test-threads=1`
- `cargo test -p sns-worker test_garbage_collect -- --test-threads=1`
- `cargo test -p sns-worker test_lifo_mode -- --test-threads=1`
- Pre-commit hooks passed (fmt/check/clippy for coprocessor scope)

Closes https://github.com/zama-ai/fhevm-internal/issues/1007
