### PR TITLE
docs: clarify fromExternal view limitations

### DIFF
--- a/docs/sdk-guides/input.md
+++ b/docs/sdk-guides/input.md
@@ -45,6 +45,9 @@ contract MyContract {
 }
 ```
 
+> Important: Functions that call `FHE.fromExternal()` or other FHE operators such as `FHE.add()` cannot be marked as `view`.
+> These operations trigger proof verification / FHE execution under the hood, so they must be executed as regular state-changing calls rather than read-only `eth_call` view functions.
+
 With `my_contract` the contract in question using `ethers` it is possible to call the add function as following.
 
 ```js

--- a/docs/solidity-guides/getting-started/quick-start-tutorial/turn_it_into_fhevm.md
+++ b/docs/solidity-guides/getting-started/quick-start-tutorial/turn_it_into_fhevm.md
@@ -220,6 +220,12 @@ FHE.fromExternal(inputEuint32, inputProof);
 
 This method verifies the zero-knowledge proof and returns a usable encrypted value within the contract.
 
+{% hint style="warning" %}
+Functions using `FHE.fromExternal()` should not be marked as `view`.
+
+Although this does not mutate your application-level contract state, the proof verification step is not compatible with Solidity's `view` modifier. Keep these functions as regular state-changing functions.
+{% endhint %}
+
 #### Replace
 
 ```solidity

--- a/docs/solidity-guides/inputs.md
+++ b/docs/solidity-guides/inputs.md
@@ -127,6 +127,12 @@ function transfer(
 2. **Type conversion**:\
    The function transforms `externalEbool`, `externalEaddress`, `externalEuintXX` into the appropriate encrypted type (`ebool`, `eaddress`, `euintXX`) for further operations within the contract.
 
+{% hint style="warning" %}
+Functions that call `FHE.fromExternal()` cannot be marked as `view`.
+
+Even if your contract logic feels read-only, `FHE.fromExternal()` performs proof verification under the hood, which makes the call incompatible with Solidity's `view` modifier. Declare these functions as regular state-changing functions and invoke them as transactions.
+{% endhint %}
+
 ## Best Practices
 
 - **Input packing**: Minimize the size and complexity of zero-knowledge proofs by packing all encrypted inputs into a single ciphertext.


### PR DESCRIPTION
## Summary

This PR documents that functions using `FHE.fromExternal()` should not be marked as `view`.

## Why

`FHE.fromExternal()` often looks like a read-only conversion step from a developer's perspective, but in practice it performs proof validation and is not compatible with Solidity's `view` modifier.

Without an explicit note, this can be a confusing DX trap when developers try to write helper functions that feel read-only and then hit compiler errors.

This PR adds that guidance in the main places where developers are introduced to encrypted input handling.

Fixes #2026.

## Changes

- add a warning note to `docs/sdk-guides/input.md`
- add a warning note to `docs/solidity-guides/inputs.md`
- add a warning note to the quick start tutorial step that introduces `FHE.fromExternal()`

## Validation

- verified the change is limited to documentation
- verified all added notes are colocated with existing `FHE.fromExternal()` guidance
