### PR TITLE
chore(kms-connector): helm chart update

### DIFF
--- a/charts/kms-connector/Chart.yaml
+++ b/charts/kms-connector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-connector
 description: A helm chart to distribute and deploy the Zama KMS Connector services
-version: 1.4.0
+version: 1.4.1
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/kms-connector/templates/kms-connector-gw-listener-deployment.yaml
+++ b/charts/kms-connector/templates/kms-connector-gw-listener-deployment.yaml
@@ -68,6 +68,12 @@ spec:
               value: {{ .Values.commonConfig.gatewayContractAddresses.gatewayConfig | quote }}
             - name: KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS
               value: {{ .Values.commonConfig.gatewayContractAddresses.kmsGeneration | quote }}
+            - name: KMS_CONNECTOR_ETHEREUM_URL
+              value: {{ .Values.commonConfig.ethereumUrl | quote }}
+            - name: KMS_CONNECTOR_ETHEREUM_CHAIN_ID
+              value: {{ .Values.commonConfig.ethereumChainId | quote }}
+            - name: KMS_CONNECTOR_KMS_VERIFIER_ADDRESS
+              value: {{ .Values.commonConfig.ethereumContractAddresses.kmsVerifier | quote }}
           {{- if default .Values.commonConfig.tracing.enabled .Values.kmsConnectorGwListener.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .Values.commonConfig.tracing.endpoint }}

--- a/charts/kms-connector/templates/kms-connector-tx-sender-deployment.yaml
+++ b/charts/kms-connector/templates/kms-connector-tx-sender-deployment.yaml
@@ -68,6 +68,12 @@ spec:
               value: {{ .Values.commonConfig.gatewayContractAddresses.gatewayConfig | quote }}
             - name: KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS
               value: {{ .Values.commonConfig.gatewayContractAddresses.kmsGeneration | quote }}
+            - name: KMS_CONNECTOR_ETHEREUM_URL
+              value: {{ .Values.commonConfig.ethereumUrl | quote }}
+            - name: KMS_CONNECTOR_ETHEREUM_CHAIN_ID
+              value: {{ .Values.commonConfig.ethereumChainId | quote }}
+            - name: KMS_CONNECTOR_KMS_VERIFIER_ADDRESS
+              value: {{ .Values.commonConfig.ethereumContractAddresses.kmsVerifier | quote }}
             {{- if .Values.kmsConnectorTxSender.wallet.awsKms.enabled }}
             - name: KMS_CONNECTOR_AWS_KMS_CONFIG__KEY_ID
               valueFrom:

--- a/charts/kms-connector/values.yaml
+++ b/charts/kms-connector/values.yaml
@@ -29,6 +29,16 @@ commonConfig:
     gatewayConfig: "0xeAC2EfFA07844aB326D92d1De29E136a6793DFFA"
     kmsGeneration: "0xF0bFB159C7381F7CB332586004d8247252C5b816"
 
+  # Ethereum chain RPC node endpoint (HTTP)
+  ethereumUrl: "http://ethereum-node:8545"
+
+  # Ethereum chain identifier
+  ethereumChainId: "11155111"
+
+  # Ethereum smart contract addresses
+  ethereumContractAddresses:
+    kmsVerifier: "0x0000000000000000000000000000000000000000"
+
   # Distributed tracing configuration
   tracing:
     enabled: false


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/1091

Only the `charts/kms-connector/templates/kms-connector-gw-listener-deployment.yaml` update is required for the RFC-003 to be completed.

Update made to `charts/kms-connector/templates/kms-connector-tx-sender-deployment.yaml` is just for the upcoming RFC-005, doing it now to avoid forgetting about it :slightly_smiling_face: 