### PR TITLE
docs: add missing winnerAddress declaration to sealed-bid tutorial

### DIFF
--- a/docs/examples/sealed-bid-auction-tutorial.md
+++ b/docs/examples/sealed-bid-auction-tutorial.md
@@ -96,6 +96,9 @@ Now, we need a way to store the highest bid and the potential winner. To store t
 euint64 private highestBid;
 eaddress private winningAddress;
 
+/// @notice Winner address, set after decryption and verification
+address public winnerAddress;
+
 /// @notice Mapping from bidder to their bid value
 mapping(address account => euint64 bidAmount) private bids;
 ```


### PR DESCRIPTION
## Summary

This PR adds the missing `winnerAddress` state variable declaration to the sealed-bid auction tutorial.

## Why

The tutorial later uses `winnerAddress` in multiple code snippets during the auction resolution and claim flow, but the state variable is not declared in the earlier state definition block.

This makes the tutorial code inconsistent and can confuse readers who copy the example as they go.

This change addresses the remaining unresolved part of issue #622.

## Validation

- verified `winnerAddress` is referenced later in the same tutorial
- verified the declaration already exists in the fuller `docs/examples/sealed-bid-auction.md` example
- kept the change limited to the tutorial state definition block
