### PR TITLE
feat(test-suite): add multi-chain e2e testing support

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -76,6 +76,10 @@ on:
         description: "KMS Core version"
         default: ""
         type: string
+      multi-chain:
+        description: "Enable multi-chain mode (deploys a second host chain)"
+        default: false
+        type: boolean
   workflow_call:
     secrets:
       GHCR_READ_TOKEN:
@@ -176,8 +180,14 @@ jobs:
 
       - name: Dry run
         working-directory: test-suite/fhevm
+        env:
+          MULTI_CHAIN: ${{ inputs.multi-chain && 'true' || 'false' }}
         run: |
-          args=(--target latest-main --scenario two-of-two)
+          scenario="two-of-two"
+          if [ "$MULTI_CHAIN" = "true" ]; then
+            scenario="two-of-two-multi-chain"
+          fi
+          args=(--target latest-main --scenario "$scenario")
           if [ "$BUILD" = "true" ]; then
             args+=(--build)
           fi
@@ -185,8 +195,14 @@ jobs:
 
       - name: Boot fhevm Stack
         working-directory: test-suite/fhevm
+        env:
+          MULTI_CHAIN: ${{ inputs.multi-chain && 'true' || 'false' }}
         run: |
-          args=(--target latest-main --scenario two-of-two)
+          scenario="two-of-two"
+          if [ "$MULTI_CHAIN" = "true" ]; then
+            scenario="two-of-two-multi-chain"
+          fi
+          args=(--target latest-main --scenario "$scenario")
           if [ "$BUILD" = "true" ]; then
             args+=(--build)
           fi
@@ -196,6 +212,18 @@ jobs:
         working-directory: test-suite/fhevm
         run: |
           ./fhevm-cli test standard
+
+      - name: Heavy e2e suite
+        working-directory: test-suite/fhevm
+        run: |
+          # Heavy is the long-running operators lane.
+          ./fhevm-cli test heavy
+
+      - name: Multi-chain isolation tests
+        if: ${{ inputs.multi-chain }}
+        working-directory: test-suite/fhevm
+        run: |
+          ./fhevm-cli test multi-chain-isolation
 
       - name: Show logs
         working-directory: test-suite/fhevm

--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -76,10 +76,10 @@ on:
         description: "KMS Core version"
         default: ""
         type: string
-      multi-chain:
-        description: "Enable multi-chain mode (deploys a second host chain)"
-        default: false
-        type: boolean
+      scenario:
+        description: "Deployment scenario (e.g. two-of-two, two-of-two-multi-chain)"
+        default: "two-of-two"
+        type: string
   workflow_call:
     secrets:
       GHCR_READ_TOKEN:
@@ -125,6 +125,7 @@ jobs:
       TEST_SUITE_VERSION: ${{ inputs.test-suite-version }}
       RELAYER_VERSION: ${{ inputs.relayer-version }}
       CORE_VERSION: ${{ inputs.kms-core-version }}
+      SCENARIO: ${{ inputs.scenario || 'two-of-two' }}
     runs-on: large_ubuntu_32
     steps:
       - name: Checkout code
@@ -180,14 +181,8 @@ jobs:
 
       - name: Dry run
         working-directory: test-suite/fhevm
-        env:
-          MULTI_CHAIN: ${{ inputs.multi-chain && 'true' || 'false' }}
         run: |
-          scenario="two-of-two"
-          if [ "$MULTI_CHAIN" = "true" ]; then
-            scenario="two-of-two-multi-chain"
-          fi
-          args=(--target latest-main --scenario "$scenario")
+          args=(--target latest-main --scenario "$SCENARIO")
           if [ "$BUILD" = "true" ]; then
             args+=(--build)
           fi
@@ -195,14 +190,8 @@ jobs:
 
       - name: Boot fhevm Stack
         working-directory: test-suite/fhevm
-        env:
-          MULTI_CHAIN: ${{ inputs.multi-chain && 'true' || 'false' }}
         run: |
-          scenario="two-of-two"
-          if [ "$MULTI_CHAIN" = "true" ]; then
-            scenario="two-of-two-multi-chain"
-          fi
-          args=(--target latest-main --scenario "$scenario")
+          args=(--target latest-main --scenario "$SCENARIO")
           if [ "$BUILD" = "true" ]; then
             args+=(--build)
           fi
@@ -212,18 +201,6 @@ jobs:
         working-directory: test-suite/fhevm
         run: |
           ./fhevm-cli test standard
-
-      - name: Heavy e2e suite
-        working-directory: test-suite/fhevm
-        run: |
-          # Heavy is the long-running operators lane.
-          ./fhevm-cli test heavy
-
-      - name: Multi-chain isolation tests
-        if: ${{ inputs.multi-chain }}
-        working-directory: test-suite/fhevm
-        run: |
-          ./fhevm-cli test multi-chain-isolation
 
       - name: Show logs
         working-directory: test-suite/fhevm

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -46,7 +46,13 @@ cd test-suite/fhevm
 ./fhevm-cli up --target sha --sha 9587546
 
 # Deploy with threshold 2 out of 2 coprocessors (local multicoprocessor mode)
-./fhevm-cli up --target latest-supported --scenario ./scenarios/two-of-two.yaml
+./fhevm-cli up --target latest-supported --scenario two-of-two
+
+# Deploy with multi-chain (two host chains)
+./fhevm-cli up --target latest-supported --scenario multi-chain
+
+# Deploy with multi-chain + multi-coprocessor
+./fhevm-cli up --target latest-supported --scenario two-of-two-multi-chain
 
 # Resume a failed deploy from a specific step (keeps existing containers/volumes)
 ./fhevm-cli up --target latest-supported --resume --from-step kms-connector
@@ -58,6 +64,7 @@ cd test-suite/fhevm
 ./fhevm-cli test public-decrypt-http-ebool
 ./fhevm-cli test erc20
 ./fhevm-cli test hcu-block-cap
+./fhevm-cli test multi-chain-isolation  # requires multi-chain scenario
 
 # Boot with a local coprocessor override (all services)
 ./fhevm-cli up --target latest-supported --override coprocessor

--- a/test-suite/e2e/test/multiChain/multiChain.fixture.ts
+++ b/test-suite/e2e/test/multiChain/multiChain.fixture.ts
@@ -1,0 +1,28 @@
+import { ethers } from 'ethers';
+
+import { deployContract } from './multiChainHelper';
+
+export interface ChainContracts {
+  erc20: ethers.Contract;
+  erc20Address: string;
+  userDecrypt: ethers.Contract;
+  userDecryptAddress: string;
+  rand: ethers.Contract;
+}
+
+export async function deployChainFixture(
+  deployer: ethers.Signer,
+): Promise<ChainContracts> {
+  const erc20 = await deployContract('EncryptedERC20', deployer, 'Token', 'TKN');
+  const erc20Address = await erc20.getAddress();
+
+  const mintTx = await erc20.connect(deployer).getFunction('mint')(1_000_000, { gasLimit: 10_000_000 });
+  await mintTx.wait();
+
+  const userDecrypt = await deployContract('UserDecrypt', deployer);
+  const userDecryptAddress = await userDecrypt.getAddress();
+
+  const rand = await deployContract('Rand', deployer);
+
+  return { erc20, erc20Address, userDecrypt, userDecryptAddress, rand };
+}

--- a/test-suite/e2e/test/multiChain/multiChainHelper.ts
+++ b/test-suite/e2e/test/multiChain/multiChainHelper.ts
@@ -1,0 +1,127 @@
+import { ethers as hardhatEthers } from 'hardhat';
+import { ethers } from 'ethers';
+import { createInstance as createFhevmInstance } from '@zama-fhe/relayer-sdk/node';
+import { vars } from 'hardhat/config';
+
+const defaultMnemonic =
+  'adapt mosquito move limb mobile illegal tree voyage juice mosquito burger raise father hope layer';
+const mnemonic: string = process.env.MNEMONIC ?? vars.get('MNEMONIC', defaultMnemonic);
+
+const aclAddress = process.env.ACL_CONTRACT_ADDRESS!;
+const kmsVerifierAddress = process.env.KMS_VERIFIER_CONTRACT_ADDRESS!;
+const inputVerifierAddress = process.env.INPUT_VERIFIER_CONTRACT_ADDRESS!;
+const decryptionAddress = process.env.DECRYPTION_ADDRESS!;
+const inputVerificationAddress = process.env.INPUT_VERIFICATION_ADDRESS!;
+const relayerUrl = process.env.RELAYER_URL!;
+const gatewayChainId = Number(process.env.CHAIN_ID_GATEWAY!);
+
+export interface ChainConfig {
+  rpcUrl: string;
+  chainId: number;
+}
+
+export const CHAIN_A: ChainConfig = {
+  rpcUrl: process.env.RPC_URL || 'http://localhost:8545',
+  chainId: Number(process.env.CHAIN_ID_HOST || 12345),
+};
+
+export const CHAIN_B: ChainConfig = {
+  rpcUrl: process.env.RPC_URL_CHAIN_B || 'http://localhost:8547',
+  chainId: Number(process.env.CHAIN_ID_HOST_B || 67890),
+};
+
+const providers = new Map<string, ethers.JsonRpcProvider>();
+
+export function getProvider(chain: ChainConfig): ethers.JsonRpcProvider {
+  if (!providers.has(chain.rpcUrl)) {
+    providers.set(chain.rpcUrl, new ethers.JsonRpcProvider(chain.rpcUrl));
+  }
+  return providers.get(chain.rpcUrl)!;
+}
+
+export type ManagedWallet = ethers.NonceManager & { address: string; reset: () => void };
+
+function wrapWithNonceManager(wallet: ethers.Wallet): ManagedWallet {
+  const nm = new ethers.NonceManager(wallet);
+  (nm as any).address = wallet.address;
+  return nm as ManagedWallet;
+}
+
+export interface NamedSigners {
+  alice: ManagedWallet;
+  bob: ManagedWallet;
+  carol: ManagedWallet;
+  dave: ManagedWallet;
+  eve: ManagedWallet;
+}
+
+const signersCache = new Map<string, NamedSigners>();
+
+export function getSigners(chain: ChainConfig): NamedSigners {
+  if (!signersCache.has(chain.rpcUrl)) {
+    const provider = getProvider(chain);
+    const hdNode = ethers.HDNodeWallet.fromMnemonic(
+      ethers.Mnemonic.fromPhrase(mnemonic),
+      "m/44'/60'/0'/0",
+    );
+    const mkWallet = (i: number) => wrapWithNonceManager(
+      new ethers.Wallet(hdNode.deriveChild(i).privateKey, provider),
+    );
+    signersCache.set(chain.rpcUrl, {
+      alice: mkWallet(0),
+      bob: mkWallet(1),
+      carol: mkWallet(2),
+      dave: mkWallet(3),
+      eve: mkWallet(4),
+    });
+  }
+  return signersCache.get(chain.rpcUrl)!;
+}
+
+export function getWallet(chain: ChainConfig, index: number): ManagedWallet {
+  const provider = getProvider(chain);
+  const hdNode = ethers.HDNodeWallet.fromMnemonic(
+    ethers.Mnemonic.fromPhrase(mnemonic),
+    "m/44'/60'/0'/0",
+  );
+  return wrapWithNonceManager(
+    new ethers.Wallet(hdNode.deriveChild(index).privateKey, provider),
+  );
+}
+
+export async function createInstance(chain: ChainConfig) {
+  return createFhevmInstance({
+    verifyingContractAddressDecryption: decryptionAddress,
+    verifyingContractAddressInputVerification: inputVerificationAddress,
+    kmsContractAddress: kmsVerifierAddress,
+    inputVerifierContractAddress: inputVerifierAddress,
+    aclContractAddress: aclAddress,
+    network: chain.rpcUrl,
+    relayerUrl,
+    gatewayChainId,
+    chainId: chain.chainId,
+  });
+}
+
+export async function deployContract(
+  contractName: string,
+  deployer: ethers.Signer,
+  ...constructorArgs: unknown[]
+): Promise<ethers.Contract> {
+  const artifact = await hardhatEthers.getContractFactory(contractName);
+  const factory = new ethers.ContractFactory(artifact.interface, artifact.bytecode, deployer);
+  const contract = await factory.deploy(...constructorArgs, { gasLimit: 10_000_000 });
+  await contract.waitForDeployment();
+  return contract as ethers.Contract;
+}
+
+export async function evmSnapshot(provider: { send: (method: string, params: unknown[]) => Promise<unknown> }): Promise<string> {
+  return provider.send('evm_snapshot', []) as Promise<string>;
+}
+
+export async function evmRevert(
+  provider: { send: (method: string, params: unknown[]) => Promise<unknown> },
+  snapshotId: string,
+): Promise<boolean> {
+  return provider.send('evm_revert', [snapshotId]) as Promise<boolean>;
+}

--- a/test-suite/e2e/test/multiChain/multiChainHelper.ts
+++ b/test-suite/e2e/test/multiChain/multiChainHelper.ts
@@ -54,12 +54,6 @@ function parseHostChains(): ChainConfig[] {
 /** All discovered host chains. Index 0 is the primary chain. */
 export const HOST_CHAINS: ChainConfig[] = parseHostChains();
 
-/** Primary host chain (always present). */
-export const CHAIN_A: ChainConfig = HOST_CHAINS[0];
-
-/** First extra host chain, or undefined in single-chain mode. Guard with `if (!CHAIN_B) this.skip()`. */
-export const CHAIN_B: ChainConfig | undefined = HOST_CHAINS[1];
-
 const providers = new Map<string, ethers.JsonRpcProvider>();
 
 export function getProvider(chain: ChainConfig): ethers.JsonRpcProvider {

--- a/test-suite/e2e/test/multiChain/multiChainHelper.ts
+++ b/test-suite/e2e/test/multiChain/multiChainHelper.ts
@@ -20,15 +20,36 @@ export interface ChainConfig {
   chainId: number;
 }
 
-export const CHAIN_A: ChainConfig = {
-  rpcUrl: process.env.RPC_URL || 'http://localhost:8545',
-  chainId: Number(process.env.CHAIN_ID_HOST || 12345),
-};
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
 
-export const CHAIN_B: ChainConfig = {
-  rpcUrl: process.env.RPC_URL_CHAIN_B || 'http://localhost:8547',
-  chainId: Number(process.env.CHAIN_ID_HOST_B || 67890),
-};
+/** Discovers all host chains from indexed env vars (HOST_CHAIN_1_*, HOST_CHAIN_2_*, …). */
+function parseHostChains(): ChainConfig[] {
+  const primary: ChainConfig = {
+    rpcUrl: requireEnv('RPC_URL'),
+    chainId: Number(requireEnv('CHAIN_ID_HOST')),
+  };
+  const chains: ChainConfig[] = [primary];
+  for (let i = 1; ; i++) {
+    const rpcUrl = process.env[`HOST_CHAIN_${i}_RPC_URL`];
+    const chainId = process.env[`HOST_CHAIN_${i}_CHAIN_ID`];
+    if (!rpcUrl || !chainId) break;
+    chains.push({ rpcUrl, chainId: Number(chainId) });
+  }
+  return chains;
+}
+
+/** All discovered host chains. Index 0 is the primary chain. */
+export const HOST_CHAINS: ChainConfig[] = parseHostChains();
+
+/** Primary host chain (always present). */
+export const CHAIN_A: ChainConfig = HOST_CHAINS[0];
+
+/** First extra host chain, or undefined in single-chain mode. Guard with `if (!CHAIN_B) this.skip()`. */
+export const CHAIN_B: ChainConfig | undefined = HOST_CHAINS[1];
 
 const providers = new Map<string, ethers.JsonRpcProvider>();
 

--- a/test-suite/e2e/test/multiChain/multiChainHelper.ts
+++ b/test-suite/e2e/test/multiChain/multiChainHelper.ts
@@ -7,9 +7,6 @@ const defaultMnemonic =
   'adapt mosquito move limb mobile illegal tree voyage juice mosquito burger raise father hope layer';
 const mnemonic: string = process.env.MNEMONIC ?? vars.get('MNEMONIC', defaultMnemonic);
 
-const aclAddress = process.env.ACL_CONTRACT_ADDRESS!;
-const kmsVerifierAddress = process.env.KMS_VERIFIER_CONTRACT_ADDRESS!;
-const inputVerifierAddress = process.env.INPUT_VERIFIER_CONTRACT_ADDRESS!;
 const decryptionAddress = process.env.DECRYPTION_ADDRESS!;
 const inputVerificationAddress = process.env.INPUT_VERIFICATION_ADDRESS!;
 const relayerUrl = process.env.RELAYER_URL!;
@@ -18,6 +15,9 @@ const gatewayChainId = Number(process.env.CHAIN_ID_GATEWAY!);
 export interface ChainConfig {
   rpcUrl: string;
   chainId: number;
+  aclAddress: string;
+  kmsVerifierAddress: string;
+  inputVerifierAddress: string;
 }
 
 function requireEnv(name: string): string {
@@ -31,13 +31,22 @@ function parseHostChains(): ChainConfig[] {
   const primary: ChainConfig = {
     rpcUrl: requireEnv('RPC_URL'),
     chainId: Number(requireEnv('CHAIN_ID_HOST')),
+    aclAddress: requireEnv('ACL_CONTRACT_ADDRESS'),
+    kmsVerifierAddress: requireEnv('KMS_VERIFIER_CONTRACT_ADDRESS'),
+    inputVerifierAddress: requireEnv('INPUT_VERIFIER_CONTRACT_ADDRESS'),
   };
   const chains: ChainConfig[] = [primary];
   for (let i = 1; ; i++) {
     const rpcUrl = process.env[`HOST_CHAIN_${i}_RPC_URL`];
     const chainId = process.env[`HOST_CHAIN_${i}_CHAIN_ID`];
     if (!rpcUrl || !chainId) break;
-    chains.push({ rpcUrl, chainId: Number(chainId) });
+    chains.push({
+      rpcUrl,
+      chainId: Number(chainId),
+      aclAddress: requireEnv(`HOST_CHAIN_${i}_ACL_CONTRACT_ADDRESS`),
+      kmsVerifierAddress: requireEnv(`HOST_CHAIN_${i}_KMS_VERIFIER_CONTRACT_ADDRESS`),
+      inputVerifierAddress: requireEnv(`HOST_CHAIN_${i}_INPUT_VERIFIER_CONTRACT_ADDRESS`),
+    });
   }
   return chains;
 }
@@ -114,9 +123,9 @@ export async function createInstance(chain: ChainConfig) {
   return createFhevmInstance({
     verifyingContractAddressDecryption: decryptionAddress,
     verifyingContractAddressInputVerification: inputVerificationAddress,
-    kmsContractAddress: kmsVerifierAddress,
-    inputVerifierContractAddress: inputVerifierAddress,
-    aclContractAddress: aclAddress,
+    kmsContractAddress: chain.kmsVerifierAddress,
+    inputVerifierContractAddress: chain.inputVerifierAddress,
+    aclContractAddress: chain.aclAddress,
     network: chain.rpcUrl,
     relayerUrl,
     gatewayChainId,

--- a/test-suite/e2e/test/multiChain/multiChainIsolation.ts
+++ b/test-suite/e2e/test/multiChain/multiChainIsolation.ts
@@ -1,0 +1,338 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { createInstance as createHardhatInstance } from '../instance';
+import { getSigners as getHardhatSigners, initSigners } from '../signers';
+import { userDecryptSingleHandle } from '../utils';
+import {
+  CHAIN_A,
+  CHAIN_B,
+  getProvider,
+  getSigners,
+  getWallet,
+  createInstance,
+  evmSnapshot,
+  evmRevert,
+} from './multiChainHelper';
+import { deployChainFixture } from './multiChain.fixture';
+
+import type { EncryptedERC20 } from '../../types/contracts';
+
+describe('Multi-Chain State Isolation', function () {
+  this.timeout(300_000);
+
+  before(async function () {
+    if (!process.env.CHAIN_ID_HOST_B) {
+      this.skip();
+    }
+
+    await initSigners(2);
+    this.hardhatSigners = await getHardhatSigners();
+    this.signersA = getSigners(CHAIN_A);
+    this.signersB = getSigners(CHAIN_B);
+
+    this.deployerA = getWallet(CHAIN_A, 50);
+    this.deployerB = getWallet(CHAIN_B, 50);
+
+    this.chainA = await deployChainFixture(this.deployerA);
+    this.chainB = await deployChainFixture(this.deployerB);
+  });
+
+  afterEach(async function () {
+    try {
+      await ethers.provider.send('evm_setAutomine', [true]);
+    } catch {
+      // automine may already be enabled
+    }
+  });
+
+  describe('User Input Across Chains', function () {
+    it('encrypted input and FHE computation work independently on both chains', async function () {
+      const erc20A = this.chainA.erc20 as unknown as EncryptedERC20;
+      const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
+
+      // Chain A: encrypted transfer to carol (unused by other tests)
+      const instanceA = await createInstance(CHAIN_A);
+      const inputA = instanceA.createEncryptedInput(this.chainA.erc20Address, this.deployerA.address);
+      inputA.add64(200);
+      const encryptedA = await inputA.encrypt();
+
+      const txA = await (erc20A.connect(this.deployerA) as EncryptedERC20)['transfer(address,bytes32,bytes)'](
+        this.signersA.carol.address,
+        encryptedA.handles[0],
+        encryptedA.inputProof,
+        { gasLimit: 10_000_000 },
+      );
+      const receiptA = await txA.wait();
+      expect(receiptA?.status).to.eq(1);
+
+      const balanceHandleCarolA = await erc20A.balanceOf(this.signersA.carol.address);
+      expect(balanceHandleCarolA).to.not.eq(ethers.ZeroHash);
+      expect(balanceHandleCarolA.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+
+      const { publicKey: pubKeyA, privateKey: privKeyA } = instanceA.generateKeypair();
+      const decryptedA = await userDecryptSingleHandle(
+        balanceHandleCarolA,
+        this.chainA.erc20Address,
+        instanceA,
+        this.signersA.carol,
+        privKeyA,
+        pubKeyA,
+      );
+      expect(decryptedA).to.equal(200n);
+
+      // Chain B: encrypted transfer to carol
+      const instanceB = await createInstance(CHAIN_B);
+      const inputB = instanceB.createEncryptedInput(this.chainB.erc20Address, this.deployerB.address);
+      inputB.add64(300);
+      const encryptedB = await inputB.encrypt();
+
+      const txB = await (erc20B.connect(this.deployerB) as EncryptedERC20)['transfer(address,bytes32,bytes)'](
+        this.signersB.carol.address,
+        encryptedB.handles[0],
+        encryptedB.inputProof,
+        { gasLimit: 10_000_000 },
+      );
+      const receiptB = await txB.wait();
+      expect(receiptB?.status).to.eq(1);
+
+      const balanceHandleCarolB = await erc20B.balanceOf(this.signersB.carol.address);
+      expect(balanceHandleCarolB).to.not.eq(ethers.ZeroHash);
+      expect(balanceHandleCarolB.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+
+      const { publicKey: pubKeyB, privateKey: privKeyB } = instanceB.generateKeypair();
+      const decryptedB = await userDecryptSingleHandle(
+        balanceHandleCarolB,
+        this.chainB.erc20Address,
+        instanceB,
+        this.signersB.carol,
+        privKeyB,
+        pubKeyB,
+      );
+      expect(decryptedB).to.equal(300n);
+    });
+  });
+
+  describe('Ciphertext Handle Isolation', function () {
+    it('ciphertext handle from Chain A cannot be used on Chain B', async function () {
+      const erc20A = this.chainA.erc20 as unknown as EncryptedERC20;
+      const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
+
+      const handleA = await erc20A.balanceOf(this.deployerA.address);
+      expect(handleA).to.not.eq(ethers.ZeroHash);
+
+      expect(handleA.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+
+      const handleB = await erc20B.balanceOf(this.deployerB.address);
+      expect(handleB).to.not.eq(ethers.ZeroHash);
+      expect(handleB.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+      expect(handleA).to.not.eq(handleB);
+
+      let crossChainSucceeded = false;
+      try {
+        const crossChainTx = await (erc20B.connect(this.deployerB) as EncryptedERC20)[
+          'transfer(address,bytes32,bytes)'
+        ](this.signersB.bob.address, handleA, '0x', { gasLimit: 10_000_000 });
+        await crossChainTx.wait();
+        crossChainSucceeded = true;
+      } catch {
+        // Expected: cross-chain handle should be rejected
+      }
+      expect(crossChainSucceeded).to.eq(false, 'cross-chain transfer should have reverted');
+
+      const handleAAfter = await erc20A.balanceOf(this.deployerA.address);
+      expect(handleAAfter).to.eq(handleA);
+    });
+  });
+
+  describe('ACL Permission Isolation', function () {
+    it('ACL allow on Chain A does not grant access on Chain B', async function () {
+      const erc20A = this.chainA.erc20 as unknown as EncryptedERC20;
+      const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
+
+      const instanceDeployerA = await createHardhatInstance();
+      const instanceBobA = await createHardhatInstance();
+
+      const inputA = instanceDeployerA.createEncryptedInput(this.chainA.erc20Address, this.deployerA.address);
+      inputA.add64(500);
+      const encryptedAmountA = await inputA.encrypt();
+
+      const transferTx = await (erc20A.connect(this.deployerA) as EncryptedERC20)['transfer(address,bytes32,bytes)'](
+        this.signersA.bob.address,
+        encryptedAmountA.handles[0],
+        encryptedAmountA.inputProof,
+        { gasLimit: 10_000_000 },
+      );
+      const transferReceipt = await transferTx.wait();
+      expect(transferReceipt?.status).to.eq(1);
+
+      const balanceHandleBobA = await erc20A.balanceOf(this.signersA.bob.address);
+      expect(balanceHandleBobA).to.not.eq(ethers.ZeroHash);
+
+      const { publicKey: pubKeyBob, privateKey: privKeyBob } = instanceBobA.generateKeypair();
+      const balanceBobA = await userDecryptSingleHandle(
+        balanceHandleBobA,
+        this.chainA.erc20Address,
+        instanceBobA,
+        this.hardhatSigners.bob,
+        privKeyBob,
+        pubKeyBob,
+      );
+      expect(balanceBobA).to.equal(500n);
+
+      const balanceHandleBobB = await erc20B.balanceOf(this.signersB.bob.address);
+      expect(balanceHandleBobB).to.eq(ethers.ZeroHash);
+    });
+  });
+
+  describe('Block Reorg Isolation', function () {
+    it('evm_revert on Chain A does not affect Chain B state', async function () {
+      const providerB = getProvider(CHAIN_B);
+      const erc20A = this.chainA.erc20 as unknown as EncryptedERC20;
+      const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
+
+      const supplyABefore = await erc20A.totalSupply();
+      const supplyBBefore = await erc20B.totalSupply();
+      const chainBBlockBefore = await providerB.getBlockNumber();
+
+      const snapshotId = await evmSnapshot(ethers.provider);
+
+      const mintTx = await (erc20A.connect(this.deployerA) as EncryptedERC20).mint(7000, { gasLimit: 10_000_000 });
+      await mintTx.wait();
+      expect(await erc20A.totalSupply()).to.eq(supplyABefore + 7000n);
+
+      const transferB = await this.deployerB.sendTransaction({
+        to: this.signersB.bob.address,
+        value: ethers.parseEther('0.1'),
+      });
+      await transferB.wait();
+
+      const chainBBlockDuring = await providerB.getBlockNumber();
+      expect(chainBBlockDuring).to.be.greaterThan(chainBBlockBefore);
+
+      const reverted = await evmRevert(ethers.provider, snapshotId);
+      expect(reverted).to.eq(true);
+
+      // After evm_revert, reset NonceManager so it re-fetches the reverted nonce
+      if (this.deployerA.reset) this.deployerA.reset();
+
+      expect(await erc20A.totalSupply()).to.eq(supplyABefore);
+      expect(await erc20B.totalSupply()).to.eq(supplyBBefore);
+      expect(await providerB.getBlockNumber()).to.be.greaterThanOrEqual(chainBBlockDuring);
+    });
+  });
+
+  describe('Chain Halt Isolation', function () {
+    it('Chain A halt does not affect Chain B operations', async function () {
+      const providerB = getProvider(CHAIN_B);
+      const chainABlockBefore = await ethers.provider.getBlockNumber();
+
+      await ethers.provider.send('evm_setAutomine', [false]);
+      await ethers.provider.send('evm_setIntervalMining', [0]);
+
+      try {
+        const chainBBlockBefore = await providerB.getBlockNumber();
+
+        const freshRecipient = ethers.Wallet.createRandom();
+        const ethTransferTx = await this.deployerB.sendTransaction({
+          to: freshRecipient.address,
+          value: ethers.parseEther('0.5'),
+        });
+        await ethTransferTx.wait();
+        expect(await providerB.getBalance(freshRecipient.address)).to.eq(ethers.parseEther('0.5'));
+
+        // Wait to mine a new block
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        expect(await ethers.provider.getBlockNumber()).to.eq(chainABlockBefore);
+        expect(await providerB.getBlockNumber()).to.be.greaterThan(chainBBlockBefore);
+      } finally {
+        await ethers.provider.send('evm_setAutomine', [true]);
+      }
+    });
+  });
+
+  describe('Simultaneous Decryption Across Chains', function () {
+    it('same user can decrypt on both chains independently', async function () {
+      const handleA = await this.chainA.userDecrypt.xUint64();
+      const handleB = await this.chainB.userDecrypt.xUint64();
+      expect(handleA).to.not.eq(ethers.ZeroHash);
+      expect(handleB).to.not.eq(ethers.ZeroHash);
+      expect(handleA).to.not.eq(handleB);
+
+      expect(handleA.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+      expect(handleB.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+
+      const instanceA = await createInstance(CHAIN_A);
+      const { publicKey: pubKeyA, privateKey: privKeyA } = instanceA.generateKeypair();
+      const decryptedA = await userDecryptSingleHandle(
+        handleA,
+        this.chainA.userDecryptAddress,
+        instanceA,
+        this.deployerA,
+        privKeyA,
+        pubKeyA,
+      );
+      expect(decryptedA).to.equal(18446744073709551600n);
+
+      const instanceB = await createInstance(CHAIN_B);
+      const { publicKey: pubKeyB, privateKey: privKeyB } = instanceB.generateKeypair();
+      const decryptedB = await userDecryptSingleHandle(
+        handleB,
+        this.chainB.userDecryptAddress,
+        instanceB,
+        this.deployerB,
+        privKeyB,
+        pubKeyB,
+      );
+      expect(decryptedB).to.equal(18446744073709551600n);
+    });
+  });
+
+  describe('Random Number Generation Independence', function () {
+    it('random numbers generated on Chain A and Chain B are independent', async function () {
+      const handlesA: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const txn = await this.chainA.rand.connect(this.deployerA).generate64({ gasLimit: 10_000_000 });
+        await txn.wait();
+        const valueHandle = await this.chainA.rand.value64();
+        expect(valueHandle).to.not.eq(ethers.ZeroHash);
+        handlesA.push(valueHandle);
+      }
+
+      const handlesB: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const txn = await this.chainB.rand.connect(this.deployerB).generate64({ gasLimit: 10_000_000 });
+        await txn.wait();
+        const valueHandle = await this.chainB.rand.value64();
+        expect(valueHandle).to.not.eq(ethers.ZeroHash);
+        handlesB.push(valueHandle);
+      }
+
+      for (const handleA of handlesA) {
+        for (const handleB of handlesB) {
+          expect(handleA).to.not.eq(handleB);
+        }
+      }
+
+      for (const handle of handlesA) {
+        expect(handle.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+      }
+      for (const handle of handlesB) {
+        expect(handle.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+      }
+
+      expect(new Set(handlesA).size).to.be.greaterThanOrEqual(2);
+      expect(new Set(handlesB).size).to.be.greaterThanOrEqual(2);
+
+      const instanceA = await createHardhatInstance();
+      const valuesA: bigint[] = [];
+      for (const handle of handlesA) {
+        const res = await instanceA.publicDecrypt([handle as `0x${string}`]);
+        const value = res.clearValues[handle as `0x${string}`] as bigint;
+        expect(typeof value).to.eq('bigint');
+        valuesA.push(value);
+      }
+      expect(new Set(valuesA).size).to.be.greaterThanOrEqual(2);
+    });
+  });
+});

--- a/test-suite/e2e/test/multiChain/multiChainIsolation.ts
+++ b/test-suite/e2e/test/multiChain/multiChainIsolation.ts
@@ -5,8 +5,7 @@ import { createInstance as createHardhatInstance } from '../instance';
 import { getSigners as getHardhatSigners, initSigners } from '../signers';
 import { userDecryptSingleHandle } from '../utils';
 import {
-  CHAIN_A,
-  CHAIN_B,
+  HOST_CHAINS,
   getProvider,
   getSigners,
   getWallet,
@@ -22,18 +21,19 @@ describe('Multi-Chain State Isolation', function () {
   this.timeout(300_000);
 
   before(async function () {
-    if (!CHAIN_B) {
+    if (HOST_CHAINS.length < 2) {
       this.skip();
       return;
     }
 
+    this.chains = HOST_CHAINS;
     await initSigners(2);
     this.hardhatSigners = await getHardhatSigners();
-    this.signersA = getSigners(CHAIN_A);
-    this.signersB = getSigners(CHAIN_B);
+    this.signersA = getSigners(this.chains[0]);
+    this.signersB = getSigners(this.chains[1]);
 
-    this.deployerA = getWallet(CHAIN_A, 50);
-    this.deployerB = getWallet(CHAIN_B, 50);
+    this.deployerA = getWallet(this.chains[0], 50);
+    this.deployerB = getWallet(this.chains[1], 50);
 
     this.chainA = await deployChainFixture(this.deployerA);
     this.chainB = await deployChainFixture(this.deployerB);
@@ -53,7 +53,7 @@ describe('Multi-Chain State Isolation', function () {
       const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
 
       // Chain A: encrypted transfer to carol (unused by other tests)
-      const instanceA = await createInstance(CHAIN_A);
+      const instanceA = await createInstance(this.chains[0]);
       const inputA = instanceA.createEncryptedInput(this.chainA.erc20Address, this.deployerA.address);
       inputA.add64(200);
       const encryptedA = await inputA.encrypt();
@@ -69,7 +69,7 @@ describe('Multi-Chain State Isolation', function () {
 
       const balanceHandleCarolA = await erc20A.balanceOf(this.signersA.carol.address);
       expect(balanceHandleCarolA).to.not.eq(ethers.ZeroHash);
-      expect(balanceHandleCarolA.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+      expect(balanceHandleCarolA.slice(46, 62)).to.eq(this.chains[0].chainId.toString(16).padStart(16, '0'));
 
       const { publicKey: pubKeyA, privateKey: privKeyA } = instanceA.generateKeypair();
       const decryptedA = await userDecryptSingleHandle(
@@ -83,7 +83,7 @@ describe('Multi-Chain State Isolation', function () {
       expect(decryptedA).to.equal(200n);
 
       // Chain B: encrypted transfer to carol
-      const instanceB = await createInstance(CHAIN_B);
+      const instanceB = await createInstance(this.chains[1]);
       const inputB = instanceB.createEncryptedInput(this.chainB.erc20Address, this.deployerB.address);
       inputB.add64(300);
       const encryptedB = await inputB.encrypt();
@@ -99,7 +99,7 @@ describe('Multi-Chain State Isolation', function () {
 
       const balanceHandleCarolB = await erc20B.balanceOf(this.signersB.carol.address);
       expect(balanceHandleCarolB).to.not.eq(ethers.ZeroHash);
-      expect(balanceHandleCarolB.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+      expect(balanceHandleCarolB.slice(46, 62)).to.eq(this.chains[1].chainId.toString(16).padStart(16, '0'));
 
       const { publicKey: pubKeyB, privateKey: privKeyB } = instanceB.generateKeypair();
       const decryptedB = await userDecryptSingleHandle(
@@ -122,11 +122,11 @@ describe('Multi-Chain State Isolation', function () {
       const handleA = await erc20A.balanceOf(this.deployerA.address);
       expect(handleA).to.not.eq(ethers.ZeroHash);
 
-      expect(handleA.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+      expect(handleA.slice(46, 62)).to.eq(this.chains[0].chainId.toString(16).padStart(16, '0'));
 
       const handleB = await erc20B.balanceOf(this.deployerB.address);
       expect(handleB).to.not.eq(ethers.ZeroHash);
-      expect(handleB.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+      expect(handleB.slice(46, 62)).to.eq(this.chains[1].chainId.toString(16).padStart(16, '0'));
       expect(handleA).to.not.eq(handleB);
 
       let crossChainSucceeded = false;
@@ -188,7 +188,7 @@ describe('Multi-Chain State Isolation', function () {
 
   describe('Block Reorg Isolation', function () {
     it('evm_revert on Chain A does not affect Chain B state', async function () {
-      const providerB = getProvider(CHAIN_B);
+      const providerB = getProvider(this.chains[1]);
       const erc20A = this.chainA.erc20 as unknown as EncryptedERC20;
       const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
 
@@ -225,7 +225,7 @@ describe('Multi-Chain State Isolation', function () {
 
   describe('Chain Halt Isolation', function () {
     it('Chain A halt does not affect Chain B operations', async function () {
-      const providerB = getProvider(CHAIN_B);
+      const providerB = getProvider(this.chains[1]);
       const chainABlockBefore = await ethers.provider.getBlockNumber();
 
       await ethers.provider.send('evm_setAutomine', [false]);
@@ -260,10 +260,10 @@ describe('Multi-Chain State Isolation', function () {
       expect(handleB).to.not.eq(ethers.ZeroHash);
       expect(handleA).to.not.eq(handleB);
 
-      expect(handleA.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
-      expect(handleB.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+      expect(handleA.slice(46, 62)).to.eq(this.chains[0].chainId.toString(16).padStart(16, '0'));
+      expect(handleB.slice(46, 62)).to.eq(this.chains[1].chainId.toString(16).padStart(16, '0'));
 
-      const instanceA = await createInstance(CHAIN_A);
+      const instanceA = await createInstance(this.chains[0]);
       const { publicKey: pubKeyA, privateKey: privKeyA } = instanceA.generateKeypair();
       const decryptedA = await userDecryptSingleHandle(
         handleA,
@@ -275,7 +275,7 @@ describe('Multi-Chain State Isolation', function () {
       );
       expect(decryptedA).to.equal(18446744073709551600n);
 
-      const instanceB = await createInstance(CHAIN_B);
+      const instanceB = await createInstance(this.chains[1]);
       const { publicKey: pubKeyB, privateKey: privKeyB } = instanceB.generateKeypair();
       const decryptedB = await userDecryptSingleHandle(
         handleB,
@@ -316,10 +316,10 @@ describe('Multi-Chain State Isolation', function () {
       }
 
       for (const handle of handlesA) {
-        expect(handle.slice(46, 62)).to.eq(CHAIN_A.chainId.toString(16).padStart(16, '0'));
+        expect(handle.slice(46, 62)).to.eq(this.chains[0].chainId.toString(16).padStart(16, '0'));
       }
       for (const handle of handlesB) {
-        expect(handle.slice(46, 62)).to.eq(CHAIN_B.chainId.toString(16).padStart(16, '0'));
+        expect(handle.slice(46, 62)).to.eq(this.chains[1].chainId.toString(16).padStart(16, '0'));
       }
 
       expect(new Set(handlesA).size).to.be.greaterThanOrEqual(2);

--- a/test-suite/e2e/test/multiChain/multiChainIsolation.ts
+++ b/test-suite/e2e/test/multiChain/multiChainIsolation.ts
@@ -22,8 +22,9 @@ describe('Multi-Chain State Isolation', function () {
   this.timeout(300_000);
 
   before(async function () {
-    if (!process.env.CHAIN_ID_HOST_B) {
+    if (!CHAIN_B) {
       this.skip();
+      return;
     }
 
     await initSigners(2);

--- a/test-suite/fhevm/scenarios/multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/multi-chain.yaml
@@ -2,7 +2,13 @@ version: 1
 kind: coprocessor-consensus
 name: Multi Chain
 description: Single coprocessor with two host chains for cross-chain isolation testing.
-multiChain: true
+hostChains:
+  - key: host
+    chainId: "12345"
+    rpcPort: 8545
+  - key: host-b
+    chainId: "67890"
+    rpcPort: 8547
 topology:
   count: 1
   threshold: 1

--- a/test-suite/fhevm/scenarios/multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/multi-chain.yaml
@@ -1,0 +1,8 @@
+version: 1
+kind: coprocessor-consensus
+name: Multi Chain
+description: Single coprocessor with two host chains for cross-chain isolation testing.
+multiChain: true
+topology:
+  count: 1
+  threshold: 1

--- a/test-suite/fhevm/scenarios/multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/multi-chain.yaml
@@ -6,7 +6,7 @@ hostChains:
   - key: host
     chainId: "12345"
     rpcPort: 8545
-  - key: host-b
+  - key: chain-b
     chainId: "67890"
     rpcPort: 8547
 topology:

--- a/test-suite/fhevm/scenarios/two-of-two-multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/two-of-two-multi-chain.yaml
@@ -1,0 +1,8 @@
+version: 1
+kind: coprocessor-consensus
+name: Two Of Two Multi Chain
+description: Two-coprocessor consensus with two host chains for multi-chain + multi-coprocessor testing.
+multiChain: true
+topology:
+  count: 2
+  threshold: 2

--- a/test-suite/fhevm/scenarios/two-of-two-multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/two-of-two-multi-chain.yaml
@@ -6,7 +6,7 @@ hostChains:
   - key: host
     chainId: "12345"
     rpcPort: 8545
-  - key: host-b
+  - key: chain-b
     chainId: "67890"
     rpcPort: 8547
 topology:

--- a/test-suite/fhevm/scenarios/two-of-two-multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/two-of-two-multi-chain.yaml
@@ -2,7 +2,13 @@ version: 1
 kind: coprocessor-consensus
 name: Two Of Two Multi Chain
 description: Two-coprocessor consensus with two host chains for multi-chain + multi-coprocessor testing.
-multiChain: true
+hostChains:
+  - key: host
+    chainId: "12345"
+    rpcPort: 8545
+  - key: host-b
+    chainId: "67890"
+    rpcPort: 8547
 topology:
   count: 2
   threshold: 2

--- a/test-suite/fhevm/src/cli.test.ts
+++ b/test-suite/fhevm/src/cli.test.ts
@@ -56,6 +56,7 @@ const persistedState = (target: State["target"] = "latest-main"): State => ({
     version: 1,
     kind: "coprocessor-consensus",
     origin: "default",
+    hostChains: [{ key: "host", chainId: "12345", rpcPort: 8545 }],
     topology: { count: 1, threshold: 1 },
     instances: [{ index: 0, source: { mode: "inherit" }, env: {}, args: {} }],
   },

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -528,6 +528,10 @@ export const test = async (testName: string | undefined, options: TestOptions) =
       } finally {
         await runWithHeartbeat(["docker", "start", "coprocessor-host-listener"], "start host listener", { allowFailure: true });
       }
+
+      if (state.scenario.hostChains.length > 1) {
+        await runProfile("multi-chain-isolation");
+      }
     });
   };
 

--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -33,6 +33,7 @@ describe("compat", () => {
         version: 1,
         kind: "coprocessor-consensus",
         origin: "default",
+        hostChains: [{ key: "host", chainId: "12345", rpcPort: 8545 }],
         topology: { count: 1, threshold: 1 },
         instances: [{ index: 0, source: { mode: "inherit" }, env: {}, args: {} }],
       },

--- a/test-suite/fhevm/src/compat/smoke.ts
+++ b/test-suite/fhevm/src/compat/smoke.ts
@@ -4,7 +4,7 @@
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
-import { COMPONENTS, GROUP_BUILD_SERVICES, STATE_DIR, TEMPLATE_ENV_DIR, versionsEnvPath, dockerArgs, envPath } from "../layout";
+import { COMPONENTS, GROUP_BUILD_SERVICES, PRIMARY_HOST_KEY, STATE_DIR, TEMPLATE_ENV_DIR, versionsEnvPath, dockerArgs, envPath } from "../layout";
 import { generateComposeOverrides, type ComposeDoc } from "../generate/compose";
 import { renderEnvMaps, type WalletMaterial } from "../generate/env";
 import { stackSpecForState } from "../stack-spec/stack-spec";
@@ -28,7 +28,7 @@ const defaultScenario: State["scenario"] = {
   version: 1,
   kind: "coprocessor-consensus",
   origin: "default",
-  hostChains: [{ key: "host", chainId: "12345", rpcPort: 8545 }],
+  hostChains: [{ key: PRIMARY_HOST_KEY, chainId: "12345", rpcPort: 8545 }],
   topology: { count: 1, threshold: 1 },
   instances: [{ index: 0, source: { mode: "inherit" }, env: {}, args: {} }],
 };

--- a/test-suite/fhevm/src/compat/smoke.ts
+++ b/test-suite/fhevm/src/compat/smoke.ts
@@ -28,6 +28,7 @@ const defaultScenario: State["scenario"] = {
   version: 1,
   kind: "coprocessor-consensus",
   origin: "default",
+  hostChains: [{ key: "host", chainId: "12345", rpcPort: 8545 }],
   topology: { count: 1, threshold: 1 },
   instances: [{ index: 0, source: { mode: "inherit" }, env: {}, args: {} }],
 };
@@ -66,12 +67,14 @@ const fakeDiscovery: NonNullable<State["discovery"]> = {
     MULTICHAIN_ACL_ADDRESS: "0x0000000000000000000000000000000000000008",
     PROTOCOL_PAYMENT_ADDRESS: "0x0000000000000000000000000000000000000009",
   },
-  host: {
-    ACL_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000010",
-    PAUSER_SET_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000011",
-    FHEVM_EXECUTOR_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000002",
-    INPUT_VERIFIER_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000012",
-    KMS_VERIFIER_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000013",
+  hosts: {
+    host: {
+      ACL_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000010",
+      PAUSER_SET_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000011",
+      FHEVM_EXECUTOR_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000002",
+      INPUT_VERIFIER_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000012",
+      KMS_VERIFIER_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000013",
+    },
   },
   kmsSigner: "0x0000000000000000000000000000000000000014",
   fheKeyId: "0000000000000000000000000000000000000000000000000000000000000001",
@@ -80,10 +83,8 @@ const fakeDiscovery: NonNullable<State["discovery"]> = {
   actualCrsKeyId: "0000000000000000000000000000000000000000000000000000000000000002",
   minioKeyPrefix: "PUB",
   endpoints: {
-    gatewayHttp: "http://localhost:8546",
-    gatewayWs: "ws://127.0.0.1:1",
-    hostHttp: "http://localhost:8545",
-    hostWs: "ws://127.0.0.1:1",
+    gateway: { http: "http://localhost:8546", ws: "ws://127.0.0.1:1" },
+    hosts: { host: { http: "http://localhost:8545", ws: "ws://127.0.0.1:1" } },
     minioInternal: "http://127.0.0.1:9000",
     minioExternal: "http://127.0.0.1:9000",
   },

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -28,6 +28,8 @@ import {
 import { describeBundle } from "../resolve/target";
 import {
   ADDRESS_DIR,
+  CHAIN_B_ID,
+  CHAIN_B_PORT,
   COMPOSE_OUT_DIR,
   COMPONENT_BY_STEP,
   COMPONENTS,
@@ -57,6 +59,7 @@ import {
   gatewayAddressesSolidityPath,
   hostAddressesPath,
   hostAddressesSolidityPath,
+  hostBAddressesPath,
   paymentBridgingAddressesSolidityPath,
   relayerConfigPath,
   versionsEnvPath,
@@ -157,6 +160,7 @@ const printBundle = (bundle: VersionBundle, options?: { detailed?: boolean }) =>
 const printPlan = (state: Pick<State, "target" | "overrides" | "scenario">, fromStep?: StepName) => {
   const topology = topologyForState(state);
   const overrides = visibleOverrides(state);
+  const multiChain = state.scenario.multiChain ?? false;
   console.log(`[plan] profile=${state.target}`);
   if (overrides.length) {
     console.log(`[plan] overrides=${overrides.map(describeOverride).join(", ")}`);
@@ -164,7 +168,7 @@ const printPlan = (state: Pick<State, "target" | "overrides" | "scenario">, from
       console.log(`[warn] ${warning}`);
     }
   }
-  console.log(`[plan] topology=n${topology.count}/t${topology.threshold}`);
+  console.log(`[plan] topology=n${topology.count}/t${topology.threshold}${multiChain ? " multi-chain" : ""}`);
   console.log(`[plan] steps=${STEP_NAMES.slice(stateStepIndex(fromStep ?? STEP_NAMES[0])).join(" -> ")}`);
 };
 
@@ -467,6 +471,7 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
           hostAddressesSolidityPath,
         ]
       : []),
+    ...(state.scenario.multiChain ? [hostBAddressesPath] : []),
   ];
   const allExist = (await Promise.all(requiredPaths.map((file) => exists(file)))).every(Boolean);
   if (allExist) {
@@ -476,9 +481,27 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
   await generateRuntime(state, stackSpecForState(state));
 };
 
-const resetAfterStep = async (step: StepName) => {
+/** Maps each multi-chain compose file to the pipeline step that creates it. */
+const MULTI_CHAIN_STEP: Record<string, StepName> = {
+  "host-node-b": "base",
+  "host-sc-b": "host-deploy",
+  "coprocessor-host-b": "coprocessor",
+};
+
+const resetAfterStep = async (step: StepName, state: Pick<State, "scenario">) => {
   const start = stateStepIndex(step);
   const failed: string[] = [];
+  if (state.scenario.multiChain) {
+    const toTearDown = Object.entries(MULTI_CHAIN_STEP)
+      .filter(([, parentStep]) => stateStepIndex(parentStep) >= start)
+      .map(([name]) => name);
+    const multiChainResults = await Promise.all(
+      toTearDown.map(async (name) => ({ name, ok: await multiChainComposeDown(name) })),
+    );
+    for (const { name, ok } of multiChainResults) {
+      if (!ok) failed.push(name);
+    }
+  }
   for (let index = STEP_NAMES.length - 1; index >= start; index -= 1) {
     for (const component of COMPONENT_BY_STEP[STEP_NAMES[index]]) {
       const ok = await composeDown(component);
@@ -988,6 +1011,47 @@ const stepComposeUp = async (
   await composeUp(component, services, options);
 };
 
+const MULTI_CHAIN_ENV_COMPONENT: Record<string, string> = {
+  "coprocessor-host-b": "coprocessor",
+  "host-sc-b": "host-sc-b",
+  "host-node-b": "host-node-b",
+};
+
+const multiChainComposeUp = async (
+  name: string,
+  services?: string[],
+) => {
+  const file = composePath(name);
+  const component = MULTI_CHAIN_ENV_COMPONENT[name] ?? name;
+  try {
+    await runStreaming(
+      ["docker", "compose", "-p", PROJECT, "-f", file, "up", "-d", "--no-deps", ...(services ?? [])],
+      { env: await composeEnv(component) },
+    );
+  } catch (error) {
+    throw new ContainerStartError(name, error instanceof Error ? error.message : String(error));
+  }
+};
+
+const multiChainComposeDown = async (name: string) => {
+  const file = composePath(name);
+  const component = MULTI_CHAIN_ENV_COMPONENT[name] ?? name;
+  try {
+    const code = await runStreaming(
+      ["docker", "compose", "-p", PROJECT, "-f", file, "down", "-v"],
+      { env: await composeEnv(component).catch(() => ({ COMPOSE_IGNORE_ORPHANS: "true" })), allowFailure: true },
+    );
+    if (code !== 0) {
+      console.log(`[warn] compose down failed for ${name} (${code})`);
+      return false;
+    }
+    return true;
+  } catch {
+    console.log(`[warn] compose down failed for ${name}`);
+    return false;
+  }
+};
+
 /** Lists the coprocessor containers whose health determines coprocessor readiness. */
 const coprocessorHealthContainers = (state: Pick<State, "scenario">) => {
   const topology = topologyForState(state);
@@ -1034,6 +1098,35 @@ const coprocessorDbsSeeded = async (state: Pick<State, "scenario">) =>
   (await Promise.all(
     Array.from({ length: topologyForState(state).count }, (_, index) => (index === 0 ? "coprocessor" : `coprocessor_${index}`)).map(coprocessorDbSeeded),
   )).every(Boolean);
+
+const registerChainBInCoprocessor = async (state: State) => {
+  const plan = stackSpecForState(state);
+  const aclAddress =
+    state.discovery?.hostB?.ACL_CONTRACT_ADDRESS ??
+    state.discovery?.host?.ACL_CONTRACT_ADDRESS ??
+    "";
+  for (let index = 0; index < plan.topology.count; index += 1) {
+    const dbName = index === 0 ? "coprocessor" : `coprocessor_${index}`;
+    const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;
+    console.log(`[multi-chain] registering Chain B in ${dbName}`);
+    await run([
+      "docker", "exec", COPROCESSOR_DB_CONTAINER,
+      "psql", "-U", "postgres", "-d", dbName, "-c",
+      `INSERT INTO host_chains (chain_id, name, acl_contract_address) VALUES (${CHAIN_B_ID}, 'test chain b', '${aclAddress}') ON CONFLICT (chain_id) DO NOTHING;`,
+    ]);
+    console.log(`[multi-chain] restarting ${prefix}zkproof-worker`);
+    await run(["docker", "stop", `${prefix}zkproof-worker`]);
+    await run(["docker", "start", `${prefix}zkproof-worker`]);
+    await waitForContainer(`${prefix}zkproof-worker`, "running");
+  }
+};
+
+const discoverChainBContracts = async () => {
+  if (!(await exists(hostBAddressesPath))) {
+    throw new PreflightError("Missing Chain B host address file");
+  }
+  return readEnvFile(hostBAddressesPath);
+};
 
 /** Waits for the kms-connector runtime services to become ready. */
 const waitForKmsConnector = async () => {
@@ -1104,7 +1197,7 @@ export const runStep = async (state: State, step: StepName) => {
     case "generate":
       await generateRuntime(state, stackSpecForState(state));
       break;
-    case "base":
+    case "base": {
       await stepComposeUp("minio", state);
       await waitForContainer("fhevm-minio", "healthy");
       await waitForContainer("fhevm-minio-setup", "complete");
@@ -1116,9 +1209,19 @@ export const runStep = async (state: State, step: StepName) => {
       await waitForRpc("http://localhost:8545");
       await stepComposeUp("gateway-node", state);
       await waitForRpc("http://localhost:8546");
+      const plan = stackSpecForState(state);
       state.discovery = createDiscovery(await defaultEndpoints());
+      if (plan.multiChain) {
+        state.discovery.endpoints.hostBHttp = `http://host-node-b:${CHAIN_B_PORT}`;
+        state.discovery.endpoints.hostBWs = `ws://host-node-b:${CHAIN_B_PORT}`;
+      }
       await generateRuntime(state, stackSpecForState(state));
+      if (plan.multiChain) {
+        await multiChainComposeUp("host-node-b");
+        await waitForRpc(`http://localhost:${CHAIN_B_PORT}`);
+      }
       break;
+    }
     case "kms-signer": {
       const discovery = await ensureDiscovery(state);
       const signer = await discoverSigner();
@@ -1140,12 +1243,25 @@ export const runStep = async (state: State, step: StepName) => {
     case "host-deploy":
       await stepComposeUp("host-sc", state, ["host-sc-deploy"]);
       await waitForContainer("host-sc-deploy", "complete");
+      if (stackSpecForState(state).multiChain) {
+        await timed("[multi-chain] host-sc-b-deploy", async () => {
+          await multiChainComposeUp("host-sc-b", ["host-sc-b-deploy"]);
+          await waitForContainer("host-sc-b-deploy", "complete");
+        });
+        await timed("[multi-chain] host-sc-b-add-pausers", async () => {
+          await multiChainComposeUp("host-sc-b", ["host-sc-b-add-pausers"]);
+          await waitForContainer("host-sc-b-add-pausers", "complete");
+        });
+      }
       break;
     case "discover": {
       const contracts = await discoverContracts();
       const discovery = await ensureDiscovery(state);
       discovery.gateway = contracts.gateway;
       discovery.host = contracts.host;
+      if (stackSpecForState(state).multiChain) {
+        discovery.hostB = await discoverChainBContracts();
+      }
       break;
     }
     case "regenerate":
@@ -1165,6 +1281,20 @@ export const runStep = async (state: State, step: StepName) => {
       await stepComposeUp("coprocessor", state, services, { noDeps: skipMigration });
       await waitForCoprocessorServices(state, skipMigration);
       await postBootHealthGate(coprocessorHealthContainers(state));
+      if (stackSpecForState(state).multiChain) {
+        await timed("[multi-chain] register Chain B in coprocessor DBs", () =>
+          registerChainBInCoprocessor(state),
+        );
+        await timed("[multi-chain] start host-listener-b services", async () => {
+          await multiChainComposeUp("coprocessor-host-b");
+          const topology = topologyForState(state);
+          for (let index = 0; index < topology.count; index += 1) {
+            const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;
+            await waitForContainer(`${prefix}host-listener-b`, "running");
+            await waitForContainer(`${prefix}host-listener-poller-b`, "running");
+          }
+        });
+      }
       break;
     }
     case "kms-connector":
@@ -1268,6 +1398,7 @@ const describeResumeState = (state: State) => {
   return [
     `profile=${state.target}`,
     `topology=${topology.count}/${topology.threshold}`,
+    ...(state.scenario.multiChain ? ["multi-chain"] : []),
     ...(state.scenario.origin !== "default"
       ? [`scenario=${state.scenario.origin}${state.scenario.sourcePath ? `:${state.scenario.sourcePath}` : ""}`]
       : []),
@@ -1399,7 +1530,7 @@ export const up = async (options: UpOptions) => {
     console.log(`[warn] ${warning}`);
   }
   if (options.resume && options.fromStep) {
-    await resetAfterStep(options.fromStep);
+    await resetAfterStep(options.fromStep, state);
     state.completedSteps = state.completedSteps.filter((step) => stateStepIndex(step) < stateStepIndex(options.fromStep!));
     await saveState(state);
   }
@@ -1465,6 +1596,14 @@ export const down = async () => {
     await ensureRuntimeArtifacts(state, "teardown");
   }
   const failed: string[] = [];
+  if (state?.scenario?.multiChain) {
+    const multiChainResults = await Promise.all(
+      ["coprocessor-host-b", "host-sc-b", "host-node-b"].map(async (name) => ({ name, ok: await multiChainComposeDown(name) })),
+    );
+    for (const { name, ok } of multiChainResults) {
+      if (!ok) failed.push(name);
+    }
+  }
   for (const component of [...COMPONENTS].reverse()) {
     console.log(`[down] ${component}`);
     const ok = await composeDown(component);
@@ -1532,7 +1671,7 @@ export const status = async () => {
         console.log(`[warn] ${warning}`);
       }
     }
-    console.log(`[topology] n=${topology.count} t=${topology.threshold}`);
+    console.log(`[topology] n=${topology.count} t=${topology.threshold}${state.scenario.multiChain ? " multi-chain" : ""}`);
     if (state.scenario.origin !== "default") {
       console.log(`[scenario] ${state.scenario.origin}${state.scenario.sourcePath ? ` ${state.scenario.sourcePath}` : ""}`);
       for (const instance of state.scenario.instances) {

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -58,7 +58,11 @@ import {
   hostAddressesPath,
   hostAddressesSolidityPath,
   hostChainAddressesPath,
+  hostChainAddressesSolidityPath,
   hostChainSuffixId,
+  hostNodeName,
+  hostScName,
+  coprocessorHostKey,
   paymentBridgingAddressesSolidityPath,
   relayerConfigPath,
   versionsEnvPath,
@@ -469,7 +473,15 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
           hostAddressesSolidityPath,
         ]
       : []),
-    ...state.scenario.hostChains.slice(1).map((chain) => hostChainAddressesPath(chain.key)),
+    // Multi-chain artifacts: address files, compose overrides, and per-chain coprocessor env files
+    ...state.scenario.hostChains.slice(1).flatMap((chain) => [
+      hostChainAddressesPath(chain.key),
+      ...(state.discovery ? [hostChainAddressesSolidityPath(chain.key)] : []),
+      composePath(hostNodeName(chain.key)),
+      composePath(hostScName(chain.key)),
+      composePath(coprocessorHostKey(chain.key)),
+      ...Array.from({ length: topology.count }, (_, index) => envPath(`coprocessor-${chain.key}.${index}`)),
+    ]),
   ];
   const allExist = (await Promise.all(requiredPaths.map((file) => exists(file)))).every(Boolean);
   if (allExist) {
@@ -483,11 +495,9 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
 const multiChainComposeEntries = (state: Pick<State, "scenario">): Array<[string, StepName]> => {
   const entries: Array<[string, StepName]> = [];
   for (const chain of state.scenario.hostChains.slice(1)) {
-    const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
-    const container = chain.key.replace(/^host/, "host-node");
-    entries.push([container, "base"]);
-    entries.push([`host-sc-${suffixId}`, "host-deploy"]);
-    entries.push([`coprocessor-host-${suffixId}`, "coprocessor"]);
+    entries.push([hostNodeName(chain.key), "base"]);
+    entries.push([hostScName(chain.key), "host-deploy"]);
+    entries.push([coprocessorHostKey(chain.key), "coprocessor"]);
   }
   return entries;
 };
@@ -1254,8 +1264,7 @@ export const runStep = async (state: State, step: StepName) => {
       await stepComposeUp("host-sc", state, ["host-sc-deploy"]);
       await waitForContainer("host-sc-deploy", "complete");
       for (const chain of stackSpecForState(state).hostChains.slice(1)) {
-        const suffixId = hostChainSuffixId(chain.key);
-        const scKey = `host-sc-${suffixId}`;
+        const scKey = hostScName(chain.key);
         await timed(`[multi-chain] ${scKey}-deploy`, async () => {
           await multiChainComposeUp(scKey, [`${scKey}-deploy`]);
           await waitForContainer(`${scKey}-deploy`, "complete");
@@ -1299,7 +1308,7 @@ export const runStep = async (state: State, step: StepName) => {
           registerExtraChainInCoprocessor(state, chain),
         );
         await timed(`[multi-chain] start host-listener-${suffixId} services`, async () => {
-          await multiChainComposeUp(`coprocessor-host-${suffixId}`);
+          await multiChainComposeUp(coprocessorHostKey(chain.key));
           const topology = topologyForState(state);
           for (let index = 0; index < topology.count; index += 1) {
             const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -60,6 +60,7 @@ import {
   hostAddressesSolidityPath,
   hostChainAddressesPath,
   hostChainAddressesSolidityPath,
+  hostChainNames,
   hostChainSuffixId,
   hostNodeName,
   hostScName,
@@ -486,14 +487,17 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
         ]
       : []),
     // Multi-chain artifacts: address files, compose overrides, and per-chain coprocessor env files
-    ...state.scenario.hostChains.slice(1).flatMap((chain) => [
-      hostChainAddressesPath(chain.key),
-      ...(state.discovery ? [hostChainAddressesSolidityPath(chain.key)] : []),
-      composePath(hostNodeName(chain.key)),
-      composePath(hostScName(chain.key)),
-      composePath(coprocessorHostKey(chain.key)),
-      ...Array.from({ length: topology.count }, (_, index) => envPath(`coprocessor-${chain.key}.${index}`)),
-    ]),
+    ...state.scenario.hostChains.slice(1).flatMap((chain) => {
+      const { node, sc, copro } = hostChainNames(chain.key);
+      return [
+        hostChainAddressesPath(chain.key),
+        ...(state.discovery ? [hostChainAddressesSolidityPath(chain.key)] : []),
+        composePath(node),
+        composePath(sc),
+        composePath(copro),
+        ...Array.from({ length: topology.count }, (_, index) => envPath(`coprocessor-${chain.key}.${index}`)),
+      ];
+    }),
   ];
   const allExist = (await Promise.all(requiredPaths.map((file) => exists(file)))).every(Boolean);
   if (allExist) {
@@ -507,9 +511,10 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
 const multiChainComposeEntries = (state: Pick<State, "scenario">): Array<[string, StepName]> => {
   const entries: Array<[string, StepName]> = [];
   for (const chain of state.scenario.hostChains.slice(1)) {
-    entries.push([hostNodeName(chain.key), "base"]);
-    entries.push([hostScName(chain.key), "host-deploy"]);
-    entries.push([coprocessorHostKey(chain.key), "coprocessor"]);
+    const { node, sc, copro } = hostChainNames(chain.key);
+    entries.push([node, "base"]);
+    entries.push([sc, "host-deploy"]);
+    entries.push([copro, "coprocessor"]);
   }
   return entries;
 };

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -61,7 +61,7 @@ import {
   hostChainAddressesPath,
   hostChainAddressesSolidityPath,
   hostChainNames,
-  hostChainSuffixId,
+  hostChainSuffix,
   hostNodeName,
   hostScName,
   coprocessorHostKey,
@@ -1042,18 +1042,16 @@ const stepComposeUp = async (
   await composeUp(component, services, options);
 };
 
-const MULTI_CHAIN_ENV_COMPONENT: Record<string, string> = {
-  "coprocessor-host-b": "coprocessor",
-  "host-sc-b": "host-sc-b",
-  "host-node-b": "host-node-b",
-};
+/** Maps a multi-chain compose name to the component whose env it needs. Coprocessor listeners share the base coprocessor env. */
+const multiChainEnvComponent = (name: string) =>
+  name.startsWith("coprocessor-") ? "coprocessor" : name;
 
 const multiChainComposeUp = async (
   name: string,
   services?: string[],
 ) => {
   const file = composePath(name);
-  const component = MULTI_CHAIN_ENV_COMPONENT[name] ?? name;
+  const component = multiChainEnvComponent(name);
   try {
     await runStreaming(
       ["docker", "compose", "-p", PROJECT, "-f", file, "up", "-d", "--no-deps", ...(services ?? [])],
@@ -1066,7 +1064,7 @@ const multiChainComposeUp = async (
 
 const multiChainComposeDown = async (name: string) => {
   const file = composePath(name);
-  const component = MULTI_CHAIN_ENV_COMPONENT[name] ?? name;
+  const component = multiChainEnvComponent(name);
   try {
     const code = await runStreaming(
       ["docker", "compose", "-p", PROJECT, "-f", file, "down", "-v"],
@@ -1133,9 +1131,8 @@ const coprocessorDbsSeeded = async (state: Pick<State, "scenario">) =>
 /** Registers an extra host chain in all coprocessor databases and restarts zkproof-workers. */
 const registerExtraChainInCoprocessor = async (state: State, chain: { key: string; chainId: string }) => {
   const plan = stackSpecForState(state);
-  const primaryHost = state.discovery?.hosts[PRIMARY_HOST_KEY] ?? {};
   const chainHost = state.discovery?.hosts[chain.key] ?? {};
-  const aclAddress = chainHost.ACL_CONTRACT_ADDRESS ?? primaryHost.ACL_CONTRACT_ADDRESS ?? "";
+  const aclAddress = chainHost.ACL_CONTRACT_ADDRESS ?? "";
   for (let index = 0; index < plan.topology.count; index += 1) {
     const dbName = index === 0 ? "coprocessor" : `coprocessor_${index}`;
     const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;
@@ -1319,17 +1316,17 @@ export const runStep = async (state: State, step: StepName) => {
       await waitForCoprocessorServices(state, skipMigration);
       await postBootHealthGate(coprocessorHealthContainers(state));
       for (const chain of stackSpecForState(state).hostChains.slice(1)) {
-        const suffixId = hostChainSuffixId(chain.key);
+        const suffix = hostChainSuffix(chain.key);
         await timed(`[multi-chain] register ${chain.key} in coprocessor DBs`, () =>
           registerExtraChainInCoprocessor(state, chain),
         );
-        await timed(`[multi-chain] start host-listener-${suffixId} services`, async () => {
+        await timed(`[multi-chain] start host-listener${suffix} services`, async () => {
           await multiChainComposeUp(coprocessorHostKey(chain.key));
           const topology = topologyForState(state);
           for (let index = 0; index < topology.count; index += 1) {
             const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;
-            await waitForContainer(`${prefix}host-listener-${suffixId}`, "running");
-            await waitForContainer(`${prefix}host-listener-poller-${suffixId}`, "running");
+            await waitForContainer(`${prefix}host-listener${suffix}`, "running");
+            await waitForContainer(`${prefix}host-listener-poller${suffix}`, "running");
           }
         });
       }

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -45,6 +45,7 @@ import {
   MINIO_EXTERNAL_URL,
   MINIO_INTERNAL_URL,
   PORTS,
+  PRIMARY_HOST_KEY,
   PROJECT,
   REPO_ROOT,
   SCHEMA_COUPLED_GROUPS,
@@ -258,7 +259,7 @@ export const discoverContracts = async () => {
   }
   return {
     gateway: await readEnvFile(gatewayAddressesPath),
-    hosts: { host: await readEnvFile(hostAddressesPath) },
+    hosts: { [PRIMARY_HOST_KEY]: await readEnvFile(hostAddressesPath) },
   };
 };
 
@@ -439,10 +440,21 @@ export const validateDiscovery = (state: Pick<State, "target" | "versions" | "di
       throw new PreflightError(`Missing gateway discovery value ${key}`);
     }
   }
-  const primaryHost = discovery.hosts["host"] ?? {};
+  const primaryHost = discovery.hosts[PRIMARY_HOST_KEY] ?? {};
   for (const key of requiredHost) {
     if (!primaryHost[key]) {
       throw new PreflightError(`Missing host discovery value ${key}`);
+    }
+  }
+  for (const chain of state.scenario.hostChains.slice(1)) {
+    const extraHost = discovery.hosts[chain.key];
+    if (!extraHost) {
+      throw new PreflightError(`Missing discovery for extra host chain "${chain.key}"`);
+    }
+    for (const key of requiredHost) {
+      if (!extraHost[key]) {
+        throw new PreflightError(`Missing host discovery value ${key} for chain "${chain.key}"`);
+      }
     }
   }
   if (!discovery.kmsSigner) {
@@ -1116,7 +1128,7 @@ const coprocessorDbsSeeded = async (state: Pick<State, "scenario">) =>
 /** Registers an extra host chain in all coprocessor databases and restarts zkproof-workers. */
 const registerExtraChainInCoprocessor = async (state: State, chain: { key: string; chainId: string }) => {
   const plan = stackSpecForState(state);
-  const primaryHost = state.discovery?.hosts["host"] ?? {};
+  const primaryHost = state.discovery?.hosts[PRIMARY_HOST_KEY] ?? {};
   const chainHost = state.discovery?.hosts[chain.key] ?? {};
   const aclAddress = chainHost.ACL_CONTRACT_ADDRESS ?? primaryHost.ACL_CONTRACT_ADDRESS ?? "";
   for (let index = 0; index < plan.topology.count; index += 1) {
@@ -1228,7 +1240,7 @@ export const runStep = async (state: State, step: StepName) => {
       const plan = stackSpecForState(state);
       state.discovery = createDiscovery(await defaultEndpoints());
       for (const chain of plan.hostChains.slice(1)) {
-        const container = chain.key.replace(/^host/, "host-node");
+        const container = hostNodeName(chain.key);
         state.discovery.endpoints.hosts[chain.key] = {
           http: `http://${container}:${chain.rpcPort}`,
           ws: `ws://${container}:${chain.rpcPort}`,
@@ -1236,8 +1248,7 @@ export const runStep = async (state: State, step: StepName) => {
       }
       await generateRuntime(state, stackSpecForState(state));
       for (const chain of plan.hostChains.slice(1)) {
-        const container = chain.key.replace(/^host/, "host-node");
-        await multiChainComposeUp(container);
+        await multiChainComposeUp(hostNodeName(chain.key));
         await waitForRpc(`http://localhost:${chain.rpcPort}`);
       }
       break;
@@ -1362,8 +1373,8 @@ export const runStep = async (state: State, step: StepName) => {
         break;
       }
       const hostPauserRegistered = await castBool(
-        state.discovery!.endpoints.hosts["host"].http,
-        withHexPrefix(state.discovery!.hosts["host"].PAUSER_SET_CONTRACT_ADDRESS),
+        state.discovery!.endpoints.hosts[PRIMARY_HOST_KEY].http,
+        withHexPrefix(state.discovery!.hosts[PRIMARY_HOST_KEY].PAUSER_SET_CONTRACT_ADDRESS),
         "isPauser(address)(bool)",
         withHexPrefix(hostEnv.PAUSER_ADDRESS_0),
       ).catch(() => false);

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -28,8 +28,6 @@ import {
 import { describeBundle } from "../resolve/target";
 import {
   ADDRESS_DIR,
-  CHAIN_B_ID,
-  CHAIN_B_PORT,
   COMPOSE_OUT_DIR,
   COMPONENT_BY_STEP,
   COMPONENTS,
@@ -59,7 +57,8 @@ import {
   gatewayAddressesSolidityPath,
   hostAddressesPath,
   hostAddressesSolidityPath,
-  hostBAddressesPath,
+  hostChainAddressesPath,
+  hostChainSuffixId,
   paymentBridgingAddressesSolidityPath,
   relayerConfigPath,
   versionsEnvPath,
@@ -160,7 +159,7 @@ const printBundle = (bundle: VersionBundle, options?: { detailed?: boolean }) =>
 const printPlan = (state: Pick<State, "target" | "overrides" | "scenario">, fromStep?: StepName) => {
   const topology = topologyForState(state);
   const overrides = visibleOverrides(state);
-  const multiChain = state.scenario.multiChain ?? false;
+  const isMultiChain = state.scenario.hostChains.length > 1;
   console.log(`[plan] profile=${state.target}`);
   if (overrides.length) {
     console.log(`[plan] overrides=${overrides.map(describeOverride).join(", ")}`);
@@ -168,7 +167,7 @@ const printPlan = (state: Pick<State, "target" | "overrides" | "scenario">, from
       console.log(`[warn] ${warning}`);
     }
   }
-  console.log(`[plan] topology=n${topology.count}/t${topology.threshold}${multiChain ? " multi-chain" : ""}`);
+  console.log(`[plan] topology=n${topology.count}/t${topology.threshold}${isMultiChain ? " multi-chain" : ""}`);
   console.log(`[plan] steps=${STEP_NAMES.slice(stateStepIndex(fromStep ?? STEP_NAMES[0])).join(" -> ")}`);
 };
 
@@ -222,10 +221,8 @@ export const minioIp = async () => {
 export const defaultEndpoints = async () => {
   const ip = await minioIp();
   return {
-    gatewayHttp: "http://gateway-node:8546",
-    gatewayWs: "ws://gateway-node:8546",
-    hostHttp: "http://host-node:8545",
-    hostWs: "ws://host-node:8545",
+    gateway: { http: "http://gateway-node:8546", ws: "ws://gateway-node:8546" },
+    hosts: { host: { http: "http://host-node:8545", ws: "ws://host-node:8545" } },
     minioInternal: MINIO_INTERNAL_URL,
     minioExternal: `http://${ip}:9000`,
   };
@@ -233,7 +230,7 @@ export const defaultEndpoints = async () => {
 
 export const createDiscovery = (endpoints: Discovery["endpoints"]): Discovery => ({
   gateway: {},
-  host: {},
+  hosts: {},
   kmsSigner: "",
   fheKeyId: predictedKeyId(),
   crsKeyId: predictedCrsId(),
@@ -257,7 +254,7 @@ export const discoverContracts = async () => {
   }
   return {
     gateway: await readEnvFile(gatewayAddressesPath),
-    host: await readEnvFile(hostAddressesPath),
+    hosts: { host: await readEnvFile(hostAddressesPath) },
   };
 };
 
@@ -438,8 +435,9 @@ export const validateDiscovery = (state: Pick<State, "target" | "versions" | "di
       throw new PreflightError(`Missing gateway discovery value ${key}`);
     }
   }
+  const primaryHost = discovery.hosts["host"] ?? {};
   for (const key of requiredHost) {
-    if (!discovery.host[key]) {
+    if (!primaryHost[key]) {
       throw new PreflightError(`Missing host discovery value ${key}`);
     }
   }
@@ -471,7 +469,7 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
           hostAddressesSolidityPath,
         ]
       : []),
-    ...(state.scenario.multiChain ? [hostBAddressesPath] : []),
+    ...state.scenario.hostChains.slice(1).map((chain) => hostChainAddressesPath(chain.key)),
   ];
   const allExist = (await Promise.all(requiredPaths.map((file) => exists(file)))).every(Boolean);
   if (allExist) {
@@ -481,24 +479,30 @@ const ensureRuntimeArtifacts = async (state: State, reason: string) => {
   await generateRuntime(state, stackSpecForState(state));
 };
 
-/** Maps each multi-chain compose file to the pipeline step that creates it. */
-const MULTI_CHAIN_STEP: Record<string, StepName> = {
-  "host-node-b": "base",
-  "host-sc-b": "host-deploy",
-  "coprocessor-host-b": "coprocessor",
+/** Returns multi-chain compose file names and their owning step for the current scenario. */
+const multiChainComposeEntries = (state: Pick<State, "scenario">): Array<[string, StepName]> => {
+  const entries: Array<[string, StepName]> = [];
+  for (const chain of state.scenario.hostChains.slice(1)) {
+    const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
+    const container = chain.key.replace(/^host/, "host-node");
+    entries.push([container, "base"]);
+    entries.push([`host-sc-${suffixId}`, "host-deploy"]);
+    entries.push([`coprocessor-host-${suffixId}`, "coprocessor"]);
+  }
+  return entries;
 };
 
 const resetAfterStep = async (step: StepName, state: Pick<State, "scenario">) => {
   const start = stateStepIndex(step);
   const failed: string[] = [];
-  if (state.scenario.multiChain) {
-    const toTearDown = Object.entries(MULTI_CHAIN_STEP)
-      .filter(([, parentStep]) => stateStepIndex(parentStep) >= start)
-      .map(([name]) => name);
-    const multiChainResults = await Promise.all(
+  const toTearDown = multiChainComposeEntries(state)
+    .filter(([, parentStep]) => stateStepIndex(parentStep) >= start)
+    .map(([name]) => name);
+  if (toTearDown.length) {
+    const results = await Promise.all(
       toTearDown.map(async (name) => ({ name, ok: await multiChainComposeDown(name) })),
     );
-    for (const { name, ok } of multiChainResults) {
+    for (const { name, ok } of results) {
       if (!ok) failed.push(name);
     }
   }
@@ -751,7 +755,7 @@ export const probeBootstrap = async (state: State) => {
   const keyPrefix = discovery.minioKeyPrefix ?? "PUB";
   try {
     const ethCallRaw = async (data: string) => {
-      const rpcUrl = hostReachableRpcUrl(discovery.endpoints.gatewayHttp);
+      const rpcUrl = hostReachableRpcUrl(discovery.endpoints.gateway.http);
       const response = await fetch(rpcUrl, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1099,20 +1103,20 @@ const coprocessorDbsSeeded = async (state: Pick<State, "scenario">) =>
     Array.from({ length: topologyForState(state).count }, (_, index) => (index === 0 ? "coprocessor" : `coprocessor_${index}`)).map(coprocessorDbSeeded),
   )).every(Boolean);
 
-const registerChainBInCoprocessor = async (state: State) => {
+/** Registers an extra host chain in all coprocessor databases and restarts zkproof-workers. */
+const registerExtraChainInCoprocessor = async (state: State, chain: { key: string; chainId: string }) => {
   const plan = stackSpecForState(state);
-  const aclAddress =
-    state.discovery?.hostB?.ACL_CONTRACT_ADDRESS ??
-    state.discovery?.host?.ACL_CONTRACT_ADDRESS ??
-    "";
+  const primaryHost = state.discovery?.hosts["host"] ?? {};
+  const chainHost = state.discovery?.hosts[chain.key] ?? {};
+  const aclAddress = chainHost.ACL_CONTRACT_ADDRESS ?? primaryHost.ACL_CONTRACT_ADDRESS ?? "";
   for (let index = 0; index < plan.topology.count; index += 1) {
     const dbName = index === 0 ? "coprocessor" : `coprocessor_${index}`;
     const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;
-    console.log(`[multi-chain] registering Chain B in ${dbName}`);
+    console.log(`[multi-chain] registering ${chain.key} in ${dbName}`);
     await run([
       "docker", "exec", COPROCESSOR_DB_CONTAINER,
       "psql", "-U", "postgres", "-d", dbName, "-c",
-      `INSERT INTO host_chains (chain_id, name, acl_contract_address) VALUES (${CHAIN_B_ID}, 'test chain b', '${aclAddress}') ON CONFLICT (chain_id) DO NOTHING;`,
+      `INSERT INTO host_chains (chain_id, name, acl_contract_address) VALUES (${chain.chainId}, '${chain.key}', '${aclAddress}') ON CONFLICT (chain_id) DO NOTHING;`,
     ]);
     console.log(`[multi-chain] restarting ${prefix}zkproof-worker`);
     await run(["docker", "stop", `${prefix}zkproof-worker`]);
@@ -1121,11 +1125,13 @@ const registerChainBInCoprocessor = async (state: State) => {
   }
 };
 
-const discoverChainBContracts = async () => {
-  if (!(await exists(hostBAddressesPath))) {
-    throw new PreflightError("Missing Chain B host address file");
+/** Discovers deployed contracts for an extra host chain from its address file. */
+const discoverExtraChainContracts = async (chainKey: string) => {
+  const addressPath = hostChainAddressesPath(chainKey);
+  if (!(await exists(addressPath))) {
+    throw new PreflightError(`Missing host address file for chain ${chainKey}`);
   }
-  return readEnvFile(hostBAddressesPath);
+  return readEnvFile(addressPath);
 };
 
 /** Waits for the kms-connector runtime services to become ready. */
@@ -1211,14 +1217,18 @@ export const runStep = async (state: State, step: StepName) => {
       await waitForRpc("http://localhost:8546");
       const plan = stackSpecForState(state);
       state.discovery = createDiscovery(await defaultEndpoints());
-      if (plan.multiChain) {
-        state.discovery.endpoints.hostBHttp = `http://host-node-b:${CHAIN_B_PORT}`;
-        state.discovery.endpoints.hostBWs = `ws://host-node-b:${CHAIN_B_PORT}`;
+      for (const chain of plan.hostChains.slice(1)) {
+        const container = chain.key.replace(/^host/, "host-node");
+        state.discovery.endpoints.hosts[chain.key] = {
+          http: `http://${container}:${chain.rpcPort}`,
+          ws: `ws://${container}:${chain.rpcPort}`,
+        };
       }
       await generateRuntime(state, stackSpecForState(state));
-      if (plan.multiChain) {
-        await multiChainComposeUp("host-node-b");
-        await waitForRpc(`http://localhost:${CHAIN_B_PORT}`);
+      for (const chain of plan.hostChains.slice(1)) {
+        const container = chain.key.replace(/^host/, "host-node");
+        await multiChainComposeUp(container);
+        await waitForRpc(`http://localhost:${chain.rpcPort}`);
       }
       break;
     }
@@ -1243,14 +1253,16 @@ export const runStep = async (state: State, step: StepName) => {
     case "host-deploy":
       await stepComposeUp("host-sc", state, ["host-sc-deploy"]);
       await waitForContainer("host-sc-deploy", "complete");
-      if (stackSpecForState(state).multiChain) {
-        await timed("[multi-chain] host-sc-b-deploy", async () => {
-          await multiChainComposeUp("host-sc-b", ["host-sc-b-deploy"]);
-          await waitForContainer("host-sc-b-deploy", "complete");
+      for (const chain of stackSpecForState(state).hostChains.slice(1)) {
+        const suffixId = hostChainSuffixId(chain.key);
+        const scKey = `host-sc-${suffixId}`;
+        await timed(`[multi-chain] ${scKey}-deploy`, async () => {
+          await multiChainComposeUp(scKey, [`${scKey}-deploy`]);
+          await waitForContainer(`${scKey}-deploy`, "complete");
         });
-        await timed("[multi-chain] host-sc-b-add-pausers", async () => {
-          await multiChainComposeUp("host-sc-b", ["host-sc-b-add-pausers"]);
-          await waitForContainer("host-sc-b-add-pausers", "complete");
+        await timed(`[multi-chain] ${scKey}-add-pausers`, async () => {
+          await multiChainComposeUp(scKey, [`${scKey}-add-pausers`]);
+          await waitForContainer(`${scKey}-add-pausers`, "complete");
         });
       }
       break;
@@ -1258,9 +1270,9 @@ export const runStep = async (state: State, step: StepName) => {
       const contracts = await discoverContracts();
       const discovery = await ensureDiscovery(state);
       discovery.gateway = contracts.gateway;
-      discovery.host = contracts.host;
-      if (stackSpecForState(state).multiChain) {
-        discovery.hostB = await discoverChainBContracts();
+      discovery.hosts = { ...discovery.hosts, ...contracts.hosts };
+      for (const chain of stackSpecForState(state).hostChains.slice(1)) {
+        discovery.hosts[chain.key] = await discoverExtraChainContracts(chain.key);
       }
       break;
     }
@@ -1281,17 +1293,18 @@ export const runStep = async (state: State, step: StepName) => {
       await stepComposeUp("coprocessor", state, services, { noDeps: skipMigration });
       await waitForCoprocessorServices(state, skipMigration);
       await postBootHealthGate(coprocessorHealthContainers(state));
-      if (stackSpecForState(state).multiChain) {
-        await timed("[multi-chain] register Chain B in coprocessor DBs", () =>
-          registerChainBInCoprocessor(state),
+      for (const chain of stackSpecForState(state).hostChains.slice(1)) {
+        const suffixId = hostChainSuffixId(chain.key);
+        await timed(`[multi-chain] register ${chain.key} in coprocessor DBs`, () =>
+          registerExtraChainInCoprocessor(state, chain),
         );
-        await timed("[multi-chain] start host-listener-b services", async () => {
-          await multiChainComposeUp("coprocessor-host-b");
+        await timed(`[multi-chain] start host-listener-${suffixId} services`, async () => {
+          await multiChainComposeUp(`coprocessor-host-${suffixId}`);
           const topology = topologyForState(state);
           for (let index = 0; index < topology.count; index += 1) {
             const prefix = index === 0 ? "coprocessor-" : `coprocessor${index}-`;
-            await waitForContainer(`${prefix}host-listener-b`, "running");
-            await waitForContainer(`${prefix}host-listener-poller-b`, "running");
+            await waitForContainer(`${prefix}host-listener-${suffixId}`, "running");
+            await waitForContainer(`${prefix}host-listener-poller-${suffixId}`, "running");
           }
         });
       }
@@ -1318,7 +1331,7 @@ export const runStep = async (state: State, step: StepName) => {
             .filter(Boolean)
             .map((chainId) =>
               castBool(
-                state.discovery!.endpoints.gatewayHttp,
+                state.discovery!.endpoints.gateway.http,
                 withHexPrefix(state.discovery!.gateway.GATEWAY_CONFIG_ADDRESS),
                 "isHostChainRegistered(uint256)(bool)",
                 chainId,
@@ -1340,8 +1353,8 @@ export const runStep = async (state: State, step: StepName) => {
         break;
       }
       const hostPauserRegistered = await castBool(
-        state.discovery!.endpoints.hostHttp,
-        withHexPrefix(state.discovery!.host.PAUSER_SET_CONTRACT_ADDRESS),
+        state.discovery!.endpoints.hosts["host"].http,
+        withHexPrefix(state.discovery!.hosts["host"].PAUSER_SET_CONTRACT_ADDRESS),
         "isPauser(address)(bool)",
         withHexPrefix(hostEnv.PAUSER_ADDRESS_0),
       ).catch(() => false);
@@ -1352,7 +1365,7 @@ export const runStep = async (state: State, step: StepName) => {
         await waitForContainer("host-sc-add-pausers", "complete");
       }
       const gatewayPauserRegistered = await castBool(
-        state.discovery!.endpoints.gatewayHttp,
+        state.discovery!.endpoints.gateway.http,
         withHexPrefix(gatewayEnv.PAUSER_SET_ADDRESS),
         "isPauser(address)(bool)",
         withHexPrefix(gatewayEnv.PAUSER_ADDRESS_0),
@@ -1398,7 +1411,7 @@ const describeResumeState = (state: State) => {
   return [
     `profile=${state.target}`,
     `topology=${topology.count}/${topology.threshold}`,
-    ...(state.scenario.multiChain ? ["multi-chain"] : []),
+    ...(state.scenario.hostChains.length > 1 ? ["multi-chain"] : []),
     ...(state.scenario.origin !== "default"
       ? [`scenario=${state.scenario.origin}${state.scenario.sourcePath ? `:${state.scenario.sourcePath}` : ""}`]
       : []),
@@ -1596,11 +1609,12 @@ export const down = async () => {
     await ensureRuntimeArtifacts(state, "teardown");
   }
   const failed: string[] = [];
-  if (state?.scenario?.multiChain) {
-    const multiChainResults = await Promise.all(
-      ["coprocessor-host-b", "host-sc-b", "host-node-b"].map(async (name) => ({ name, ok: await multiChainComposeDown(name) })),
+  if (state && state.scenario?.hostChains?.length > 1) {
+    const toTearDown = multiChainComposeEntries(state).map(([name]) => name);
+    const results = await Promise.all(
+      toTearDown.map(async (name) => ({ name, ok: await multiChainComposeDown(name) })),
     );
-    for (const { name, ok } of multiChainResults) {
+    for (const { name, ok } of results) {
       if (!ok) failed.push(name);
     }
   }
@@ -1671,7 +1685,7 @@ export const status = async () => {
         console.log(`[warn] ${warning}`);
       }
     }
-    console.log(`[topology] n=${topology.count} t=${topology.threshold}${state.scenario.multiChain ? " multi-chain" : ""}`);
+    console.log(`[topology] n=${topology.count} t=${topology.threshold}${state.scenario.hostChains.length > 1 ? " multi-chain" : ""}`);
     if (state.scenario.origin !== "default") {
       console.log(`[scenario] ${state.scenario.origin}${state.scenario.sourcePath ? ` ${state.scenario.sourcePath}` : ""}`);
       for (const instance of state.scenario.instances) {

--- a/test-suite/fhevm/src/generate/addresses.ts
+++ b/test-suite/fhevm/src/generate/addresses.ts
@@ -58,16 +58,24 @@ export const renderPaymentBridgingAddressesSolidity = (gatewayEnv: Record<string
     ["feesSenderToBurnerAddress", gatewayEnv.FEES_SENDER_TO_BURNER_ADDRESS],
   ]);
 
+const HOST_ADDRESS_KEYS = [
+  "ACL_CONTRACT_ADDRESS",
+  "FHEVM_EXECUTOR_CONTRACT_ADDRESS",
+  "KMS_VERIFIER_CONTRACT_ADDRESS",
+  "INPUT_VERIFIER_CONTRACT_ADDRESS",
+  "HCU_LIMIT_CONTRACT_ADDRESS",
+  "PAUSER_SET_CONTRACT_ADDRESS",
+] as const;
+
+const renderHostChainAddressesEnv = (addresses?: Record<string, string>) =>
+  renderEnvFile(HOST_ADDRESS_KEYS.map((key) => [key, addresses?.[key]]));
+
 /** Renders discovered host addresses into a dotenv artifact. */
 export const renderHostAddressesEnv = (state: Pick<State, "discovery">) =>
-  renderEnvFile([
-    ["ACL_CONTRACT_ADDRESS", state.discovery?.host.ACL_CONTRACT_ADDRESS],
-    ["FHEVM_EXECUTOR_CONTRACT_ADDRESS", state.discovery?.host.FHEVM_EXECUTOR_CONTRACT_ADDRESS],
-    ["KMS_VERIFIER_CONTRACT_ADDRESS", state.discovery?.host.KMS_VERIFIER_CONTRACT_ADDRESS],
-    ["INPUT_VERIFIER_CONTRACT_ADDRESS", state.discovery?.host.INPUT_VERIFIER_CONTRACT_ADDRESS],
-    ["HCU_LIMIT_CONTRACT_ADDRESS", state.discovery?.host.HCU_LIMIT_CONTRACT_ADDRESS],
-    ["PAUSER_SET_CONTRACT_ADDRESS", state.discovery?.host.PAUSER_SET_CONTRACT_ADDRESS],
-  ]);
+  renderHostChainAddressesEnv(state.discovery?.host);
+
+export const renderHostBAddressesEnv = (state: Pick<State, "discovery">) =>
+  renderHostChainAddressesEnv(state.discovery?.hostB);
 
 /** Renders discovered host addresses into Solidity constants. */
 export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) =>

--- a/test-suite/fhevm/src/generate/addresses.ts
+++ b/test-suite/fhevm/src/generate/addresses.ts
@@ -78,9 +78,9 @@ export const renderHostChainAddresses = (state: Pick<State, "discovery">, chainK
 export const renderHostAddressesEnv = (state: Pick<State, "discovery">) =>
   renderHostChainAddresses(state, "host");
 
-/** Renders discovered host addresses into Solidity constants. */
-export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) => {
-  const host = state.discovery?.hosts["host"];
+/** Renders discovered host addresses for a given chain key into Solidity constants. */
+export const renderHostChainAddressesSolidity = (state: Pick<State, "discovery">, chainKey: string) => {
+  const host = state.discovery?.hosts[chainKey];
   return renderSolidityFile([
     ["aclAdd", host?.ACL_CONTRACT_ADDRESS],
     ["fhevmExecutorAdd", host?.FHEVM_EXECUTOR_CONTRACT_ADDRESS],
@@ -90,3 +90,7 @@ export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) => 
     ["pauserSetAdd", host?.PAUSER_SET_CONTRACT_ADDRESS],
   ]);
 };
+
+/** Renders discovered primary host addresses into Solidity constants. */
+export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) =>
+  renderHostChainAddressesSolidity(state, "host");

--- a/test-suite/fhevm/src/generate/addresses.ts
+++ b/test-suite/fhevm/src/generate/addresses.ts
@@ -1,6 +1,7 @@
 /**
  * Renders address artifacts consumed by contracts, operators, and local tooling after deployment discovery.
  */
+import { PRIMARY_HOST_KEY } from "../layout";
 import type { State } from "../types";
 
 const SOLIDITY_HEADER = `// SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -76,7 +77,7 @@ export const renderHostChainAddresses = (state: Pick<State, "discovery">, chainK
 
 /** Renders discovered primary host addresses into a dotenv artifact. */
 export const renderHostAddressesEnv = (state: Pick<State, "discovery">) =>
-  renderHostChainAddresses(state, "host");
+  renderHostChainAddresses(state, PRIMARY_HOST_KEY);
 
 /** Renders discovered host addresses for a given chain key into Solidity constants. */
 export const renderHostChainAddressesSolidity = (state: Pick<State, "discovery">, chainKey: string) => {
@@ -93,4 +94,4 @@ export const renderHostChainAddressesSolidity = (state: Pick<State, "discovery">
 
 /** Renders discovered primary host addresses into Solidity constants. */
 export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) =>
-  renderHostChainAddressesSolidity(state, "host");
+  renderHostChainAddressesSolidity(state, PRIMARY_HOST_KEY);

--- a/test-suite/fhevm/src/generate/addresses.ts
+++ b/test-suite/fhevm/src/generate/addresses.ts
@@ -70,20 +70,23 @@ const HOST_ADDRESS_KEYS = [
 const renderHostChainAddressesEnv = (addresses?: Record<string, string>) =>
   renderEnvFile(HOST_ADDRESS_KEYS.map((key) => [key, addresses?.[key]]));
 
-/** Renders discovered host addresses into a dotenv artifact. */
-export const renderHostAddressesEnv = (state: Pick<State, "discovery">) =>
-  renderHostChainAddressesEnv(state.discovery?.host);
+/** Renders discovered host addresses for a given chain key into a dotenv artifact. */
+export const renderHostChainAddresses = (state: Pick<State, "discovery">, chainKey: string) =>
+  renderHostChainAddressesEnv(state.discovery?.hosts[chainKey]);
 
-export const renderHostBAddressesEnv = (state: Pick<State, "discovery">) =>
-  renderHostChainAddressesEnv(state.discovery?.hostB);
+/** Renders discovered primary host addresses into a dotenv artifact. */
+export const renderHostAddressesEnv = (state: Pick<State, "discovery">) =>
+  renderHostChainAddresses(state, "host");
 
 /** Renders discovered host addresses into Solidity constants. */
-export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) =>
-  renderSolidityFile([
-    ["aclAdd", state.discovery?.host.ACL_CONTRACT_ADDRESS],
-    ["fhevmExecutorAdd", state.discovery?.host.FHEVM_EXECUTOR_CONTRACT_ADDRESS],
-    ["kmsVerifierAdd", state.discovery?.host.KMS_VERIFIER_CONTRACT_ADDRESS],
-    ["inputVerifierAdd", state.discovery?.host.INPUT_VERIFIER_CONTRACT_ADDRESS],
-    ["hcuLimitAdd", state.discovery?.host.HCU_LIMIT_CONTRACT_ADDRESS],
-    ["pauserSetAdd", state.discovery?.host.PAUSER_SET_CONTRACT_ADDRESS],
+export const renderHostAddressesSolidity = (state: Pick<State, "discovery">) => {
+  const host = state.discovery?.hosts["host"];
+  return renderSolidityFile([
+    ["aclAdd", host?.ACL_CONTRACT_ADDRESS],
+    ["fhevmExecutorAdd", host?.FHEVM_EXECUTOR_CONTRACT_ADDRESS],
+    ["kmsVerifierAdd", host?.KMS_VERIFIER_CONTRACT_ADDRESS],
+    ["inputVerifierAdd", host?.INPUT_VERIFIER_CONTRACT_ADDRESS],
+    ["hcuLimitAdd", host?.HCU_LIMIT_CONTRACT_ADDRESS],
+    ["pauserSetAdd", host?.PAUSER_SET_CONTRACT_ADDRESS],
   ]);
+};

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -9,8 +9,11 @@ import YAML from "yaml";
 import { compatPolicyForState, type CompatPolicy } from "../compat/compat";
 import { topologyForState, type StackSpec } from "../stack-spec/stack-spec";
 import {
+  CHAIN_B_ID,
+  CHAIN_B_PORT,
   COMPONENTS,
   COMPOSE_OUT_DIR,
+  DEFAULT_CHAIN_ID,
   GROUP_BUILD_COMPONENTS,
   GROUP_BUILD_SERVICES,
   GROUP_SERVICE_SUFFIXES,
@@ -324,6 +327,92 @@ const buildComposeOverride = async (component: string, plan: StackSpec) => {
   return { services };
 };
 
+const buildHostNodeBOverride = async (_plan: StackSpec): Promise<ComposeDoc> => {
+  const doc = rewriteComposePaths(await loadComposeDoc("host-node"));
+  const hostNode = doc.services["host-node"];
+  if (!hostNode) return { services: {} };
+  const hostNodeB = structuredClone(hostNode);
+  hostNodeB.container_name = "host-node-b";
+  hostNodeB.env_file = [envPath("host-node-b")];
+  hostNodeB.ports = [`${CHAIN_B_PORT}:${CHAIN_B_PORT}`];
+  if (Array.isArray(hostNodeB.entrypoint)) {
+    hostNodeB.entrypoint = hostNodeB.entrypoint.map((arg: string) => {
+      if (arg === "8545") return String(CHAIN_B_PORT);
+      if (arg === DEFAULT_CHAIN_ID) return CHAIN_B_ID;
+      return arg;
+    });
+  }
+  return { services: { "host-node-b": hostNodeB } };
+};
+
+const buildHostScBOverride = async (_plan: StackSpec): Promise<ComposeDoc> => {
+  const doc = rewriteComposePaths(await loadComposeDoc("host-sc"));
+  const services: Record<string, Record<string, unknown>> = {};
+  for (const [name, service] of Object.entries(doc.services)) {
+    const bName = name.replace("host-sc-", "host-sc-b-");
+    const bService = structuredClone(service);
+    bService.container_name = bName;
+    bService.env_file = [envPath("host-sc-b")];
+    delete bService.build;
+    if (bService.depends_on && typeof bService.depends_on === "object") {
+      bService.depends_on = Object.fromEntries(
+        Object.entries(bService.depends_on as Record<string, unknown>).map(([dep, value]) => [
+          dep.replace("host-sc-", "host-sc-b-"),
+          value,
+        ]),
+      );
+    }
+    if (Array.isArray(bService.volumes)) {
+      bService.volumes = (bService.volumes as string[]).map((vol: string) =>
+        vol.replace("/addresses/host:", "/addresses/host-b:"),
+      );
+    }
+    services[bName] = bService;
+  }
+  return { services };
+};
+
+const buildCoprocessorHostListenerBOverride = async (plan: StackSpec): Promise<ComposeDoc> => {
+  const doc = rewriteComposePaths(await loadComposeDoc("coprocessor"));
+  const services: Record<string, Record<string, unknown>> = {};
+  const compat = compatPolicyForState(plan);
+  const inheritedBuildServices = coprocessorBuildServices(plan);
+  const listenerServices = ["coprocessor-host-listener", "coprocessor-host-listener-poller"];
+  for (const instance of plan.coprocessor.instances) {
+    const localServices =
+      instance.source.mode === "local"
+        ? localServicesForInstance(instance)
+        : instance.source.mode === "inherit"
+          ? inheritedBuildServices
+          : new Set<string>();
+    const prefix = instance.index === 0 ? "coprocessor-" : `coprocessor${instance.index}-`;
+    const envName = `coprocessor-b.${instance.index}`;
+    const envFileValue = envPath(envName);
+    const instanceEnv = await readEnvFile(envFileValue);
+    for (const baseName of listenerServices) {
+      const suffix = baseName.replace(/^coprocessor-/, "");
+      const bName = `${prefix}${suffix}-b`;
+      const baseService = doc.services[baseName];
+      if (!baseService) continue;
+      const locallyBuilt = localServices.has(baseName);
+      const adjusted = applyInstanceAdjustments(
+        baseName,
+        baseService,
+        envFileValue,
+        instanceEnv,
+        instance,
+        locallyBuilt ? {} : compat.coprocessorArgs,
+        locallyBuilt ? {} : compat.coprocessorDropFlags,
+      );
+      adjusted.container_name = bName;
+      applyCoprocessorSource(adjusted, instance, locallyBuilt);
+      delete adjusted.depends_on;
+      services[bName] = adjusted;
+    }
+  }
+  return { services };
+};
+
 /** Lists which components need generated compose overrides for a runtime plan. */
 export const generatedComposeComponents = (plan: Pick<StackSpec, "overrides">) =>
   new Set(["coprocessor", ...plan.overrides.flatMap((override) => GROUP_BUILD_COMPONENTS[override.group])]);
@@ -340,5 +429,22 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
     }
     const doc = await buildComposeOverride(component, plan);
     await fs.writeFile(target, YAML.stringify(doc));
+  }
+
+  // Multi-chain compose overrides
+  const multiChainFiles = ["host-node-b", "host-sc-b", "coprocessor-host-b"];
+  if (plan.multiChain) {
+    const [hostNodeB, hostScB, coproHostB] = await Promise.all([
+      buildHostNodeBOverride(plan),
+      buildHostScBOverride(plan),
+      buildCoprocessorHostListenerBOverride(plan),
+    ]);
+    await fs.writeFile(composePath("host-node-b"), YAML.stringify(hostNodeB));
+    await fs.writeFile(composePath("host-sc-b"), YAML.stringify(hostScB));
+    await fs.writeFile(composePath("coprocessor-host-b"), YAML.stringify(coproHostB));
+  } else {
+    for (const name of multiChainFiles) {
+      await remove(composePath(name));
+    }
   }
 };

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -9,19 +9,17 @@ import YAML from "yaml";
 import { compatPolicyForState, type CompatPolicy } from "../compat/compat";
 import { topologyForState, type StackSpec } from "../stack-spec/stack-spec";
 import {
-  CHAIN_B_ID,
-  CHAIN_B_PORT,
   COMPONENTS,
   COMPOSE_OUT_DIR,
-  DEFAULT_CHAIN_ID,
   GROUP_BUILD_COMPONENTS,
   GROUP_BUILD_SERVICES,
   GROUP_SERVICE_SUFFIXES,
   TEMPLATE_COMPOSE_DIR,
   composePath,
   envPath,
+  hostChainSuffixId,
 } from "../layout";
-import type { ResolvedCoprocessorScenarioInstance, State } from "../types";
+import type { HostChainScenario, ResolvedCoprocessorScenarioInstance, State } from "../types";
 import { ensureDir, exists, mergeArgs, readEnvFile, remove, toServiceName } from "../utils/fs";
 
 export type ComposeDoc = Record<string, unknown> & {
@@ -327,57 +325,64 @@ const buildComposeOverride = async (component: string, plan: StackSpec) => {
   return { services };
 };
 
-const buildHostNodeBOverride = async (_plan: StackSpec): Promise<ComposeDoc> => {
+/** Builds a host-node compose override for an extra host chain. */
+const buildExtraHostNodeOverride = async (chain: HostChainScenario, primaryChainId: string): Promise<ComposeDoc> => {
   const doc = rewriteComposePaths(await loadComposeDoc("host-node"));
   const hostNode = doc.services["host-node"];
   if (!hostNode) return { services: {} };
-  const hostNodeB = structuredClone(hostNode);
-  hostNodeB.container_name = "host-node-b";
-  hostNodeB.env_file = [envPath("host-node-b")];
-  hostNodeB.ports = [`${CHAIN_B_PORT}:${CHAIN_B_PORT}`];
-  if (Array.isArray(hostNodeB.entrypoint)) {
-    hostNodeB.entrypoint = hostNodeB.entrypoint.map((arg: string) => {
-      if (arg === "8545") return String(CHAIN_B_PORT);
-      if (arg === DEFAULT_CHAIN_ID) return CHAIN_B_ID;
+  const container = chain.key.replace(/^host/, "host-node");
+  const clone = structuredClone(hostNode);
+  clone.container_name = container;
+  clone.env_file = [envPath(container)];
+  clone.ports = [`${chain.rpcPort}:${chain.rpcPort}`];
+  if (Array.isArray(clone.entrypoint)) {
+    clone.entrypoint = clone.entrypoint.map((arg: string) => {
+      if (arg === "8545") return String(chain.rpcPort);
+      if (arg === primaryChainId) return chain.chainId;
       return arg;
     });
   }
-  return { services: { "host-node-b": hostNodeB } };
+  return { services: { [container]: clone } };
 };
 
-const buildHostScBOverride = async (_plan: StackSpec): Promise<ComposeDoc> => {
+/** Builds a host-sc compose override for an extra host chain. */
+const buildExtraHostScOverride = async (chain: HostChainScenario): Promise<ComposeDoc> => {
   const doc = rewriteComposePaths(await loadComposeDoc("host-sc"));
+  const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
+  const scPrefix = `host-sc-${suffixId}`;
   const services: Record<string, Record<string, unknown>> = {};
   for (const [name, service] of Object.entries(doc.services)) {
-    const bName = name.replace("host-sc-", "host-sc-b-");
-    const bService = structuredClone(service);
-    bService.container_name = bName;
-    bService.env_file = [envPath("host-sc-b")];
-    delete bService.build;
-    if (bService.depends_on && typeof bService.depends_on === "object") {
-      bService.depends_on = Object.fromEntries(
-        Object.entries(bService.depends_on as Record<string, unknown>).map(([dep, value]) => [
-          dep.replace("host-sc-", "host-sc-b-"),
+    const cloneName = name.replace("host-sc-", `${scPrefix}-`);
+    const cloneService = structuredClone(service);
+    cloneService.container_name = cloneName;
+    cloneService.env_file = [envPath(scPrefix)];
+    delete cloneService.build;
+    if (cloneService.depends_on && typeof cloneService.depends_on === "object") {
+      cloneService.depends_on = Object.fromEntries(
+        Object.entries(cloneService.depends_on as Record<string, unknown>).map(([dep, value]) => [
+          dep.replace("host-sc-", `${scPrefix}-`),
           value,
         ]),
       );
     }
-    if (Array.isArray(bService.volumes)) {
-      bService.volumes = (bService.volumes as string[]).map((vol: string) =>
-        vol.replace("/addresses/host:", "/addresses/host-b:"),
+    if (Array.isArray(cloneService.volumes)) {
+      cloneService.volumes = (cloneService.volumes as string[]).map((vol: string) =>
+        vol.replace("/addresses/host:", `/addresses/${chain.key}:`),
       );
     }
-    services[bName] = bService;
+    services[cloneName] = cloneService;
   }
   return { services };
 };
 
-const buildCoprocessorHostListenerBOverride = async (plan: StackSpec): Promise<ComposeDoc> => {
+/** Builds coprocessor host-listener overrides for an extra host chain. */
+const buildExtraCoprocessorListenerOverride = async (plan: StackSpec, chain: HostChainScenario): Promise<ComposeDoc> => {
   const doc = rewriteComposePaths(await loadComposeDoc("coprocessor"));
   const services: Record<string, Record<string, unknown>> = {};
   const compat = compatPolicyForState(plan);
   const inheritedBuildServices = coprocessorBuildServices(plan);
   const listenerServices = ["coprocessor-host-listener", "coprocessor-host-listener-poller"];
+  const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
   for (const instance of plan.coprocessor.instances) {
     const localServices =
       instance.source.mode === "local"
@@ -386,12 +391,12 @@ const buildCoprocessorHostListenerBOverride = async (plan: StackSpec): Promise<C
           ? inheritedBuildServices
           : new Set<string>();
     const prefix = instance.index === 0 ? "coprocessor-" : `coprocessor${instance.index}-`;
-    const envName = `coprocessor-b.${instance.index}`;
+    const envName = `coprocessor-${suffixId}.${instance.index}`;
     const envFileValue = envPath(envName);
     const instanceEnv = await readEnvFile(envFileValue);
     for (const baseName of listenerServices) {
       const suffix = baseName.replace(/^coprocessor-/, "");
-      const bName = `${prefix}${suffix}-b`;
+      const cloneName = `${prefix}${suffix}-${suffixId}`;
       const baseService = doc.services[baseName];
       if (!baseService) continue;
       const locallyBuilt = localServices.has(baseName);
@@ -404,10 +409,10 @@ const buildCoprocessorHostListenerBOverride = async (plan: StackSpec): Promise<C
         locallyBuilt ? {} : compat.coprocessorArgs,
         locallyBuilt ? {} : compat.coprocessorDropFlags,
       );
-      adjusted.container_name = bName;
+      adjusted.container_name = cloneName;
       applyCoprocessorSource(adjusted, instance, locallyBuilt);
       delete adjusted.depends_on;
-      services[bName] = adjusted;
+      services[cloneName] = adjusted;
     }
   }
   return { services };
@@ -431,19 +436,28 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
     await fs.writeFile(target, YAML.stringify(doc));
   }
 
-  // Multi-chain compose overrides
-  const multiChainFiles = ["host-node-b", "host-sc-b", "coprocessor-host-b"];
-  if (plan.multiChain) {
-    const [hostNodeB, hostScB, coproHostB] = await Promise.all([
-      buildHostNodeBOverride(plan),
-      buildHostScBOverride(plan),
-      buildCoprocessorHostListenerBOverride(plan),
+  // Extra host chain compose overrides
+  const extraChains = plan.hostChains.slice(1);
+  const primaryChainId = plan.hostChains[0]?.chainId ?? "12345";
+  const extraChainFileNames: string[] = [];
+  for (const chain of extraChains) {
+    const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
+    const container = chain.key.replace(/^host/, "host-node");
+    const hostScKey = `host-sc-${suffixId}`;
+    const coproKey = `coprocessor-host-${suffixId}`;
+    extraChainFileNames.push(container, hostScKey, coproKey);
+    const [hostNodeDoc, hostScDoc, coproDoc] = await Promise.all([
+      buildExtraHostNodeOverride(chain, primaryChainId),
+      buildExtraHostScOverride(chain),
+      buildExtraCoprocessorListenerOverride(plan, chain),
     ]);
-    await fs.writeFile(composePath("host-node-b"), YAML.stringify(hostNodeB));
-    await fs.writeFile(composePath("host-sc-b"), YAML.stringify(hostScB));
-    await fs.writeFile(composePath("coprocessor-host-b"), YAML.stringify(coproHostB));
-  } else {
-    for (const name of multiChainFiles) {
+    await fs.writeFile(composePath(container), YAML.stringify(hostNodeDoc));
+    await fs.writeFile(composePath(hostScKey), YAML.stringify(hostScDoc));
+    await fs.writeFile(composePath(coproKey), YAML.stringify(coproDoc));
+  }
+  // Clean up stale multi-chain files from previous runs
+  for (const name of ["host-node-b", "host-sc-b", "coprocessor-host-b"]) {
+    if (!extraChainFileNames.includes(name)) {
       await remove(composePath(name));
     }
   }

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -18,7 +18,7 @@ import {
   composePath,
   envPath,
   hostChainNames,
-  hostChainSuffixId,
+  hostChainSuffix,
   hostNodeName,
   hostScName,
 } from "../layout";
@@ -384,7 +384,7 @@ const buildExtraCoprocessorListenerOverride = async (plan: StackSpec, chain: Hos
   const compat = compatPolicyForState(plan);
   const inheritedBuildServices = coprocessorBuildServices(plan);
   const listenerServices = ["coprocessor-host-listener", "coprocessor-host-listener-poller"];
-  const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
+  const chainSuffix = hostChainSuffix(chain.key);
   for (const instance of plan.coprocessor.instances) {
     const localServices =
       instance.source.mode === "local"
@@ -398,7 +398,7 @@ const buildExtraCoprocessorListenerOverride = async (plan: StackSpec, chain: Hos
     const instanceEnv = await readEnvFile(envFileValue);
     for (const baseName of listenerServices) {
       const suffix = baseName.replace(/^coprocessor-/, "");
-      const cloneName = `${prefix}${suffix}-${suffixId}`;
+      const cloneName = `${prefix}${suffix}${chainSuffix}`;
       const baseService = doc.services[baseName];
       if (!baseService) continue;
       const locallyBuilt = localServices.has(baseName);

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -16,8 +16,8 @@ import {
   GROUP_SERVICE_SUFFIXES,
   TEMPLATE_COMPOSE_DIR,
   composePath,
-  coprocessorHostKey,
   envPath,
+  hostChainNames,
   hostChainSuffixId,
   hostNodeName,
   hostScName,
@@ -443,18 +443,16 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
   const primaryChainId = plan.hostChains[0]?.chainId ?? "12345";
   const extraChainFileNames: string[] = [];
   for (const chain of extraChains) {
-    const container = hostNodeName(chain.key);
-    const hostScKey = hostScName(chain.key);
-    const coproKey = coprocessorHostKey(chain.key);
-    extraChainFileNames.push(container, hostScKey, coproKey);
+    const { node, sc, copro } = hostChainNames(chain.key);
+    extraChainFileNames.push(node, sc, copro);
     const [hostNodeDoc, hostScDoc, coproDoc] = await Promise.all([
       buildExtraHostNodeOverride(chain, primaryChainId),
       buildExtraHostScOverride(chain),
       buildExtraCoprocessorListenerOverride(plan, chain),
     ]);
-    await fs.writeFile(composePath(container), YAML.stringify(hostNodeDoc));
-    await fs.writeFile(composePath(hostScKey), YAML.stringify(hostScDoc));
-    await fs.writeFile(composePath(coproKey), YAML.stringify(coproDoc));
+    await fs.writeFile(composePath(node), YAML.stringify(hostNodeDoc));
+    await fs.writeFile(composePath(sc), YAML.stringify(hostScDoc));
+    await fs.writeFile(composePath(copro), YAML.stringify(coproDoc));
   }
   // Clean up stale multi-chain compose files from previous runs.
   // Scan the output directory for files matching multi-chain naming patterns

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -16,8 +16,11 @@ import {
   GROUP_SERVICE_SUFFIXES,
   TEMPLATE_COMPOSE_DIR,
   composePath,
+  coprocessorHostKey,
   envPath,
   hostChainSuffixId,
+  hostNodeName,
+  hostScName,
 } from "../layout";
 import type { HostChainScenario, ResolvedCoprocessorScenarioInstance, State } from "../types";
 import { ensureDir, exists, mergeArgs, readEnvFile, remove, toServiceName } from "../utils/fs";
@@ -330,7 +333,7 @@ const buildExtraHostNodeOverride = async (chain: HostChainScenario, primaryChain
   const doc = rewriteComposePaths(await loadComposeDoc("host-node"));
   const hostNode = doc.services["host-node"];
   if (!hostNode) return { services: {} };
-  const container = chain.key.replace(/^host/, "host-node");
+  const container = hostNodeName(chain.key);
   const clone = structuredClone(hostNode);
   clone.container_name = container;
   clone.env_file = [envPath(container)];
@@ -348,8 +351,7 @@ const buildExtraHostNodeOverride = async (chain: HostChainScenario, primaryChain
 /** Builds a host-sc compose override for an extra host chain. */
 const buildExtraHostScOverride = async (chain: HostChainScenario): Promise<ComposeDoc> => {
   const doc = rewriteComposePaths(await loadComposeDoc("host-sc"));
-  const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
-  const scPrefix = `host-sc-${suffixId}`;
+  const scPrefix = hostScName(chain.key);
   const services: Record<string, Record<string, unknown>> = {};
   for (const [name, service] of Object.entries(doc.services)) {
     const cloneName = name.replace("host-sc-", `${scPrefix}-`);
@@ -391,7 +393,7 @@ const buildExtraCoprocessorListenerOverride = async (plan: StackSpec, chain: Hos
           ? inheritedBuildServices
           : new Set<string>();
     const prefix = instance.index === 0 ? "coprocessor-" : `coprocessor${instance.index}-`;
-    const envName = `coprocessor-${suffixId}.${instance.index}`;
+    const envName = `coprocessor-${chain.key}.${instance.index}`;
     const envFileValue = envPath(envName);
     const instanceEnv = await readEnvFile(envFileValue);
     for (const baseName of listenerServices) {
@@ -441,10 +443,9 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
   const primaryChainId = plan.hostChains[0]?.chainId ?? "12345";
   const extraChainFileNames: string[] = [];
   for (const chain of extraChains) {
-    const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
-    const container = chain.key.replace(/^host/, "host-node");
-    const hostScKey = `host-sc-${suffixId}`;
-    const coproKey = `coprocessor-host-${suffixId}`;
+    const container = hostNodeName(chain.key);
+    const hostScKey = hostScName(chain.key);
+    const coproKey = coprocessorHostKey(chain.key);
     extraChainFileNames.push(container, hostScKey, coproKey);
     const [hostNodeDoc, hostScDoc, coproDoc] = await Promise.all([
       buildExtraHostNodeOverride(chain, primaryChainId),
@@ -455,9 +456,16 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
     await fs.writeFile(composePath(hostScKey), YAML.stringify(hostScDoc));
     await fs.writeFile(composePath(coproKey), YAML.stringify(coproDoc));
   }
-  // Clean up stale multi-chain files from previous runs
-  for (const name of ["host-node-b", "host-sc-b", "coprocessor-host-b"]) {
-    if (!extraChainFileNames.includes(name)) {
+  // Clean up stale multi-chain compose files from previous runs.
+  // Scan the output directory for files matching multi-chain naming patterns
+  // and remove any that are not part of the current active set.
+  const MULTI_CHAIN_PREFIXES = ["host-node-", "host-sc-", "coprocessor-host-"];
+  const activeSet = new Set(extraChainFileNames);
+  const dirEntries = await fs.readdir(COMPOSE_OUT_DIR).catch(() => [] as string[]);
+  for (const entry of dirEntries) {
+    if (!entry.endsWith(".yml")) continue;
+    const name = entry.slice(0, -4); // strip .yml
+    if (MULTI_CHAIN_PREFIXES.some((prefix) => name.startsWith(prefix)) && !activeSet.has(name)) {
       await remove(composePath(name));
     }
   }

--- a/test-suite/fhevm/src/generate/config.ts
+++ b/test-suite/fhevm/src/generate/config.ts
@@ -4,6 +4,8 @@
 import YAML from "yaml";
 
 import { requiresLegacyRelayerReadinessConfig } from "../compat/compat";
+import { CHAIN_B_ID, CHAIN_B_PORT } from "../layout";
+import type { StackSpec } from "../stack-spec/stack-spec";
 import type { State } from "../types";
 
 /** Rewrites relayer readiness config into the legacy shape when required. */
@@ -37,9 +39,37 @@ const rewriteRelayerConfig = (
   return config;
 };
 
+const appendChainB = (
+  config: Record<string, unknown>,
+  state: Pick<State, "discovery">,
+) => {
+  const hostChains = config.host_chains;
+  if (!Array.isArray(hostChains)) return config;
+  const alreadyHasChainB = hostChains.some(
+    (entry: unknown) => typeof entry === "object" && entry !== null && (entry as Record<string, unknown>).chain_id === Number(CHAIN_B_ID),
+  );
+  if (alreadyHasChainB) return config;
+  const aclAddress =
+    state.discovery?.hostB?.ACL_CONTRACT_ADDRESS ??
+    state.discovery?.host?.ACL_CONTRACT_ADDRESS ??
+    "";
+  hostChains.push({
+    chain_id: Number(CHAIN_B_ID),
+    url: `http://host-node-b:${CHAIN_B_PORT}`,
+    acl_address: aclAddress,
+  });
+  return config;
+};
+
 /** Renders the relayer config file from the template and compatibility policy. */
 export const renderRelayerConfig = (
-  state: Pick<State, "versions"> & Partial<Pick<State, "overrides">>,
+  state: Pick<State, "versions" | "discovery"> & Partial<Pick<State, "overrides">>,
   templateText: string,
-) =>
-  YAML.stringify(rewriteRelayerConfig(YAML.parse(templateText) as Record<string, unknown>, state));
+  plan?: Pick<StackSpec, "multiChain">,
+) => {
+  let config = rewriteRelayerConfig(YAML.parse(templateText) as Record<string, unknown>, state);
+  if (plan?.multiChain) {
+    config = appendChainB(config, state);
+  }
+  return YAML.stringify(config);
+};

--- a/test-suite/fhevm/src/generate/config.ts
+++ b/test-suite/fhevm/src/generate/config.ts
@@ -4,6 +4,7 @@
 import YAML from "yaml";
 
 import { requiresLegacyRelayerReadinessConfig } from "../compat/compat";
+import { PRIMARY_HOST_KEY, hostNodeName } from "../layout";
 import type { StackSpec } from "../stack-spec/stack-spec";
 import type { HostChainScenario, State } from "../types";
 
@@ -51,11 +52,11 @@ const appendExtraHostChains = (
       typeof entry === "object" && entry !== null ? (entry as Record<string, unknown>).chain_id : undefined,
     ),
   );
-  const primaryAcl = Object.values(state.discovery?.hosts ?? {})[0]?.ACL_CONTRACT_ADDRESS ?? "";
+  const primaryAcl = state.discovery?.hosts[PRIMARY_HOST_KEY]?.ACL_CONTRACT_ADDRESS ?? "";
   for (const chain of extraChains) {
     const chainId = Number(chain.chainId);
     if (existing.has(chainId)) continue;
-    const container = chain.key.replace(/^host/, "host-node");
+    const container = hostNodeName(chain.key);
     const aclAddress = state.discovery?.hosts[chain.key]?.ACL_CONTRACT_ADDRESS ?? primaryAcl;
     hostChainsList.push({
       chain_id: chainId,

--- a/test-suite/fhevm/src/generate/config.ts
+++ b/test-suite/fhevm/src/generate/config.ts
@@ -4,7 +4,7 @@
 import YAML from "yaml";
 
 import { requiresLegacyRelayerReadinessConfig } from "../compat/compat";
-import { PRIMARY_HOST_KEY, hostNodeName } from "../layout";
+import { hostNodeName } from "../layout";
 import type { StackSpec } from "../stack-spec/stack-spec";
 import type { HostChainScenario, State } from "../types";
 
@@ -52,12 +52,11 @@ const appendExtraHostChains = (
       typeof entry === "object" && entry !== null ? (entry as Record<string, unknown>).chain_id : undefined,
     ),
   );
-  const primaryAcl = state.discovery?.hosts[PRIMARY_HOST_KEY]?.ACL_CONTRACT_ADDRESS ?? "";
   for (const chain of extraChains) {
     const chainId = Number(chain.chainId);
     if (existing.has(chainId)) continue;
     const container = hostNodeName(chain.key);
-    const aclAddress = state.discovery?.hosts[chain.key]?.ACL_CONTRACT_ADDRESS ?? primaryAcl;
+    const aclAddress = state.discovery?.hosts[chain.key]?.ACL_CONTRACT_ADDRESS ?? "";
     hostChainsList.push({
       chain_id: chainId,
       url: `http://${container}:${chain.rpcPort}`,

--- a/test-suite/fhevm/src/generate/config.ts
+++ b/test-suite/fhevm/src/generate/config.ts
@@ -4,9 +4,8 @@
 import YAML from "yaml";
 
 import { requiresLegacyRelayerReadinessConfig } from "../compat/compat";
-import { CHAIN_B_ID, CHAIN_B_PORT } from "../layout";
 import type { StackSpec } from "../stack-spec/stack-spec";
-import type { State } from "../types";
+import type { HostChainScenario, State } from "../types";
 
 /** Rewrites relayer readiness config into the legacy shape when required. */
 const rewriteRelayerConfig = (
@@ -39,25 +38,31 @@ const rewriteRelayerConfig = (
   return config;
 };
 
-const appendChainB = (
+/** Appends extra host chains to the relayer config, driven by hostChains topology. */
+const appendExtraHostChains = (
   config: Record<string, unknown>,
   state: Pick<State, "discovery">,
+  extraChains: HostChainScenario[],
 ) => {
-  const hostChains = config.host_chains;
-  if (!Array.isArray(hostChains)) return config;
-  const alreadyHasChainB = hostChains.some(
-    (entry: unknown) => typeof entry === "object" && entry !== null && (entry as Record<string, unknown>).chain_id === Number(CHAIN_B_ID),
+  const hostChainsList = config.host_chains;
+  if (!Array.isArray(hostChainsList)) return config;
+  const existing = new Set(
+    hostChainsList.map((entry: unknown) =>
+      typeof entry === "object" && entry !== null ? (entry as Record<string, unknown>).chain_id : undefined,
+    ),
   );
-  if (alreadyHasChainB) return config;
-  const aclAddress =
-    state.discovery?.hostB?.ACL_CONTRACT_ADDRESS ??
-    state.discovery?.host?.ACL_CONTRACT_ADDRESS ??
-    "";
-  hostChains.push({
-    chain_id: Number(CHAIN_B_ID),
-    url: `http://host-node-b:${CHAIN_B_PORT}`,
-    acl_address: aclAddress,
-  });
+  const primaryAcl = Object.values(state.discovery?.hosts ?? {})[0]?.ACL_CONTRACT_ADDRESS ?? "";
+  for (const chain of extraChains) {
+    const chainId = Number(chain.chainId);
+    if (existing.has(chainId)) continue;
+    const container = chain.key.replace(/^host/, "host-node");
+    const aclAddress = state.discovery?.hosts[chain.key]?.ACL_CONTRACT_ADDRESS ?? primaryAcl;
+    hostChainsList.push({
+      chain_id: chainId,
+      url: `http://${container}:${chain.rpcPort}`,
+      acl_address: aclAddress,
+    });
+  }
   return config;
 };
 
@@ -65,11 +70,12 @@ const appendChainB = (
 export const renderRelayerConfig = (
   state: Pick<State, "versions" | "discovery"> & Partial<Pick<State, "overrides">>,
   templateText: string,
-  plan?: Pick<StackSpec, "multiChain">,
+  plan?: Pick<StackSpec, "hostChains">,
 ) => {
   let config = rewriteRelayerConfig(YAML.parse(templateText) as Record<string, unknown>, state);
-  if (plan?.multiChain) {
-    config = appendChainB(config, state);
+  const extraChains = (plan?.hostChains ?? []).slice(1);
+  if (extraChains.length > 0) {
+    config = appendExtraHostChains(config, state, extraChains);
   }
   return YAML.stringify(config);
 };

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -8,15 +8,13 @@ import {
 } from "../compat/compat";
 import type { StackSpec } from "../stack-spec/stack-spec";
 import {
-  CHAIN_B_ID,
-  CHAIN_B_PORT,
   COPROCESSOR_WALLET_INDICES,
-  DEFAULT_CHAIN_ID,
   DEFAULT_TENANT_API_KEY,
   MINIO_INTERNAL_URL,
   POSTGRES_HOST,
+  hostChainSuffixId,
 } from "../layout";
-import type { State } from "../types";
+import type { HostChainScenario, State } from "../types";
 import { predictedCrsId, predictedKeyId } from "../utils/fs";
 import { interpolateString } from "./compose";
 
@@ -24,6 +22,10 @@ export type WalletMaterial = {
   address: string;
   privateKey: string;
 };
+
+/** Derives the docker container name for a host chain. "host" → "host-node", "host-b" → "host-node-b". */
+const hostNodeContainer = (chain: HostChainScenario) =>
+  chain.key.replace(/^host/, "host-node");
 
 const HAS_PLACEHOLDER = /(?<!\$)\$\{[A-Z0-9_]+\}/;
 
@@ -134,6 +136,9 @@ const applyDiscoveryEnv = (
     return;
   }
 
+  const primaryKey = plan.hostChains[0].key;
+  const primaryHost = state.discovery.hosts[primaryKey] ?? {};
+
   updateContracts(envs["gateway-sc"], state.discovery.gateway);
   updateContracts(envs["gateway-mocked-payment"], {
     PROTOCOL_PAYMENT_ADDRESS: state.discovery.gateway.PROTOCOL_PAYMENT_ADDRESS,
@@ -141,31 +146,35 @@ const applyDiscoveryEnv = (
   updateContracts(envs["host-sc"], {
     DECRYPTION_ADDRESS: state.discovery.gateway.DECRYPTION_ADDRESS,
     INPUT_VERIFICATION_ADDRESS: state.discovery.gateway.INPUT_VERIFICATION_ADDRESS,
-    ACL_CONTRACT_ADDRESS: state.discovery.host.ACL_CONTRACT_ADDRESS,
-    PAUSER_SET_CONTRACT_ADDRESS: state.discovery.host.PAUSER_SET_CONTRACT_ADDRESS,
+    ACL_CONTRACT_ADDRESS: primaryHost.ACL_CONTRACT_ADDRESS,
+    PAUSER_SET_CONTRACT_ADDRESS: primaryHost.PAUSER_SET_CONTRACT_ADDRESS,
   });
-  envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 = state.discovery.host.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
-  envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 = state.discovery.host.ACL_CONTRACT_ADDRESS;
+  envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 = primaryHost.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
+  envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 = primaryHost.ACL_CONTRACT_ADDRESS;
   updateContracts(envs["coprocessor"], {
-    ACL_CONTRACT_ADDRESS: state.discovery.host.ACL_CONTRACT_ADDRESS,
-    FHEVM_EXECUTOR_CONTRACT_ADDRESS: state.discovery.host.FHEVM_EXECUTOR_CONTRACT_ADDRESS,
-    INPUT_VERIFIER_ADDRESS: state.discovery.host.INPUT_VERIFIER_CONTRACT_ADDRESS,
+    ACL_CONTRACT_ADDRESS: primaryHost.ACL_CONTRACT_ADDRESS,
+    FHEVM_EXECUTOR_CONTRACT_ADDRESS: primaryHost.FHEVM_EXECUTOR_CONTRACT_ADDRESS,
+    INPUT_VERIFIER_ADDRESS: primaryHost.INPUT_VERIFIER_CONTRACT_ADDRESS,
     INPUT_VERIFICATION_ADDRESS: state.discovery.gateway.INPUT_VERIFICATION_ADDRESS,
     CIPHERTEXT_COMMITS_ADDRESS: state.discovery.gateway.CIPHERTEXT_COMMITS_ADDRESS,
     ...(requiresMultichainAclAddress(plan) ? { MULTICHAIN_ACL_ADDRESS: state.discovery.gateway.MULTICHAIN_ACL_ADDRESS } : {}),
     KMS_GENERATION_ADDRESS: state.discovery.gateway.KMS_GENERATION_ADDRESS,
   });
+
+  const kmsHostChains = plan.hostChains.map((chain) => {
+    const hostAddresses = state.discovery!.hosts[chain.key] ?? {};
+    const endpoints = state.discovery!.endpoints.hosts[chain.key];
+    return {
+      url: endpoints?.http ?? `http://${hostNodeContainer(chain)}:${chain.rpcPort}`,
+      chain_id: Number(chain.chainId),
+      acl_address: hostAddresses.ACL_CONTRACT_ADDRESS ?? primaryHost.ACL_CONTRACT_ADDRESS,
+    };
+  });
   updateContracts(envs["kms-connector"], {
     KMS_CONNECTOR_DECRYPTION_CONTRACT__ADDRESS: state.discovery.gateway.DECRYPTION_ADDRESS,
     KMS_CONNECTOR_GATEWAY_CONFIG_CONTRACT__ADDRESS: state.discovery.gateway.GATEWAY_CONFIG_ADDRESS,
     KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS: state.discovery.gateway.KMS_GENERATION_ADDRESS,
-    KMS_CONNECTOR_HOST_CHAINS: JSON.stringify([
-      {
-        url: state.discovery.endpoints.hostHttp,
-        chain_id: Number(envs["coprocessor"].CHAIN_ID ?? DEFAULT_CHAIN_ID),
-        acl_address: state.discovery.host.ACL_CONTRACT_ADDRESS,
-      },
-    ]),
+    KMS_CONNECTOR_HOST_CHAINS: JSON.stringify(kmsHostChains),
   });
   updateContracts(envs["relayer"], {
     APP_GATEWAY__CONTRACTS__DECRYPTION_ADDRESS: state.discovery.gateway.DECRYPTION_ADDRESS,
@@ -174,10 +183,10 @@ const applyDiscoveryEnv = (
   updateContracts(envs["test-suite"], {
     DECRYPTION_ADDRESS: state.discovery.gateway.DECRYPTION_ADDRESS,
     INPUT_VERIFICATION_ADDRESS: state.discovery.gateway.INPUT_VERIFICATION_ADDRESS,
-    KMS_VERIFIER_CONTRACT_ADDRESS: state.discovery.host.KMS_VERIFIER_CONTRACT_ADDRESS,
-    ACL_CONTRACT_ADDRESS: state.discovery.host.ACL_CONTRACT_ADDRESS,
-    INPUT_VERIFIER_CONTRACT_ADDRESS: state.discovery.host.INPUT_VERIFIER_CONTRACT_ADDRESS,
-    FHEVM_EXECUTOR_CONTRACT_ADDRESS: state.discovery.host.FHEVM_EXECUTOR_CONTRACT_ADDRESS,
+    KMS_VERIFIER_CONTRACT_ADDRESS: primaryHost.KMS_VERIFIER_CONTRACT_ADDRESS,
+    ACL_CONTRACT_ADDRESS: primaryHost.ACL_CONTRACT_ADDRESS,
+    INPUT_VERIFIER_CONTRACT_ADDRESS: primaryHost.INPUT_VERIFIER_CONTRACT_ADDRESS,
+    FHEVM_EXECUTOR_CONTRACT_ADDRESS: primaryHost.FHEVM_EXECUTOR_CONTRACT_ADDRESS,
   });
 };
 
@@ -247,77 +256,68 @@ export const renderEnvMaps = async (
   applyDiscoveryEnv(envs, state, plan);
   const instanceEnvs = await buildInstanceEnvs(envs, plan, deriveWallet);
 
-  if (plan.multiChain) {
-    const hostBHttp = `http://host-node-b:${CHAIN_B_PORT}`;
-    const hostBWs = `ws://host-node-b:${CHAIN_B_PORT}`;
+  const extraChains = plan.hostChains.slice(1);
+  if (extraChains.length > 0) {
+    envs["gateway-sc"].NUM_HOST_CHAINS = String(plan.hostChains.length);
 
-    envs["gateway-sc"].NUM_HOST_CHAINS = "2";
-    envs["gateway-sc"].HOST_CHAIN_CHAIN_ID_1 = CHAIN_B_ID;
-    envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_1 =
-      state.discovery?.hostB?.FHEVM_EXECUTOR_CONTRACT_ADDRESS ??
-      envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 ?? "";
-    envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_1 =
-      state.discovery?.hostB?.ACL_CONTRACT_ADDRESS ??
-      envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 ?? "";
-    envs["gateway-sc"].HOST_CHAIN_NAME_1 = "";
-    envs["gateway-sc"].HOST_CHAIN_WEBSITE_1 = "";
+    for (let ci = 0; ci < extraChains.length; ci += 1) {
+      const chain = extraChains[ci];
+      const chainIndex = ci + 1;
+      const container = hostNodeContainer(chain);
+      const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
+      const hostHttp = `http://${container}:${chain.rpcPort}`;
+      const hostWs = `ws://${container}:${chain.rpcPort}`;
+      const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
 
-    instanceEnvs["host-node-b"] = {
-      ...envs["host-node"],
-      HOST_NODE_CONTAINER_NAME: "host-node-b",
-      HOST_NODE_PORT: String(CHAIN_B_PORT),
-      HOST_NODE_CHAIN_ID: CHAIN_B_ID,
-    };
+      envs["gateway-sc"][`HOST_CHAIN_CHAIN_ID_${chainIndex}`] = chain.chainId;
+      envs["gateway-sc"][`HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_${chainIndex}`] =
+        hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS ??
+        envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 ?? "";
+      envs["gateway-sc"][`HOST_CHAIN_ACL_ADDRESS_${chainIndex}`] =
+        hostAddresses.ACL_CONTRACT_ADDRESS ??
+        envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 ?? "";
+      envs["gateway-sc"][`HOST_CHAIN_NAME_${chainIndex}`] = chain.name ?? "";
+      envs["gateway-sc"][`HOST_CHAIN_WEBSITE_${chainIndex}`] = "";
 
-    const hostScB = { ...envs["host-sc"] };
-    hostScB.RPC_URL = hostBHttp;
-    hostScB.CHAIN_ID = CHAIN_B_ID;
-    hostScB.HOST_SC_DEPLOY_CONTAINER_NAME = "host-sc-b-deploy";
-    hostScB.HOST_SC_PAUSERS_CONTAINER_NAME = "host-sc-b-add-pausers";
-    hostScB.NUM_COPROCESSORS = String(plan.topology.count);
-    hostScB.COPROCESSOR_THRESHOLD = String(plan.topology.threshold);
-    for (let i = 0; i < plan.topology.count; i += 1) {
-      const signer = envs["host-sc"][`COPROCESSOR_SIGNER_ADDRESS_${i}`];
-      if (signer) {
-        hostScB[`COPROCESSOR_SIGNER_ADDRESS_${i}`] = signer;
+      instanceEnvs[container] = {
+        ...envs["host-node"],
+        HOST_NODE_CONTAINER_NAME: container,
+        HOST_NODE_PORT: String(chain.rpcPort),
+        HOST_NODE_CHAIN_ID: chain.chainId,
+      };
+
+      const hostScKey = `host-sc-${suffixId}`;
+      const hostSc = { ...envs["host-sc"] };
+      hostSc.RPC_URL = hostHttp;
+      hostSc.CHAIN_ID = chain.chainId;
+      hostSc.HOST_SC_DEPLOY_CONTAINER_NAME = `${hostScKey}-deploy`;
+      hostSc.HOST_SC_PAUSERS_CONTAINER_NAME = `${hostScKey}-add-pausers`;
+      hostSc.NUM_COPROCESSORS = String(plan.topology.count);
+      hostSc.COPROCESSOR_THRESHOLD = String(plan.topology.threshold);
+      for (let i = 0; i < plan.topology.count; i += 1) {
+        const signer = envs["host-sc"][`COPROCESSOR_SIGNER_ADDRESS_${i}`];
+        if (signer) hostSc[`COPROCESSOR_SIGNER_ADDRESS_${i}`] = signer;
       }
-    }
-    instanceEnvs["host-sc-b"] = hostScB;
+      instanceEnvs[hostScKey] = hostSc;
 
-    for (let index = 0; index < plan.topology.count; index += 1) {
-      const baseKey = index === 0 ? "coprocessor" : `coprocessor.${index}`;
-      const baseEnv = index === 0 ? envs["coprocessor"] : instanceEnvs[baseKey];
-      if (!baseEnv) continue;
-      const coproB = { ...baseEnv };
-      coproB.RPC_HTTP_URL = hostBHttp;
-      coproB.RPC_WS_URL = hostBWs;
-      coproB.CHAIN_ID = CHAIN_B_ID;
-      if (state.discovery?.hostB) {
-        coproB.ACL_CONTRACT_ADDRESS = state.discovery.hostB.ACL_CONTRACT_ADDRESS;
-        coproB.FHEVM_EXECUTOR_CONTRACT_ADDRESS = state.discovery.hostB.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
-        coproB.INPUT_VERIFIER_ADDRESS = state.discovery.hostB.INPUT_VERIFIER_CONTRACT_ADDRESS;
+      for (let index = 0; index < plan.topology.count; index += 1) {
+        const baseKey = index === 0 ? "coprocessor" : `coprocessor.${index}`;
+        const baseEnv = index === 0 ? envs["coprocessor"] : instanceEnvs[baseKey];
+        if (!baseEnv) continue;
+        const coproChain = { ...baseEnv };
+        coproChain.RPC_HTTP_URL = hostHttp;
+        coproChain.RPC_WS_URL = hostWs;
+        coproChain.CHAIN_ID = chain.chainId;
+        if (hostAddresses.ACL_CONTRACT_ADDRESS) {
+          coproChain.ACL_CONTRACT_ADDRESS = hostAddresses.ACL_CONTRACT_ADDRESS;
+          coproChain.FHEVM_EXECUTOR_CONTRACT_ADDRESS = hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
+          coproChain.INPUT_VERIFIER_ADDRESS = hostAddresses.INPUT_VERIFIER_CONTRACT_ADDRESS;
+        }
+        instanceEnvs[`coprocessor-${suffixId}.${index}`] = coproChain;
       }
-      instanceEnvs[`coprocessor-b.${index}`] = coproB;
-    }
 
-    envs["test-suite"].RPC_URL_CHAIN_B = hostBHttp;
-    envs["test-suite"].CHAIN_ID_HOST_B = CHAIN_B_ID;
-
-    if (state.discovery) {
-      const chainAChainId = Number(envs["coprocessor"].CHAIN_ID ?? DEFAULT_CHAIN_ID);
-      const chainBAcl = state.discovery.hostB?.ACL_CONTRACT_ADDRESS ?? state.discovery.host.ACL_CONTRACT_ADDRESS;
-      envs["kms-connector"].KMS_CONNECTOR_HOST_CHAINS = JSON.stringify([
-        {
-          url: state.discovery.endpoints.hostHttp,
-          chain_id: chainAChainId,
-          acl_address: state.discovery.host.ACL_CONTRACT_ADDRESS,
-        },
-        {
-          url: hostBHttp,
-          chain_id: Number(CHAIN_B_ID),
-          acl_address: chainBAcl,
-        },
-      ]);
+      envs["test-suite"][`RPC_URL_CHAIN_${suffixId.toUpperCase()}`] = hostHttp;
+      envs["test-suite"][`CHAIN_ID_HOST_${suffixId.toUpperCase()}`] = chain.chainId;
     }
   }
 

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -8,7 +8,10 @@ import {
 } from "../compat/compat";
 import type { StackSpec } from "../stack-spec/stack-spec";
 import {
+  CHAIN_B_ID,
+  CHAIN_B_PORT,
   COPROCESSOR_WALLET_INDICES,
+  DEFAULT_CHAIN_ID,
   DEFAULT_TENANT_API_KEY,
   MINIO_INTERNAL_URL,
   POSTGRES_HOST,
@@ -159,7 +162,7 @@ const applyDiscoveryEnv = (
     KMS_CONNECTOR_HOST_CHAINS: JSON.stringify([
       {
         url: state.discovery.endpoints.hostHttp,
-        chain_id: Number(envs["coprocessor"].CHAIN_ID ?? "12345"),
+        chain_id: Number(envs["coprocessor"].CHAIN_ID ?? DEFAULT_CHAIN_ID),
         acl_address: state.discovery.host.ACL_CONTRACT_ADDRESS,
       },
     ]),
@@ -243,6 +246,81 @@ export const renderEnvMaps = async (
   applyCompatEnv(envs, plan);
   applyDiscoveryEnv(envs, state, plan);
   const instanceEnvs = await buildInstanceEnvs(envs, plan, deriveWallet);
+
+  if (plan.multiChain) {
+    const hostBHttp = `http://host-node-b:${CHAIN_B_PORT}`;
+    const hostBWs = `ws://host-node-b:${CHAIN_B_PORT}`;
+
+    envs["gateway-sc"].NUM_HOST_CHAINS = "2";
+    envs["gateway-sc"].HOST_CHAIN_CHAIN_ID_1 = CHAIN_B_ID;
+    envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_1 =
+      state.discovery?.hostB?.FHEVM_EXECUTOR_CONTRACT_ADDRESS ??
+      envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 ?? "";
+    envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_1 =
+      state.discovery?.hostB?.ACL_CONTRACT_ADDRESS ??
+      envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 ?? "";
+    envs["gateway-sc"].HOST_CHAIN_NAME_1 = "";
+    envs["gateway-sc"].HOST_CHAIN_WEBSITE_1 = "";
+
+    instanceEnvs["host-node-b"] = {
+      ...envs["host-node"],
+      HOST_NODE_CONTAINER_NAME: "host-node-b",
+      HOST_NODE_PORT: String(CHAIN_B_PORT),
+      HOST_NODE_CHAIN_ID: CHAIN_B_ID,
+    };
+
+    const hostScB = { ...envs["host-sc"] };
+    hostScB.RPC_URL = hostBHttp;
+    hostScB.CHAIN_ID = CHAIN_B_ID;
+    hostScB.HOST_SC_DEPLOY_CONTAINER_NAME = "host-sc-b-deploy";
+    hostScB.HOST_SC_PAUSERS_CONTAINER_NAME = "host-sc-b-add-pausers";
+    hostScB.NUM_COPROCESSORS = String(plan.topology.count);
+    hostScB.COPROCESSOR_THRESHOLD = String(plan.topology.threshold);
+    for (let i = 0; i < plan.topology.count; i += 1) {
+      const signer = envs["host-sc"][`COPROCESSOR_SIGNER_ADDRESS_${i}`];
+      if (signer) {
+        hostScB[`COPROCESSOR_SIGNER_ADDRESS_${i}`] = signer;
+      }
+    }
+    instanceEnvs["host-sc-b"] = hostScB;
+
+    for (let index = 0; index < plan.topology.count; index += 1) {
+      const baseKey = index === 0 ? "coprocessor" : `coprocessor.${index}`;
+      const baseEnv = index === 0 ? envs["coprocessor"] : instanceEnvs[baseKey];
+      if (!baseEnv) continue;
+      const coproB = { ...baseEnv };
+      coproB.RPC_HTTP_URL = hostBHttp;
+      coproB.RPC_WS_URL = hostBWs;
+      coproB.CHAIN_ID = CHAIN_B_ID;
+      if (state.discovery?.hostB) {
+        coproB.ACL_CONTRACT_ADDRESS = state.discovery.hostB.ACL_CONTRACT_ADDRESS;
+        coproB.FHEVM_EXECUTOR_CONTRACT_ADDRESS = state.discovery.hostB.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
+        coproB.INPUT_VERIFIER_ADDRESS = state.discovery.hostB.INPUT_VERIFIER_CONTRACT_ADDRESS;
+      }
+      instanceEnvs[`coprocessor-b.${index}`] = coproB;
+    }
+
+    envs["test-suite"].RPC_URL_CHAIN_B = hostBHttp;
+    envs["test-suite"].CHAIN_ID_HOST_B = CHAIN_B_ID;
+
+    if (state.discovery) {
+      const chainAChainId = Number(envs["coprocessor"].CHAIN_ID ?? DEFAULT_CHAIN_ID);
+      const chainBAcl = state.discovery.hostB?.ACL_CONTRACT_ADDRESS ?? state.discovery.host.ACL_CONTRACT_ADDRESS;
+      envs["kms-connector"].KMS_CONNECTOR_HOST_CHAINS = JSON.stringify([
+        {
+          url: state.discovery.endpoints.hostHttp,
+          chain_id: chainAChainId,
+          acl_address: state.discovery.host.ACL_CONTRACT_ADDRESS,
+        },
+        {
+          url: hostBHttp,
+          chain_id: Number(CHAIN_B_ID),
+          acl_address: chainBAcl,
+        },
+      ]);
+    }
+  }
+
   resolveAllEnvMaps(envs, instanceEnvs);
 
   return {

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -12,9 +12,10 @@ import {
   DEFAULT_TENANT_API_KEY,
   MINIO_INTERNAL_URL,
   POSTGRES_HOST,
-  hostChainSuffixId,
+  hostNodeName,
+  hostScName,
 } from "../layout";
-import type { HostChainScenario, State } from "../types";
+import type { State } from "../types";
 import { predictedCrsId, predictedKeyId } from "../utils/fs";
 import { interpolateString } from "./compose";
 
@@ -23,9 +24,6 @@ export type WalletMaterial = {
   privateKey: string;
 };
 
-/** Derives the docker container name for a host chain. "host" → "host-node", "host-b" → "host-node-b". */
-const hostNodeContainer = (chain: HostChainScenario) =>
-  chain.key.replace(/^host/, "host-node");
 
 const HAS_PLACEHOLDER = /(?<!\$)\$\{[A-Z0-9_]+\}/;
 
@@ -165,7 +163,7 @@ const applyDiscoveryEnv = (
     const hostAddresses = state.discovery!.hosts[chain.key] ?? {};
     const endpoints = state.discovery!.endpoints.hosts[chain.key];
     return {
-      url: endpoints?.http ?? `http://${hostNodeContainer(chain)}:${chain.rpcPort}`,
+      url: endpoints?.http ?? `http://${hostNodeName(chain.key)}:${chain.rpcPort}`,
       chain_id: Number(chain.chainId),
       acl_address: hostAddresses.ACL_CONTRACT_ADDRESS ?? primaryHost.ACL_CONTRACT_ADDRESS,
     };
@@ -263,8 +261,7 @@ export const renderEnvMaps = async (
     for (let ci = 0; ci < extraChains.length; ci += 1) {
       const chain = extraChains[ci];
       const chainIndex = ci + 1;
-      const container = hostNodeContainer(chain);
-      const suffixId = hostChainSuffixId(chain.key); // "host-b" → "b"
+      const container = hostNodeName(chain.key);
       const hostHttp = `http://${container}:${chain.rpcPort}`;
       const hostWs = `ws://${container}:${chain.rpcPort}`;
       const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
@@ -286,7 +283,7 @@ export const renderEnvMaps = async (
         HOST_NODE_CHAIN_ID: chain.chainId,
       };
 
-      const hostScKey = `host-sc-${suffixId}`;
+      const hostScKey = hostScName(chain.key);
       const hostSc = { ...envs["host-sc"] };
       hostSc.RPC_URL = hostHttp;
       hostSc.CHAIN_ID = chain.chainId;
@@ -313,11 +310,11 @@ export const renderEnvMaps = async (
           coproChain.FHEVM_EXECUTOR_CONTRACT_ADDRESS = hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
           coproChain.INPUT_VERIFIER_ADDRESS = hostAddresses.INPUT_VERIFIER_CONTRACT_ADDRESS;
         }
-        instanceEnvs[`coprocessor-${suffixId}.${index}`] = coproChain;
+        instanceEnvs[`coprocessor-${chain.key}.${index}`] = coproChain;
       }
 
-      envs["test-suite"][`RPC_URL_CHAIN_${suffixId.toUpperCase()}`] = hostHttp;
-      envs["test-suite"][`CHAIN_ID_HOST_${suffixId.toUpperCase()}`] = chain.chainId;
+      envs["test-suite"][`HOST_CHAIN_${chainIndex}_RPC_URL`] = hostHttp;
+      envs["test-suite"][`HOST_CHAIN_${chainIndex}_CHAIN_ID`] = chain.chainId;
     }
   }
 

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -147,8 +147,7 @@ const applyDiscoveryEnv = (
     ACL_CONTRACT_ADDRESS: primaryHost.ACL_CONTRACT_ADDRESS,
     PAUSER_SET_CONTRACT_ADDRESS: primaryHost.PAUSER_SET_CONTRACT_ADDRESS,
   });
-  envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 = primaryHost.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
-  envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 = primaryHost.ACL_CONTRACT_ADDRESS;
+  // Per-chain gateway-sc indexed vars are set uniformly in renderEnvMaps below.
   updateContracts(envs["coprocessor"], {
     ACL_CONTRACT_ADDRESS: primaryHost.ACL_CONTRACT_ADDRESS,
     FHEVM_EXECUTOR_CONTRACT_ADDRESS: primaryHost.FHEVM_EXECUTOR_CONTRACT_ADDRESS,
@@ -165,7 +164,7 @@ const applyDiscoveryEnv = (
     return {
       url: endpoints?.http ?? `http://${hostNodeName(chain.key)}:${chain.rpcPort}`,
       chain_id: Number(chain.chainId),
-      acl_address: hostAddresses.ACL_CONTRACT_ADDRESS ?? primaryHost.ACL_CONTRACT_ADDRESS,
+      acl_address: hostAddresses.ACL_CONTRACT_ADDRESS ?? "",
     };
   });
   updateContracts(envs["kms-connector"], {
@@ -254,68 +253,72 @@ export const renderEnvMaps = async (
   applyDiscoveryEnv(envs, state, plan);
   const instanceEnvs = await buildInstanceEnvs(envs, plan, deriveWallet);
 
-  const extraChains = plan.hostChains.slice(1);
-  if (extraChains.length > 0) {
-    envs["gateway-sc"].NUM_HOST_CHAINS = String(plan.hostChains.length);
+  // Uniform per-chain gateway-sc indexed vars for ALL host chains.
+  envs["gateway-sc"].NUM_HOST_CHAINS = String(plan.hostChains.length);
+  for (let ci = 0; ci < plan.hostChains.length; ci += 1) {
+    const chain = plan.hostChains[ci];
+    const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
+    envs["gateway-sc"][`HOST_CHAIN_CHAIN_ID_${ci}`] = chain.chainId;
+    envs["gateway-sc"][`HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_${ci}`] =
+      hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS ?? "";
+    envs["gateway-sc"][`HOST_CHAIN_ACL_ADDRESS_${ci}`] =
+      hostAddresses.ACL_CONTRACT_ADDRESS ?? "";
+    envs["gateway-sc"][`HOST_CHAIN_NAME_${ci}`] = chain.name ?? "";
+    envs["gateway-sc"][`HOST_CHAIN_WEBSITE_${ci}`] = "";
+  }
 
-    for (let ci = 0; ci < extraChains.length; ci += 1) {
-      const chain = extraChains[ci];
-      const chainIndex = ci + 1;
-      const container = hostNodeName(chain.key);
-      const hostHttp = `http://${container}:${chain.rpcPort}`;
-      const hostWs = `ws://${container}:${chain.rpcPort}`;
-      const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
+  // Extra chain infrastructure: host-node, host-sc, coprocessor, and test-suite env files.
+  for (let ci = 0; ci < plan.hostChains.length - 1; ci += 1) {
+    const chain = plan.hostChains[ci + 1];
+    const chainIndex = ci + 1;
+    const container = hostNodeName(chain.key);
+    const hostHttp = `http://${container}:${chain.rpcPort}`;
+    const hostWs = `ws://${container}:${chain.rpcPort}`;
+    const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
 
-      envs["gateway-sc"][`HOST_CHAIN_CHAIN_ID_${chainIndex}`] = chain.chainId;
-      envs["gateway-sc"][`HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_${chainIndex}`] =
-        hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS ??
-        envs["gateway-sc"].HOST_CHAIN_FHEVM_EXECUTOR_ADDRESS_0 ?? "";
-      envs["gateway-sc"][`HOST_CHAIN_ACL_ADDRESS_${chainIndex}`] =
-        hostAddresses.ACL_CONTRACT_ADDRESS ??
-        envs["gateway-sc"].HOST_CHAIN_ACL_ADDRESS_0 ?? "";
-      envs["gateway-sc"][`HOST_CHAIN_NAME_${chainIndex}`] = chain.name ?? "";
-      envs["gateway-sc"][`HOST_CHAIN_WEBSITE_${chainIndex}`] = "";
+    instanceEnvs[container] = {
+      ...envs["host-node"],
+      HOST_NODE_CONTAINER_NAME: container,
+      HOST_NODE_PORT: String(chain.rpcPort),
+      HOST_NODE_CHAIN_ID: chain.chainId,
+    };
 
-      instanceEnvs[container] = {
-        ...envs["host-node"],
-        HOST_NODE_CONTAINER_NAME: container,
-        HOST_NODE_PORT: String(chain.rpcPort),
-        HOST_NODE_CHAIN_ID: chain.chainId,
-      };
-
-      const hostScKey = hostScName(chain.key);
-      const hostSc = { ...envs["host-sc"] };
-      hostSc.RPC_URL = hostHttp;
-      hostSc.CHAIN_ID = chain.chainId;
-      hostSc.HOST_SC_DEPLOY_CONTAINER_NAME = `${hostScKey}-deploy`;
-      hostSc.HOST_SC_PAUSERS_CONTAINER_NAME = `${hostScKey}-add-pausers`;
-      hostSc.NUM_COPROCESSORS = String(plan.topology.count);
-      hostSc.COPROCESSOR_THRESHOLD = String(plan.topology.threshold);
-      for (let i = 0; i < plan.topology.count; i += 1) {
-        const signer = envs["host-sc"][`COPROCESSOR_SIGNER_ADDRESS_${i}`];
-        if (signer) hostSc[`COPROCESSOR_SIGNER_ADDRESS_${i}`] = signer;
-      }
-      instanceEnvs[hostScKey] = hostSc;
-
-      for (let index = 0; index < plan.topology.count; index += 1) {
-        const baseKey = index === 0 ? "coprocessor" : `coprocessor.${index}`;
-        const baseEnv = index === 0 ? envs["coprocessor"] : instanceEnvs[baseKey];
-        if (!baseEnv) continue;
-        const coproChain = { ...baseEnv };
-        coproChain.RPC_HTTP_URL = hostHttp;
-        coproChain.RPC_WS_URL = hostWs;
-        coproChain.CHAIN_ID = chain.chainId;
-        if (hostAddresses.ACL_CONTRACT_ADDRESS) {
-          coproChain.ACL_CONTRACT_ADDRESS = hostAddresses.ACL_CONTRACT_ADDRESS;
-          coproChain.FHEVM_EXECUTOR_CONTRACT_ADDRESS = hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
-          coproChain.INPUT_VERIFIER_ADDRESS = hostAddresses.INPUT_VERIFIER_CONTRACT_ADDRESS;
-        }
-        instanceEnvs[`coprocessor-${chain.key}.${index}`] = coproChain;
-      }
-
-      envs["test-suite"][`HOST_CHAIN_${chainIndex}_RPC_URL`] = hostHttp;
-      envs["test-suite"][`HOST_CHAIN_${chainIndex}_CHAIN_ID`] = chain.chainId;
+    const hostScKey = hostScName(chain.key);
+    const hostSc = { ...envs["host-sc"] };
+    hostSc.RPC_URL = hostHttp;
+    hostSc.CHAIN_ID = chain.chainId;
+    hostSc.HOST_SC_DEPLOY_CONTAINER_NAME = `${hostScKey}-deploy`;
+    hostSc.HOST_SC_PAUSERS_CONTAINER_NAME = `${hostScKey}-add-pausers`;
+    hostSc.NUM_COPROCESSORS = String(plan.topology.count);
+    hostSc.COPROCESSOR_THRESHOLD = String(plan.topology.threshold);
+    for (let i = 0; i < plan.topology.count; i += 1) {
+      const signer = envs["host-sc"][`COPROCESSOR_SIGNER_ADDRESS_${i}`];
+      if (signer) hostSc[`COPROCESSOR_SIGNER_ADDRESS_${i}`] = signer;
     }
+    instanceEnvs[hostScKey] = hostSc;
+
+    for (let index = 0; index < plan.topology.count; index += 1) {
+      const baseKey = index === 0 ? "coprocessor" : `coprocessor.${index}`;
+      const baseEnv = index === 0 ? envs["coprocessor"] : instanceEnvs[baseKey];
+      if (!baseEnv) continue;
+      const coproChain = { ...baseEnv };
+      coproChain.RPC_HTTP_URL = hostHttp;
+      coproChain.RPC_WS_URL = hostWs;
+      coproChain.CHAIN_ID = chain.chainId;
+      if (hostAddresses.ACL_CONTRACT_ADDRESS) {
+        coproChain.ACL_CONTRACT_ADDRESS = hostAddresses.ACL_CONTRACT_ADDRESS;
+        coproChain.FHEVM_EXECUTOR_CONTRACT_ADDRESS = hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
+        coproChain.INPUT_VERIFIER_ADDRESS = hostAddresses.INPUT_VERIFIER_CONTRACT_ADDRESS;
+      }
+      instanceEnvs[`coprocessor-${chain.key}.${index}`] = coproChain;
+    }
+
+    envs["test-suite"][`HOST_CHAIN_${chainIndex}_RPC_URL`] = hostHttp;
+    envs["test-suite"][`HOST_CHAIN_${chainIndex}_CHAIN_ID`] = chain.chainId;
+    envs["test-suite"][`HOST_CHAIN_${chainIndex}_ACL_CONTRACT_ADDRESS`] = hostAddresses.ACL_CONTRACT_ADDRESS ?? "";
+    envs["test-suite"][`HOST_CHAIN_${chainIndex}_KMS_VERIFIER_CONTRACT_ADDRESS`] = hostAddresses.KMS_VERIFIER_CONTRACT_ADDRESS ?? "";
+    envs["test-suite"][`HOST_CHAIN_${chainIndex}_INPUT_VERIFIER_CONTRACT_ADDRESS`] = hostAddresses.INPUT_VERIFIER_CONTRACT_ADDRESS ?? "";
+    envs["test-suite"][`HOST_CHAIN_${chainIndex}_FHEVM_EXECUTOR_CONTRACT_ADDRESS`] = hostAddresses.FHEVM_EXECUTOR_CONTRACT_ADDRESS ?? "";
   }
 
   resolveAllEnvMaps(envs, instanceEnvs);

--- a/test-suite/fhevm/src/generate/index.ts
+++ b/test-suite/fhevm/src/generate/index.ts
@@ -10,10 +10,8 @@ import { renderEnvMaps, type WalletMaterial } from "./env";
 import {
   renderGatewayAddressesEnv,
   renderGatewayAddressesSolidity,
-  renderHostAddressesEnv,
   renderHostChainAddresses,
   renderHostChainAddressesSolidity,
-  renderHostAddressesSolidity,
   renderPaymentBridgingAddressesSolidity,
 } from "./addresses";
 import { generateComposeOverrides } from "./compose";
@@ -29,8 +27,6 @@ import {
   envPath,
   gatewayAddressesPath,
   gatewayAddressesSolidityPath,
-  hostAddressesPath,
-  hostAddressesSolidityPath,
   hostChainAddressesPath,
   hostChainAddressesSolidityPath,
   paymentBridgingAddressesSolidityPath,
@@ -112,9 +108,7 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
     paymentBridgingAddressesSolidityPath,
     renderPaymentBridgingAddressesSolidity(rendered.componentEnvs["gateway-sc"]),
   );
-  await writeWritableFile(hostAddressesPath, renderHostAddressesEnv(state));
-  await writeWritableFile(hostAddressesSolidityPath, renderHostAddressesSolidity(state));
-  for (const chain of plan.hostChains.slice(1)) {
+  for (const chain of plan.hostChains) {
     await writeWritableFile(hostChainAddressesPath(chain.key), renderHostChainAddresses(state, chain.key));
     await writeWritableFile(hostChainAddressesSolidityPath(chain.key), renderHostChainAddressesSolidity(state, chain.key));
   }

--- a/test-suite/fhevm/src/generate/index.ts
+++ b/test-suite/fhevm/src/generate/index.ts
@@ -11,6 +11,7 @@ import {
   renderGatewayAddressesEnv,
   renderGatewayAddressesSolidity,
   renderHostAddressesEnv,
+  renderHostBAddressesEnv,
   renderHostAddressesSolidity,
   renderPaymentBridgingAddressesSolidity,
 } from "./addresses";
@@ -29,6 +30,7 @@ import {
   gatewayAddressesSolidityPath,
   hostAddressesPath,
   hostAddressesSolidityPath,
+  hostBAddressesPath,
   paymentBridgingAddressesSolidityPath,
   relayerConfigPath,
   versionsEnvPath,
@@ -77,6 +79,7 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
     ensureDir(ENV_DIR),
     ensureWritableDir(path.join(ADDRESS_DIR, "gateway")),
     ensureWritableDir(path.join(ADDRESS_DIR, "host")),
+    ...(plan.multiChain ? [ensureWritableDir(path.join(ADDRESS_DIR, "host-b"))] : []),
     ensureDir(GENERATED_CONFIG_DIR),
   ]);
 
@@ -100,7 +103,7 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
 
   await fs.writeFile(
     relayerConfigPath,
-    renderRelayerConfig(state, await fs.readFile(TEMPLATE_RELAYER_CONFIG, "utf8")),
+    renderRelayerConfig(state, await fs.readFile(TEMPLATE_RELAYER_CONFIG, "utf8"), plan),
   );
   await writeWritableFile(gatewayAddressesPath, renderGatewayAddressesEnv(state));
   await writeWritableFile(gatewayAddressesSolidityPath, renderGatewayAddressesSolidity(state));
@@ -110,6 +113,9 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
   );
   await writeWritableFile(hostAddressesPath, renderHostAddressesEnv(state));
   await writeWritableFile(hostAddressesSolidityPath, renderHostAddressesSolidity(state));
+  if (plan.multiChain) {
+    await writeWritableFile(hostBAddressesPath, renderHostBAddressesEnv(state));
+  }
 
   await generateComposeOverrides(state, plan);
 };

--- a/test-suite/fhevm/src/generate/index.ts
+++ b/test-suite/fhevm/src/generate/index.ts
@@ -12,6 +12,7 @@ import {
   renderGatewayAddressesSolidity,
   renderHostAddressesEnv,
   renderHostChainAddresses,
+  renderHostChainAddressesSolidity,
   renderHostAddressesSolidity,
   renderPaymentBridgingAddressesSolidity,
 } from "./addresses";
@@ -31,6 +32,7 @@ import {
   hostAddressesPath,
   hostAddressesSolidityPath,
   hostChainAddressesPath,
+  hostChainAddressesSolidityPath,
   paymentBridgingAddressesSolidityPath,
   relayerConfigPath,
   versionsEnvPath,
@@ -114,6 +116,7 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
   await writeWritableFile(hostAddressesSolidityPath, renderHostAddressesSolidity(state));
   for (const chain of plan.hostChains.slice(1)) {
     await writeWritableFile(hostChainAddressesPath(chain.key), renderHostChainAddresses(state, chain.key));
+    await writeWritableFile(hostChainAddressesSolidityPath(chain.key), renderHostChainAddressesSolidity(state, chain.key));
   }
 
   await generateComposeOverrides(state, plan);

--- a/test-suite/fhevm/src/generate/index.ts
+++ b/test-suite/fhevm/src/generate/index.ts
@@ -11,7 +11,7 @@ import {
   renderGatewayAddressesEnv,
   renderGatewayAddressesSolidity,
   renderHostAddressesEnv,
-  renderHostBAddressesEnv,
+  renderHostChainAddresses,
   renderHostAddressesSolidity,
   renderPaymentBridgingAddressesSolidity,
 } from "./addresses";
@@ -30,7 +30,7 @@ import {
   gatewayAddressesSolidityPath,
   hostAddressesPath,
   hostAddressesSolidityPath,
-  hostBAddressesPath,
+  hostChainAddressesPath,
   paymentBridgingAddressesSolidityPath,
   relayerConfigPath,
   versionsEnvPath,
@@ -78,8 +78,7 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
   await Promise.all([
     ensureDir(ENV_DIR),
     ensureWritableDir(path.join(ADDRESS_DIR, "gateway")),
-    ensureWritableDir(path.join(ADDRESS_DIR, "host")),
-    ...(plan.multiChain ? [ensureWritableDir(path.join(ADDRESS_DIR, "host-b"))] : []),
+    ...plan.hostChains.map((chain) => ensureWritableDir(path.join(ADDRESS_DIR, chain.key))),
     ensureDir(GENERATED_CONFIG_DIR),
   ]);
 
@@ -113,8 +112,8 @@ export const generateRuntime = async (state: State, plan: StackSpec) => {
   );
   await writeWritableFile(hostAddressesPath, renderHostAddressesEnv(state));
   await writeWritableFile(hostAddressesSolidityPath, renderHostAddressesSolidity(state));
-  if (plan.multiChain) {
-    await writeWritableFile(hostBAddressesPath, renderHostBAddressesEnv(state));
+  for (const chain of plan.hostChains.slice(1)) {
+    await writeWritableFile(hostChainAddressesPath(chain.key), renderHostChainAddresses(state, chain.key));
   }
 
   await generateComposeOverrides(state, plan);

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -250,16 +250,19 @@ export const hostChainAddressesPath = (key: string) =>
   path.join(ADDRESS_DIR, key, ".env.host");
 export const hostAddressesPath = hostChainAddressesPath(PRIMARY_HOST_KEY);
 
-/** Extracts the suffix ID from a host chain key. "host" → "", "host-b" → "b", "host-foo" → "foo". */
-export const hostChainSuffixId = (key: string) => (key.length > 5 ? key.slice(5) : "");
+/**
+ * Derives the suffix appended to service names for a chain key.
+ * Primary chain ("host") has no suffix; extra chains use "-{key}" e.g. "-chain-b".
+ */
+export const hostChainSuffix = (key: string) => (key === PRIMARY_HOST_KEY ? "" : `-${key}`);
 
-/** Derives the host-node container name from a chain key. "host" → "host-node", "host-b" → "host-node-b". */
-export const hostNodeName = (key: string) => key.replace(/^host/, "host-node");
+/** Derives the host-node container name from a chain key. "host" → "host-node", "chain-b" → "host-node-chain-b". */
+export const hostNodeName = (key: string) => `host-node${hostChainSuffix(key)}`;
 
-/** Derives the host-sc service prefix from a chain key. "host" → "host-sc", "host-b" → "host-sc-b". */
-export const hostScName = (key: string) => key.replace(/^host/, "host-sc");
+/** Derives the host-sc service prefix from a chain key. "host" → "host-sc", "chain-b" → "host-sc-chain-b". */
+export const hostScName = (key: string) => `host-sc${hostChainSuffix(key)}`;
 
-/** Derives the coprocessor-host compose key from a chain key. "host" → "coprocessor-host", "host-b" → "coprocessor-host-b". */
+/** Derives the coprocessor-host compose key from a chain key. "host" → "coprocessor-host", "chain-b" → "coprocessor-chain-b". */
 export const coprocessorHostKey = (key: string) => `coprocessor-${key}`;
 
 /** Returns all derived runtime names for a host chain key in one call. */
@@ -267,7 +270,7 @@ export const hostChainNames = (key: string) => ({
   node: hostNodeName(key),
   sc: hostScName(key),
   copro: coprocessorHostKey(key),
-  suffix: hostChainSuffixId(key),
+  suffix: hostChainSuffix(key),
 });
 export const hostChainAddressesSolidityPath = (key: string) =>
   path.join(ADDRESS_DIR, key, "FHEVMHostAddresses.sol");

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -26,7 +26,7 @@ const STATIC_CONFIG_DIR = path.join(CLI_DIR, "static", "config");
 export const TEMPLATE_RELAYER_CONFIG = path.join(TEMPLATE_CONFIG_DIR, "relayer.yaml");
 export const LATEST_SUPPORTED_PROFILE = path.join(PROFILE_DIR, "latest-supported.json");
 export const PROJECT = "fhevm";
-export const PORTS = [3000, 3001, 5432, 5433, 8545, 8546, 9000, 9001];
+export const PORTS = [3000, 3001, 5432, 5433, 8545, 8546, 8547, 9000, 9001];
 export const MINIO_INTERNAL_URL = "http://minio:9000";
 export const MINIO_EXTERNAL_URL = "http://localhost:9000";
 export const POSTGRES_HOST = "db:5432";
@@ -35,6 +35,9 @@ export const KMS_CORE_CONTAINER = "kms-core";
 export const TEST_SUITE_CONTAINER = "fhevm-test-suite-e2e-debug";
 export const KEYGEN_ID_SELECTOR = "0xd52f10eb";
 export const CRSGEN_ID_SELECTOR = "0xbaff211e";
+export const DEFAULT_CHAIN_ID = "12345";
+export const CHAIN_B_ID = "67890";
+export const CHAIN_B_PORT = 8547;
 
 export const COMPONENTS = [
   "minio",
@@ -180,6 +183,7 @@ export const TEST_GREP: Record<string, string> = {
   "hcu-block-cap": "block cap scenarios",
   "erc20": "should transfer tokens between two users.",
   "negative-acl": "negative-acl",
+  "multi-chain-isolation": "Multi-Chain State Isolation",
 };
 
 export const TEST_PARALLEL: Record<string, boolean> = {
@@ -248,6 +252,7 @@ export const hostAddressesSolidityPath = path.join(
   "host",
   "FHEVMHostAddresses.sol",
 );
+export const hostBAddressesPath = path.join(ADDRESS_DIR, "host-b", ".env.host");
 
 /** Builds the docker compose argv prefix for one component. */
 export const dockerArgs = (component: string) => [

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -36,8 +36,6 @@ export const TEST_SUITE_CONTAINER = "fhevm-test-suite-e2e-debug";
 export const KEYGEN_ID_SELECTOR = "0xd52f10eb";
 export const CRSGEN_ID_SELECTOR = "0xbaff211e";
 export const DEFAULT_CHAIN_ID = "12345";
-export const CHAIN_B_ID = "67890";
-export const CHAIN_B_PORT = 8547;
 
 export const COMPONENTS = [
   "minio",
@@ -246,13 +244,17 @@ export const paymentBridgingAddressesSolidityPath = path.join(
   "gateway",
   "PaymentBridgingAddresses.sol",
 );
-export const hostAddressesPath = path.join(ADDRESS_DIR, "host", ".env.host");
+export const hostChainAddressesPath = (key: string) =>
+  path.join(ADDRESS_DIR, key, ".env.host");
+export const hostAddressesPath = hostChainAddressesPath("host");
+
+/** Extracts the suffix ID from a host chain key. "host" → "", "host-b" → "b", "host-foo" → "foo". */
+export const hostChainSuffixId = (key: string) => (key.length > 5 ? key.slice(5) : "");
 export const hostAddressesSolidityPath = path.join(
   ADDRESS_DIR,
   "host",
   "FHEVMHostAddresses.sol",
 );
-export const hostBAddressesPath = path.join(ADDRESS_DIR, "host-b", ".env.host");
 
 /** Builds the docker compose argv prefix for one component. */
 export const dockerArgs = (component: string) => [

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -244,9 +244,11 @@ export const paymentBridgingAddressesSolidityPath = path.join(
   "gateway",
   "PaymentBridgingAddresses.sol",
 );
+/** The chain key used by the primary host chain (hostChains[0]). */
+export const PRIMARY_HOST_KEY = "host";
 export const hostChainAddressesPath = (key: string) =>
   path.join(ADDRESS_DIR, key, ".env.host");
-export const hostAddressesPath = hostChainAddressesPath("host");
+export const hostAddressesPath = hostChainAddressesPath(PRIMARY_HOST_KEY);
 
 /** Extracts the suffix ID from a host chain key. "host" → "", "host-b" → "b", "host-foo" → "foo". */
 export const hostChainSuffixId = (key: string) => (key.length > 5 ? key.slice(5) : "");
@@ -261,7 +263,7 @@ export const hostScName = (key: string) => key.replace(/^host/, "host-sc");
 export const coprocessorHostKey = (key: string) => `coprocessor-${key}`;
 export const hostChainAddressesSolidityPath = (key: string) =>
   path.join(ADDRESS_DIR, key, "FHEVMHostAddresses.sol");
-export const hostAddressesSolidityPath = hostChainAddressesSolidityPath("host");
+export const hostAddressesSolidityPath = hostChainAddressesSolidityPath(PRIMARY_HOST_KEY);
 
 /** Builds the docker compose argv prefix for one component. */
 export const dockerArgs = (component: string) => [

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -250,11 +250,18 @@ export const hostAddressesPath = hostChainAddressesPath("host");
 
 /** Extracts the suffix ID from a host chain key. "host" → "", "host-b" → "b", "host-foo" → "foo". */
 export const hostChainSuffixId = (key: string) => (key.length > 5 ? key.slice(5) : "");
-export const hostAddressesSolidityPath = path.join(
-  ADDRESS_DIR,
-  "host",
-  "FHEVMHostAddresses.sol",
-);
+
+/** Derives the host-node container name from a chain key. "host" → "host-node", "host-b" → "host-node-b". */
+export const hostNodeName = (key: string) => key.replace(/^host/, "host-node");
+
+/** Derives the host-sc service prefix from a chain key. "host" → "host-sc", "host-b" → "host-sc-b". */
+export const hostScName = (key: string) => key.replace(/^host/, "host-sc");
+
+/** Derives the coprocessor-host compose key from a chain key. "host" → "coprocessor-host", "host-b" → "coprocessor-host-b". */
+export const coprocessorHostKey = (key: string) => `coprocessor-${key}`;
+export const hostChainAddressesSolidityPath = (key: string) =>
+  path.join(ADDRESS_DIR, key, "FHEVMHostAddresses.sol");
+export const hostAddressesSolidityPath = hostChainAddressesSolidityPath("host");
 
 /** Builds the docker compose argv prefix for one component. */
 export const dockerArgs = (component: string) => [

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -261,6 +261,14 @@ export const hostScName = (key: string) => key.replace(/^host/, "host-sc");
 
 /** Derives the coprocessor-host compose key from a chain key. "host" → "coprocessor-host", "host-b" → "coprocessor-host-b". */
 export const coprocessorHostKey = (key: string) => `coprocessor-${key}`;
+
+/** Returns all derived runtime names for a host chain key in one call. */
+export const hostChainNames = (key: string) => ({
+  node: hostNodeName(key),
+  sc: hostScName(key),
+  copro: coprocessorHostKey(key),
+  suffix: hostChainSuffixId(key),
+});
 export const hostChainAddressesSolidityPath = (key: string) =>
   path.join(ADDRESS_DIR, key, "FHEVMHostAddresses.sol");
 export const hostAddressesSolidityPath = hostChainAddressesSolidityPath(PRIMARY_HOST_KEY);

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -8,6 +8,7 @@ import YAML from "yaml";
 
 import { PreflightError } from "../errors";
 import {
+  DEFAULT_CHAIN_ID,
   GROUP_SERVICE_SUFFIXES,
   MAX_COPROCESSOR_INSTANCES,
   REPO_ROOT,
@@ -16,6 +17,7 @@ import {
 import type {
   CoprocessorInstanceSource,
   CoprocessorScenario,
+  HostChainScenario,
   LocalOverride,
   OverrideGroup,
   ResolvedCoprocessorScenario,
@@ -88,6 +90,49 @@ const scenarioCandidatePaths = (value: string) => {
       ];
 };
 
+const DEFAULT_HOST_CHAIN: HostChainScenario = { key: "host", chainId: DEFAULT_CHAIN_ID, rpcPort: 8545 };
+const LEGACY_CHAIN_B: HostChainScenario = { key: "host-b", chainId: "67890", rpcPort: 8547 };
+
+/** Parses hostChains from YAML, with backward compat for multiChain: true. */
+const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): HostChainScenario[] | undefined => {
+  if (parsed.hostChains !== undefined) {
+    if (!Array.isArray(parsed.hostChains)) {
+      throw new Error(`${sourceLabel}: hostChains must be an array`);
+    }
+    const seen = new Set<string>();
+    return parsed.hostChains.map((entry, index) => {
+      if (!entry || typeof entry !== "object") {
+        throw new Error(`${sourceLabel}: hostChains[${index}] must be an object`);
+      }
+      const chain = entry as Record<string, unknown>;
+      const key = normalizeScalar(chain.key, `${sourceLabel}: hostChains[${index}].key`);
+      if (seen.has(key)) {
+        throw new Error(`${sourceLabel}: duplicate hostChains key "${key}"`);
+      }
+      seen.add(key);
+      const chainId = normalizeScalar(chain.chainId, `${sourceLabel}: hostChains[${index}].chainId`);
+      const rpcPort = Number(chain.rpcPort);
+      if (!Number.isInteger(rpcPort) || rpcPort < 1) {
+        throw new Error(`${sourceLabel}: hostChains[${index}].rpcPort must be a positive integer`);
+      }
+      return {
+        key,
+        chainId,
+        rpcPort,
+        name: normalizeOptionalText(chain.name, `${sourceLabel}: hostChains[${index}].name`),
+      };
+    });
+  }
+  if (parsed.multiChain === true) {
+    return [DEFAULT_HOST_CHAIN, LEGACY_CHAIN_B];
+  }
+  return undefined;
+};
+
+/** Resolves hostChains, defaulting to the single primary chain when omitted. */
+const resolveHostChains = (hostChains: HostChainScenario[] | undefined): HostChainScenario[] =>
+  hostChains ?? [DEFAULT_HOST_CHAIN];
+
 /** Returns the default single-instance inherited coprocessor scenario. */
 export const defaultCoprocessorScenario = (): ResolvedCoprocessorScenario => ({
   version: COPROCESSOR_SCENARIO_VERSION,
@@ -95,6 +140,7 @@ export const defaultCoprocessorScenario = (): ResolvedCoprocessorScenario => ({
   origin: "default",
   name: "Default",
   description: "Single inherited coprocessor instance.",
+  hostChains: resolveHostChains(undefined),
   topology: { count: 1, threshold: 1 },
   instances: [{ index: 0, source: { mode: "inherit" }, env: {}, args: {} }],
 });
@@ -212,14 +258,14 @@ export const parseCoprocessorScenario = (text: string, sourceLabel = "scenario")
     };
   });
 
-  const multiChain = parsed.multiChain === true ? true : undefined;
+  const hostChains = parseHostChains(parsed, sourceLabel);
 
   return {
     version: COPROCESSOR_SCENARIO_VERSION,
     kind: COPROCESSOR_SCENARIO_KIND,
     name: normalizeOptionalText(parsed.name, `${sourceLabel}: name`),
     description: normalizeOptionalText(parsed.description, `${sourceLabel}: description`),
-    multiChain,
+    hostChains,
     topology: { count, threshold },
     instances,
   };
@@ -267,7 +313,7 @@ export const resolveScenarioFile = (filePath: string, input: CoprocessorScenario
     origin: "file",
     name: input.name,
     description: input.description,
-    multiChain: input.multiChain,
+    hostChains: resolveHostChains(input.hostChains),
     sourcePath: path.resolve(filePath),
     topology: { ...input.topology },
     instances: Array.from({ length: input.topology.count }, (_, index) => {
@@ -369,6 +415,7 @@ export const synthesizeOverrideScenario = (overrides: LocalOverride[]): Resolved
     origin: "override-shorthand",
     name: "Override Shorthand",
     description: "Single local coprocessor instance synthesized from --override coprocessor.",
+    hostChains: resolveHostChains(undefined),
     topology: { count: 1, threshold: 1 },
     instances: [{ index: 0, source: { mode: "local" }, env: {}, args: {}, localServices: mergeOverrideServices(overrides) }],
   };

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -106,9 +106,9 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
       }
       const chain = entry as Record<string, unknown>;
       const key = normalizeScalar(chain.key, `${sourceLabel}: hostChains[${index}].key`);
-      if (!/^host(-[a-z0-9]+)?$/.test(key)) {
+      if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(key)) {
         throw new Error(
-          `${sourceLabel}: hostChains[${index}].key "${key}" must match "host" or "host-{id}" where id is lowercase alphanumeric`,
+          `${sourceLabel}: hostChains[${index}].key "${key}" must be a lowercase slug (e.g. "host", "chain-b", "my-chain")`,
         );
       }
       if (seen.has(key)) {

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -91,9 +91,8 @@ const scenarioCandidatePaths = (value: string) => {
 };
 
 const DEFAULT_HOST_CHAIN: HostChainScenario = { key: "host", chainId: DEFAULT_CHAIN_ID, rpcPort: 8545 };
-const LEGACY_CHAIN_B: HostChainScenario = { key: "host-b", chainId: "67890", rpcPort: 8547 };
 
-/** Parses hostChains from YAML, with backward compat for multiChain: true. */
+/** Parses hostChains from YAML. */
 const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): HostChainScenario[] | undefined => {
   if (parsed.hostChains !== undefined) {
     if (!Array.isArray(parsed.hostChains)) {
@@ -106,6 +105,11 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
       }
       const chain = entry as Record<string, unknown>;
       const key = normalizeScalar(chain.key, `${sourceLabel}: hostChains[${index}].key`);
+      if (!/^host(-[a-z0-9]+)?$/.test(key)) {
+        throw new Error(
+          `${sourceLabel}: hostChains[${index}].key "${key}" must match "host" or "host-{id}" where id is lowercase alphanumeric`,
+        );
+      }
       if (seen.has(key)) {
         throw new Error(`${sourceLabel}: duplicate hostChains key "${key}"`);
       }
@@ -122,9 +126,6 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
         name: normalizeOptionalText(chain.name, `${sourceLabel}: hostChains[${index}].name`),
       };
     });
-  }
-  if (parsed.multiChain === true) {
-    return [DEFAULT_HOST_CHAIN, LEGACY_CHAIN_B];
   }
   return undefined;
 };

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -212,11 +212,14 @@ export const parseCoprocessorScenario = (text: string, sourceLabel = "scenario")
     };
   });
 
+  const multiChain = parsed.multiChain === true ? true : undefined;
+
   return {
     version: COPROCESSOR_SCENARIO_VERSION,
     kind: COPROCESSOR_SCENARIO_KIND,
     name: normalizeOptionalText(parsed.name, `${sourceLabel}: name`),
     description: normalizeOptionalText(parsed.description, `${sourceLabel}: description`),
+    multiChain,
     topology: { count, threshold },
     instances,
   };
@@ -264,6 +267,7 @@ export const resolveScenarioFile = (filePath: string, input: CoprocessorScenario
     origin: "file",
     name: input.name,
     description: input.description,
+    multiChain: input.multiChain,
     sourcePath: path.resolve(filePath),
     topology: { ...input.topology },
     instances: Array.from({ length: input.topology.count }, (_, index) => {

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_CHAIN_ID,
   GROUP_SERVICE_SUFFIXES,
   MAX_COPROCESSOR_INSTANCES,
+  PRIMARY_HOST_KEY,
   REPO_ROOT,
   resolveServiceOverrides,
 } from "../layout";
@@ -90,7 +91,7 @@ const scenarioCandidatePaths = (value: string) => {
       ];
 };
 
-const DEFAULT_HOST_CHAIN: HostChainScenario = { key: "host", chainId: DEFAULT_CHAIN_ID, rpcPort: 8545 };
+const DEFAULT_HOST_CHAIN: HostChainScenario = { key: PRIMARY_HOST_KEY, chainId: DEFAULT_CHAIN_ID, rpcPort: 8545 };
 
 /** Parses hostChains from YAML. */
 const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): HostChainScenario[] | undefined => {
@@ -115,6 +116,9 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
       }
       seen.add(key);
       const chainId = normalizeScalar(chain.chainId, `${sourceLabel}: hostChains[${index}].chainId`);
+      if (!/^\d+$/.test(chainId)) {
+        throw new Error(`${sourceLabel}: hostChains[${index}].chainId "${chainId}" must be a numeric string`);
+      }
       const rpcPort = Number(chain.rpcPort);
       if (!Number.isInteger(rpcPort) || rpcPort < 1) {
         throw new Error(`${sourceLabel}: hostChains[${index}].rpcPort must be a positive integer`);

--- a/test-suite/fhevm/src/stack-spec/stack-spec.ts
+++ b/test-suite/fhevm/src/stack-spec/stack-spec.ts
@@ -2,6 +2,7 @@
  * Combines resolved versions, overrides, and scenario topology into the stack spec used for generation and orchestration.
  */
 import type {
+  HostChainScenario,
   ResolvedCoprocessorScenario,
   State,
   Topology,
@@ -23,7 +24,7 @@ export type StackSpec = {
   versions: VersionBundle;
   overrides: State["overrides"];
   topology: Topology;
-  multiChain: boolean;
+  hostChains: HostChainScenario[];
   coprocessor: ResolvedCoprocessorScenario;
 };
 
@@ -63,7 +64,7 @@ const stackSpecFromResolved = (input: {
   versions: input.versions,
   overrides: input.overrides,
   topology: topologyFromScenario(input.scenario),
-  multiChain: input.scenario.multiChain ?? false,
+  hostChains: input.scenario.hostChains,
   coprocessor: input.scenario,
 });
 

--- a/test-suite/fhevm/src/stack-spec/stack-spec.ts
+++ b/test-suite/fhevm/src/stack-spec/stack-spec.ts
@@ -23,6 +23,7 @@ export type StackSpec = {
   versions: VersionBundle;
   overrides: State["overrides"];
   topology: Topology;
+  multiChain: boolean;
   coprocessor: ResolvedCoprocessorScenario;
 };
 
@@ -62,6 +63,7 @@ const stackSpecFromResolved = (input: {
   versions: input.versions,
   overrides: input.overrides,
   topology: topologyFromScenario(input.scenario),
+  multiChain: input.scenario.multiChain ?? false,
   coprocessor: input.scenario,
 });
 

--- a/test-suite/fhevm/src/stack.test.ts
+++ b/test-suite/fhevm/src/stack.test.ts
@@ -8,6 +8,7 @@ const defaultScenario: State["scenario"] = {
   version: 1,
   kind: "coprocessor-consensus",
   origin: "default",
+  hostChains: [{ key: "host", chainId: "12345", rpcPort: 8545 }],
   topology: { count: 1, threshold: 1 },
   instances: [{ index: 0, source: { mode: "inherit" }, env: {}, args: {} }],
 };

--- a/test-suite/fhevm/src/types.ts
+++ b/test-suite/fhevm/src/types.ts
@@ -42,12 +42,19 @@ export type CoprocessorScenarioInstance = {
   localServices?: string[];
 };
 
+export type HostChainScenario = {
+  key: string;
+  chainId: string;
+  rpcPort: number;
+  name?: string;
+};
+
 export type CoprocessorScenario = {
   version: 1;
   kind: "coprocessor-consensus";
   name?: string;
   description?: string;
-  multiChain?: boolean;
+  hostChains?: HostChainScenario[];
   topology: {
     count: number;
     threshold: number;
@@ -69,7 +76,7 @@ export type ResolvedCoprocessorScenario = {
   origin: "default" | "file" | "override-shorthand";
   name?: string;
   description?: string;
-  multiChain?: boolean;
+  hostChains: HostChainScenario[];
   sourcePath?: string;
   topology: {
     count: number;
@@ -95,10 +102,14 @@ export type Topology = {
   threshold: number;
 };
 
+export type RpcEndpoints = {
+  http: string;
+  ws: string;
+};
+
 export type Discovery = {
   gateway: Record<string, string>;
-  host: Record<string, string>;
-  hostB?: Record<string, string>;
+  hosts: Record<string, Record<string, string>>;
   kmsSigner: string;
   fheKeyId: string;
   crsKeyId: string;
@@ -106,12 +117,8 @@ export type Discovery = {
   actualCrsKeyId?: string;
   minioKeyPrefix?: string;
   endpoints: {
-    gatewayHttp: string;
-    gatewayWs: string;
-    hostHttp: string;
-    hostWs: string;
-    hostBHttp?: string;
-    hostBWs?: string;
+    gateway: RpcEndpoints;
+    hosts: Record<string, RpcEndpoints>;
     minioInternal: string;
     minioExternal: string;
   };

--- a/test-suite/fhevm/src/types.ts
+++ b/test-suite/fhevm/src/types.ts
@@ -47,6 +47,7 @@ export type CoprocessorScenario = {
   kind: "coprocessor-consensus";
   name?: string;
   description?: string;
+  multiChain?: boolean;
   topology: {
     count: number;
     threshold: number;
@@ -68,6 +69,7 @@ export type ResolvedCoprocessorScenario = {
   origin: "default" | "file" | "override-shorthand";
   name?: string;
   description?: string;
+  multiChain?: boolean;
   sourcePath?: string;
   topology: {
     count: number;
@@ -96,6 +98,7 @@ export type Topology = {
 export type Discovery = {
   gateway: Record<string, string>;
   host: Record<string, string>;
+  hostB?: Record<string, string>;
   kmsSigner: string;
   fheKeyId: string;
   crsKeyId: string;
@@ -107,6 +110,8 @@ export type Discovery = {
     gatewayWs: string;
     hostHttp: string;
     hostWs: string;
+    hostBHttp?: string;
+    hostBWs?: string;
     minioInternal: string;
     minioExternal: string;
   };


### PR DESCRIPTION
## Summary

- Adds multi-chain (2 host chains) e2e testing to the TypeScript CLI, with full support for multi-coprocessor scenarios
- Introduces 7 multi-chain isolation tests covering cross-chain ciphertext isolation, ACL isolation, independent decryption, chain halt resilience, and random number independence
- Extends compose generation, env rendering, relayer config, and stack orchestration to deploy a second host chain (Chain B) with its own smart contracts and coprocessor listeners

## Details

**New scenarios:**
- `multi-chain.yaml` — 1 coprocessor, 2 host chains
- `two-of-two-multi-chain.yaml` — 2 coprocessors, 2 host chains

Closes: https://github.com/zama-ai/fhevm-internal/issues/1163