### PR TITLE
fix(coprocessor): decompress all ciphertexts per operation

### DIFF
--- a/coprocessor/fhevm-engine/scheduler/src/dfg.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg.rs
@@ -179,7 +179,7 @@ pub fn build_component_nodes(
                         dependence_pairs.push((*producer, index, pos));
                     }
                 }
-                DFGTaskInput::Value(_) | DFGTaskInput::Compressed(_) => {}
+                DFGTaskInput::Immediate(_) | DFGTaskInput::Compressed(_) => {}
             }
         }
         let node_idx = graph.add_node((op.is_allowed, index)).index();
@@ -251,7 +251,7 @@ impl ComponentNode {
                             self.inputs.entry(dh.clone()).or_insert(None);
                         }
                     }
-                    DFGTaskInput::Value(_) | DFGTaskInput::Compressed(_) => {}
+                    DFGTaskInput::Immediate(_) | DFGTaskInput::Compressed(_) => {}
                 }
             }
             self.results.push(op.output_handle.clone());
@@ -633,10 +633,12 @@ impl OpNode {
     fn check_ready_inputs(&mut self, ct_map: &mut HashMap<Handle, Option<DFGTxInput>>) -> bool {
         for i in self.inputs.iter_mut() {
             match i {
-                DFGTaskInput::Value(_) | DFGTaskInput::Compressed(_) => continue,
+                DFGTaskInput::Immediate(_) | DFGTaskInput::Compressed(_) => continue,
                 DFGTaskInput::Dependence(d) => {
                     let resolved = match ct_map.get(d) {
-                        Some(Some(DFGTxInput::Value((val, _)))) => DFGTaskInput::Value(val.clone()),
+                        Some(Some(DFGTxInput::Value((val, _)))) => {
+                            DFGTaskInput::Immediate(val.clone())
+                        }
                         Some(Some(DFGTxInput::Compressed(((t, c), _)))) => {
                             DFGTaskInput::Compressed((*t, c.clone()))
                         }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg.rs
@@ -505,7 +505,10 @@ impl DFComponentGraph {
                             .node_weight_mut(dependent_tx_index)
                             .ok_or(SchedulerError::DataflowGraphError)?;
                         dependent_tx.inputs.entry(handle.to_vec()).and_modify(|v| {
-                            *v = Some(DFGTxInput::Value((result.ct.clone(), result.is_allowed)))
+                            *v = Some(DFGTxInput::Compressed((
+                                (result.ct_type, result.compressed_ct.clone()),
+                                result.is_allowed,
+                            )))
                         });
                     }
                 } else {
@@ -524,14 +527,7 @@ impl DFComponentGraph {
                     self.results.push(DFGTxResult {
                         transaction_id: producer_tx.transaction_id.clone(),
                         handle: handle.to_vec(),
-                        compressed_ct: result.and_then(|rok| {
-                            rok.compressed_ct
-                                .map(|cct| (cct.0, cct.1))
-                                .ok_or_else(|| {
-                                    error!(target: "scheduler", {handle = ?hex::encode(handle) }, "Missing compressed ciphertext in task result");
-                                    SchedulerError::SchedulerError.into()
-                                })
-                        }),
+                        compressed_ct: result.map(|rok| (rok.ct_type, rok.compressed_ct)),
                     });
                 }
             }
@@ -636,14 +632,18 @@ impl std::fmt::Debug for OpNode {
 impl OpNode {
     fn check_ready_inputs(&mut self, ct_map: &mut HashMap<Handle, Option<DFGTxInput>>) -> bool {
         for i in self.inputs.iter_mut() {
-            if !matches!(i, DFGTaskInput::Value(_)) {
-                let DFGTaskInput::Dependence(d) = i else {
-                    return false;
-                };
-                let Some(Some(DFGTxInput::Value((val, _)))) = ct_map.get(d) else {
-                    return false;
-                };
-                *i = DFGTaskInput::Value(val.clone());
+            match i {
+                DFGTaskInput::Value(_) | DFGTaskInput::Compressed(_) => continue,
+                DFGTaskInput::Dependence(d) => {
+                    let resolved = match ct_map.get(d) {
+                        Some(Some(DFGTxInput::Value((val, _)))) => DFGTaskInput::Value(val.clone()),
+                        Some(Some(DFGTxInput::Compressed(((t, c), _)))) => {
+                            DFGTaskInput::Compressed((*t, c.clone()))
+                        }
+                        _ => return false,
+                    };
+                    *i = resolved;
+                }
             }
         }
         true

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -403,25 +403,6 @@ fn execute_partition(
                         is_allowed: node.is_allowed,
                         transaction_id: tid.clone(),
                     });
-                    if let (Some(Ok(prev)), Ok(new)) = (res.get(&handle), &value) {
-                        let same =
-                            prev.ct_type == new.ct_type && prev.compressed_ct == new.compressed_ct;
-                        debug_assert!(
-                            same,
-                            "Invariant violation: same handle produced different compressed ciphertext"
-                        );
-                        if !same {
-                            warn!(
-                                target: "scheduler",
-                                {
-                                    handle = ?hex::encode(&handle),
-                                    prev_tx = ?hex::encode(prev.transaction_id.clone()),
-                                    new_tx = ?hex::encode(new.transaction_id.clone())
-                                },
-                                "Same handle produced different compressed ciphertext"
-                            );
-                        }
-                    }
                     res.entry(handle).or_insert(value);
                 }
                 Err(e) => {

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -251,21 +251,6 @@ impl<'a> Scheduler<'a> {
     }
 }
 
-fn decompress_transaction_inputs(
-    inputs: &mut HashMap<Handle, Option<DFGTxInput>>,
-    gpu_idx: usize,
-) -> Result<usize> {
-    let mut count = 0;
-    for txinput in inputs.values_mut() {
-        if let Some(DFGTxInput::Compressed(((t, c), allowed))) = txinput {
-            let decomp = SupportedFheCiphertexts::decompress(*t, c, gpu_idx)?;
-            *txinput = Some(DFGTxInput::Value((decomp, *allowed)));
-            count += 1;
-        }
-    }
-    Ok(count)
-}
-
 fn re_randomise_operation_inputs(
     cts: &mut [SupportedFheCiphertexts],
     opcode: i32,
@@ -327,41 +312,10 @@ fn execute_partition(
                     }
                     continue 'tx;
                 };
-                *i = Some(DFGTxInput::Value((ct.ct.clone(), ct.is_allowed)));
-            }
-        }
-
-        // Decompress ciphertexts
-        {
-            let _guard = tracing::info_span!(
-                "decompress_ciphertexts",
-                txn_id = %txn_id_short,
-                count = tracing::field::Empty,
-            )
-            .entered();
-
-            match decompress_transaction_inputs(tx_inputs, gpu_idx) {
-                Ok(count) => {
-                    tracing::Span::current().record("count", count as i64);
-                }
-                Err(e) => {
-                    error!(target: "scheduler", {transaction_id = ?hex::encode(&tid), error = ?e },
-                           "Error while decompressing inputs");
-                    telemetry::set_current_span_error(&e);
-                    for nidx in dfg.graph.node_identifiers() {
-                        let Some(node) = dfg.graph.node_weight_mut(nidx) else {
-                            error!(target: "scheduler", {index = ?nidx.index() }, "Wrong dataflow graph index");
-                            continue;
-                        };
-                        if node.is_allowed {
-                            res.insert(
-                                node.result_handle.clone(),
-                                Err(SchedulerError::DecompressionError.into()),
-                            );
-                        }
-                    }
-                    continue 'tx;
-                }
+                *i = Some(DFGTxInput::Compressed((
+                    (ct.ct_type, ct.compressed_ct.clone()),
+                    ct.is_allowed,
+                )));
             }
         }
 
@@ -410,7 +364,7 @@ fn execute_partition(
                             // Update input of consumers
                             if let Ok(ref res) = result.1 {
                                 child_node.inputs[*edge.weight() as usize] =
-                                    DFGTaskInput::Value(res.0.clone());
+                                    DFGTaskInput::Compressed((res.0, res.1.clone()));
                             }
                         }
                     }
@@ -422,8 +376,8 @@ fn execute_partition(
                     res.insert(
                         node.result_handle.clone(),
                         result.1.map(|v| TaskResult {
-                            ct: v.0,
-                            compressed_ct: if node.is_allowed { v.1 } else { None },
+                            ct_type: v.0,
+                            compressed_ct: v.1,
                             is_allowed: node.is_allowed,
                             transaction_id: tid.clone(),
                         }),
@@ -460,12 +414,15 @@ fn try_execute_node(
     }
     let mut cts = Vec::with_capacity(node.inputs.len());
     for i in std::mem::take(&mut node.inputs) {
-        if let DFGTaskInput::Value(i) = i {
-            cts.push(i);
-        } else {
-            // That should not be possible as we called the checker.
-            error!(target: "scheduler", { handle = ?hex::encode(&node.result_handle) }, "Computation missing inputs");
-            return Err(SchedulerError::MissingInputs.into());
+        match i {
+            DFGTaskInput::Value(v) => cts.push(v),
+            DFGTaskInput::Compressed((t, c)) => {
+                cts.push(SupportedFheCiphertexts::decompress(t, &c, gpu_idx)?);
+            }
+            DFGTaskInput::Dependence(_) => {
+                error!(target: "scheduler", { handle = ?hex::encode(&node.result_handle) }, "Computation missing inputs");
+                return Err(SchedulerError::MissingInputs.into());
+            }
         }
     }
     // Re-randomize inputs for this operation
@@ -482,24 +439,20 @@ fn try_execute_node(
         RERAND_LATENCY_BATCH_HISTOGRAM.observe(elapsed.as_secs_f64());
     }
     let opcode = node.opcode;
-    let is_allowed = node.is_allowed;
     Ok(run_computation(
         opcode,
         cts,
         node_index,
-        is_allowed,
         gpu_idx,
         transaction_id,
     ))
 }
 
-type OpResult = Result<(SupportedFheCiphertexts, Option<(i16, Vec<u8>)>)>;
-
+type OpResult = Result<(i16, Vec<u8>)>;
 fn run_computation(
     operation: i32,
     inputs: Vec<SupportedFheCiphertexts>,
     graph_node_index: usize,
-    is_allowed: bool,
     gpu_idx: usize,
     transaction_id: &Handle,
 ) -> (usize, OpResult) {
@@ -522,10 +475,7 @@ fn run_computation(
             match compressed {
                 Ok(ct_bytes) => {
                     tracing::Span::current().record("compressed_size", ct_bytes.len() as i64);
-                    (
-                        graph_node_index,
-                        Ok((inputs[0].clone(), Some((ct_type, ct_bytes)))),
-                    )
+                    (graph_node_index, Ok((ct_type, ct_bytes)))
                 }
                 Err(error) => {
                     telemetry::set_current_span_error(&error);
@@ -553,31 +503,26 @@ fn run_computation(
 
             match result {
                 Ok(result) => {
-                    if is_allowed {
-                        // Compression span
-                        let _guard = tracing::info_span!(
-                            "compress_ciphertext",
-                            txn_id = %txn_id_short,
-                            ct_type = result.type_name(),
-                            operation = op_name,
-                            compressed_size = tracing::field::Empty,
-                        )
-                        .entered();
-                        let ct_type = result.type_num();
-                        let compressed = result.compress();
-                        match compressed {
-                            Ok(ct_bytes) => {
-                                tracing::Span::current()
-                                    .record("compressed_size", ct_bytes.len() as i64);
-                                (graph_node_index, Ok((result, Some((ct_type, ct_bytes)))))
-                            }
-                            Err(error) => {
-                                telemetry::set_current_span_error(&error);
-                                (graph_node_index, Err(error.into()))
-                            }
+                    let _guard = tracing::info_span!(
+                        "compress_ciphertext",
+                        txn_id = %txn_id_short,
+                        ct_type = result.type_name(),
+                        operation = op_name,
+                        compressed_size = tracing::field::Empty,
+                    )
+                    .entered();
+                    let ct_type = result.type_num();
+                    let compressed = result.compress();
+                    match compressed {
+                        Ok(ct_bytes) => {
+                            tracing::Span::current()
+                                .record("compressed_size", ct_bytes.len() as i64);
+                            (graph_node_index, Ok((ct_type, ct_bytes)))
                         }
-                    } else {
-                        (graph_node_index, Ok((result, None)))
+                        Err(error) => {
+                            telemetry::set_current_span_error(&error);
+                            (graph_node_index, Err(error.into()))
+                        }
                     }
                 }
                 Err(e) => {

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -273,46 +273,6 @@ fn re_randomise_operation_inputs(
     Ok(())
 }
 
-fn insert_partition_result(
-    res: &mut HashMap<Handle, Result<TaskResult>>,
-    handle: Handle,
-    value: Result<TaskResult>,
-) {
-    let Some(existing) = res.get(&handle) else {
-        res.insert(handle, value);
-        return;
-    };
-
-    match (existing, &value) {
-        // Same handle + same bytes is benign (idempotent propagation).
-        (Ok(prev), Ok(new))
-            if prev.ct_type == new.ct_type && prev.compressed_ct == new.compressed_ct =>
-        {
-            return;
-        }
-        // Same handle + different bytes is a hard invariant break.
-        (Ok(prev), Ok(new)) => {
-            error!(
-                target: "scheduler",
-                {
-                    handle = ?hex::encode(&handle),
-                    prev_tx = ?hex::encode(prev.transaction_id.clone()),
-                    new_tx = ?hex::encode(new.transaction_id.clone())
-                },
-                "Invariant violation: same handle produced different compressed ciphertext"
-            );
-            res.insert(handle, Err(SchedulerError::SchedulerError.into()));
-            return;
-        }
-        // Keep prior failure once present (fail-closed).
-        (Err(_), Ok(_)) => return,
-        // New failures always overwrite.
-        _ => {}
-    }
-
-    res.insert(handle, value);
-}
-
 fn resolve_task_input(
     input: DFGTaskInput,
     gpu_idx: usize,
@@ -436,16 +396,33 @@ fn execute_partition(
                         error!(target: "scheduler", {index = ?nidx.index() }, "Wrong dataflow graph index");
                         continue;
                     };
-                    insert_partition_result(
-                        &mut res,
-                        node.result_handle.clone(),
-                        result.1.map(|v| TaskResult {
-                            ct_type: v.0,
-                            compressed_ct: v.1,
-                            is_allowed: node.is_allowed,
-                            transaction_id: tid.clone(),
-                        }),
-                    );
+                    let handle = node.result_handle.clone();
+                    let value = result.1.map(|v| TaskResult {
+                        ct_type: v.0,
+                        compressed_ct: v.1,
+                        is_allowed: node.is_allowed,
+                        transaction_id: tid.clone(),
+                    });
+                    if let (Some(Ok(prev)), Ok(new)) = (res.get(&handle), &value) {
+                        let same =
+                            prev.ct_type == new.ct_type && prev.compressed_ct == new.compressed_ct;
+                        debug_assert!(
+                            same,
+                            "Invariant violation: same handle produced different compressed ciphertext"
+                        );
+                        if !same {
+                            warn!(
+                                target: "scheduler",
+                                {
+                                    handle = ?hex::encode(&handle),
+                                    prev_tx = ?hex::encode(prev.transaction_id.clone()),
+                                    new_tx = ?hex::encode(new.transaction_id.clone())
+                                },
+                                "Same handle produced different compressed ciphertext"
+                            );
+                        }
+                    }
+                    res.entry(handle).or_insert(value);
                 }
                 Err(e) => {
                     let Some(node) = dfg.graph.node_weight(*nidx) else {
@@ -593,42 +570,6 @@ fn run_computation(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn task_result(tx: u8, ct_type: i16, bytes: &[u8]) -> TaskResult {
-        TaskResult {
-            ct_type,
-            compressed_ct: bytes.to_vec(),
-            is_allowed: true,
-            transaction_id: vec![tx],
-        }
-    }
-
-    #[test]
-    fn insert_partition_result_accepts_same_handle_same_bytes() {
-        let handle = vec![0xAA];
-        let mut res: HashMap<Handle, Result<TaskResult>> = HashMap::new();
-
-        insert_partition_result(&mut res, handle.clone(), Ok(task_result(1, 4, &[1, 2, 3])));
-        insert_partition_result(&mut res, handle.clone(), Ok(task_result(2, 4, &[1, 2, 3])));
-
-        let stored = res.get(&handle).expect("handle must exist");
-        assert!(stored.is_ok(), "same-handle same-bytes must be accepted");
-    }
-
-    #[test]
-    fn insert_partition_result_rejects_same_handle_different_bytes() {
-        let handle = vec![0xBB];
-        let mut res: HashMap<Handle, Result<TaskResult>> = HashMap::new();
-
-        insert_partition_result(&mut res, handle.clone(), Ok(task_result(1, 4, &[1, 2, 3])));
-        insert_partition_result(&mut res, handle.clone(), Ok(task_result(2, 4, &[9, 9, 9])));
-
-        let stored = res.get(&handle).expect("handle must exist");
-        assert!(
-            stored.is_err(),
-            "same-handle different-bytes must fail closed"
-        );
-    }
 
     #[test]
     fn resolve_task_input_accepts_immediate_scalar() {

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -17,7 +17,7 @@ use fhevm_engine_common::telemetry;
 use fhevm_engine_common::tfhe_ops::perform_fhe_operation;
 use fhevm_engine_common::types::{Handle, SupportedFheCiphertexts};
 use fhevm_engine_common::utils::HeartBeat;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use tfhe::ReRandomizationContext;
 use tokio::task::JoinSet;
 use tracing::{error, info, warn};
@@ -273,6 +273,64 @@ fn re_randomise_operation_inputs(
     Ok(())
 }
 
+fn insert_partition_result(
+    res: &mut HashMap<Handle, Result<TaskResult>>,
+    handle: Handle,
+    value: Result<TaskResult>,
+) {
+    match res.entry(handle.clone()) {
+        Entry::Vacant(v) => {
+            v.insert(value);
+        }
+        Entry::Occupied(mut o) => match (o.get(), value) {
+            (Ok(prev), Ok(new)) => {
+                if prev.ct_type == new.ct_type && prev.compressed_ct == new.compressed_ct {
+                    // Same handle + same bytes is benign (idempotent propagation).
+                    return;
+                }
+                error!(
+                    target: "scheduler",
+                    {
+                        handle = ?hex::encode(handle),
+                        prev_tx = ?hex::encode(prev.transaction_id.clone()),
+                        new_tx = ?hex::encode(new.transaction_id.clone())
+                    },
+                    "Invariant violation: same handle produced different compressed ciphertext"
+                );
+                let _ = o.insert(Err(SchedulerError::SchedulerError.into()));
+            }
+            (_, Ok(_)) => {
+                // Keep prior failure once present (fail-closed).
+            }
+            (_, Err(e)) => {
+                let _ = o.insert(Err(e));
+            }
+        },
+    }
+}
+
+fn materialize_task_input(
+    input: DFGTaskInput,
+    gpu_idx: usize,
+    output_handle: &Handle,
+) -> Result<SupportedFheCiphertexts> {
+    match input {
+        DFGTaskInput::Immediate(v) => {
+            if !matches!(v, SupportedFheCiphertexts::Scalar(_)) {
+                error!(target: "scheduler", { handle = ?hex::encode(output_handle) },
+                       "Invariant violation: Immediate input must be scalar");
+                return Err(SchedulerError::SchedulerError.into());
+            }
+            Ok(v)
+        }
+        DFGTaskInput::Compressed((t, c)) => SupportedFheCiphertexts::decompress(t, &c, gpu_idx),
+        DFGTaskInput::Dependence(_) => {
+            error!(target: "scheduler", { handle = ?hex::encode(output_handle) }, "Computation missing inputs");
+            Err(SchedulerError::MissingInputs.into())
+        }
+    }
+}
+
 type ComponentSet = Vec<(DFGraph, HashMap<Handle, Option<DFGTxInput>>, Handle, usize)>;
 fn execute_partition(
     transactions: ComponentSet,
@@ -373,7 +431,8 @@ fn execute_partition(
                         error!(target: "scheduler", {index = ?nidx.index() }, "Wrong dataflow graph index");
                         continue;
                     };
-                    res.insert(
+                    insert_partition_result(
+                        &mut res,
                         node.result_handle.clone(),
                         result.1.map(|v| TaskResult {
                             ct_type: v.0,
@@ -414,16 +473,7 @@ fn try_execute_node(
     }
     let mut cts = Vec::with_capacity(node.inputs.len());
     for i in std::mem::take(&mut node.inputs) {
-        match i {
-            DFGTaskInput::Immediate(v) => cts.push(v),
-            DFGTaskInput::Compressed((t, c)) => {
-                cts.push(SupportedFheCiphertexts::decompress(t, &c, gpu_idx)?);
-            }
-            DFGTaskInput::Dependence(_) => {
-                error!(target: "scheduler", { handle = ?hex::encode(&node.result_handle) }, "Computation missing inputs");
-                return Err(SchedulerError::MissingInputs.into());
-            }
-        }
+        cts.push(materialize_task_input(i, gpu_idx, &node.result_handle)?);
     }
     // Re-randomize inputs for this operation
     {
@@ -532,5 +582,60 @@ fn run_computation(
             }
         }
         Err(e) => (graph_node_index, Err(e.into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task_result(tx: u8, ct_type: i16, bytes: &[u8]) -> TaskResult {
+        TaskResult {
+            ct_type,
+            compressed_ct: bytes.to_vec(),
+            is_allowed: true,
+            transaction_id: vec![tx],
+        }
+    }
+
+    #[test]
+    fn insert_partition_result_accepts_same_handle_same_bytes() {
+        let handle = vec![0xAA];
+        let mut res: HashMap<Handle, Result<TaskResult>> = HashMap::new();
+
+        insert_partition_result(&mut res, handle.clone(), Ok(task_result(1, 4, &[1, 2, 3])));
+        insert_partition_result(&mut res, handle.clone(), Ok(task_result(2, 4, &[1, 2, 3])));
+
+        let stored = res.get(&handle).expect("handle must exist");
+        assert!(stored.is_ok(), "same-handle same-bytes must be accepted");
+    }
+
+    #[test]
+    fn insert_partition_result_rejects_same_handle_different_bytes() {
+        let handle = vec![0xBB];
+        let mut res: HashMap<Handle, Result<TaskResult>> = HashMap::new();
+
+        insert_partition_result(&mut res, handle.clone(), Ok(task_result(1, 4, &[1, 2, 3])));
+        insert_partition_result(&mut res, handle.clone(), Ok(task_result(2, 4, &[9, 9, 9])));
+
+        let stored = res.get(&handle).expect("handle must exist");
+        assert!(
+            stored.is_err(),
+            "same-handle different-bytes must fail closed"
+        );
+    }
+
+    #[test]
+    fn materialize_task_input_accepts_immediate_scalar() {
+        let out = vec![0xCC];
+        let input = DFGTaskInput::Immediate(SupportedFheCiphertexts::Scalar(vec![0x01]));
+        assert!(materialize_task_input(input, 0, &out).is_ok());
+    }
+
+    #[test]
+    fn materialize_task_input_rejects_unresolved_dependence() {
+        let out = vec![0xDD];
+        let input = DFGTaskInput::Dependence(vec![0x01]);
+        assert!(materialize_task_input(input, 0, &out).is_err());
     }
 }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -17,7 +17,7 @@ use fhevm_engine_common::telemetry;
 use fhevm_engine_common::tfhe_ops::perform_fhe_operation;
 use fhevm_engine_common::types::{Handle, SupportedFheCiphertexts};
 use fhevm_engine_common::utils::HeartBeat;
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::HashMap;
 use tfhe::ReRandomizationContext;
 use tokio::task::JoinSet;
 use tracing::{error, info, warn};
@@ -278,35 +278,39 @@ fn insert_partition_result(
     handle: Handle,
     value: Result<TaskResult>,
 ) {
-    match res.entry(handle.clone()) {
-        Entry::Vacant(v) => {
-            v.insert(value);
+    let Some(existing) = res.get(&handle) else {
+        res.insert(handle, value);
+        return;
+    };
+
+    match (existing, &value) {
+        // Same handle + same bytes is benign (idempotent propagation).
+        (Ok(prev), Ok(new))
+            if prev.ct_type == new.ct_type && prev.compressed_ct == new.compressed_ct =>
+        {
+            return;
         }
-        Entry::Occupied(mut o) => match (o.get(), value) {
-            (Ok(prev), Ok(new)) => {
-                if prev.ct_type == new.ct_type && prev.compressed_ct == new.compressed_ct {
-                    // Same handle + same bytes is benign (idempotent propagation).
-                    return;
-                }
-                error!(
-                    target: "scheduler",
-                    {
-                        handle = ?hex::encode(handle),
-                        prev_tx = ?hex::encode(prev.transaction_id.clone()),
-                        new_tx = ?hex::encode(new.transaction_id.clone())
-                    },
-                    "Invariant violation: same handle produced different compressed ciphertext"
-                );
-                let _ = o.insert(Err(SchedulerError::SchedulerError.into()));
-            }
-            (_, Ok(_)) => {
-                // Keep prior failure once present (fail-closed).
-            }
-            (_, Err(e)) => {
-                let _ = o.insert(Err(e));
-            }
-        },
+        // Same handle + different bytes is a hard invariant break.
+        (Ok(prev), Ok(new)) => {
+            error!(
+                target: "scheduler",
+                {
+                    handle = ?hex::encode(&handle),
+                    prev_tx = ?hex::encode(prev.transaction_id.clone()),
+                    new_tx = ?hex::encode(new.transaction_id.clone())
+                },
+                "Invariant violation: same handle produced different compressed ciphertext"
+            );
+            res.insert(handle, Err(SchedulerError::SchedulerError.into()));
+            return;
+        }
+        // Keep prior failure once present (fail-closed).
+        (Err(_), Ok(_)) => return,
+        // New failures always overwrite.
+        _ => {}
     }
+
+    res.insert(handle, value);
 }
 
 fn materialize_task_input(
@@ -315,13 +319,14 @@ fn materialize_task_input(
     output_handle: &Handle,
 ) -> Result<SupportedFheCiphertexts> {
     match input {
-        DFGTaskInput::Immediate(v) => {
-            if !matches!(v, SupportedFheCiphertexts::Scalar(_)) {
-                error!(target: "scheduler", { handle = ?hex::encode(output_handle) },
-                       "Invariant violation: Immediate input must be scalar");
-                return Err(SchedulerError::SchedulerError.into());
-            }
-            Ok(v)
+        DFGTaskInput::Immediate(v @ SupportedFheCiphertexts::Scalar(_)) => Ok(v),
+        DFGTaskInput::Immediate(_) => {
+            error!(
+                target: "scheduler",
+                { handle = ?hex::encode(output_handle) },
+                "Invariant violation: Immediate input must be scalar"
+            );
+            Err(SchedulerError::SchedulerError.into())
         }
         DFGTaskInput::Compressed((t, c)) => SupportedFheCiphertexts::decompress(t, &c, gpu_idx),
         DFGTaskInput::Dependence(_) => {

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -313,7 +313,7 @@ fn insert_partition_result(
     res.insert(handle, value);
 }
 
-fn materialize_task_input(
+fn resolve_task_input(
     input: DFGTaskInput,
     gpu_idx: usize,
     output_handle: &Handle,
@@ -478,7 +478,7 @@ fn try_execute_node(
     }
     let mut cts = Vec::with_capacity(node.inputs.len());
     for i in std::mem::take(&mut node.inputs) {
-        cts.push(materialize_task_input(i, gpu_idx, &node.result_handle)?);
+        cts.push(resolve_task_input(i, gpu_idx, &node.result_handle)?);
     }
     // Re-randomize inputs for this operation
     {
@@ -631,16 +631,16 @@ mod tests {
     }
 
     #[test]
-    fn materialize_task_input_accepts_immediate_scalar() {
+    fn resolve_task_input_accepts_immediate_scalar() {
         let out = vec![0xCC];
         let input = DFGTaskInput::Immediate(SupportedFheCiphertexts::Scalar(vec![0x01]));
-        assert!(materialize_task_input(input, 0, &out).is_ok());
+        assert!(resolve_task_input(input, 0, &out).is_ok());
     }
 
     #[test]
-    fn materialize_task_input_rejects_unresolved_dependence() {
+    fn resolve_task_input_rejects_unresolved_dependence() {
         let out = vec![0xDD];
         let input = DFGTaskInput::Dependence(vec![0x01]);
-        assert!(materialize_task_input(input, 0, &out).is_err());
+        assert!(resolve_task_input(input, 0, &out).is_err());
     }
 }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -415,7 +415,7 @@ fn try_execute_node(
     let mut cts = Vec::with_capacity(node.inputs.len());
     for i in std::mem::take(&mut node.inputs) {
         match i {
-            DFGTaskInput::Value(v) => cts.push(v),
+            DFGTaskInput::Immediate(v) => cts.push(v),
             DFGTaskInput::Compressed((t, c)) => {
                 cts.push(SupportedFheCiphertexts::decompress(t, &c, gpu_idx)?);
             }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs
@@ -396,14 +396,15 @@ fn execute_partition(
                         error!(target: "scheduler", {index = ?nidx.index() }, "Wrong dataflow graph index");
                         continue;
                     };
-                    let handle = node.result_handle.clone();
-                    let value = result.1.map(|v| TaskResult {
-                        ct_type: v.0,
-                        compressed_ct: v.1,
-                        is_allowed: node.is_allowed,
-                        transaction_id: tid.clone(),
-                    });
-                    res.entry(handle).or_insert(value);
+                    res.insert(
+                        node.result_handle.clone(),
+                        result.1.map(|v| TaskResult {
+                            ct_type: v.0,
+                            compressed_ct: v.1,
+                            is_allowed: node.is_allowed,
+                            transaction_id: tid.clone(),
+                        }),
+                    );
                 }
                 Err(e) => {
                     let Some(node) = dfg.graph.node_weight(*nidx) else {

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use fhevm_engine_common::types::{Handle, SupportedFheCiphertexts};
 
 pub struct TaskResult {
-    pub ct: SupportedFheCiphertexts,
-    pub compressed_ct: Option<(i16, Vec<u8>)>,
+    pub ct_type: i16,
+    pub compressed_ct: Vec<u8>,
     pub is_allowed: bool,
     pub transaction_id: Handle,
 }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
@@ -43,14 +43,15 @@ impl std::fmt::Debug for DFGTxInput {
 
 #[derive(Clone)]
 pub enum DFGTaskInput {
-    Value(SupportedFheCiphertexts),
+    // Immediate/scalar operand materialized in the op input list.
+    Immediate(SupportedFheCiphertexts),
     Compressed((i16, Vec<u8>)),
     Dependence(Handle),
 }
 impl std::fmt::Debug for DFGTaskInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Value(_) => write!(f, "DecCT"),
+            Self::Immediate(_) => write!(f, "ImmCT"),
             Self::Compressed(_) => write!(f, "ComCT"),
             Self::Dependence(_) => write!(f, "DepHL"),
         }

--- a/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
+++ b/coprocessor/fhevm-engine/scheduler/src/dfg/types.rs
@@ -43,7 +43,9 @@ impl std::fmt::Debug for DFGTxInput {
 
 #[derive(Clone)]
 pub enum DFGTaskInput {
-    // Immediate/scalar operand materialized in the op input list.
+    // Immediate scalar operand materialized directly in the op input list.
+    // Ciphertext operands must never use this variant: they are always
+    // propagated as compressed bytes across scheduler hops.
     Immediate(SupportedFheCiphertexts),
     Compressed((i16, Vec<u8>)),
     Dependence(Handle),
@@ -63,7 +65,6 @@ pub enum SchedulerError {
     CyclicDependence,
     DataflowGraphError,
     MissingInputs,
-    DecompressionError,
     ReRandomisationError,
     SchedulerError,
 }
@@ -81,9 +82,6 @@ impl std::fmt::Display for SchedulerError {
             }
             Self::MissingInputs => {
                 write!(f, "Missing inputs")
-            }
-            Self::DecompressionError => {
-                write!(f, "Decompression error")
             }
             Self::ReRandomisationError => {
                 write!(f, "Re-randomisation error")

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -413,7 +413,7 @@ WHERE c.transaction_id IN (
                     is_scalar_op_vec.push(is_operand_scalar);
                     this_comp_inputs.push(dh.clone());
                     if is_operand_scalar {
-                        inputs.push(DFGTaskInput::Value(SupportedFheCiphertexts::Scalar(
+                        inputs.push(DFGTaskInput::Immediate(SupportedFheCiphertexts::Scalar(
                             dh.clone(),
                         )));
                     } else {


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1086

## Summary
Rebuild this fix from `main` with a single focused change:
force ciphertext dependencies through a compressed-at-hop path, and decompress only at operation execution.

This aligns with the updated consensus model:
`compress/decompress` and `rerand` are both representation-changing transforms and must be on the same deterministic path.

## What changed
- `coprocessor/fhevm-engine/scheduler/src/dfg/scheduler.rs`
  - remove transaction-wide pre-decompression path
  - when filling missing tx inputs from prior results, always propagate as `DFGTxInput::Compressed`
  - in `try_execute_node`, accept compressed task inputs and decompress right before rerand/compute
  - in `run_computation`, always compress operation outputs (not only allowed)

- `coprocessor/fhevm-engine/scheduler/src/dfg.rs`
  - propagate outputs to dependents as compressed task inputs
  - store task results as `(ct_type, compressed_ct)` payload

- `coprocessor/fhevm-engine/scheduler/src/dfg/types.rs`
  - simplify `TaskResult` to compressed payload only:
    - `ct_type`
    - `compressed_ct`
    - `is_allowed`
    - `transaction_id`

## Deterministic path now
For ciphertext dependencies:
`compressed -> decompress -> rerand -> compute -> compress`

## Validation
```bash
cd coprocessor/fhevm-engine
cargo check -p scheduler
SQLX_OFFLINE=true cargo test -p scheduler --lib
```
