### PR TITLE
fix(coprocessor): don't insert test host chain in db-migration image

### DIFF
--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -201,6 +201,7 @@ COPY --from=sqlx_builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 
 # Copy migrations and initialization script from source
 COPY coprocessor/fhevm-engine/db-migration/initialize_db.sh /initialize_db.sh
+COPY coprocessor/fhevm-engine/db-migration/insert_test_host_chain.sh /insert_test_host_chain.sh
 COPY coprocessor/fhevm-engine/db-migration/migrations /migrations
 
 # Copy user/group from builder for consistency
@@ -208,7 +209,7 @@ COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
 
 # Set ownership
-RUN chown -R fhevm:fhevm /initialize_db.sh /migrations
+RUN chown -R fhevm:fhevm /initialize_db.sh /insert_test_host_chain.sh /migrations
 
 USER fhevm:fhevm
 

--- a/coprocessor/fhevm-engine/db-migration/Dockerfile
+++ b/coprocessor/fhevm-engine/db-migration/Dockerfile
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 COPY coprocessor/fhevm-engine/ ./coprocessor/fhevm-engine
 COPY coprocessor/proto/ ./coprocessor/proto/
 COPY coprocessor/fhevm-engine/db-migration/initialize_db.sh ./initialize_db.sh
+COPY coprocessor/fhevm-engine/db-migration/insert_test_host_chain.sh ./insert_test_host_chain.sh
 COPY coprocessor/fhevm-engine/db-migration/migrations ./migrations
 
 WORKDIR /app/coprocessor/fhevm-engine
@@ -23,6 +24,7 @@ FROM cgr.dev/zama.ai/postgres:17 AS prod
 
 COPY  --from=builder --chown=fhevm:fhevm /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 COPY  --from=builder --chown=fhevm:fhevm /app/initialize_db.sh /initialize_db.sh
+COPY  --from=builder --chown=fhevm:fhevm /app/insert_test_host_chain.sh /insert_test_host_chain.sh
 COPY  --from=builder --chown=fhevm:fhevm /app/migrations /migrations
 COPY  --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/db-migration/db-scripts /db-scripts
 COPY  --from=builder --chown=fhevm:fhevm /app/coprocessor/fhevm-engine/db-migration/revert_coprocessor_db_state.sh /revert_coprocessor_db_state.sh

--- a/coprocessor/fhevm-engine/db-migration/initialize_db.sh
+++ b/coprocessor/fhevm-engine/db-migration/initialize_db.sh
@@ -25,18 +25,4 @@ sqlx database create || { echo "Failed to create database."; exit 1; }
 echo "Running migrations..."
 sqlx migrate run --source $MIGRATION_DIR || { echo "Failed to run migrations."; exit 1; }
 
-echo "-------------- Start inserting a host chain --------------"
-
-CHAIN_ID=${CHAIN_ID:-"12345"}
-
-if [[ -z "$DATABASE_URL" || -z "$ACL_CONTRACT_ADDRESS" ]]; then
-    echo "Error: One or more required environment variables are missing."; exit 1;
-fi
-
-psql "$DATABASE_URL" -c \
-  "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
-   VALUES ('$CHAIN_ID', 'test chain', '$ACL_CONTRACT_ADDRESS');" || {
-    echo "Error: Failed to insert host chain data."; exit 1;
-}
-
 echo "Database initialization completed successfully."

--- a/coprocessor/fhevm-engine/db-migration/insert_test_host_chain.sh
+++ b/coprocessor/fhevm-engine/db-migration/insert_test_host_chain.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CHAIN_ID=${CHAIN_ID:-"12345"}
+
+if [[ -z "$DATABASE_URL" || -z "$ACL_CONTRACT_ADDRESS" ]]; then
+    echo "Error: One or more required environment variables are missing."; exit 1;
+fi
+
+psql "$DATABASE_URL" -c \
+  "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+   VALUES ('$CHAIN_ID', 'test chain', '$ACL_CONTRACT_ADDRESS') \
+   ON CONFLICT DO NOTHING;"

--- a/coprocessor/fhevm-engine/tfhe-worker/docker-compose.yml
+++ b/coprocessor/fhevm-engine/tfhe-worker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/coprocessor
       ACL_CONTRACT_ADDRESS: "0x339EcE85B9E11a3A3AA557582784a15d7F82AAf2"
     command:
-      - /initialize_db.sh
+      - /initialize_db.sh && /insert_test_host_chain.sh
     healthcheck:
       test: [ "CMD-SHELL", "psql --version" ]
       interval: 15s

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       - KEY_ID=${FHE_KEY_ID}
     command:
-      - /initialize_db.sh
+      - /initialize_db.sh && /insert_test_host_chain.sh
     volumes:
       - keys-cache:/fhevm-keys
 


### PR DESCRIPTION
Test host chain insert should only happen when on CI or testing, it doesn't have to run on the prod invocation of the db-migration image.