### PR TITLE
docs: fix mocked mode foundry link

### DIFF
--- a/docs/solidity-guides/mocked.md
+++ b/docs/solidity-guides/mocked.md
@@ -16,7 +16,7 @@ Refer to the [[Quick start - Hardhat]](../getting-started/overview-1/hardhat/REA
 
 ### 2. **Foundry (coming soon)**
 
-Mocked mode support is planned for [Foundry](./write_contract/foundry.md) in future releases.
+Mocked mode support is planned for [Foundry](./foundry.md) in future releases.
 
 ## How mocked mode works
 


### PR DESCRIPTION
## Summary
- fix the broken Foundry link in `docs/solidity-guides/mocked.md`
- point the mocked-mode page at the shipped `foundry.md` guide instead of the removed `write_contract/foundry.md` path
- keep the change scoped to a single docs link fix

## Testing
- verified the updated relative link resolves to the existing `docs/solidity-guides/foundry.md` file