### PR TITLE
docs: fix stale coprocessor documentation links

### DIFF
--- a/coprocessor/docs/README.md
+++ b/coprocessor/docs/README.md
@@ -46,9 +46,7 @@ Collaborate with us to advance the FHE spaces and drive innovation together.
 - [Contribute to FHEVM](developer/contribute.md)
 - [Follow the development roadmap](developer/roadmap.md)
 <!-- markdown-link-check-disable -->
-- [See the latest test release note](https://github.com/zama-ai/fhevm-backend/releases)
-- [Request a feature](https://github.com/zama-ai/fhevm-backend/issues/new)
-- [Report a bug](https://github.com/zama-ai/fhevm-backend/issues/new)
+- [See the latest release note](https://github.com/zama-ai/fhevm/releases)
+- [Request a feature](https://github.com/zama-ai/fhevm/issues/new/choose)
+- [Report a bug](https://github.com/zama-ai/fhevm/issues/new/choose)
 <!-- markdown-link-check-enable -->
-
-

--- a/coprocessor/docs/SUMMARY.md
+++ b/coprocessor/docs/SUMMARY.md
@@ -61,6 +61,6 @@
 
 - [Contributing](developer/contribute.md)
 - [Development roadmap](developer/roadmap.md)
-- [Release note](https://github.com/zama-ai/fhevm-backend/releases)
-- [Feature request](https://github.com/zama-ai/fhevm-backend/issues/new)
-- [Bug report](https://github.com/zama-ai/fhevm-backend/issues/new)
+- [Release note](https://github.com/zama-ai/fhevm/releases)
+- [Feature request](https://github.com/zama-ai/fhevm/issues/new/choose)
+- [Bug report](https://github.com/zama-ai/fhevm/issues/new/choose)


### PR DESCRIPTION
## Summary

This PR removes stale `fhevm-backend` links from the coprocessor docs entrypoints.

## Changes

- update the coprocessor docs README to point to the current `zama-ai/fhevm` releases and issue forms
- update the coprocessor docs SUMMARY page to point to the current `zama-ai/fhevm` releases and issue forms

## Why

The coprocessor docs still exposed several developer-facing links that pointed to the old `zama-ai/fhevm-backend` repository.

This creates unnecessary friction for external users because the public docs entrypoints should send readers to the current repository.

Note: `coprocessor/docs/developer/contribute.md` is intentionally not changed in this PR because that file is already covered by a separate open PR.

## Validation

- verified the touched links now point to the current `zama-ai/fhevm` repository
- verified this PR is limited to the two coprocessor docs entrypoint files
