### PR TITLE
chore(coprocessor): chore: upgrade localstack from pinned 4.14.0 to stable with auth token

### DIFF
--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -172,7 +172,9 @@ jobs:
 
       - name: Start localstack
         run: |
-          docker run --rm -d -p 4566:4566 --name localstack localstack/localstack:4.14.0
+          docker run --rm -d -p 4566:4566 --name localstack -e LOCALSTACK_AUTH_TOKEN="$LOCALSTACK_AUTH_TOKEN" localstack/localstack:stable
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Run benchmarks on CPU
         run: |

--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -127,7 +127,14 @@ jobs:
 
     - name: Start localstack
       if: ${{ matrix.needs_localstack }}
-      run: docker run --rm -d -p 4566:4566 --name localstack localstack/localstack:4.14.0
+      run: |
+        docker run --rm -d -p 4566:4566 --name localstack -e LOCALSTACK_AUTH_TOKEN="$LOCALSTACK_AUTH_TOKEN" localstack/localstack:stable
+      env:
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+
+    - name: Clean previous coverage data
+      run: cargo llvm-cov clean --workspace --profile coverage
+      working-directory: coprocessor/fhevm-engine
 
     - name: Run tests with coverage
       env:

--- a/coprocessor/fhevm-engine/test-harness/src/localstack.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/localstack.rs
@@ -24,10 +24,12 @@ pub struct LocalstackContainer {
 
 pub async fn start_localstack() -> anyhow::Result<LocalstackContainer> {
     let host_port = pick_free_port();
-    let container = GenericImage::new("localstack/localstack", "4.14.0")
+    let auth_token = std::env::var("LOCALSTACK_AUTH_TOKEN").unwrap_or_default();
+    let container = GenericImage::new("localstack/localstack", "stable")
         .with_exposed_port(LOCALSTACK_PORT.into())
         .with_wait_for(WaitFor::message_on_stdout("Ready."))
         .with_mapped_port(host_port, LOCALSTACK_PORT.into())
+        .with_env_var("LOCALSTACK_AUTH_TOKEN", &auth_token)
         .start()
         .await?;
     Ok(LocalstackContainer {


### PR DESCRIPTION
## Summary
- Upgrade LocalStack from pinned `4.14.0` to `stable` tag across CI workflows and Rust test harness
- Pass `LOCALSTACK_AUTH_TOKEN` to containers — required since LocalStack now mandates authentication
- Localstack announcement: https://blog.localstack.cloud/localstack-single-image-next-steps/

Closes: https://github.com/zama-ai/fhevm-internal/issues/1187