### PR TITLE
docs: remove leftover TODO from example snippet

### DIFF
--- a/docs/examples/fhe-encrypt-multiple-values.md
+++ b/docs/examples/fhe-encrypt-multiple-values.md
@@ -82,7 +82,6 @@ contract EncryptMultipleValues is ZamaEthereumConfig {
 {% tab title="EncryptMultipleValues.ts" %}
 
 ```typescript
-//TODO;
 import { EncryptMultipleValues, EncryptMultipleValues__factory } from "../../../types";
 import type { Signers } from "../../types";
 import { FhevmType, HardhatFhevmRuntimeEnvironment } from "@fhevm/hardhat-plugin";


### PR DESCRIPTION
## Summary

This PR removes a leftover `//TODO;` placeholder from the `EncryptMultipleValues.ts` example snippet.

## Why

This placeholder appears in a copy-pastable example block and looks like an unfinished editing artifact rather than an intentional note.

Removing it makes the example cleaner and avoids confusion for readers who use the snippet directly.

## Validation

- verified the change is limited to the example snippet
- verified there are no remaining `//TODO;` placeholders under `docs/examples`
