### PR TITLE
chore(kms-connector): gateway events renamed protocol events

### DIFF
--- a/kms-connector/crates/gw-listener/src/core/gateway.rs
+++ b/kms-connector/crates/gw-listener/src/core/gateway.rs
@@ -11,7 +11,7 @@ use alloy::{
 use anyhow::anyhow;
 use connector_utils::{
     monitoring::otlp::PropagationContext,
-    types::{GatewayEvent, GatewayEventKind, db::EventType},
+    types::{ProtocolEvent, ProtocolEventKind, db::EventType},
 };
 use fhevm_gateway_bindings::{
     decryption::Decryption::DecryptionEvents, kms_generation::KMSGeneration::KMSGenerationEvents,
@@ -210,8 +210,8 @@ where
         Ok((to_block.saturating_add(1), to_block < current_block))
     }
 
-    /// Decodes a log into a `GatewayEventKind`.
-    fn decode_log(contract: MonitoredContract, log: &Log) -> anyhow::Result<GatewayEventKind> {
+    /// Decodes a log into a `ProtocolEventKind`.
+    fn decode_log(contract: MonitoredContract, log: &Log) -> anyhow::Result<ProtocolEventKind> {
         match contract {
             MonitoredContract::Decryption => {
                 let event = DecryptionEvents::decode_log(&log.inner)
@@ -237,11 +237,11 @@ where
         }
     }
 
-    /// Decodes logs and prepares `GatewayEvent` structs with OTLP context and metrics.
+    /// Decodes logs and prepares `ProtocolEvent` structs with OTLP context and metrics.
     fn prepare_events(
         contract: MonitoredContract,
         logs: Vec<Log>,
-    ) -> anyhow::Result<Vec<GatewayEvent>> {
+    ) -> anyhow::Result<Vec<ProtocolEvent>> {
         let mut events = Vec::with_capacity(logs.len());
         for log in logs {
             let event_kind = Self::decode_log(contract, &log)?;
@@ -251,7 +251,7 @@ where
 
             let span = info_span!("handle_gateway_event", event = %event_kind);
             let otlp_ctx = PropagationContext::inject(&span.context());
-            events.push(GatewayEvent::new(
+            events.push(ProtocolEvent::new(
                 event_kind,
                 log.transaction_hash,
                 otlp_ctx,

--- a/kms-connector/crates/gw-listener/src/core/publish.rs
+++ b/kms-connector/crates/gw-listener/src/core/publish.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use connector_utils::{
     monitoring::otlp::PropagationContext,
     types::{
-        GatewayEvent, GatewayEventKind,
+        ProtocolEvent, ProtocolEventKind,
         db::{EventType, ParamsTypeDb, SnsCiphertextMaterialDbItem},
     },
 };
@@ -25,7 +25,7 @@ use tracing::{debug, info, warn};
 #[tracing::instrument(skip_all)]
 pub async fn publish_batch(
     db_pool: &Pool<Postgres>,
-    events: Vec<GatewayEvent>,
+    events: Vec<ProtocolEvent>,
     event_types: &[EventType],
     block_number: u64,
 ) -> anyhow::Result<()> {
@@ -40,7 +40,7 @@ pub async fn publish_batch(
 
 async fn publish_event_inner<'e>(
     executor: impl PgExecutor<'e>,
-    event: GatewayEvent,
+    event: ProtocolEvent,
 ) -> anyhow::Result<()> {
     info!("Storing {:?} in DB...", event.kind);
 
@@ -48,28 +48,28 @@ async fn publish_event_inner<'e>(
     let tx_hash = event.tx_hash;
     let created_at = event.created_at;
     let query_result = match event.kind {
-        GatewayEventKind::PublicDecryption(e) => {
+        ProtocolEventKind::PublicDecryption(e) => {
             publish_public_decryption(executor, e, tx_hash, created_at, otlp_ctx).await
         }
-        GatewayEventKind::UserDecryption(e) => {
+        ProtocolEventKind::UserDecryption(e) => {
             publish_user_decryption(executor, e, tx_hash, created_at, otlp_ctx).await
         }
-        GatewayEventKind::PrepKeygen(e) => {
+        ProtocolEventKind::PrepKeygen(e) => {
             let params_type: ParamsTypeDb = e.paramsType.try_into()?;
             publish_prep_keygen_request(executor, e, params_type, tx_hash, created_at, otlp_ctx)
                 .await
         }
-        GatewayEventKind::Keygen(e) => {
+        ProtocolEventKind::Keygen(e) => {
             publish_keygen_request(executor, e, tx_hash, created_at, otlp_ctx).await
         }
-        GatewayEventKind::Crsgen(e) => {
+        ProtocolEventKind::Crsgen(e) => {
             let params_type: ParamsTypeDb = e.paramsType.try_into()?;
             publish_crsgen_request(executor, e, params_type, tx_hash, created_at, otlp_ctx).await
         }
-        GatewayEventKind::PrssInit(id) => {
+        ProtocolEventKind::PrssInit(id) => {
             publish_prss_init(executor, id, tx_hash, created_at, otlp_ctx).await
         }
-        GatewayEventKind::KeyReshareSameSet(e) => {
+        ProtocolEventKind::KeyReshareSameSet(e) => {
             let params_type: ParamsTypeDb = e.paramsType.try_into()?;
             publish_key_reshare_same_set(executor, e, params_type, tx_hash, created_at, otlp_ctx)
                 .await

--- a/kms-connector/crates/gw-listener/tests/block_tracking.rs
+++ b/kms-connector/crates/gw-listener/tests/block_tracking.rs
@@ -8,59 +8,18 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 #[rstest]
+#[case::public_decryption(EventType::PublicDecryptionRequest)]
+#[case::user_decryption(EventType::UserDecryptionRequest)]
+#[case::prep_keygen(EventType::PrepKeygenRequest)]
+#[case::keygen(EventType::KeygenRequest)]
+#[case::crsgen(EventType::CrsgenRequest)]
+// As there is currently only one PRSS init ID allowed, the test won't pass as there will be only
+// one row in the DB instead of two.
+// #[case::prss_init(EventType::PrssInit)]
+#[case::key_reshare_same_set(EventType::KeyReshareSameSet)]
 #[timeout(Duration::from_secs(90))]
 #[tokio::test]
-async fn test_block_tracking_public_decryption() -> anyhow::Result<()> {
-    test_block_tracking(EventType::PublicDecryptionRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(90))]
-#[tokio::test]
-async fn test_block_tracking_user_decryption() -> anyhow::Result<()> {
-    test_block_tracking(EventType::UserDecryptionRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(90))]
-#[tokio::test]
-async fn test_block_tracking_prep_keygen() -> anyhow::Result<()> {
-    test_block_tracking(EventType::PrepKeygenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(90))]
-#[tokio::test]
-async fn test_block_tracking_keygen() -> anyhow::Result<()> {
-    test_block_tracking(EventType::KeygenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(90))]
-#[tokio::test]
-async fn test_block_tracking_crsgen() -> anyhow::Result<()> {
-    test_block_tracking(EventType::CrsgenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(90))]
-#[tokio::test]
-#[ignore = "
-    As there is currently only one PRSS init ID allowed,
-    the test won't pass as there will be only one row in the DB instead of two
-"]
-async fn test_block_tracking_prss_init() -> anyhow::Result<()> {
-    test_block_tracking(EventType::PrssInit).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(90))]
-#[tokio::test]
-async fn test_block_tracking_key_reshare_same_set() -> anyhow::Result<()> {
-    test_block_tracking(EventType::KeyReshareSameSet).await
-}
-
-async fn test_block_tracking(event_type: EventType) -> anyhow::Result<()> {
+async fn test_block_tracking(#[case] event_type: EventType) -> anyhow::Result<()> {
     let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task =

--- a/kms-connector/crates/gw-listener/tests/catchup.rs
+++ b/kms-connector/crates/gw-listener/tests/catchup.rs
@@ -8,55 +8,16 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 #[rstest]
+#[case::public_decryption(EventType::PublicDecryptionRequest)]
+#[case::user_decryption(EventType::UserDecryptionRequest)]
+#[case::prep_keygen(EventType::PrepKeygenRequest)]
+#[case::keygen(EventType::KeygenRequest)]
+#[case::crsgen(EventType::CrsgenRequest)]
+#[case::prss_init(EventType::PrssInit)]
+#[case::key_reshare_same_set(EventType::KeyReshareSameSet)]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-async fn test_catchup_public_decryption_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::PublicDecryptionRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_catchup_user_decryption_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::UserDecryptionRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_catchup_prep_keygen_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::PrepKeygenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_catchup_keygen_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::KeygenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_catchup_crsgen_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::CrsgenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_catchup_prss_init_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::PrssInit).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_catchup_key_reshare_same_set_from_block() -> anyhow::Result<()> {
-    test_catchup_from_block(EventType::KeyReshareSameSet).await
-}
-
-async fn test_catchup_from_block(event_type: EventType) -> anyhow::Result<()> {
+async fn test_catchup_from_block(#[case] event_type: EventType) -> anyhow::Result<()> {
     let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
 

--- a/kms-connector/crates/gw-listener/tests/common/mod.rs
+++ b/kms-connector/crates/gw-listener/tests/common/mod.rs
@@ -11,9 +11,9 @@ use connector_utils::{
         setup::TestInstance,
     },
     types::{
-        GatewayEventKind,
+        ProtocolEventKind,
         db::{EventType, ParamsTypeDb},
-        gw_event::PRSS_INIT_ID,
+        event::PRSS_INIT_ID,
     },
 };
 use fhevm_gateway_bindings::{
@@ -67,7 +67,7 @@ pub async fn start_test_listener(
 pub async fn mock_event_on_gw(
     test_instance: &TestInstance,
     event_type: EventType,
-) -> anyhow::Result<(GatewayEventKind, Option<u64>)> {
+) -> anyhow::Result<(ProtocolEventKind, Option<u64>)> {
     info!("Mocking {event_type} on Anvil...");
     let (pending_tx, event) = match event_type {
         EventType::PublicDecryptionRequest => {
@@ -194,7 +194,7 @@ pub async fn fetch_from_db(db: &Pool<Postgres>, event_type: EventType) -> sqlx::
 pub async fn poll_db_for_event(
     db: &Pool<Postgres>,
     event_type: EventType,
-    expected_event: &GatewayEventKind,
+    expected_event: &ProtocolEventKind,
 ) -> anyhow::Result<()> {
     let timeout = Duration::from_secs(30);
     let poll_interval = Duration::from_millis(200);
@@ -211,16 +211,16 @@ pub async fn poll_db_for_event(
     }
 }
 
-pub fn check_event_in_db(rows: &[PgRow], event: GatewayEventKind) -> anyhow::Result<()> {
+pub fn check_event_in_db(rows: &[PgRow], event: ProtocolEventKind) -> anyhow::Result<()> {
     match event {
-        GatewayEventKind::PublicDecryption(e) => {
+        ProtocolEventKind::PublicDecryption(e) => {
             for r in rows {
                 if e.extraData.to_vec() == r.try_get::<Vec<u8>, _>("extra_data")? {
                     return Ok(());
                 }
             }
         }
-        GatewayEventKind::UserDecryption(e) => {
+        ProtocolEventKind::UserDecryption(e) => {
             for r in rows {
                 if e.publicKey.to_vec() == r.try_get::<Vec<u8>, _>("public_key")?
                     && e.userAddress == Address::from(r.try_get::<[u8; 20], _>("user_address")?)
@@ -229,14 +229,14 @@ pub fn check_event_in_db(rows: &[PgRow], event: GatewayEventKind) -> anyhow::Res
                 }
             }
         }
-        GatewayEventKind::PrepKeygen(_) => {
+        ProtocolEventKind::PrepKeygen(_) => {
             for r in rows {
                 if r.try_get::<ParamsTypeDb, _>("params_type")? == ParamsTypeDb::Test {
                     return Ok(());
                 }
             }
         }
-        GatewayEventKind::Keygen(e) => {
+        ProtocolEventKind::Keygen(e) => {
             for r in rows {
                 if e.prepKeygenId
                     == U256::from_le_bytes(r.try_get::<[u8; 32], _>("prep_keygen_id")?)
@@ -245,7 +245,7 @@ pub fn check_event_in_db(rows: &[PgRow], event: GatewayEventKind) -> anyhow::Res
                 }
             }
         }
-        GatewayEventKind::Crsgen(e) => {
+        ProtocolEventKind::Crsgen(e) => {
             for r in rows {
                 if e.maxBitLength
                     == U256::from_le_bytes(r.try_get::<[u8; 32], _>("max_bit_length")?)
@@ -254,14 +254,14 @@ pub fn check_event_in_db(rows: &[PgRow], event: GatewayEventKind) -> anyhow::Res
                 }
             }
         }
-        GatewayEventKind::PrssInit(_) => {
+        ProtocolEventKind::PrssInit(_) => {
             for r in rows {
                 if U256::from_le_bytes(r.try_get::<[u8; 32], _>("id")?) == PRSS_INIT_ID {
                     return Ok(());
                 }
             }
         }
-        GatewayEventKind::KeyReshareSameSet(e) => {
+        ProtocolEventKind::KeyReshareSameSet(e) => {
             for r in rows {
                 if e.keyId == U256::from_le_bytes(r.try_get::<[u8; 32], _>("key_id")?) {
                     return Ok(());

--- a/kms-connector/crates/gw-listener/tests/integration_test.rs
+++ b/kms-connector/crates/gw-listener/tests/integration_test.rs
@@ -9,55 +9,16 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 #[rstest]
+#[case::public_decryption(EventType::PublicDecryptionRequest)]
+#[case::user_decryption(EventType::UserDecryptionRequest)]
+#[case::prep_keygen(EventType::PrepKeygenRequest)]
+#[case::keygen(EventType::KeygenRequest)]
+#[case::crsgen(EventType::CrsgenRequest)]
+#[case::prss_init(EventType::PrssInit)]
+#[case::key_reshare_same_set(EventType::KeyReshareSameSet)]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-async fn test_publish_public_decryption() -> anyhow::Result<()> {
-    test_publish_event(EventType::PublicDecryptionRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_publish_user_decryption() -> anyhow::Result<()> {
-    test_publish_event(EventType::UserDecryptionRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_publish_prep_keygen() -> anyhow::Result<()> {
-    test_publish_event(EventType::PrepKeygenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_publish_keygen() -> anyhow::Result<()> {
-    test_publish_event(EventType::KeygenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_publish_crsgen() -> anyhow::Result<()> {
-    test_publish_event(EventType::CrsgenRequest).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_publish_prss_init() -> anyhow::Result<()> {
-    test_publish_event(EventType::PrssInit).await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn test_publish_key_reshare_same_set() -> anyhow::Result<()> {
-    test_publish_event(EventType::KeyReshareSameSet).await
-}
-
-async fn test_publish_event(event_type: EventType) -> anyhow::Result<()> {
+async fn test_publish_event(#[case] event_type: EventType) -> anyhow::Result<()> {
     let mut test_instance = TestInstanceBuilder::db_gw_setup().await?;
     let cancel_token = CancellationToken::new();
     let gw_listener_task =

--- a/kms-connector/crates/kms-worker/src/core/event_picker/picker.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_picker/picker.rs
@@ -3,7 +3,7 @@ use crate::{
     monitoring::metrics::{EVENT_RECEIVED_COUNTER, EVENT_RECEIVED_ERRORS},
 };
 use anyhow::anyhow;
-use connector_utils::types::{GatewayEvent, db::EventType, gw_event};
+use connector_utils::types::{ProtocolEvent, db::EventType, event};
 use sqlx::{Pool, Postgres};
 use tokio::sync::mpsc::{self, Receiver};
 use tracing::{debug, info, warn};
@@ -52,7 +52,7 @@ impl DbEventPicker {
 }
 
 impl EventPicker for DbEventPicker {
-    type Event = GatewayEvent;
+    type Event = ProtocolEvent;
 
     /// Picks events from the database.
     ///
@@ -94,7 +94,7 @@ impl DbEventPicker {
     async fn pick_notified_events(
         &self,
         notification: &EventType,
-    ) -> anyhow::Result<Vec<GatewayEvent>> {
+    ) -> anyhow::Result<Vec<ProtocolEvent>> {
         match notification {
             EventType::PublicDecryptionRequest => self.pick_public_decryption_requests().await,
             EventType::UserDecryptionRequest => self.pick_user_decryption_requests().await,
@@ -106,7 +106,7 @@ impl DbEventPicker {
         }
     }
 
-    async fn pick_public_decryption_requests(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_public_decryption_requests(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE public_decryption_requests
@@ -126,11 +126,11 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_public_decryption_row)
+        .map(event::from_public_decryption_row)
         .collect()
     }
 
-    async fn pick_user_decryption_requests(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_user_decryption_requests(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE user_decryption_requests
@@ -150,11 +150,11 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_user_decryption_row)
+        .map(event::from_user_decryption_row)
         .collect()
     }
 
-    async fn pick_prep_keygen_requests(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_prep_keygen_requests(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE prep_keygen_requests
@@ -173,11 +173,11 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_prep_keygen_row)
+        .map(event::from_prep_keygen_row)
         .collect()
     }
 
-    async fn pick_keygen_requests(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_keygen_requests(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE keygen_requests
@@ -196,11 +196,11 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_keygen_row)
+        .map(event::from_keygen_row)
         .collect()
     }
 
-    async fn pick_crsgen_requests(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_crsgen_requests(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE crsgen_requests
@@ -219,11 +219,11 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_crsgen_row)
+        .map(event::from_crsgen_row)
         .collect()
     }
 
-    async fn pick_prss_init(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_prss_init(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE prss_init
@@ -241,11 +241,11 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_prss_init_row)
+        .map(event::from_prss_init_row)
         .collect()
     }
 
-    async fn pick_key_reshare_same_set(&self) -> anyhow::Result<Vec<GatewayEvent>> {
+    async fn pick_key_reshare_same_set(&self) -> anyhow::Result<Vec<ProtocolEvent>> {
         sqlx::query(
             "
                 UPDATE key_reshare_same_set
@@ -264,7 +264,7 @@ impl DbEventPicker {
         .fetch_all(&self.db_pool)
         .await?
         .iter()
-        .map(gw_event::from_key_reshare_same_set_row)
+        .map(event::from_key_reshare_same_set_row)
         .collect()
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
@@ -10,7 +10,7 @@ use anyhow::anyhow;
 use connector_utils::{
     conn::{CONNECTION_RETRY_DELAY, CONNECTION_RETRY_NUMBER},
     types::{
-        KmsGrpcRequest, KmsGrpcResponse, db::EventType, gw_event::PRSS_INIT_ID, request_id_to_u256,
+        KmsGrpcRequest, KmsGrpcResponse, db::EventType, event::PRSS_INIT_ID, request_id_to_u256,
         u256_to_request_id, u256_to_u32,
     },
 };

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -7,7 +7,7 @@ use crate::core::event_processor::{
 use alloy::providers::Provider;
 use anyhow::anyhow;
 use connector_utils::types::{
-    GatewayEvent, GatewayEventKind, KmsGrpcRequest, KmsGrpcResponse, KmsResponseKind,
+    KmsGrpcRequest, KmsGrpcResponse, KmsResponseKind, ProtocolEvent, ProtocolEventKind,
 };
 use sqlx::{Pool, Postgres};
 use thiserror::Error;
@@ -44,7 +44,7 @@ pub struct DbEventProcessor<GP: Provider, HP: Provider, C> {
 }
 
 impl<GP: Provider, HP: Provider, C: ContextManager> EventProcessor for DbEventProcessor<GP, HP, C> {
-    type Event = GatewayEvent;
+    type Event = ProtocolEvent;
 
     #[tracing::instrument(skip_all)]
     async fn process(&mut self, event: &mut Self::Event) -> Option<KmsResponseKind> {
@@ -59,7 +59,7 @@ impl<GP: Provider, HP: Provider, C: ContextManager> EventProcessor for DbEventPr
                 Err(ProcessingError::Recoverable(e)),
                 // Consider all errors as irrecoverable for PrssInit and KeyReshareSameSet, as KMS does
                 // not provide any response for these operations
-                GatewayEventKind::PrssInit(_) | GatewayEventKind::KeyReshareSameSet(_),
+                ProtocolEventKind::PrssInit(_) | ProtocolEventKind::KeyReshareSameSet(_),
             ) => {
                 error!("{}", ProcessingError::Irrecoverable(e));
                 event.mark_as_failed(&self.db_pool).await;
@@ -72,7 +72,7 @@ impl<GP: Provider, HP: Provider, C: ContextManager> EventProcessor for DbEventPr
             // key management operation at all cost.
             (
                 Err(ProcessingError::Recoverable(e)),
-                GatewayEventKind::PublicDecryption(_) | GatewayEventKind::UserDecryption(_),
+                ProtocolEventKind::PublicDecryption(_) | ProtocolEventKind::UserDecryption(_),
             ) if event.error_counter as u16 >= self.max_decryption_attempts => {
                 error!(
                     "{}. Maximum number of decryption attempts reached: {}",
@@ -120,10 +120,10 @@ impl<GP: Provider, HP: Provider, C: ContextManager> DbEventProcessor<GP, HP, C> 
     #[tracing::instrument(skip_all)]
     async fn prepare_request(
         &self,
-        event: &mut GatewayEvent,
+        event: &mut ProtocolEvent,
     ) -> Result<KmsGrpcRequest, ProcessingError> {
         let request = match &event.kind {
-            GatewayEventKind::PublicDecryption(req) => {
+            ProtocolEventKind::PublicDecryption(req) => {
                 self.decryption_processor
                     .check_ciphertexts_allowed_for_public_decryption(&req.snsCtMaterials)
                     .await?;
@@ -137,7 +137,7 @@ impl<GP: Provider, HP: Provider, C: ContextManager> DbEventProcessor<GP, HP, C> 
                     )
                     .await?
             }
-            GatewayEventKind::UserDecryption(req) => {
+            ProtocolEventKind::UserDecryption(req) => {
                 // No need to check decryption is done for user decrypt, as MPC parties don't
                 // communicate between each other for user decrypt
 
@@ -166,19 +166,19 @@ impl<GP: Provider, HP: Provider, C: ContextManager> DbEventProcessor<GP, HP, C> 
                     )
                     .await?
             }
-            GatewayEventKind::PrepKeygen(req) => self
+            ProtocolEventKind::PrepKeygen(req) => self
                 .kms_generation_processor
                 .prepare_prep_keygen_request(req),
-            GatewayEventKind::Keygen(req) => {
+            ProtocolEventKind::Keygen(req) => {
                 self.kms_generation_processor.prepare_keygen_request(req)
             }
-            GatewayEventKind::Crsgen(req) => {
+            ProtocolEventKind::Crsgen(req) => {
                 self.kms_generation_processor.prepare_crsgen_request(req)
             }
-            GatewayEventKind::PrssInit(id) => {
+            ProtocolEventKind::PrssInit(id) => {
                 self.kms_generation_processor.prepare_prss_init_request(*id)
             }
-            GatewayEventKind::KeyReshareSameSet(req) => self
+            ProtocolEventKind::KeyReshareSameSet(req) => self
                 .kms_generation_processor
                 .prepare_initiate_resharing_request(req),
         };
@@ -188,7 +188,7 @@ impl<GP: Provider, HP: Provider, C: ContextManager> DbEventProcessor<GP, HP, C> 
     /// Core event processing logic function.
     async fn inner_process(
         &mut self,
-        event: &mut GatewayEvent,
+        event: &mut ProtocolEvent,
     ) -> Result<Option<KmsResponseKind>, ProcessingError> {
         let request = self
             .prepare_request(event)

--- a/kms-connector/crates/kms-worker/src/core/kms_response_publisher.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_response_publisher.rs
@@ -1,8 +1,8 @@
 use connector_utils::{
     monitoring::otlp::PropagationContext,
     types::{
-        CrsgenResponse, GatewayEvent, KeygenResponse, KmsResponse, KmsResponseKind,
-        PrepKeygenResponse, PublicDecryptionResponse, UserDecryptionResponse, db::KeyDigestDbItem,
+        CrsgenResponse, KeygenResponse, KmsResponse, KmsResponseKind, PrepKeygenResponse,
+        ProtocolEvent, PublicDecryptionResponse, UserDecryptionResponse, db::KeyDigestDbItem,
     },
 };
 use sqlx::{
@@ -175,7 +175,7 @@ impl DbKmsResponsePublisher {
     }
 
     /// Sets the `status` field of the event to `pending` in the database.
-    pub async fn mark_event_as_pending(&self, event: GatewayEvent) {
+    pub async fn mark_event_as_pending(&self, event: ProtocolEvent) {
         event.mark_as_pending(&self.db_pool).await
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -19,7 +19,7 @@ use anyhow::anyhow;
 use connector_utils::{
     conn::{DefaultProvider, connect_to_db, connect_to_rpc_node},
     tasks::spawn_with_limit,
-    types::{GatewayEvent, KmsResponse},
+    types::{KmsResponse, ProtocolEvent},
 };
 use fhevm_host_bindings::acl::ACL;
 use std::collections::HashMap;
@@ -41,8 +41,8 @@ pub struct KmsWorker<E, Proc> {
 
 impl<E, Proc> KmsWorker<E, Proc>
 where
-    E: EventPicker<Event = GatewayEvent>,
-    Proc: EventProcessor<Event = GatewayEvent> + Clone + Send + 'static,
+    E: EventPicker<Event = ProtocolEvent>,
+    Proc: EventProcessor<Event = ProtocolEvent> + Clone + Send + 'static,
 {
     /// Creates a new `KmsWorker<E, Proc>`.
     pub fn new(
@@ -77,7 +77,7 @@ where
     }
 
     /// Spawns a new task to process each event.
-    async fn spawn_event_processing_tasks(&self, events: Vec<GatewayEvent>) {
+    async fn spawn_event_processing_tasks(&self, events: Vec<ProtocolEvent>) {
         for event in events {
             let event_processor = self.event_processor.clone();
             let response_publisher = self.response_publisher.clone();
@@ -94,7 +94,7 @@ where
     async fn handle_event(
         mut event_processor: Proc,
         response_publisher: DbKmsResponsePublisher,
-        mut event: GatewayEvent,
+        mut event: ProtocolEvent,
     ) {
         let otlp_context = event.otlp_context.clone();
         tracing::Span::current().set_parent(otlp_context.extract());

--- a/kms-connector/crates/kms-worker/src/monitoring/metrics.rs
+++ b/kms-connector/crates/kms-worker/src/monitoring/metrics.rs
@@ -1,4 +1,4 @@
-use connector_utils::types::{GatewayEvent, GatewayEventKind, db::EventType};
+use connector_utils::types::{ProtocolEvent, ProtocolEventKind, db::EventType};
 use prometheus::{
     HistogramOpts, HistogramVec, IntCounter, IntCounterVec, register_histogram_vec,
     register_int_counter, register_int_counter_vec,
@@ -92,10 +92,10 @@ pub static DECRYPTION_LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(
     .unwrap()
 });
 
-pub fn register_event_latency(event: &GatewayEvent) {
+pub fn register_event_latency(event: &ProtocolEvent) {
     if matches!(
         event.kind,
-        GatewayEventKind::PublicDecryption(_) | GatewayEventKind::UserDecryption(_)
+        ProtocolEventKind::PublicDecryption(_) | ProtocolEventKind::UserDecryption(_)
     ) {
         let elapsed = Utc::now() - event.created_at;
         DECRYPTION_LATENCY_HISTOGRAM

--- a/kms-connector/crates/kms-worker/tests/attempt_limit.rs
+++ b/kms-connector/crates/kms-worker/tests/attempt_limit.rs
@@ -18,7 +18,7 @@ use connector_utils::{
             init_host_chains_acl_contracts_mock,
         },
     },
-    types::{GatewayEventKind, db::EventType},
+    types::{ProtocolEventKind, db::EventType},
 };
 use fhevm_gateway_bindings::gateway_config::GatewayConfig::Coprocessor;
 use kms_grpc::kms::v1::{Empty, InitiateResharingResponse};
@@ -126,10 +126,10 @@ async fn test_request_processing(#[case] event_type: EventType) -> anyhow::Resul
 
     match &request {
         // Wait for kms_worker to remove the request from DB, then stop it
-        GatewayEventKind::PublicDecryption(_)
-        | GatewayEventKind::UserDecryption(_)
-        | GatewayEventKind::PrssInit(_)
-        | GatewayEventKind::KeyReshareSameSet(_) => {
+        ProtocolEventKind::PublicDecryption(_)
+        | ProtocolEventKind::UserDecryption(_)
+        | ProtocolEventKind::PrssInit(_)
+        | ProtocolEventKind::KeyReshareSameSet(_) => {
             while check_no_uncompleted_request_in_db(test_instance.db(), event_type)
                 .await
                 .is_err()
@@ -157,18 +157,18 @@ async fn test_request_processing(#[case] event_type: EventType) -> anyhow::Resul
     Ok(())
 }
 
-fn prepare_mocks(req: &GatewayEventKind) -> MockSet {
+fn prepare_mocks(req: &ProtocolEventKind) -> MockSet {
     let mut kms_mocks = MockSet::new();
 
     // Gets the endpoints for the given request type
     let (req_endpoint, resp_endpoint) = match req {
-        GatewayEventKind::PublicDecryption(_) => ("PublicDecrypt", "GetPublicDecryptionResult"),
-        GatewayEventKind::UserDecryption(_) => ("UserDecrypt", "GetUserDecryptionResult"),
-        GatewayEventKind::PrepKeygen(_) => ("KeyGenPreproc", "GetKeyGenPreprocResult"),
-        GatewayEventKind::Keygen(_) => ("KeyGen", "GetKeyGenResult"),
-        GatewayEventKind::Crsgen(_) => ("CrsGen", "GetCrsGenResult"),
-        GatewayEventKind::PrssInit(_) => ("Init", ""),
-        GatewayEventKind::KeyReshareSameSet(_) => ("InitiateResharing", ""),
+        ProtocolEventKind::PublicDecryption(_) => ("PublicDecrypt", "GetPublicDecryptionResult"),
+        ProtocolEventKind::UserDecryption(_) => ("UserDecrypt", "GetUserDecryptionResult"),
+        ProtocolEventKind::PrepKeygen(_) => ("KeyGenPreproc", "GetKeyGenPreprocResult"),
+        ProtocolEventKind::Keygen(_) => ("KeyGen", "GetKeyGenResult"),
+        ProtocolEventKind::Crsgen(_) => ("CrsGen", "GetCrsGenResult"),
+        ProtocolEventKind::PrssInit(_) => ("Init", ""),
+        ProtocolEventKind::KeyReshareSameSet(_) => ("InitiateResharing", ""),
     };
 
     // Mock initial KMS response to initial GRPC request
@@ -177,7 +177,9 @@ fn prepare_mocks(req: &GatewayEventKind) -> MockSet {
             "/kms_service.v1.CoreServiceEndpoint/{req_endpoint}"
         ));
         match req {
-            GatewayEventKind::KeyReshareSameSet(_) => then.pb(InitiateResharingResponse::default()),
+            ProtocolEventKind::KeyReshareSameSet(_) => {
+                then.pb(InitiateResharingResponse::default())
+            }
             // KMS returns `Empty` for all kind of requests except `KeyReshareSameSet`
             _ => then.pb(Empty::default()),
         };

--- a/kms-connector/crates/kms-worker/tests/event_picker/simple.rs
+++ b/kms-connector/crates/kms-worker/tests/event_picker/simple.rs
@@ -5,7 +5,7 @@ use connector_utils::{
         setup::TestInstanceBuilder,
     },
     types::{
-        GatewayEvent, GatewayEventKind,
+        ProtocolEvent, ProtocolEventKind,
         db::{ParamsTypeDb, SnsCiphertextMaterialDbItem},
     },
 };
@@ -49,10 +49,10 @@ async fn test_pick_public_decryption() -> anyhow::Result<()> {
     info!("Checking PublicDecryptionRequest data...");
     assert_eq!(
         events,
-        vec![GatewayEvent {
+        vec![ProtocolEvent {
             otlp_context: PropagationContext::empty(),
             already_sent: false,
-            kind: GatewayEventKind::PublicDecryption(PublicDecryptionRequest {
+            kind: ProtocolEventKind::PublicDecryption(PublicDecryptionRequest {
                 decryptionId: decryption_id,
                 snsCtMaterials: sns_ct,
                 extraData: vec![].into(),
@@ -101,10 +101,10 @@ async fn test_pick_user_decryption() -> anyhow::Result<()> {
     info!("Checking UserDecryptionRequest data...");
     assert_eq!(
         events,
-        vec![GatewayEvent {
+        vec![ProtocolEvent {
             otlp_context: PropagationContext::empty(),
             already_sent: false,
-            kind: GatewayEventKind::UserDecryption(UserDecryptionRequest {
+            kind: ProtocolEventKind::UserDecryption(UserDecryptionRequest {
                 decryptionId: decryption_id,
                 snsCtMaterials: sns_ct,
                 userAddress: user_address,
@@ -146,10 +146,10 @@ async fn test_pick_prep_keygen() -> anyhow::Result<()> {
     info!("Checking PrepKeygenRequest data...");
     assert_eq!(
         events,
-        vec![GatewayEvent {
+        vec![ProtocolEvent {
             otlp_context: PropagationContext::empty(),
             already_sent: false,
-            kind: GatewayEventKind::PrepKeygen(PrepKeygenRequest {
+            kind: ProtocolEventKind::PrepKeygen(PrepKeygenRequest {
                 prepKeygenId: prep_keygen_request_id,
                 epochId: epoch_id,
                 paramsType: params_type as u8,
@@ -187,10 +187,10 @@ async fn test_pick_keygen() -> anyhow::Result<()> {
     info!("Checking KeygenRequest data...");
     assert_eq!(
         events,
-        vec![GatewayEvent {
+        vec![ProtocolEvent {
             otlp_context: PropagationContext::empty(),
             already_sent: false,
-            kind: GatewayEventKind::Keygen(KeygenRequest {
+            kind: ProtocolEventKind::Keygen(KeygenRequest {
                 prepKeygenId: prep_key_id,
                 keyId: key_id,
             }),
@@ -229,10 +229,10 @@ async fn test_pick_crsgen() -> anyhow::Result<()> {
     info!("Checking CrsgenRequest data...");
     assert_eq!(
         events,
-        vec![GatewayEvent {
+        vec![ProtocolEvent {
             otlp_context: PropagationContext::empty(),
             already_sent: false,
-            kind: GatewayEventKind::Crsgen(CrsgenRequest {
+            kind: ProtocolEventKind::Crsgen(CrsgenRequest {
                 crsId: crs_id,
                 maxBitLength: max_bit_length,
                 paramsType: params_type as u8,
@@ -277,10 +277,10 @@ async fn test_polling_backup() -> anyhow::Result<()> {
     info!("Checking PublicDecryptionRequest data...");
     assert_eq!(
         events,
-        vec![GatewayEvent {
+        vec![ProtocolEvent {
             otlp_context: PropagationContext::empty(),
             already_sent: false,
-            kind: GatewayEventKind::PublicDecryption(PublicDecryptionRequest {
+            kind: ProtocolEventKind::PublicDecryption(PublicDecryptionRequest {
                 decryptionId: decryption_id,
                 snsCtMaterials: sns_ct,
                 extraData: vec![].into(),

--- a/kms-connector/crates/kms-worker/tests/integration_tests.rs
+++ b/kms-connector/crates/kms-worker/tests/integration_tests.rs
@@ -19,7 +19,7 @@ use connector_utils::{
         },
     },
     types::{
-        GatewayEventKind, KmsGrpcResponse, KmsResponse, KmsResponseKind, db::EventType,
+        KmsGrpcResponse, KmsResponse, KmsResponseKind, ProtocolEventKind, db::EventType,
         kms_response, u256_to_request_id,
     },
 };
@@ -127,7 +127,7 @@ async fn test_processing_request(
 
     // Waiting for kms_worker to process the request
     match &request {
-        GatewayEventKind::PrssInit(_) | GatewayEventKind::KeyReshareSameSet(_) => {
+        ProtocolEventKind::PrssInit(_) | ProtocolEventKind::KeyReshareSameSet(_) => {
             while let Err(e) =
                 check_no_uncompleted_request_in_db(test_instance.db(), event_type).await
             {
@@ -148,24 +148,24 @@ async fn test_processing_request(
     Ok(())
 }
 
-fn prepare_mocks(req: &GatewayEventKind, already_sent: bool) -> MockSet {
+fn prepare_mocks(req: &ProtocolEventKind, already_sent: bool) -> MockSet {
     let mut kms_mocks = MockSet::new();
 
     // Gets the request ID and endpoints for the given request type
     let (request_id_u256, req_endpoint, resp_endpoint) = match req {
-        GatewayEventKind::PublicDecryption(r) => {
+        ProtocolEventKind::PublicDecryption(r) => {
             (r.decryptionId, "PublicDecrypt", "GetPublicDecryptionResult")
         }
-        GatewayEventKind::UserDecryption(r) => {
+        ProtocolEventKind::UserDecryption(r) => {
             (r.decryptionId, "UserDecrypt", "GetUserDecryptionResult")
         }
-        GatewayEventKind::PrepKeygen(r) => {
+        ProtocolEventKind::PrepKeygen(r) => {
             (r.prepKeygenId, "KeyGenPreproc", "GetKeyGenPreprocResult")
         }
-        GatewayEventKind::Keygen(r) => (r.keyId, "KeyGen", "GetKeyGenResult"),
-        GatewayEventKind::Crsgen(r) => (r.crsId, "CrsGen", "GetCrsGenResult"),
-        GatewayEventKind::PrssInit(id) => (*id, "Init", ""),
-        GatewayEventKind::KeyReshareSameSet(r) => (r.keyId, "InitiateResharing", ""),
+        ProtocolEventKind::Keygen(r) => (r.keyId, "KeyGen", "GetKeyGenResult"),
+        ProtocolEventKind::Crsgen(r) => (r.crsId, "CrsGen", "GetCrsGenResult"),
+        ProtocolEventKind::PrssInit(id) => (*id, "Init", ""),
+        ProtocolEventKind::KeyReshareSameSet(r) => (r.keyId, "InitiateResharing", ""),
     };
     let request_id = Some(u256_to_request_id(request_id_u256));
 
@@ -177,7 +177,7 @@ fn prepare_mocks(req: &GatewayEventKind, already_sent: bool) -> MockSet {
                 "/kms_service.v1.CoreServiceEndpoint/{req_endpoint}"
             ));
             match req {
-                GatewayEventKind::KeyReshareSameSet(_) => {
+                ProtocolEventKind::KeyReshareSameSet(_) => {
                     then.pb(InitiateResharingResponse::default())
                 }
                 // KMS returns `Empty` for all kind of requests except `KeyReshareSameSet`
@@ -192,23 +192,23 @@ fn prepare_mocks(req: &GatewayEventKind, already_sent: bool) -> MockSet {
             "/kms_service.v1.CoreServiceEndpoint/{resp_endpoint}"
         ));
         match req {
-            GatewayEventKind::PublicDecryption(_) => then.pb(PublicDecryptionResponse {
+            ProtocolEventKind::PublicDecryption(_) => then.pb(PublicDecryptionResponse {
                 payload: Some(PublicDecryptionResponsePayload::default()),
                 ..Default::default()
             }),
-            GatewayEventKind::UserDecryption(_) => then.pb(UserDecryptionResponse {
+            ProtocolEventKind::UserDecryption(_) => then.pb(UserDecryptionResponse {
                 payload: Some(UserDecryptionResponsePayload::default()),
                 ..Default::default()
             }),
-            GatewayEventKind::PrepKeygen(_) => then.pb(KeyGenPreprocResult {
+            ProtocolEventKind::PrepKeygen(_) => then.pb(KeyGenPreprocResult {
                 preprocessing_id: request_id,
                 ..Default::default()
             }),
-            GatewayEventKind::Keygen(_) => then.pb(KeyGenResult {
+            ProtocolEventKind::Keygen(_) => then.pb(KeyGenResult {
                 request_id,
                 ..Default::default()
             }),
-            GatewayEventKind::Crsgen(_) => then.pb(CrsGenResult {
+            ProtocolEventKind::Crsgen(_) => then.pb(CrsGenResult {
                 request_id,
                 ..Default::default()
             }),
@@ -221,15 +221,15 @@ fn prepare_mocks(req: &GatewayEventKind, already_sent: bool) -> MockSet {
 
 async fn wait_for_response_in_db(
     db: &Pool<Postgres>,
-    req: &GatewayEventKind,
+    req: &ProtocolEventKind,
 ) -> anyhow::Result<KmsResponse> {
     info!("Waiting for response to be stored in DB...");
     let query = match req {
-        GatewayEventKind::PublicDecryption(_) => "SELECT * FROM public_decryption_responses",
-        GatewayEventKind::UserDecryption(_) => "SELECT * FROM user_decryption_responses",
-        GatewayEventKind::PrepKeygen(_) => "SELECT * FROM prep_keygen_responses",
-        GatewayEventKind::Keygen(_) => "SELECT * FROM keygen_responses",
-        GatewayEventKind::Crsgen(_) => "SELECT * FROM crsgen_responses",
+        ProtocolEventKind::PublicDecryption(_) => "SELECT * FROM public_decryption_responses",
+        ProtocolEventKind::UserDecryption(_) => "SELECT * FROM user_decryption_responses",
+        ProtocolEventKind::PrepKeygen(_) => "SELECT * FROM prep_keygen_responses",
+        ProtocolEventKind::Keygen(_) => "SELECT * FROM keygen_responses",
+        ProtocolEventKind::Crsgen(_) => "SELECT * FROM crsgen_responses",
         _ => unimplemented!(),
     };
     let response = loop {
@@ -240,19 +240,19 @@ async fn wait_for_response_in_db(
             tokio::time::sleep(Duration::from_millis(200)).await;
         } else {
             match req {
-                GatewayEventKind::PublicDecryption(_) => {
+                ProtocolEventKind::PublicDecryption(_) => {
                     break kms_response::from_public_decryption_row(&result[0])?;
                 }
-                GatewayEventKind::UserDecryption(_) => {
+                ProtocolEventKind::UserDecryption(_) => {
                     break kms_response::from_user_decryption_row(&result[0])?;
                 }
-                GatewayEventKind::PrepKeygen(_) => {
+                ProtocolEventKind::PrepKeygen(_) => {
                     break kms_response::from_prep_keygen_row(&result[0])?;
                 }
-                GatewayEventKind::Keygen(_) => {
+                ProtocolEventKind::Keygen(_) => {
                     break kms_response::from_keygen_row(&result[0])?;
                 }
-                GatewayEventKind::Crsgen(_) => {
+                ProtocolEventKind::Crsgen(_) => {
                     break kms_response::from_crsgen_row(&result[0])?;
                 }
                 _ => unimplemented!(),
@@ -263,32 +263,32 @@ async fn wait_for_response_in_db(
     Ok(response)
 }
 
-fn check_response_data(request: &GatewayEventKind, response: KmsResponse) -> anyhow::Result<()> {
+fn check_response_data(request: &ProtocolEventKind, response: KmsResponse) -> anyhow::Result<()> {
     info!("Checking response data...");
     let expected_response = match request {
-        GatewayEventKind::PublicDecryption(r) => KmsGrpcResponse::PublicDecryption {
+        ProtocolEventKind::PublicDecryption(r) => KmsGrpcResponse::PublicDecryption {
             decryption_id: r.decryptionId,
             grpc_response: PublicDecryptionResponse {
                 payload: Some(PublicDecryptionResponsePayload::default()),
                 ..Default::default()
             },
         },
-        GatewayEventKind::UserDecryption(r) => KmsGrpcResponse::UserDecryption {
+        ProtocolEventKind::UserDecryption(r) => KmsGrpcResponse::UserDecryption {
             decryption_id: r.decryptionId,
             grpc_response: UserDecryptionResponse {
                 payload: Some(UserDecryptionResponsePayload::default()),
                 ..Default::default()
             },
         },
-        GatewayEventKind::PrepKeygen(r) => KmsGrpcResponse::PrepKeygen(KeyGenPreprocResult {
+        ProtocolEventKind::PrepKeygen(r) => KmsGrpcResponse::PrepKeygen(KeyGenPreprocResult {
             preprocessing_id: Some(u256_to_request_id(r.prepKeygenId)),
             ..Default::default()
         }),
-        GatewayEventKind::Keygen(r) => KmsGrpcResponse::Keygen(KeyGenResult {
+        ProtocolEventKind::Keygen(r) => KmsGrpcResponse::Keygen(KeyGenResult {
             request_id: Some(u256_to_request_id(r.keyId)),
             ..Default::default()
         }),
-        GatewayEventKind::Crsgen(r) => KmsGrpcResponse::Crsgen(CrsGenResult {
+        ProtocolEventKind::Crsgen(r) => KmsGrpcResponse::Crsgen(CrsGenResult {
             request_id: Some(u256_to_request_id(r.crsId)),
             ..Default::default()
         }),

--- a/kms-connector/crates/utils/src/tests/db/requests.rs
+++ b/kms-connector/crates/utils/src/tests/db/requests.rs
@@ -5,9 +5,9 @@ use crate::{
         setup::{S3_CT_DIGEST, S3_CT_HANDLE, TESTING_KMS_CONTEXT},
     },
     types::{
-        GatewayEventKind,
+        ProtocolEventKind,
         db::{EventType, OperationStatus, ParamsTypeDb, SnsCiphertextMaterialDbItem},
-        gw_event::PRSS_INIT_ID,
+        event::PRSS_INIT_ID,
     },
 };
 use alloy::{
@@ -30,7 +30,7 @@ pub async fn insert_rand_request(
     db: &Pool<Postgres>,
     event_type: EventType,
     options: InsertRequestOptions,
-) -> anyhow::Result<GatewayEventKind> {
+) -> anyhow::Result<ProtocolEventKind> {
     let inserted_response = match event_type {
         EventType::PublicDecryptionRequest => insert_rand_public_decryption_request(db, options)
             .await?

--- a/kms-connector/crates/utils/src/types/db.rs
+++ b/kms-connector/crates/utils/src/types/db.rs
@@ -1,4 +1,4 @@
-use crate::types::GatewayEventKind;
+use crate::types::ProtocolEventKind;
 use alloy::{
     primitives::{Address, B256, U256},
     sol_types::SolEvent,
@@ -159,16 +159,16 @@ impl Display for EventType {
     }
 }
 
-impl From<&GatewayEventKind> for EventType {
-    fn from(value: &GatewayEventKind) -> Self {
+impl From<&ProtocolEventKind> for EventType {
+    fn from(value: &ProtocolEventKind) -> Self {
         match value {
-            GatewayEventKind::PublicDecryption(_) => Self::PublicDecryptionRequest,
-            GatewayEventKind::UserDecryption(_) => Self::UserDecryptionRequest,
-            GatewayEventKind::PrepKeygen(_) => Self::PrepKeygenRequest,
-            GatewayEventKind::Keygen(_) => Self::KeygenRequest,
-            GatewayEventKind::Crsgen(_) => Self::CrsgenRequest,
-            GatewayEventKind::PrssInit(_) => Self::PrssInit,
-            GatewayEventKind::KeyReshareSameSet(_) => Self::KeyReshareSameSet,
+            ProtocolEventKind::PublicDecryption(_) => Self::PublicDecryptionRequest,
+            ProtocolEventKind::UserDecryption(_) => Self::UserDecryptionRequest,
+            ProtocolEventKind::PrepKeygen(_) => Self::PrepKeygenRequest,
+            ProtocolEventKind::Keygen(_) => Self::KeygenRequest,
+            ProtocolEventKind::Crsgen(_) => Self::CrsgenRequest,
+            ProtocolEventKind::PrssInit(_) => Self::PrssInit,
+            ProtocolEventKind::KeyReshareSameSet(_) => Self::KeyReshareSameSet,
         }
     }
 }

--- a/kms-connector/crates/utils/src/types/event.rs
+++ b/kms-connector/crates/utils/src/types/event.rs
@@ -20,10 +20,10 @@ use sqlx::{
 use std::fmt::Display;
 use tracing::{info, warn};
 
-/// The events emitted by the Gateway which are monitored by the KMS Connector.
+/// The events emitted by the Zama Protocol which are monitored by the KMS Connector.
 #[derive(Clone, Debug, PartialEq)]
-pub struct GatewayEvent {
-    pub kind: GatewayEventKind,
+pub struct ProtocolEvent {
+    pub kind: ProtocolEventKind,
     pub tx_hash: Option<FixedBytes<32>>,
     pub already_sent: bool,
     pub error_counter: i16,
@@ -31,13 +31,13 @@ pub struct GatewayEvent {
     pub otlp_context: PropagationContext,
 }
 
-impl GatewayEvent {
+impl ProtocolEvent {
     pub fn new(
-        kind: GatewayEventKind,
+        kind: ProtocolEventKind,
         tx_hash: Option<FixedBytes<32>>,
         otlp_context: PropagationContext,
     ) -> Self {
-        GatewayEvent {
+        ProtocolEvent {
             kind,
             tx_hash,
             already_sent: false,
@@ -69,25 +69,25 @@ impl GatewayEvent {
         let already_sent = self.already_sent;
         let err_count = self.error_counter;
         match &self.kind {
-            GatewayEventKind::PublicDecryption(e) => {
+            ProtocolEventKind::PublicDecryption(e) => {
                 update_public_decryption_status(db, e.decryptionId, status, already_sent, err_count)
                     .await
             }
-            GatewayEventKind::UserDecryption(e) => {
+            ProtocolEventKind::UserDecryption(e) => {
                 update_user_decryption_status(db, e.decryptionId, status, already_sent, err_count)
                     .await
             }
-            GatewayEventKind::PrepKeygen(e) => {
+            ProtocolEventKind::PrepKeygen(e) => {
                 update_prep_keygen_status(db, e.prepKeygenId, status, already_sent).await
             }
-            GatewayEventKind::Keygen(e) => {
+            ProtocolEventKind::Keygen(e) => {
                 update_keygen_status(db, e.keyId, status, already_sent).await
             }
-            GatewayEventKind::Crsgen(e) => {
+            ProtocolEventKind::Crsgen(e) => {
                 update_crsgen_status(db, e.crsId, status, already_sent).await
             }
-            GatewayEventKind::PrssInit(id) => update_prss_init_status(db, *id, status).await,
-            GatewayEventKind::KeyReshareSameSet(e) => {
+            ProtocolEventKind::PrssInit(id) => update_prss_init_status(db, *id, status).await,
+            ProtocolEventKind::KeyReshareSameSet(e) => {
                 update_key_reshare_same_set_status(db, e.keyId, status).await
             }
         }
@@ -95,7 +95,7 @@ impl GatewayEvent {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum GatewayEventKind {
+pub enum ProtocolEventKind {
     PublicDecryption(PublicDecryptionRequest),
     UserDecryption(UserDecryptionRequest),
     PrepKeygen(PrepKeygenRequest),
@@ -105,19 +105,19 @@ pub enum GatewayEventKind {
     KeyReshareSameSet(KeyReshareSameSet),
 }
 
-pub fn from_public_decryption_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
+pub fn from_public_decryption_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
     let sns_ct_materials = row
         .try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?
         .iter()
         .map(SnsCiphertextMaterial::from)
         .collect();
 
-    let kind = GatewayEventKind::PublicDecryption(PublicDecryptionRequest {
+    let kind = ProtocolEventKind::PublicDecryption(PublicDecryptionRequest {
         decryptionId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?),
         snsCtMaterials: sns_ct_materials,
         extraData: row.try_get::<Vec<u8>, _>("extra_data")?.into(),
     });
-    Ok(GatewayEvent {
+    Ok(ProtocolEvent {
         kind,
         tx_hash: row
             .try_get::<Vec<u8>, _>("tx_hash")
@@ -130,14 +130,14 @@ pub fn from_public_decryption_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
     })
 }
 
-pub fn from_user_decryption_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
+pub fn from_user_decryption_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
     let sns_ct_materials = row
         .try_get::<Vec<SnsCiphertextMaterialDbItem>, _>("sns_ct_materials")?
         .iter()
         .map(SnsCiphertextMaterial::from)
         .collect();
 
-    let kind = GatewayEventKind::UserDecryption(UserDecryptionRequest {
+    let kind = ProtocolEventKind::UserDecryption(UserDecryptionRequest {
         decryptionId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("decryption_id")?),
         snsCtMaterials: sns_ct_materials,
         userAddress: row.try_get::<[u8; 20], _>("user_address")?.into(),
@@ -145,7 +145,7 @@ pub fn from_user_decryption_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
         extraData: row.try_get::<Vec<u8>, _>("extra_data")?.into(),
     });
 
-    Ok(GatewayEvent {
+    Ok(ProtocolEvent {
         kind,
         tx_hash: row
             .try_get::<Vec<u8>, _>("tx_hash")
@@ -158,13 +158,13 @@ pub fn from_user_decryption_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
     })
 }
 
-pub fn from_prep_keygen_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
-    let kind = GatewayEventKind::PrepKeygen(PrepKeygenRequest {
+pub fn from_prep_keygen_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
+    let kind = ProtocolEventKind::PrepKeygen(PrepKeygenRequest {
         prepKeygenId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("prep_keygen_id")?),
         epochId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("epoch_id")?),
         paramsType: row.try_get::<ParamsTypeDb, _>("params_type")? as u8,
     });
-    Ok(GatewayEvent {
+    Ok(ProtocolEvent {
         kind,
 
         tx_hash: row
@@ -179,12 +179,12 @@ pub fn from_prep_keygen_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
     })
 }
 
-pub fn from_keygen_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
-    let kind = GatewayEventKind::Keygen(KeygenRequest {
+pub fn from_keygen_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
+    let kind = ProtocolEventKind::Keygen(KeygenRequest {
         prepKeygenId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("prep_keygen_id")?),
         keyId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("key_id")?),
     });
-    Ok(GatewayEvent {
+    Ok(ProtocolEvent {
         kind,
 
         tx_hash: row
@@ -199,13 +199,13 @@ pub fn from_keygen_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
     })
 }
 
-pub fn from_crsgen_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
-    let kind = GatewayEventKind::Crsgen(CrsgenRequest {
+pub fn from_crsgen_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
+    let kind = ProtocolEventKind::Crsgen(CrsgenRequest {
         crsId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("crs_id")?),
         maxBitLength: U256::from_le_bytes(row.try_get::<[u8; 32], _>("max_bit_length")?),
         paramsType: row.try_get::<ParamsTypeDb, _>("params_type")? as u8,
     });
-    Ok(GatewayEvent {
+    Ok(ProtocolEvent {
         kind,
 
         tx_hash: row
@@ -220,9 +220,9 @@ pub fn from_crsgen_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
     })
 }
 
-pub fn from_prss_init_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
-    let kind = GatewayEventKind::PrssInit(U256::from_le_bytes(row.try_get::<[u8; 32], _>("id")?));
-    Ok(GatewayEvent {
+pub fn from_prss_init_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
+    let kind = ProtocolEventKind::PrssInit(U256::from_le_bytes(row.try_get::<[u8; 32], _>("id")?));
+    Ok(ProtocolEvent {
         kind,
 
         tx_hash: row
@@ -237,14 +237,14 @@ pub fn from_prss_init_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
     })
 }
 
-pub fn from_key_reshare_same_set_row(row: &PgRow) -> anyhow::Result<GatewayEvent> {
-    let kind = GatewayEventKind::KeyReshareSameSet(KeyReshareSameSet {
+pub fn from_key_reshare_same_set_row(row: &PgRow) -> anyhow::Result<ProtocolEvent> {
+    let kind = ProtocolEventKind::KeyReshareSameSet(KeyReshareSameSet {
         prepKeygenId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("prep_keygen_id")?),
         keyId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("key_id")?),
         keyReshareId: U256::from_le_bytes(row.try_get::<[u8; 32], _>("key_reshare_id")?),
         paramsType: row.try_get::<ParamsTypeDb, _>("params_type")? as u8,
     });
-    Ok(GatewayEvent {
+    Ok(ProtocolEvent {
         kind,
         tx_hash: row
             .try_get::<Vec<u8>, _>("tx_hash")
@@ -380,65 +380,65 @@ async fn execute_update_event_query(db: &Pool<Postgres>, query: Query<'_, Postgr
     }
 }
 
-impl Display for GatewayEventKind {
+impl Display for ProtocolEventKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            GatewayEventKind::PublicDecryption(e) => {
+            ProtocolEventKind::PublicDecryption(e) => {
                 write!(f, "PublicDecryptionRequest #{}", e.decryptionId)
             }
-            GatewayEventKind::UserDecryption(e) => {
+            ProtocolEventKind::UserDecryption(e) => {
                 write!(f, "UserDecryptionRequest #{}", e.decryptionId)
             }
-            GatewayEventKind::PrepKeygen(e) => {
+            ProtocolEventKind::PrepKeygen(e) => {
                 write!(f, "PrepKeygenRequest #{}", e.prepKeygenId)
             }
-            GatewayEventKind::Keygen(e) => write!(f, "KeygenRequest #{}", e.keyId),
-            GatewayEventKind::Crsgen(e) => write!(f, "CrsgenRequest #{}", e.crsId),
-            GatewayEventKind::PrssInit(id) => write!(f, "PrssInit #{id}"),
-            GatewayEventKind::KeyReshareSameSet(e) => {
+            ProtocolEventKind::Keygen(e) => write!(f, "KeygenRequest #{}", e.keyId),
+            ProtocolEventKind::Crsgen(e) => write!(f, "CrsgenRequest #{}", e.crsId),
+            ProtocolEventKind::PrssInit(id) => write!(f, "PrssInit #{id}"),
+            ProtocolEventKind::KeyReshareSameSet(e) => {
                 write!(f, "KeyReshareSameSet #{}", e.keyId)
             }
         }
     }
 }
 
-impl From<PublicDecryptionRequest> for GatewayEventKind {
+impl From<PublicDecryptionRequest> for ProtocolEventKind {
     fn from(value: PublicDecryptionRequest) -> Self {
         Self::PublicDecryption(value)
     }
 }
 
-impl From<UserDecryptionRequest> for GatewayEventKind {
+impl From<UserDecryptionRequest> for ProtocolEventKind {
     fn from(value: UserDecryptionRequest) -> Self {
         Self::UserDecryption(value)
     }
 }
 
-impl From<PrepKeygenRequest> for GatewayEventKind {
+impl From<PrepKeygenRequest> for ProtocolEventKind {
     fn from(value: PrepKeygenRequest) -> Self {
         Self::PrepKeygen(value)
     }
 }
 
-impl From<KeygenRequest> for GatewayEventKind {
+impl From<KeygenRequest> for ProtocolEventKind {
     fn from(value: KeygenRequest) -> Self {
         Self::Keygen(value)
     }
 }
 
-impl From<CrsgenRequest> for GatewayEventKind {
+impl From<CrsgenRequest> for ProtocolEventKind {
     fn from(value: CrsgenRequest) -> Self {
         Self::Crsgen(value)
     }
 }
 
-impl From<PRSSInit> for GatewayEventKind {
+impl From<PRSSInit> for ProtocolEventKind {
     fn from(_value: PRSSInit) -> Self {
         Self::PrssInit(PRSS_INIT_ID)
     }
 }
 
-impl From<KeyReshareSameSet> for GatewayEventKind {
+impl From<KeyReshareSameSet> for ProtocolEventKind {
     fn from(value: KeyReshareSameSet) -> Self {
         Self::KeyReshareSameSet(value)
     }

--- a/kms-connector/crates/utils/src/types/mod.rs
+++ b/kms-connector/crates/utils/src/types/mod.rs
@@ -1,12 +1,12 @@
 pub mod db;
+pub mod event;
 pub mod extra_data;
 mod grpc;
-pub mod gw_event;
 pub mod handle;
 pub mod kms_response;
 
+pub use event::{ProtocolEvent, ProtocolEventKind};
 pub use grpc::{KmsGrpcRequest, KmsGrpcResponse};
-pub use gw_event::{GatewayEvent, GatewayEventKind};
 pub use kms_response::{
     CrsgenResponse, KeygenResponse, KmsResponse, KmsResponseKind, PrepKeygenResponse,
     PublicDecryptionResponse, UserDecryptionResponse,


### PR DESCRIPTION
With the upcoming listening of Ethereum events (KMS contexts...)
- renamed the `GatewayEvent` and `GatewayEventKind` to `ProtocolEvent` and `ProtocolEventKind`
- renamed the `gw_event` module into `event`

Pushing the PR already for lighter PR reviews when KMS context feature will be implemented.

In a dedicated commits, also parametrized the integration tests of the `gw-listener` as it's cleaner.