### PR TITLE
ci(coprocessor): pin sqlx-cli installs in workflows

### DIFF
--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -132,7 +132,7 @@ jobs:
                                                                  libclang-dev docker-compose-v2 \
                                                                  docker.io acl
           sudo systemctl start docker
-          cargo install sqlx-cli
+          cargo +stable install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -188,7 +188,7 @@ jobs:
           sudo usermod -aG docker "$USER"
           newgrp docker
           sudo setfacl --modify user:"$USER":rw /var/run/docker.sock
-          cargo install sqlx-cli
+          cargo +stable install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c

--- a/.github/workflows/coprocessor-cargo-listener-tests.yml
+++ b/.github/workflows/coprocessor-cargo-listener-tests.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y protobuf-compiler && \
-        cargo install sqlx-cli
+        cargo install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
     - name: Install foundry
       uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c

--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y protobuf-compiler && \
-        cargo install sqlx-cli
+        cargo install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
     - name: Install foundry
       uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c

--- a/.github/workflows/coprocessor-gpu-tests.yml
+++ b/.github/workflows/coprocessor-gpu-tests.yml
@@ -138,7 +138,7 @@ jobs:
           sudo usermod -aG docker "$USER"
           newgrp docker
           sudo setfacl --modify user:"$USER":rw /var/run/docker.sock
-          cargo install sqlx-cli
+          cargo install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c


### PR DESCRIPTION
## Summary
This is a standalone CI hotfix PR to make `sqlx-cli` installation deterministic across coprocessor workflows.

## Changes
- Pin and lock `sqlx-cli` installs in stable workflows:
  - `.github/workflows/coprocessor-cargo-tests.yml`
  - `.github/workflows/coprocessor-cargo-listener-tests.yml`
  - `.github/workflows/coprocessor-gpu-tests.yml`
- For nightly benchmark workflows, install `sqlx-cli` with stable explicitly:
  - `.github/workflows/coprocessor-benchmark-cpu.yml`
  - `.github/workflows/coprocessor-benchmark-gpu.yml`

Commands used:
- Stable workflows:
  - `cargo install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked`
- Nightly benchmark workflows:
  - `cargo +stable install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked`

## Why
Main is currently exposed to dependency drift from unpinned `cargo install sqlx-cli`, causing failures before tests/benchmarks start (example merge-queue failure: https://github.com/zama-ai/fhevm/actions/runs/22147564614/job/64029150488).

closes: https://github.com/zama-ai/fhevm-internal/issues/1060
