### PR TITLE
docs: add contributing guide and fix stale contribution links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to FHEVM
+
+There are two ways to contribute to FHEVM:
+
+- Open an issue to report bugs, typos, or suggest ideas:
+  - https://github.com/zama-ai/fhevm/issues/new/choose
+- Request to become an approved contributor by emailing [hello@zama.ai](mailto:hello@zama.ai)
+
+Becoming an approved contributor involves signing Zama's Contributor License Agreement (CLA). Only approved contributors can send pull requests, so please contact the team before preparing a code contribution.
+
+## Repository guides
+
+For module-specific development and operating guidance, start with:
+
+- Root project overview: [README.md](README.md)
+- Protocol documentation: [docs/protocol/README.md](docs/protocol/README.md)
+- Relayer development guide: [relayer/docs/DEVELOPMENT.md](relayer/docs/DEVELOPMENT.md)
+- Coprocessor documentation: [coprocessor/docs/README.md](coprocessor/docs/README.md)
+
+## Bounty program
+
+Zama also runs a public bounty program:
+
+- https://github.com/zama-ai/bounty-program

--- a/coprocessor/docs/developer/contribute.md
+++ b/coprocessor/docs/developer/contribute.md
@@ -2,7 +2,7 @@
 
 There are two ways to contribute to the Zama FHEVM:
 
-- [Open issues](https://github.com/zama-ai/fhevm-backend/issues/new/choose) to report bugs and typos, or to suggest new ideas
+- [Open issues](https://github.com/zama-ai/fhevm/issues/new/choose) to report bugs and typos, or to suggest new ideas
 - Request to become an official contributor by emailing [hello@zama.ai](mailto:hello@zama.ai).
 
-Becoming an approved contributor involves signing our Contributor License Agreement (CLA)). Only approved contributors can send pull requests, so please make sure to get in touch before you do!
+Becoming an approved contributor involves signing our Contributor License Agreement (CLA). Only approved contributors can send pull requests, so please make sure to get in touch before you do!

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -140,7 +140,7 @@ make health              # Verify health endpoints
 ## Development
 
 For build, test, lint, local stack, and CI instructions, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
-For contribution guidelines, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+For contribution guidelines, see [../CONTRIBUTING.md](../CONTRIBUTING.md).
 
 `make setup` is the dev-oriented shortcut (db-start + db-migrate + copies local mock config).
 

--- a/relayer/docs/DEVELOPMENT.md
+++ b/relayer/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This document covers building, testing, linting, and running the relayer locally
 It is intended for people who hack on the relayer code.
 For operator-facing self-hosting instructions, see [SELF_HOSTING.md](SELF_HOSTING.md).
 
-For contribution guidelines, see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+For contribution guidelines, see [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary

This PR fixes the repository's contribution entrypoints and removes a few stale contribution references.

## Changes

- add a root CONTRIBUTING.md as the canonical contribution guide
- fix broken contribution links in the relayer docs
- update the coprocessor contribution page to point to the current zama-ai/fhevm issue tracker
- fix a small typo in the CLA sentence

## Why

At the moment:
- the relayer docs point to a non-existent root CONTRIBUTING.md
- .github/CONTRIBUTING.md is about GitHub workflows, not contributor onboarding
- the coprocessor contribution page still references the old fhevm-backend issue tracker

This makes the contribution path harder to discover for new external contributors.

## Validation

- verified the updated contribution links point to existing files
- verified the stale fhevm-backend issue link is removed from the touched docs