### PR TITLE
fix(coprocessor): stop logging errors for unknown input verif events

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -5389,9 +5389,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -201,19 +201,16 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                                 continue;
                             }
                             if let Ok(event) = InputVerification::InputVerificationEvents::decode_log(&log.inner) {
-                                match event.data {
-                                    InputVerification::InputVerificationEvents::VerifyProofRequest(request) => {
-                                        self.verify_proof_request(db_pool, request, log.clone()).await.
-                                            inspect(|_| {
-                                                verify_proof_success += 1;
-                                            }).inspect_err(|e| {
-                                                error!(error = %e, "VerifyProofRequest processing failed");
-                                                VERIFY_PROOF_FAIL_COUNTER.inc();
-                                        })?;
-                                    },
-                                    _ => {
-                                        error!(log = ?log, "Unknown InputVerification event");
-                                    }
+                                // This listener only reacts to proof requests. Other known InputVerification
+                                // events are expected when multiple coprocessors interact with the gateway.
+                                if let InputVerification::InputVerificationEvents::VerifyProofRequest(request) = event.data {
+                                    self.verify_proof_request(db_pool, request, log.clone()).await.
+                                        inspect(|_| {
+                                            verify_proof_success += 1;
+                                        }).inspect_err(|e| {
+                                            error!(error = %e, "VerifyProofRequest processing failed");
+                                            VERIFY_PROOF_FAIL_COUNTER.inc();
+                                    })?;
                                 }
                             } else {
                                 error!(log = ?log, "Failed to decode InputVerification event log");


### PR DESCRIPTION
Once we have more than one coprocessor running, each coprocessor can see on GW the others' events (e.g. input verification responses) and currently emitting an error which is needless noise.