### PR TITLE
test(host-contracts): add targeted invariant harnesses

### DIFF
--- a/host-contracts/foundry.toml
+++ b/host-contracts/foundry.toml
@@ -17,5 +17,15 @@ remappings = [
 # The number of fuzz runs for fuzz tests
 runs = 2560
 
+[profile.default.invariant]
+runs = 96
+depth = 24
+fail_on_revert = false
+
+[profile.invariant_stress.invariant]
+runs = 256
+depth = 64
+fail_on_revert = false
+
 [dependencies]
 forge-std = "1.11.0"

--- a/host-contracts/test/invariants/README.md
+++ b/host-contracts/test/invariants/README.md
@@ -1,0 +1,28 @@
+# Host Contracts Invariants
+
+Targeted, scenario-based stateful invariant suites for host contracts.
+
+## Scenario map
+
+- `scenarios/signer-governance/`: signer-set and threshold safety (`InputVerifier`, `KMSVerifier`).
+- `scenarios/acl-permissions/`: ACL permission composition, pause, deny-list, and privilege enforcement.
+- `scenarios/acl-delegation/`: delegation/revocation state machine and delegated-access coherence.
+
+Each scenario folder has its own `README.md` with invariant IDs and intent.
+
+## Runtime guardrails
+
+- `host-contracts/foundry.toml` uses short deterministic defaults under `[profile.default.invariant]`.
+- Handlers use explicit selector allowlists and bounded domains for reproducible runtime.
+
+## Repro commands
+
+```bash
+cd host-contracts && forge test --match-path 'test/invariants/scenarios/**/*.sol' -vv
+```
+
+Stress sweep:
+
+```bash
+cd host-contracts && FOUNDRY_PROFILE=invariant_stress forge test --match-path 'test/invariants/scenarios/**/*.sol' -vv
+```

--- a/host-contracts/test/invariants/base/BaseScenarioInvariant.t.sol
+++ b/host-contracts/test/invariants/base/BaseScenarioInvariant.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {HostContractsDeployerTestUtils} from "../../../fhevm-foundry/HostContractsDeployerTestUtils.sol";
+
+abstract contract BaseScenarioInvariant is StdInvariant, HostContractsDeployerTestUtils {
+    function _targetInvariant(address handler, bytes4[] memory selectors, address[] memory senders) internal {
+        targetContract(handler);
+        for (uint256 i = 0; i < senders.length; i++) {
+            targetSender(senders[i]);
+        }
+        targetSelector(FuzzSelector({addr: handler, selectors: selectors}));
+    }
+
+    function _contains(address[] memory values, address candidate) internal pure returns (bool) {
+        for (uint256 i = 0; i < values.length; i++) {
+            if (values[i] == candidate) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/host-contracts/test/invariants/scenarios/acl-delegation/ACLDelegationHandler.t.sol
+++ b/host-contracts/test/invariants/scenarios/acl-delegation/ACLDelegationHandler.t.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ACL} from "../../../../contracts/ACL.sol";
+import {fhevmExecutorAdd} from "../../../../addresses/FHEVMHostAddresses.sol";
+
+contract ACLDelegationHandler is Test {
+    uint256 internal constant MAX_TRACKED_TUPLES = 24;
+    uint8 internal constant STATUS_ACTIVE = 1;
+    uint8 internal constant STATUS_REVOKED = 2;
+
+    ACL internal immutable acl;
+    address internal immutable owner;
+    address internal immutable pauser;
+    address internal immutable actor1;
+    address internal immutable actor2;
+    address internal immutable actor3;
+
+    bool public pausedBypassViolation;
+    bool public privilegeViolation;
+
+    address[MAX_TRACKED_TUPLES] internal trackedDelegators;
+    address[MAX_TRACKED_TUPLES] internal trackedDelegates;
+    address[MAX_TRACKED_TUPLES] internal trackedContractAddresses;
+    bytes32[MAX_TRACKED_TUPLES] internal trackedDelegationHandles;
+    uint8[MAX_TRACKED_TUPLES] internal trackedDelegationStatuses;
+    uint256 public trackedDelegationCount;
+    uint256 internal trackedDelegationWriteIndex;
+    uint256 public successfulDelegationCount;
+    uint256 public successfulRevocationCount;
+
+    constructor(ACL _acl, address _owner, address _pauser, address _actor1, address _actor2, address _actor3) {
+        acl = _acl;
+        owner = _owner;
+        pauser = _pauser;
+        actor1 = _actor1;
+        actor2 = _actor2;
+        actor3 = _actor3;
+    }
+
+    function delegateForUserDecryption(
+        uint8 delegateSeed,
+        uint8 contractSeed,
+        uint8 hoursAheadSeed,
+        uint256 handleSeed
+    ) external {
+        address delegate = _actorFromSeed(delegateSeed);
+        address contractAddress = _actorFromSeed(uint8(uint256(contractSeed) + 11));
+
+        if (delegate == msg.sender) {
+            delegate = address(uint160(delegate) + 1000);
+        }
+        if (contractAddress == msg.sender || contractAddress == delegate) {
+            contractAddress = address(uint160(contractAddress) + 2000);
+        }
+        bytes32 handle = keccak256(abi.encode(handleSeed));
+
+        uint64 expirationDate = uint64(block.timestamp + bound(uint256(hoursAheadSeed), 1, 72) * 1 hours);
+        bool wasPaused = acl.paused();
+        if (!wasPaused) {
+            _prepareSenderHandle(handle, msg.sender);
+            _prepareSenderHandle(handle, contractAddress);
+        }
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(
+            abi.encodeCall(ACL.delegateForUserDecryption, (delegate, contractAddress, expirationDate))
+        );
+        if (ok) {
+            if (wasPaused) {
+                pausedBypassViolation = true;
+            } else {
+                _upsertDelegation(msg.sender, delegate, contractAddress, handle, STATUS_ACTIVE);
+                successfulDelegationCount++;
+                vm.roll(block.number + 1);
+            }
+        }
+    }
+
+    function revokeTrackedDelegationAsDelegator(uint8 trackedIndexSeed) external {
+        if (trackedDelegationCount == 0) {
+            return;
+        }
+        uint256 index = bound(uint256(trackedIndexSeed), 0, trackedDelegationCount - 1);
+        address delegator = trackedDelegators[index];
+        address delegate = trackedDelegates[index];
+        address contractAddress = trackedContractAddresses[index];
+
+        bool wasPaused = acl.paused();
+        vm.prank(delegator);
+        (bool ok, ) = address(acl).call(
+            abi.encodeCall(ACL.revokeDelegationForUserDecryption, (delegate, contractAddress))
+        );
+        if (ok) {
+            if (wasPaused) {
+                pausedBypassViolation = true;
+            } else {
+                if (_markRevoked(delegator, delegate, contractAddress)) {
+                    successfulRevocationCount++;
+                    vm.roll(block.number + 1);
+                }
+            }
+        }
+    }
+
+    function revokeTrackedDelegationAsCaller(uint8 trackedIndexSeed) external {
+        if (trackedDelegationCount == 0) {
+            return;
+        }
+        uint256 index = bound(uint256(trackedIndexSeed), 0, trackedDelegationCount - 1);
+        address selectedDelegator = trackedDelegators[index];
+        address delegate = trackedDelegates[index];
+        address contractAddress = trackedContractAddresses[index];
+        uint64 selectedBefore = acl.getUserDecryptionDelegationExpirationDate(selectedDelegator, delegate, contractAddress);
+        uint64 callerBefore = acl.getUserDecryptionDelegationExpirationDate(msg.sender, delegate, contractAddress);
+
+        bool wasPaused = acl.paused();
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(
+            abi.encodeCall(ACL.revokeDelegationForUserDecryption, (delegate, contractAddress))
+        );
+        if (ok) {
+            if (wasPaused) {
+                pausedBypassViolation = true;
+            } else {
+                // Successful revocation by a non-selected delegator must not mutate selected tuple state.
+                if (msg.sender != selectedDelegator) {
+                    if (callerBefore == 0) {
+                        privilegeViolation = true;
+                    }
+                    uint64 selectedAfter = acl.getUserDecryptionDelegationExpirationDate(
+                        selectedDelegator,
+                        delegate,
+                        contractAddress
+                    );
+                    if (selectedBefore != 0 && selectedAfter == 0) {
+                        privilegeViolation = true;
+                    }
+                }
+                // This call path is auth-pressure only: caller can revoke only their own tuple.
+                // We update the model when it has the tuple and otherwise ignore.
+                if (_markRevoked(msg.sender, delegate, contractAddress)) {
+                    successfulRevocationCount++;
+                    vm.roll(block.number + 1);
+                }
+            }
+        }
+    }
+
+    function pause() external {
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.pause, ()));
+        if (ok && !acl.isPauser(msg.sender)) {
+            privilegeViolation = true;
+        }
+    }
+
+    function unpause() external {
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.unpause, ()));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function getTrackedDelegation(
+        uint256 index
+    ) external view returns (address delegator, address delegate, address contractAddress, bytes32 handle, uint8 status) {
+        return (
+            trackedDelegators[index],
+            trackedDelegates[index],
+            trackedContractAddresses[index],
+            trackedDelegationHandles[index],
+            trackedDelegationStatuses[index]
+        );
+    }
+
+    function _prepareSenderHandle(bytes32 handle, address sender) internal {
+        vm.prank(fhevmExecutorAdd);
+        acl.allowTransient(handle, sender);
+        vm.prank(sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.allow, (handle, sender)));
+        if (ok) {
+            vm.prank(sender);
+            acl.cleanTransientStorage();
+        }
+    }
+
+    function _upsertDelegation(
+        address delegator,
+        address delegate,
+        address contractAddress,
+        bytes32 handle,
+        uint8 status
+    ) internal {
+        (bool found, uint256 index) = _findTrackedIndex(delegator, delegate, contractAddress);
+        if (found) {
+            trackedDelegationHandles[index] = handle;
+            trackedDelegationStatuses[index] = status;
+            return;
+        }
+
+        if (trackedDelegationCount < MAX_TRACKED_TUPLES) {
+            trackedDelegators[trackedDelegationCount] = delegator;
+            trackedDelegates[trackedDelegationCount] = delegate;
+            trackedContractAddresses[trackedDelegationCount] = contractAddress;
+            trackedDelegationHandles[trackedDelegationCount] = handle;
+            trackedDelegationStatuses[trackedDelegationCount] = status;
+            trackedDelegationCount++;
+        } else {
+            uint256 slot = trackedDelegationWriteIndex % MAX_TRACKED_TUPLES;
+            trackedDelegators[slot] = delegator;
+            trackedDelegates[slot] = delegate;
+            trackedContractAddresses[slot] = contractAddress;
+            trackedDelegationHandles[slot] = handle;
+            trackedDelegationStatuses[slot] = status;
+            trackedDelegationWriteIndex++;
+        }
+    }
+
+    function _markRevoked(address delegator, address delegate, address contractAddress) internal returns (bool) {
+        (bool found, uint256 index) = _findTrackedIndex(delegator, delegate, contractAddress);
+        if (!found) {
+            return false;
+        }
+        trackedDelegationStatuses[index] = STATUS_REVOKED;
+        return true;
+    }
+
+    function _findTrackedIndex(
+        address delegator,
+        address delegate,
+        address contractAddress
+    ) internal view returns (bool found, uint256 index) {
+        for (uint256 i = 0; i < trackedDelegationCount; i++) {
+            if (
+                trackedDelegators[i] == delegator &&
+                trackedDelegates[i] == delegate &&
+                trackedContractAddresses[i] == contractAddress
+            ) {
+                return (true, i);
+            }
+        }
+        return (false, 0);
+    }
+
+    function _actorFromSeed(uint8 seed) internal view returns (address) {
+        uint8 role = seed % 5;
+        if (role == 0) {
+            return owner;
+        }
+        if (role == 1) {
+            return pauser;
+        }
+        if (role == 2) {
+            return actor1;
+        }
+        if (role == 3) {
+            return actor2;
+        }
+        return actor3;
+    }
+}

--- a/host-contracts/test/invariants/scenarios/acl-delegation/ACLDelegationInvariants.t.sol
+++ b/host-contracts/test/invariants/scenarios/acl-delegation/ACLDelegationInvariants.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {ACL} from "../../../../contracts/ACL.sol";
+import {PauserSet} from "../../../../contracts/immutable/PauserSet.sol";
+import {aclAdd, pauserSetAdd} from "../../../../addresses/FHEVMHostAddresses.sol";
+import {BaseScenarioInvariant} from "../../base/BaseScenarioInvariant.t.sol";
+import {ACLDelegationHandler} from "./ACLDelegationHandler.t.sol";
+
+contract ACLDelegationInvariants is BaseScenarioInvariant {
+    uint8 internal constant STATUS_ACTIVE = 1;
+    uint8 internal constant STATUS_REVOKED = 2;
+
+    address internal constant OWNER = address(0xA11);
+    address internal constant PAUSER = address(0xA12);
+    address internal constant ACTOR_1 = address(0x1201);
+    address internal constant ACTOR_2 = address(0x1202);
+    address internal constant ACTOR_3 = address(0x1203);
+
+    ACL internal acl;
+    ACLDelegationHandler internal handler;
+
+    function setUp() public {
+        _deployACL(OWNER);
+        _deployPauserSet();
+        vm.prank(OWNER);
+        PauserSet(pauserSetAdd).addPauser(PAUSER);
+
+        acl = ACL(aclAdd);
+        handler = new ACLDelegationHandler(acl, OWNER, PAUSER, ACTOR_1, ACTOR_2, ACTOR_3);
+
+        address[] memory senders = new address[](5);
+        senders[0] = OWNER;
+        senders[1] = PAUSER;
+        senders[2] = ACTOR_1;
+        senders[3] = ACTOR_2;
+        senders[4] = ACTOR_3;
+
+        bytes4[] memory selectors = new bytes4[](5);
+        selectors[0] = ACLDelegationHandler.delegateForUserDecryption.selector;
+        selectors[1] = ACLDelegationHandler.revokeTrackedDelegationAsDelegator.selector;
+        selectors[2] = ACLDelegationHandler.revokeTrackedDelegationAsCaller.selector;
+        selectors[3] = ACLDelegationHandler.pause.selector;
+        selectors[4] = ACLDelegationHandler.unpause.selector;
+        _targetInvariant(address(handler), selectors, senders);
+    }
+
+    /// @custom:invariant ACL-DEL-001
+    function invariant_RevokedDelegationHasZeroExpiration() public view {
+        uint256 count = handler.trackedDelegationCount();
+        for (uint256 i = 0; i < count; i++) {
+            (address delegator, address delegate, address contractAddress, bytes32 handle, uint8 status) = handler
+                .getTrackedDelegation(i);
+            if (status != STATUS_REVOKED) {
+                continue;
+            }
+            uint64 expiration = acl.getUserDecryptionDelegationExpirationDate(delegator, delegate, contractAddress);
+            assertEq(expiration, 0);
+            assertFalse(acl.isHandleDelegatedForUserDecryption(delegator, delegate, contractAddress, handle));
+        }
+    }
+
+    /// @custom:invariant ACL-DEL-002
+    function invariant_ActiveDelegationFromModelHasAccess() public view {
+        uint256 count = handler.trackedDelegationCount();
+        for (uint256 i = 0; i < count; i++) {
+            (address delegator, address delegate, address contractAddress, bytes32 handle, uint8 status) = handler
+                .getTrackedDelegation(i);
+            if (status != STATUS_ACTIVE) {
+                continue;
+            }
+            assertTrue(acl.isHandleDelegatedForUserDecryption(delegator, delegate, contractAddress, handle));
+        }
+    }
+
+    /// @custom:invariant ACL-DEL-003
+    function invariant_PausedDelegationMutationsCannotSucceed() public view {
+        assertFalse(handler.pausedBypassViolation());
+    }
+
+    /// @custom:invariant ACL-DEL-004
+    function invariant_OnlyDelegatorCanRevokeDelegation() public view {
+        assertFalse(handler.privilegeViolation());
+    }
+}

--- a/host-contracts/test/invariants/scenarios/acl-delegation/README.md
+++ b/host-contracts/test/invariants/scenarios/acl-delegation/README.md
@@ -1,0 +1,22 @@
+# ACL Delegation Scenario
+
+Focus: user decryption delegation state machine and delegated-access coherence.
+
+## Actions
+- `delegateForUserDecryption`
+- `revokeTrackedDelegationAsDelegator`
+- `revokeTrackedDelegationAsCaller`
+- `pause` / `unpause`
+
+## Model state
+- Per tuple `(delegator, delegate, contractAddress)`: tracked `handle` and status (`ACTIVE` / `REVOKED`).
+- Violation flags: paused bypass and non-delegator revoke success.
+
+## Invariants (IDs)
+- `ACL-DEL-001`: tuples marked `REVOKED` have expiration `0` and no delegated access.
+- `ACL-DEL-002`: tuples marked `ACTIVE` grant delegated access for their tracked handle.
+- `ACL-DEL-003`: delegation/revocation cannot succeed while ACL is paused.
+- `ACL-DEL-004`: non-delegators cannot revoke tracked delegations.
+
+## Known non-goals
+- No assertion on event payloads or delegation counters.

--- a/host-contracts/test/invariants/scenarios/acl-permissions/ACLPermissionsHandler.t.sol
+++ b/host-contracts/test/invariants/scenarios/acl-permissions/ACLPermissionsHandler.t.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ACL} from "../../../../contracts/ACL.sol";
+import {fhevmExecutorAdd} from "../../../../addresses/FHEVMHostAddresses.sol";
+
+contract ACLPermissionsHandler is Test {
+    uint256 internal constant MAX_TRACKED_PAIRS = 24;
+
+    ACL internal immutable acl;
+    address internal immutable owner;
+    address internal immutable pauser;
+    address internal immutable actor1;
+    address internal immutable actor2;
+    address internal immutable actor3;
+
+    bool public privilegeViolation;
+    bool public deniedBypassViolation;
+    bool public pausedBypassViolation;
+    bool public senderPermissionBypassViolation;
+    bool public transientVisibilityViolation;
+
+    bytes32[MAX_TRACKED_PAIRS] internal successfulAllowHandles;
+    address[MAX_TRACKED_PAIRS] internal successfulAllowAccounts;
+    uint256 public successfulAllowCount;
+
+    bytes32[MAX_TRACKED_PAIRS] internal successfulDecryptHandles;
+    uint256 public successfulDecryptHandleCount;
+
+    constructor(ACL _acl, address _owner, address _pauser, address _actor1, address _actor2, address _actor3) {
+        acl = _acl;
+        owner = _owner;
+        pauser = _pauser;
+        actor1 = _actor1;
+        actor2 = _actor2;
+        actor3 = _actor3;
+    }
+
+    function allow(bytes32 handle, uint8 accountSeed, bool prepareSender) external {
+        address account = _seededAddress(accountSeed, 220);
+        bool wasPaused = acl.paused();
+
+        if (prepareSender && !wasPaused) {
+            _prepareSenderHandle(handle, msg.sender);
+        }
+        bool senderAllowed = acl.isAllowed(handle, msg.sender);
+
+        bool wasDenied = acl.isAccountDenied(msg.sender);
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.allow, (handle, account)));
+        if (ok && wasDenied) {
+            deniedBypassViolation = true;
+        }
+        if (ok && wasPaused) {
+            pausedBypassViolation = true;
+        }
+        if (ok && !senderAllowed) {
+            senderPermissionBypassViolation = true;
+        }
+        if (ok) {
+            _trackSuccessfulAllow(handle, account);
+        }
+    }
+
+    function allowTransient(bytes32 handle, uint8 accountSeed, bool prepareSender) external {
+        address account = _seededAddress(accountSeed, 250);
+        bool wasPaused = acl.paused();
+
+        if (prepareSender && !wasPaused) {
+            _prepareSenderHandle(handle, msg.sender);
+        }
+        bool senderAllowed = acl.isAllowed(handle, msg.sender);
+
+        bool wasDenied = acl.isAccountDenied(msg.sender);
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.allowTransient, (handle, account)));
+        if (ok && wasDenied) {
+            deniedBypassViolation = true;
+        }
+        if (ok && wasPaused) {
+            pausedBypassViolation = true;
+        }
+        if (ok && !senderAllowed) {
+            senderPermissionBypassViolation = true;
+        }
+        if (ok && !acl.isAllowed(handle, account)) {
+            transientVisibilityViolation = true;
+        }
+    }
+
+    function allowForDecryption(uint8 handleCountSeed, uint256 handleSeed, bool prepareSender) external {
+        uint256 len = bound(uint256(handleCountSeed), 1, 3);
+        bool wasPaused = acl.paused();
+        bytes32[] memory handles = new bytes32[](len);
+        bool senderAllowedAll = true;
+        for (uint256 i = 0; i < len; i++) {
+            handles[i] = keccak256(abi.encode(handleSeed, i));
+            if (prepareSender && !wasPaused) {
+                _prepareSenderHandle(handles[i], msg.sender);
+            }
+            if (!acl.isAllowed(handles[i], msg.sender)) {
+                senderAllowedAll = false;
+            }
+        }
+
+        bool wasDenied = acl.isAccountDenied(msg.sender);
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.allowForDecryption, (handles)));
+        if (ok && wasDenied) {
+            deniedBypassViolation = true;
+        }
+        if (ok && wasPaused) {
+            pausedBypassViolation = true;
+        }
+        if (ok && !senderAllowedAll) {
+            senderPermissionBypassViolation = true;
+        }
+        if (ok) {
+            for (uint256 i = 0; i < handles.length; i++) {
+                _trackSuccessfulDecryptHandle(handles[i]);
+            }
+        }
+    }
+
+    function pause() external {
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.pause, ()));
+        if (ok && !acl.isPauser(msg.sender)) {
+            privilegeViolation = true;
+        }
+    }
+
+    function unpause() external {
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.unpause, ()));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function blockAccount(uint8 accountSeed) external {
+        address account = _actorFromSeed(accountSeed);
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.blockAccount, (account)));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function unblockAccount(uint8 accountSeed) external {
+        address account = _actorFromSeed(accountSeed);
+        vm.prank(msg.sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.unblockAccount, (account)));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function cleanTransientStorage() external {
+        vm.prank(msg.sender);
+        acl.cleanTransientStorage();
+    }
+
+    function getSuccessfulAllowPair(uint256 index) external view returns (bytes32 handle, address account) {
+        return (successfulAllowHandles[index], successfulAllowAccounts[index]);
+    }
+
+    function getSuccessfulDecryptHandle(uint256 index) external view returns (bytes32 handle) {
+        return successfulDecryptHandles[index];
+    }
+
+    function _prepareSenderHandle(bytes32 handle, address sender) internal {
+        vm.prank(fhevmExecutorAdd);
+        acl.allowTransient(handle, sender);
+        vm.prank(sender);
+        (bool ok, ) = address(acl).call(abi.encodeCall(ACL.allow, (handle, sender)));
+        if (ok) {
+            vm.prank(sender);
+            acl.cleanTransientStorage();
+        }
+    }
+
+    function _trackSuccessfulAllow(bytes32 handle, address account) internal {
+        for (uint256 i = 0; i < successfulAllowCount; i++) {
+            if (successfulAllowHandles[i] == handle && successfulAllowAccounts[i] == account) {
+                return;
+            }
+        }
+
+        if (successfulAllowCount < MAX_TRACKED_PAIRS) {
+            successfulAllowHandles[successfulAllowCount] = handle;
+            successfulAllowAccounts[successfulAllowCount] = account;
+            successfulAllowCount++;
+        }
+    }
+
+    function _trackSuccessfulDecryptHandle(bytes32 handle) internal {
+        for (uint256 i = 0; i < successfulDecryptHandleCount; i++) {
+            if (successfulDecryptHandles[i] == handle) {
+                return;
+            }
+        }
+
+        if (successfulDecryptHandleCount < MAX_TRACKED_PAIRS) {
+            successfulDecryptHandles[successfulDecryptHandleCount] = handle;
+            successfulDecryptHandleCount++;
+        }
+    }
+
+    function _seededAddress(uint8 seed, uint160 offset) internal pure returns (address) {
+        return address(offset + uint160(seed) + 1);
+    }
+
+    function _actorFromSeed(uint8 seed) internal view returns (address) {
+        uint8 role = seed % 5;
+        if (role == 0) {
+            return owner;
+        }
+        if (role == 1) {
+            return pauser;
+        }
+        if (role == 2) {
+            return actor1;
+        }
+        if (role == 3) {
+            return actor2;
+        }
+        return actor3;
+    }
+}

--- a/host-contracts/test/invariants/scenarios/acl-permissions/ACLPermissionsInvariants.t.sol
+++ b/host-contracts/test/invariants/scenarios/acl-permissions/ACLPermissionsInvariants.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {ACL} from "../../../../contracts/ACL.sol";
+import {PauserSet} from "../../../../contracts/immutable/PauserSet.sol";
+import {aclAdd, pauserSetAdd} from "../../../../addresses/FHEVMHostAddresses.sol";
+import {BaseScenarioInvariant} from "../../base/BaseScenarioInvariant.t.sol";
+import {ACLPermissionsHandler} from "./ACLPermissionsHandler.t.sol";
+
+contract ACLPermissionsInvariants is BaseScenarioInvariant {
+    address internal constant OWNER = address(0xA11);
+    address internal constant PAUSER = address(0xA12);
+    address internal constant ACTOR_1 = address(0x1201);
+    address internal constant ACTOR_2 = address(0x1202);
+    address internal constant ACTOR_3 = address(0x1203);
+
+    ACL internal acl;
+    ACLPermissionsHandler internal handler;
+
+    function setUp() public {
+        _deployACL(OWNER);
+        _deployPauserSet();
+        vm.prank(OWNER);
+        PauserSet(pauserSetAdd).addPauser(PAUSER);
+
+        acl = ACL(aclAdd);
+        handler = new ACLPermissionsHandler(acl, OWNER, PAUSER, ACTOR_1, ACTOR_2, ACTOR_3);
+
+        address[] memory senders = new address[](5);
+        senders[0] = OWNER;
+        senders[1] = PAUSER;
+        senders[2] = ACTOR_1;
+        senders[3] = ACTOR_2;
+        senders[4] = ACTOR_3;
+
+        bytes4[] memory selectors = new bytes4[](8);
+        selectors[0] = ACLPermissionsHandler.allow.selector;
+        selectors[1] = ACLPermissionsHandler.allowTransient.selector;
+        selectors[2] = ACLPermissionsHandler.allowForDecryption.selector;
+        selectors[3] = ACLPermissionsHandler.pause.selector;
+        selectors[4] = ACLPermissionsHandler.unpause.selector;
+        selectors[5] = ACLPermissionsHandler.blockAccount.selector;
+        selectors[6] = ACLPermissionsHandler.unblockAccount.selector;
+        selectors[7] = ACLPermissionsHandler.cleanTransientStorage.selector;
+        _targetInvariant(address(handler), selectors, senders);
+    }
+
+    /// @custom:invariant ACL-PERM-001
+    function invariant_SuccessfulPermissionWritesPersist() public view {
+        uint256 count = handler.successfulAllowCount();
+        for (uint256 i = 0; i < count; i++) {
+            (bytes32 handle, address account) = handler.getSuccessfulAllowPair(i);
+            assertTrue(acl.persistAllowed(handle, account));
+        }
+
+        uint256 decryptCount = handler.successfulDecryptHandleCount();
+        for (uint256 i = 0; i < decryptCount; i++) {
+            bytes32 handle = handler.getSuccessfulDecryptHandle(i);
+            assertTrue(acl.isAllowedForDecryption(handle));
+        }
+    }
+
+    /// @custom:invariant ACL-PERM-002
+    function invariant_EnforcementGuardsHold() public view {
+        assertFalse(handler.privilegeViolation());
+        assertFalse(handler.deniedBypassViolation());
+        assertFalse(handler.senderPermissionBypassViolation());
+        assertFalse(handler.transientVisibilityViolation());
+    }
+
+    /// @custom:invariant ACL-PERM-003
+    function invariant_PausedMutationsCannotSucceed() public view {
+        assertFalse(handler.pausedBypassViolation());
+    }
+}

--- a/host-contracts/test/invariants/scenarios/acl-permissions/README.md
+++ b/host-contracts/test/invariants/scenarios/acl-permissions/README.md
@@ -1,0 +1,23 @@
+# ACL Permissions Scenario
+
+Focus: ACL permission, pause, deny-list, and privileged-operation safety.
+
+## Actions
+- `allow`
+- `allowTransient`
+- `allowForDecryption`
+- `pause` / `unpause`
+- `blockAccount` / `unblockAccount`
+
+## Model state
+- Successful persistent `allow(handle, account)` pairs.
+- Successful `allowForDecryption(handle)` handles.
+- Violation flags: privilege bypass, deny-list bypass, sender-permission bypass, paused bypass, transient visibility mismatch.
+
+## Invariants (IDs)
+- `ACL-PERM-001`: successful persistent/decryption writes remain visible in ACL storage.
+- `ACL-PERM-002`: privilege, deny-list, sender-permission, and transient visibility guarantees are never violated.
+- `ACL-PERM-003`: ACL mutating flows never succeed while paused.
+
+## Known non-goals
+- No cross-transaction invariant over `allowedTransient` (transient storage resets at tx boundary).

--- a/host-contracts/test/invariants/scenarios/signer-governance/InputVerifierSignerGovernanceHandler.t.sol
+++ b/host-contracts/test/invariants/scenarios/signer-governance/InputVerifierSignerGovernanceHandler.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {InputVerifier} from "../../../../contracts/InputVerifier.sol";
+import {FHEVMExecutor} from "../../../../contracts/FHEVMExecutor.sol";
+
+contract InputVerifierSignerGovernanceHandler is Test {
+    uint8 internal constant SIGNER_DOMAIN = 32;
+
+    InputVerifier internal immutable inputVerifier;
+    address internal immutable owner;
+
+    bool public unexpectedContextMutation;
+    bool public privilegeViolation;
+
+    constructor(InputVerifier _inputVerifier, address _owner) {
+        inputVerifier = _inputVerifier;
+        owner = _owner;
+    }
+
+    function defineNewContext(uint8 signerCountSeed, uint8 thresholdSeed, uint8 baseSeed, bool forceDuplicate) external {
+        uint256 signerCount = bound(uint256(signerCountSeed), 1, 5);
+        uint256 threshold = bound(uint256(thresholdSeed), 0, 6);
+        address[] memory signers = _buildSignerSet(signerCount, baseSeed, forceDuplicate);
+
+        vm.prank(msg.sender);
+        (bool ok, ) = address(inputVerifier).call(abi.encodeCall(InputVerifier.defineNewContext, (signers, threshold)));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function setThreshold(uint8 thresholdSeed) external {
+        uint256 threshold = bound(uint256(thresholdSeed), 0, 6);
+
+        vm.prank(msg.sender);
+        (bool ok, ) = address(inputVerifier).call(abi.encodeCall(InputVerifier.setThreshold, (threshold)));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function verifyInput(
+        bytes32 inputHandle,
+        uint8 proofLenSeed,
+        uint8 userSeed,
+        uint8 contractSeed,
+        uint256 proofSeed
+    ) external {
+        bytes32 beforeHash = _contextHash();
+        FHEVMExecutor.ContextUserInputs memory context = FHEVMExecutor.ContextUserInputs({
+            userAddress: _seededAddress(userSeed, 200),
+            contractAddress: _seededAddress(contractSeed, 240)
+        });
+        bytes memory inputProof = _buildProof(bound(uint256(proofLenSeed), 0, 48), proofSeed);
+
+        vm.prank(msg.sender);
+        try inputVerifier.verifyInput(context, inputHandle, inputProof) {} catch {}
+
+        if (beforeHash != _contextHash()) {
+            unexpectedContextMutation = true;
+        }
+    }
+
+    function cleanTransientStorage() external {
+        bytes32 beforeHash = _contextHash();
+
+        vm.prank(msg.sender);
+        inputVerifier.cleanTransientStorage();
+
+        if (beforeHash != _contextHash()) {
+            unexpectedContextMutation = true;
+        }
+    }
+
+    function candidateDomainSize() external pure returns (uint256) {
+        return SIGNER_DOMAIN;
+    }
+
+    function candidateAt(uint256 seed) external pure returns (address) {
+        return _seededAddress(seed, 20);
+    }
+
+    function _contextHash() internal view returns (bytes32) {
+        return keccak256(abi.encode(inputVerifier.getThreshold(), inputVerifier.getCoprocessorSigners()));
+    }
+
+    function _buildSignerSet(
+        uint256 signerCount,
+        uint8 baseSeed,
+        bool forceDuplicate
+    ) internal pure returns (address[] memory signers) {
+        signers = new address[](signerCount);
+        for (uint256 i = 0; i < signerCount; i++) {
+            signers[i] = _seededAddress(uint256(baseSeed) + i, 20);
+        }
+
+        if (forceDuplicate && signerCount > 1) {
+            signers[signerCount - 1] = signers[0];
+        }
+    }
+
+    function _buildProof(uint256 len, uint256 seed) internal pure returns (bytes memory proof) {
+        proof = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            proof[i] = bytes1(uint8(uint256(keccak256(abi.encode(seed, i)))));
+        }
+    }
+
+    function _seededAddress(uint256 seed, uint160 offset) internal pure returns (address) {
+        return address(offset + uint160(seed % SIGNER_DOMAIN) + 1);
+    }
+}

--- a/host-contracts/test/invariants/scenarios/signer-governance/InputVerifierSignerGovernanceInvariants.t.sol
+++ b/host-contracts/test/invariants/scenarios/signer-governance/InputVerifierSignerGovernanceInvariants.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {InputVerifier} from "../../../../contracts/InputVerifier.sol";
+import {inputVerifierAdd} from "../../../../addresses/FHEVMHostAddresses.sol";
+import {SignerGovernanceInvariantBase} from "./SignerGovernanceInvariantBase.t.sol";
+import {InputVerifierSignerGovernanceHandler} from "./InputVerifierSignerGovernanceHandler.t.sol";
+
+contract InputVerifierSignerGovernanceInvariants is SignerGovernanceInvariantBase {
+    address internal constant OWNER = address(0x0A11CE);
+    address internal constant ACTOR_1 = address(0x1001);
+    address internal constant ACTOR_2 = address(0x1002);
+    address internal constant ACTOR_3 = address(0x1003);
+
+    InputVerifier internal inputVerifier;
+    InputVerifierSignerGovernanceHandler internal handler;
+
+    function setUp() public {
+        _deployACL(OWNER);
+
+        address[] memory initialSigners = new address[](3);
+        initialSigners[0] = address(21);
+        initialSigners[1] = address(22);
+        initialSigners[2] = address(23);
+        _deployInputVerifier(OWNER, address(0xBEEF), uint64(block.chainid), initialSigners, 2);
+
+        inputVerifier = InputVerifier(inputVerifierAdd);
+        handler = new InputVerifierSignerGovernanceHandler(inputVerifier, OWNER);
+
+        address[] memory senders = new address[](4);
+        senders[0] = OWNER;
+        senders[1] = ACTOR_1;
+        senders[2] = ACTOR_2;
+        senders[3] = ACTOR_3;
+
+        bytes4[] memory selectors = new bytes4[](4);
+        selectors[0] = InputVerifierSignerGovernanceHandler.defineNewContext.selector;
+        selectors[1] = InputVerifierSignerGovernanceHandler.setThreshold.selector;
+        selectors[2] = InputVerifierSignerGovernanceHandler.verifyInput.selector;
+        selectors[3] = InputVerifierSignerGovernanceHandler.cleanTransientStorage.selector;
+        _targetInvariant(address(handler), selectors, senders);
+    }
+
+    /// @custom:invariant SG-INPUT-001
+    function invariant_ThresholdWithinSignerBounds() public view {
+        _assertThresholdWithinSignerBounds();
+    }
+
+    /// @custom:invariant SG-INPUT-002
+    function invariant_SignerSetUniqueAndConsistent() public view {
+        _assertSignerSetUniqueAndConsistent();
+    }
+
+    /// @custom:invariant SG-INPUT-003
+    function invariant_VerificationAndCleanupDoNotMutateContext() public view {
+        assertFalse(handler.unexpectedContextMutation());
+    }
+
+    /// @custom:invariant SG-INPUT-004
+    function invariant_OnlyOwnerCanMutateSignerGovernance() public view {
+        assertFalse(handler.privilegeViolation());
+    }
+
+    function _getSigners() internal view override returns (address[] memory) {
+        return inputVerifier.getCoprocessorSigners();
+    }
+
+    function _getThreshold() internal view override returns (uint256) {
+        return inputVerifier.getThreshold();
+    }
+
+    function _isSigner(address signer) internal view override returns (bool) {
+        return inputVerifier.isSigner(signer);
+    }
+
+    function _candidateDomainSize() internal view override returns (uint256) {
+        return handler.candidateDomainSize();
+    }
+
+    function _candidateAt(uint256 seed) internal view override returns (address) {
+        return handler.candidateAt(seed);
+    }
+}

--- a/host-contracts/test/invariants/scenarios/signer-governance/KMSSignerGovernanceHandler.t.sol
+++ b/host-contracts/test/invariants/scenarios/signer-governance/KMSSignerGovernanceHandler.t.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {KMSVerifier} from "../../../../contracts/KMSVerifier.sol";
+
+contract KMSSignerGovernanceHandler is Test {
+    uint8 internal constant SIGNER_DOMAIN = 32;
+
+    KMSVerifier internal immutable kmsVerifier;
+    address internal immutable owner;
+
+    bool public unexpectedContextMutation;
+    bool public privilegeViolation;
+
+    constructor(KMSVerifier _kmsVerifier, address _owner) {
+        kmsVerifier = _kmsVerifier;
+        owner = _owner;
+    }
+
+    function defineNewContext(uint8 signerCountSeed, uint8 thresholdSeed, uint8 baseSeed, bool forceDuplicate) external {
+        uint256 signerCount = bound(uint256(signerCountSeed), 1, 5);
+        uint256 threshold = bound(uint256(thresholdSeed), 0, 6);
+        address[] memory signers = _buildSignerSet(signerCount, baseSeed, forceDuplicate);
+
+        vm.prank(msg.sender);
+        (bool ok, ) = address(kmsVerifier).call(abi.encodeCall(KMSVerifier.defineNewContext, (signers, threshold)));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function setThreshold(uint8 thresholdSeed) external {
+        uint256 threshold = bound(uint256(thresholdSeed), 0, 6);
+
+        vm.prank(msg.sender);
+        (bool ok, ) = address(kmsVerifier).call(abi.encodeCall(KMSVerifier.setThreshold, (threshold)));
+        if (ok && msg.sender != owner) {
+            privilegeViolation = true;
+        }
+    }
+
+    function verifyDecryptionEIP712KMSSignatures(
+        uint8 handlesLenSeed,
+        uint8 decryptedLenSeed,
+        uint8 proofLenSeed,
+        uint256 dataSeed
+    ) external {
+        bytes32 beforeHash = _contextHash();
+        bytes32[] memory handles = _buildHandles(bound(uint256(handlesLenSeed), 0, 4), dataSeed);
+        bytes memory decryptedResult = _buildBytes(bound(uint256(decryptedLenSeed), 0, 32), dataSeed ^ 0xAAA1);
+        bytes memory decryptionProof = _buildBytes(bound(uint256(proofLenSeed), 0, 64), dataSeed ^ 0xBBB2);
+
+        vm.prank(msg.sender);
+        try kmsVerifier.verifyDecryptionEIP712KMSSignatures(handles, decryptedResult, decryptionProof) {} catch {}
+
+        if (beforeHash != _contextHash()) {
+            unexpectedContextMutation = true;
+        }
+    }
+
+    function _contextHash() internal view returns (bytes32) {
+        return keccak256(abi.encode(kmsVerifier.getThreshold(), kmsVerifier.getKmsSigners()));
+    }
+
+    function candidateDomainSize() external pure returns (uint256) {
+        return SIGNER_DOMAIN;
+    }
+
+    function candidateAt(uint256 seed) external pure returns (address) {
+        return _seededAddress(seed, 40);
+    }
+
+    function _buildSignerSet(
+        uint256 signerCount,
+        uint8 baseSeed,
+        bool forceDuplicate
+    ) internal pure returns (address[] memory signers) {
+        signers = new address[](signerCount);
+        for (uint256 i = 0; i < signerCount; i++) {
+            signers[i] = _seededAddress(uint256(baseSeed) + i, 40);
+        }
+
+        if (forceDuplicate && signerCount > 1) {
+            signers[signerCount - 1] = signers[0];
+        }
+    }
+
+    function _buildHandles(uint256 len, uint256 seed) internal pure returns (bytes32[] memory handles) {
+        handles = new bytes32[](len);
+        for (uint256 i = 0; i < len; i++) {
+            handles[i] = keccak256(abi.encode(seed, i));
+        }
+    }
+
+    function _buildBytes(uint256 len, uint256 seed) internal pure returns (bytes memory data) {
+        data = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            data[i] = bytes1(uint8(uint256(keccak256(abi.encode(seed, i)))));
+        }
+    }
+
+    function _seededAddress(uint256 seed, uint160 offset) internal pure returns (address) {
+        return address(offset + uint160(seed % SIGNER_DOMAIN) + 1);
+    }
+}

--- a/host-contracts/test/invariants/scenarios/signer-governance/KMSSignerGovernanceInvariants.t.sol
+++ b/host-contracts/test/invariants/scenarios/signer-governance/KMSSignerGovernanceInvariants.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {KMSVerifier} from "../../../../contracts/KMSVerifier.sol";
+import {kmsVerifierAdd} from "../../../../addresses/FHEVMHostAddresses.sol";
+import {SignerGovernanceInvariantBase} from "./SignerGovernanceInvariantBase.t.sol";
+import {KMSSignerGovernanceHandler} from "./KMSSignerGovernanceHandler.t.sol";
+
+contract KMSSignerGovernanceInvariants is SignerGovernanceInvariantBase {
+    address internal constant OWNER = address(0x0B0B);
+    address internal constant ACTOR_1 = address(0x1101);
+    address internal constant ACTOR_2 = address(0x1102);
+    address internal constant ACTOR_3 = address(0x1103);
+
+    KMSVerifier internal kmsVerifier;
+    KMSSignerGovernanceHandler internal handler;
+
+    function setUp() public {
+        _deployACL(OWNER);
+
+        address[] memory initialSigners = new address[](3);
+        initialSigners[0] = address(41);
+        initialSigners[1] = address(42);
+        initialSigners[2] = address(43);
+        _deployKMSVerifier(OWNER, address(0xCAFE), uint64(block.chainid), initialSigners, 2);
+
+        kmsVerifier = KMSVerifier(kmsVerifierAdd);
+        handler = new KMSSignerGovernanceHandler(kmsVerifier, OWNER);
+
+        address[] memory senders = new address[](4);
+        senders[0] = OWNER;
+        senders[1] = ACTOR_1;
+        senders[2] = ACTOR_2;
+        senders[3] = ACTOR_3;
+
+        bytes4[] memory selectors = new bytes4[](3);
+        selectors[0] = KMSSignerGovernanceHandler.defineNewContext.selector;
+        selectors[1] = KMSSignerGovernanceHandler.setThreshold.selector;
+        selectors[2] = KMSSignerGovernanceHandler.verifyDecryptionEIP712KMSSignatures.selector;
+        _targetInvariant(address(handler), selectors, senders);
+    }
+
+    /// @custom:invariant SG-KMS-001
+    function invariant_ThresholdWithinSignerBounds() public view {
+        _assertThresholdWithinSignerBounds();
+    }
+
+    /// @custom:invariant SG-KMS-002
+    function invariant_SignerSetUniqueAndConsistent() public view {
+        _assertSignerSetUniqueAndConsistent();
+    }
+
+    /// @custom:invariant SG-KMS-003
+    function invariant_VerificationDoesNotMutateContext() public view {
+        assertFalse(handler.unexpectedContextMutation());
+    }
+
+    /// @custom:invariant SG-KMS-004
+    function invariant_OnlyOwnerCanMutateSignerGovernance() public view {
+        assertFalse(handler.privilegeViolation());
+    }
+
+    function _getSigners() internal view override returns (address[] memory) {
+        return kmsVerifier.getKmsSigners();
+    }
+
+    function _getThreshold() internal view override returns (uint256) {
+        return kmsVerifier.getThreshold();
+    }
+
+    function _isSigner(address signer) internal view override returns (bool) {
+        return kmsVerifier.isSigner(signer);
+    }
+
+    function _candidateDomainSize() internal view override returns (uint256) {
+        return handler.candidateDomainSize();
+    }
+
+    function _candidateAt(uint256 seed) internal view override returns (address) {
+        return handler.candidateAt(seed);
+    }
+}

--- a/host-contracts/test/invariants/scenarios/signer-governance/README.md
+++ b/host-contracts/test/invariants/scenarios/signer-governance/README.md
@@ -1,0 +1,27 @@
+# Signer Governance Scenario
+
+Focus: signer-set and threshold governance state machines for `InputVerifier` and `KMSVerifier`.
+Signer candidate-domain assumptions are centralized in each handler (`candidateDomainSize`/`candidateAt`) and consumed by shared checks.
+
+## Actions
+- `defineNewContext`
+- `setThreshold`
+- `verifyInput` / `verifyDecryptionEIP712KMSSignatures`
+- `cleanTransientStorage` (`InputVerifier` scenario)
+
+## Model state
+- Shared signer candidate domain exported by handlers.
+- Violation flags: unexpected context mutation, unauthorized governance success.
+
+## Invariants (IDs)
+- `SG-INPUT-001`: threshold always in `[1, signers.length]`.
+- `SG-INPUT-002`: `InputVerifier` signer array and `isSigner` mapping stay consistent both ways.
+- `SG-INPUT-003`: verification/cleanup flows do not mutate signer governance state.
+- `SG-INPUT-004`: only ACL owner can mutate signer governance (`defineNewContext`, `setThreshold`).
+- `SG-KMS-001`: threshold always in `[1, signers.length]`.
+- `SG-KMS-002`: `KMSVerifier` signer array and `isSigner` mapping stay consistent both ways.
+- `SG-KMS-003`: decryption verification flow does not mutate signer governance state.
+- `SG-KMS-004`: only ACL owner can mutate signer governance (`defineNewContext`, `setThreshold`).
+
+## Known non-goals
+- No cryptographic correctness checks for signature/proof contents.

--- a/host-contracts/test/invariants/scenarios/signer-governance/SignerGovernanceInvariantBase.t.sol
+++ b/host-contracts/test/invariants/scenarios/signer-governance/SignerGovernanceInvariantBase.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {BaseScenarioInvariant} from "../../base/BaseScenarioInvariant.t.sol";
+
+abstract contract SignerGovernanceInvariantBase is BaseScenarioInvariant {
+    function _getSigners() internal view virtual returns (address[] memory);
+    function _getThreshold() internal view virtual returns (uint256);
+    function _isSigner(address signer) internal view virtual returns (bool);
+    function _candidateDomainSize() internal view virtual returns (uint256);
+    function _candidateAt(uint256 seed) internal view virtual returns (address);
+
+    function _assertThresholdWithinSignerBounds() internal view {
+        address[] memory signers = _getSigners();
+        uint256 threshold = _getThreshold();
+        assertGe(signers.length, 1);
+        assertGe(threshold, 1);
+        assertLe(threshold, signers.length);
+    }
+
+    function _assertSignerSetUniqueAndConsistent() internal view {
+        address[] memory signers = _getSigners();
+        for (uint256 i = 0; i < signers.length; i++) {
+            assertTrue(_isSigner(signers[i]));
+            for (uint256 j = i + 1; j < signers.length; j++) {
+                assertTrue(signers[i] != signers[j]);
+            }
+        }
+
+        uint256 domain = _candidateDomainSize();
+        for (uint256 i = 0; i < domain; i++) {
+            address candidate = _candidateAt(i);
+            assertEq(_isSigner(candidate), _contains(signers, candidate));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add targeted handler-based invariant suites for `InputVerifier`, `KMSVerifier`, and `ACL`
- add deterministic low-runtime invariant config in `host-contracts/foundry.toml`
- add short invariants README with non-goals and repro commands

## Why this scope
- focuses on state-machine heavy surfaces
- skips a blanket `FHEVMExecutor` harness to keep signal/runtime ratio high

## Validation
- `cd host-contracts && forge test --match-contract InputVerifierInvariantTest`
- `cd host-contracts && forge test --match-contract KMSVerifierInvariantTest`
- `cd host-contracts && forge test --match-contract ACLInvariantTest`

closes: zama-ai/fhevm-internal#1055
