### PR TITLE
feat(kms-connector): context-aware extraData handling for decryption

### DIFF
--- a/kms-connector/.sqlx/query-551f458def566b06bad02c30fe615be7dee905539b3d823315538258f9712d31.json
+++ b/kms-connector/.sqlx/query-551f458def566b06bad02c30fe615be7dee905539b3d823315538258f9712d31.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO kms_context(id, is_valid, created_at, updated_at) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Bool",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "551f458def566b06bad02c30fe615be7dee905539b3d823315538258f9712d31"
+}

--- a/kms-connector/.sqlx/query-83a6ab076de12e0ce3a99994657457f398df49a34ad2c357364b7be84538c5b6.json
+++ b/kms-connector/.sqlx/query-83a6ab076de12e0ce3a99994657457f398df49a34ad2c357364b7be84538c5b6.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE kms_context SET is_valid = false WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "83a6ab076de12e0ce3a99994657457f398df49a34ad2c357364b7be84538c5b6"
+}

--- a/kms-connector/.sqlx/query-da50f04c1ed0cb99cad26fc116e1fa7ffd8a2531b18ceab723ad710a552ae6c7.json
+++ b/kms-connector/.sqlx/query-da50f04c1ed0cb99cad26fc116e1fa7ffd8a2531b18ceab723ad710a552ae6c7.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT is_valid FROM kms_context WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_valid",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "da50f04c1ed0cb99cad26fc116e1fa7ffd8a2531b18ceab723ad710a552ae6c7"
+}

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2998,7 +2998,6 @@ dependencies = [
 [[package]]
 name = "fhevm_host_bindings"
 version = "0.10.0"
-source = "git+https://github.com/zama-ai/fhevm.git?rev=e2dc53b6a9dcb3fdb8ec92bf1a8157eece7be46c#e2dc53b6a9dcb3fdb8ec92bf1a8157eece7be46c"
 dependencies = [
  "alloy",
  "serde",

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -2998,6 +2998,7 @@ dependencies = [
 [[package]]
 name = "fhevm_host_bindings"
 version = "0.10.0"
+source = "git+https://github.com/zama-ai/fhevm.git?rev=e2dc53b6a9dcb3fdb8ec92bf1a8157eece7be46c#e2dc53b6a9dcb3fdb8ec92bf1a8157eece7be46c"
 dependencies = [
  "alloy",
  "serde",
@@ -3336,6 +3337,7 @@ dependencies = [
  "bc2wrap",
  "connector-utils",
  "fhevm_gateway_bindings",
+ "fhevm_host_bindings",
  "humantime-serde",
  "opentelemetry",
  "prometheus",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -19,7 +19,9 @@ kms-worker.path = "crates/kms-worker"
 tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
 fhevm_gateway_bindings = { path = "../gateway-contracts/rust_bindings", default-features = false }
-fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
+# TODO: use path for host bindings once PR has been merged
+# fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
+fhevm_host_bindings = { git = "https://github.com/zama-ai/fhevm.git", rev = "e2dc53b6a9dcb3fdb8ec92bf1a8157eece7be46c", default-features = false }
 kms-grpc = { git = "https://github.com/zama-ai/kms.git", tag = "v0.13.0-rc.1", default-features = true }
 bc2wrap = { git = "https://github.com/zama-ai/kms.git", tag = "v0.13.0-rc.1", default-features = true }
 tfhe = "=1.5.1"

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -19,9 +19,7 @@ kms-worker.path = "crates/kms-worker"
 tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
 fhevm_gateway_bindings = { path = "../gateway-contracts/rust_bindings", default-features = false }
-# TODO: use path for host bindings once PR has been merged
-# fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
-fhevm_host_bindings = { git = "https://github.com/zama-ai/fhevm.git", rev = "e2dc53b6a9dcb3fdb8ec92bf1a8157eece7be46c", default-features = false }
+fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
 kms-grpc = { git = "https://github.com/zama-ai/kms.git", tag = "v0.13.0-rc.1", default-features = true }
 bc2wrap = { git = "https://github.com/zama-ai/kms.git", tag = "v0.13.0-rc.1", default-features = true }
 tfhe = "=1.5.1"

--- a/kms-connector/config/gw-listener.toml
+++ b/kms-connector/config/gw-listener.toml
@@ -12,6 +12,19 @@ gateway_chain_id = 54321
 # ENV: KMS_CONNECTOR_GATEWAY_URL
 gateway_url = "http://localhost:8545"
 
+# Ethereum RPC node endpoint (required)
+# ENV: KMS_CONNECTOR_ETHEREUM_URL
+ethereum_url = "http://localhost:8545"
+
+# Chain ID for the Ethereum network (required)
+# ENV: KMS_CONNECTOR_ETHEREUM_CHAIN_ID
+ethereum_chain_id = 11155111
+
+# Address of the KMS verifier contract (required)
+# Format: hex string with 0x prefix
+# ENV: KMS_CONNECTOR_KMS_VERIFIER_ADDRESS
+kms_verifier_address = "0x0000000000000000000000000000000000000000"
+
 # URL of the KMS Connector internal database (required)
 # Format: see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
 # ENV: KMS_CONNECTOR_DATABASE_URL

--- a/kms-connector/connector-db/migrations/20260226161117_add_kms_context.sql
+++ b/kms-connector/connector-db/migrations/20260226161117_add_kms_context.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS kms_context (
+    id BYTEA NOT NULL,
+    is_valid BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/kms-connector/crates/gw-listener/Cargo.toml
+++ b/kms-connector/crates/gw-listener/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 bc2wrap.workspace = true
 connector-utils.workspace = true
 fhevm_gateway_bindings.workspace = true
+fhevm_host_bindings.workspace = true
 
 actix-web.workspace = true
 alloy.workspace = true

--- a/kms-connector/crates/gw-listener/src/bin/gw_listener.rs
+++ b/kms-connector/crates/gw-listener/src/bin/gw_listener.rs
@@ -48,7 +48,7 @@ async fn run() -> anyhow::Result<()> {
             let (event_listener, state) =
                 EventListener::from_config(config, cancel_token.clone()).await?;
             start_monitoring_server(monitoring_endpoint, state, cancel_token);
-            event_listener.start().await
+            event_listener.start().await?;
         }
     }
     Ok(())

--- a/kms-connector/crates/gw-listener/src/bin/gw_listener.rs
+++ b/kms-connector/crates/gw-listener/src/bin/gw_listener.rs
@@ -1,5 +1,5 @@
 use gw_listener::{
-    core::{Config, GatewayListener},
+    core::{Config, EventListener},
     monitoring::health::HealthStatus,
 };
 
@@ -44,11 +44,11 @@ async fn run() -> anyhow::Result<()> {
             install_signal_handlers(cancel_token.clone())?;
             let monitoring_endpoint = config.monitoring_endpoint;
 
-            info!("Starting GatewayListener");
-            let (gw_listener, state) =
-                GatewayListener::from_config(config, cancel_token.clone()).await?;
+            info!("Starting EventListener");
+            let (event_listener, state) =
+                EventListener::from_config(config, cancel_token.clone()).await?;
             start_monitoring_server(monitoring_endpoint, state, cancel_token);
-            gw_listener.start().await
+            event_listener.start().await
         }
     }
     Ok(())

--- a/kms-connector/crates/gw-listener/src/core/config.rs
+++ b/kms-connector/crates/gw-listener/src/core/config.rs
@@ -1,4 +1,4 @@
-use alloy::transports::http::reqwest::Url;
+use alloy::{primitives::Address, transports::http::reqwest::Url};
 use connector_utils::{
     config::{
         ContractConfig, DeserializeConfig,
@@ -34,6 +34,13 @@ pub struct Config {
     /// The `KMSGeneration` contract configuration.
     #[serde(deserialize_with = "deserialize_kms_generation_contract_config")]
     pub kms_generation_contract: ContractConfig,
+
+    /// The Ethereum RPC node endpoint.
+    pub ethereum_url: Url,
+    /// The Chain ID of the Ethereum chain.
+    pub ethereum_chain_id: u64,
+    /// The address of the `KMSVerifier` contract.
+    pub kms_verifier_address: Address,
 
     /// The service name used for tracing.
     #[serde(default = "default_service_name")]
@@ -83,6 +90,9 @@ impl Default for Config {
             database_pool_size: default_database_pool_size(),
             gateway_url: Url::from_str("http://localhost:8545").unwrap(),
             gateway_chain_id: 54321,
+            ethereum_url: Url::from_str("http://localhost:8545").unwrap(),
+            ethereum_chain_id: 11155111,
+            kms_verifier_address: Address::default(),
             decryption_contract: default_decryption_contract_config(),
             kms_generation_contract: default_kms_generation_contract_config(),
             service_name: default_service_name(),
@@ -109,6 +119,9 @@ mod tests {
             env::remove_var("KMS_CONNECTOR_DATABASE_URL");
             env::remove_var("KMS_CONNECTOR_GATEWAY_URL");
             env::remove_var("KMS_CONNECTOR_GATEWAY_CHAIN_ID");
+            env::remove_var("KMS_CONNECTOR_ETHEREUM_URL");
+            env::remove_var("KMS_CONNECTOR_ETHEREUM_CHAIN_ID");
+            env::remove_var("KMS_CONNECTOR_KMS_VERIFIER_ADDRESS");
             env::remove_var("KMS_CONNECTOR_DECRYPTION_CONTRACT__ADDRESS");
             env::remove_var("KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS");
             env::remove_var("KMS_CONNECTOR_SERVICE_NAME");
@@ -137,6 +150,12 @@ mod tests {
             );
             env::set_var("KMS_CONNECTOR_GATEWAY_URL", "http://localhost:9545");
             env::set_var("KMS_CONNECTOR_GATEWAY_CHAIN_ID", "31888");
+            env::set_var("KMS_CONNECTOR_ETHEREUM_URL", "http://localhost:9545");
+            env::set_var("KMS_CONNECTOR_ETHEREUM_CHAIN_ID", "31444");
+            env::set_var(
+                "KMS_CONNECTOR_KMS_VERIFIER_ADDRESS",
+                "0x0000000000000000000000000000000000000001",
+            );
             env::set_var(
                 "KMS_CONNECTOR_DECRYPTION_CONTRACT__ADDRESS",
                 "0x5fbdb2315678afecb367f032d93f642f64180aa3",
@@ -164,6 +183,15 @@ mod tests {
         assert_eq!(
             config.kms_generation_contract.address,
             address!("0x0000000000000000000000000000000000000002")
+        );
+        assert_eq!(
+            config.ethereum_url,
+            Url::from_str("http://localhost:9545").unwrap()
+        );
+        assert_eq!(config.ethereum_chain_id, 31444);
+        assert_eq!(
+            config.kms_verifier_address,
+            address!("0x0000000000000000000000000000000000000001")
         );
         assert_eq!(config.service_name, "kms-connector-test");
 

--- a/kms-connector/crates/gw-listener/src/core/ethereum.rs
+++ b/kms-connector/crates/gw-listener/src/core/ethereum.rs
@@ -1,0 +1,91 @@
+use crate::core::{Config, publish::publish_context_id};
+use alloy::{network::Ethereum, providers::Provider};
+use fhevm_host_bindings::kms_verifier::KMSVerifier::{self, KMSVerifierInstance};
+use sqlx::{Pool, Postgres};
+use tracing::{error, info};
+
+pub struct EthereumListener<P> {
+    /// The database pool for storing Ethereum's events.
+    db_pool: Pool<Postgres>,
+
+    /// The `KMSVerifier` contract instance on Ethereum.
+    kms_verifier_contract: KMSVerifierInstance<P>,
+}
+
+impl<P> EthereumListener<P>
+where
+    P: Provider<Ethereum> + Clone + 'static,
+{
+    /// Creates a new `EthereumListener` instance.
+    pub fn new(db_pool: Pool<Postgres>, provider: P, config: &Config) -> Self {
+        let kms_verifier_contract = KMSVerifier::new(config.kms_verifier_address, provider);
+        Self {
+            db_pool,
+            kms_verifier_contract,
+        }
+    }
+
+    /// Starts the `EthereumListener`.
+    pub async fn start(self) {
+        if let Err(e) = self.store_on_chain_context().await {
+            error!("Failed to store current context: {e}");
+        }
+
+        // No listening for now, will be done when implementing RFC-005.
+
+        info!("EthereumListener stopped successfully!");
+    }
+
+    /// Stores the current context ID found on-chain in the database.
+    pub async fn store_on_chain_context(&self) -> anyhow::Result<()> {
+        let current_context_id = self
+            .kms_verifier_contract
+            .getCurrentKmsContextId()
+            .call()
+            .await?;
+
+        publish_context_id(&self.db_pool, current_context_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        primitives::U256,
+        providers::{ProviderBuilder, mock::Asserter},
+        sol_types::SolValue,
+    };
+    use connector_utils::tests::setup::TestInstanceBuilder;
+    use sqlx::Row;
+    use std::time::Duration;
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_store_current_context_id() {
+        let test_instance = TestInstanceBuilder::db_setup().await.unwrap();
+        let context_id = U256::from(69_u64);
+
+        let asserter = Asserter::new();
+        asserter.push_success(&context_id.abi_encode());
+
+        let mock_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_mocked_client(asserter);
+
+        let config = Config::default();
+        let listener = EthereumListener::new(test_instance.db().clone(), mock_provider, &config);
+
+        listener.store_on_chain_context().await.unwrap();
+
+        let row = sqlx::query("SELECT id, is_valid FROM kms_context")
+            .fetch_one(test_instance.db())
+            .await
+            .unwrap();
+
+        let stored_id = U256::from_le_bytes(row.try_get::<[u8; 32], _>("id").unwrap());
+        assert_eq!(stored_id, context_id);
+        assert!(row.try_get::<bool, _>("is_valid").unwrap());
+    }
+}

--- a/kms-connector/crates/gw-listener/src/core/gateway.rs
+++ b/kms-connector/crates/gw-listener/src/core/gateway.rs
@@ -1,0 +1,468 @@
+use crate::{
+    core::{Config, publish::update_last_block_polled, publish_event},
+    monitoring::metrics::{EVENT_RECEIVED_COUNTER, EVENT_RECEIVED_ERRORS},
+};
+use alloy::{
+    contract::{Event, EventPoller},
+    network::Ethereum,
+    primitives::LogData,
+    providers::Provider,
+    rpc::types::{Filter, Log},
+    sol_types::SolEvent,
+};
+use anyhow::anyhow;
+use connector_utils::{
+    monitoring::otlp::PropagationContext,
+    tasks::spawn_with_limit,
+    types::{GatewayEvent, GatewayEventKind, db::EventType},
+};
+use fhevm_gateway_bindings::{
+    decryption::Decryption::{self, DecryptionInstance},
+    kms_generation::KMSGeneration::{self, KMSGenerationInstance},
+};
+use sqlx::{Pool, Postgres, Row};
+use std::time::Duration;
+use tokio::{select, task::JoinSet, time::timeout};
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// Struct monitoring and storing Gateway's events.
+#[derive(Clone)]
+pub struct GatewayListener<P>
+where
+    P: Provider,
+{
+    /// The database pool for storing Gateway's events.
+    db_pool: Pool<Postgres>,
+
+    /// The Gateway's `Decryption` contract instance which is monitored.
+    decryption_contract: DecryptionInstance<P>,
+
+    /// The Gateway's `KMSGeneration` contract instance which is monitored.
+    kms_generation_contract: KMSGenerationInstance<P>,
+
+    /// The configuration of the `GatewayListener`.
+    config: Config,
+
+    /// The cancellation token to handle the graceful shutdown of the listener.
+    cancel_token: CancellationToken,
+}
+
+impl<P> GatewayListener<P>
+where
+    P: Provider<Ethereum> + Clone + 'static,
+{
+    /// Creates a new `GatewayListener` instance.
+    pub fn new(
+        db_pool: Pool<Postgres>,
+        provider: P,
+        config: &Config,
+        cancel_token: CancellationToken,
+    ) -> Self {
+        let decryption_contract =
+            Decryption::new(config.decryption_contract.address, provider.clone());
+        let kms_generation_contract =
+            KMSGeneration::new(config.kms_generation_contract.address, provider);
+
+        Self {
+            db_pool,
+            decryption_contract,
+            kms_generation_contract,
+            config: config.clone(),
+            cancel_token,
+        }
+    }
+
+    /// Starts the `GatewayListener`.
+    ///
+    /// Spawns and joins the `GatewayListener` event monitoring tasks.
+    pub async fn start(self) {
+        let mut tasks = JoinSet::new();
+
+        tasks.spawn(self.clone().subscribe(EventType::PublicDecryptionRequest));
+        tasks.spawn(self.clone().subscribe(EventType::UserDecryptionRequest));
+        tasks.spawn(self.clone().subscribe(EventType::PrepKeygenRequest));
+        tasks.spawn(self.clone().subscribe(EventType::KeygenRequest));
+        tasks.spawn(self.clone().subscribe(EventType::CrsgenRequest));
+        tasks.spawn(self.clone().subscribe(EventType::PrssInit));
+        tasks.spawn(self.subscribe(EventType::KeyReshareSameSet));
+
+        while let Some(res) = tasks.join_next().await {
+            if let Err(e) = res {
+                error!("{e}");
+            }
+        }
+        info!("GatewayListener stopped successfully!");
+    }
+
+    /// Subscribes to a particular set of events.
+    ///
+    /// Each event received from the `event_filer` is then published in the DB.
+    pub async fn subscribe(self, event_type: EventType) {
+        let polling = match &event_type {
+            EventType::PublicDecryptionRequest | EventType::UserDecryptionRequest => {
+                self.config.decryption_polling
+            }
+            _ => self.config.key_management_polling,
+        };
+
+        let result = match &event_type {
+            EventType::PublicDecryptionRequest => {
+                let filter = self.decryption_contract.PublicDecryptionRequest_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+            EventType::UserDecryptionRequest => {
+                let filter = self.decryption_contract.UserDecryptionRequest_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+            EventType::PrepKeygenRequest => {
+                let filter = self.kms_generation_contract.PrepKeygenRequest_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+            EventType::KeygenRequest => {
+                let filter = self.kms_generation_contract.KeygenRequest_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+            EventType::CrsgenRequest => {
+                let filter = self.kms_generation_contract.CrsgenRequest_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+            EventType::PrssInit => {
+                let filter = self.kms_generation_contract.PRSSInit_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+            EventType::KeyReshareSameSet => {
+                let filter = self.kms_generation_contract.KeyReshareSameSet_filter();
+                self.subscribe_inner(event_type, filter, polling).await
+            }
+        };
+        self.cancel_token.cancel(); // Cancel other event subscription tasks
+
+        if let Err(e) = result {
+            error!("{e}");
+        }
+    }
+
+    async fn subscribe_inner<E>(
+        &self,
+        event_type: EventType,
+        event_filter: Event<&'_ P, E>,
+        poll_interval: Duration,
+    ) -> anyhow::Result<()>
+    where
+        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
+    {
+        let mut last_block_polled = self.get_last_block_polled(event_type).await?;
+        let mut event_poller = event_filter
+            .watch()
+            .await
+            .map_err(|e| anyhow!("Failed to subscribe to {event_type} events: {e}"))?;
+        event_poller.poller = event_poller.poller.with_poll_interval(poll_interval);
+        info!("✓ Subscribed to {event_type} events");
+
+        let _ = self
+            .catchup_past_events::<E>(&mut last_block_polled, event_type)
+            .await
+            .inspect_err(|e| warn!("Failed to catch up past {event_type} events: {e}"));
+
+        select! {
+            _ = self.process_events(event_type, event_poller, &mut last_block_polled) => (),
+            _ = self.cancel_token.cancelled() => info!("{event_type} subscription cancelled..."),
+        }
+
+        // Use a timeout to ensure we are not preventing the `GatewayListener` from being shutdown
+        // if the `last_block_polled` update get stuck for some reason.
+        timeout(
+            LAST_BLOCK_POLLED_UPDATE_TIMEOUT,
+            update_last_block_polled(&self.db_pool, event_type, last_block_polled),
+        )
+        .await??;
+        Ok(())
+    }
+
+    /// Catches events created before the event filter using `eth_getFilterLogs`.
+    async fn catchup_past_events<E>(
+        &self,
+        last_block_polled: &mut Option<u64>,
+        event_type: EventType,
+    ) -> anyhow::Result<()>
+    where
+        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
+    {
+        let catchup_from_block = match last_block_polled {
+            None => {
+                info!(
+                    "No previously polled block for {event_type}; skipping catchup of past events."
+                );
+                return Ok(());
+            }
+            Some(block) => *block,
+        };
+
+        let contract_address = match event_type {
+            EventType::PublicDecryptionRequest | EventType::UserDecryptionRequest => {
+                self.decryption_contract.address()
+            }
+            _ => self.kms_generation_contract.address(),
+        };
+
+        let filter = Filter::new()
+            .address(*contract_address)
+            .event_signature(E::SIGNATURE_HASH)
+            .from_block(catchup_from_block);
+        let provider = self.decryption_contract.provider();
+
+        info!("Catching up {event_type} from {catchup_from_block}...");
+        let mut event_count = 0;
+        let event_filter_id = provider.new_filter(&filter).await?;
+        let past_events = provider
+            .get_filter_logs(event_filter_id)
+            .await?
+            .into_iter()
+            .map(|log| {
+                decode_log::<E>(&log).map(|event| {
+                    event_count += 1;
+                    (event, log)
+                })
+            });
+
+        for event in past_events {
+            self.spawn_event_handling(event_type, event, last_block_polled)
+                .await;
+        }
+
+        info!(
+            "Successfully caught {event_count} {event_type} events from block {catchup_from_block}!"
+        );
+        if let Err(e) = provider.uninstall_filter(event_filter_id).await {
+            warn!("Failed to uninstall {event_type} event catchup filter: {e}");
+        }
+        Ok(())
+    }
+
+    /// Event processing loop.
+    async fn process_events<E>(
+        &self,
+        event_type: EventType,
+        event_poller: EventPoller<E>,
+        last_block_polled: &mut Option<u64>,
+    ) where
+        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
+    {
+        let mut events = event_poller.into_stream();
+        loop {
+            info!("Waiting for next {event_type}...");
+            match events.next().await {
+                Some(event) => {
+                    self.spawn_event_handling(event_type, event, last_block_polled)
+                        .await
+                }
+                None => break error!("Alloy Provider was dropped for {event_type}"),
+            }
+        }
+    }
+
+    async fn spawn_event_handling<E>(
+        &self,
+        event_type: EventType,
+        event: alloy::sol_types::Result<(E, Log)>,
+        last_block: &mut Option<u64>,
+    ) where
+        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
+    {
+        match event {
+            Ok((event, log)) => {
+                *last_block = log.block_number;
+                EVENT_RECEIVED_COUNTER
+                    .with_label_values(&[event_type.as_str()])
+                    .inc();
+
+                let db = self.db_pool.clone();
+                spawn_with_limit(handle_gateway_event(db, event.into(), log)).await;
+            }
+            Err(err) => {
+                error!("Error while listening for {event_type} events: {err}");
+                EVENT_RECEIVED_ERRORS
+                    .with_label_values(&[event_type.as_str()])
+                    .inc();
+            }
+        }
+    }
+
+    /// Get the last block polled from config or DB.
+    async fn get_last_block_polled(&self, event_type: EventType) -> anyhow::Result<Option<u64>> {
+        let from_block_number = match event_type {
+            EventType::PublicDecryptionRequest | EventType::UserDecryptionRequest => {
+                self.config.decryption_from_block_number
+            }
+            _ => self.config.kms_operation_from_block_number,
+        };
+
+        let last_block_polled = match from_block_number {
+            // Start polling event from the configured `from_block_number` if set
+            Some(from_block) => {
+                info!(
+                    "Found configured `from_block_number` ({from_block}) for {event_type} subscriptions!"
+                );
+                Some(from_block)
+            }
+            // Start from `last_block_polled` stored in DB + 1 if not configured
+            None => self
+                .get_last_block_polled_from_db(event_type)
+                .await?
+                .map(|n| n + 1),
+        };
+
+        info!(
+            "Starting {} subscriptions from block {}...",
+            event_type,
+            last_block_polled
+                .map(|b| b.to_string())
+                .unwrap_or_else(|| "latest".into())
+        );
+
+        Ok(last_block_polled)
+    }
+
+    async fn get_last_block_polled_from_db(
+        &self,
+        event_type: EventType,
+    ) -> anyhow::Result<Option<u64>> {
+        info!("Fetching last block polled from DB for {event_type}...");
+        let query_result =
+            sqlx::query("SELECT block_number FROM last_block_polled WHERE event_type = $1")
+                .bind(event_type)
+                .fetch_one(&self.db_pool)
+                .await?
+                .try_get::<Option<i64>, _>("block_number")?;
+
+        let Some(block_number) = query_result else {
+            info!("No block number stored in DB yet for {event_type}");
+            return Ok(None);
+        };
+        Ok(Some(block_number as u64))
+    }
+}
+
+/// Main function used to trace a single event handling across all Connector's services.
+#[tracing::instrument(skip_all, fields(event = %event_kind))]
+async fn handle_gateway_event(db_pool: Pool<Postgres>, event_kind: GatewayEventKind, log: Log) {
+    let event = GatewayEvent::new(
+        event_kind,
+        log.transaction_hash,
+        PropagationContext::inject(&tracing::Span::current().context()),
+    );
+    if let Err(err) = publish_event(&db_pool, event, log.block_number).await {
+        error!("Failed to publish event: {err}");
+    }
+}
+
+fn decode_log<E: SolEvent>(log: &Log) -> alloy::sol_types::Result<E> {
+    let log_data: &LogData = log.as_ref();
+    E::decode_raw_log(log_data.topics().iter().copied(), &log_data.data)
+}
+
+/// The timeout we allow for the listener to store the last block polled in DB.
+const LAST_BLOCK_POLLED_UPDATE_TIMEOUT: Duration = Duration::from_mins(5);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        primitives::Address,
+        providers::{
+            Identity, ProviderBuilder, RootProvider,
+            fillers::{
+                BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+            },
+            mock::Asserter,
+        },
+        rpc::json_rpc::ErrorPayload,
+    };
+    use connector_utils::tests::setup::{TestInstance, TestInstanceBuilder};
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_reset_filter_stops_listener() {
+        let (_test_instance, asserter, gw_listener) = test_setup(None).await;
+
+        asserter.push_failure(ErrorPayload {
+            code: -32000,
+            message: "filter not found".into(),
+            data: None,
+        });
+
+        gw_listener.subscribe(EventType::KeygenRequest).await;
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_failed_catchup_does_not_stop_listener() {
+        let (mut test_instance, asserter, gw_listener) = test_setup(Some(0)).await;
+
+        asserter.push_failure(ErrorPayload {
+            code: -32002,
+            message: "request timed out".into(),
+            data: None,
+        });
+
+        let event_type = EventType::KeygenRequest;
+        tokio::spawn(gw_listener.subscribe(event_type));
+        test_instance.wait_for_log("Failed to catch up").await;
+        test_instance
+            .wait_for_log(&format!("Waiting for next {event_type}"))
+            .await;
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_listener_ended_by_end_of_any_task() {
+        let (mut test_instance, _asserter, gw_listener) = test_setup(None).await;
+
+        // Will stop because some subscription tasks will not be able to init their event filter
+        gw_listener.start().await;
+
+        test_instance.wait_for_log("Failed to subscribe to").await;
+    }
+
+    type MockProvider = FillProvider<
+        JoinFill<
+            Identity,
+            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+        >,
+        RootProvider,
+    >;
+
+    async fn test_setup(
+        kms_operation_from_block_number: Option<u64>,
+    ) -> (TestInstance, Asserter, GatewayListener<MockProvider>) {
+        let test_instance = TestInstanceBuilder::db_setup().await.unwrap();
+
+        // Create a mocked `alloy::Provider`
+        let asserter = Asserter::new();
+        let mock_provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+
+        // Used to mock response of `filter.watch()` operation
+        let mocked_eth_get_filter_changes_result = Address::default();
+        asserter.push_success(&mocked_eth_get_filter_changes_result);
+
+        let config = Config {
+            decryption_polling: Duration::from_millis(500),
+            key_management_polling: Duration::from_millis(500),
+            kms_operation_from_block_number,
+            ..Default::default()
+        };
+        let listener = GatewayListener::new(
+            test_instance.db().clone(),
+            mock_provider,
+            &config,
+            CancellationToken::new(),
+        );
+        (test_instance, asserter, listener)
+    }
+}

--- a/kms-connector/crates/gw-listener/src/core/gw_listener.rs
+++ b/kms-connector/crates/gw-listener/src/core/gw_listener.rs
@@ -1,494 +1,72 @@
-use super::Config;
 use crate::{
-    core::{publish::update_last_block_polled, publish_event},
-    monitoring::{
-        health::State,
-        metrics::{EVENT_RECEIVED_COUNTER, EVENT_RECEIVED_ERRORS},
-    },
+    core::{Config, ethereum::EthereumListener, gateway::GatewayListener},
+    monitoring::health::State,
 };
-use alloy::{
-    contract::{Event, EventPoller},
-    network::Ethereum,
-    primitives::LogData,
-    providers::Provider,
-    rpc::types::{Filter, Log},
-    sol_types::SolEvent,
-};
-use anyhow::anyhow;
-use connector_utils::{
-    conn::{DefaultProvider, connect_to_db, connect_to_rpc_node},
-    monitoring::otlp::PropagationContext,
-    tasks::spawn_with_limit,
-    types::{GatewayEvent, GatewayEventKind, db::EventType},
-};
-use fhevm_gateway_bindings::{
-    decryption::Decryption::{self, DecryptionInstance},
-    kms_generation::KMSGeneration::{self, KMSGenerationInstance},
-};
-use sqlx::{Pool, Postgres, Row};
-use std::time::Duration;
-use tokio::{select, task::JoinSet, time::timeout};
-use tokio_stream::StreamExt;
+use alloy::{network::Ethereum, providers::Provider};
+use connector_utils::conn::{DefaultProvider, connect_to_db, connect_to_rpc_node};
+use tokio::join;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing::info;
 
-/// Struct monitoring and storing Gateway's events.
-#[derive(Clone)]
-pub struct GatewayListener<P>
+/// Struct monitoring and storing events of the Zama Protocol.
+pub struct EventListener<GP, HP>
 where
-    P: Provider,
+    GP: Provider,
+    HP: Provider,
 {
-    /// The database pool for storing Gateway's events.
-    db_pool: Pool<Postgres>,
+    /// The listener of Gateway's events.
+    gateway_listener: GatewayListener<GP>,
 
-    /// The Gateway's `Decryption` contract instance which is monitored.
-    decryption_contract: DecryptionInstance<P>,
-
-    /// The Gateway's `KMSGeneration` contract instance which is monitored.
-    kms_generation_contract: KMSGenerationInstance<P>,
-
-    /// The configuration of the `GatewayListener`.
-    config: Config,
-
-    /// The cancellation token to handle the graceful shutdown of the listener.
-    cancel_token: CancellationToken,
+    /// The listener of Ethereum's events.
+    ethereum_listener: EthereumListener<HP>,
 }
 
-impl<P> GatewayListener<P>
+impl<GP, HP> EventListener<GP, HP>
 where
-    P: Provider<Ethereum> + Clone + 'static,
+    GP: Provider<Ethereum> + Clone + 'static,
+    HP: Provider<Ethereum> + Clone + 'static,
 {
-    /// Creates a new `GatewayListener` instance.
     pub fn new(
-        db_pool: Pool<Postgres>,
-        provider: P,
-        config: &Config,
-        cancel_token: CancellationToken,
+        gateway_listener: GatewayListener<GP>,
+        ethereum_listener: EthereumListener<HP>,
     ) -> Self {
-        let decryption_contract =
-            Decryption::new(config.decryption_contract.address, provider.clone());
-        let kms_generation_contract =
-            KMSGeneration::new(config.kms_generation_contract.address, provider);
-
         Self {
-            db_pool,
-            decryption_contract,
-            kms_generation_contract,
-            config: config.clone(),
-            cancel_token,
+            gateway_listener,
+            ethereum_listener,
         }
     }
 
-    /// Starts the `GatewayListener`.
-    ///
-    /// Spawns and joins the `GatewayListener` event monitoring tasks.
     pub async fn start(self) {
-        let mut tasks = JoinSet::new();
-
-        tasks.spawn(self.clone().subscribe(EventType::PublicDecryptionRequest));
-        tasks.spawn(self.clone().subscribe(EventType::UserDecryptionRequest));
-        tasks.spawn(self.clone().subscribe(EventType::PrepKeygenRequest));
-        tasks.spawn(self.clone().subscribe(EventType::KeygenRequest));
-        tasks.spawn(self.clone().subscribe(EventType::CrsgenRequest));
-        tasks.spawn(self.clone().subscribe(EventType::PrssInit));
-        tasks.spawn(self.subscribe(EventType::KeyReshareSameSet));
-
-        while let Some(res) = tasks.join_next().await {
-            if let Err(e) = res {
-                error!("{e}");
-            }
-        }
-        info!("GatewayListener stopped successfully!");
-    }
-
-    /// Subscribes to a particular set of events.
-    ///
-    /// Each event received from the `event_filer` is then published in the DB.
-    pub async fn subscribe(self, event_type: EventType) {
-        let polling = match &event_type {
-            EventType::PublicDecryptionRequest | EventType::UserDecryptionRequest => {
-                self.config.decryption_polling
-            }
-            _ => self.config.key_management_polling,
-        };
-
-        let result = match &event_type {
-            EventType::PublicDecryptionRequest => {
-                let filter = self.decryption_contract.PublicDecryptionRequest_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-            EventType::UserDecryptionRequest => {
-                let filter = self.decryption_contract.UserDecryptionRequest_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-            EventType::PrepKeygenRequest => {
-                let filter = self.kms_generation_contract.PrepKeygenRequest_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-            EventType::KeygenRequest => {
-                let filter = self.kms_generation_contract.KeygenRequest_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-            EventType::CrsgenRequest => {
-                let filter = self.kms_generation_contract.CrsgenRequest_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-            EventType::PrssInit => {
-                let filter = self.kms_generation_contract.PRSSInit_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-            EventType::KeyReshareSameSet => {
-                let filter = self.kms_generation_contract.KeyReshareSameSet_filter();
-                self.subscribe_inner(event_type, filter, polling).await
-            }
-        };
-        self.cancel_token.cancel(); // Cancel other event subscription tasks
-
-        if let Err(e) = result {
-            error!("{e}");
-        }
-    }
-
-    async fn subscribe_inner<E>(
-        &self,
-        event_type: EventType,
-        event_filter: Event<&'_ P, E>,
-        poll_interval: Duration,
-    ) -> anyhow::Result<()>
-    where
-        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
-    {
-        let mut last_block_polled = self.get_last_block_polled(event_type).await?;
-        let mut event_poller = event_filter
-            .watch()
-            .await
-            .map_err(|e| anyhow!("Failed to subscribe to {event_type} events: {e}"))?;
-        event_poller.poller = event_poller.poller.with_poll_interval(poll_interval);
-        info!("✓ Subscribed to {event_type} events");
-
-        let _ = self
-            .catchup_past_events::<E>(&mut last_block_polled, event_type)
-            .await
-            .inspect_err(|e| warn!("Failed to catch up past {event_type} events: {e}"));
-
-        select! {
-            _ = self.process_events(event_type, event_poller, &mut last_block_polled) => (),
-            _ = self.cancel_token.cancelled() => info!("{event_type} subscription cancelled..."),
-        }
-
-        // Use a timeout to ensure we are not preventing the `GatewayListener` from being shutdown
-        // if the `last_block_polled` update get stuck for some reason.
-        timeout(
-            LAST_BLOCK_POLLED_UPDATE_TIMEOUT,
-            update_last_block_polled(&self.db_pool, event_type, last_block_polled),
-        )
-        .await??;
-        Ok(())
-    }
-
-    /// Catches events created before the event filter using `eth_getFilterLogs`.
-    async fn catchup_past_events<E>(
-        &self,
-        last_block_polled: &mut Option<u64>,
-        event_type: EventType,
-    ) -> anyhow::Result<()>
-    where
-        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
-    {
-        let catchup_from_block = match last_block_polled {
-            None => {
-                info!(
-                    "No previously polled block for {event_type}; skipping catchup of past events."
-                );
-                return Ok(());
-            }
-            Some(block) => *block,
-        };
-
-        let contract_address = match event_type {
-            EventType::PublicDecryptionRequest | EventType::UserDecryptionRequest => {
-                self.decryption_contract.address()
-            }
-            _ => self.kms_generation_contract.address(),
-        };
-
-        let filter = Filter::new()
-            .address(*contract_address)
-            .event_signature(E::SIGNATURE_HASH)
-            .from_block(catchup_from_block);
-        let provider = self.decryption_contract.provider();
-
-        info!("Catching up {event_type} from {catchup_from_block}...");
-        let mut event_count = 0;
-        let event_filter_id = provider.new_filter(&filter).await?;
-        let past_events = provider
-            .get_filter_logs(event_filter_id)
-            .await?
-            .into_iter()
-            .map(|log| {
-                decode_log::<E>(&log).map(|event| {
-                    event_count += 1;
-                    (event, log)
-                })
-            });
-
-        for event in past_events {
-            self.spawn_event_handling(event_type, event, last_block_polled)
-                .await;
-        }
-
-        info!(
-            "Successfully caught {event_count} {event_type} events from block {catchup_from_block}!"
+        join!(
+            self.gateway_listener.start(),
+            self.ethereum_listener.start()
         );
-        if let Err(e) = provider.uninstall_filter(event_filter_id).await {
-            warn!("Failed to uninstall {event_type} event catchup filter: {e}");
-        }
-        Ok(())
-    }
-
-    /// Event processing loop.
-    async fn process_events<E>(
-        &self,
-        event_type: EventType,
-        event_poller: EventPoller<E>,
-        last_block_polled: &mut Option<u64>,
-    ) where
-        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
-    {
-        let mut events = event_poller.into_stream();
-        loop {
-            info!("Waiting for next {event_type}...");
-            match events.next().await {
-                Some(event) => {
-                    self.spawn_event_handling(event_type, event, last_block_polled)
-                        .await
-                }
-                None => break error!("Alloy Provider was dropped for {event_type}"),
-            }
-        }
-    }
-
-    async fn spawn_event_handling<E>(
-        &self,
-        event_type: EventType,
-        event: alloy::sol_types::Result<(E, Log)>,
-        last_block: &mut Option<u64>,
-    ) where
-        E: Into<GatewayEventKind> + SolEvent + Send + Sync + 'static,
-    {
-        match event {
-            Ok((event, log)) => {
-                *last_block = log.block_number;
-                EVENT_RECEIVED_COUNTER
-                    .with_label_values(&[event_type.as_str()])
-                    .inc();
-
-                let db = self.db_pool.clone();
-                spawn_with_limit(handle_gateway_event(db, event.into(), log)).await;
-            }
-            Err(err) => {
-                error!("Error while listening for {event_type} events: {err}");
-                EVENT_RECEIVED_ERRORS
-                    .with_label_values(&[event_type.as_str()])
-                    .inc();
-            }
-        }
-    }
-
-    /// Get the last block polled from config or DB.
-    async fn get_last_block_polled(&self, event_type: EventType) -> anyhow::Result<Option<u64>> {
-        let from_block_number = match event_type {
-            EventType::PublicDecryptionRequest | EventType::UserDecryptionRequest => {
-                self.config.decryption_from_block_number
-            }
-            _ => self.config.kms_operation_from_block_number,
-        };
-
-        let last_block_polled = match from_block_number {
-            // Start polling event from the configured `from_block_number` if set
-            Some(from_block) => {
-                info!(
-                    "Found configured `from_block_number` ({from_block}) for {event_type} subscriptions!"
-                );
-                Some(from_block)
-            }
-            // Start from `last_block_polled` stored in DB + 1 if not configured
-            None => self
-                .get_last_block_polled_from_db(event_type)
-                .await?
-                .map(|n| n + 1),
-        };
-
-        info!(
-            "Starting {} subscriptions from block {}...",
-            event_type,
-            last_block_polled
-                .map(|b| b.to_string())
-                .unwrap_or_else(|| "latest".into())
-        );
-
-        Ok(last_block_polled)
-    }
-
-    async fn get_last_block_polled_from_db(
-        &self,
-        event_type: EventType,
-    ) -> anyhow::Result<Option<u64>> {
-        info!("Fetching last block polled from DB for {event_type}...");
-        let query_result =
-            sqlx::query("SELECT block_number FROM last_block_polled WHERE event_type = $1")
-                .bind(event_type)
-                .fetch_one(&self.db_pool)
-                .await?
-                .try_get::<Option<i64>, _>("block_number")?;
-
-        let Some(block_number) = query_result else {
-            info!("No block number stored in DB yet for {event_type}");
-            return Ok(None);
-        };
-        Ok(Some(block_number as u64))
+        info!("EventListener stopped successfully!");
     }
 }
 
-/// Main function used to trace a single event handling across all Connector's services.
-#[tracing::instrument(skip_all, fields(event = %event_kind))]
-async fn handle_gateway_event(db_pool: Pool<Postgres>, event_kind: GatewayEventKind, log: Log) {
-    let event = GatewayEvent::new(
-        event_kind,
-        log.transaction_hash,
-        PropagationContext::inject(&tracing::Span::current().context()),
-    );
-    if let Err(err) = publish_event(&db_pool, event, log.block_number).await {
-        error!("Failed to publish event: {err}");
-    }
-}
-
-fn decode_log<E: SolEvent>(log: &Log) -> alloy::sol_types::Result<E> {
-    let log_data: &LogData = log.as_ref();
-    E::decode_raw_log(log_data.topics().iter().copied(), &log_data.data)
-}
-
-impl GatewayListener<DefaultProvider> {
-    /// Creates a new `GatewayListener` instance from a valid `Config`.
+impl EventListener<DefaultProvider, DefaultProvider> {
+    /// Creates a new `EventListener` instance from a valid `Config`.
     pub async fn from_config(
         config: Config,
         cancel_token: CancellationToken,
     ) -> anyhow::Result<(Self, State<DefaultProvider>)> {
         let db_pool = connect_to_db(&config.database_url, config.database_pool_size).await?;
-        let provider =
+        let gateway_provider =
             connect_to_rpc_node(config.gateway_url.clone(), config.gateway_chain_id).await?;
+        let ethereum_provider =
+            connect_to_rpc_node(config.ethereum_url.clone(), config.ethereum_chain_id).await?;
 
         let state = State::new(
             db_pool.clone(),
-            provider.clone(),
+            gateway_provider.clone(),
             config.healthcheck_timeout,
         );
 
-        let gw_listener = GatewayListener::new(db_pool, provider, &config, cancel_token);
-        Ok((gw_listener, state))
-    }
-}
-
-/// The timeout we allow for the listener to store the last block polled in DB.
-const LAST_BLOCK_POLLED_UPDATE_TIMEOUT: Duration = Duration::from_mins(5);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy::{
-        primitives::Address,
-        providers::{
-            Identity, ProviderBuilder, RootProvider,
-            fillers::{
-                BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
-            },
-            mock::Asserter,
-        },
-        rpc::json_rpc::ErrorPayload,
-    };
-    use connector_utils::tests::setup::{TestInstance, TestInstanceBuilder};
-
-    #[rstest::rstest]
-    #[timeout(Duration::from_secs(90))]
-    #[tokio::test]
-    async fn test_reset_filter_stops_listener() {
-        let (_test_instance, asserter, gw_listener) = test_setup(None).await;
-
-        asserter.push_failure(ErrorPayload {
-            code: -32000,
-            message: "filter not found".into(),
-            data: None,
-        });
-
-        gw_listener.subscribe(EventType::KeygenRequest).await;
-    }
-
-    #[rstest::rstest]
-    #[timeout(Duration::from_secs(90))]
-    #[tokio::test]
-    async fn test_failed_catchup_does_not_stop_listener() {
-        let (mut test_instance, asserter, gw_listener) = test_setup(Some(0)).await;
-
-        asserter.push_failure(ErrorPayload {
-            code: -32002,
-            message: "request timed out".into(),
-            data: None,
-        });
-
-        let event_type = EventType::KeygenRequest;
-        tokio::spawn(gw_listener.subscribe(event_type));
-        test_instance.wait_for_log("Failed to catch up").await;
-        test_instance
-            .wait_for_log(&format!("Waiting for next {event_type}"))
-            .await;
-    }
-
-    #[rstest::rstest]
-    #[timeout(Duration::from_secs(90))]
-    #[tokio::test]
-    async fn test_listener_ended_by_end_of_any_task() {
-        let (mut test_instance, _asserter, gw_listener) = test_setup(None).await;
-
-        // Will stop because some subscription tasks will not be able to init their event filter
-        gw_listener.start().await;
-
-        test_instance.wait_for_log("Failed to subscribe to").await;
-    }
-
-    type MockProvider = FillProvider<
-        JoinFill<
-            Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-        >,
-        RootProvider,
-    >;
-
-    async fn test_setup(
-        kms_operation_from_block_number: Option<u64>,
-    ) -> (TestInstance, Asserter, GatewayListener<MockProvider>) {
-        let test_instance = TestInstanceBuilder::db_setup().await.unwrap();
-
-        // Create a mocked `alloy::Provider`
-        let asserter = Asserter::new();
-        let mock_provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
-
-        // Used to mock response of `filter.watch()` operation
-        let mocked_eth_get_filter_changes_result = Address::default();
-        asserter.push_success(&mocked_eth_get_filter_changes_result);
-
-        let config = Config {
-            decryption_polling: Duration::from_millis(500),
-            key_management_polling: Duration::from_millis(500),
-            kms_operation_from_block_number,
-            ..Default::default()
-        };
-        let listener = GatewayListener::new(
-            test_instance.db().clone(),
-            mock_provider,
-            &config,
-            CancellationToken::new(),
-        );
-        (test_instance, asserter, listener)
+        let gateway_listener =
+            GatewayListener::new(db_pool.clone(), gateway_provider, &config, cancel_token);
+        let ethereum_listener = EthereumListener::new(db_pool, ethereum_provider, &config);
+        let event_listener = EventListener::new(gateway_listener, ethereum_listener);
+        Ok((event_listener, state))
     }
 }

--- a/kms-connector/crates/gw-listener/src/core/mod.rs
+++ b/kms-connector/crates/gw-listener/src/core/mod.rs
@@ -1,7 +1,10 @@
 mod config;
+mod ethereum;
+mod gateway;
 mod gw_listener;
 mod publish;
 
 pub use config::Config;
-pub use gw_listener::GatewayListener;
+pub use gateway::GatewayListener;
+pub use gw_listener::EventListener;
 pub use publish::publish_event;

--- a/kms-connector/crates/kms-worker/src/core/event_processor/context.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/context.rs
@@ -1,0 +1,49 @@
+use crate::core::event_processor::ProcessingError;
+use alloy::primitives::U256;
+use anyhow::anyhow;
+use sqlx::{Pool, Postgres};
+
+pub trait ContextManager: Send + Sync {
+    fn validate_context(
+        &self,
+        context_id: U256,
+    ) -> impl Future<Output = Result<(), ProcessingError>> + Send;
+}
+
+#[derive(Clone)]
+pub struct DbContextManager {
+    db_pool: Pool<Postgres>,
+}
+
+impl ContextManager for DbContextManager {
+    async fn validate_context(&self, context_id: U256) -> Result<(), ProcessingError> {
+        let context_row = sqlx::query!(
+            "SELECT is_valid FROM kms_context WHERE id = $1",
+            context_id.as_le_slice()
+        )
+        .fetch_optional(&self.db_pool)
+        .await
+        .map_err(|e| {
+            ProcessingError::Recoverable(anyhow!(
+                "Query to check context #{context_id} failed: {e}"
+            ))
+        })?
+        .map(|c| c.is_valid);
+
+        match context_row {
+            None => Err(ProcessingError::Recoverable(anyhow!(
+                "Context #{context_id} not found in DB"
+            ))),
+            Some(false) => Err(ProcessingError::Irrecoverable(anyhow!(
+                "Context #{context_id} is invalid"
+            ))),
+            Some(true) => Ok(()),
+        }
+    }
+}
+
+impl DbContextManager {
+    pub fn new(db_pool: Pool<Postgres>) -> Self {
+        Self { db_pool }
+    }
+}

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -31,7 +31,7 @@ pub struct DecryptionProcessor<GP: Provider, HP: Provider, C> {
     /// The EIP712 domain of the `Decryption` contract.
     domain: Eip712DomainMsg,
 
-    /// TODO.
+    /// The entity used to validate KMS context.
     context_manager: C,
 
     /// The instance of the `Decryption` contract used to check decryption were not already done.

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -1,6 +1,6 @@
 use crate::core::{
     config::Config,
-    event_processor::{ProcessingError, s3::S3Service},
+    event_processor::{ProcessingError, context::ContextManager, s3::S3Service},
 };
 use alloy::{
     consensus::Transaction,
@@ -10,7 +10,10 @@ use alloy::{
     sol_types::SolCall,
 };
 use anyhow::anyhow;
-use connector_utils::types::{KmsGrpcRequest, fhe::extract_chain_id_from_handle};
+use connector_utils::types::{
+    KmsGrpcRequest, extra_data::parse_extra_data_context, handle::extract_chain_id_from_handle,
+    u256_to_request_id,
+};
 use fhevm_gateway_bindings::decryption::Decryption::{
     self, DecryptionInstance, SnsCiphertextMaterial, delegatedUserDecryptionRequestCall,
     userDecryptionRequestCall,
@@ -24,9 +27,12 @@ use tracing::info;
 
 #[derive(Clone)]
 /// The struct responsible of processing incoming decryption requests.
-pub struct DecryptionProcessor<GP: Provider, HP: Provider> {
+pub struct DecryptionProcessor<GP: Provider, HP: Provider, C> {
     /// The EIP712 domain of the `Decryption` contract.
     domain: Eip712DomainMsg,
+
+    /// TODO.
+    context_manager: C,
 
     /// The instance of the `Decryption` contract used to check decryption were not already done.
     decryption_contract: DecryptionInstance<GP>,
@@ -38,13 +44,15 @@ pub struct DecryptionProcessor<GP: Provider, HP: Provider> {
     s3_service: S3Service<GP>,
 }
 
-impl<GP, HP> DecryptionProcessor<GP, HP>
+impl<GP, HP, C> DecryptionProcessor<GP, HP, C>
 where
     GP: Provider,
     HP: Provider,
+    C: ContextManager,
 {
     pub fn new(
         config: &Config,
+        context_manager: C,
         gateway_provider: GP,
         acl_contracts: HashMap<u64, ACLInstance<HP>>,
         s3_service: S3Service<GP>,
@@ -61,6 +69,7 @@ where
 
         Self {
             domain,
+            context_manager,
             decryption_contract,
             acl_contracts,
             s3_service,
@@ -291,11 +300,10 @@ where
             })?;
         info!("Extracted key_id {key_id} from snsCtMaterials[0]");
 
+        let context_id = self.extract_and_validate_context(extra_data).await?;
         let ciphertexts = self.prepare_ciphertexts(&key_id, sns_materials).await?;
 
-        let request_id = Some(RequestId {
-            request_id: hex::encode(decryption_id.to_be_bytes::<32>()),
-        });
+        let request_id = Some(u256_to_request_id(decryption_id));
         let extra_data = extra_data.to_vec();
 
         if let Some(user_decrypt_data) = user_decrypt_data {
@@ -310,7 +318,7 @@ where
                 typed_ciphertexts: ciphertexts,
                 extra_data,
                 epoch_id: None,
-                context_id: None,
+                context_id,
             };
 
             Ok(user_decryption_request.into())
@@ -322,7 +330,7 @@ where
                 domain: Some(self.domain.clone()),
                 extra_data,
                 epoch_id: None,
-                context_id: None,
+                context_id,
             };
             Ok(public_decryption_request.into())
         }
@@ -374,6 +382,21 @@ where
                 ProcessingError::Irrecoverable(anyhow!("No transaction found with hash {tx_hash}!"))
             })
             .map(|tx| tx.input().to_vec())
+    }
+
+    /// Parses `extraData` for a context ID and validates it if present.
+    async fn extract_and_validate_context(
+        &self,
+        extra_data: &[u8],
+    ) -> Result<Option<RequestId>, ProcessingError> {
+        match parse_extra_data_context(extra_data) {
+            Err(e) => Err(ProcessingError::Irrecoverable(e)),
+            Ok(None) => Ok(None),
+            Ok(Some(context_id)) => {
+                self.context_manager.validate_context(context_id).await?;
+                Ok(Some(u256_to_request_id(context_id)))
+            }
+        }
     }
 }
 
@@ -438,8 +461,13 @@ mod tests {
 
         let config = Config::default();
         let s3_service = S3Service::new(&config, mock_provider.clone(), reqwest::Client::new());
-        let decryption_processor =
-            DecryptionProcessor::new(&config, mock_provider, acl_contracts_mock, s3_service);
+        let decryption_processor = DecryptionProcessor::new(
+            &config,
+            MockContextManager,
+            mock_provider,
+            acl_contracts_mock,
+            s3_service,
+        );
 
         match mock_response {
             DecryptionReadyMock::Failure(msg) => asserter.push_failure_msg(msg),
@@ -491,8 +519,13 @@ mod tests {
         let sns_ciphertexts = vec![sns_ct];
         let config = Config::default();
         let s3_service = S3Service::new(&config, mock_provider.clone(), reqwest::Client::new());
-        let decryption_processor =
-            DecryptionProcessor::new(&config, mock_provider, acl_contracts_mock, s3_service);
+        let decryption_processor = DecryptionProcessor::new(
+            &config,
+            MockContextManager,
+            mock_provider,
+            acl_contracts_mock,
+            s3_service,
+        );
 
         match mock_response {
             PubDecryptACLMock::Failure(msg) => asserter.push_failure_msg(msg),
@@ -572,8 +605,13 @@ mod tests {
         let user_address = Address::default();
         let config = Config::default();
         let s3_service = S3Service::new(&config, mock_provider.clone(), reqwest::Client::new());
-        let decryption_processor =
-            DecryptionProcessor::new(&config, mock_provider, acl_contracts_mock, s3_service);
+        let decryption_processor = DecryptionProcessor::new(
+            &config,
+            MockContextManager,
+            mock_provider,
+            acl_contracts_mock,
+            s3_service,
+        );
 
         match mock_response {
             UserDecryptACLMock::Failure(msg) => asserter.push_failure_msg(msg),
@@ -665,8 +703,13 @@ mod tests {
         let user_address = Address::default();
         let config = Config::default();
         let s3_service = S3Service::new(&config, mock_provider.clone(), reqwest::Client::new());
-        let decryption_processor =
-            DecryptionProcessor::new(&config, mock_provider, acl_contracts_mock, s3_service);
+        let decryption_processor = DecryptionProcessor::new(
+            &config,
+            MockContextManager,
+            mock_provider,
+            acl_contracts_mock,
+            s3_service,
+        );
 
         match mock_response {
             DelegatedUserDecryptACLMock::Failure(msg) => asserter.push_failure_msg(msg),
@@ -700,6 +743,14 @@ mod tests {
                 }
                 _ => panic!("Expected Irrecoverable error, got: {:?}", result),
             },
+        }
+    }
+
+    struct MockContextManager;
+
+    impl ContextManager for MockContextManager {
+        async fn validate_context(&self, _context_id: U256) -> Result<(), ProcessingError> {
+            Ok(())
         }
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
@@ -1,9 +1,11 @@
+mod context;
 mod decryption;
 mod kms;
 mod kms_client;
 mod processor;
 pub mod s3;
 
+pub use context::{ContextManager, DbContextManager};
 pub use decryption::DecryptionProcessor;
 pub use kms::KMSGenerationProcessor;
 pub use kms_client::KmsClient;

--- a/kms-connector/crates/kms-worker/src/core/event_processor/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/s3.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alloy::{hex, primitives::Address, providers::Provider, transports::http::Client};
 use anyhow::anyhow;
-use connector_utils::types::fhe::extract_fhe_type_from_handle;
+use connector_utils::types::handle::extract_fhe_type_from_handle;
 use dashmap::DashMap;
 use fhevm_gateway_bindings::{
     decryption::Decryption::SnsCiphertextMaterial,

--- a/kms-connector/crates/kms-worker/tests/context.rs
+++ b/kms-connector/crates/kms-worker/tests/context.rs
@@ -1,0 +1,215 @@
+mod common;
+
+use crate::common::{create_mock_user_decryption_request_tx, init_kms_worker};
+use alloy::{
+    primitives::U256,
+    providers::{ProviderBuilder, mock::Asserter},
+    sol_types::SolValue,
+};
+use connector_utils::{
+    tests::{
+        db::requests::{
+            InsertRequestOptions, check_no_uncompleted_request_in_db, check_request_failed_in_db,
+            insert_rand_request,
+        },
+        rand::{rand_digest, rand_sns_ct},
+        setup::{
+            DbInstance, TESTING_KMS_CONTEXT, TestInstanceBuilder,
+            init_host_chains_acl_contracts_mock,
+        },
+    },
+    types::db::EventType,
+};
+use kms_worker::core::Config;
+use mocktail::server::MockServer;
+use rstest::rstest;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+/// Context ID does not exist in the DB → Recoverable error → retried until max attempts → failed.
+#[rstest]
+#[case::public_decryption(EventType::PublicDecryptionRequest)]
+#[case::user_decryption(EventType::UserDecryptionRequest)]
+#[timeout(Duration::from_secs(60))]
+#[tokio::test]
+async fn test_decryption_context_not_found(#[case] event_type: EventType) -> anyhow::Result<()> {
+    let test_instance = TestInstanceBuilder::default()
+        .with_db(DbInstance::setup().await?)
+        .build();
+
+    const MAX_DECRYPTION_ATTEMPTS: u16 = 3;
+
+    // Use a context_id that does not exist in the DB
+    let unknown_context_id = U256::from(69);
+
+    let asserter = Asserter::new();
+    let sns_ct = rand_sns_ct();
+    let tx_hash = rand_digest();
+    let insert_options = InsertRequestOptions::new()
+        .with_sns_ct_materials(vec![sns_ct.clone()])
+        .with_tx_hash(tx_hash)
+        .with_context_id(unknown_context_id);
+
+    for _ in 0..MAX_DECRYPTION_ATTEMPTS {
+        match event_type {
+            EventType::PublicDecryptionRequest => {
+                // Mocking isDecryptionDone returns false
+                asserter.push_success(&false.abi_encode());
+            }
+            EventType::UserDecryptionRequest => {
+                // Mocking `get_transaction_by_hash` call result
+                let mock_tx = create_mock_user_decryption_request_tx(tx_hash, sns_ct.ctHandle)?;
+                asserter.push_success(&mock_tx);
+            }
+            _ => panic!("Unexpected event type"),
+        };
+    }
+
+    let gateway_mock_provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .connect_mocked_client(asserter);
+    info!("Gateway mock started!");
+
+    // Mocking Host chain ACL to ALLOW decryption
+    // Public: 1 ACL check, User: 2 ACL checks (user + contract)
+    let acl_responses = match event_type {
+        EventType::PublicDecryptionRequest => vec![true; MAX_DECRYPTION_ATTEMPTS as usize],
+        EventType::UserDecryptionRequest => vec![true; 2 * MAX_DECRYPTION_ATTEMPTS as usize],
+        _ => unreachable!(),
+    };
+    let acl_contracts_mock =
+        init_host_chains_acl_contracts_mock(sns_ct.ctHandle.as_slice(), acl_responses);
+
+    // No KMS mocks needed - request should fail before reaching KMS
+    let kms_mock_server = MockServer::new_grpc("kms_service.v1.CoreServiceEndpoint");
+    kms_mock_server.start().await?;
+    info!("KMS mock server started!");
+
+    let config = Config {
+        kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
+        max_decryption_attempts: MAX_DECRYPTION_ATTEMPTS,
+        db_fast_event_polling: Duration::from_millis(500),
+        ..Default::default()
+    };
+    let kms_worker = init_kms_worker(
+        config,
+        gateway_mock_provider,
+        acl_contracts_mock,
+        test_instance.db(),
+    )
+    .await?;
+
+    insert_rand_request(test_instance.db(), event_type, insert_options).await?;
+
+    let cancel_token = CancellationToken::new();
+    let kms_worker_task = tokio::spawn(kms_worker.start(cancel_token.clone()));
+    info!("KmsWorker started!");
+
+    // Waiting for kms_worker to mark the request as failed (after MAX_DECRYPTION_ATTEMPTS retries)
+    while let Err(e) = check_request_failed_in_db(test_instance.db(), event_type).await {
+        warn!("Request not yet failed: {e}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Verify no pending requests remain
+    check_no_uncompleted_request_in_db(test_instance.db(), event_type).await?;
+
+    cancel_token.cancel();
+    kms_worker_task.await.unwrap();
+    Ok(())
+}
+
+/// Context exists but is_valid = false → Irrecoverable error → immediately failed.
+#[rstest]
+#[case::public_decryption(EventType::PublicDecryptionRequest)]
+#[case::user_decryption(EventType::UserDecryptionRequest)]
+#[timeout(Duration::from_secs(60))]
+#[tokio::test]
+async fn test_decryption_context_invalid(#[case] event_type: EventType) -> anyhow::Result<()> {
+    let test_instance = TestInstanceBuilder::default()
+        .with_db(DbInstance::setup().await?)
+        .build();
+
+    const MAX_DECRYPTION_ATTEMPTS: u16 = 3;
+
+    // Invalidate the testing context that was created by DbInstance::setup
+    sqlx::query!(
+        "UPDATE kms_context SET is_valid = false WHERE id = $1",
+        TESTING_KMS_CONTEXT.as_le_slice(),
+    )
+    .execute(test_instance.db())
+    .await?;
+    info!("Context #{TESTING_KMS_CONTEXT} marked as invalid!");
+
+    let asserter = Asserter::new();
+    let sns_ct = rand_sns_ct();
+    let tx_hash = rand_digest();
+    let insert_options = InsertRequestOptions::new()
+        .with_sns_ct_materials(vec![sns_ct.clone()])
+        .with_tx_hash(tx_hash);
+    // Default context_id = TESTING_KMS_CONTEXT
+
+    // Only 1 attempt needed — irrecoverable error means no retry
+    match event_type {
+        EventType::PublicDecryptionRequest => {
+            asserter.push_success(&false.abi_encode());
+        }
+        EventType::UserDecryptionRequest => {
+            let mock_tx = create_mock_user_decryption_request_tx(tx_hash, sns_ct.ctHandle)?;
+            asserter.push_success(&mock_tx);
+        }
+        _ => panic!("Unexpected event type"),
+    };
+
+    let gateway_mock_provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .connect_mocked_client(asserter);
+    info!("Gateway mock started!");
+
+    // Mocking Host chain ACL to ALLOW decryption (1 attempt only)
+    let acl_responses = match event_type {
+        EventType::PublicDecryptionRequest => vec![true],
+        EventType::UserDecryptionRequest => vec![true; 2],
+        _ => unreachable!(),
+    };
+    let acl_contracts_mock =
+        init_host_chains_acl_contracts_mock(sns_ct.ctHandle.as_slice(), acl_responses);
+
+    let kms_mock_server = MockServer::new_grpc("kms_service.v1.CoreServiceEndpoint");
+    kms_mock_server.start().await?;
+    info!("KMS mock server started!");
+
+    let config = Config {
+        kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
+        max_decryption_attempts: MAX_DECRYPTION_ATTEMPTS,
+        db_fast_event_polling: Duration::from_millis(500),
+        ..Default::default()
+    };
+    let kms_worker = init_kms_worker(
+        config,
+        gateway_mock_provider,
+        acl_contracts_mock,
+        test_instance.db(),
+    )
+    .await?;
+
+    insert_rand_request(test_instance.db(), event_type, insert_options).await?;
+
+    let cancel_token = CancellationToken::new();
+    let kms_worker_task = tokio::spawn(kms_worker.start(cancel_token.clone()));
+    info!("KmsWorker started!");
+
+    // Waiting for kms_worker to mark the request as failed (immediately — irrecoverable)
+    while let Err(e) = check_request_failed_in_db(test_instance.db(), event_type).await {
+        warn!("Request not yet failed: {e}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Verify no pending requests remain
+    check_no_uncompleted_request_in_db(test_instance.db(), event_type).await?;
+
+    cancel_token.cancel();
+    kms_worker_task.await.unwrap();
+    Ok(())
+}

--- a/kms-connector/crates/kms-worker/tests/response_publisher.rs
+++ b/kms-connector/crates/kms-worker/tests/response_publisher.rs
@@ -1,4 +1,4 @@
-use alloy::{hex, primitives::U256};
+use alloy::primitives::U256;
 use connector_utils::{
     monitoring::otlp::PropagationContext,
     tests::{
@@ -8,12 +8,12 @@ use connector_utils::{
     types::{
         KmsGrpcResponse, KmsResponse, KmsResponseKind,
         db::{KeyDigestDbItem, KeyType},
+        u256_to_request_id,
     },
 };
 use kms_grpc::kms::v1::{
     CrsGenResult, KeyDigest, KeyGenPreprocResult, KeyGenResult, PublicDecryptionResponse,
-    PublicDecryptionResponsePayload, RequestId, UserDecryptionResponse,
-    UserDecryptionResponsePayload,
+    PublicDecryptionResponsePayload, UserDecryptionResponse, UserDecryptionResponsePayload,
 };
 use kms_worker::core::{DbKmsResponsePublisher, KmsResponsePublisher};
 use sqlx::Row;
@@ -109,9 +109,7 @@ async fn test_publish_prep_keygen_response() -> anyhow::Result<()> {
     let rand_prep_keygen_id = rand_u256();
     let rand_signature = rand_signature();
     let grpc_response = KmsGrpcResponse::PrepKeygen(KeyGenPreprocResult {
-        preprocessing_id: Some(RequestId {
-            request_id: hex::encode(rand_prep_keygen_id.to_be_bytes_vec()),
-        }),
+        preprocessing_id: Some(u256_to_request_id(rand_prep_keygen_id)),
         external_signature: rand_signature.clone(),
     });
     let response = KmsResponse::new(
@@ -156,13 +154,9 @@ async fn test_publish_keygen_response() -> anyhow::Result<()> {
     ];
 
     let grpc_response = KmsGrpcResponse::Keygen(KeyGenResult {
-        request_id: Some(RequestId {
-            request_id: hex::encode(rand_key_id.to_be_bytes_vec()),
-        }),
+        request_id: Some(u256_to_request_id(rand_key_id)),
         external_signature: rand_signature.clone(),
-        preprocessing_id: Some(RequestId {
-            request_id: hex::encode(rand_prep_keygen_id.to_be_bytes_vec()),
-        }),
+        preprocessing_id: Some(u256_to_request_id(rand_prep_keygen_id)),
         key_digests: rand_key_digests.clone(),
     });
     let response = KmsResponse::new(
@@ -204,9 +198,7 @@ async fn test_publish_crsgen_response() -> anyhow::Result<()> {
     let rand_crs_digest = rand_digest().to_vec();
     let rand_signature = rand_signature();
     let grpc_response = KmsGrpcResponse::Crsgen(CrsGenResult {
-        request_id: Some(RequestId {
-            request_id: hex::encode(rand_crs_id.to_be_bytes_vec()),
-        }),
+        request_id: Some(u256_to_request_id(rand_crs_id)),
         crs_digest: rand_crs_digest.clone(),
         external_signature: rand_signature.clone(),
         max_num_bits: 256,

--- a/kms-connector/crates/utils/src/tests/setup/host.rs
+++ b/kms-connector/crates/utils/src/tests/setup/host.rs
@@ -1,4 +1,4 @@
-use crate::types::fhe::extract_chain_id_from_handle;
+use crate::types::handle::extract_chain_id_from_handle;
 use alloy::{
     primitives::Address,
     providers::{ProviderBuilder, RootProvider, mock::Asserter},

--- a/kms-connector/crates/utils/src/types/extra_data.rs
+++ b/kms-connector/crates/utils/src/types/extra_data.rs
@@ -1,0 +1,103 @@
+use alloy::primitives::U256;
+use anyhow::anyhow;
+
+/// The expected length of the `extra_data` bytes.
+const EXPECTED_EXTRA_DATA_LENGTH: usize = 33;
+
+/// The version of the `extra_data` format.
+const EXTRA_DATA_VERSION: u8 = 0x01;
+
+/// Parses the `extra_data` bytes to extract an optional context ID.
+///
+/// Format (v1):
+/// - Byte 0: version (`0x01`)
+/// - Bytes 1..33: context ID (32 bytes, big-endian U256)
+/// - Bytes 33..: optional additional data (ignored)
+///
+/// Special cases for backward compatibility:
+/// - Empty `extra_data` → `Ok(None)`
+/// - `extra_data == [0x00]` → `Ok(None)` (legacy sentinel)
+pub fn parse_extra_data_context(extra_data: &[u8]) -> anyhow::Result<Option<U256>> {
+    if extra_data.is_empty() {
+        return Ok(None);
+    }
+
+    if extra_data == [0x00] {
+        return Ok(None);
+    }
+
+    if extra_data.len() < EXPECTED_EXTRA_DATA_LENGTH {
+        return Err(anyhow!(
+            "extra_data too short: {} bytes, expected at least {} bytes",
+            extra_data.len(),
+            EXPECTED_EXTRA_DATA_LENGTH
+        ));
+    }
+
+    let version = extra_data[0];
+    if version != EXTRA_DATA_VERSION {
+        return Err(anyhow!(
+            "Unsupported extra_data version: 0x{:02x}, expected 0x{:02x}",
+            version,
+            EXTRA_DATA_VERSION
+        ));
+    }
+
+    let context_id_bytes: [u8; 32] = extra_data[1..33]
+        .try_into()
+        .map_err(|e| anyhow!("Failed to extract context_id from extra_data: {e}"))?;
+
+    Ok(Some(U256::from_be_bytes(context_id_bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_returns_none() {
+        assert_eq!(parse_extra_data_context(&[]).unwrap(), None);
+    }
+
+    #[test]
+    fn single_zero_byte_returns_none() {
+        assert_eq!(parse_extra_data_context(&[0x00]).unwrap(), None);
+    }
+
+    #[test]
+    fn valid_v1_exactly() {
+        let mut data = vec![0x01]; // version
+        let context_id = U256::from(69u64);
+        data.extend_from_slice(&context_id.to_be_bytes::<32>());
+        assert_eq!(data.len(), 33);
+
+        let result = parse_extra_data_context(&data).unwrap();
+        assert_eq!(result, Some(U256::from(69u64)));
+    }
+
+    #[test]
+    fn wrong_version_byte_errors() {
+        let mut data = vec![0x02]; // wrong version
+        data.extend_from_slice(&[0u8; 32]);
+
+        let err = parse_extra_data_context(&data).unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported extra_data version"),
+            "Unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn too_short_error() {
+        let mut data = vec![0x01]; // version
+
+        // Add 10 bytes: not empty, not [0x00], but < 33
+        data.extend_from_slice(&[0u8; 10]);
+
+        let err = parse_extra_data_context(&data).unwrap_err();
+        assert!(
+            err.to_string().contains("extra_data too short"),
+            "Unexpected error: {err}"
+        );
+    }
+}

--- a/kms-connector/crates/utils/src/types/grpc.rs
+++ b/kms-connector/crates/utils/src/types/grpc.rs
@@ -1,4 +1,4 @@
-use crate::types::decode_request_id;
+use crate::types::request_id_to_u256;
 use alloy::primitives::U256;
 use anyhow::anyhow;
 use kms_grpc::kms::v1::{
@@ -55,7 +55,7 @@ impl TryFrom<(RequestId, Response<PublicDecryptionResponse>)> for KmsGrpcRespons
     fn try_from(
         value: (RequestId, Response<PublicDecryptionResponse>),
     ) -> Result<Self, Self::Error> {
-        let decryption_id = decode_request_id(value.0)
+        let decryption_id = request_id_to_u256(value.0)
             .map_err(|e| anyhow!("Failed to parse decryption_id: {e}"))?;
 
         Ok(Self::PublicDecryption {
@@ -69,7 +69,7 @@ impl TryFrom<(RequestId, Response<UserDecryptionResponse>)> for KmsGrpcResponse 
     type Error = anyhow::Error;
 
     fn try_from(value: (RequestId, Response<UserDecryptionResponse>)) -> Result<Self, Self::Error> {
-        let decryption_id = decode_request_id(value.0)
+        let decryption_id = request_id_to_u256(value.0)
             .map_err(|e| anyhow!("Failed to parse decryption_id: {e}"))?;
 
         Ok(Self::UserDecryption {

--- a/kms-connector/crates/utils/src/types/handle.rs
+++ b/kms-connector/crates/utils/src/types/handle.rs
@@ -1,4 +1,3 @@
-use alloy::{hex, primitives::U256};
 use anyhow::anyhow;
 use tfhe::FheTypes;
 
@@ -36,14 +35,4 @@ pub fn extract_chain_id_from_handle(handle: &[u8]) -> anyhow::Result<u64> {
             handle.len()
         ))
     }
-}
-
-/// Converts a U256 request ID to a valid hex format that KMS Core expects.
-///
-/// The KMS Core expects a hex string that decodes to exactly 32 bytes.
-pub fn format_request_id(request_id: U256) -> String {
-    // Convert U256 to big-endian bytes
-    let bytes = request_id.to_be_bytes::<32>();
-    // Encode as hex string
-    hex::encode(bytes)
 }

--- a/kms-connector/crates/utils/src/types/mod.rs
+++ b/kms-connector/crates/utils/src/types/mod.rs
@@ -1,7 +1,8 @@
 pub mod db;
-pub mod fhe;
+pub mod extra_data;
 mod grpc;
 pub mod gw_event;
+pub mod handle;
 pub mod kms_response;
 
 pub use grpc::{KmsGrpcRequest, KmsGrpcResponse};
@@ -29,6 +30,17 @@ pub fn u256_to_u32(integer: U256) -> anyhow::Result<u32> {
     Ok(u32::from_le_bytes(integer_lsb.try_into()?))
 }
 
-pub fn decode_request_id(request_id: RequestId) -> Result<U256, FromHexError> {
+/// Converts a U256 request ID to a valid hex format that KMS Core expects.
+///
+/// The KMS Core expects a hex string that decodes to exactly 32 bytes (big-endian).
+pub fn u256_to_request_id(request_id: U256) -> RequestId {
+    let bytes = request_id.to_be_bytes::<32>();
+    RequestId {
+        request_id: hex::encode(bytes),
+    }
+}
+
+/// Converts a RequestId to a U256 (big-endian).
+pub fn request_id_to_u256(request_id: RequestId) -> Result<U256, FromHexError> {
     hex::decode_to_array::<_, 32>(request_id.request_id).map(U256::from_be_bytes)
 }


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/1071

## Summary

The two first commits are just some refactoring/cleaning a bit the way for the upcoming work.

The other commits add KMS context validation to the decryption pipeline. Before sending a decryption request to KMS Core, the kms-connector now extracts a context_id from the request's extraData field, checks it against a local DB table, and rejects requests with unknown or invalidated contexts.

## Key changes
1. New `kms_context` DB table (`migrations/20260226161117_add_kms_context.sql`) — stores context IDs with an `is_valid` boolean flag.
2. New `EthereumListener` (`gw-listener/src/core/ethereum.rs`) — connects to the Ethereum L1 `KMSVerifier` contract, reads the current context ID via `getCurrentKmsContextId()`, and stores it in the DB. Runs alongside the existing `GatewayListener` inside a new parent `EventListener` struct. No live subscription yet (deferred to RFC-005).
3. `extraData` parsing (`utils/src/types/extra_data.rs`) — versioned format: byte 0 = version (0x01), bytes 1-32 = context ID (big-endian U256). Empty or `[0x00]` treated as no-context for backward compat