### PR TITLE
feat(coprocessor): allow skipping verify proof requests during GW catchup

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.8.1
+version: 0.8.2
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -447,6 +447,7 @@ gwListener:
     # --replay-from-block BLOCK_NUMBER
     # To go back in time from latest block
     # --replay-from-block -NB_BLOCK
+    # --replay-skip-verify-proof  # Skip VerifyProofRequest events during replay
 
   # Service ports configuration
   ports:

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -82,6 +82,13 @@ struct Conf {
 
     #[arg(long, default_value = None, help = "Can be negative from last processed block", allow_hyphen_values = true, alias = "catchup-kms-generation-from-block")]
     pub replay_from_block: Option<i64>,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Skip VerifyProofRequest events during replay"
+    )]
+    pub replay_skip_verify_proof: bool,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -170,6 +177,7 @@ async fn main() -> anyhow::Result<()> {
         get_logs_poll_interval: conf.get_logs_poll_interval,
         get_logs_block_batch_size: conf.get_logs_block_batch_size,
         replay_from_block: conf.replay_from_block,
+        replay_skip_verify_proof: conf.replay_skip_verify_proof,
         log_last_processed_every_number_of_updates: conf.log_last_processed_every_number_of_updates,
     };
 

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -196,6 +196,10 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                     }
                     for log in logs {
                         if log.address() == self.input_verification_address {
+                            if replay_from_block.is_some() && self.conf.replay_skip_verify_proof {
+                                debug!(log = ?log, "Skipping VerifyProofRequest during replay");
+                                continue;
+                            }
                             if let Ok(event) = InputVerification::InputVerificationEvents::decode_log(&log.inner) {
                                 match event.data {
                                     InputVerification::InputVerificationEvents::VerifyProofRequest(request) => {

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -52,6 +52,7 @@ pub struct ConfigSettings {
     pub get_logs_poll_interval: Duration,
     pub get_logs_block_batch_size: u64,
     pub replay_from_block: Option<i64>,
+    pub replay_skip_verify_proof: bool,
 
     pub log_last_processed_every_number_of_updates: u64,
 }
@@ -86,6 +87,7 @@ impl Default for ConfigSettings {
             get_logs_poll_interval: Duration::from_millis(500),
             get_logs_block_batch_size: 100,
             replay_from_block: None,
+            replay_skip_verify_proof: false,
             log_last_processed_every_number_of_updates: 50,
         }
     }


### PR DESCRIPTION
This is needed when spinning up a coprocessor as the keygen/crsgen events can be quite far back and we don't necessarily want to replay all verify proof requests since genesis if we don't have the precise location of these events.