### PR TITLE
test(test-suite): add live-safe e2e variants

### DIFF
--- a/library-solidity/test/FHEDelegation.t.sol
+++ b/library-solidity/test/FHEDelegation.t.sol
@@ -74,6 +74,9 @@ contract DelegationLibraryAdapter {
 }
 
 contract FHEDelegationTest is HostContractsDeployerTestUtils {
+    uint64 internal constant MIN_FUTURE_EXPIRY_OFFSET = 1;
+    uint64 internal constant DEFAULT_FUTURE_EXPIRY_OFFSET = 120;
+
     DelegationLibraryAdapter internal adapter;
     ACL internal acl;
 
@@ -120,7 +123,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
     }
 
     function _boundValidFutureExpiry(uint256 expirationDate) internal view returns (uint64) {
-        uint256 minExpiry = block.timestamp + 1 hours;
+        uint256 minExpiry = block.timestamp + MIN_FUTURE_EXPIRY_OFFSET;
         uint256 maxExpiry = type(uint64).max;
         return uint64(bound(expirationDate, minExpiry, maxExpiry));
     }
@@ -191,7 +194,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
         bytes32 handle = adapter.mintAndPersistHandle(plaintext);
         adapter.allowHandle(handle, contractContext);
 
-        uint64 expirationDate = uint64(block.timestamp + 2 hours);
+        uint64 expirationDate = uint64(block.timestamp + DEFAULT_FUTURE_EXPIRY_OFFSET);
         adapter.delegateUserDecryption(delegate, contractContext, expirationDate);
 
         bool delegated = adapter.isDelegatedForUserDecryption(address(adapter), delegate, contractContext, handle);
@@ -207,7 +210,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
         bytes32 handle = adapter.mintAndPersistHandle(plaintext);
         adapter.allowHandle(handle, contractContext);
 
-        uint64 expirationDate = uint64(block.timestamp + 2 hours);
+        uint64 expirationDate = uint64(block.timestamp + DEFAULT_FUTURE_EXPIRY_OFFSET);
         adapter.delegateUserDecryption(delegate, contractContext, expirationDate);
 
         vm.warp(uint256(expirationDate) + 1);
@@ -230,7 +233,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
 
     function test_DelegateUserDecryption_RevertsWhenSenderIsContractAddress(address delegate) public {
         vm.assume(delegate != address(adapter));
-        uint64 expirationDate = uint64(block.timestamp + 2 hours);
+        uint64 expirationDate = uint64(block.timestamp + DEFAULT_FUTURE_EXPIRY_OFFSET);
 
         vm.expectRevert(abi.encodeWithSelector(ACL.SenderCannotBeContractAddress.selector, address(adapter)));
         adapter.delegateUserDecryption(delegate, address(adapter), expirationDate);
@@ -238,7 +241,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
 
     function test_DelegateUserDecryption_RevertsWhenDelegateEqualsSender(address contractContext) public {
         vm.assume(contractContext != address(adapter));
-        uint64 expirationDate = uint64(block.timestamp + 2 hours);
+        uint64 expirationDate = uint64(block.timestamp + DEFAULT_FUTURE_EXPIRY_OFFSET);
 
         vm.expectRevert(abi.encodeWithSelector(ACL.SenderCannotBeDelegate.selector, address(adapter)));
         adapter.delegateUserDecryption(address(adapter), contractContext, expirationDate);
@@ -246,7 +249,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
 
     function test_DelegateUserDecryption_RevertsWhenDelegateEqualsContract(address contractContext) public {
         vm.assume(contractContext != address(adapter));
-        uint64 expirationDate = uint64(block.timestamp + 2 hours);
+        uint64 expirationDate = uint64(block.timestamp + DEFAULT_FUTURE_EXPIRY_OFFSET);
 
         vm.expectRevert(abi.encodeWithSelector(ACL.DelegateCannotBeContractAddress.selector, contractContext));
         adapter.delegateUserDecryption(contractContext, contractContext, expirationDate);
@@ -347,7 +350,7 @@ contract FHEDelegationTest is HostContractsDeployerTestUtils {
     ) public {
         address[] memory contracts = new address[](0);
 
-        adapter.delegateUserDecryptions(delegate, contracts, uint64(block.timestamp + 2 hours));
+        adapter.delegateUserDecryptions(delegate, contracts, uint64(block.timestamp + DEFAULT_FUTURE_EXPIRY_OFFSET));
 
         uint64 stored = acl.getUserDecryptionDelegationExpirationDate(address(adapter), delegate, contractContext);
         assertEq(stored, 0, "no delegation should be recorded");

--- a/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
+++ b/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
@@ -9,6 +9,13 @@ const NOT_ALLOWED_ON_HOST_ACL = 'not_allowed_on_host_acl';
 const DELEGATION_EXPIRY_SECONDS = 75;
 const DELEGATION_EXPIRY_POLL_MS = 2_000;
 
+const relayerErrorLabel = (error: unknown): string | undefined => {
+  if (typeof error !== 'object' || error === null || !('relayerApiError' in error)) {
+    return undefined;
+  }
+  return (error as { relayerApiError?: { label?: string } }).relayerApiError?.label;
+};
+
 const waitForDelegationExpiry = async (expirationTimestamp: number) => {
   while (true) {
     const latestBlock = await ethers.provider.getBlock('latest');
@@ -258,8 +265,8 @@ describe('Delegated user decryption', function () {
           publicKey,
         );
         expect.fail('Expected delegated user decrypt to be rejected after revocation');
-      } catch (err: any) {
-        expect(err.relayerApiError?.label).to.equal(NOT_ALLOWED_ON_HOST_ACL);
+      } catch (error: unknown) {
+        expect(relayerErrorLabel(error)).to.equal(NOT_ALLOWED_ON_HOST_ACL);
       }
     });
 
@@ -279,8 +286,8 @@ describe('Delegated user decryption', function () {
           publicKey,
         );
         expect.fail('Expected delegated user decrypt to be rejected without delegation');
-      } catch (err: any) {
-        expect(err.relayerApiError?.label).to.equal(NOT_ALLOWED_ON_HOST_ACL);
+      } catch (error: unknown) {
+        expect(relayerErrorLabel(error)).to.equal(NOT_ALLOWED_ON_HOST_ACL);
       }
     });
 
@@ -313,8 +320,8 @@ describe('Delegated user decryption', function () {
           publicKey,
         );
         expect.fail('Expected delegated user decrypt to be rejected for wrong contract');
-      } catch (err: any) {
-        expect(err.relayerApiError?.label).to.equal(NOT_ALLOWED_ON_HOST_ACL);
+      } catch (error: unknown) {
+        expect(relayerErrorLabel(error)).to.equal(NOT_ALLOWED_ON_HOST_ACL);
       }
     });
 
@@ -346,8 +353,8 @@ describe('Delegated user decryption', function () {
           publicKey,
         );
         expect.fail('Expected delegated user decrypt to be rejected for expired delegation');
-      } catch (err: any) {
-        expect(err.relayerApiError?.label).to.equal(NOT_ALLOWED_ON_HOST_ACL);
+      } catch (error: unknown) {
+        expect(relayerErrorLabel(error)).to.equal(NOT_ALLOWED_ON_HOST_ACL);
       }
     });
   });

--- a/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
+++ b/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
 import { createInstances } from '../instance';
+import { isLiveNetwork } from '../network';
 import { getSigners, initSigners } from '../signers';
 import { delegatedUserDecryptSingleHandle, waitForBlock } from '../utils';
 
@@ -307,6 +308,9 @@ describe('Delegated user decryption', function () {
     });
 
     it('should reject when delegation has expired', async function () {
+      if (isLiveNetwork()) {
+        this.skip();
+      }
       // Expiration must be >1h from chain time (FHE library constraint).
       // Use block timestamp, not Date.now(), since evm_increaseTime shifts chain clock.
       const oneHour = 3600;

--- a/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
+++ b/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
@@ -2,11 +2,22 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
 import { createInstances } from '../instance';
-import { isLiveNetwork } from '../network';
 import { getSigners, initSigners } from '../signers';
 import { delegatedUserDecryptSingleHandle, waitForBlock } from '../utils';
 
 const NOT_ALLOWED_ON_HOST_ACL = 'not_allowed_on_host_acl';
+const DELEGATION_EXPIRY_SECONDS = 75;
+const DELEGATION_EXPIRY_POLL_MS = 2_000;
+
+const waitForDelegationExpiry = async (expirationTimestamp: number) => {
+  while (true) {
+    const latestBlock = await ethers.provider.getBlock('latest');
+    if (latestBlock && latestBlock.timestamp > expirationTimestamp) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, DELEGATION_EXPIRY_POLL_MS));
+  }
+};
 
 describe('Delegated user decryption', function () {
   before(async function () {
@@ -308,23 +319,14 @@ describe('Delegated user decryption', function () {
     });
 
     it('should reject when delegation has expired', async function () {
-      if (isLiveNetwork()) {
-        this.skip();
-      }
-      // Expiration must be >1h from chain time (FHE library constraint).
-      // Use block timestamp, not Date.now(), since evm_increaseTime shifts chain clock.
-      const oneHour = 3600;
-      const buffer = 60;
       const latestBlock = await ethers.provider.getBlock('latest');
-      const expirationTimestamp = latestBlock!.timestamp + oneHour + buffer;
+      const expirationTimestamp = latestBlock!.timestamp + DELEGATION_EXPIRY_SECONDS;
       const tx = await this.smartWallet
         .connect(this.signers.bob)
         .delegateUserDecryption(this.signers.eve.address, this.tokenAddress, expirationTimestamp);
       await tx.wait();
 
-      // Fast-forward time past the expiration.
-      await ethers.provider.send('evm_increaseTime', [oneHour + buffer + 1]);
-      await ethers.provider.send('evm_mine', []);
+      await waitForDelegationExpiry(expirationTimestamp);
 
       const currentBlock = await ethers.provider.getBlockNumber();
       await waitForBlock(currentBlock + 15);

--- a/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
+++ b/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
@@ -242,6 +242,9 @@ describe('EncryptedERC20:HCU', function () {
       });
 
       afterEach(async function () {
+        if (isLiveNetwork()) {
+          return;
+        }
         await ethers.provider.send('evm_setAutomine', [true]);
         await ethers.provider.send('evm_setIntervalMining', [1]);
 

--- a/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
+++ b/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
+import type { ContractRunner, ContractTransactionResponse, TransactionReceipt, TransactionRequest, Wallet } from 'ethers';
 import { ethers } from 'hardhat';
 
+import type { EncryptedERC20 } from '../../types';
 import { createInstances } from '../instance';
 import { isLiveNetwork } from '../network';
+import type { Signers } from '../signers';
 import { getSigners, initSigners } from '../signers';
+import type { FhevmInstances } from '../types';
 import { getTxHCUFromTxReceipt, mineNBlocks, waitForPendingTransactions, waitForTransactionReceipt } from '../utils';
 import { deployEncryptedERC20Fixture } from './EncryptedERC20.fixture';
 
@@ -23,12 +27,55 @@ const HCU_LIMIT_ABI = [
   'error NotHostOwner(address)',
 ];
 
+type HcuLimitContract = {
+  connect(runner: ContractRunner): HcuLimitContract;
+  getBlockMeter(): Promise<[bigint, bigint]>;
+  getGlobalHCUCapPerBlock(): Promise<bigint>;
+  getMaxHCUPerTx(): Promise<bigint>;
+  getMaxHCUDepthPerTx(): Promise<bigint>;
+  setHCUPerBlock(value: bigint | number): Promise<ContractTransactionResponse>;
+  setMaxHCUPerTx(value: bigint | number): Promise<ContractTransactionResponse>;
+  setMaxHCUDepthPerTx(value: bigint | number): Promise<ContractTransactionResponse>;
+  addToBlockHCUWhitelist(address: string): Promise<ContractTransactionResponse>;
+  removeFromBlockHCUWhitelist(address: string): Promise<ContractTransactionResponse>;
+  isBlockHCUWhitelisted(address: string): Promise<boolean>;
+};
+
+type TransferSender = 'alice' | 'bob';
+
+type HcuTransferContext = {
+  contractAddress: string;
+  erc20: EncryptedERC20;
+  instances: FhevmInstances;
+  signers: Signers;
+};
+
+const LIVE_HCU_LIMIT_ERROR = 'HCU_LIMIT_CONTRACT_ADDRESS env var is required for live HCU block-cap coverage';
+const LOCAL_HCU_LIMIT_ERROR = 'HCU_LIMIT_CONTRACT_ADDRESS env var is required for block cap tests';
+
+const requireHcuLimit = (hcuLimit: HcuLimitContract | null, message: string): HcuLimitContract => {
+  if (!hcuLimit) {
+    throw new Error(message);
+  }
+  return hcuLimit;
+};
+
+const requireDeployer = (deployer: Wallet | undefined): Wallet => {
+  if (!deployer) {
+    throw new Error('DEPLOYER_PRIVATE_KEY env var is required for block cap tests');
+  }
+  return deployer;
+};
+
+const requireReceipt = (receipt: TransactionReceipt | null, label: string): TransactionReceipt => {
+  if (!receipt) {
+    throw new Error(`${label} receipt is missing`);
+  }
+  return receipt;
+};
+
 describe('EncryptedERC20:HCU', function () {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async function assertWithinConfiguredCaps(hcuLimit: any, receipt: any, label: string) {
-    if (!hcuLimit) {
-      throw new Error('HCU_LIMIT_CONTRACT_ADDRESS env var is required for live HCU block-cap coverage');
-    }
+  async function assertWithinConfiguredCaps(hcuLimit: HcuLimitContract, receipt: TransactionReceipt, label: string) {
     const { globalTxHCU, maxTxHCUDepth } = getTxHCUFromTxReceipt(receipt);
     const [perBlock, maxPerTx, maxDepth] = await Promise.all([
       hcuLimit.getGlobalHCUCapPerBlock(),
@@ -51,7 +98,9 @@ describe('EncryptedERC20:HCU', function () {
     this.erc20 = contract;
     this.instances = await createInstances(this.signers);
     const hcuLimitAddress = process.env.HCU_LIMIT_CONTRACT_ADDRESS;
-    this.hcuLimit = hcuLimitAddress ? new ethers.Contract(hcuLimitAddress, HCU_LIMIT_ABI, ethers.provider) : null;
+    this.hcuLimit = hcuLimitAddress
+      ? (new ethers.Contract(hcuLimitAddress, HCU_LIMIT_ABI, ethers.provider) as unknown as HcuLimitContract)
+      : null;
   });
 
   it('should transfer tokens between two users', async function () {
@@ -67,8 +116,8 @@ describe('EncryptedERC20:HCU', function () {
       encryptedTransferAmount.handles[0],
       encryptedTransferAmount.inputProof,
     );
-    const t2 = await tx.wait();
-    expect(t2?.status).to.eq(1);
+    const t2 = requireReceipt(await tx.wait(), 'transfer');
+    expect(t2.status).to.eq(1);
 
     const { globalTxHCU: HCUTransfer, maxTxHCUDepth: HCUMaxDepthTransfer } = getTxHCUFromTxReceipt(t2);
     console.log('Total HCU in transfer', HCUTransfer);
@@ -76,7 +125,7 @@ describe('EncryptedERC20:HCU', function () {
     console.log('Native Gas Consumed in transfer', t2.gasUsed);
 
     if (isLiveNetwork()) {
-      await assertWithinConfiguredCaps(this.hcuLimit, t2, 'transfer');
+      await assertWithinConfiguredCaps(requireHcuLimit(this.hcuLimit, LIVE_HCU_LIMIT_ERROR), t2, 'transfer');
       return;
     }
 
@@ -113,7 +162,7 @@ describe('EncryptedERC20:HCU', function () {
       encryptedTransferAmount2.inputProof,
     );
 
-    const t3 = await tx3.wait();
+    const t3 = requireReceipt(await tx3.wait(), 'transferFrom');
 
     const { globalTxHCU: HCUTransferFrom, maxTxHCUDepth: HCUMaxDepthTransferFrom } = getTxHCUFromTxReceipt(t3);
     console.log('Total HCU in transferFrom', HCUTransferFrom);
@@ -121,7 +170,7 @@ describe('EncryptedERC20:HCU', function () {
     console.log('Native Gas Consumed in transferFrom', t3.gasUsed);
 
     if (isLiveNetwork()) {
-      await assertWithinConfiguredCaps(this.hcuLimit, t3, 'transferFrom');
+      await assertWithinConfiguredCaps(requireHcuLimit(this.hcuLimit, LIVE_HCU_LIMIT_ERROR), t3, 'transferFrom');
       return;
     }
 
@@ -136,8 +185,13 @@ describe('EncryptedERC20:HCU', function () {
   describe('block cap scenarios', function () {
     const BATCHED_TRANSFER_GAS_LIMIT = 1_000_000;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async function sendEncryptedTransfer(ctx: any, sender: string, recipient: string, amount: number, overrides?: any) {
+    async function sendEncryptedTransfer(
+      ctx: HcuTransferContext,
+      sender: TransferSender,
+      recipient: string,
+      amount: number,
+      overrides?: TransactionRequest,
+    ) {
       const erc20 = ctx.erc20.connect(ctx.signers[sender]);
       const input = ctx.instances[sender].createEncryptedInput(ctx.contractAddress, ctx.signers[sender].address);
       input.add64(amount);
@@ -145,8 +199,7 @@ describe('EncryptedERC20:HCU', function () {
       return erc20['transfer(address,bytes32,bytes)'](recipient, enc.handles[0], enc.inputProof, overrides ?? {});
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async function mintAndDistribute(ctx: any) {
+    async function mintAndDistribute(ctx: HcuTransferContext) {
       const mintTx = await ctx.erc20.mint(10000);
       await mintTx.wait();
       const setupTx = await sendEncryptedTransfer(ctx, 'alice', ctx.signers.bob.address, 5000);
@@ -173,20 +226,16 @@ describe('EncryptedERC20:HCU', function () {
         if (isLiveNetwork()) {
           this.skip();
         }
-        if (!this.hcuLimit) {
-          throw new Error('HCU_LIMIT_CONTRACT_ADDRESS env var is required for block cap tests');
-        }
-        if (!this.deployer) {
-          throw new Error('DEPLOYER_PRIVATE_KEY env var is required for block cap tests');
-        }
+        const hcuLimit = requireHcuLimit(this.hcuLimit, LOCAL_HCU_LIMIT_ERROR);
+        const deployer = requireDeployer(this.deployer);
         [savedHCUPerBlock, savedMaxHCUPerTx, savedMaxHCUDepthPerTx, wasWhitelisted] = await Promise.all([
-          this.hcuLimit.getGlobalHCUCapPerBlock(),
-          this.hcuLimit.getMaxHCUPerTx(),
-          this.hcuLimit.getMaxHCUDepthPerTx(),
-          this.hcuLimit.isBlockHCUWhitelisted(this.contractAddress),
+          hcuLimit.getGlobalHCUCapPerBlock(),
+          hcuLimit.getMaxHCUPerTx(),
+          hcuLimit.getMaxHCUDepthPerTx(),
+          hcuLimit.isBlockHCUWhitelisted(this.contractAddress),
         ]);
         // Narrowest-first when lowering: hcuPerBlock >= maxHCUPerTx >= maxHCUDepthPerTx
-        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
+        const ownerHcuLimit = hcuLimit.connect(deployer);
         await (await ownerHcuLimit.setMaxHCUDepthPerTx(TIGHT_DEPTH_PER_TX)).wait();
         await (await ownerHcuLimit.setMaxHCUPerTx(TIGHT_MAX_PER_TX)).wait();
         await (await ownerHcuLimit.setHCUPerBlock(TIGHT_PER_BLOCK)).wait();
@@ -196,12 +245,13 @@ describe('EncryptedERC20:HCU', function () {
         await ethers.provider.send('evm_setAutomine', [true]);
         await ethers.provider.send('evm_setIntervalMining', [1]);
 
-        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
+        const hcuLimit = requireHcuLimit(this.hcuLimit, LOCAL_HCU_LIMIT_ERROR);
+        const ownerHcuLimit = hcuLimit.connect(requireDeployer(this.deployer));
         await (await ownerHcuLimit.setHCUPerBlock(savedHCUPerBlock)).wait();
         await (await ownerHcuLimit.setMaxHCUPerTx(savedMaxHCUPerTx)).wait();
         await (await ownerHcuLimit.setMaxHCUDepthPerTx(savedMaxHCUDepthPerTx)).wait();
 
-        const isWhitelisted = await this.hcuLimit.isBlockHCUWhitelisted(this.contractAddress);
+        const isWhitelisted = await hcuLimit.isBlockHCUWhitelisted(this.contractAddress);
         if (wasWhitelisted && !isWhitelisted) {
           await (await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress)).wait();
         } else if (!wasWhitelisted && isWhitelisted) {
@@ -231,7 +281,7 @@ describe('EncryptedERC20:HCU', function () {
         await ethers.provider.send('evm_setIntervalMining', [1]);
 
         const receipt1 = await waitForTransactionReceipt(tx1.hash);
-        expect(receipt1?.status).to.eq(1, 'First transfer should succeed');
+        expect(receipt1.status).to.eq(1, 'First transfer should succeed');
 
         // Use getTransactionReceipt to avoid ethers throwing on reverted tx
         const receipt2 = await ethers.provider.getTransactionReceipt(tx2.hash);
@@ -241,6 +291,7 @@ describe('EncryptedERC20:HCU', function () {
 
       it('should allow previously blocked caller to succeed after block rollover', async function () {
         await mintAndDistribute(this);
+        const hcuLimit = requireHcuLimit(this.hcuLimit, LOCAL_HCU_LIMIT_ERROR);
 
         // Block N: alice fills the cap, bob gets blocked
         await mineNBlocks(1);
@@ -260,7 +311,7 @@ describe('EncryptedERC20:HCU', function () {
         await ethers.provider.send('evm_setIntervalMining', [1]);
 
         const receiptAlice = await waitForTransactionReceipt(txAlice.hash);
-        expect(receiptAlice?.status).to.eq(1, 'Alice should succeed');
+        expect(receiptAlice.status).to.eq(1, 'Alice should succeed');
 
         const receiptBob = await ethers.provider.getTransactionReceipt(txBob.hash);
         expect(receiptBob?.status).to.eq(0, 'Bob should be blocked in block N');
@@ -268,15 +319,17 @@ describe('EncryptedERC20:HCU', function () {
         // Block N+1: meter resets, bob retries and succeeds
         await mineNBlocks(1);
 
-        const [, usedHCUAfterReset] = await this.hcuLimit.getBlockMeter();
+        const [, usedHCUAfterReset] = await hcuLimit.getBlockMeter();
         expect(usedHCUAfterReset).to.eq(0n, 'Meter should reset after new block');
 
         const retryBob = await sendEncryptedTransfer(this, 'bob', this.signers.carol.address, 100);
-        const receiptRetry = await retryBob.wait();
-        expect(receiptRetry?.status).to.eq(1, 'Bob should succeed after rollover');
+        const receiptRetry = requireReceipt(await retryBob.wait(), 'retry transfer');
+        expect(receiptRetry.status).to.eq(1, 'Bob should succeed after rollover');
       });
+
       it('should count HCU after whitelist removal', async function () {
-        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
+        const hcuLimit = requireHcuLimit(this.hcuLimit, LOCAL_HCU_LIMIT_ERROR);
+        const ownerHcuLimit = hcuLimit.connect(requireDeployer(this.deployer));
 
         // Use manual mining (automine=false + explicit evm_mine) to avoid
         // the unreliable automine+intervalMining(0) combo that hangs in CI.
@@ -302,7 +355,7 @@ describe('EncryptedERC20:HCU', function () {
         await ethers.provider.send('evm_mine');
         await waitForTransactionReceipt(tx1.hash);
 
-        const [, usedHCUWhitelisted] = await this.hcuLimit.getBlockMeter();
+        const [, usedHCUWhitelisted] = await hcuLimit.getBlockMeter();
         expect(usedHCUWhitelisted).to.eq(0n, 'Whitelisted contract should not count HCU');
 
         const unwhitelistTx = await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress);
@@ -316,14 +369,15 @@ describe('EncryptedERC20:HCU', function () {
         await ethers.provider.send('evm_mine');
         await waitForTransactionReceipt(tx2.hash);
 
-        const [, usedHCUAfterRemoval] = await this.hcuLimit.getBlockMeter();
+        const [, usedHCUAfterRemoval] = await hcuLimit.getBlockMeter();
         expect(usedHCUAfterRemoval).to.be.greaterThan(0n, 'Should count HCU after whitelist removal');
       });
 
       it('should reject setHCUPerBlock from non-owner', async function () {
-        const aliceHcuLimit = this.hcuLimit.connect(this.signers.alice);
+        const hcuLimit = requireHcuLimit(this.hcuLimit, LOCAL_HCU_LIMIT_ERROR);
+        const aliceHcuLimit = hcuLimit.connect(this.signers.alice);
         await expect(aliceHcuLimit.setHCUPerBlock(1_000_000)).to.be.revertedWithCustomError(
-          this.hcuLimit,
+          hcuLimit,
           'NotHostOwner',
         );
       });

--- a/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
+++ b/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import type { TransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 
 import { createInstances } from '../instance';
@@ -25,6 +24,22 @@ const HCU_LIMIT_ABI = [
 ];
 
 describe('EncryptedERC20:HCU', function () {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function assertWithinConfiguredCaps(hcuLimit: any, receipt: any, label: string) {
+    if (!hcuLimit) {
+      throw new Error('HCU_LIMIT_CONTRACT_ADDRESS env var is required for live HCU block-cap coverage');
+    }
+    const { globalTxHCU, maxTxHCUDepth } = getTxHCUFromTxReceipt(receipt);
+    const [perBlock, maxPerTx, maxDepth] = await Promise.all([
+      hcuLimit.getGlobalHCUCapPerBlock(),
+      hcuLimit.getMaxHCUPerTx(),
+      hcuLimit.getMaxHCUDepthPerTx(),
+    ]);
+    expect(BigInt(globalTxHCU) <= perBlock).to.eq(true, `${label} should stay within the deployed block cap`);
+    expect(BigInt(globalTxHCU) <= maxPerTx).to.eq(true, `${label} should stay within the deployed per-tx cap`);
+    expect(BigInt(maxTxHCUDepth) <= maxDepth).to.eq(true, `${label} should stay within the deployed depth cap`);
+  }
+
   before(async function () {
     await initSigners(2);
     this.signers = await getSigners();
@@ -35,6 +50,8 @@ describe('EncryptedERC20:HCU', function () {
     this.contractAddress = await contract.getAddress();
     this.erc20 = contract;
     this.instances = await createInstances(this.signers);
+    const hcuLimitAddress = process.env.HCU_LIMIT_CONTRACT_ADDRESS;
+    this.hcuLimit = hcuLimitAddress ? new ethers.Contract(hcuLimitAddress, HCU_LIMIT_ABI, ethers.provider) : null;
   });
 
   it('should transfer tokens between two users', async function () {
@@ -57,6 +74,11 @@ describe('EncryptedERC20:HCU', function () {
     console.log('Total HCU in transfer', HCUTransfer);
     console.log('HCU Depth in transfer', HCUMaxDepthTransfer);
     console.log('Native Gas Consumed in transfer', t2.gasUsed);
+
+    if (isLiveNetwork()) {
+      await assertWithinConfiguredCaps(this.hcuLimit, t2, 'transfer');
+      return;
+    }
 
     // Le euint64 (149000) +  TrivialEncrypt euint64 (32) + Select euint64 (55000) + Add euint64 (162000)
     /// + TrivialEncrypt euint64(32) (Initialize balance to 0) + Sub euint euint64 (162000)
@@ -98,6 +120,11 @@ describe('EncryptedERC20:HCU', function () {
     console.log('HCU Depth in transferFrom', HCUMaxDepthTransferFrom);
     console.log('Native Gas Consumed in transferFrom', t3.gasUsed);
 
+    if (isLiveNetwork()) {
+      await assertWithinConfiguredCaps(this.hcuLimit, t3, 'transferFrom');
+      return;
+    }
+
     // Le euint64 (149000) + Le euint64 (149000) + And ebool (34000) + Sub euint64 (162000) + TrivialEncrypt (32) + Select euint64 (55000) +
     // Select euint64 (55000) + Add ebool (25000) + TrivialEncrypt (Initialize balance to 0) (32) + Sub euint64 (162000)
     expect(HCUTransferFrom).to.eq(919_064, 'HCU incorrect');
@@ -108,18 +135,6 @@ describe('EncryptedERC20:HCU', function () {
 
   describe('block cap scenarios', function () {
     const BATCHED_TRANSFER_GAS_LIMIT = 1_000_000;
-    const RECEIPT_TIMEOUT_MS = 300_000;
-    let savedHCUPerBlock: bigint;
-    let savedMaxHCUPerTx: bigint;
-    let savedMaxHCUDepthPerTx: bigint;
-    let wasWhitelisted: boolean;
-
-    async function waitForConfirmedTx(tx: TransactionResponse, label: string) {
-      console.log(`[HCU] waiting ${label} ${tx.hash}`);
-      const receipt = await tx.wait(1, RECEIPT_TIMEOUT_MS);
-      console.log(`[HCU] mined ${label} ${tx.hash} block=${receipt?.blockNumber} status=${receipt?.status}`);
-      return receipt;
-    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async function sendEncryptedTransfer(ctx: any, sender: string, recipient: string, amount: number, overrides?: any) {
@@ -139,53 +154,9 @@ describe('EncryptedERC20:HCU', function () {
     }
 
     before(async function () {
-      const hcuLimitAddress = process.env.HCU_LIMIT_CONTRACT_ADDRESS;
-      if (!hcuLimitAddress) {
-        throw new Error('HCU_LIMIT_CONTRACT_ADDRESS env var is required for block cap tests');
-      }
-      this.hcuLimit = new ethers.Contract(hcuLimitAddress, HCU_LIMIT_ABI, ethers.provider);
-
       const deployerKey = process.env.DEPLOYER_PRIVATE_KEY;
       if (deployerKey) {
         this.deployer = new ethers.Wallet(deployerKey, ethers.provider);
-      }
-    });
-
-    beforeEach(async function () {
-      if (!this.deployer) {
-        if (isLiveNetwork()) {
-          this.skip();
-        }
-        throw new Error('DEPLOYER_PRIVATE_KEY env var is required for block cap tests');
-      }
-      [savedHCUPerBlock, savedMaxHCUPerTx, savedMaxHCUDepthPerTx, wasWhitelisted] = await Promise.all([
-        this.hcuLimit.getGlobalHCUCapPerBlock(),
-        this.hcuLimit.getMaxHCUPerTx(),
-        this.hcuLimit.getMaxHCUDepthPerTx(),
-        this.hcuLimit.isBlockHCUWhitelisted(this.contractAddress),
-      ]);
-    });
-
-    afterEach(async function () {
-      if (!this.deployer) {
-        return;
-      }
-      if (!isLiveNetwork()) {
-        // Restore automine + 1-second interval mining (Anvil --block-time 1)
-        await ethers.provider.send('evm_setAutomine', [true]);
-        await ethers.provider.send('evm_setIntervalMining', [1]);
-      }
-
-      const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
-      await (await ownerHcuLimit.setHCUPerBlock(savedHCUPerBlock)).wait();
-      await (await ownerHcuLimit.setMaxHCUPerTx(savedMaxHCUPerTx)).wait();
-      await (await ownerHcuLimit.setMaxHCUDepthPerTx(savedMaxHCUDepthPerTx)).wait();
-
-      const isWhitelisted = await this.hcuLimit.isBlockHCUWhitelisted(this.contractAddress);
-      if (wasWhitelisted && !isWhitelisted) {
-        await (await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress)).wait();
-      } else if (!wasWhitelisted && isWhitelisted) {
-        await (await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress)).wait();
       }
     });
 
@@ -193,16 +164,49 @@ describe('EncryptedERC20:HCU', function () {
       const TIGHT_DEPTH_PER_TX = 400_000;
       const TIGHT_MAX_PER_TX = 600_000;
       const TIGHT_PER_BLOCK = 600_000;
+      let savedHCUPerBlock: bigint;
+      let savedMaxHCUPerTx: bigint;
+      let savedMaxHCUDepthPerTx: bigint;
+      let wasWhitelisted: boolean;
 
       beforeEach(async function () {
         if (isLiveNetwork()) {
           this.skip();
         }
+        if (!this.hcuLimit) {
+          throw new Error('HCU_LIMIT_CONTRACT_ADDRESS env var is required for block cap tests');
+        }
+        if (!this.deployer) {
+          throw new Error('DEPLOYER_PRIVATE_KEY env var is required for block cap tests');
+        }
+        [savedHCUPerBlock, savedMaxHCUPerTx, savedMaxHCUDepthPerTx, wasWhitelisted] = await Promise.all([
+          this.hcuLimit.getGlobalHCUCapPerBlock(),
+          this.hcuLimit.getMaxHCUPerTx(),
+          this.hcuLimit.getMaxHCUDepthPerTx(),
+          this.hcuLimit.isBlockHCUWhitelisted(this.contractAddress),
+        ]);
         // Narrowest-first when lowering: hcuPerBlock >= maxHCUPerTx >= maxHCUDepthPerTx
         const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
         await (await ownerHcuLimit.setMaxHCUDepthPerTx(TIGHT_DEPTH_PER_TX)).wait();
         await (await ownerHcuLimit.setMaxHCUPerTx(TIGHT_MAX_PER_TX)).wait();
         await (await ownerHcuLimit.setHCUPerBlock(TIGHT_PER_BLOCK)).wait();
+      });
+
+      afterEach(async function () {
+        await ethers.provider.send('evm_setAutomine', [true]);
+        await ethers.provider.send('evm_setIntervalMining', [1]);
+
+        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
+        await (await ownerHcuLimit.setHCUPerBlock(savedHCUPerBlock)).wait();
+        await (await ownerHcuLimit.setMaxHCUPerTx(savedMaxHCUPerTx)).wait();
+        await (await ownerHcuLimit.setMaxHCUDepthPerTx(savedMaxHCUDepthPerTx)).wait();
+
+        const isWhitelisted = await this.hcuLimit.isBlockHCUWhitelisted(this.contractAddress);
+        if (wasWhitelisted && !isWhitelisted) {
+          await (await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress)).wait();
+        } else if (!wasWhitelisted && isWhitelisted) {
+          await (await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress)).wait();
+        }
       });
 
       it('should accumulate HCU across users until the block cap is exhausted', async function () {
@@ -324,36 +328,5 @@ describe('EncryptedERC20:HCU', function () {
         );
       });
     });
-
-    describe('live-network-safe coverage', function () {
-      beforeEach(function () {
-        if (!isLiveNetwork()) {
-          this.skip();
-        }
-      });
-
-      it('should count HCU after whitelist removal', async function () {
-        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
-
-        const mintTx = await this.erc20.mint(10000);
-        const mintReceipt = await waitForConfirmedTx(mintTx, 'mint');
-        expect(mintReceipt?.status).to.eq(1, 'Mint should succeed');
-
-        await (await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress)).wait();
-
-        const whitelistedTransfer = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100);
-        const whitelistedReceipt = await waitForConfirmedTx(whitelistedTransfer, 'whitelisted transfer');
-        const [, usedHCUWhitelisted] = await this.hcuLimit.getBlockMeter({ blockTag: whitelistedReceipt!.blockNumber });
-        expect(usedHCUWhitelisted).to.eq(0n, 'Whitelisted contract should not count HCU');
-
-        await (await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress)).wait();
-
-        const countedTransfer = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100);
-        const countedReceipt = await waitForConfirmedTx(countedTransfer, 'counted transfer');
-        const [, usedHCUAfterRemoval] = await this.hcuLimit.getBlockMeter({ blockTag: countedReceipt!.blockNumber });
-        expect(usedHCUAfterRemoval).to.be.greaterThan(0n, 'Should count HCU after whitelist removal');
-      });
-    });
-
   });
 });

--- a/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
+++ b/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
@@ -3,6 +3,7 @@ import type { TransactionResponse } from 'ethers';
 import { ethers } from 'hardhat';
 
 import { createInstances } from '../instance';
+import { isLiveNetwork } from '../network';
 import { getSigners, initSigners } from '../signers';
 import { getTxHCUFromTxReceipt, mineNBlocks, waitForPendingTransactions, waitForTransactionReceipt } from '../utils';
 import { deployEncryptedERC20Fixture } from './EncryptedERC20.fixture';
@@ -145,13 +146,18 @@ describe('EncryptedERC20:HCU', function () {
       this.hcuLimit = new ethers.Contract(hcuLimitAddress, HCU_LIMIT_ABI, ethers.provider);
 
       const deployerKey = process.env.DEPLOYER_PRIVATE_KEY;
-      if (!deployerKey) {
-        throw new Error('DEPLOYER_PRIVATE_KEY env var is required for block cap tests');
+      if (deployerKey) {
+        this.deployer = new ethers.Wallet(deployerKey, ethers.provider);
       }
-      this.deployer = new ethers.Wallet(deployerKey, ethers.provider);
     });
 
     beforeEach(async function () {
+      if (!this.deployer) {
+        if (isLiveNetwork()) {
+          this.skip();
+        }
+        throw new Error('DEPLOYER_PRIVATE_KEY env var is required for block cap tests');
+      }
       [savedHCUPerBlock, savedMaxHCUPerTx, savedMaxHCUDepthPerTx, wasWhitelisted] = await Promise.all([
         this.hcuLimit.getGlobalHCUCapPerBlock(),
         this.hcuLimit.getMaxHCUPerTx(),
@@ -161,9 +167,14 @@ describe('EncryptedERC20:HCU', function () {
     });
 
     afterEach(async function () {
-      // Restore automine + 1-second interval mining (Anvil --block-time 1)
-      await ethers.provider.send('evm_setAutomine', [true]);
-      await ethers.provider.send('evm_setIntervalMining', [1]);
+      if (!this.deployer) {
+        return;
+      }
+      if (!isLiveNetwork()) {
+        // Restore automine + 1-second interval mining (Anvil --block-time 1)
+        await ethers.provider.send('evm_setAutomine', [true]);
+        await ethers.provider.send('evm_setIntervalMining', [1]);
+      }
 
       const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
       await (await ownerHcuLimit.setHCUPerBlock(savedHCUPerBlock)).wait();
@@ -178,12 +189,15 @@ describe('EncryptedERC20:HCU', function () {
       }
     });
 
-    describe('with lowered limits', function () {
+    describe('local deterministic coverage', function () {
       const TIGHT_DEPTH_PER_TX = 400_000;
       const TIGHT_MAX_PER_TX = 600_000;
       const TIGHT_PER_BLOCK = 600_000;
 
       beforeEach(async function () {
+        if (isLiveNetwork()) {
+          this.skip();
+        }
         // Narrowest-first when lowering: hcuPerBlock >= maxHCUPerTx >= maxHCUDepthPerTx
         const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
         await (await ownerHcuLimit.setMaxHCUDepthPerTx(TIGHT_DEPTH_PER_TX)).wait();
@@ -257,59 +271,89 @@ describe('EncryptedERC20:HCU', function () {
         const receiptRetry = await retryBob.wait();
         expect(receiptRetry?.status).to.eq(1, 'Bob should succeed after rollover');
       });
-    });
+      it('should count HCU after whitelist removal', async function () {
+        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
 
-    it('should count HCU after whitelist removal', async function () {
-      const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
+        // Use manual mining (automine=false + explicit evm_mine) to avoid
+        // the unreliable automine+intervalMining(0) combo that hangs in CI.
+        await ethers.provider.send('evm_setIntervalMining', [0]);
+        await ethers.provider.send('evm_setAutomine', [false]);
 
-      // Use manual mining (automine=false + explicit evm_mine) to avoid
-      // the unreliable automine+intervalMining(0) combo that hangs in CI.
-      await ethers.provider.send('evm_setIntervalMining', [0]);
-      await ethers.provider.send('evm_setAutomine', [false]);
+        const mintTx = await this.erc20.mint(10000);
+        await ethers.provider.send('evm_mine');
+        const mintReceipt = await waitForTransactionReceipt(mintTx.hash);
+        expect(mintReceipt.status).to.eq(1, 'Mint should succeed');
 
-      const mintTx = await this.erc20.mint(10000);
-      await ethers.provider.send('evm_mine');
-      const mintReceipt = await waitForTransactionReceipt(mintTx.hash);
-      expect(mintReceipt.status).to.eq(1, 'Mint should succeed');
+        const whitelistTx = await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress);
+        await ethers.provider.send('evm_mine');
+        await waitForTransactionReceipt(whitelistTx.hash);
 
-      const whitelistTx = await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress);
-      await ethers.provider.send('evm_mine');
-      await waitForTransactionReceipt(whitelistTx.hash);
+        // Advance to a fresh block so the transfer starts with a clean meter
+        await mineNBlocks(1);
 
-      // Advance to a fresh block so the transfer starts with a clean meter
-      await mineNBlocks(1);
+        // Transfer while whitelisted — meter stays at 0
+        const tx1 = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100, {
+          gasLimit: BATCHED_TRANSFER_GAS_LIMIT,
+        });
+        await ethers.provider.send('evm_mine');
+        await waitForTransactionReceipt(tx1.hash);
 
-      // Transfer while whitelisted — meter stays at 0
-      const tx1 = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100, {
-        gasLimit: BATCHED_TRANSFER_GAS_LIMIT,
+        const [, usedHCUWhitelisted] = await this.hcuLimit.getBlockMeter();
+        expect(usedHCUWhitelisted).to.eq(0n, 'Whitelisted contract should not count HCU');
+
+        const unwhitelistTx = await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress);
+        await ethers.provider.send('evm_mine');
+        await waitForTransactionReceipt(unwhitelistTx.hash);
+
+        // Transfer after removal — meter should count HCU
+        const tx2 = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100, {
+          gasLimit: BATCHED_TRANSFER_GAS_LIMIT,
+        });
+        await ethers.provider.send('evm_mine');
+        await waitForTransactionReceipt(tx2.hash);
+
+        const [, usedHCUAfterRemoval] = await this.hcuLimit.getBlockMeter();
+        expect(usedHCUAfterRemoval).to.be.greaterThan(0n, 'Should count HCU after whitelist removal');
       });
-      await ethers.provider.send('evm_mine');
-      await waitForTransactionReceipt(tx1.hash);
 
-      const [, usedHCUWhitelisted] = await this.hcuLimit.getBlockMeter();
-      expect(usedHCUWhitelisted).to.eq(0n, 'Whitelisted contract should not count HCU');
-
-      const unwhitelistTx = await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress);
-      await ethers.provider.send('evm_mine');
-      await waitForTransactionReceipt(unwhitelistTx.hash);
-
-      // Transfer after removal — meter should count HCU
-      const tx2 = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100, {
-        gasLimit: BATCHED_TRANSFER_GAS_LIMIT,
+      it('should reject setHCUPerBlock from non-owner', async function () {
+        const aliceHcuLimit = this.hcuLimit.connect(this.signers.alice);
+        await expect(aliceHcuLimit.setHCUPerBlock(1_000_000)).to.be.revertedWithCustomError(
+          this.hcuLimit,
+          'NotHostOwner',
+        );
       });
-      await ethers.provider.send('evm_mine');
-      await waitForTransactionReceipt(tx2.hash);
-
-      const [, usedHCUAfterRemoval] = await this.hcuLimit.getBlockMeter();
-      expect(usedHCUAfterRemoval).to.be.greaterThan(0n, 'Should count HCU after whitelist removal');
     });
 
-    it('should reject setHCUPerBlock from non-owner', async function () {
-      const aliceHcuLimit = this.hcuLimit.connect(this.signers.alice);
-      await expect(aliceHcuLimit.setHCUPerBlock(1_000_000)).to.be.revertedWithCustomError(
-        this.hcuLimit,
-        'NotHostOwner',
-      );
+    describe('live-network-safe coverage', function () {
+      beforeEach(function () {
+        if (!isLiveNetwork()) {
+          this.skip();
+        }
+      });
+
+      it('should count HCU after whitelist removal', async function () {
+        const ownerHcuLimit = this.hcuLimit.connect(this.deployer);
+
+        const mintTx = await this.erc20.mint(10000);
+        const mintReceipt = await waitForConfirmedTx(mintTx, 'mint');
+        expect(mintReceipt?.status).to.eq(1, 'Mint should succeed');
+
+        await (await ownerHcuLimit.addToBlockHCUWhitelist(this.contractAddress)).wait();
+
+        const whitelistedTransfer = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100);
+        const whitelistedReceipt = await waitForConfirmedTx(whitelistedTransfer, 'whitelisted transfer');
+        const [, usedHCUWhitelisted] = await this.hcuLimit.getBlockMeter({ blockTag: whitelistedReceipt!.blockNumber });
+        expect(usedHCUWhitelisted).to.eq(0n, 'Whitelisted contract should not count HCU');
+
+        await (await ownerHcuLimit.removeFromBlockHCUWhitelist(this.contractAddress)).wait();
+
+        const countedTransfer = await sendEncryptedTransfer(this, 'alice', this.signers.bob.address, 100);
+        const countedReceipt = await waitForConfirmedTx(countedTransfer, 'counted transfer');
+        const [, usedHCUAfterRemoval] = await this.hcuLimit.getBlockMeter({ blockTag: countedReceipt!.blockNumber });
+        expect(usedHCUAfterRemoval).to.be.greaterThan(0n, 'Should count HCU after whitelist removal');
+      });
     });
+
   });
 });

--- a/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
+++ b/test-suite/e2e/test/encryptedERC20/EncryptedERC20.HCU.ts
@@ -29,7 +29,7 @@ const HCU_LIMIT_ABI = [
 
 type HcuLimitContract = {
   connect(runner: ContractRunner): HcuLimitContract;
-  getBlockMeter(): Promise<[bigint, bigint]>;
+  getBlockMeter(overrides?: ReadAtBlock): Promise<[bigint, bigint]>;
   getGlobalHCUCapPerBlock(): Promise<bigint>;
   getMaxHCUPerTx(): Promise<bigint>;
   getMaxHCUDepthPerTx(): Promise<bigint>;
@@ -39,6 +39,10 @@ type HcuLimitContract = {
   addToBlockHCUWhitelist(address: string): Promise<ContractTransactionResponse>;
   removeFromBlockHCUWhitelist(address: string): Promise<ContractTransactionResponse>;
   isBlockHCUWhitelisted(address: string): Promise<boolean>;
+};
+
+type ReadAtBlock = {
+  blockTag?: number | string;
 };
 
 type TransferSender = 'alice' | 'bob';
@@ -87,6 +91,18 @@ describe('EncryptedERC20:HCU', function () {
     expect(BigInt(maxTxHCUDepth) <= maxDepth).to.eq(true, `${label} should stay within the deployed depth cap`);
   }
 
+  async function assertBlockMeterIncludesTransaction(hcuLimit: HcuLimitContract, receipt: TransactionReceipt, label: string) {
+    const { globalTxHCU } = getTxHCUFromTxReceipt(receipt);
+    const [[blockNumber, usedHCU], perBlock] = await Promise.all([
+      hcuLimit.getBlockMeter({ blockTag: receipt.blockNumber }),
+      hcuLimit.getGlobalHCUCapPerBlock(),
+    ]);
+    expect(blockNumber).to.eq(BigInt(receipt.blockNumber), `${label} should read the receipt block meter`);
+    expect(usedHCU).to.be.greaterThan(0n, `${label} should record non-zero HCU in the block meter`);
+    expect(usedHCU >= BigInt(globalTxHCU)).to.eq(true, `${label} block meter should include this tx HCU`);
+    expect(usedHCU <= perBlock).to.eq(true, `${label} block meter should stay within the deployed block cap`);
+  }
+
   before(async function () {
     await initSigners(2);
     this.signers = await getSigners();
@@ -125,7 +141,6 @@ describe('EncryptedERC20:HCU', function () {
     console.log('Native Gas Consumed in transfer', t2.gasUsed);
 
     if (isLiveNetwork()) {
-      await assertWithinConfiguredCaps(requireHcuLimit(this.hcuLimit, LIVE_HCU_LIMIT_ERROR), t2, 'transfer');
       return;
     }
 
@@ -170,7 +185,6 @@ describe('EncryptedERC20:HCU', function () {
     console.log('Native Gas Consumed in transferFrom', t3.gasUsed);
 
     if (isLiveNetwork()) {
-      await assertWithinConfiguredCaps(requireHcuLimit(this.hcuLimit, LIVE_HCU_LIMIT_ERROR), t3, 'transferFrom');
       return;
     }
 
@@ -211,6 +225,60 @@ describe('EncryptedERC20:HCU', function () {
       if (deployerKey) {
         this.deployer = new ethers.Wallet(deployerKey, ethers.provider);
       }
+    });
+
+    describe('live read-only coverage', function () {
+      beforeEach(function () {
+        if (!isLiveNetwork()) {
+          this.skip();
+        }
+      });
+
+      it('should keep transfer HCU within deployed caps', async function () {
+        const mintTx = await this.erc20.mint(10000);
+        await mintTx.wait();
+
+        const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+        input.add64(1337);
+        const encryptedTransferAmount = await input.encrypt();
+        const tx = await this.erc20['transfer(address,bytes32,bytes)'](
+          this.signers.bob.address,
+          encryptedTransferAmount.handles[0],
+          encryptedTransferAmount.inputProof,
+        );
+        const receipt = requireReceipt(await tx.wait(), 'live transfer');
+        const hcuLimit = requireHcuLimit(this.hcuLimit, LIVE_HCU_LIMIT_ERROR);
+        await assertWithinConfiguredCaps(hcuLimit, receipt, 'transfer');
+        await assertBlockMeterIncludesTransaction(hcuLimit, receipt, 'transfer');
+      });
+
+      it('should keep transferFrom HCU within deployed caps', async function () {
+        const mintTx = await this.erc20.mint(10000);
+        await mintTx.wait();
+
+        const inputAlice = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+        inputAlice.add64(1337);
+        const encryptedAllowanceAmount = await inputAlice.encrypt();
+        const approveTx = await this.erc20['approve(address,bytes32,bytes)'](
+          this.signers.bob.address,
+          encryptedAllowanceAmount.handles[0],
+          encryptedAllowanceAmount.inputProof,
+        );
+        await approveTx.wait();
+
+        const bobErc20 = this.erc20.connect(this.signers.bob);
+        const inputBob = this.instances.bob.createEncryptedInput(this.contractAddress, this.signers.bob.address);
+        inputBob.add64(1337);
+        const encryptedTransferAmount = await inputBob.encrypt();
+        const tx = await bobErc20['transferFrom(address,address,bytes32,bytes)'](
+          this.signers.alice.address,
+          this.signers.bob.address,
+          encryptedTransferAmount.handles[0],
+          encryptedTransferAmount.inputProof,
+        );
+        const receipt = requireReceipt(await tx.wait(), 'live transferFrom');
+        await assertWithinConfiguredCaps(requireHcuLimit(this.hcuLimit, LIVE_HCU_LIMIT_ERROR), receipt, 'transferFrom');
+      });
     });
 
     describe('local deterministic coverage', function () {

--- a/test-suite/e2e/test/multiChain/multiChainIsolation.ts
+++ b/test-suite/e2e/test/multiChain/multiChainIsolation.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
 import { createInstance as createHardhatInstance } from '../instance';
+import { isLiveNetwork } from '../network';
 import { getSigners as getHardhatSigners, initSigners } from '../signers';
 import { userDecryptSingleHandle } from '../utils';
 import {
@@ -188,6 +189,10 @@ describe('Multi-Chain State Isolation', function () {
 
   describe('Block Reorg Isolation', function () {
     it('evm_revert on Chain A does not affect Chain B state', async function () {
+      if (isLiveNetwork()) {
+        this.skip();
+      }
+
       const providerB = getProvider(this.chains[1]);
       const erc20A = this.chainA.erc20 as unknown as EncryptedERC20;
       const erc20B = this.chainB.erc20 as unknown as EncryptedERC20;
@@ -225,6 +230,10 @@ describe('Multi-Chain State Isolation', function () {
 
   describe('Chain Halt Isolation', function () {
     it('Chain A halt does not affect Chain B operations', async function () {
+      if (isLiveNetwork()) {
+        this.skip();
+      }
+
       const providerB = getProvider(this.chains[1]);
       const chainABlockBefore = await ethers.provider.getBlockNumber();
 

--- a/test-suite/e2e/test/network.ts
+++ b/test-suite/e2e/test/network.ts
@@ -2,6 +2,6 @@ import { network } from 'hardhat';
 
 const LIVE_NETWORKS = new Set(['devnet', 'devnetNative', 'zwsDev', 'sepolia', 'mainnet']);
 
-export const activeNetworkName = () => process.env.NETWORK ?? process.env.HARDHAT_NETWORK ?? network.name;
+export const activeNetworkName = () => network.name;
 
 export const isLiveNetwork = () => LIVE_NETWORKS.has(activeNetworkName());

--- a/test-suite/e2e/test/network.ts
+++ b/test-suite/e2e/test/network.ts
@@ -1,0 +1,7 @@
+import { network } from 'hardhat';
+
+const LIVE_NETWORKS = new Set(['devnet', 'devnetNative', 'zwsDev', 'sepolia', 'mainnet']);
+
+export const activeNetworkName = () => process.env.NETWORK ?? process.env.HARDHAT_NETWORK ?? network.name;
+
+export const isLiveNetwork = () => LIVE_NETWORKS.has(activeNetworkName());

--- a/test-suite/e2e/test/rand/Rand.ts
+++ b/test-suite/e2e/test/rand/Rand.ts
@@ -277,67 +277,69 @@ describe('Rand', function () {
   });
 
   it('8 and 16 bits generate and decrypt with hardhat snapshots [skip-on-coverage]', async function () {
-    if (network.name === 'hardhat') {
-      // snapshots are only possible in hardhat node, i.e in mocked mode
-      this.snapshotId = await ethers.provider.send('evm_snapshot');
-      const values: number[] = [];
-      for (let i = 0; i < 5; i++) {
-        const txn = await this.rand.generate8();
-        await txn.wait();
-        const valueHandle = (await this.rand.value8()) as `0x${string}`;
-        const res = await this.instances.alice.publicDecrypt([valueHandle]);
-        const value = res.clearValues[valueHandle] as bigint;
-        expect(typeof value).to.eq('bigint');
-        const valueNum = Number(value);
-        expect(valueNum).to.be.lessThanOrEqual(0xff);
-        values.push(valueNum);
-      }
-      // Expect at least two different generated values.
-      const unique = new Set(values);
-      expect(unique.size).to.be.greaterThanOrEqual(2);
-
-      await ethers.provider.send('evm_revert', [this.snapshotId]);
-      this.snapshotId = await ethers.provider.send('evm_snapshot');
-
-      const values2: number[] = [];
-      for (let i = 0; i < 5; i++) {
-        const txn = await this.rand.generate8();
-        await txn.wait();
-        const valueHandle = (await this.rand.value8()) as `0x${string}`;
-        const res = await this.instances.alice.publicDecrypt([valueHandle]);
-        const value = res.clearValues[valueHandle] as bigint;
-        expect(typeof value).to.eq('bigint');
-        const valueNum = Number(value);
-        expect(valueNum).to.be.lessThanOrEqual(0xff);
-        values2.push(valueNum);
-      }
-      // Expect at least two different generated values.
-      const unique2 = new Set(values2);
-      expect(unique2.size).to.be.greaterThanOrEqual(2);
-
-      await ethers.provider.send('evm_revert', [this.snapshotId]);
-      const values3: number[] = [];
-      let has16bit: boolean = false;
-      for (let i = 0; i < 5; i++) {
-        const txn = await this.rand.generate16();
-        await txn.wait();
-        const valueHandle = (await this.rand.value16()) as `0x${string}`;
-        const res = await this.instances.alice.publicDecrypt([valueHandle]);
-        const value = res.clearValues[valueHandle] as bigint;
-        expect(typeof value).to.eq('bigint');
-        const valueNum = Number(value);
-        expect(valueNum).to.be.lessThanOrEqual(0xffff);
-        if (valueNum > 0xff) {
-          has16bit = true;
-        }
-        values3.push(valueNum);
-      }
-      // Make sure we actually generate 16 bit integers.
-      expect(has16bit).to.be.true;
-      // Expect at least two different generated values.
-      const unique3 = new Set(values3);
-      expect(unique3.size).to.be.greaterThanOrEqual(2);
+    if (network.name !== 'hardhat') {
+      this.skip();
     }
+
+    // snapshots are only possible in hardhat node, i.e in mocked mode
+    this.snapshotId = await ethers.provider.send('evm_snapshot');
+    const values: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const txn = await this.rand.generate8();
+      await txn.wait();
+      const valueHandle = (await this.rand.value8()) as `0x${string}`;
+      const res = await this.instances.alice.publicDecrypt([valueHandle]);
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(0xff);
+      values.push(valueNum);
+    }
+    // Expect at least two different generated values.
+    const unique = new Set(values);
+    expect(unique.size).to.be.greaterThanOrEqual(2);
+
+    await ethers.provider.send('evm_revert', [this.snapshotId]);
+    this.snapshotId = await ethers.provider.send('evm_snapshot');
+
+    const values2: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const txn = await this.rand.generate8();
+      await txn.wait();
+      const valueHandle = (await this.rand.value8()) as `0x${string}`;
+      const res = await this.instances.alice.publicDecrypt([valueHandle]);
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(0xff);
+      values2.push(valueNum);
+    }
+    // Expect at least two different generated values.
+    const unique2 = new Set(values2);
+    expect(unique2.size).to.be.greaterThanOrEqual(2);
+
+    await ethers.provider.send('evm_revert', [this.snapshotId]);
+    const values3: number[] = [];
+    let has16bit: boolean = false;
+    for (let i = 0; i < 5; i++) {
+      const txn = await this.rand.generate16();
+      await txn.wait();
+      const valueHandle = (await this.rand.value16()) as `0x${string}`;
+      const res = await this.instances.alice.publicDecrypt([valueHandle]);
+      const value = res.clearValues[valueHandle] as bigint;
+      expect(typeof value).to.eq('bigint');
+      const valueNum = Number(value);
+      expect(valueNum).to.be.lessThanOrEqual(0xffff);
+      if (valueNum > 0xff) {
+        has16bit = true;
+      }
+      values3.push(valueNum);
+    }
+    // Make sure we actually generate 16 bit integers.
+    expect(has16bit).to.be.true;
+    // Expect at least two different generated values.
+    const unique3 = new Set(values3);
+    expect(unique3.size).to.be.greaterThanOrEqual(2);
   });
 
   it('generating rand in reverting sub-call', async function () {

--- a/test-suite/e2e/test/utils.ts
+++ b/test-suite/e2e/test/utils.ts
@@ -8,9 +8,8 @@ import { Signer } from 'ethers';
 import { ethers, network } from 'hardhat';
 import hre from 'hardhat';
 
+import { coprocessorAddress } from './instance';
 import { TypedContractMethod } from '../types/common';
-
-const coprocAddress = process.env.FHEVM_EXECUTOR_CONTRACT_ADDRESS;
 
 export async function checkIsHardhatSigner(signer: HardhatEthersSigner) {
   const signers: HardhatEthersSigner[] = await hre.ethers.getSigners();
@@ -287,9 +286,9 @@ export function getTxHCUFromTxReceipt(
   let hcuMap: Record<string, number> = {};
   let handleSet: Set<string> = new Set();
 
-  const contract = new ethers.Contract(coprocAddress!, abi, ethers.provider);
+  const contract = new ethers.Contract(coprocessorAddress, abi, ethers.provider);
   const relevantLogs = receipt.logs.filter((log: Log) => {
-    if (log.address.toLowerCase() !== coprocAddress!.toLowerCase()) {
+    if (log.address.toLowerCase() !== coprocessorAddress.toLowerCase()) {
       return false;
     }
     try {


### PR DESCRIPTION
## Summary
- keep the deterministic local-only HCU block-cap tests as the strong coverage path
- make the live HCU path non-mutating by checking that standard encrypted transfers stay within the deployed caps
- make delegated-expiry work on both local and live networks with a short real expiry instead of time travel

## Details
This PR keeps the split small and explicit:
- local: strong deterministic tests where we need them
- live networks: weaker but still useful non-mutating checks where mutation is not acceptable

Changes in this PR:
- add a tiny `test/network.ts` helper to classify live networks
- for HCU:
  - local-only block-cap tests still mutate local config and use local mining controls
  - live-network coverage no longer writes shared contract state
  - live-network coverage verifies that real encrypted `transfer` / `transferFrom` calls stay within the currently deployed caps
- for delegated expiry:
  - remove the stale 1-hour/time-travel assumption
  - use a short real expiry and wait for chain time to pass on both local and live networks

## Validation
- `bash -n test-suite/e2e/run-tests.sh`
- `git diff --check`

## Notes
The full e2e package toolchain is not installed in this checkout, so Hardhat-based execution and package-level formatter/typechecker runs could not be completed locally here.

closes https://github.com/zama-ai/fhevm-internal/issues/1246
