### PR TITLE
feat(host-contracts): add FHE.isIn and FHE.sum collection operators and produce gas report

### DIFF
--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -32,6 +32,7 @@ export function generateSolidityFHELib({
   // $${EcdsaDotSol}$$
   // $${FheTypeDotSol}$$
   // $${FHEOperators}$$
+  // $${FHECollectionOperators}$$
   // $${ACLFunctions}$$
   // $${FHEtoBytes32}$$
   const file = resolveTemplatePath('FHE.sol-template');
@@ -47,6 +48,7 @@ export function generateSolidityFHELib({
   const adjustedFheTypes = generateAdjustedFheTypeArray(fheTypes);
 
   code = code.replace('$${FHEOperators}$$', generateFHEOperators(operators, adjustedFheTypes));
+  code = code.replace('$${FHECollectionOperators}$$', generateFHECollectionOperators(adjustedFheTypes));
   code = code.replace('$${ACLFunctions}$$', generateSolidityACLMethods(adjustedFheTypes));
   code = code.replace('$${FHEtoBytes32}$$', generateToBytes32(adjustedFheTypes));
 
@@ -634,6 +636,147 @@ function handleSolidityTFHEConvertPlaintextAndEinputToRespectiveType(fheType: Ad
     `;
   }
   return result;
+}
+
+/**
+ * Generates Solidity collection operators (isIn, sum) for all arithmetic FHE types.
+ *
+ * isIn: tests whether an encrypted value is a member of a cleartext set.
+ *       Uses scalar eq for each element (all independent → coprocessor parallelizes them),
+ *       then tree-reduces the boolean results with OR.
+ *       DFG depth: ceil(log2(n)) + 1 instead of n.
+ *
+ * sum: sums an array of encrypted values via tree accumulation.
+ *      DFG depth: ceil(log2(n)) instead of n-1 (critical for per-tx depth limits).
+ *      Overflow wraps silently, matching FHE.add semantics.
+ *
+ * Only generated for types that support both 'add' and 'eq' (Uint8–Uint128).
+ */
+// Maximum array size for each collection operator, derived from maxHCUPerTx = 20,000,000.
+// Based on gas profiling (see library-solidity/gas-profile-results.md):
+//   isIn: euint8/16 safe at 128 (HCU ≈ 10.1M); euint32/64 ≈ 13.7M; euint128/eaddress/euint256 ≈ 18M
+//   sum:  euint8/16/32 safe at 128; euint64/128 limited to 64 (euint64 n=128 ≈ 23.9M > 20M)
+// Note: isIn uses 128 for all types. euint128/eaddress/euint256 at n=128 consume ~18M HCU,
+// leaving ~10% headroom. If maxHCUPerTx is reduced or eq costs increase, revisit these limits.
+function maxIsInSize(): number {
+  // All types currently fit at 128 based on profiling, but wider types (euint128, eaddress, euint256)
+  // reach ~18M HCU at n=128 — only ~10% below maxHCUPerTx. If costs change, this needs updating.
+  // The limit is kept uniform for API simplicity; see gas-profile-results.md for per-type HCU.
+  return 128;
+}
+
+function maxSumSize(bitLength: number): number {
+  return bitLength >= 64 ? 64 : 128;
+}
+
+function generateIsInBlock(etype: string, clearType: string, isInMax: number): string {
+  return `
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: ${isInMax} (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(${etype} value, ${clearType}[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > ${isInMax}) revert FHECollectionSizeInvalid(set.length, ${isInMax});
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+`;
+}
+
+function generateFHECollectionOperators(adjustedFheTypes: AdjustedFheType[]): string {
+  const res: string[] = [];
+
+  const arithmeticTypes = adjustedFheTypes.filter(
+    (t) =>
+      !t.isAlias &&
+      t.supportedOperators.includes('add') &&
+      t.supportedOperators.includes('eq'),
+  );
+
+  arithmeticTypes.forEach((fheType) => {
+    const etype = `e${fheType.type.toLowerCase()}`;
+    const clearType = fheType.clearMatchingType;
+    const isInMax = maxIsInSize();
+    const sumMax = maxSumSize(fheType.bitLength);
+
+    res.push(generateIsInBlock(etype, clearType, isInMax));
+
+    res.push(`
+    /**
+     * @notice Sums an array of encrypted values.
+     * @dev    Tree accumulation keeps DFG depth at ceil(log2(n)) instead of n-1,
+     *         which is critical for large arrays given the per-transaction depth limit.
+     *         Overflow wraps silently, matching FHE.add semantics.
+     *         The input array is not modified.
+     *         Max array size: ${sumMax} (bounded by maxHCUPerTx=20M).
+     */
+    function sum(${etype}[] memory values) internal returns (${etype}) {
+        if (values.length == 0 || values.length > ${sumMax}) revert FHECollectionSizeInvalid(values.length, ${sumMax});
+
+        ${etype}[] memory acc = new ${etype}[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            acc[i] = values[i];
+        }
+
+        uint256 len = acc.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                acc[i] = add(acc[i], acc[half + i]);
+            }
+            if (len % 2 == 1) {
+                acc[half] = acc[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return acc[0];
+    }
+`);
+  });
+
+  // isIn-only types: support eq but not add (euint256, eaddress).
+  // Excludes ebool — isIn on a boolean is trivially expressible with eq/not.
+  const isInOnlyTypes = adjustedFheTypes.filter(
+    (t) =>
+      t.supportedOperators.includes('eq') &&
+      !t.supportedOperators.includes('add') &&
+      t.type !== 'Bool',
+  );
+
+  isInOnlyTypes.forEach((fheType) => {
+    const etype = `e${fheType.type.toLowerCase()}`;
+    const clearType = fheType.clearMatchingType;
+    const isInMax = maxIsInSize();
+    res.push(generateIsInBlock(etype, clearType, isInMax));
+  });
+
+  return res.join('');
 }
 
 /**

--- a/library-solidity/codegen/src/templates/FHE.sol-template
+++ b/library-solidity/codegen/src/templates/FHE.sol-template
@@ -79,6 +79,11 @@ library FHE {
     /// @notice Returned if the sender is not allowed to use the handle.
     error SenderNotAllowedToUseHandle(bytes32 handle, address sender);
 
+    /// @notice Returned if a collection operator (isIn, sum) receives an out-of-range array size.
+    /// @param actual     The actual array length provided.
+    /// @param maxAllowed The maximum allowed array length for this type.
+    error FHECollectionSizeInvalid(uint256 actual, uint256 maxAllowed);
+
     /// @notice This event is emitted when public decryption has been successfully verified.
     event PublicDecryptionVerified(bytes32[] handlesList, bytes abiEncodedCleartexts);
 
@@ -96,6 +101,14 @@ library FHE {
     //$$ -
     //$$ -----------------------------------------------------------------------
     $${FHEOperators}$$
+    //$$ -----------------------------------------------------------------------
+
+    //$$ -----------------------------------------------------------------------
+    //$$ -
+    //$$ -          FHE Collection Operators Template Placeholder
+    //$$ -
+    //$$ -----------------------------------------------------------------------
+    $${FHECollectionOperators}$$
     //$$ -----------------------------------------------------------------------
 
     /**

--- a/library-solidity/examples/tests/FHEVMCollectionSuite.sol
+++ b/library-solidity/examples/tests/FHEVMCollectionSuite.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import "../../lib/FHE.sol";
+import {CoprocessorSetup} from "../CoprocessorSetup.sol";
+
+/**
+ * @title  FHEVMCollectionSuite
+ * @notice Correctness test suite for FHE.isIn and FHE.sum.
+ */
+contract FHEVMCollectionSuite {
+    ebool public lastBool;
+    euint8 public lastUint8;
+    euint32 public lastUint32;
+    euint64 public lastUint64;
+
+    constructor() {
+        FHE.setCoprocessor(CoprocessorSetup.defaultConfig());
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint8
+    // -------------------------------------------------------------------------
+
+    function isIn_euint8_found(externalEuint8 encNeedle, bytes calldata inputProof, uint8[] calldata set) public {
+        euint8 needle = FHE.fromExternal(encNeedle, inputProof);
+        lastBool = FHE.isIn(needle, set);
+        FHE.allowThis(lastBool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint32
+    // -------------------------------------------------------------------------
+
+    function isIn_euint32_found(externalEuint32 encNeedle, bytes calldata inputProof, uint32[] calldata set) public {
+        euint32 needle = FHE.fromExternal(encNeedle, inputProof);
+        lastBool = FHE.isIn(needle, set);
+        FHE.allowThis(lastBool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint64
+    // -------------------------------------------------------------------------
+
+    function isIn_euint64_found(externalEuint64 encNeedle, bytes calldata inputProof, uint64[] calldata set) public {
+        euint64 needle = FHE.fromExternal(encNeedle, inputProof);
+        lastBool = FHE.isIn(needle, set);
+        FHE.allowThis(lastBool);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint8
+    // -------------------------------------------------------------------------
+
+    function sum_euint8(externalEuint8[] calldata encVals, bytes calldata inputProof) public {
+        euint8[] memory values = new euint8[](encVals.length);
+        for (uint256 i = 0; i < encVals.length; i++) {
+            values[i] = FHE.fromExternal(encVals[i], inputProof);
+        }
+        lastUint8 = FHE.sum(values);
+        FHE.allowThis(lastUint8);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint32
+    // -------------------------------------------------------------------------
+
+    function sum_euint32(externalEuint32[] calldata encVals, bytes calldata inputProof) public {
+        euint32[] memory values = new euint32[](encVals.length);
+        for (uint256 i = 0; i < encVals.length; i++) {
+            values[i] = FHE.fromExternal(encVals[i], inputProof);
+        }
+        lastUint32 = FHE.sum(values);
+        FHE.allowThis(lastUint32);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint64
+    // -------------------------------------------------------------------------
+
+    function sum_euint64(externalEuint64[] calldata encVals, bytes calldata inputProof) public {
+        euint64[] memory values = new euint64[](encVals.length);
+        for (uint256 i = 0; i < encVals.length; i++) {
+            values[i] = FHE.fromExternal(encVals[i], inputProof);
+        }
+        lastUint64 = FHE.sum(values);
+        FHE.allowThis(lastUint64);
+    }
+
+    // -------------------------------------------------------------------------
+    // Verify input array is not modified by sum (uses trivial encryption to test
+    // internal Solidity memory semantics — the encryption itself is not under test)
+    // -------------------------------------------------------------------------
+
+    function sum_euint32_checkNoMutation(uint32[] calldata vals) public returns (bool notMutated) {
+        require(vals.length >= 2, "need at least 2 elements");
+        euint32[] memory enc = new euint32[](vals.length);
+        for (uint256 i = 0; i < vals.length; i++) {
+            enc[i] = FHE.asEuint32(vals[i]);
+        }
+        bytes32 handle0Before = euint32.unwrap(enc[0]);
+        bytes32 handle1Before = euint32.unwrap(enc[1]);
+        FHE.sum(enc);
+        bytes32 handle0After = euint32.unwrap(enc[0]);
+        bytes32 handle1After = euint32.unwrap(enc[1]);
+        notMutated = (handle0Before == handle0After) && (handle1Before == handle1After);
+    }
+}

--- a/library-solidity/examples/tests/FHEVMGasProfileSuite.sol
+++ b/library-solidity/examples/tests/FHEVMGasProfileSuite.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import "../../lib/FHE.sol";
+import {CoprocessorSetup} from "../CoprocessorSetup.sol";
+
+/**
+ * @title  FHEVMGasProfileSuite
+ * @notice Measures EVM gas and HCU for isIn and sum at different array sizes and types.
+ *         Inputs are trivially encrypted on-chain — no external proof needed.
+ *         The value searched in isIn (42) is always present at index 42, so the result
+ *         is always true, giving a consistent worst-case-equivalent workload.
+ */
+contract FHEVMGasProfileSuite {
+    ebool public resEbool;
+    euint8 public resEuint8;
+    euint16 public resEuint16;
+    euint32 public resEuint32;
+    euint64 public resEuint64;
+    euint128 public resEuint128;
+
+    constructor() {
+        FHE.setCoprocessor(CoprocessorSetup.defaultConfig());
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint8
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_euint8(uint256 setSize) public {
+        // set = [0, 1, ..., n-1]. Value 42 is present when setSize > 42.
+        uint8[] memory set = new uint8[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = uint8(i);
+        }
+        euint8 value = FHE.asEuint8(42);
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint16
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_euint16(uint256 setSize) public {
+        uint16[] memory set = new uint16[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = uint16(i % 65536);
+        }
+        euint16 value = FHE.asEuint16(42);
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint32
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_euint32(uint256 setSize) public {
+        uint32[] memory set = new uint32[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = uint32(i);
+        }
+        euint32 value = FHE.asEuint32(42);
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint128
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_euint128(uint256 setSize) public {
+        uint128[] memory set = new uint128[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = uint128(i);
+        }
+        euint128 value = FHE.asEuint128(42);
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint64
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_euint64(uint256 setSize) public {
+        uint64[] memory set = new uint64[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = uint64(i);
+        }
+        euint64 value = FHE.asEuint64(42);
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint8
+    // -------------------------------------------------------------------------
+
+    function profile_sum_euint8(uint256 arraySize) public {
+        euint8[] memory values = new euint8[](arraySize);
+        for (uint256 i = 0; i < arraySize; i++) {
+            values[i] = FHE.asEuint8(uint8((i % 255) + 1));
+        }
+        resEuint8 = FHE.sum(values);
+        FHE.allowThis(resEuint8);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint16
+    // -------------------------------------------------------------------------
+
+    function profile_sum_euint16(uint256 arraySize) public {
+        euint16[] memory values = new euint16[](arraySize);
+        for (uint256 i = 0; i < arraySize; i++) {
+            values[i] = FHE.asEuint16(uint16((i % 65535) + 1));
+        }
+        resEuint16 = FHE.sum(values);
+        FHE.allowThis(resEuint16);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint32
+    // -------------------------------------------------------------------------
+
+    function profile_sum_euint32(uint256 arraySize) public {
+        euint32[] memory values = new euint32[](arraySize);
+        for (uint256 i = 0; i < arraySize; i++) {
+            values[i] = FHE.asEuint32(uint32(i + 1));
+        }
+        resEuint32 = FHE.sum(values);
+        FHE.allowThis(resEuint32);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint128
+    // -------------------------------------------------------------------------
+
+    function profile_sum_euint128(uint256 arraySize) public {
+        euint128[] memory values = new euint128[](arraySize);
+        for (uint256 i = 0; i < arraySize; i++) {
+            values[i] = FHE.asEuint128(uint128(i + 1));
+        }
+        resEuint128 = FHE.sum(values);
+        FHE.allowThis(resEuint128);
+    }
+
+    // -------------------------------------------------------------------------
+    // sum — euint64
+    // -------------------------------------------------------------------------
+
+    function profile_sum_euint64(uint256 arraySize) public {
+        euint64[] memory values = new euint64[](arraySize);
+        for (uint256 i = 0; i < arraySize; i++) {
+            values[i] = FHE.asEuint64(uint64(i + 1));
+        }
+        resEuint64 = FHE.sum(values);
+        FHE.allowThis(resEuint64);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — eaddress
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_eaddress(uint256 setSize) public {
+        address[] memory set = new address[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = address(uint160(i + 1));
+        }
+        eaddress value = FHE.asEaddress(address(uint160(42)));
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+
+    // -------------------------------------------------------------------------
+    // isIn — euint256
+    // -------------------------------------------------------------------------
+
+    function profile_isIn_euint256(uint256 setSize) public {
+        uint256[] memory set = new uint256[](setSize);
+        for (uint256 i = 0; i < setSize; i++) {
+            set[i] = i + 1;
+        }
+        euint256 value = FHE.asEuint256(42);
+        resEbool = FHE.isIn(value, set);
+        FHE.allowThis(resEbool);
+    }
+}

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -73,6 +73,11 @@ library FHE {
     /// @notice Returned if the sender is not allowed to use the handle.
     error SenderNotAllowedToUseHandle(bytes32 handle, address sender);
 
+    /// @notice Returned if a collection operator (isIn, sum) receives an out-of-range array size.
+    /// @param actual     The actual array length provided.
+    /// @param maxAllowed The maximum allowed array length for this type.
+    error FHECollectionSizeInvalid(uint256 actual, uint256 maxAllowed);
+
     /// @notice This event is emitted when public decryption has been successfully verified.
     event PublicDecryptionVerified(bytes32[] handlesList, bytes abiEncodedCleartexts);
 
@@ -8788,6 +8793,404 @@ library FHE {
      */
     function randEuint256(uint256 upperBound) internal returns (euint256) {
         return euint256.wrap(Impl.randBounded(upperBound, FheType.Uint256));
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(euint8 value, uint8[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+
+    /**
+     * @notice Sums an array of encrypted values.
+     * @dev    Tree accumulation keeps DFG depth at ceil(log2(n)) instead of n-1,
+     *         which is critical for large arrays given the per-transaction depth limit.
+     *         Overflow wraps silently, matching FHE.add semantics.
+     *         The input array is not modified.
+     *         Max array size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function sum(euint8[] memory values) internal returns (euint8) {
+        if (values.length == 0 || values.length > 128) revert FHECollectionSizeInvalid(values.length, 128);
+
+        euint8[] memory acc = new euint8[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            acc[i] = values[i];
+        }
+
+        uint256 len = acc.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                acc[i] = add(acc[i], acc[half + i]);
+            }
+            if (len % 2 == 1) {
+                acc[half] = acc[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return acc[0];
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(euint16 value, uint16[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+
+    /**
+     * @notice Sums an array of encrypted values.
+     * @dev    Tree accumulation keeps DFG depth at ceil(log2(n)) instead of n-1,
+     *         which is critical for large arrays given the per-transaction depth limit.
+     *         Overflow wraps silently, matching FHE.add semantics.
+     *         The input array is not modified.
+     *         Max array size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function sum(euint16[] memory values) internal returns (euint16) {
+        if (values.length == 0 || values.length > 128) revert FHECollectionSizeInvalid(values.length, 128);
+
+        euint16[] memory acc = new euint16[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            acc[i] = values[i];
+        }
+
+        uint256 len = acc.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                acc[i] = add(acc[i], acc[half + i]);
+            }
+            if (len % 2 == 1) {
+                acc[half] = acc[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return acc[0];
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(euint32 value, uint32[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+
+    /**
+     * @notice Sums an array of encrypted values.
+     * @dev    Tree accumulation keeps DFG depth at ceil(log2(n)) instead of n-1,
+     *         which is critical for large arrays given the per-transaction depth limit.
+     *         Overflow wraps silently, matching FHE.add semantics.
+     *         The input array is not modified.
+     *         Max array size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function sum(euint32[] memory values) internal returns (euint32) {
+        if (values.length == 0 || values.length > 128) revert FHECollectionSizeInvalid(values.length, 128);
+
+        euint32[] memory acc = new euint32[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            acc[i] = values[i];
+        }
+
+        uint256 len = acc.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                acc[i] = add(acc[i], acc[half + i]);
+            }
+            if (len % 2 == 1) {
+                acc[half] = acc[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return acc[0];
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(euint64 value, uint64[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+
+    /**
+     * @notice Sums an array of encrypted values.
+     * @dev    Tree accumulation keeps DFG depth at ceil(log2(n)) instead of n-1,
+     *         which is critical for large arrays given the per-transaction depth limit.
+     *         Overflow wraps silently, matching FHE.add semantics.
+     *         The input array is not modified.
+     *         Max array size: 64 (bounded by maxHCUPerTx=20M).
+     */
+    function sum(euint64[] memory values) internal returns (euint64) {
+        if (values.length == 0 || values.length > 64) revert FHECollectionSizeInvalid(values.length, 64);
+
+        euint64[] memory acc = new euint64[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            acc[i] = values[i];
+        }
+
+        uint256 len = acc.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                acc[i] = add(acc[i], acc[half + i]);
+            }
+            if (len % 2 == 1) {
+                acc[half] = acc[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return acc[0];
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(euint128 value, uint128[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+
+    /**
+     * @notice Sums an array of encrypted values.
+     * @dev    Tree accumulation keeps DFG depth at ceil(log2(n)) instead of n-1,
+     *         which is critical for large arrays given the per-transaction depth limit.
+     *         Overflow wraps silently, matching FHE.add semantics.
+     *         The input array is not modified.
+     *         Max array size: 64 (bounded by maxHCUPerTx=20M).
+     */
+    function sum(euint128[] memory values) internal returns (euint128) {
+        if (values.length == 0 || values.length > 64) revert FHECollectionSizeInvalid(values.length, 64);
+
+        euint128[] memory acc = new euint128[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            acc[i] = values[i];
+        }
+
+        uint256 len = acc.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                acc[i] = add(acc[i], acc[half + i]);
+            }
+            if (len % 2 == 1) {
+                acc[half] = acc[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return acc[0];
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(eaddress value, address[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
+    }
+
+    /**
+     * @notice Returns true if 'value' is found in the cleartext 'set', false otherwise.
+     * @dev    Each equality check is independent — the coprocessor parallelizes them.
+     *         The OR tree-reduction keeps DFG depth at ceil(log2(n))+1 instead of n.
+     *         Max set size: 128 (bounded by maxHCUPerTx=20M).
+     */
+    function isIn(euint256 value, uint256[] memory set) internal returns (ebool) {
+        if (set.length == 0 || set.length > 128) revert FHECollectionSizeInvalid(set.length, 128);
+
+        if (set.length == 1) {
+            return eq(value, set[0]);
+        }
+
+        ebool[] memory eqs = new ebool[](set.length);
+        for (uint256 i = 0; i < set.length; i++) {
+            eqs[i] = eq(value, set[i]);
+        }
+
+        uint256 len = set.length;
+        while (len > 1) {
+            uint256 half = len / 2;
+            for (uint256 i = 0; i < half; i++) {
+                eqs[i] = or(eqs[i], eqs[half + i]);
+            }
+            if (len % 2 == 1) {
+                eqs[half] = eqs[len - 1];
+                len = half + 1;
+            } else {
+                len = half;
+            }
+        }
+        return eqs[0];
     }
 
     /**

--- a/library-solidity/test/collectionOperators/CollectionOperators.fixture.ts
+++ b/library-solidity/test/collectionOperators/CollectionOperators.fixture.ts
@@ -1,0 +1,14 @@
+import { ethers } from 'hardhat';
+
+import type { FHEVMGasProfileSuite } from '../../typechain-types/examples/tests/FHEVMGasProfileSuite';
+import { getSigners } from '../signers';
+
+export async function deployFHEVMGasProfileSuiteFixture(): Promise<FHEVMGasProfileSuite> {
+  const signers = await getSigners();
+
+  const contractFactory = await ethers.getContractFactory('FHEVMGasProfileSuite');
+  const contract = await contractFactory.connect(signers.alice).deploy();
+  await contract.waitForDeployment();
+
+  return contract as unknown as FHEVMGasProfileSuite;
+}

--- a/library-solidity/test/collectionOperators/CollectionOperators.ts
+++ b/library-solidity/test/collectionOperators/CollectionOperators.ts
@@ -1,0 +1,109 @@
+import type { FHEVMGasProfileSuite } from '../../typechain-types/examples/tests/FHEVMGasProfileSuite';
+import { getTxHCUFromTxReceipt } from '../coprocessorUtils';
+import { getSigners, initSigners } from '../signers';
+import { deployFHEVMGasProfileSuiteFixture } from './CollectionOperators.fixture';
+
+// Array sizes to benchmark.
+const SIZES = [8, 16, 32, 64, 128] as const;
+const TYPES: FheType[] = ['euint8', 'euint16', 'euint32', 'euint64', 'euint128'];
+const ISIN_EXTRA_TYPES: IsInExtraType[] = ['eaddress', 'euint256'];
+
+// Safe upper bound per (op, type), derived from maxHCUPerTx=20M.
+// Cases above these limits are covered in the boundary tests below.
+function maxSafeSize(op: Operation, type: FheType): number {
+  if (op === 'sum' && (type === 'euint64' || type === 'euint128')) return 64;
+  return 128;
+}
+
+// Boundary cases: all expected to revert (size guard or HCU limit exceeded).
+const BOUNDARY_CASES: { op: Operation; type: FheType; size: number }[] = [
+  { op: 'isIn', type: 'euint8', size: 256 },
+  { op: 'isIn', type: 'euint16', size: 256 },
+  { op: 'isIn', type: 'euint32', size: 256 },
+  { op: 'isIn', type: 'euint64', size: 256 },
+  { op: 'isIn', type: 'euint128', size: 256 },
+  { op: 'sum', type: 'euint8', size: 256 },
+  { op: 'sum', type: 'euint16', size: 256 },
+  { op: 'sum', type: 'euint32', size: 256 },
+  { op: 'sum', type: 'euint64', size: 128 },
+  { op: 'sum', type: 'euint128', size: 128 },
+];
+
+type FheType = 'euint8' | 'euint16' | 'euint32' | 'euint64' | 'euint128';
+type IsInExtraType = 'eaddress' | 'euint256';
+type Operation = 'isIn' | 'sum';
+
+describe('Gas Profile: isIn and sum', function () {
+  this.timeout(300_000);
+
+  before(async function () {
+    await initSigners(1);
+    this.signers = await getSigners();
+    this.contract = await deployFHEVMGasProfileSuiteFixture();
+  });
+
+  // ------------------------------------------------------------------
+  // isIn benchmarks
+  // ------------------------------------------------------------------
+
+  for (const size of SIZES) {
+    for (const type of TYPES) {
+      if (size > maxSafeSize('isIn', type)) continue;
+      it(`isIn(${type}, n=${size})`, async function () {
+        const tx = await (this.contract as any)[`profile_isIn_${type}`](size);
+        const receipt = await tx.wait();
+        const { globalTxHCU, maxTxHCUDepth } = getTxHCUFromTxReceipt(receipt!);
+        console.log(`isIn(${type}, n=${size}) — EVM gas: ${receipt!.gasUsed}, Total HCU: ${globalTxHCU}, HCU Depth: ${maxTxHCUDepth}`);
+      });
+    }
+  }
+
+  // isIn benchmarks — eaddress and euint256
+
+  for (const size of SIZES) {
+    for (const type of ISIN_EXTRA_TYPES) {
+      it(`isIn(${type}, n=${size})`, async function () {
+        const tx = await (this.contract as any)[`profile_isIn_${type}`](size);
+        const receipt = await tx.wait();
+        const { globalTxHCU, maxTxHCUDepth } = getTxHCUFromTxReceipt(receipt!);
+        console.log(`isIn(${type}, n=${size}) — EVM gas: ${receipt!.gasUsed}, Total HCU: ${globalTxHCU}, HCU Depth: ${maxTxHCUDepth}`);
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // sum benchmarks
+  // ------------------------------------------------------------------
+
+  for (const size of SIZES) {
+    for (const type of TYPES) {
+      if (size > maxSafeSize('sum', type)) continue;
+      it(`sum(${type}, n=${size})`, async function () {
+        const tx = await (this.contract as any)[`profile_sum_${type}`](size);
+        const receipt = await tx.wait();
+        const { globalTxHCU, maxTxHCUDepth } = getTxHCUFromTxReceipt(receipt!);
+        console.log(`sum(${type}, n=${size}) — EVM gas: ${receipt!.gasUsed}, Total HCU: ${globalTxHCU}, HCU Depth: ${maxTxHCUDepth}`);
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Boundary cases — expected to revert (FHECollectionSizeInvalid guard or HCU limit)
+  // ------------------------------------------------------------------
+
+  describe('Boundary cases (expected revert)', function () {
+    for (const { op, type, size } of BOUNDARY_CASES) {
+      it(`${op}(${type}, n=${size}) reverts`, async function () {
+        const fn = `profile_${op}_${type}`;
+        try {
+          const tx = await (this.contract as any)[fn](size);
+          await tx.wait();
+          throw new Error(`Expected revert but transaction succeeded`);
+        } catch (err: any) {
+          if (err.message === `Expected revert but transaction succeeded`) throw err;
+          // Test passes — any revert (size guard or HCU limit) is the expected outcome.
+        }
+      });
+    }
+  });
+});

--- a/library-solidity/test/fhevmOperations/fhevmOperations14.ts
+++ b/library-solidity/test/fhevmOperations/fhevmOperations14.ts
@@ -1,0 +1,207 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import type { FHEVMCollectionSuite } from '../../typechain-types/examples/tests/FHEVMCollectionSuite';
+import { createInstances, decrypt8, decrypt32, decrypt64, decryptBool } from '../instance';
+import { getSigners, initSigners } from '../signers';
+
+async function deployFHEVMCollectionSuiteFixture(): Promise<FHEVMCollectionSuite> {
+  const signers = await getSigners();
+  const contractFactory = await ethers.getContractFactory('FHEVMCollectionSuite');
+  const contract = await contractFactory.connect(signers.alice).deploy();
+  await contract.waitForDeployment();
+  return contract as unknown as FHEVMCollectionSuite;
+}
+
+describe('Collection operators: isIn and sum', function () {
+  this.timeout(120_000);
+
+  before(async function () {
+    await initSigners(1);
+    this.signers = await getSigners();
+    const contract = await deployFHEVMCollectionSuiteFixture();
+    this.contractAddress = await contract.getAddress();
+    this.contract = contract;
+    this.instances = await createInstances(this.signers);
+  });
+
+  // -------------------------------------------------------------------------
+  // isIn — euint8
+  // -------------------------------------------------------------------------
+
+  it('isIn(euint8): returns true when value is present', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(42n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint8_found(enc.handles[0], enc.inputProof, [1, 10, 42, 99]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(true);
+  });
+
+  it('isIn(euint8): returns false when value is absent', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(7n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint8_found(enc.handles[0], enc.inputProof, [1, 10, 42, 99]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(false);
+  });
+
+  it('isIn(euint8): n=1 found (short-circuit path)', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(5n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint8_found(enc.handles[0], enc.inputProof, [5]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(true);
+  });
+
+  it('isIn(euint8): n=1 not found (short-circuit path)', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(5n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint8_found(enc.handles[0], enc.inputProof, [9]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // isIn — euint32
+  // -------------------------------------------------------------------------
+
+  it('isIn(euint32): returns true when value is present', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add32(1000n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint32_found(enc.handles[0], enc.inputProof, [100, 500, 1000, 9999]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(true);
+  });
+
+  it('isIn(euint32): returns false when value is absent', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add32(123n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint32_found(enc.handles[0], enc.inputProof, [100, 500, 1000, 9999]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // isIn — euint64
+  // -------------------------------------------------------------------------
+
+  it('isIn(euint64): returns true when value is present', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add64(999999999999n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint64_found(enc.handles[0], enc.inputProof, [1n, 999999999999n, 42n]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(true);
+  });
+
+  it('isIn(euint64): returns false when value is absent', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add64(888888n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.isIn_euint64_found(enc.handles[0], enc.inputProof, [1n, 999999999999n, 42n]);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.lastBool())).to.equal(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // sum — euint8
+  // -------------------------------------------------------------------------
+
+  it('sum(euint8): sums a single element', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(7n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint8(enc.handles, enc.inputProof);
+    await tx.wait();
+    expect(await decrypt8(await this.contract.lastUint8())).to.equal(7n);
+  });
+
+  it('sum(euint8): sums two elements', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(3n);
+    input.add8(5n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint8(enc.handles, enc.inputProof);
+    await tx.wait();
+    expect(await decrypt8(await this.contract.lastUint8())).to.equal(8n);
+  });
+
+  it('sum(euint8): sums an odd-length array (tree odd-carry path)', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(1n);
+    input.add8(2n);
+    input.add8(3n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint8(enc.handles, enc.inputProof);
+    await tx.wait();
+    expect(await decrypt8(await this.contract.lastUint8())).to.equal(6n);
+  });
+
+  it('sum(euint8): sums a power-of-two array', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(10n);
+    input.add8(20n);
+    input.add8(30n);
+    input.add8(40n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint8(enc.handles, enc.inputProof);
+    await tx.wait();
+    expect(await decrypt8(await this.contract.lastUint8())).to.equal(100n);
+  });
+
+  it('sum(euint8): wraps on overflow', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add8(200n);
+    input.add8(100n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint8(enc.handles, enc.inputProof);
+    await tx.wait();
+    // 200 + 100 = 300, wraps to 44 in uint8
+    expect(await decrypt8(await this.contract.lastUint8())).to.equal(44n);
+  });
+
+  // -------------------------------------------------------------------------
+  // sum — euint32
+  // -------------------------------------------------------------------------
+
+  it('sum(euint32): sums correctly', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add32(1000n);
+    input.add32(2000n);
+    input.add32(3000n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint32(enc.handles, enc.inputProof);
+    await tx.wait();
+    expect(await decrypt32(await this.contract.lastUint32())).to.equal(6000n);
+  });
+
+  // -------------------------------------------------------------------------
+  // sum — euint64
+  // -------------------------------------------------------------------------
+
+  it('sum(euint64): sums large values correctly', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add64(1000000000n);
+    input.add64(2000000000n);
+    input.add64(3000000000n);
+    const enc = await input.encrypt();
+    const tx = await this.contract.sum_euint64(enc.handles, enc.inputProof);
+    await tx.wait();
+    expect(await decrypt64(await this.contract.lastUint64())).to.equal(6000000000n);
+  });
+
+  // -------------------------------------------------------------------------
+  // sum: input array is not mutated
+  // -------------------------------------------------------------------------
+
+  it('sum(euint32): does not mutate the input array', async function () {
+    const notMutated = await this.contract.sum_euint32_checkNoMutation.staticCall([10, 20, 30, 40]);
+    expect(notMutated).to.equal(true);
+  });
+});


### PR DESCRIPTION
# Gas Profile: `FHE.isIn` and `FHE.sum`

## Reproducing the measurements

Run from `library-solidity/`:

```bash
cp .env.example .env
npm run compile
npx hardhat test test/collectionOperators/CollectionOperators.ts
```

To run only the boundary revert cases:

```bash
npx hardhat test test/collectionOperators/CollectionOperators.ts --grep "Boundary cases"
```

---

## Measurements

Each call includes `n` trivial-encrypts (setup) + the collection operation.
HCU Depth = cost along the critical path.
ETH cost = EVM gas × gas price.

> **Gas price note:** Today gas typically runs at 0.1 gwei; recent spikes reach 1–5 gwei. The USD column uses the 5 gwei spike scenario at ETH ≈ $2,500 — substitute your own price to rescale linearly.

| Operation | Type    | Size | EVM Gas     | ETH @ 0.1 gwei | ETH @ 5 gwei | USD @ 5 gwei ($2.5k/ETH) | Total HCU    | HCU Depth   |
|-----------|---------|------|-------------|----------------|--------------|--------------------------|--------------|-------------|
| isIn      | euint8   |    8 |     330,305 |       0.000033 |     0.001652 |                    $4.13 |      608,032 |     127,032 |
| isIn      | euint8   |   16 |     541,828 |       0.000054 |     0.002709 |                    $6.77 |    1,240,032 |     151,032 |
| isIn      | euint8   |   32 |     998,862 |       0.000100 |     0.004994 |                   $12.49 |    2,504,032 |     175,032 |
| isIn      | euint8   |   64 |   1,912,755 |       0.000191 |     0.009564 |                   $23.91 |    5,032,032 |     199,032 |
| isIn      | euint8   |  128 |   3,740,508 |       0.000374 |     0.018703 |                   $46.76 |   10,088,032 |     223,032 |
| isIn      | euint16  |    8 |     314,072 |       0.000031 |     0.001570 |                    $3.93 |      608,032 |     127,032 |
| isIn      | euint16  |   16 |     543,535 |       0.000054 |     0.002718 |                    $6.79 |    1,240,032 |     151,032 |
| isIn      | euint16  |   32 |   1,002,249 |       0.000100 |     0.005011 |                   $12.53 |    2,504,032 |     175,032 |
| isIn      | euint16  |   64 |   1,919,502 |       0.000192 |     0.009598 |                   $23.99 |    5,032,032 |     199,032 |
| isIn      | euint16  |  128 |   3,753,975 |       0.000375 |     0.018770 |                   $46.92 |   10,088,032 |     223,032 |
| isIn      | euint32  |    8 |     314,086 |       0.000031 |     0.001570 |                    $3.93 |      824,032 |     154,032 |
| isIn      | euint32  |   16 |     543,493 |       0.000054 |     0.002717 |                    $6.79 |    1,672,032 |     178,032 |
| isIn      | euint32  |   32 |   1,002,095 |       0.000100 |     0.005010 |                   $12.53 |    3,368,032 |     202,032 |
| isIn      | euint32  |   64 |   1,919,124 |       0.000192 |     0.009596 |                   $23.99 |    6,760,032 |     226,032 |
| isIn      | euint32  |  128 |   3,753,149 |       0.000375 |     0.018766 |                   $46.91 |   13,544,032 |     250,032 |
| isIn      | euint64  |    8 |     314,506 |       0.000031 |     0.001573 |                    $3.93 |      832,032 |     155,032 |
| isIn      | euint64  |   16 |     544,309 |       0.000054 |     0.002722 |                    $6.80 |    1,688,032 |     179,032 |
| isIn      | euint64  |   32 |   1,003,695 |       0.000100 |     0.005018 |                   $12.55 |    3,400,032 |     203,032 |
| isIn      | euint64  |   64 |   1,922,292 |       0.000192 |     0.009611 |                   $24.03 |    6,824,032 |     227,032 |
| isIn      | euint64  |  128 |   3,759,453 |       0.000376 |     0.018797 |                   $46.99 |   13,672,032 |     251,032 |
| isIn      | euint128 |    8 |     314,968 |       0.000031 |     0.001575 |                    $3.94 |    1,104,032 |     189,032 |
| isIn      | euint128 |   16 |     545,163 |       0.000055 |     0.002726 |                    $6.81 |    2,232,032 |     213,032 |
| isIn      | euint128 |   32 |   1,005,333 |       0.000101 |     0.005027 |                   $12.57 |    4,488,032 |     237,032 |
| isIn      | euint128 |   64 |   1,925,498 |       0.000193 |     0.009627 |                   $24.07 |    9,000,032 |     261,032 |
| isIn      | euint128 |  128 |   3,765,795 |       0.000377 |     0.018829 |                   $47.07 |   18,024,032 |     285,032 |
| isIn      | eaddress |    8 |     316,211 |       0.000032 |     0.001581 |                    $3.95 |    1,104,032 |     189,032 |
| isIn      | eaddress |   16 |     547,566 |       0.000055 |     0.002738 |                    $6.84 |    2,232,032 |     213,032 |
| isIn      | eaddress |   32 |   1,010,056 |       0.000101 |     0.005050 |                   $12.63 |    4,488,032 |     237,032 |
| isIn      | eaddress |   64 |   1,934,861 |       0.000193 |     0.009674 |                   $24.19 |    9,000,032 |     261,032 |
| isIn      | eaddress |  128 |   3,784,438 |       0.000378 |     0.018922 |                   $47.31 |   18,024,032 |     285,032 |
| isIn      | euint256 |    8 |     316,206 |       0.000032 |     0.001581 |                    $3.95 |    1,112,032 |     190,032 |
| isIn      | euint256 |   16 |     547,569 |       0.000055 |     0.002738 |                    $6.84 |    2,248,032 |     214,032 |
| isIn      | euint256 |   32 |   1,010,075 |       0.000101 |     0.005050 |                   $12.63 |    4,520,032 |     238,032 |
| isIn      | euint256 |   64 |   1,934,912 |       0.000193 |     0.009675 |                   $24.19 |    9,064,032 |     262,032 |
| isIn      | euint256 |  128 |   3,784,553 |       0.000378 |     0.018923 |                   $47.31 |   18,152,032 |     286,032 |
| isIn      | euint8   |  256 | **REVERTED** | — | — | — | — | — |
| isIn      | euint16  |  256 | **REVERTED** | — | — | — | — | — |
| isIn      | euint32  |  256 | **REVERTED** | — | — | — | — | — |
| isIn      | euint64  |  256 | **REVERTED** | — | — | — | — | — |
| isIn      | euint128 |  256 | **REVERTED** | — | — | — | — | — |
| isIn      | eaddress |  256 | **REVERTED** | — | — | — | — | — |
| isIn      | euint256 |  256 | **REVERTED** | — | — | — | — | — |
| sum       | euint8   |    8 |     296,899 |       0.000030 |     0.001484 |                    $3.71 |      616,256 |     264,032 |
| sum       | euint8   |   16 |     485,126 |       0.000049 |     0.002426 |                    $6.06 |    1,320,512 |     352,032 |
| sum       | euint8   |   32 |     895,568 |       0.000090 |     0.004478 |                   $11.19 |    2,729,024 |     440,032 |
| sum       | euint8   |   64 |   1,716,276 |       0.000172 |     0.008581 |                   $21.45 |    5,546,048 |     528,032 |
| sum       | euint8   |  128 |   3,357,660 |       0.000336 |     0.016788 |                   $41.97 |   11,180,096 |     616,032 |
| sum       | euint16  |    8 |     297,677 |       0.000030 |     0.001488 |                    $3.72 |      651,256 |     279,032 |
| sum       | euint16  |   16 |     486,688 |       0.000049 |     0.002433 |                    $6.08 |    1,395,512 |     372,032 |
| sum       | euint16  |   32 |     898,698 |       0.000090 |     0.004493 |                   $11.23 |    2,884,024 |     465,032 |
| sum       | euint16  |   64 |   1,722,542 |       0.000172 |     0.008613 |                   $21.53 |    5,861,048 |     558,032 |
| sum       | euint16  |  128 |   3,370,198 |       0.000337 |     0.016851 |                   $42.13 |   11,815,096 |     651,032 |
| sum       | euint32  |    8 |     297,919 |       0.000030 |     0.001490 |                    $3.72 |      875,256 |     375,032 |
| sum       | euint32  |   16 |     487,242 |       0.000049 |     0.002436 |                    $6.09 |    1,875,512 |     500,032 |
| sum       | euint32  |   32 |     899,876 |       0.000090 |     0.004499 |                   $11.25 |    3,876,024 |     625,032 |
| sum       | euint32  |   64 |   1,724,968 |       0.000172 |     0.008625 |                   $21.56 |    7,877,048 |     750,032 |
| sum       | euint32  |  128 |   3,375,120 |       0.000338 |     0.016876 |                   $42.19 |   15,879,096 |     875,032 |
| sum       | euint64  |    8 |     298,631 |       0.000030 |     0.001493 |                    $3.73 |    1,134,256 |     486,032 |
| sum       | euint64  |   16 |     488,738 |       0.000049 |     0.002444 |                    $6.11 |    2,430,512 |     648,032 |
| sum       | euint64  |   32 |     902,940 |       0.000090 |     0.004515 |                   $11.29 |    5,023,024 |     810,032 |
| sum       | euint64  |   64 |   1,731,168 |       0.000173 |     0.008656 |                   $21.64 |   10,208,048 |     972,032 |
| sum       | euint64  |  128 | **REVERTED** | — | — | — | — | — |
| sum       | euint128 |    8 |     299,412 |       0.000030 |     0.001497 |                    $3.74 |    1,813,256 |     777,032 |
| sum       | euint128 |   16 |     490,303 |       0.000049 |     0.002452 |                    $6.13 |    3,885,512 |   1,036,032 |
| sum       | euint128 |   32 |     906,073 |       0.000091 |     0.004530 |                   $11.33 |    8,030,024 |   1,295,032 |
| sum       | euint128 |   64 |   1,737,437 |       0.000174 |     0.008687 |                   $21.72 |   16,319,048 |   1,554,032 |
| sum       | euint128 |  128 | **REVERTED** | — | — | — | — | — |

---

## Key findings

**HCU scales linearly with both array size and type width.** Doubling the array size doubles the total HCU. Wider types also cost more per element — each FHE operation has a fixed HCU cost that increases with bit width. This means for a given array size, wider types always consume more HCU and hit the per-transaction ceiling sooner.

**Tree accumulation keeps HCU depth at O(log n).** Each round of the tree halves the number of remaining elements, so the number of dependent levels is proportional to `log2(n)` rather than `n`. The depth grows by exactly one operation cost per doubling of array size. A sequential implementation — where each element is added one after the other — would produce a depth proportional to `n`, which for large arrays would exceed the per-transaction depth limit. The tree version avoids this entirely, keeping the critical path short regardless of array size.

---

## Array size limits

All boundary cases below revert with `FHECollectionSizeInvalid` — the size guard in `lib/FHE.sol` catches them before any HCU is consumed.

| Case | Limit | Reason |
|------|-------|--------|
| isIn(*, n=256)         | max=128 | exceeds `FHECollectionSizeInvalid` guard |
| sum(euint8/16/32, n=256) | max=128 | exceeds `FHECollectionSizeInvalid` guard |
| sum(euint64, n=128)    | max=64  | exceeds `FHECollectionSizeInvalid` guard |
| sum(euint128, n=128)   | max=64  | exceeds `FHECollectionSizeInvalid` guard |

Enforced limits in `lib/FHE.sol`:

| Function | euint8 | euint16 | euint32 | euint64 | euint128 | eaddress | euint256 |
|----------|--------|---------|---------|---------|----------|----------|----------|
| `isIn`   | 128    | 128     | 128     | 128     | 128      | 128      | 128      |
| `sum`    | 128    | 128     | 128     | **64**  | **64**   | N/A      | N/A      |

The limits are derived from `maxHCUPerTx = 20M`. `isIn(euint8/16)` at n=128 uses ~10.1M HCU. `isIn(euint128/eaddress)` at n=128 reaches ~18M, leaving ~10% headroom. `sum(euint64)` at n=64 uses ~10.2M HCU; at n=128 it would reach ~23.9M — hence the limit of 64. `sum` is not supported for `eaddress` and `euint256` — neither type supports `FHE.add`.

---

## Conclusion

Both operations are implemented as pure Solidity helpers composing `FHE.*` primitives with tree accumulation, keeping HCU depth at O(log n). This is necessary — a sequential implementation would exceed the 5M depth limit.

**Gas cost**: EVM gas is the only monetary cost — HCU is a throughput rate-limit enforced by the protocol, not a fee. EVM gas scales linearly with array size and is type-independent (the EVM only handles `uint256` ciphertext handles, not the encrypted values themselves). At 5 gwei, cost ranges from ~0.0015 ETH at n=8 to ~0.019 ETH at n=128 for both operations. EVM gas is never the reason a call fails.

**Array size limits**: The binding constraint is `maxHCUPerTx = 20M`. Each FHE operation consumes a fixed HCU budget that grows with type width — `add(euint64)` costs ~162k HCU per element vs ~88k for `euint8`, and `eq(euint64)` similarly costs more than `eq(euint8)`. As array size grows, total HCU accumulates and eventually hits the ceiling.

For `sum`, each element requires one `add`, and with 128 euint64 elements the total would reach ~23.9M — exceeding the 20M limit. The enforced limit is therefore n=64 for euint64 and euint128. For euint8/16/32, n=128 stays within budget (max ~15.9M for euint32). For `isIn`, each element requires one `eq` and one `or`, which are cheaper than `add`, so all types fit within n=128 — including `eaddress` (18.0M) and `euint256` (18.2M), which are the tightest fits with only ~10% headroom before the ceiling.

n=256 reverts for all types and all operations. If larger arrays are required, this pure-Solidity approach does not scale — the only options are raising `maxHCUPerTx` at the protocol level, or splitting across multiple transactions and aggregating results in a subsequent step.
