### PR TITLE
chore(coprocessor): update tfhe-rs to 1.5.4

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -1922,7 +1922,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1942,7 +1942,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -4420,7 +4420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -6622,7 +6622,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tracing",
  "unicode-width",
 ]
@@ -7089,7 +7089,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "url",
  "zip",
 ]
@@ -7234,9 +7234,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe"
-version = "1.5.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fea64405f4e7bce2cea50c3638a32086bc0e22e039bb7bc054389e6633754b3"
+checksum = "3c8dd9c738c359a36c23c5816240bdd1ec4d0029030019fbb832c06c5dfd3e2c"
 dependencies = [
  "aligned-vec",
  "bincode",
@@ -7261,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-csprng"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e944e0db763d6957e5c2214f06d46da73b8a29b2d1ef087f534f6a3d239777"
+checksum = "c7a55bd4a1063a4792d50028efec52e5002beb142ab69ddcf7828a14af9698e3"
 dependencies = [
  "aes",
  "getrandom 0.2.16",
@@ -7275,9 +7275,9 @@ dependencies = [
 
 [[package]]
 name = "tfhe-cuda-backend"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d3c47abe0f26b7b1d021b15bf0ca5d7a3512dda830cfa2df8eb11ba6128527"
+checksum = "07408b8faff3ca4f9a486aaebd5f4cb5445bb8fc5aaf8e12c4f947b4474a01e3"
 dependencies = [
  "bindgen 0.71.1",
  "cmake",

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -56,7 +56,9 @@ prometheus = "0.14.0"
 prost = "0.13.5"
 rand = "0.9.1"
 rayon = "1.11.0"
-reqwest = { version = "0.12.20", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12.20", default-features = false, features = [
+    "rustls-tls",
+] }
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 semver = "1.0.26"
 serde = "1.0.225"
@@ -71,11 +73,11 @@ sqlx = { version = "0.8.6", default-features = false, features = [
     "time",
     "postgres",
     "uuid",
-    "chrono"
+    "chrono",
 ] }
 testcontainers = "0.24.0"
 thiserror = "2.0.12"
-tfhe = { version = "=1.5.1", features = [
+tfhe = { version = "=1.5.4", features = [
     "boolean",
     "shortint",
     "integer",

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/tfhe_ops.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/tfhe_ops.rs
@@ -291,10 +291,10 @@ pub fn extract_ct_list(
 ) -> Result<Vec<SupportedFheCiphertexts>, FhevmError> {
     let mut res = Vec::new();
     for idx in 0..expanded.len() {
-        let Some(data_kind) = expanded.get_kind_of(idx) else {
+        let data_kind = expanded.get_kind_of(idx).ok_or_else(|| {
             tracing::error!(len = expanded.len(), idx, "get_kind_of returned None");
-            continue;
-        };
+            FhevmError::MissingTfheRsData
+        })?;
 
         match data_kind {
             tfhe::FheTypes::Bool => {


### PR DESCRIPTION
Also, treat `get_kind_of()` returning None for a correct index as an error instead of skipping the index. The skipping was there to workaround a bug in tfhe-rs that is now fixed in 1.5.4.