### PR TITLE
test(coprocessor): strengthen error and random bounded test assertions

### DIFF
--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/errors.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/errors.rs
@@ -53,6 +53,11 @@ async fn test_coprocessor_input_errors() -> Result<(), Box<dyn std::error::Error
         is_error,
         "expected unknown operation to fail, last_error_message={msg:?}"
     );
+    let error_msg = msg.as_deref().unwrap_or("");
+    assert!(
+        error_msg.contains("Unknown fhe operation"),
+        "expected 'Unknown fhe operation' error, got: {error_msg}"
+    );
     Ok(())
 }
 
@@ -100,6 +105,11 @@ async fn test_coprocessor_computation_errors() -> Result<(), Box<dyn std::error:
         is_error,
         "expected FheSub on mismatched types to fail, last_error_message={msg:?}"
     );
+    let error_msg = msg.as_deref().unwrap_or("");
+    assert!(
+        error_msg.contains("UnsupportedFheTypes"),
+        "expected UnsupportedFheTypes error, got: {error_msg}"
+    );
     Ok(())
 }
 
@@ -146,6 +156,11 @@ async fn test_type_mismatch_error() -> Result<(), Box<dyn std::error::Error>> {
         is_error,
         "expected FheAdd on mismatched types to fail, last_error_message={msg:?}"
     );
+    let error_msg = msg.as_deref().unwrap_or("");
+    assert!(
+        error_msg.contains("UnsupportedFheTypes"),
+        "expected UnsupportedFheTypes error, got: {error_msg}"
+    );
     Ok(())
 }
 
@@ -190,6 +205,11 @@ async fn test_binary_boolean_inputs_error() -> Result<(), Box<dyn std::error::Er
         is_error,
         "expected FheAdd on bool inputs to fail, last_error_message={msg:?}"
     );
+    let error_msg = msg.as_deref().unwrap_or("");
+    assert!(
+        error_msg.contains("UnsupportedFheTypes"),
+        "expected UnsupportedFheTypes error, got: {error_msg}"
+    );
     Ok(())
 }
 
@@ -229,6 +249,11 @@ async fn test_unary_boolean_inputs_error() -> Result<(), Box<dyn std::error::Err
     assert!(
         is_error,
         "expected FheNeg on bool input to fail, last_error_message={msg:?}"
+    );
+    let error_msg = msg.as_deref().unwrap_or("");
+    assert!(
+        error_msg.contains("UnsupportedFheTypes"),
+        "expected UnsupportedFheTypes error, got: {error_msg}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Error tests now assert the specific error variant name (`UnknownFheOperation` or `UnsupportedFheTypes`) instead of only checking `is_error == true`
- Bounded random test generates two samples per type with different seeds and asserts they differ (for non-bool types with bound > 16), catching any constant-output RNG implementation

Follow-up to #1982.

Closes https://github.com/zama-ai/fhevm-internal/issues/1077

## Test plan

- [x] `cargo check --tests` passes (SQLX_OFFLINE)
- [x] `cargo clippy` passes (pre-commit hook)
- [ ] CI CPU test job passes
- [ ] CI GPU test job passes