### PR TITLE
fix(coprocessor): do not retry on `VerifyProofNotRequested`

### DIFF
--- a/coprocessor/fhevm-engine/transaction-sender/contracts/InputVerification.sol
+++ b/coprocessor/fhevm-engine/transaction-sender/contracts/InputVerification.sol
@@ -21,12 +21,14 @@ contract InputVerification {
      * @param signer The signer address of the coprocessor that has already rejected.
      */
     error CoprocessorAlreadyRejected(uint256 zkProofId, address txSender, address signer);
+    error VerifyProofNotRequested(uint256 zkProofId);
     error NotCoprocessorSigner(address signerAddress);
     error NotCoprocessorTxSender(address txSenderAddress);
     error CoprocessorSignerDoesNotMatchTxSender(address signerAddress, address txSenderAddress);
 
     bool alreadyVerifiedRevert;
     bool alreadyRejectedRevert;
+    bool verifyProofNotRequestedRevert;
     bool otherRevert;
     ConfigErrorMode configErrorMode;
 
@@ -37,9 +39,10 @@ contract InputVerification {
         CoprocessorSignerDoesNotMatchTxSender
     }
 
-    constructor(bool _alreadyVerifiedRevert, bool _alreadyRejectedRevert, bool _otherRevert) {
+    constructor(bool _alreadyVerifiedRevert, bool _alreadyRejectedRevert, bool _verifyProofNotRequestedRevert, bool _otherRevert) {
         alreadyVerifiedRevert = _alreadyVerifiedRevert;
         alreadyRejectedRevert = _alreadyRejectedRevert;
+        verifyProofNotRequestedRevert = _verifyProofNotRequestedRevert;
         otherRevert = _otherRevert;
     }
 
@@ -71,6 +74,10 @@ contract InputVerification {
             revert("Other revert");
         }
 
+        if (verifyProofNotRequestedRevert) {
+            revert VerifyProofNotRequested(zkProofId);
+        }
+
         if (alreadyVerifiedRevert) {
             revert CoprocessorAlreadyVerified(zkProofId, msg.sender, msg.sender);
         }
@@ -83,6 +90,9 @@ contract InputVerification {
     function rejectProofResponse(uint256 zkProofId, bytes calldata /* extraData */) public {
         if (configErrorMode == ConfigErrorMode.NotCoprocessorTxSender) {
             revert NotCoprocessorTxSender(msg.sender);
+        }
+        if (verifyProofNotRequestedRevert) {
+            revert VerifyProofNotRequested(zkProofId);
         }
         if (otherRevert) {
             revert("Other revert");

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -165,6 +165,17 @@ where
                     );
                     self.remove_proof_by_id(txn_request.0).await?;
                     return Ok(());
+                } else if let Some(InputVerificationErrors::VerifyProofNotRequested(_)) =
+                    e.as_error_resp().and_then(|payload| {
+                        payload.as_decoded_interface_error::<InputVerificationErrors>()
+                    })
+                {
+                    warn!(
+                        zk_proof_id = txn_request.0,
+                        "Verify proof was not requested, removing from DB"
+                    );
+                    self.remove_proof_by_id(txn_request.0).await?;
+                    return Ok(());
                 } else if let Some(non_retryable_config_error) =
                     try_extract_non_retryable_config_error(&e)
                 {

--- a/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
@@ -49,11 +49,13 @@ async fn verify_proof_response_success(#[case] signer_type: SignerType) -> anyho
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -165,11 +167,13 @@ async fn verify_proof_response_empty_handles_success(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -284,11 +288,13 @@ async fn verify_proof_response_concurrent_success(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -401,11 +407,13 @@ async fn reject_proof_response_success(#[case] signer_type: SignerType) -> anyho
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -511,11 +519,13 @@ async fn verify_proof_response_reversal_already_verified(
     );
     let already_verified_revert = true;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -595,6 +605,213 @@ async fn verify_proof_response_reversal_already_verified(
 #[case::aws_kms(SignerType::AwsKms)]
 #[tokio::test]
 #[serial(db)]
+async fn verify_proof_response_reversal_not_requested(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    let env = TestEnvironment::new(signer_type).await?;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = true;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        verify_proof_not_requested_revert,
+        other_revert,
+    )
+    .await?;
+    let already_added_revert = false;
+    let ciphertext_commits =
+        CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input_verification.address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Record initial transaction count.
+    let initial_tx_count = provider
+        .get_transaction_count(TxSigner::address(&env.signer))
+        .await?;
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof is removed from the database.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    // Verify that no transaction has been sent.
+    let final_tx_count = provider
+        .get_transaction_count(TxSigner::address(&env.signer))
+        .await?;
+    assert_eq!(
+        final_tx_count, initial_tx_count,
+        "Expected no new transaction to be sent"
+    );
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}
+
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[case::aws_kms(SignerType::AwsKms)]
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_reversal_not_requested(
+    #[case] signer_type: SignerType,
+) -> anyhow::Result<()> {
+    let env = TestEnvironment::new(signer_type).await?;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .connect_ws(WsConnect::new(env.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = true;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        verify_proof_not_requested_revert,
+        other_revert,
+    )
+    .await?;
+    let already_added_revert = false;
+    let ciphertext_commits =
+        CiphertextCommits::deploy(&provider_deploy, already_added_revert).await?;
+    let txn_sender = TransactionSender::new(
+        env.db_pool.clone(),
+        *input_verification.address(),
+        *ciphertext_commits.address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Record initial transaction count.
+    let initial_tx_count = provider
+        .get_transaction_count(TxSigner::address(&env.signer))
+        .await?;
+
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, false)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof is removed from the database.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    // Verify that no transaction has been sent.
+    let final_tx_count = provider
+        .get_transaction_count(TxSigner::address(&env.signer))
+        .await?;
+    assert_eq!(
+        final_tx_count, initial_tx_count,
+        "Expected no new transaction to be sent"
+    );
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}
+
+#[rstest]
+#[case::private_key(SignerType::PrivateKey)]
+#[case::aws_kms(SignerType::AwsKms)]
+#[tokio::test]
+#[serial(db)]
 async fn reject_proof_response_reversal_already_rejected(
     #[case] signer_type: SignerType,
 ) -> anyhow::Result<()> {
@@ -613,11 +830,13 @@ async fn reject_proof_response_reversal_already_rejected(
     );
     let already_verified_revert = false;
     let already_rejected_revert = true;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -714,11 +933,13 @@ async fn verify_proof_response_other_reversal(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = true;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -813,11 +1034,13 @@ async fn reject_proof_response_other_reversal(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = true;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -908,11 +1131,13 @@ async fn verify_proof_response_other_reversal_gas_estimation(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = true;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -1006,11 +1231,13 @@ async fn reject_proof_response_other_reversal_gas_estimation(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = true;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -1106,11 +1333,13 @@ async fn verify_proof_max_retries_remove_entry(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = true;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -1196,11 +1425,13 @@ async fn verify_proof_max_retries_do_not_remove_entry(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = true;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;
@@ -1305,11 +1536,13 @@ async fn stop_retrying_verify_proof_on_gw_config_error(
     );
     let already_verified_revert = false;
     let already_rejected_revert = false;
+    let verify_proof_not_requested_revert = false;
     let other_revert = false;
     let input_verification = InputVerification::deploy(
         &provider_deploy,
         already_verified_revert,
         already_rejected_revert,
+        verify_proof_not_requested_revert,
         other_revert,
     )
     .await?;


### PR DESCRIPTION
If `VerifyProofNotRequested` is returned, the txn-sender should not retry as it can never succeed. This error is not supposed to happen, but it is better if we handle it explicitly.