### PR TITLE
feat(library-solidity): add Soldeer publishing to library-solidity CI

### DIFF
--- a/.github/workflows/library-solidity-publish.yml
+++ b/.github/workflows/library-solidity-publish.yml
@@ -89,4 +89,5 @@ jobs:
       - name: Publish to Soldeer
         env:
           SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_TOKEN }}
-        run: forge soldeer push @fhevm-solidity~${{ steps.version.outputs.version }} . --skip-warnings
+          VERSION: ${{ steps.version.outputs.version }}
+        run: forge soldeer push "@fhevm-solidity~${VERSION}" . --skip-warnings

--- a/.github/workflows/library-solidity-publish.yml
+++ b/.github/workflows/library-solidity-publish.yml
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: "false"
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
 
       - name: Read version from package.json
         id: version

--- a/.github/workflows/library-solidity-publish.yml
+++ b/.github/workflows/library-solidity-publish.yml
@@ -63,3 +63,30 @@ jobs:
           package: ./library-solidity/package.json
           provenance: true
           access: public
+
+  publish-soldeer:
+    name: library-solidity-publish/publish-soldeer
+    if: ${{ inputs.release == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./library-solidity
+    permissions:
+      contents: "read"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: "false"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Read version from package.json
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to Soldeer
+        env:
+          SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_TOKEN }}
+        run: forge soldeer push @fhevm-solidity~${{ steps.version.outputs.version }} . --skip-warnings

--- a/library-solidity/.soldeerignore
+++ b/library-solidity/.soldeerignore
@@ -1,0 +1,47 @@
+# CI & config files
+ci/
+.github/
+
+# Node.js
+node_modules/
+package.json
+package-lock.json
+
+# Config & tooling
+.env*
+.eslintignore
+.eslintrc.yml
+.gitpod.yml
+.lintstagedrc.json
+.npmignore
+.prettierignore
+.prettierrc.json
+.solcover.js
+.solhintignore
+hardhat.config.ts
+tsconfig.json
+commitlint.config.ts
+codegen.config.json
+mlc_config.json
+foundry.toml
+remappings.txt
+soldeer.lock
+CustomProvider.ts
+
+# Source directories not needed by consumers
+codegen/
+test/
+tasks/
+examples/
+lib-js/
+dependencies/
+
+# Build artifacts
+artifacts/
+cache/
+cache_forge/
+out/
+types/
+typechain/
+typechain-types/
+coverage/


### PR DESCRIPTION
## Summary
- Add `publish-soldeer` job to `library-solidity-publish` workflow, publishing `@fhevm-solidity` to [soldeer.xyz](https://soldeer.xyz) on release (parallel with npm publish)
- Add `.soldeerignore` in `library-solidity/` to ship only Solidity sources (`lib/`, `config/`, README, SECURITY)

## Prerequisites before going live
- [ ] Create `@fhevm-solidity` project on soldeer.xyz (public, under `zama-bot` account)
- [x] Ensure `SOLDEER_TOKEN` secret is set on this repo