### PR TITLE
feat(coprocessor): standardize tracing/OTEL spans across workers

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -7680,6 +7680,7 @@ dependencies = [
  "tonic-types",
  "tonic-web",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -9215,6 +9216,7 @@ dependencies = [
  "hex",
  "humantime",
  "lru 0.13.0",
+ "opentelemetry",
  "prometheus",
  "rand 0.9.2",
  "serial_test",
@@ -9226,6 +9228,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -6320,13 +6320,12 @@ dependencies = [
  "fhevm-engine-common",
  "hex",
  "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "prometheus",
  "rayon",
  "tfhe",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
@@ -50,8 +50,9 @@ impl TryFrom<u64> for ChainId {
     type Error = InvalidChainId;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        if let Ok(v) = i64::try_from(value) {
-            Ok(ChainId(v))
+        #[allow(clippy::checked_conversions)]
+        if value <= i64::MAX as u64 {
+            Ok(ChainId(value as i64))
         } else {
             Err(InvalidChainId {
                 value: value.to_string(),

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
@@ -50,8 +50,8 @@ impl TryFrom<u64> for ChainId {
     type Error = InvalidChainId;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        if i64::try_from(value).is_ok() {
-            Ok(ChainId(value as i64))
+        if let Ok(v) = i64::try_from(value) {
+            Ok(ChainId(v))
         } else {
             Err(InvalidChainId {
                 value: value.to_string(),

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
@@ -50,9 +50,8 @@ impl TryFrom<u64> for ChainId {
     type Error = InvalidChainId;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        #[allow(clippy::checked_conversions)]
-        if value <= i64::MAX as u64 {
-            Ok(ChainId(value as i64))
+        if let Ok(value) = i64::try_from(value) {
+            Ok(ChainId(value))
         } else {
             Err(InvalidChainId {
                 value: value.to_string(),

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/chain_id.rs
@@ -50,8 +50,8 @@ impl TryFrom<u64> for ChainId {
     type Error = InvalidChainId;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        if let Ok(value) = i64::try_from(value) {
-            Ok(ChainId(value))
+        if i64::try_from(value).is_ok() {
+            Ok(ChainId(value as i64))
         } else {
             Err(InvalidChainId {
                 value: value.to_string(),

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -61,18 +61,6 @@ pub(crate) static ZKPROOF_TXN_LATENCY_HISTOGRAM: LazyLock<Histogram> = LazyLock:
     )
 });
 
-pub fn init_otel(
-    service_name: &str,
-) -> Result<Option<TracerProviderGuard>, Box<dyn std::error::Error + Send + Sync + 'static>> {
-    if service_name.is_empty() {
-        return Ok(None);
-    }
-
-    let (_tracer, trace_provider) = setup_otel_with_tracer(service_name, "otlp-layer")?;
-    opentelemetry::global::set_tracer_provider(trace_provider.clone());
-    Ok(Some(TracerProviderGuard::new(trace_provider)))
-}
-
 pub fn init_json_subscriber(
     log_level: tracing::Level,
     service_name: &str,
@@ -537,11 +525,5 @@ mod tests {
         // A second shutdown is a no-op.
         guard.shutdown_once();
         assert!(guard.tracer_provider.is_none());
-    }
-
-    #[test]
-    fn setup_otel_empty_service_name_returns_none() {
-        let otel_guard = init_otel("").unwrap();
-        assert!(otel_guard.is_none());
     }
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -1,7 +1,7 @@
 use crate::chain_id::ChainId;
 use crate::utils::to_hex;
 use bigdecimal::num_traits::ToPrimitive;
-use opentelemetry::{global::BoxedSpan, trace::TracerProvider, KeyValue};
+use opentelemetry::{trace::TracerProvider, KeyValue};
 use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
 use prometheus::{register_histogram, Histogram};
 use sqlx::PgConnection;
@@ -14,20 +14,6 @@ use std::{
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-pub const TXN_ID_ATTR_KEY: &str = "txn_id";
-
-// Sets the txn_id attribute to the span
-// The txn_id is a shortened version of the transaction_id (first 10 characters of the hex representation)
-pub fn set_txn_id(span: &mut BoxedSpan, transaction_id: &[u8]) {
-    use opentelemetry::trace::Span;
-    let txn_id_short = to_hex(transaction_id)
-        .get(0..10)
-        .unwrap_or_default()
-        .to_owned();
-
-    span.set_attribute(KeyValue::new(TXN_ID_ATTR_KEY, txn_id_short));
-}
 
 /// Calls provider shutdown exactly once when dropped.
 pub struct TracerProviderGuard {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -208,10 +208,16 @@ pub fn register_histogram(config: Option<&MetricsConfig>, name: &str, desc: &str
 
 /// Returns the legacy short-form transaction id used by older telemetry helpers.
 pub fn short_txn_id(transaction_id: &[u8]) -> String {
-    to_hex(transaction_id)
-        .get(0..10)
-        .unwrap_or_default()
-        .to_owned()
+    short_hex_id(transaction_id)
+}
+
+/// Returns the short-form handle id used by legacy tracer_with_handle spans.
+pub fn short_handle_id(handle: &[u8]) -> String {
+    short_hex_id(handle)
+}
+
+fn short_hex_id(value: &[u8]) -> String {
+    to_hex(value).get(0..10).unwrap_or_default().to_owned()
 }
 
 pub(crate) static TXN_METRICS_MANAGER: LazyLock<TransactionMetrics> =

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -206,6 +206,14 @@ pub fn register_histogram(config: Option<&MetricsConfig>, name: &str, desc: &str
         .unwrap_or_else(|_| panic!("Failed to register latency histogram: {}", name))
 }
 
+/// Returns the legacy short-form transaction id used by older telemetry helpers.
+pub fn short_txn_id(transaction_id: &[u8]) -> String {
+    to_hex(transaction_id)
+        .get(0..10)
+        .unwrap_or_default()
+        .to_owned()
+}
+
 pub(crate) static TXN_METRICS_MANAGER: LazyLock<TransactionMetrics> =
     LazyLock::new(|| TransactionMetrics::new(NonZeroUsize::new(100).unwrap()));
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -206,17 +206,8 @@ pub fn register_histogram(config: Option<&MetricsConfig>, name: &str, desc: &str
         .unwrap_or_else(|_| panic!("Failed to register latency histogram: {}", name))
 }
 
-/// Returns the legacy short-form transaction id used by older telemetry helpers.
-pub fn short_txn_id(transaction_id: &[u8]) -> String {
-    short_hex_id(transaction_id)
-}
-
-/// Returns the short-form handle id used by legacy tracer_with_handle spans.
-pub fn short_handle_id(handle: &[u8]) -> String {
-    short_hex_id(handle)
-}
-
-fn short_hex_id(value: &[u8]) -> String {
+/// Returns the legacy short-form hex id used by telemetry spans.
+pub fn short_hex_id(value: &[u8]) -> String {
     to_hex(value).get(0..10).unwrap_or_default().to_owned()
 }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -97,6 +97,11 @@ pub fn init_json_subscriber(
     Ok(Some(TracerProviderGuard::new(trace_provider)))
 }
 
+/// Initializes tracing with JSON logs and best-effort OTLP export.
+///
+/// Fallback here means "logs-only mode": if OTLP setup fails, we keep
+/// JSON logging enabled and continue execution without an OTLP exporter.
+/// It does not try alternate OTLP endpoints.
 pub fn init_json_subscriber_with_otlp_fallback(
     log_level: tracing::Level,
     service_name: &str,

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -215,9 +215,13 @@ pub fn record_short_hex(span: &Span, field: &'static str, value: &[u8]) {
     span.record(field, tracing::field::display(short_hex_id(value)));
 }
 
-pub fn record_short_hex_if_some(span: &Span, field: &'static str, value: Option<&[u8]>) {
+pub fn record_short_hex_if_some<T: AsRef<[u8]>>(
+    span: &Span,
+    field: &'static str,
+    value: Option<T>,
+) {
     if let Some(value) = value {
-        record_short_hex(span, field, value);
+        record_short_hex(span, field, value.as_ref());
     }
 }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -12,7 +12,7 @@ use std::{
     sync::{Arc, LazyLock, OnceLock},
 };
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, warn, Span};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Calls provider shutdown exactly once when dropped.
@@ -209,6 +209,16 @@ pub fn register_histogram(config: Option<&MetricsConfig>, name: &str, desc: &str
 /// Returns the legacy short-form hex id used by telemetry spans.
 pub fn short_hex_id(value: &[u8]) -> String {
     to_hex(value).get(0..10).unwrap_or_default().to_owned()
+}
+
+pub fn record_short_hex(span: &Span, field: &'static str, value: &[u8]) {
+    span.record(field, tracing::field::display(short_hex_id(value)));
+}
+
+pub fn record_short_hex_if_some(span: &Span, field: &'static str, value: Option<&[u8]>) {
+    if let Some(value) = value {
+        record_short_hex(span, field, value);
+    }
 }
 
 pub(crate) static TXN_METRICS_MANAGER: LazyLock<TransactionMetrics> =

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -102,7 +102,7 @@ pub fn init_json_subscriber(
 /// Fallback here means "logs-only mode": if OTLP setup fails, we keep
 /// JSON logging enabled and continue execution without an OTLP exporter.
 /// It does not try alternate OTLP endpoints.
-pub fn init_json_subscriber_with_otlp_fallback(
+pub fn init_tracing_otel_with_logs_only_fallback(
     log_level: tracing::Level,
     service_name: &str,
     tracer_name: &'static str,

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -103,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
 
     let conf = Conf::parse();
 
-    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
         conf.log_level,
         &conf.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -103,18 +103,11 @@ async fn main() -> anyhow::Result<()> {
 
     let conf = Conf::parse();
 
-    let mut otlp_setup_error: Option<String> = None;
-    let _otel_guard =
-        match telemetry::init_json_subscriber(conf.log_level, &conf.service_name, "otlp-layer") {
-            Ok(guard) => guard,
-            Err(err) => {
-                otlp_setup_error = Some(err.to_string());
-                None
-            }
-        };
-    if let Some(err) = otlp_setup_error {
-        error!(error = %err, "Failed to setup OTLP");
-    }
+    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+        conf.log_level,
+        &conf.service_name,
+        "otlp-layer",
+    );
 
     info!(gateway_url = %conf.gw_url, max_retries = %conf.provider_max_retries,
          retry_interval = ?conf.provider_retry_interval, "Connecting to Gateway");

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -103,19 +103,18 @@ async fn main() -> anyhow::Result<()> {
 
     let conf = Conf::parse();
 
-    tracing_subscriber::fmt()
-        .json()
-        .with_level(true)
-        .with_max_level(conf.log_level)
-        .init();
-
-    let _otel_guard = match telemetry::init_otel(&conf.service_name) {
-        Ok(otel_guard) => otel_guard,
-        Err(err) => {
-            error!(error = %err, "Failed to setup OTLP");
-            None
-        }
-    };
+    let mut otlp_setup_error: Option<String> = None;
+    let _otel_guard =
+        match telemetry::init_json_subscriber(conf.log_level, &conf.service_name, "otlp-layer") {
+            Ok(guard) => guard,
+            Err(err) => {
+                otlp_setup_error = Some(err.to_string());
+                None
+            }
+        };
+    if let Some(err) = otlp_setup_error {
+        error!(error = %err, "Failed to setup OTLP");
+    }
 
     info!(gateway_url = %conf.gw_url, max_retries = %conf.provider_max_retries,
          retry_interval = ?conf.provider_retry_interval, "Connecting to Gateway");

--- a/coprocessor/fhevm-engine/host-listener/src/bin/main.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/main.rs
@@ -5,7 +5,7 @@ use fhevm_engine_common::telemetry;
 async fn main() -> anyhow::Result<()> {
     let args = host_listener::cmd::Args::parse();
 
-    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
         args.log_level,
         &args.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/host-listener/src/bin/main.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/main.rs
@@ -1,26 +1,15 @@
 use clap::Parser;
 use fhevm_engine_common::telemetry;
-use tracing::error;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = host_listener::cmd::Args::parse();
 
-    let mut otlp_setup_error: Option<String> = None;
-    let _otel_guard = match telemetry::init_json_subscriber(
+    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
         args.log_level,
         &args.service_name,
         "otlp-layer",
-    ) {
-        Ok(guard) => guard,
-        Err(err) => {
-            otlp_setup_error = Some(err.to_string());
-            None
-        }
-    };
-    if let Some(err) = otlp_setup_error {
-        error!(error = %err, "Failed to setup OTLP");
-    }
+    );
 
     host_listener::cmd::main(args).await
 }

--- a/coprocessor/fhevm-engine/host-listener/src/bin/main.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/main.rs
@@ -1,14 +1,26 @@
 use clap::Parser;
+use fhevm_engine_common::telemetry;
+use tracing::error;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = host_listener::cmd::Args::parse();
 
-    tracing_subscriber::fmt()
-        .json()
-        .with_level(true)
-        .with_max_level(args.log_level)
-        .init();
+    let mut otlp_setup_error: Option<String> = None;
+    let _otel_guard = match telemetry::init_json_subscriber(
+        args.log_level,
+        &args.service_name,
+        "otlp-layer",
+    ) {
+        Ok(guard) => guard,
+        Err(err) => {
+            otlp_setup_error = Some(err.to_string());
+            None
+        }
+    };
+    if let Some(err) = otlp_setup_error {
+        error!(error = %err, "Failed to setup OTLP");
+    }
 
     host_listener::cmd::main(args).await
 }

--- a/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
@@ -126,7 +126,7 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
         args.log_level,
         &args.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use fhevm_engine_common::healthz_server::HttpServer as HealthHttpServer;
-use fhevm_engine_common::telemetry;
 use fhevm_engine_common::types::BlockchainProvider;
 use fhevm_engine_common::utils::{DatabaseURL, HeartBeat};
 
@@ -1040,14 +1039,6 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
                 anyhow!("Invalid tfhe contract address: {err}")
             })?,
         )
-    };
-
-    let _otel_guard = match telemetry::init_otel(&args.service_name) {
-        Ok(otel_guard) => otel_guard,
-        Err(err) => {
-            error!(error = %err, "Failed to setup OTLP");
-            None
-        }
     };
 
     let mut log_iter = InfiniteLogIter::new(&args);

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -415,7 +415,7 @@ impl Database {
         if let Some(transaction_hash) = log.transaction_hash.as_ref() {
             tracing::Span::current().record(
                 "txn_id",
-                tracing::field::display(telemetry::short_txn_id(transaction_hash.as_ref())),
+                tracing::field::display(telemetry::short_hex_id(transaction_hash.as_ref())),
             );
         }
         let insert_computation = |tx, result, dependencies, scalar_byte| {
@@ -579,7 +579,7 @@ impl Database {
         if let Some(transaction_hash) = transaction_hash.as_ref() {
             tracing::Span::current().record(
                 "txn_id",
-                tracing::field::display(telemetry::short_txn_id(
+                tracing::field::display(telemetry::short_hex_id(
                     transaction_hash.as_ref(),
                 )),
             );

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -412,12 +412,11 @@ impl Database {
         let ty = |to_type: &ToType| vec![*to_type];
         let as_bytes = |x: &ClearConst| x.to_be_bytes_vec();
         let fhe_operation = event_to_op_int(event);
-        if let Some(transaction_hash) = log.transaction_hash.as_ref() {
-            tracing::Span::current().record(
-                "txn_id",
-                tracing::field::display(telemetry::short_hex_id(transaction_hash.as_ref())),
-            );
-        }
+        telemetry::record_short_hex_if_some(
+            &tracing::Span::current(),
+            "txn_id",
+            log.transaction_hash.as_ref().map(|transaction_hash| transaction_hash.as_ref()),
+        );
         let insert_computation = |tx, result, dependencies, scalar_byte| {
             self.insert_computation(tx, result, dependencies, fhe_operation, scalar_byte, log)
         };
@@ -576,14 +575,13 @@ impl Database {
         block_number: u64,
     ) -> Result<bool, SqlxError> {
         let data = &event.data;
-        if let Some(transaction_hash) = transaction_hash.as_ref() {
-            tracing::Span::current().record(
-                "txn_id",
-                tracing::field::display(telemetry::short_hex_id(
-                    transaction_hash.as_ref(),
-                )),
-            );
-        }
+        telemetry::record_short_hex_if_some(
+            &tracing::Span::current(),
+            "txn_id",
+            transaction_hash
+                .as_ref()
+                .map(|transaction_hash| transaction_hash.as_ref()),
+        );
 
         let transaction_hash = transaction_hash.map(|h| h.to_vec());
 

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -415,7 +415,7 @@ impl Database {
         telemetry::record_short_hex_if_some(
             &tracing::Span::current(),
             "txn_id",
-            log.transaction_hash.as_ref().map(|transaction_hash| transaction_hash.as_ref()),
+            log.transaction_hash.as_ref(),
         );
         let insert_computation = |tx, result, dependencies, scalar_byte| {
             self.insert_computation(tx, result, dependencies, fhe_operation, scalar_byte, log)
@@ -578,9 +578,7 @@ impl Database {
         telemetry::record_short_hex_if_some(
             &tracing::Span::current(),
             "txn_id",
-            transaction_hash
-                .as_ref()
-                .map(|transaction_hash| transaction_hash.as_ref()),
+            transaction_hash.as_ref(),
         );
 
         let transaction_hash = transaction_hash.map(|h| h.to_vec());

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -418,10 +418,8 @@ impl Database {
             self.insert_computation_bytes(tx, result, dependencies_handles, dependencies_bytes, fhe_operation, scalar_byte, log)
         };
 
-        let _t = telemetry::tracer(
-            "handle_tfhe_event",
-            &log.transaction_hash.map(|h| h.to_vec()),
-        );
+        let _span = tracing::info_span!("handle_tfhe_event", operation = "handle_tfhe_event");
+        let _enter = _span.enter();
 
         // Record the transaction if this is a computation event
         if !matches!(
@@ -576,7 +574,11 @@ impl Database {
 
         let transaction_hash = transaction_hash.map(|h| h.to_vec());
 
-        let _t = telemetry::tracer("handle_acl_event", &transaction_hash);
+        let _span = tracing::info_span!(
+            "handle_acl_event",
+            operation = "handle_acl_event"
+        );
+        let _enter = _span.enter();
 
         // Record only Allowed or AllowedForDecryption events
         if matches!(

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -397,6 +397,7 @@ impl Database {
     }
 
     #[rustfmt::skip]
+    #[tracing::instrument(skip_all, fields(operation = "handle_tfhe_event"))]
     pub async fn insert_tfhe_event(
         &self,
         tx: &mut Transaction<'_>,
@@ -417,9 +418,6 @@ impl Database {
         let insert_computation_bytes = |tx, result, dependencies_handles, dependencies_bytes, scalar_byte| {
             self.insert_computation_bytes(tx, result, dependencies_handles, dependencies_bytes, fhe_operation, scalar_byte, log)
         };
-
-        let _span = tracing::info_span!("handle_tfhe_event", operation = "handle_tfhe_event");
-        let _enter = _span.enter();
 
         // Record the transaction if this is a computation event
         if !matches!(
@@ -561,6 +559,7 @@ impl Database {
     }
 
     /// Handles all types of ACL events
+    #[tracing::instrument(skip_all, fields(operation = "handle_acl_event"))]
     pub async fn handle_acl_event(
         &self,
         tx: &mut Transaction<'_>,
@@ -573,12 +572,6 @@ impl Database {
         let data = &event.data;
 
         let transaction_hash = transaction_hash.map(|h| h.to_vec());
-
-        let _span = tracing::info_span!(
-            "handle_acl_event",
-            operation = "handle_acl_event"
-        );
-        let _enter = _span.enter();
 
         // Record only Allowed or AllowedForDecryption events
         if matches!(

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -397,7 +397,7 @@ impl Database {
     }
 
     #[rustfmt::skip]
-    #[tracing::instrument(skip_all, fields(operation = "handle_tfhe_event", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "handle_tfhe_event", skip_all, fields(txn_id = tracing::field::Empty))]
     pub async fn insert_tfhe_event(
         &self,
         tx: &mut Transaction<'_>,
@@ -564,7 +564,7 @@ impl Database {
     }
 
     /// Handles all types of ACL events
-    #[tracing::instrument(skip_all, fields(operation = "handle_acl_event", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(skip_all, fields(txn_id = tracing::field::Empty))]
     pub async fn handle_acl_event(
         &self,
         tx: &mut Transaction<'_>,

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -16,7 +16,6 @@ use tracing::{error, info, warn};
 
 use fhevm_engine_common::chain_id::ChainId;
 use fhevm_engine_common::healthz_server::HttpServer as HealthHttpServer;
-use fhevm_engine_common::telemetry;
 use fhevm_engine_common::utils::{DatabaseURL, HeartBeat};
 
 use crate::cmd::block_history::BlockSummary;
@@ -90,14 +89,6 @@ pub struct PollerConfig {
 }
 
 pub async fn run_poller(config: PollerConfig) -> Result<()> {
-    let _otel_guard = match telemetry::init_otel(&config.service_name) {
-        Ok(otel_guard) => otel_guard,
-        Err(err) => {
-            error!(error = %err, "Failed to setup OTLP");
-            None
-        }
-    };
-
     let acl_address = config.acl_address;
     let tfhe_address = config.tfhe_address;
 

--- a/coprocessor/fhevm-engine/scheduler/Cargo.toml
+++ b/coprocessor/fhevm-engine/scheduler/Cargo.toml
@@ -10,9 +10,8 @@ anyhow = { workspace = true }
 daggy = { workspace = true }
 hex = { workspace = true }
 opentelemetry = { workspace = true }
-opentelemetry-otlp = { workspace = true }
-opentelemetry_sdk = { workspace = true }
 rayon = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 tfhe = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -12,16 +12,16 @@ use daggy::{
     },
     Dag, NodeIndex,
 };
+use fhevm_engine_common::common::FheOperation;
 use fhevm_engine_common::tfhe_ops::perform_fhe_operation;
 use fhevm_engine_common::types::{Handle, SupportedFheCiphertexts};
 use fhevm_engine_common::utils::HeartBeat;
-use fhevm_engine_common::{common::FheOperation, telemetry};
-use opentelemetry::trace::{Span, Status, TraceContextExt, Tracer};
-use opentelemetry::KeyValue;
+use opentelemetry::trace::{Status, TraceContextExt};
 use std::collections::HashMap;
 use tfhe::ReRandomizationContext;
 use tokio::task::JoinSet;
 use tracing::{error, info, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use super::{DFComponentGraph, DFGraph, OpNode};
 
@@ -79,16 +79,16 @@ impl<'a> Scheduler<'a> {
         }
     }
 
-    pub async fn schedule(&mut self, loop_ctx: &'a opentelemetry::Context) -> Result<()> {
+    pub async fn schedule(&mut self) -> Result<()> {
         let schedule_type = std::env::var("FHEVM_DF_SCHEDULE");
         match schedule_type {
             Ok(val) => match val.as_str() {
                 "MAX_PARALLELISM" => {
-                    self.schedule_coarse_grain(PartitionStrategy::MaxParallelism, loop_ctx)
+                    self.schedule_coarse_grain(PartitionStrategy::MaxParallelism)
                         .await
                 }
                 "MAX_LOCALITY" => {
-                    self.schedule_coarse_grain(PartitionStrategy::MaxLocality, loop_ctx)
+                    self.schedule_coarse_grain(PartitionStrategy::MaxLocality)
                         .await
                 }
                 unhandled => {
@@ -96,19 +96,19 @@ impl<'a> Scheduler<'a> {
 			   "Scheduling strategy does not exist");
                     info!(target: "scheduler", { },
 			  "Reverting to default (generally best performance) strategy MAX_PARALLELISM");
-                    self.schedule_coarse_grain(PartitionStrategy::MaxParallelism, loop_ctx)
+                    self.schedule_coarse_grain(PartitionStrategy::MaxParallelism)
                         .await
                 }
             },
             // Use overall best strategy as default
             #[cfg(not(feature = "gpu"))]
             _ => {
-                self.schedule_coarse_grain(PartitionStrategy::MaxParallelism, loop_ctx)
+                self.schedule_coarse_grain(PartitionStrategy::MaxParallelism)
                     .await
             }
             #[cfg(feature = "gpu")]
             _ => {
-                self.schedule_coarse_grain(PartitionStrategy::MaxParallelism, loop_ctx)
+                self.schedule_coarse_grain(PartitionStrategy::MaxParallelism)
                     .await
             }
         }
@@ -150,11 +150,7 @@ impl<'a> Scheduler<'a> {
         }
     }
 
-    async fn schedule_coarse_grain(
-        &mut self,
-        strategy: PartitionStrategy,
-        loop_ctx: &'a opentelemetry::Context,
-    ) -> Result<()> {
+    async fn schedule_coarse_grain(&mut self, strategy: PartitionStrategy) -> Result<()> {
         let mut execution_graph: Dag<ExecNode, ()> = Dag::default();
         match strategy {
             PartitionStrategy::MaxLocality => {
@@ -188,8 +184,13 @@ impl<'a> Scheduler<'a> {
                     ));
                 }
                 let (sks, cpk) = self.get_keys(DeviceSelection::RoundRobin)?;
-                let loop_ctx = loop_ctx.clone();
-                set.spawn_blocking(move || execute_partition(args, index, 0, sks, cpk, loop_ctx));
+                // Cross-boundary: partition runs on a blocking thread-pool worker;
+                // carry the tracing context across.
+                let parent_span = tracing::Span::current();
+                set.spawn_blocking(move || {
+                    let _guard = parent_span.enter();
+                    execute_partition(args, index, 0, sks, cpk)
+                });
             }
         }
         while let Some(result) = set.join_next().await {
@@ -237,9 +238,12 @@ impl<'a> Scheduler<'a> {
                         ));
                     }
                     let (sks, cpk) = self.get_keys(DeviceSelection::RoundRobin)?;
-                    let loop_ctx = loop_ctx.clone();
+                    // Cross-boundary: partition runs on a blocking thread-pool worker;
+                    // carry the tracing context across.
+                    let parent_span = tracing::Span::current();
                     set.spawn_blocking(move || {
-                        execute_partition(args, dependent_task_index, 0, sks, cpk, loop_ctx)
+                        let _guard = parent_span.enter();
+                        execute_partition(args, dependent_task_index, 0, sks, cpk)
                     });
                 }
             }
@@ -293,14 +297,14 @@ fn execute_partition(
     #[cfg(not(feature = "gpu"))] sks: tfhe::ServerKey,
     #[cfg(feature = "gpu")] sks: tfhe::CudaServerKey,
     cpk: tfhe::CompactPublicKey,
-    loop_ctx: opentelemetry::Context,
 ) -> PartitionResult {
     tfhe::set_server_key(sks);
     let mut res: HashMap<Handle, Result<TaskResult>> = HashMap::with_capacity(transactions.len());
-    let tracer = opentelemetry::global::tracer("tfhe_worker");
     // Traverse transactions within the partition. The transactions
     // are topologically sorted so the order is executable
     'tx: for (ref mut dfg, ref mut tx_inputs, tid, _cid) in transactions {
+        let txn_id_short = hex::encode(&tid).get(0..10).unwrap_or_default().to_owned();
+
         // Update the transaction inputs based on allowed handles so
         // far. If any input is still missing, and we cannot fill it
         // (e.g., error in the producer transaction) we cannot execute
@@ -330,21 +334,26 @@ fn execute_partition(
 
         // Decompress ciphertexts
         {
-            let mut decomp_span = tracer.start_with_context("decompress_ciphertexts", &loop_ctx);
-            telemetry::set_txn_id(&mut decomp_span, &tid);
+            let _guard = tracing::info_span!(
+                "decompress_ciphertexts",
+                txn_id = %txn_id_short,
+                count = tracing::field::Empty,
+            )
+            .entered();
 
             match decompress_transaction_inputs(tx_inputs, gpu_idx) {
                 Ok(count) => {
-                    decomp_span.set_attribute(KeyValue::new("count", count as i64));
-                    decomp_span.end();
+                    tracing::Span::current().record("count", count as i64);
                 }
                 Err(e) => {
                     error!(target: "scheduler", {transaction_id = ?hex::encode(&tid), error = ?e },
                            "Error while decompressing inputs");
-                    decomp_span.set_status(Status::Error {
-                        description: e.to_string().into(),
-                    });
-                    decomp_span.end();
+                    tracing::Span::current()
+                        .context()
+                        .span()
+                        .set_status(Status::Error {
+                            description: e.to_string().into(),
+                        });
                     for nidx in dfg.graph.node_identifiers() {
                         let Some(node) = dfg.graph.node_weight_mut(nidx) else {
                             error!(target: "scheduler", {index = ?nidx.index() }, "Wrong dataflow graph index");
@@ -363,10 +372,12 @@ fn execute_partition(
         }
 
         // Prime the scheduler with ready ops from the transaction's subgraph
-        let mut s = tracer.start_with_context("execute_transaction", &loop_ctx);
-        telemetry::set_txn_id(&mut s, &tid);
+        let _exec_guard = tracing::info_span!(
+            "execute_transaction",
+            txn_id = %txn_id_short,
+        )
+        .entered();
         let started_at = std::time::Instant::now();
-        let exec_ctx = loop_ctx.with_remote_span_context(s.span_context().clone());
 
         let Ok(ts) = daggy::petgraph::algo::toposort(&dfg.graph, None) else {
             error!(target: "scheduler", {transaction_id = ?tid },
@@ -391,16 +402,7 @@ fn execute_partition(
                 error!(target: "scheduler", {index = ?nidx.index() }, "Wrong dataflow graph index");
                 continue;
             };
-            let result = try_execute_node(
-                node,
-                nidx.index(),
-                tx_inputs,
-                gpu_idx,
-                &tid,
-                &cpk,
-                &tracer,
-                &exec_ctx,
-            );
+            let result = try_execute_node(node, nidx.index(), tx_inputs, gpu_idx, &tid, &cpk);
             match result {
                 Ok(result) => {
                     let nidx = NodeIndex::new(result.0);
@@ -444,14 +446,13 @@ fn execute_partition(
                 }
             }
         }
-        s.end();
+        drop(_exec_guard);
         let elapsed = started_at.elapsed();
         FHE_BATCH_LATENCY_HISTOGRAM.observe(elapsed.as_secs_f64());
     }
     (res, task_id)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn try_execute_node(
     node: &mut OpNode,
     node_index: usize,
@@ -459,8 +460,6 @@ fn try_execute_node(
     gpu_idx: usize,
     transaction_id: &Handle,
     cpk: &tfhe::CompactPublicKey,
-    tracer: &opentelemetry::global::BoxedTracer,
-    ctx: &opentelemetry::Context,
 ) -> Result<(usize, OpResult)> {
     if !node.check_ready_inputs(tx_inputs) {
         return Err(SchedulerError::SchedulerError.into());
@@ -477,20 +476,21 @@ fn try_execute_node(
     }
     // Re-randomize inputs for this operation
     {
-        let mut rerand_span = tracer.start_with_context("rerandomise_op_inputs", ctx);
+        let _guard = tracing::info_span!("rerandomise_op_inputs").entered();
         let started_at = std::time::Instant::now();
         if let Err(e) = re_randomise_operation_inputs(&mut cts, node.opcode, cpk) {
             error!(target: "scheduler", { handle = ?hex::encode(&node.result_handle), error = ?e },
                    "Error while re-randomising operation inputs");
-            rerand_span.set_status(Status::Error {
-                description: e.to_string().into(),
-            });
-            rerand_span.end();
+            tracing::Span::current()
+                .context()
+                .span()
+                .set_status(Status::Error {
+                    description: e.to_string().into(),
+                });
             return Err(SchedulerError::ReRandomisationError.into());
         }
         let elapsed = started_at.elapsed();
         RERAND_LATENCY_BATCH_HISTOGRAM.observe(elapsed.as_secs_f64());
-        rerand_span.end();
     }
     let opcode = node.opcode;
     let is_allowed = node.is_allowed;
@@ -501,13 +501,10 @@ fn try_execute_node(
         is_allowed,
         gpu_idx,
         transaction_id,
-        tracer,
-        ctx,
     ))
 }
 
 type OpResult = Result<(SupportedFheCiphertexts, Option<(i16, Vec<u8>)>)>;
-#[allow(clippy::too_many_arguments)]
 fn run_computation(
     operation: i32,
     inputs: Vec<SupportedFheCiphertexts>,
@@ -515,35 +512,41 @@ fn run_computation(
     is_allowed: bool,
     gpu_idx: usize,
     transaction_id: &Handle,
-    tracer: &opentelemetry::global::BoxedTracer,
-    ctx: &opentelemetry::Context,
 ) -> (usize, OpResult) {
+    let txn_id_short = hex::encode(transaction_id)
+        .get(0..10)
+        .unwrap_or_default()
+        .to_owned();
     let op = FheOperation::try_from(operation);
     match op {
         Ok(FheOperation::FheGetCiphertext) => {
             // Compression span (no FHE here)
-            let mut compress_span = tracer.start_with_context("compress_ciphertext", ctx);
-            telemetry::set_txn_id(&mut compress_span, transaction_id);
-            compress_span.set_attribute(KeyValue::new("ct_type", inputs[0].type_name()));
-            compress_span.set_attribute(KeyValue::new("operation", "FheGetCiphertext"));
+            let _guard = tracing::info_span!(
+                "compress_ciphertext",
+                txn_id = %txn_id_short,
+                ct_type = inputs[0].type_name(),
+                operation = "FheGetCiphertext",
+                compressed_size = tracing::field::Empty,
+            )
+            .entered();
 
             let ct_type = inputs[0].type_num();
             let compressed = inputs[0].compress();
             match compressed {
                 Ok(ct_bytes) => {
-                    compress_span
-                        .set_attribute(KeyValue::new("compressed_size", ct_bytes.len() as i64));
-                    compress_span.end();
+                    tracing::Span::current().record("compressed_size", ct_bytes.len() as i64);
                     (
                         graph_node_index,
                         Ok((inputs[0].clone(), Some((ct_type, ct_bytes)))),
                     )
                 }
                 Err(error) => {
-                    compress_span.set_status(Status::Error {
-                        description: error.to_string().into(),
-                    });
-                    compress_span.end();
+                    tracing::Span::current()
+                        .context()
+                        .span()
+                        .set_status(Status::Error {
+                            description: error.to_string().into(),
+                        });
                     (graph_node_index, Err(error.into()))
                 }
             }
@@ -552,41 +555,46 @@ fn run_computation(
             let op_name = fhe_op.as_str_name();
 
             // FHE operation span
-            let mut fhe_span = tracer.start_with_context("fhe_operation", ctx);
-            telemetry::set_txn_id(&mut fhe_span, transaction_id);
-            fhe_span.set_attribute(KeyValue::new("operation", op_name));
-            fhe_span.set_attribute(KeyValue::new("operation_code", operation as i64));
+            let _fhe_guard = tracing::info_span!(
+                "fhe_operation",
+                txn_id = %txn_id_short,
+                operation = op_name,
+                operation_code = operation as i64,
+                input_type = tracing::field::Empty,
+            )
+            .entered();
             if !inputs.is_empty() {
-                fhe_span.set_attribute(KeyValue::new("input_type", inputs[0].type_name()));
+                tracing::Span::current().record("input_type", inputs[0].type_name());
             }
 
             let result = perform_fhe_operation(operation as i16, &inputs, gpu_idx);
 
-            let op_result = match result {
+            match result {
                 Ok(result) => {
                     if is_allowed {
                         // Compression span
-                        let mut compress_span =
-                            tracer.start_with_context("compress_ciphertext", ctx);
-                        telemetry::set_txn_id(&mut compress_span, transaction_id);
-                        compress_span.set_attribute(KeyValue::new("ct_type", result.type_name()));
-                        compress_span.set_attribute(KeyValue::new("operation", op_name));
+                        let _guard = tracing::info_span!(
+                            "compress_ciphertext",
+                            txn_id = %txn_id_short,
+                            ct_type = result.type_name(),
+                            operation = op_name,
+                            compressed_size = tracing::field::Empty,
+                        )
+                        .entered();
                         let ct_type = result.type_num();
                         let compressed = result.compress();
                         match compressed {
                             Ok(ct_bytes) => {
-                                compress_span.set_attribute(KeyValue::new(
-                                    "compressed_size",
-                                    ct_bytes.len() as i64,
-                                ));
-                                compress_span.end();
+                                tracing::Span::current()
+                                    .record("compressed_size", ct_bytes.len() as i64);
                                 (graph_node_index, Ok((result, Some((ct_type, ct_bytes)))))
                             }
                             Err(error) => {
-                                compress_span.set_status(Status::Error {
-                                    description: error.to_string().into(),
-                                });
-                                compress_span.end();
+                                tracing::Span::current().context().span().set_status(
+                                    Status::Error {
+                                        description: error.to_string().into(),
+                                    },
+                                );
                                 (graph_node_index, Err(error.into()))
                             }
                         }
@@ -595,14 +603,15 @@ fn run_computation(
                     }
                 }
                 Err(e) => {
-                    fhe_span.set_status(Status::Error {
-                        description: e.to_string().into(),
-                    });
+                    tracing::Span::current()
+                        .context()
+                        .span()
+                        .set_status(Status::Error {
+                            description: e.to_string().into(),
+                        });
                     (graph_node_index, Err(e.into()))
                 }
-            };
-            fhe_span.end();
-            op_result
+            }
         }
         Err(e) => (graph_node_index, Err(e.into())),
     }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -304,7 +304,7 @@ fn execute_partition(
     // Traverse transactions within the partition. The transactions
     // are topologically sorted so the order is executable
     'tx: for (ref mut dfg, ref mut tx_inputs, tid, _cid) in transactions {
-        let txn_id_short = telemetry::short_txn_id(&tid);
+        let txn_id_short = telemetry::short_hex_id(&tid);
 
         // Update the transaction inputs based on allowed handles so
         // far. If any input is still missing, and we cannot fill it
@@ -513,7 +513,7 @@ fn run_computation(
     gpu_idx: usize,
     transaction_id: &Handle,
 ) -> (usize, OpResult) {
-    let txn_id_short = telemetry::short_txn_id(transaction_id);
+    let txn_id_short = telemetry::short_hex_id(transaction_id);
     let op = FheOperation::try_from(operation);
     match op {
         Ok(FheOperation::FheGetCiphertext) => {

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -545,12 +545,12 @@ async fn fetch_pending_uploads(
             );
             recovery_span.record(
                 "handle",
-                tracing::field::display(telemetry::short_handle_id(&handle)),
+                tracing::field::display(telemetry::short_hex_id(&handle)),
             );
             if let Some(transaction_id) = transaction_id.as_deref() {
                 recovery_span.record(
                     "txn_id",
-                    tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
                 );
             }
             let item = HandleItem {

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -544,7 +544,11 @@ async fn fetch_pending_uploads(
                 handle: handle.clone(),
                 ct64_compressed,
                 ct128: Arc::new(ct128),
-                otel: tracing::info_span!("recovery_task", operation = "recovery_task"),
+                otel: tracing::info_span!(
+                    "recovery_task",
+                    operation = "recovery_task",
+                    handle = %to_hex(&handle)
+                ),
                 transaction_id,
             };
 

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -166,7 +166,7 @@ async fn run_uploader_loop(
                 let h = tokio::spawn(async move {
                     // Cross-boundary: spawned task; restore the OTel context
                     // that was captured when the upload item was created.
-                    let upload_span = error_span!("upload_s3", operation = "upload_s3");
+                    let upload_span = error_span!("upload_s3");
                     upload_span.set_parent(item.span.context());
                     match upload_ciphertexts(trx, item, &client, &conf)
                         .instrument(upload_span.clone())
@@ -257,7 +257,6 @@ async fn upload_ciphertexts(
 
         let ct128_check_span = tracing::info_span!(
             "ct128_check_s3",
-            operation = "ct128_check_s3",
             ct_type = "ct128",
             exists = tracing::field::Empty,
         );
@@ -280,7 +279,6 @@ async fn upload_ciphertexts(
         if !exists {
             let ct128_upload_span = tracing::info_span!(
                 "ct128_upload_s3",
-                operation = "ct128_upload_s3",
                 ct_type = "ct128",
                 format = %format_as_str,
                 len = ct128_bytes.len(),
@@ -330,7 +328,6 @@ async fn upload_ciphertexts(
 
         let ct64_check_span = tracing::info_span!(
             "ct64_check_s3",
-            operation = "ct64_check_s3",
             ct_type = "ct64",
             exists = tracing::field::Empty,
         );
@@ -353,7 +350,6 @@ async fn upload_ciphertexts(
         if !exists {
             let ct64_upload_span = tracing::info_span!(
                 "ct64_upload_s3",
-                operation = "ct64_upload_s3",
                 ct_type = "ct64",
                 len = ct64_compressed.len(),
             );
@@ -539,7 +535,6 @@ async fn fetch_pending_uploads(
         if !ct64_compressed.is_empty() || !is_ct128_empty {
             let recovery_span = tracing::info_span!(
                 "recovery_task",
-                operation = "recovery_task",
                 txn_id = tracing::field::Empty,
                 handle = tracing::field::Empty
             );

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -164,6 +164,8 @@ async fn run_uploader_loop(
 
                 // Spawn a new task to upload the ciphertexts
                 let h = tokio::spawn(async move {
+                    // Cross-boundary: spawned task; restore the OTel context
+                    // that was captured when the upload item was created.
                     let upload_span = error_span!("upload_s3", operation = "upload_s3");
                     upload_span.set_parent(item.otel.context());
                     match upload_ciphertexts(trx, item, &client, &conf)

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -540,7 +540,12 @@ async fn fetch_pending_uploads(
             let recovery_span = tracing::info_span!(
                 "recovery_task",
                 operation = "recovery_task",
-                txn_id = tracing::field::Empty
+                txn_id = tracing::field::Empty,
+                handle = tracing::field::Empty
+            );
+            recovery_span.record(
+                "handle",
+                tracing::field::display(telemetry::short_handle_id(&handle)),
             );
             if let Some(transaction_id) = transaction_id.as_deref() {
                 recovery_span.record(

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -65,21 +65,11 @@ async fn main() {
     let config: Config = construct_config();
     let parent = CancellationToken::new();
 
-    let mut otlp_setup_error: Option<String> = None;
-
-    let _otel_guard =
-        match telemetry::init_json_subscriber(config.log_level, &config.service_name, "otlp-layer")
-        {
-            Ok(guard) => guard,
-            Err(err) => {
-                otlp_setup_error = Some(err.to_string());
-                None
-            }
-        };
-
-    if let Some(err) = otlp_setup_error {
-        error!(error = %err, "Failed to setup OTLP");
-    }
+    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+        config.log_level,
+        &config.service_name,
+        "otlp-layer",
+    );
 
     // Handle SIGINIT signals
     handle_sigint(parent.clone());

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -65,7 +65,7 @@ async fn main() {
     let config: Config = construct_config();
     let parent = CancellationToken::new();
 
-    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
         config.log_level,
         &config.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -499,12 +499,12 @@ pub async fn query_sns_tasks(
             );
             task_span.record(
                 "handle",
-                tracing::field::display(telemetry::short_handle_id(&handle)),
+                tracing::field::display(telemetry::short_hex_id(&handle)),
             );
             if let Some(transaction_id) = transaction_id.as_deref() {
                 task_span.record(
                     "txn_id",
-                    tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
                 );
             }
 

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -454,12 +454,6 @@ pub async fn query_sns_tasks(
     order: Order,
     key_id_gw: &DbKeyId,
 ) -> Result<Option<Vec<HandleItem>>, ExecutionError> {
-    let fetch_span = tracing::info_span!(
-        "db_fetch_tasks",
-        operation = "db_fetch_tasks",
-        count = tracing::field::Empty
-    );
-
     let query = format!(
         "
         SELECT a.*, c.ciphertext
@@ -478,9 +472,7 @@ pub async fn query_sns_tasks(
     let records = sqlx::query(&query)
         .bind(limit as i64)
         .fetch_all(db_txn.as_mut())
-        .instrument(fetch_span.clone())
         .await?;
-    fetch_span.record("count", records.len() as i64);
 
     info!(target: "worker", { count = records.len(), order = order.to_string() }, "Fetched SnS tasks");
     tracing::Span::current().record("count", records.len());

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -491,8 +491,16 @@ pub async fn query_sns_tasks(
             let handle: Vec<u8> = record.try_get("handle")?;
             let ciphertext: Vec<u8> = record.try_get("ciphertext")?;
             let transaction_id: Option<Vec<u8>> = record.try_get("transaction_id")?;
-            let task_span =
-                tracing::info_span!("task", operation = "task", txn_id = tracing::field::Empty);
+            let task_span = tracing::info_span!(
+                "task",
+                operation = "task",
+                txn_id = tracing::field::Empty,
+                handle = tracing::field::Empty
+            );
+            task_span.record(
+                "handle",
+                tracing::field::display(telemetry::short_handle_id(&handle)),
+            );
             if let Some(transaction_id) = transaction_id.as_deref() {
                 task_span.record(
                     "txn_id",

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -24,7 +24,6 @@ use fhevm_engine_common::{
     healthz_server::{self},
     metrics_server,
     pg_pool::{PostgresPoolManager, ServiceError},
-    telemetry::OtelTracer,
     types::FhevmError,
     utils::{to_hex, DatabaseURL},
 };
@@ -237,7 +236,7 @@ pub struct HandleItem {
     /// The computed 128-bit ciphertext
     pub(crate) ct128: Arc<BigCiphertext>,
 
-    pub otel: OtelTracer,
+    pub otel: tracing::Span,
     pub transaction_id: Option<Vec<u8>>,
 }
 

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -236,7 +236,7 @@ pub struct HandleItem {
     /// The computed 128-bit ciphertext
     pub(crate) ct128: Arc<BigCiphertext>,
 
-    pub otel: tracing::Span,
+    pub span: tracing::Span,
     pub transaction_id: Option<Vec<u8>>,
 }
 

--- a/coprocessor/fhevm-engine/sns-worker/src/squash_noise.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/squash_noise.rs
@@ -20,7 +20,6 @@ macro_rules! squash_and_serialize_with_error {
             let span = tracing::info_span!(
                 "squash_noise_fhe",
                 ct_type = %ct_type,
-                operation = "squash_noise_fhe"
             );
 
             let res = {
@@ -45,8 +44,7 @@ macro_rules! squash_and_serialize_with_error {
         if !$enable_compression {
             let span = tracing::info_span!(
                 "serialize",
-                ct_type = %ct_type,
-                operation = "serialize"
+                ct_type = %ct_type
             );
 
             let res = {
@@ -69,8 +67,7 @@ macro_rules! squash_and_serialize_with_error {
         let list = {
             let span = tracing::info_span!(
                 "compress",
-                ct_type = %ct_type,
-                operation = "compress"
+                ct_type = %ct_type
             );
 
             let res = {
@@ -94,8 +91,7 @@ macro_rules! squash_and_serialize_with_error {
 
         let span = tracing::info_span!(
             "serialize",
-            ct_type = %ct_type,
-            operation = "serialize"
+            ct_type = %ct_type
         );
 
         let res = {

--- a/coprocessor/fhevm-engine/tfhe-worker/Cargo.toml
+++ b/coprocessor/fhevm-engine/tfhe-worker/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 # opentelemetry support
 opentelemetry = { workspace = true }

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -3,7 +3,7 @@ use fhevm_engine_common::keys::{FhevmKeys, SerializedFhevmKeys};
 use fhevm_engine_common::{healthz_server, metrics_server, telemetry};
 use tokio_util::sync::CancellationToken;
 
-use std::sync::Once;
+use std::sync::{Once, OnceLock};
 use tokio::task::JoinSet;
 
 pub mod daemon_cli;
@@ -49,28 +49,30 @@ pub fn start_runtime(
 
 // Used for testing as we would call `async_main()` multiple times.
 static TRACING_INIT: Once = Once::new();
+static OTLP_SETUP_ERROR: OnceLock<String> = OnceLock::new();
+static OTEL_GUARD: OnceLock<Option<telemetry::TracerProviderGuard>> = OnceLock::new();
 
 pub async fn async_main(
     args: daemon_cli::Args,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     TRACING_INIT.call_once(|| {
-        tracing_subscriber::fmt()
-            .json()
-            .with_level(true)
-            .with_max_level(args.log_level)
-            .init();
+        let otel_guard =
+            match telemetry::init_json_subscriber(args.log_level, &args.service_name, "otlp-layer")
+            {
+                Ok(guard) => guard,
+                Err(err) => {
+                    let _ = OTLP_SETUP_ERROR.set(err.to_string());
+                    None
+                }
+            };
+        let _ = OTEL_GUARD.set(otel_guard);
     });
+    if let Some(err) = OTLP_SETUP_ERROR.get() {
+        error!(error = %err, "Failed to setup OTLP");
+    }
 
     let cancel_token = CancellationToken::new();
     info!(target: "async_main", args = ?args, "Starting runtime with args");
-
-    let _otel_guard = match telemetry::init_otel(&args.service_name) {
-        Ok(otel_guard) => otel_guard,
-        Err(err) => {
-            error!(error = %err, "Failed to setup OTLP");
-            None
-        }
-    };
 
     let database_url = args.database_url.clone().unwrap_or_default();
     let health_check = health_check::HealthCheck::new(database_url);

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -55,7 +55,7 @@ pub async fn async_main(
     args: daemon_cli::Args,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     TRACING_INIT.call_once(|| {
-        let otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+        let otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
             args.log_level,
             &args.service_name,
             "otlp-layer",

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -622,15 +622,12 @@ async fn upload_transaction_graph_results<'a>(
         }
     }
     if !cts_to_insert.is_empty() {
-        let s_insert = tracing::info_span!("insert_ct_into_db", operation = "insert_ct_into_db");
+        let s_insert = tracing::info_span!(
+            "insert_ct_into_db",
+            operation = "insert_ct_into_db",
+            count = cts_to_insert.len()
+        );
         let cts_inserted = async {
-            for (h, (_, (_, db_type))) in cts_to_insert.iter() {
-                tracing::info!(
-                    handle = %format!("0x{}", hex::encode(h)),
-                    ciphertext_type = *db_type as i64,
-                    "inserting ciphertext"
-                );
-            }
             #[allow(clippy::type_complexity)]
             let (handles, (ciphertexts, (ciphertext_versions, ciphertext_types))): (
                 Vec<_>,
@@ -662,11 +659,12 @@ async fn upload_transaction_graph_results<'a>(
     }
 
     if !handles_to_update.is_empty() {
-        let s_update = tracing::info_span!("update_computation", operation = "update_computation");
+        let s_update = tracing::info_span!(
+            "update_computation",
+            operation = "update_computation",
+            count = handles_to_update.len()
+        );
         let comp_updated = async {
-            for (h, _) in handles_to_update.iter() {
-                tracing::info!(handle = %format!("0x{}", hex::encode(h)), "updating computation");
-            }
             let (handles_vec, txn_ids_vec): (Vec<_>, Vec<_>) = handles_to_update.into_iter().unzip();
             let comp_updated = query!(
                 "

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -409,6 +409,7 @@ WHERE c.transaction_id IN (
         // Traverse transactions and build transaction nodes
         let mut transactions: Vec<ComponentNode> = vec![];
         for (transaction_id, txwork) in work_by_transaction.iter() {
+            let transaction_id: &Vec<u8> = transaction_id;
             let mut ops = vec![];
             for w in txwork {
                 let fhe_op: SupportedFheOperations = match w.fhe_operation.try_into() {
@@ -457,7 +458,7 @@ WHERE c.transaction_id IN (
                     earliest_schedule_order = w.schedule_order;
                 }
             }
-            let (mut components, _) = build_component_nodes(ops, &transaction_id.to_vec())?;
+            let (mut components, _) = build_component_nodes(ops, transaction_id)?;
             transactions.append(&mut components);
         }
         Ok::<_, Box<dyn std::error::Error + Send + Sync>>((transactions, earliest_schedule_order))

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -188,7 +188,7 @@ async fn tfhe_worker_cycle(
                         .unwrap_or_else(|| "none".to_string()),
                 ),
             );
-            tracing::info!(
+            info!(
                 parent: &dcid_span,
                 dependence_chain_id = ?dependence_chain_id.as_ref().map(hex::encode),
                 "acquired dependence chain lock"
@@ -334,7 +334,7 @@ async fn query_for_work<'a>(
                 .unwrap_or_else(|| "none".to_string()),
         ),
     );
-    tracing::info!(parent: &s_dcid, "query dependence chain result");
+    info!(parent: &s_dcid, "query dependence chain result");
     let s_work = tracing::info_span!(
         "query_work_items",
         operation = "query_work_items",
@@ -383,7 +383,7 @@ WHERE c.transaction_id IN (
 
     WORK_ITEMS_QUERY_HISTOGRAM.observe(started_at.elapsed().unwrap_or_default().as_secs_f64());
     s_work.record("count", the_work.len());
-    tracing::info!(parent: &s_work, "work items queried");
+    info!(parent: &s_work, "work items queried");
     health_check.update_db_access();
     if the_work.is_empty() {
         if let Some(dependence_chain_id) = &dependence_chain_id {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -187,12 +187,6 @@ async fn tfhe_worker_cycle(
                         .unwrap_or_else(|| "none".to_string()),
                 ),
             );
-            info!(
-                parent: &dcid_span,
-                dependence_chain_id = ?dependence_chain_id.as_ref().map(hex::encode),
-                "acquired dependence chain lock"
-            );
-
             continue;
         }
 
@@ -333,7 +327,6 @@ async fn query_for_work<'a>(
                 .unwrap_or_else(|| "none".to_string()),
         ),
     );
-    info!(parent: &s_dcid, "query dependence chain result");
     let s_work = tracing::info_span!(
         "query_work_items",
         operation = "query_work_items",
@@ -382,7 +375,6 @@ WHERE c.transaction_id IN (
 
     WORK_ITEMS_QUERY_HISTOGRAM.observe(started_at.elapsed().unwrap_or_default().as_secs_f64());
     s_work.record("count", the_work.len());
-    info!(parent: &s_work, "work items queried");
     health_check.update_db_access();
     if the_work.is_empty() {
         if let Some(dependence_chain_id) = &dependence_chain_id {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -494,7 +494,6 @@ async fn build_transaction_graph_and_execute<'a>(
 
         // Schedule computations in parallel as dependences allow
         tfhe::set_server_key(keys.sks.clone());
-        let otel_ctx = tracing::Span::current().context();
         let mut sched = Scheduler::new(
             &mut tx_graph,
             #[cfg(not(feature = "gpu"))]
@@ -504,7 +503,7 @@ async fn build_transaction_graph_and_execute<'a>(
             keys.gpu_sks.clone(),
             health_check.activity_heartbeat.clone(),
         );
-        sched.schedule(&otel_ctx).await?;
+        sched.schedule().await?;
     }
     drop(s_compute);
     Ok(tx_graph)

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -164,16 +164,26 @@ async fn tfhe_worker_cycle(
 
             // Lock another dependence chain if available and
             // continue processing without waiting for notification
-            let _dcid_span = tracing::info_span!(parent: &loop_span, "query_dependence_chain", operation = "query_dependence_chain");
+            let _dcid_span = tracing::info_span!(
+                parent: &loop_span,
+                "query_dependence_chain",
+                operation = "query_dependence_chain",
+                dependence_chain_id = tracing::field::Empty
+            );
 
             let (dependence_chain_id, _) = dcid_mngr.acquire_next_lock().await?;
             immediately_poll_more_work = dependence_chain_id.is_some();
 
-            tracing::info!(
-                parent: &_dcid_span,
-                dependence_chain_id = ?dependence_chain_id.as_ref().map(hex::encode),
-                "acquired dependence chain lock"
+            _dcid_span.record(
+                "dependence_chain_id",
+                tracing::field::display(
+                    dependence_chain_id
+                        .as_ref()
+                        .map(hex::encode)
+                        .unwrap_or_else(|| "none".to_string()),
+                ),
             );
+            tracing::info!(parent: &_dcid_span, "acquired dependence chain lock");
             drop(_dcid_span);
 
             continue;
@@ -277,7 +287,8 @@ async fn query_for_work<'a>(
 {
     let _s_dcid = tracing::info_span!(
         "query_dependence_chain",
-        operation = "query_dependence_chain"
+        operation = "query_dependence_chain",
+        dependence_chain_id = tracing::field::Empty
     );
     // Lock dependence chain
     let (dependence_chain_id, locking_reason) =
@@ -302,14 +313,23 @@ async fn query_for_work<'a>(
         info!(target: "tfhe_worker", "No dcid found to process");
         return Ok((vec![], PrimitiveDateTime::MAX, false));
     }
-    tracing::info!(
-        parent: &_s_dcid,
-        dependence_chain_id = ?dependence_chain_id.as_ref().map(hex::encode),
-        "query dependence chain result"
+    _s_dcid.record(
+        "dependence_chain_id",
+        tracing::field::display(
+            dependence_chain_id
+                .as_ref()
+                .map(hex::encode)
+                .unwrap_or_else(|| "none".to_string()),
+        ),
     );
+    tracing::info!(parent: &_s_dcid, "query dependence chain result");
     drop(_s_dcid);
 
-    let _s_work = tracing::info_span!("query_work_items", operation = "query_work_items");
+    let _s_work = tracing::info_span!(
+        "query_work_items",
+        operation = "query_work_items",
+        count = tracing::field::Empty
+    );
     let transaction_batch_size = args.work_items_batch_size;
     let started_at = SystemTime::now();
     let the_work = query!(
@@ -351,7 +371,8 @@ WHERE c.transaction_id IN (
     })?;
 
     WORK_ITEMS_QUERY_HISTOGRAM.observe(started_at.elapsed().unwrap_or_default().as_secs_f64());
-    tracing::info!(parent: &_s_work, count = the_work.len(), "work items queried");
+    _s_work.record("count", the_work.len());
+    tracing::info!(parent: &_s_work, "work items queried");
     drop(_s_work);
     health_check.update_db_access();
     if the_work.is_empty() {

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -286,7 +286,7 @@ async fn main() -> anyhow::Result<()> {
 
     let conf = parse_args();
 
-    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
         conf.log_level,
         &conf.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -286,18 +286,11 @@ async fn main() -> anyhow::Result<()> {
 
     let conf = parse_args();
 
-    let mut otlp_setup_error: Option<String> = None;
-    let _otel_guard =
-        match telemetry::init_json_subscriber(conf.log_level, &conf.service_name, "otlp-layer") {
-            Ok(guard) => guard,
-            Err(err) => {
-                otlp_setup_error = Some(err.to_string());
-                None
-            }
-        };
-    if let Some(err) = otlp_setup_error {
-        error!(error = %err, "Failed to setup OTLP");
-    }
+    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+        conf.log_level,
+        &conf.service_name,
+        "otlp-layer",
+    );
 
     let cancel_token = CancellationToken::new();
     install_signal_handlers(cancel_token.clone())?;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -41,7 +41,7 @@ impl<P> AddCiphertextOperation<P>
 where
     P: Provider<Ethereum> + Clone + 'static,
 {
-    #[tracing::instrument(name = "call_add_ciphertext", skip_all, fields(operation = "call_add_ciphertext", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_add_ciphertext", skip_all, fields(txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         handle: &[u8],
@@ -340,11 +340,8 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let transaction_id = row.transaction_id.clone();
-            let _span = tracing::info_span!(
-                "prepare_add_ciphertext",
-                operation = "prepare_add_ciphertext",
-                txn_id = tracing::field::Empty
-            );
+            let _span =
+                tracing::info_span!("prepare_add_ciphertext", txn_id = tracing::field::Empty);
             telemetry::record_short_hex_if_some(&_span, "txn_id", transaction_id.as_deref());
             let _enter = _span.enter();
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -340,12 +340,18 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let transaction_id = row.transaction_id.clone();
-            let _span = tracing::info_span!(
-                "prepare_add_ciphertext",
-                operation = "prepare_add_ciphertext",
-                txn_id = tracing::field::Empty
-            );
-            telemetry::record_short_hex_if_some(&_span, "txn_id", transaction_id.as_deref());
+            let transaction_id_short = transaction_id.as_deref().map(telemetry::short_hex_id);
+            let _span = match transaction_id_short.as_deref() {
+                Some(txn_id) => tracing::info_span!(
+                    "prepare_add_ciphertext",
+                    operation = "prepare_add_ciphertext",
+                    txn_id = %txn_id
+                ),
+                None => tracing::info_span!(
+                    "prepare_add_ciphertext",
+                    operation = "prepare_add_ciphertext"
+                ),
+            };
             let _enter = _span.enter();
 
             let handle = row.handle.clone();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -41,6 +41,7 @@ impl<P> AddCiphertextOperation<P>
 where
     P: Provider<Ethereum> + Clone + 'static,
 {
+    #[tracing::instrument(skip_all, fields(operation = "call_add_ciphertext"))]
     async fn send_transaction(
         &self,
         handle: &[u8],
@@ -52,8 +53,6 @@ where
         let h = to_hex(handle);
 
         info!(handle = h, "Processing transaction");
-        let _span = tracing::info_span!("call_add_ciphertext", operation = "call_add_ciphertext");
-        let _enter = _span.enter();
 
         let receipt = match self
             .provider

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -41,7 +41,7 @@ impl<P> AddCiphertextOperation<P>
 where
     P: Provider<Ethereum> + Clone + 'static,
 {
-    #[tracing::instrument(skip_all, fields(operation = "call_add_ciphertext", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_add_ciphertext", skip_all, fields(operation = "call_add_ciphertext", txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         handle: &[u8],

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -52,7 +52,8 @@ where
         let h = to_hex(handle);
 
         info!(handle = h, "Processing transaction");
-        let _t = telemetry::tracer("call_add_ciphertext", &src_transaction_id);
+        let _span = tracing::info_span!("call_add_ciphertext", operation = "call_add_ciphertext");
+        let _enter = _span.enter();
 
         let receipt = match self
             .provider
@@ -335,7 +336,11 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let transaction_id = row.transaction_id.clone();
-            let t = telemetry::tracer("prepare_add_ciphertext", &transaction_id);
+            let _span = tracing::info_span!(
+                "prepare_add_ciphertext",
+                operation = "prepare_add_ciphertext"
+            );
+            let _enter = _span.enter();
 
             let handle = row.handle.clone();
 
@@ -391,7 +396,8 @@ where
                     .into_transaction_request(),
             };
 
-            t.end();
+            drop(_enter);
+            drop(_span);
 
             let operation = self.clone();
             join_set.spawn(async move {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -53,7 +53,7 @@ where
         if let Some(transaction_id) = src_transaction_id.as_deref() {
             tracing::Span::current().record(
                 "txn_id",
-                tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                tracing::field::display(telemetry::short_hex_id(transaction_id)),
             );
         }
         let h = to_hex(handle);
@@ -349,7 +349,7 @@ where
             if let Some(transaction_id) = transaction_id.as_deref() {
                 _span.record(
                     "txn_id",
-                    tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
                 );
             }
             let _enter = _span.enter();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -50,12 +50,11 @@ where
         current_unlimited_retries_count: i32,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        if let Some(transaction_id) = src_transaction_id.as_deref() {
-            tracing::Span::current().record(
-                "txn_id",
-                tracing::field::display(telemetry::short_hex_id(transaction_id)),
-            );
-        }
+        telemetry::record_short_hex_if_some(
+            &tracing::Span::current(),
+            "txn_id",
+            src_transaction_id.as_deref(),
+        );
         let h = to_hex(handle);
 
         info!(handle = h, "Processing transaction");
@@ -346,12 +345,7 @@ where
                 operation = "prepare_add_ciphertext",
                 txn_id = tracing::field::Empty
             );
-            if let Some(transaction_id) = transaction_id.as_deref() {
-                _span.record(
-                    "txn_id",
-                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
-                );
-            }
+            telemetry::record_short_hex_if_some(&_span, "txn_id", transaction_id.as_deref());
             let _enter = _span.enter();
 
             let handle = row.handle.clone();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -340,18 +340,12 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let transaction_id = row.transaction_id.clone();
-            let transaction_id_short = transaction_id.as_deref().map(telemetry::short_hex_id);
-            let _span = match transaction_id_short.as_deref() {
-                Some(txn_id) => tracing::info_span!(
-                    "prepare_add_ciphertext",
-                    operation = "prepare_add_ciphertext",
-                    txn_id = %txn_id
-                ),
-                None => tracing::info_span!(
-                    "prepare_add_ciphertext",
-                    operation = "prepare_add_ciphertext"
-                ),
-            };
+            let _span = tracing::info_span!(
+                "prepare_add_ciphertext",
+                operation = "prepare_add_ciphertext",
+                txn_id = tracing::field::Empty
+            );
+            telemetry::record_short_hex_if_some(&_span, "txn_id", transaction_id.as_deref());
             let _enter = _span.enter();
 
             let handle = row.handle.clone();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -66,6 +66,7 @@ where
     /// Sends a transaction
     ///
     /// TODO: Refactor: Avoid code duplication
+    #[tracing::instrument(skip_all, fields(operation = "call_allow_account"))]
     async fn send_transaction(
         &self,
         key: &Key,
@@ -77,8 +78,6 @@ where
         let h = to_hex(&key.handle);
 
         info!(handle = h, "Processing transaction");
-        let _span = tracing::info_span!("call_allow_account", operation = "call_allow_account");
-        let _enter = _span.enter();
 
         let receipt = match self
             .provider

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -66,7 +66,7 @@ where
     /// Sends a transaction
     ///
     /// TODO: Refactor: Avoid code duplication
-    #[tracing::instrument(skip_all, fields(operation = "call_allow_account"))]
+    #[tracing::instrument(skip_all, fields(operation = "call_allow_account", txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         key: &Key,
@@ -75,6 +75,12 @@ where
         current_unlimited_retries_count: i32,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
+        if let Some(transaction_id) = src_transaction_id.as_deref() {
+            tracing::Span::current().record(
+                "txn_id",
+                tracing::field::display(telemetry::short_txn_id(transaction_id)),
+            );
+        }
         let h = to_hex(&key.handle);
 
         info!(handle = h, "Processing transaction");
@@ -359,10 +365,17 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let src_transaction_id = row.transaction_id.clone();
-            let _span =
-                tracing::info_span!("prepare_allow_account", operation = "prepare_allow_account");
-            // Use `enter()` in async loops to avoid keeping a non-Send
-            // entered guard across await points.
+            let _span = tracing::info_span!(
+                "prepare_allow_account",
+                operation = "prepare_allow_account",
+                txn_id = tracing::field::Empty
+            );
+            if let Some(transaction_id) = src_transaction_id.as_deref() {
+                _span.record(
+                    "txn_id",
+                    tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                );
+            }
             let _enter = _span.enter();
 
             let handle = row.handle.clone();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -361,6 +361,8 @@ where
             let src_transaction_id = row.transaction_id.clone();
             let _span =
                 tracing::info_span!("prepare_allow_account", operation = "prepare_allow_account");
+            // Use `enter()` in async loops to avoid keeping a non-Send
+            // entered guard across await points.
             let _enter = _span.enter();
 
             let handle = row.handle.clone();
@@ -429,9 +431,6 @@ where
                 account_addr: account_addr.to_string(),
                 event_type,
             };
-
-            drop(_enter);
-            drop(_span);
 
             let operation = self.clone();
             join_set.spawn(async move {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -77,7 +77,8 @@ where
         let h = to_hex(&key.handle);
 
         info!(handle = h, "Processing transaction");
-        let _t = telemetry::tracer("call_allow_account", &src_transaction_id);
+        let _span = tracing::info_span!("call_allow_account", operation = "call_allow_account");
+        let _enter = _span.enter();
 
         let receipt = match self
             .provider
@@ -359,7 +360,9 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let src_transaction_id = row.transaction_id.clone();
-            let t = telemetry::tracer("prepare_allow_account", &src_transaction_id);
+            let _span =
+                tracing::info_span!("prepare_allow_account", operation = "prepare_allow_account");
+            let _enter = _span.enter();
 
             let handle = row.handle.clone();
             let chain_id = u64::from_be_bytes(handle[22..30].try_into()?);
@@ -428,7 +431,8 @@ where
                 event_type,
             };
 
-            t.end();
+            drop(_enter);
+            drop(_span);
 
             let operation = self.clone();
             join_set.spawn(async move {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -66,7 +66,7 @@ where
     /// Sends a transaction
     ///
     /// TODO: Refactor: Avoid code duplication
-    #[tracing::instrument(skip_all, fields(operation = "call_allow_account", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_allow_account", skip_all, fields(operation = "call_allow_account", txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         key: &Key,

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -78,7 +78,7 @@ where
         if let Some(transaction_id) = src_transaction_id.as_deref() {
             tracing::Span::current().record(
                 "txn_id",
-                tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                tracing::field::display(telemetry::short_hex_id(transaction_id)),
             );
         }
         let h = to_hex(&key.handle);
@@ -373,7 +373,7 @@ where
             if let Some(transaction_id) = src_transaction_id.as_deref() {
                 _span.record(
                     "txn_id",
-                    tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
                 );
             }
             let _enter = _span.enter();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -75,12 +75,11 @@ where
         current_unlimited_retries_count: i32,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        if let Some(transaction_id) = src_transaction_id.as_deref() {
-            tracing::Span::current().record(
-                "txn_id",
-                tracing::field::display(telemetry::short_hex_id(transaction_id)),
-            );
-        }
+        telemetry::record_short_hex_if_some(
+            &tracing::Span::current(),
+            "txn_id",
+            src_transaction_id.as_deref(),
+        );
         let h = to_hex(&key.handle);
 
         info!(handle = h, "Processing transaction");
@@ -370,12 +369,7 @@ where
                 operation = "prepare_allow_account",
                 txn_id = tracing::field::Empty
             );
-            if let Some(transaction_id) = src_transaction_id.as_deref() {
-                _span.record(
-                    "txn_id",
-                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
-                );
-            }
+            telemetry::record_short_hex_if_some(&_span, "txn_id", src_transaction_id.as_deref());
             let _enter = _span.enter();
 
             let handle = row.handle.clone();

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/allow_handle.rs
@@ -66,7 +66,7 @@ where
     /// Sends a transaction
     ///
     /// TODO: Refactor: Avoid code duplication
-    #[tracing::instrument(name = "call_allow_account", skip_all, fields(operation = "call_allow_account", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_allow_account", skip_all, fields(txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         key: &Key,
@@ -364,11 +364,8 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let src_transaction_id = row.transaction_id.clone();
-            let _span = tracing::info_span!(
-                "prepare_allow_account",
-                operation = "prepare_allow_account",
-                txn_id = tracing::field::Empty
-            );
+            let _span =
+                tracing::info_span!("prepare_allow_account", txn_id = tracing::field::Empty);
             telemetry::record_short_hex_if_some(&_span, "txn_id", src_transaction_id.as_deref());
             let _enter = _span.enter();
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -113,7 +113,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         }
     }
     /// Sends a transaction
-    #[tracing::instrument(skip_all, fields(operation = "call_delegate_user_decrypt", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_delegate_user_decrypt", skip_all, fields(operation = "call_delegate_user_decrypt", txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         delegation: &DelegationRow,

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -114,7 +114,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         }
     }
     /// Sends a transaction
-    #[tracing::instrument(skip_all, fields(operation = "call_delegate_user_decrypt", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(skip_all, fields(operation = "call_delegate_user_decript", txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         delegation: &DelegationRow,

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -113,7 +113,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         }
     }
     /// Sends a transaction
-    #[tracing::instrument(name = "call_delegate_user_decrypt", skip_all, fields(operation = "call_delegate_user_decrypt", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_delegate_user_decrypt", skip_all, fields(txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         delegation: &DelegationRow,
@@ -425,11 +425,8 @@ where
             }
         };
         for delegation in ready_delegations {
-            let prepare_delegate_span = tracing::info_span!(
-                "prepare_delegate",
-                operation = "prepare_delegate",
-                txn_id = tracing::field::Empty
-            );
+            let prepare_delegate_span =
+                tracing::info_span!("prepare_delegate", txn_id = tracing::field::Empty);
             fhevm_engine_common::telemetry::record_short_hex_if_some(
                 &prepare_delegate_span,
                 "txn_id",

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -114,17 +114,13 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         }
     }
     /// Sends a transaction
+    #[tracing::instrument(skip_all, fields(operation = "call_delegate_user_decrypt"))]
     async fn send_transaction(
         &self,
         delegation: &DelegationRow,
         txn_request: impl Into<TransactionRequest>,
     ) -> TxResult {
         info!(key = ?delegation, "Processing transaction for DelegateUserDecryptOperation");
-        let _span = tracing::info_span!(
-            "call_delegate_user_decrypt",
-            operation = "call_delegate_user_decrypt"
-        );
-        let _enter = _span.enter();
         let operation = if delegation.new_expiration_date == 0 {
             "RevokeUserDecryptionDelegation"
         } else {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -46,7 +46,6 @@ pub struct DelegationRow {
     pub host_chain_id: ChainId,
     pub block_hash: Vec<u8>,
     pub block_number: u64,
-    #[allow(dead_code)]
     pub transaction_id: Option<Vec<u8>>,
     pub gateway_nb_attempts: u64,
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -123,7 +123,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         if let Some(transaction_id) = delegation.transaction_id.as_deref() {
             tracing::Span::current().record(
                 "txn_id",
-                tracing::field::display(fhevm_engine_common::telemetry::short_txn_id(
+                tracing::field::display(fhevm_engine_common::telemetry::short_hex_id(
                     transaction_id,
                 )),
             );

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::{ops::DerefMut, time::Duration};
 
@@ -25,8 +25,6 @@ use sqlx::{postgres::PgListener, Pool, Postgres};
 use tokio::task::JoinSet;
 use tracing::{error, info, warn};
 
-use fhevm_engine_common::telemetry;
-
 use super::TransactionOperation;
 
 pub type BlockHash = FixedBytes<32>;
@@ -48,6 +46,7 @@ pub struct DelegationRow {
     pub host_chain_id: ChainId,
     pub block_hash: Vec<u8>,
     pub block_number: u64,
+    #[allow(dead_code)]
     pub transaction_id: Option<Vec<u8>>,
     pub gateway_nb_attempts: u64,
 }
@@ -120,9 +119,12 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         delegation: &DelegationRow,
         txn_request: impl Into<TransactionRequest>,
     ) -> TxResult {
-        let src_transaction_id = delegation.transaction_id.clone();
         info!(key = ?delegation, "Processing transaction for DelegateUserDecryptOperation");
-        let _t = telemetry::tracer("call_delegate_user_decript", &src_transaction_id);
+        let _span = tracing::info_span!(
+            "call_delegate_user_decrypt",
+            operation = "call_delegate_user_decrypt"
+        );
+        let _enter = _span.enter();
         let operation = if delegation.new_expiration_date == 0 {
             "RevokeUserDecryptionDelegation"
         } else {
@@ -395,17 +397,10 @@ where
         {
             error!("Cannot update useless delegations");
         }
-        let mut all_transaction_id = HashSet::<Option<Vec<u8>>>::new();
-        for delegation in &ready_delegations {
-            let tx_id = delegation.transaction_id.clone();
-            all_transaction_id.insert(tx_id);
-        }
-        // we don't split by transition_id because delegations have an internal order
-        // it's expected that both order are compatible but we don't know the transaction_id order
-        let ts = all_transaction_id
-            .iter()
-            .map(|id| telemetry::tracer("prepare_delegate", id))
-            .collect::<Vec<_>>();
+        // we don't split by transition_id because delegations have an internal order.
+        // It's expected that both orders are compatible, but we don't know the transaction_id order.
+        let _prepare_span = tracing::info_span!("prepare_delegate", operation = "prepare_delegate");
+        let _prepare_enter = _prepare_span.enter();
         let mut requests = Vec::with_capacity(ready_delegations.len());
         let to_transaction = |delegation: &DelegationRow| {
             let is_revoke = delegation.new_expiration_date == 0;
@@ -442,9 +437,8 @@ where
             };
             requests.push((delegation, txn_request));
         }
-        for t in ts {
-            t.end();
-        }
+        drop(_prepare_enter);
+        drop(_prepare_span);
         let mut join_set = JoinSet::new();
         for (delegation, txn_request) in requests.iter() {
             // parallel transaction can fail if any of the transaction fail

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -426,7 +426,17 @@ where
             }
         };
         for delegation in ready_delegations {
-            let txn_request = to_transaction(&delegation);
+            let prepare_delegate_span = tracing::info_span!(
+                "prepare_delegate",
+                operation = "prepare_delegate",
+                txn_id = tracing::field::Empty
+            );
+            fhevm_engine_common::telemetry::record_short_hex_if_some(
+                &prepare_delegate_span,
+                "txn_id",
+                delegation.transaction_id.as_deref(),
+            );
+            let txn_request = prepare_delegate_span.in_scope(|| to_transaction(&delegation));
             let txn_request = if let Some(gaz_limit) = &self.gas {
                 txn_request.with_gas_limit(*gaz_limit)
             } else {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/delegate_user_decrypt.rs
@@ -114,7 +114,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> DelegateUserDecryptOperation<P> {
         }
     }
     /// Sends a transaction
-    #[tracing::instrument(skip_all, fields(operation = "call_delegate_user_decript", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(skip_all, fields(operation = "call_delegate_user_decrypt", txn_id = tracing::field::Empty))]
     async fn send_transaction(
         &self,
         delegation: &DelegationRow,

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -117,7 +117,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(name = "call_verify_proof_resp", skip_all, fields(operation = "call_verify_proof_resp", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_verify_proof_resp", skip_all, fields(txn_id = tracing::field::Empty))]
     async fn process_proof(
         &self,
         txn_request: (i64, impl Into<TransactionRequest>),
@@ -252,11 +252,8 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let transaction_id = row.transaction_id.clone();
-            let span = tracing::info_span!(
-                "prepare_verify_proof_resp",
-                operation = "prepare_verify_proof_resp",
-                txn_id = tracing::field::Empty
-            );
+            let span =
+                tracing::info_span!("prepare_verify_proof_resp", txn_id = tracing::field::Empty);
             telemetry::record_short_hex_if_some(&span, "txn_id", transaction_id.as_deref());
 
             let txn_request = match row.verified {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -124,7 +124,11 @@ where
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
         info!(zk_proof_id = txn_request.0, "Processing transaction");
-        let _t = telemetry::tracer("call_verify_proof_resp", &src_transaction_id);
+        let _span = tracing::info_span!(
+            "call_verify_proof_resp",
+            operation = "call_verify_proof_resp"
+        );
+        let _enter = _span.enter();
 
         let receipt = match self
             .provider
@@ -247,7 +251,11 @@ where
         let mut join_set = JoinSet::new();
         for row in rows.into_iter() {
             let transaction_id = row.transaction_id.clone();
-            let t = telemetry::tracer("prepare_verify_proof_resp", &transaction_id);
+            let _span = tracing::info_span!(
+                "prepare_verify_proof_resp",
+                operation = "prepare_verify_proof_resp"
+            );
+            let _enter = _span.enter();
 
             let txn_request = match row.verified {
                 Some(true) => {
@@ -350,7 +358,8 @@ where
                 }
             };
 
-            t.end();
+            drop(_enter);
+            drop(_span);
 
             let self_clone = self.clone();
             let src_transaction_id = transaction_id;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -251,6 +251,8 @@ where
                 "prepare_verify_proof_resp",
                 operation = "prepare_verify_proof_resp"
             );
+            // Use `enter()` in async loops to avoid keeping a non-Send
+            // entered guard across await points.
             let _enter = _span.enter();
 
             let txn_request = match row.verified {
@@ -353,9 +355,6 @@ where
                     continue;
                 }
             };
-
-            drop(_enter);
-            drop(_span);
 
             let self_clone = self.clone();
             let src_transaction_id = transaction_id;

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -127,7 +127,7 @@ where
         if let Some(transaction_id) = src_transaction_id.as_deref() {
             tracing::Span::current().record(
                 "txn_id",
-                tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                tracing::field::display(telemetry::short_hex_id(transaction_id)),
             );
         }
         info!(zk_proof_id = txn_request.0, "Processing transaction");
@@ -261,7 +261,7 @@ where
             if let Some(transaction_id) = transaction_id.as_deref() {
                 span.record(
                     "txn_id",
-                    tracing::field::display(telemetry::short_txn_id(transaction_id)),
+                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
                 );
             }
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -124,12 +124,11 @@ where
         current_retry_count: i32,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        if let Some(transaction_id) = src_transaction_id.as_deref() {
-            tracing::Span::current().record(
-                "txn_id",
-                tracing::field::display(telemetry::short_hex_id(transaction_id)),
-            );
-        }
+        telemetry::record_short_hex_if_some(
+            &tracing::Span::current(),
+            "txn_id",
+            src_transaction_id.as_deref(),
+        );
         info!(zk_proof_id = txn_request.0, "Processing transaction");
 
         let receipt = match self
@@ -258,12 +257,7 @@ where
                 operation = "prepare_verify_proof_resp",
                 txn_id = tracing::field::Empty
             );
-            if let Some(transaction_id) = transaction_id.as_deref() {
-                span.record(
-                    "txn_id",
-                    tracing::field::display(telemetry::short_hex_id(transaction_id)),
-                );
-            }
+            telemetry::record_short_hex_if_some(&span, "txn_id", transaction_id.as_deref());
 
             let txn_request = match row.verified {
                 Some(true) => {

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -117,6 +117,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(operation = "call_verify_proof_resp"))]
     async fn process_proof(
         &self,
         txn_request: (i64, impl Into<TransactionRequest>),
@@ -124,11 +125,6 @@ where
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
         info!(zk_proof_id = txn_request.0, "Processing transaction");
-        let _span = tracing::info_span!(
-            "call_verify_proof_resp",
-            operation = "call_verify_proof_resp"
-        );
-        let _enter = _span.enter();
 
         let receipt = match self
             .provider

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -117,7 +117,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip_all, fields(operation = "call_verify_proof_resp", txn_id = tracing::field::Empty))]
+    #[tracing::instrument(name = "call_verify_proof_resp", skip_all, fields(operation = "call_verify_proof_resp", txn_id = tracing::field::Empty))]
     async fn process_proof(
         &self,
         txn_request: (i64, impl Into<TransactionRequest>),

--- a/coprocessor/fhevm-engine/zkproof-worker/Cargo.toml
+++ b/coprocessor/fhevm-engine/zkproof-worker/Cargo.toml
@@ -20,7 +20,9 @@ anyhow = { workspace = true }
 tokio-util = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
+opentelemetry = { workspace = true }
 humantime = { workspace = true }
 prometheus = { workspace = true }
 

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -82,7 +82,7 @@ pub fn parse_args() -> Args {
 async fn main() {
     let args = parse_args();
 
-    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+    let _otel_guard = telemetry::init_tracing_otel_with_logs_only_fallback(
         args.log_level,
         &args.service_name,
         "otlp-layer",

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -82,18 +82,11 @@ pub fn parse_args() -> Args {
 async fn main() {
     let args = parse_args();
 
-    let mut otlp_setup_error: Option<String> = None;
-    let _otel_guard =
-        match telemetry::init_json_subscriber(args.log_level, &args.service_name, "otlp-layer") {
-            Ok(guard) => guard,
-            Err(err) => {
-                otlp_setup_error = Some(err.to_string());
-                None
-            }
-        };
-    if let Some(err) = otlp_setup_error {
-        error!(error = %err, "Failed to setup OTLP");
-    }
+    let _otel_guard = telemetry::init_json_subscriber_with_otlp_fallback(
+        args.log_level,
+        &args.service_name,
+        "otlp-layer",
+    );
 
     let database_url = args.database_url.clone().unwrap_or_default();
 

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -509,7 +509,7 @@ fn expand_verified_list(
 
 /// Creates a ciphertext
 #[tracing::instrument(skip_all, fields(
-    operation = "create_handle",
+    operation = "create_ciphertext",
     ct_type = tracing::field::Empty,
     ct_idx = ct_idx,
     chain_id = %aux_data.chain_id,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -350,8 +350,7 @@ async fn execute_verify_proof_routine(
                     let count = cts.len();
                     insert_ciphertexts(&mut txn, cts, blob_hash).await?;
 
-                    info!(message = "Ciphertexts inserted", request_id);
-                    tracing::info!(count = count, "ciphertexts inserted");
+                    info!(message = "Ciphertexts inserted", request_id, count);
                 }
                 Err(err) => {
                     error!(
@@ -362,7 +361,7 @@ async fn execute_verify_proof_routine(
                 }
             }
 
-            tracing::info!(valid = verified, "db_insert result");
+            info!(valid = verified, "db_insert result");
 
             // Mark as verified=true/false and set handles, if computed
             sqlx::query(
@@ -483,7 +482,7 @@ fn verify_proof_only(
         return Err(err);
     }
 
-    tracing::info!(list_len = the_list.len(), "proof verified");
+    info!(list_len = the_list.len(), "proof verified");
     Ok(the_list)
 }
 
@@ -553,7 +552,7 @@ fn create_ciphertext(
     handle[31] = current_ciphertext_version() as u8;
 
     tracing::Span::current().record("ct_type", tracing::field::display(serialized_type));
-    tracing::info!(
+    info!(
         request_id,
         handle = %hex::encode(&handle),
         user_address = %aux_data.user_address,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -82,7 +82,7 @@ impl HealthCheckService for ZkProofService {
 }
 
 impl ZkProofService {
-    #[tracing::instrument(skip_all, fields(operation = "init_service"))]
+    #[tracing::instrument(name = "init_service", skip_all)]
     pub async fn create(conf: Config, token: CancellationToken) -> Option<ZkProofService> {
         // Each worker needs at least 3 pg connections
         let max_pool_connections =
@@ -295,12 +295,8 @@ async fn execute_verify_proof_routine(
 
         let acl_contract_address = host_chain.acl_contract_address.clone();
 
-        let verify_span = tracing::info_span!(
-            "verify_task",
-            operation = "verify_task",
-            request_id,
-            txn_id = tracing::field::Empty
-        );
+        let verify_span =
+            tracing::info_span!("verify_task", request_id, txn_id = tracing::field::Empty);
         fhevm_engine_common::telemetry::record_short_hex_if_some(
             &verify_span,
             "txn_id",
@@ -321,7 +317,6 @@ async fn execute_verify_proof_routine(
 
         let db_insert_span = tracing::info_span!(
             "db_insert",
-            operation = "db_insert",
             request_id,
             txn_id = tracing::field::Empty,
             valid = tracing::field::Empty,
@@ -436,7 +431,7 @@ pub(crate) fn verify_proof(
     Ok((cts, blob_hash))
 }
 
-#[tracing::instrument(skip_all, fields(operation = "verify_proof", list_len = tracing::field::Empty))]
+#[tracing::instrument(name = "verify_proof", skip_all, fields(list_len = tracing::field::Empty))]
 fn verify_proof_only(
     request_id: i64,
     raw_ct: &[u8],
@@ -489,7 +484,7 @@ fn verify_proof_only(
     Ok(the_list)
 }
 
-#[tracing::instrument(skip_all, fields(operation = "expand_ciphertext_list", count = tracing::field::Empty))]
+#[tracing::instrument(name = "expand_ciphertext_list", skip_all, fields(count = tracing::field::Empty))]
 fn expand_verified_list(
     request_id: i64,
     the_list: &tfhe::ProvenCompactCiphertextList,
@@ -512,7 +507,6 @@ fn expand_verified_list(
 
 /// Creates a ciphertext
 #[tracing::instrument(skip_all, fields(
-    operation = "create_ciphertext",
     ct_type = tracing::field::Empty,
     ct_idx = ct_idx,
     chain_id = %aux_data.chain_id,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -10,7 +10,6 @@ use fhevm_engine_common::tfhe_ops::{current_ciphertext_version, extract_ct_list}
 use fhevm_engine_common::types::SupportedFheCiphertexts;
 
 use fhevm_engine_common::utils::safe_deserialize_conformant;
-use hex::encode;
 use sha3::Digest;
 use sha3::Keccak256;
 use sqlx::{postgres::PgListener, PgPool, Row};
@@ -563,8 +562,6 @@ fn create_ciphertext(
         acl_contract_address = %aux_data.acl_contract_address,
         "create_handle details"
     );
-
-    info!(handle = ?encode(&handle), "Create new handle");
 
     Ok(Ciphertext {
         handle,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -302,14 +302,11 @@ async fn execute_verify_proof_routine(
             request_id,
             txn_id = tracing::field::Empty
         );
-        if let Some(transaction_id) = transaction_id.as_deref() {
-            verify_span.record(
-                "txn_id",
-                tracing::field::display(fhevm_engine_common::telemetry::short_hex_id(
-                    transaction_id,
-                )),
-            );
-        }
+        fhevm_engine_common::telemetry::record_short_hex_if_some(
+            &verify_span,
+            "txn_id",
+            transaction_id.as_deref(),
+        );
         let res = tokio::task::spawn_blocking(move || {
             let _guard = verify_span.enter();
             let aux_data = auxiliary::ZkData {
@@ -329,14 +326,11 @@ async fn execute_verify_proof_routine(
             request_id,
             txn_id = tracing::field::Empty
         );
-        if let Some(transaction_id) = transaction_id.as_deref() {
-            t.record(
-                "txn_id",
-                tracing::field::display(fhevm_engine_common::telemetry::short_hex_id(
-                    transaction_id,
-                )),
-            );
-        }
+        fhevm_engine_common::telemetry::record_short_hex_if_some(
+            &t,
+            "txn_id",
+            transaction_id.as_deref(),
+        );
 
         let mut verified = false;
         let mut handles_bytes = vec![];

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -305,7 +305,7 @@ async fn execute_verify_proof_routine(
         if let Some(transaction_id) = transaction_id.as_deref() {
             verify_span.record(
                 "txn_id",
-                tracing::field::display(fhevm_engine_common::telemetry::short_txn_id(
+                tracing::field::display(fhevm_engine_common::telemetry::short_hex_id(
                     transaction_id,
                 )),
             );
@@ -332,7 +332,7 @@ async fn execute_verify_proof_routine(
         if let Some(transaction_id) = transaction_id.as_deref() {
             t.record(
                 "txn_id",
-                tracing::field::display(fhevm_engine_common::telemetry::short_txn_id(
+                tracing::field::display(fhevm_engine_common::telemetry::short_hex_id(
                     transaction_id,
                 )),
             );

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -521,7 +521,7 @@ fn create_ciphertext(
     handle[30] = serialized_type as u8;
     handle[31] = current_ciphertext_version() as u8;
 
-    tracing::Span::current().record("ct_type", serialized_type as i64);
+    tracing::Span::current().record("ct_type", tracing::field::display(serialized_type));
     tracing::info!(
         request_id,
         handle = %hex::encode(&handle),


### PR DESCRIPTION
## Outcome
This PR completes the coprocessor migration from legacy `OtelTracer` helpers to idiomatic `tracing` + OTEL bridge spans, so telemetry is cleaner to write/maintain while keeping production observability intact.

## What changed
- Migrated remaining coprocessor paths to declarative `tracing` instrumentation:
  - `zkproof-worker`
  - `tfhe-worker`
  - `host-listener` DB propagation
  - `transaction-sender` ops (`add_ciphertext`, `allow_handle`, `delegate_user_decrypt`, `verify_proof`)
- Removed legacy telemetry wrapper usage in migrated paths.
- Kept explicit parent/context restoration only across real async/thread boundaries (`spawn` / `spawn_blocking`).
- Preserved span granularity where it matters (dedicated child spans for key execution boundaries).

## Scope guardrails
- Telemetry-only migration work for the paths above.
- No feature-level behavior change intended.

## Validation
- Coprocessor crates pass pre-commit checks (`fmt`, `cargo check`, `clippy`).
- A/B telemetry validation run performed with working Jaeger OTLP endpoint to compare span structure (operation names, parent topology, attrs).

Closes zama-ai/fhevm-internal#935
Closes zama-ai/fhevm-internal#1008
Closes zama-ai/fhevm-internal#1009
Closes zama-ai/fhevm-internal#1034
Closes zama-ai/fhevm-internal#1036

Closes zama-ai/fhevm-internal#1010
Closes zama-ai/fhevm-internal#1011
Closes zama-ai/fhevm-internal#1035
