### PR TITLE
chore(coprocessor): multi copro listener chart updates

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.9.0
+version: 0.10.0
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/templates/_helpers.tpl
+++ b/charts/coprocessor/templates/_helpers.tpl
@@ -5,17 +5,69 @@
 
 {{- define "hostListenerName" -}}
 {{- $hostListenerNameDefault := printf "%s-%s" .Release.Name "host-listener" }}
-{{- default $hostListenerNameDefault .Values.hostListener.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default $hostListenerNameDefault .Values.hostListenerShared.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "hostListenerPollerName" -}}
 {{- $hostListenerPollerNameDefault := printf "%s-%s" .Release.Name "host-listener-poller" }}
-{{- default $hostListenerPollerNameDefault .Values.hostListenerPoller.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default $hostListenerPollerNameDefault .Values.hostListenerPollerShared.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "hostListenerCatchupOnlyName" -}}
 {{- $hostListenerCatchupOnlyNameDefault := printf "%s-%s" .Release.Name "host-listener-catchup-only" }}
-{{- default $hostListenerCatchupOnlyNameDefault .Values.hostListenerCatchupOnly.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default $hostListenerCatchupOnlyNameDefault .Values.hostListenerCatchupOnlyShared.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "coprocessor.failIfDeprecatedTopLevelListenerKeysPresent" -}}
+{{- $deprecatedKeys := list -}}
+{{- if hasKey .Values "hostListener" -}}
+  {{- $deprecatedKeys = append $deprecatedKeys "hostListener" -}}
+{{- end -}}
+{{- if hasKey .Values "hostListenerPoller" -}}
+  {{- $deprecatedKeys = append $deprecatedKeys "hostListenerPoller" -}}
+{{- end -}}
+{{- if hasKey .Values "hostListenerCatchupOnly" -}}
+  {{- $deprecatedKeys = append $deprecatedKeys "hostListenerCatchupOnly" -}}
+{{- end -}}
+{{- if gt (len $deprecatedKeys) 0 -}}
+{{- fail (printf "deprecated top-level listener keys are no longer supported: %s. Use hostListenerShared / hostListenerPollerShared / hostListenerCatchupOnlyShared plus .Values.chains instead" (join ", " $deprecatedKeys)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "coprocessor.failIfMultipleLegacyNameClaims" -}}
+{{- $componentKey := .componentKey -}}
+{{- $claims := 0 -}}
+{{- range $chain := .root.Values.chains -}}
+  {{- if and (hasKey $chain $componentKey) ((index $chain $componentKey).useLegacyName | default false) -}}
+    {{- $claims = add1 $claims -}}
+  {{- end -}}
+{{- end -}}
+{{- if gt $claims 1 -}}
+{{- fail (printf "only one chains entry may set %s.useLegacyName=true" $componentKey) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "coprocessor.renderChainEnvValue" -}}
+{{- $name := .name -}}
+{{- $value := .value -}}
+{{- $valueFrom := .valueFrom -}}
+{{- $fieldName := .fieldName -}}
+{{- $chainName := .chainName -}}
+{{- $hasValue := not (empty $value) -}}
+{{- $hasValueFrom := not (empty $valueFrom) -}}
+{{- if and $hasValue $hasValueFrom -}}
+{{- fail (printf "chains entry %q: only one of %s or %sValueFrom may be set" $chainName $fieldName $fieldName) -}}
+{{- end -}}
+{{- if not (or $hasValue $hasValueFrom) -}}
+{{- fail (printf "chains entry %q: %s or %sValueFrom is required" $chainName $fieldName $fieldName) -}}
+{{- end -}}
+- name: {{ $name }}
+{{- if $hasValue }}
+  value: {{ $value | quote }}
+{{- else }}
+  valueFrom:
+{{ toYaml $valueFrom | nindent 4 }}
+{{- end }}
 {{- end -}}
 
 {{- define "txSenderName" -}}

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-deployment.yaml
@@ -1,7 +1,9 @@
 {{- range $i, $chain := .Values.chains }}
 {{- if (($chain.hostListenerCatchupOnly).enabled) }}
-{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) (eq $i 0) -}}
+{{- $useLegacyName := $chain.hostListenerCatchupOnly.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) $useLegacyName -}}
+{{- $serviceName := coalesce $chain.hostListenerCatchupOnly.serviceName $.Values.hostListenerCatchupOnlyShared.args.serviceName (printf "host-listener-catchup-only-%s" $chain.name) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11,13 +13,13 @@ metadata:
     app.kubernetes.io/name: {{ $deploymentName }}
   name: {{ $deploymentName }}
 spec:
-  replicas: {{ $.Values.hostListenerCatchupOnly.replicas }}
+  replicas: {{ $.Values.hostListenerCatchupOnlyShared.replicas }}
   selector:
     matchLabels:
       app: {{ $appLabel }}
-  {{- if $.Values.hostListenerCatchupOnly.updateStrategy }}
+  {{- if $.Values.hostListenerCatchupOnlyShared.updateStrategy }}
   strategy:
-    {{- toYaml $.Values.hostListenerCatchupOnly.updateStrategy | nindent 4 }}
+    {{- toYaml $.Values.hostListenerCatchupOnlyShared.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -35,45 +37,45 @@ spec:
       imagePullSecrets:
         - name: registry-credentials
       restartPolicy: Always
-      {{- with $.Values.hostListenerCatchupOnly.nodeSelector }}
+      {{- with $.Values.hostListenerCatchupOnlyShared.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.hostListenerCatchupOnly.affinity }}
+      {{- with $.Values.hostListenerCatchupOnlyShared.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.hostListenerCatchupOnly.tolerations }}
+      {{- with $.Values.hostListenerCatchupOnlyShared.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $.Values.hostListenerCatchupOnly.serviceAccountName }}
-      serviceAccountName: {{ $.Values.hostListenerCatchupOnly.serviceAccountName }}
+      {{- if $.Values.hostListenerCatchupOnlyShared.serviceAccountName }}
+      serviceAccountName: {{ $.Values.hostListenerCatchupOnlyShared.serviceAccountName }}
       {{- end }}
       containers:
         - name: coprocessor-host-listener-catchup-only
-          image: {{ $.Values.hostListenerCatchupOnly.image.name }}:{{ $.Values.hostListenerCatchupOnly.image.tag }}
+          image: {{ $.Values.hostListenerCatchupOnlyShared.image.name }}:{{ $.Values.hostListenerCatchupOnlyShared.image.tag }}
           command: ["host_listener"]
           args:
             - --database-url=$(DATABASE_URL)
             - --url=$(ETHEREUM_RPC_URL)
             - --acl-contract-address=$(ACL_CONTRACT_ADDRESS)
             - --tfhe-contract-address=$(FHEVM_EXECUTOR_CONTRACT_ADDRESS)
-            - --health-port={{ $.Values.hostListenerCatchupOnly.ports.healthcheck }}
+            - --health-port={{ $.Values.hostListenerCatchupOnlyShared.ports.healthcheck }}
             - --dependent-ops-max-per-chain={{ int $.Values.commonConfig.dependentOpsMaxPerChain }}
-            - --log-level={{ $.Values.hostListenerCatchupOnly.args.logLevel }}
-            - --initial-block-time={{ $.Values.hostListenerCatchupOnly.args.initialBlockTime }}
-            - --dependence-cache-size={{ $.Values.hostListenerCatchupOnly.args.dependenceCacheSize }}
-            - --reorg-maximum-duration-in-blocks={{ $.Values.hostListenerCatchupOnly.args.reorgMaximumDurationInBlocks }}
-            - --service-name=host-listener-catchup-only-{{ $chain.name }}
-            - --catchup-finalization-in-blocks={{ $.Values.hostListenerCatchupOnly.args.catchupFinalizationInBlocks }}
-            {{- if $.Values.hostListenerCatchupOnly.args.onlyCatchupLoop }}
+            - --log-level={{ $.Values.hostListenerCatchupOnlyShared.args.logLevel }}
+            - --initial-block-time={{ $.Values.hostListenerCatchupOnlyShared.args.initialBlockTime }}
+            - --dependence-cache-size={{ $.Values.hostListenerCatchupOnlyShared.args.dependenceCacheSize }}
+            - --reorg-maximum-duration-in-blocks={{ $.Values.hostListenerCatchupOnlyShared.args.reorgMaximumDurationInBlocks }}
+            - --service-name={{ $serviceName }}
+            - --catchup-finalization-in-blocks={{ $.Values.hostListenerCatchupOnlyShared.args.catchupFinalizationInBlocks }}
+            {{- if $.Values.hostListenerCatchupOnlyShared.args.onlyCatchupLoop }}
             - --only-catchup-loop
             {{- end }}
-            - --end-at-block={{ $.Values.hostListenerCatchupOnly.args.endAtBlock }}
-            - --catchup-loop-sleep-secs={{ $.Values.hostListenerCatchupOnly.args.catchupLoopSleepSecs }}
+            - --end-at-block={{ $.Values.hostListenerCatchupOnlyShared.args.endAtBlock }}
+            - --catchup-loop-sleep-secs={{ $.Values.hostListenerCatchupOnlyShared.args.catchupLoopSleepSecs }}
             - --coprocessor-api-key=$(TENANT_API_KEY)
-            {{- with $.Values.hostListenerCatchupOnly.extraArgs }}
+            {{- with $.Values.hostListenerCatchupOnlyShared.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with $chain.hostListenerCatchupOnly.extraArgs }}
@@ -82,13 +84,12 @@ spec:
           env:
             - name: DATABASE_URL
               value: {{ $.Values.commonConfig.databaseUrl | quote }}
-            - name: ETHEREUM_RPC_URL
-              value: {{ required (printf "chains entry %q: wsUrl is required" $chain.name) $chain.wsUrl | quote }}
+            {{- include "coprocessor.renderChainEnvValue" (dict "name" "ETHEREUM_RPC_URL" "value" $chain.wsUrl "valueFrom" $chain.wsUrlValueFrom "fieldName" "wsUrl" "chainName" $chain.name) | nindent 12 }}
             - name: ACL_CONTRACT_ADDRESS
               value: {{ required (printf "chains entry %q: aclContractAddress is required" $chain.name) $chain.aclContractAddress | quote }}
             - name: FHEVM_EXECUTOR_CONTRACT_ADDRESS
               value: {{ required (printf "chains entry %q: fhevmExecutorContractAddress is required" $chain.name) $chain.fhevmExecutorContractAddress | quote }}
-          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerCatchupOnly.tracing.enabled }}
+          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerCatchupOnlyShared.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ $.Values.commonConfig.tracing.endpoint | quote }}
             - name: OTEL_SERVICE_NAME
@@ -99,32 +100,32 @@ spec:
           {{- with $.Values.commonConfig.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $.Values.hostListenerCatchupOnly.env }}
+          {{- with $.Values.hostListenerCatchupOnlyShared.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $chain.hostListenerCatchupOnly.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $portName, $portValue := $.Values.hostListenerCatchupOnly.ports }}
+            {{- range $portName, $portValue := $.Values.hostListenerCatchupOnlyShared.ports }}
             - name: {{ $portName }}
               containerPort: {{ $portValue }}
               protocol: TCP
             {{- end }}
           resources:
             requests:
-              cpu: {{ $.Values.hostListenerCatchupOnly.resources.requests.cpu | default "100m" }}
-              memory: {{ $.Values.hostListenerCatchupOnly.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.hostListenerCatchupOnlyShared.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.hostListenerCatchupOnlyShared.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ $.Values.hostListenerCatchupOnly.resources.limits.cpu | default "500m" }}
-              memory: {{ $.Values.hostListenerCatchupOnly.resources.limits.memory | default "512Mi" }}
-          {{- if and $.Values.hostListenerCatchupOnly.probes $.Values.hostListenerCatchupOnly.probes.liveness.enabled }}
+              cpu: {{ $.Values.hostListenerCatchupOnlyShared.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.hostListenerCatchupOnlyShared.resources.limits.memory | default "512Mi" }}
+          {{- if and $.Values.hostListenerCatchupOnlyShared.probes $.Values.hostListenerCatchupOnlyShared.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml (omit $.Values.hostListenerCatchupOnly.probes.liveness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerCatchupOnlyShared.probes.liveness "enabled") | nindent 12 }}
           {{- end }}
-          {{- if and $.Values.hostListenerCatchupOnly.probes $.Values.hostListenerCatchupOnly.probes.readiness.enabled }}
+          {{- if and $.Values.hostListenerCatchupOnlyShared.probes $.Values.hostListenerCatchupOnlyShared.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml (omit $.Values.hostListenerCatchupOnly.probes.readiness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerCatchupOnlyShared.probes.readiness "enabled") | nindent 12 }}
           {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-deployment.yaml
@@ -1,29 +1,33 @@
-{{- if .Values.hostListenerCatchupOnly.enabled -}}
+{{- range $i, $chain := .Values.chains }}
+{{- if (($chain.hostListenerCatchupOnly).enabled) }}
+{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: coprocessor-host-listener-catchup-only
-    app.kubernetes.io/name: {{ include "hostListenerCatchupOnlyName" . }}
-  name: {{ include "hostListenerCatchupOnlyName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
-  replicas: {{ .Values.hostListenerCatchupOnly.replicas }}
+  replicas: {{ $.Values.hostListenerCatchupOnly.replicas }}
   selector:
     matchLabels:
-      app: coprocessor-host-listener-catchup-only
-  {{- if .Values.hostListenerCatchupOnly.updateStrategy }}
+      app: {{ $appLabel }}
+  {{- if $.Values.hostListenerCatchupOnly.updateStrategy }}
   strategy:
-    {{- toYaml .Values.hostListenerCatchupOnly.updateStrategy | nindent 4 }}
+    {{- toYaml $.Values.hostListenerCatchupOnly.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
       labels:
-        app: coprocessor-host-listener-catchup-only
-        app.kubernetes.io/name: {{ include "hostListenerCatchupOnlyName" . }}
-        {{- with .Values.podLabels }}
+        app: {{ $appLabel }}
+        app.kubernetes.io/name: {{ $deploymentName }}
+        {{- with $.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with $.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,89 +35,96 @@ spec:
       imagePullSecrets:
         - name: registry-credentials
       restartPolicy: Always
-      {{- with .Values.hostListenerCatchupOnly.nodeSelector }}
+      {{- with $.Values.hostListenerCatchupOnly.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.hostListenerCatchupOnly.affinity }}
+      {{- with $.Values.hostListenerCatchupOnly.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.hostListenerCatchupOnly.tolerations }}
+      {{- with $.Values.hostListenerCatchupOnly.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.hostListenerCatchupOnly.serviceAccountName }}
-      serviceAccountName: {{ .Values.hostListenerCatchupOnly.serviceAccountName }}
+      {{- if $.Values.hostListenerCatchupOnly.serviceAccountName }}
+      serviceAccountName: {{ $.Values.hostListenerCatchupOnly.serviceAccountName }}
       {{- end }}
       containers:
         - name: coprocessor-host-listener-catchup-only
-          image: {{ .Values.hostListenerCatchupOnly.image.name }}:{{ .Values.hostListenerCatchupOnly.image.tag }}
+          image: {{ $.Values.hostListenerCatchupOnly.image.name }}:{{ $.Values.hostListenerCatchupOnly.image.tag }}
           command: ["host_listener"]
           args:
             - --database-url=$(DATABASE_URL)
             - --url=$(ETHEREUM_RPC_URL)
             - --acl-contract-address=$(ACL_CONTRACT_ADDRESS)
             - --tfhe-contract-address=$(FHEVM_EXECUTOR_CONTRACT_ADDRESS)
-            - --health-port={{ .Values.hostListenerCatchupOnly.ports.healthcheck }}
-            - --dependent-ops-max-per-chain={{ int .Values.commonConfig.dependentOpsMaxPerChain }}
-            - --log-level={{ .Values.hostListenerCatchupOnly.args.logLevel }}
-            - --initial-block-time={{ .Values.hostListenerCatchupOnly.args.initialBlockTime }}
-            - --dependence-cache-size={{ .Values.hostListenerCatchupOnly.args.dependenceCacheSize }}
-            - --reorg-maximum-duration-in-blocks={{ .Values.hostListenerCatchupOnly.args.reorgMaximumDurationInBlocks }}
-            - --service-name={{ .Values.hostListenerCatchupOnly.args.serviceName }}
-            - --catchup-finalization-in-blocks={{ .Values.hostListenerCatchupOnly.args.catchupFinalizationInBlocks }}
-            {{- if .Values.hostListenerCatchupOnly.args.onlyCatchupLoop }}
+            - --health-port={{ $.Values.hostListenerCatchupOnly.ports.healthcheck }}
+            - --dependent-ops-max-per-chain={{ int $.Values.commonConfig.dependentOpsMaxPerChain }}
+            - --log-level={{ $.Values.hostListenerCatchupOnly.args.logLevel }}
+            - --initial-block-time={{ $.Values.hostListenerCatchupOnly.args.initialBlockTime }}
+            - --dependence-cache-size={{ $.Values.hostListenerCatchupOnly.args.dependenceCacheSize }}
+            - --reorg-maximum-duration-in-blocks={{ $.Values.hostListenerCatchupOnly.args.reorgMaximumDurationInBlocks }}
+            - --service-name=host-listener-catchup-only-{{ $chain.name }}
+            - --catchup-finalization-in-blocks={{ $.Values.hostListenerCatchupOnly.args.catchupFinalizationInBlocks }}
+            {{- if $.Values.hostListenerCatchupOnly.args.onlyCatchupLoop }}
             - --only-catchup-loop
             {{- end }}
-            - --end-at-block={{ .Values.hostListenerCatchupOnly.args.endAtBlock }}
-            - --catchup-loop-sleep-secs={{ .Values.hostListenerCatchupOnly.args.catchupLoopSleepSecs }}
+            - --end-at-block={{ $.Values.hostListenerCatchupOnly.args.endAtBlock }}
+            - --catchup-loop-sleep-secs={{ $.Values.hostListenerCatchupOnly.args.catchupLoopSleepSecs }}
             - --coprocessor-api-key=$(TENANT_API_KEY)
-            {{- with .Values.hostListenerCatchupOnly.extraArgs }}
+            {{- with $.Values.hostListenerCatchupOnly.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $chain.hostListenerCatchupOnly.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: DATABASE_URL
-              value: {{ .Values.commonConfig.databaseUrl | quote }}
+              value: {{ $.Values.commonConfig.databaseUrl | quote }}
             - name: ETHEREUM_RPC_URL
-              value: {{ .Values.commonConfig.hostChainWsUrl | quote }}
+              value: {{ required (printf "chains entry %q: wsUrl is required" $chain.name) $chain.wsUrl | quote }}
             - name: ACL_CONTRACT_ADDRESS
-              value: {{ required "commonConfig.aclContractAddress is required" .Values.commonConfig.aclContractAddress | quote }}
+              value: {{ required (printf "chains entry %q: aclContractAddress is required" $chain.name) $chain.aclContractAddress | quote }}
             - name: FHEVM_EXECUTOR_CONTRACT_ADDRESS
-              value: {{ required "commonConfig.fhevmExecutorContractAddress is required" .Values.commonConfig.fhevmExecutorContractAddress | quote }}
-          {{- if default .Values.commonConfig.tracing.enabled .Values.hostListenerCatchupOnly.tracing.enabled }}
+              value: {{ required (printf "chains entry %q: fhevmExecutorContractAddress is required" $chain.name) $chain.fhevmExecutorContractAddress | quote }}
+          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerCatchupOnly.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.commonConfig.tracing.endpoint | quote }}
+              value: {{ $.Values.commonConfig.tracing.endpoint | quote }}
             - name: OTEL_SERVICE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
           {{- end }}
-          {{- with .Values.commonConfig.env }}
+          {{- with $.Values.commonConfig.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.hostListenerCatchupOnly.env }}
+          {{- with $.Values.hostListenerCatchupOnly.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $chain.hostListenerCatchupOnly.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $portName, $portValue := .Values.hostListenerCatchupOnly.ports }}
+            {{- range $portName, $portValue := $.Values.hostListenerCatchupOnly.ports }}
             - name: {{ $portName }}
               containerPort: {{ $portValue }}
               protocol: TCP
             {{- end }}
           resources:
             requests:
-              cpu: {{ .Values.hostListenerCatchupOnly.resources.requests.cpu | default "100m" }}
-              memory: {{ .Values.hostListenerCatchupOnly.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.hostListenerCatchupOnly.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.hostListenerCatchupOnly.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ .Values.hostListenerCatchupOnly.resources.limits.cpu | default "500m" }}
-              memory: {{ .Values.hostListenerCatchupOnly.resources.limits.memory | default "512Mi" }}
-          {{- if and .Values.hostListenerCatchupOnly.probes .Values.hostListenerCatchupOnly.probes.liveness.enabled }}
+              cpu: {{ $.Values.hostListenerCatchupOnly.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.hostListenerCatchupOnly.resources.limits.memory | default "512Mi" }}
+          {{- if and $.Values.hostListenerCatchupOnly.probes $.Values.hostListenerCatchupOnly.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml (omit .Values.hostListenerCatchupOnly.probes.liveness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerCatchupOnly.probes.liveness "enabled") | nindent 12 }}
           {{- end }}
-          {{- if and .Values.hostListenerCatchupOnly.probes .Values.hostListenerCatchupOnly.probes.readiness.enabled }}
+          {{- if and $.Values.hostListenerCatchupOnly.probes $.Values.hostListenerCatchupOnly.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml (omit .Values.hostListenerCatchupOnly.probes.readiness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerCatchupOnly.probes.readiness "enabled") | nindent 12 }}
           {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service-monitor.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service-monitor.yaml
@@ -1,7 +1,8 @@
 {{- range $i, $chain := .Values.chains }}
-{{- if and (($chain.hostListenerCatchupOnly).enabled) $.Values.hostListenerCatchupOnly.serviceMonitor.enabled }}
-{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) (eq $i 0) -}}
+{{- if and (($chain.hostListenerCatchupOnly).enabled) $.Values.hostListenerCatchupOnlyShared.serviceMonitor.enabled }}
+{{- $useLegacyName := $chain.hostListenerCatchupOnly.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) $useLegacyName -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service-monitor.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service-monitor.yaml
@@ -1,16 +1,21 @@
-{{- if .Values.hostListenerCatchupOnly.serviceMonitor.enabled -}}
+{{- range $i, $chain := .Values.chains }}
+{{- if and (($chain.hostListenerCatchupOnly).enabled) $.Values.hostListenerCatchupOnly.serviceMonitor.enabled }}
+{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: coprocessor-host-listener-catchup-only
-    app.kubernetes.io/name: {{ include "hostListenerCatchupOnlyName" . }}
-  name: {{ include "hostListenerCatchupOnlyName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
   selector:
     matchLabels:
-      app: coprocessor-host-listener-catchup-only
-      app.kubernetes.io/name: {{ include "hostListenerCatchupOnlyName" . }}
+      app: {{ $appLabel }}
+      app.kubernetes.io/name: {{ $deploymentName }}
   endpoints:
   - port: metrics
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service.yaml
@@ -1,7 +1,8 @@
 {{- range $i, $chain := .Values.chains }}
 {{- if (($chain.hostListenerCatchupOnly).enabled) }}
-{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) (eq $i 0) -}}
+{{- $useLegacyName := $chain.hostListenerCatchupOnly.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) $useLegacyName -}}
 ---
 apiVersion: v1
 kind: Service
@@ -13,10 +14,10 @@ metadata:
 spec:
   ports:
     - name: metrics
-      port: {{ $.Values.hostListenerCatchupOnly.ports.metrics }}
+      port: {{ $.Values.hostListenerCatchupOnlyShared.ports.metrics }}
       targetPort: metrics
     - name: healthcheck
-      port: {{ $.Values.hostListenerCatchupOnly.ports.healthcheck }}
+      port: {{ $.Values.hostListenerCatchupOnlyShared.ports.healthcheck }}
       targetPort: healthcheck
   selector:
     app: {{ $appLabel }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-service.yaml
@@ -1,21 +1,26 @@
-{{- if .Values.hostListenerCatchupOnly.enabled }}
+{{- range $i, $chain := .Values.chains }}
+{{- if (($chain.hostListenerCatchupOnly).enabled) }}
+{{- $deploymentName := ternary (printf "%s-host-listener-catchup-only" $.Release.Name) (printf "%s-host-listener-catchup-only-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener-catchup-only" (printf "coprocessor-host-listener-catchup-only-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: coprocessor-host-listener-catchup-only
-    app.kubernetes.io/name: {{ include "hostListenerCatchupOnlyName" . }}
-  name: {{ include "hostListenerCatchupOnlyName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
   ports:
     - name: metrics
-      port: {{ .Values.hostListenerCatchupOnly.ports.metrics }}
+      port: {{ $.Values.hostListenerCatchupOnly.ports.metrics }}
       targetPort: metrics
     - name: healthcheck
-      port: {{ .Values.hostListenerCatchupOnly.ports.healthcheck }}
+      port: {{ $.Values.hostListenerCatchupOnly.ports.healthcheck }}
       targetPort: healthcheck
   selector:
-    app: coprocessor-host-listener-catchup-only
-    app.kubernetes.io/name: {{ include "hostListenerCatchupOnlyName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
   type: ClusterIP
+{{- end }}
 {{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-deployment.yaml
@@ -1,29 +1,33 @@
-{{- if .Values.hostListener.enabled -}}
+{{- range $i, $chain := .Values.chains }}
+{{- if (($chain.hostListener).enabled) }}
+{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: coprocessor-host-listener
-    app.kubernetes.io/name: {{ include "hostListenerName" . }}
-  name: {{ include "hostListenerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
-  replicas: {{ .Values.hostListener.replicas }}
+  replicas: {{ $.Values.hostListener.replicas }}
   selector:
     matchLabels:
-      app: coprocessor-host-listener
-  {{- if .Values.hostListener.updateStrategy }}
+      app: {{ $appLabel }}
+  {{- if $.Values.hostListener.updateStrategy }}
   strategy:
-    {{- toYaml .Values.hostListener.updateStrategy | nindent 4 }}
+    {{- toYaml $.Values.hostListener.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
       labels:
-        app: coprocessor-host-listener
-        app.kubernetes.io/name: {{ include "hostListenerName" . }}
-        {{- with .Values.podLabels }}
+        app: {{ $appLabel }}
+        app.kubernetes.io/name: {{ $deploymentName }}
+        {{- with $.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with $.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,83 +35,90 @@ spec:
       imagePullSecrets:
         - name: registry-credentials
       restartPolicy: Always
-      {{- with .Values.hostListener.nodeSelector }}
+      {{- with $.Values.hostListener.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.hostListener.affinity }}
+      {{- with $.Values.hostListener.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.hostListener.tolerations }}
+      {{- with $.Values.hostListener.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.hostListener.serviceAccountName }}
-      serviceAccountName: {{ .Values.hostListener.serviceAccountName }}
+      {{- if $.Values.hostListener.serviceAccountName }}
+      serviceAccountName: {{ $.Values.hostListener.serviceAccountName }}
       {{- end }}
       containers:
         - name: coprocessor-host-listener
-          image: {{ .Values.hostListener.image.name }}:{{ .Values.hostListener.image.tag }}
+          image: {{ $.Values.hostListener.image.name }}:{{ $.Values.hostListener.image.tag }}
           command: ["host_listener"]
           args:
             - --database-url=$(DATABASE_URL)
             - --url=$(ETHEREUM_RPC_URL)
             - --acl-contract-address=$(ACL_CONTRACT_ADDRESS)
             - --tfhe-contract-address=$(FHEVM_EXECUTOR_CONTRACT_ADDRESS)
-            - --health-port={{ .Values.hostListener.ports.healthcheck }}
-            - --dependent-ops-max-per-chain={{ int .Values.commonConfig.dependentOpsMaxPerChain }}
-            - --log-level={{ .Values.hostListener.args.logLevel }}
-            - --initial-block-time={{ .Values.hostListener.args.initialBlockTime }}
-            - --reorg-maximum-duration-in-blocks={{ .Values.hostListener.args.reorgMaximumDurationInBlocks }}
-            - --service-name={{ .Values.hostListener.args.serviceName }}
-            - --catchup-finalization-in-blocks={{ .Values.hostListener.args.catchupFinalizationInBlocks }}
+            - --health-port={{ $.Values.hostListener.ports.healthcheck }}
+            - --dependent-ops-max-per-chain={{ int $.Values.commonConfig.dependentOpsMaxPerChain }}
+            - --log-level={{ $.Values.hostListener.args.logLevel }}
+            - --initial-block-time={{ $.Values.hostListener.args.initialBlockTime }}
+            - --reorg-maximum-duration-in-blocks={{ $.Values.hostListener.args.reorgMaximumDurationInBlocks }}
+            - --service-name=host-listener-{{ $chain.name }}
+            - --catchup-finalization-in-blocks={{ $.Values.hostListener.args.catchupFinalizationInBlocks }}
             - --coprocessor-api-key=$(TENANT_API_KEY)
-            {{- with .Values.hostListener.extraArgs }}
+            {{- with $.Values.hostListener.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $chain.hostListener.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: DATABASE_URL
-              value: {{ .Values.commonConfig.databaseUrl | quote }}
+              value: {{ $.Values.commonConfig.databaseUrl | quote }}
             - name: ETHEREUM_RPC_URL
-              value: {{ .Values.commonConfig.hostChainWsUrl | quote }}
+              value: {{ required (printf "chains entry %q: wsUrl is required" $chain.name) $chain.wsUrl | quote }}
             - name: ACL_CONTRACT_ADDRESS
-              value: {{ required "commonConfig.aclContractAddress is required" .Values.commonConfig.aclContractAddress | quote }}
+              value: {{ required (printf "chains entry %q: aclContractAddress is required" $chain.name) $chain.aclContractAddress | quote }}
             - name: FHEVM_EXECUTOR_CONTRACT_ADDRESS
-              value: {{ required "commonConfig.fhevmExecutorContractAddress is required" .Values.commonConfig.fhevmExecutorContractAddress | quote }}
-          {{- if default .Values.commonConfig.tracing.enabled .Values.hostListener.tracing.enabled }}
+              value: {{ required (printf "chains entry %q: fhevmExecutorContractAddress is required" $chain.name) $chain.fhevmExecutorContractAddress | quote }}
+          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListener.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.commonConfig.tracing.endpoint | quote }}
+              value: {{ $.Values.commonConfig.tracing.endpoint | quote }}
             - name: OTEL_SERVICE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
           {{- end }}
-          {{- with .Values.commonConfig.env }}
+          {{- with $.Values.commonConfig.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.hostListener.env }}
+          {{- with $.Values.hostListener.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $chain.hostListener.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $portName, $portValue := .Values.hostListener.ports }}
+            {{- range $portName, $portValue := $.Values.hostListener.ports }}
             - name: {{ $portName }}
               containerPort: {{ $portValue }}
               protocol: TCP
             {{- end }}
           resources:
             requests:
-              cpu: {{ .Values.hostListener.resources.requests.cpu | default "100m" }}
-              memory: {{ .Values.hostListener.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.hostListener.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.hostListener.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ .Values.hostListener.resources.limits.cpu | default "500m" }}
-              memory: {{ .Values.hostListener.resources.limits.memory | default "512Mi" }}
-          {{- if and .Values.hostListener.probes .Values.hostListener.probes.liveness.enabled }}
+              cpu: {{ $.Values.hostListener.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.hostListener.resources.limits.memory | default "512Mi" }}
+          {{- if and $.Values.hostListener.probes $.Values.hostListener.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml (omit .Values.hostListener.probes.liveness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListener.probes.liveness "enabled") | nindent 12 }}
           {{- end }}
-          {{- if and .Values.hostListener.probes .Values.hostListener.probes.readiness.enabled }}
+          {{- if and $.Values.hostListener.probes $.Values.hostListener.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml (omit .Values.hostListener.probes.readiness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListener.probes.readiness "enabled") | nindent 12 }}
           {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-deployment.yaml
@@ -1,7 +1,9 @@
 {{- range $i, $chain := .Values.chains }}
 {{- if (($chain.hostListener).enabled) }}
-{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) (eq $i 0) -}}
+{{- $useLegacyName := $chain.hostListener.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) $useLegacyName -}}
+{{- $serviceName := coalesce $chain.hostListener.serviceName $.Values.hostListenerShared.args.serviceName (printf "host-listener-%s" $chain.name) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11,13 +13,13 @@ metadata:
     app.kubernetes.io/name: {{ $deploymentName }}
   name: {{ $deploymentName }}
 spec:
-  replicas: {{ $.Values.hostListener.replicas }}
+  replicas: {{ $.Values.hostListenerShared.replicas }}
   selector:
     matchLabels:
       app: {{ $appLabel }}
-  {{- if $.Values.hostListener.updateStrategy }}
+  {{- if $.Values.hostListenerShared.updateStrategy }}
   strategy:
-    {{- toYaml $.Values.hostListener.updateStrategy | nindent 4 }}
+    {{- toYaml $.Values.hostListenerShared.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -35,39 +37,39 @@ spec:
       imagePullSecrets:
         - name: registry-credentials
       restartPolicy: Always
-      {{- with $.Values.hostListener.nodeSelector }}
+      {{- with $.Values.hostListenerShared.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.hostListener.affinity }}
+      {{- with $.Values.hostListenerShared.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.hostListener.tolerations }}
+      {{- with $.Values.hostListenerShared.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $.Values.hostListener.serviceAccountName }}
-      serviceAccountName: {{ $.Values.hostListener.serviceAccountName }}
+      {{- if $.Values.hostListenerShared.serviceAccountName }}
+      serviceAccountName: {{ $.Values.hostListenerShared.serviceAccountName }}
       {{- end }}
       containers:
         - name: coprocessor-host-listener
-          image: {{ $.Values.hostListener.image.name }}:{{ $.Values.hostListener.image.tag }}
+          image: {{ $.Values.hostListenerShared.image.name }}:{{ $.Values.hostListenerShared.image.tag }}
           command: ["host_listener"]
           args:
             - --database-url=$(DATABASE_URL)
             - --url=$(ETHEREUM_RPC_URL)
             - --acl-contract-address=$(ACL_CONTRACT_ADDRESS)
             - --tfhe-contract-address=$(FHEVM_EXECUTOR_CONTRACT_ADDRESS)
-            - --health-port={{ $.Values.hostListener.ports.healthcheck }}
+            - --health-port={{ $.Values.hostListenerShared.ports.healthcheck }}
             - --dependent-ops-max-per-chain={{ int $.Values.commonConfig.dependentOpsMaxPerChain }}
-            - --log-level={{ $.Values.hostListener.args.logLevel }}
-            - --initial-block-time={{ $.Values.hostListener.args.initialBlockTime }}
-            - --reorg-maximum-duration-in-blocks={{ $.Values.hostListener.args.reorgMaximumDurationInBlocks }}
-            - --service-name=host-listener-{{ $chain.name }}
-            - --catchup-finalization-in-blocks={{ $.Values.hostListener.args.catchupFinalizationInBlocks }}
+            - --log-level={{ $.Values.hostListenerShared.args.logLevel }}
+            - --initial-block-time={{ $.Values.hostListenerShared.args.initialBlockTime }}
+            - --reorg-maximum-duration-in-blocks={{ $.Values.hostListenerShared.args.reorgMaximumDurationInBlocks }}
+            - --service-name={{ $serviceName }}
+            - --catchup-finalization-in-blocks={{ $.Values.hostListenerShared.args.catchupFinalizationInBlocks }}
             - --coprocessor-api-key=$(TENANT_API_KEY)
-            {{- with $.Values.hostListener.extraArgs }}
+            {{- with $.Values.hostListenerShared.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with $chain.hostListener.extraArgs }}
@@ -76,13 +78,12 @@ spec:
           env:
             - name: DATABASE_URL
               value: {{ $.Values.commonConfig.databaseUrl | quote }}
-            - name: ETHEREUM_RPC_URL
-              value: {{ required (printf "chains entry %q: wsUrl is required" $chain.name) $chain.wsUrl | quote }}
+            {{- include "coprocessor.renderChainEnvValue" (dict "name" "ETHEREUM_RPC_URL" "value" $chain.wsUrl "valueFrom" $chain.wsUrlValueFrom "fieldName" "wsUrl" "chainName" $chain.name) | nindent 12 }}
             - name: ACL_CONTRACT_ADDRESS
               value: {{ required (printf "chains entry %q: aclContractAddress is required" $chain.name) $chain.aclContractAddress | quote }}
             - name: FHEVM_EXECUTOR_CONTRACT_ADDRESS
               value: {{ required (printf "chains entry %q: fhevmExecutorContractAddress is required" $chain.name) $chain.fhevmExecutorContractAddress | quote }}
-          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListener.tracing.enabled }}
+          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerShared.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ $.Values.commonConfig.tracing.endpoint | quote }}
             - name: OTEL_SERVICE_NAME
@@ -93,32 +94,32 @@ spec:
           {{- with $.Values.commonConfig.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $.Values.hostListener.env }}
+          {{- with $.Values.hostListenerShared.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $chain.hostListener.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $portName, $portValue := $.Values.hostListener.ports }}
+            {{- range $portName, $portValue := $.Values.hostListenerShared.ports }}
             - name: {{ $portName }}
               containerPort: {{ $portValue }}
               protocol: TCP
             {{- end }}
           resources:
             requests:
-              cpu: {{ $.Values.hostListener.resources.requests.cpu | default "100m" }}
-              memory: {{ $.Values.hostListener.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.hostListenerShared.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.hostListenerShared.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ $.Values.hostListener.resources.limits.cpu | default "500m" }}
-              memory: {{ $.Values.hostListener.resources.limits.memory | default "512Mi" }}
-          {{- if and $.Values.hostListener.probes $.Values.hostListener.probes.liveness.enabled }}
+              cpu: {{ $.Values.hostListenerShared.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.hostListenerShared.resources.limits.memory | default "512Mi" }}
+          {{- if and $.Values.hostListenerShared.probes $.Values.hostListenerShared.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml (omit $.Values.hostListener.probes.liveness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerShared.probes.liveness "enabled") | nindent 12 }}
           {{- end }}
-          {{- if and $.Values.hostListener.probes $.Values.hostListener.probes.readiness.enabled }}
+          {{- if and $.Values.hostListenerShared.probes $.Values.hostListenerShared.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml (omit $.Values.hostListener.probes.readiness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerShared.probes.readiness "enabled") | nindent 12 }}
           {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-deployment.yaml
@@ -1,29 +1,33 @@
-{{- if .Values.hostListenerPoller.enabled -}}
+{{- range $i, $chain := .Values.chains }}
+{{- if (($chain.hostListenerPoller).enabled) }}
+{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: coprocessor-host-listener-poller
-    app.kubernetes.io/name: {{ include "hostListenerPollerName" . }}
-  name: {{ include "hostListenerPollerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
-  replicas: {{ .Values.hostListenerPoller.replicas }}
+  replicas: {{ $.Values.hostListenerPoller.replicas }}
   selector:
     matchLabels:
-      app: coprocessor-host-listener-poller
-  {{- if .Values.hostListenerPoller.updateStrategy }}
+      app: {{ $appLabel }}
+  {{- if $.Values.hostListenerPoller.updateStrategy }}
   strategy:
-    {{- toYaml .Values.hostListenerPoller.updateStrategy | nindent 4 }}
+    {{- toYaml $.Values.hostListenerPoller.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
       labels:
-        app: coprocessor-host-listener-poller
-        app.kubernetes.io/name: {{ include "hostListenerPollerName" . }}
-        {{- with .Values.podLabels }}
+        app: {{ $appLabel }}
+        app.kubernetes.io/name: {{ $deploymentName }}
+        {{- with $.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- with $.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -31,87 +35,94 @@ spec:
       imagePullSecrets:
         - name: registry-credentials
       restartPolicy: Always
-      {{- with .Values.hostListenerPoller.nodeSelector }}
+      {{- with $.Values.hostListenerPoller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.hostListenerPoller.affinity }}
+      {{- with $.Values.hostListenerPoller.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.hostListenerPoller.tolerations }}
+      {{- with $.Values.hostListenerPoller.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.hostListenerPoller.serviceAccountName }}
-      serviceAccountName: {{ .Values.hostListenerPoller.serviceAccountName }}
+      {{- if $.Values.hostListenerPoller.serviceAccountName }}
+      serviceAccountName: {{ $.Values.hostListenerPoller.serviceAccountName }}
       {{- end }}
       containers:
         - name: coprocessor-host-listener-poller
-          image: {{ .Values.hostListenerPoller.image.name }}:{{ .Values.hostListenerPoller.image.tag }}
+          image: {{ $.Values.hostListenerPoller.image.name }}:{{ $.Values.hostListenerPoller.image.tag }}
           command: ["host_listener_poller"]
           args:
             - --database-url=$(DATABASE_URL)
             - --url=$(ETHEREUM_RPC_HTTP_URL)
             - --acl-contract-address=$(ACL_CONTRACT_ADDRESS)
             - --tfhe-contract-address=$(FHEVM_EXECUTOR_CONTRACT_ADDRESS)
-            - --health-port={{ .Values.hostListenerPoller.ports.healthcheck }}
-            - --metrics-addr=0.0.0.0:{{ .Values.hostListenerPoller.ports.metrics }}
-            - --dependent-ops-max-per-chain={{ int .Values.commonConfig.dependentOpsMaxPerChain }}
-            - --log-level={{ .Values.hostListenerPoller.args.logLevel }}
-            - --service-name={{ .Values.hostListenerPoller.args.serviceName }}
-            - --finality-lag={{ .Values.hostListenerPoller.args.finalityLag }}
-            - --batch-size={{ .Values.hostListenerPoller.args.batchSize }}
-            - --poll-interval-ms={{ .Values.hostListenerPoller.args.pollIntervalMs }}
-            - --retry-interval-ms={{ .Values.hostListenerPoller.args.retryIntervalMs }}
-            - --max-http-retries={{ .Values.hostListenerPoller.args.maxHttpRetries }}
-            - --rpc-compute-units-per-second={{ .Values.hostListenerPoller.args.rpcComputeUnitsPerSecond }}
+            - --health-port={{ $.Values.hostListenerPoller.ports.healthcheck }}
+            - --metrics-addr=0.0.0.0:{{ $.Values.hostListenerPoller.ports.metrics }}
+            - --dependent-ops-max-per-chain={{ int $.Values.commonConfig.dependentOpsMaxPerChain }}
+            - --log-level={{ $.Values.hostListenerPoller.args.logLevel }}
+            - --service-name=host-listener-poller-{{ $chain.name }}
+            - --finality-lag={{ $.Values.hostListenerPoller.args.finalityLag }}
+            - --batch-size={{ $.Values.hostListenerPoller.args.batchSize }}
+            - --poll-interval-ms={{ $.Values.hostListenerPoller.args.pollIntervalMs }}
+            - --retry-interval-ms={{ $.Values.hostListenerPoller.args.retryIntervalMs }}
+            - --max-http-retries={{ $.Values.hostListenerPoller.args.maxHttpRetries }}
+            - --rpc-compute-units-per-second={{ $.Values.hostListenerPoller.args.rpcComputeUnitsPerSecond }}
             - --coprocessor-api-key=$(TENANT_API_KEY)
-            {{- with .Values.hostListenerPoller.extraArgs }}
+            {{- with $.Values.hostListenerPoller.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $chain.hostListenerPoller.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: DATABASE_URL
-              value: {{ .Values.commonConfig.databaseUrl | quote }}
+              value: {{ $.Values.commonConfig.databaseUrl | quote }}
             - name: ETHEREUM_RPC_HTTP_URL
-              value: {{ .Values.commonConfig.hostChainHttpUrl | quote }}
+              value: {{ required (printf "chains entry %q: httpUrl is required" $chain.name) $chain.httpUrl | quote }}
             - name: ACL_CONTRACT_ADDRESS
-              value: {{ required "commonConfig.aclContractAddress is required" .Values.commonConfig.aclContractAddress | quote }}
+              value: {{ required (printf "chains entry %q: aclContractAddress is required" $chain.name) $chain.aclContractAddress | quote }}
             - name: FHEVM_EXECUTOR_CONTRACT_ADDRESS
-              value: {{ required "commonConfig.fhevmExecutorContractAddress is required" .Values.commonConfig.fhevmExecutorContractAddress | quote }}
-          {{- if default .Values.commonConfig.tracing.enabled .Values.hostListenerPoller.tracing.enabled }}
+              value: {{ required (printf "chains entry %q: fhevmExecutorContractAddress is required" $chain.name) $chain.fhevmExecutorContractAddress | quote }}
+          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerPoller.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.commonConfig.tracing.endpoint | quote }}
+              value: {{ $.Values.commonConfig.tracing.endpoint | quote }}
             - name: OTEL_SERVICE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
           {{- end }}
-          {{- with .Values.commonConfig.env }}
+          {{- with $.Values.commonConfig.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.hostListenerPoller.env }}
+          {{- with $.Values.hostListenerPoller.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $chain.hostListenerPoller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $portName, $portValue := .Values.hostListenerPoller.ports }}
+            {{- range $portName, $portValue := $.Values.hostListenerPoller.ports }}
             - name: {{ $portName }}
               containerPort: {{ $portValue }}
               protocol: TCP
             {{- end }}
           resources:
             requests:
-              cpu: {{ .Values.hostListenerPoller.resources.requests.cpu | default "100m" }}
-              memory: {{ .Values.hostListenerPoller.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.hostListenerPoller.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.hostListenerPoller.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ .Values.hostListenerPoller.resources.limits.cpu | default "500m" }}
-              memory: {{ .Values.hostListenerPoller.resources.limits.memory | default "512Mi" }}
-          {{- if and .Values.hostListenerPoller.probes .Values.hostListenerPoller.probes.liveness.enabled }}
+              cpu: {{ $.Values.hostListenerPoller.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.hostListenerPoller.resources.limits.memory | default "512Mi" }}
+          {{- if and $.Values.hostListenerPoller.probes $.Values.hostListenerPoller.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml (omit .Values.hostListenerPoller.probes.liveness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerPoller.probes.liveness "enabled") | nindent 12 }}
           {{- end }}
-          {{- if and .Values.hostListenerPoller.probes .Values.hostListenerPoller.probes.readiness.enabled }}
+          {{- if and $.Values.hostListenerPoller.probes $.Values.hostListenerPoller.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml (omit .Values.hostListenerPoller.probes.readiness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerPoller.probes.readiness "enabled") | nindent 12 }}
           {{- end }}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-deployment.yaml
@@ -1,7 +1,9 @@
 {{- range $i, $chain := .Values.chains }}
 {{- if (($chain.hostListenerPoller).enabled) }}
-{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) (eq $i 0) -}}
+{{- $useLegacyName := $chain.hostListenerPoller.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) $useLegacyName -}}
+{{- $serviceName := coalesce $chain.hostListenerPoller.serviceName $.Values.hostListenerPollerShared.args.serviceName (printf "host-listener-poller-%s" $chain.name) -}}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11,13 +13,13 @@ metadata:
     app.kubernetes.io/name: {{ $deploymentName }}
   name: {{ $deploymentName }}
 spec:
-  replicas: {{ $.Values.hostListenerPoller.replicas }}
+  replicas: {{ $.Values.hostListenerPollerShared.replicas }}
   selector:
     matchLabels:
       app: {{ $appLabel }}
-  {{- if $.Values.hostListenerPoller.updateStrategy }}
+  {{- if $.Values.hostListenerPollerShared.updateStrategy }}
   strategy:
-    {{- toYaml $.Values.hostListenerPoller.updateStrategy | nindent 4 }}
+    {{- toYaml $.Values.hostListenerPollerShared.updateStrategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -35,43 +37,43 @@ spec:
       imagePullSecrets:
         - name: registry-credentials
       restartPolicy: Always
-      {{- with $.Values.hostListenerPoller.nodeSelector }}
+      {{- with $.Values.hostListenerPollerShared.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.hostListenerPoller.affinity }}
+      {{- with $.Values.hostListenerPollerShared.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $.Values.hostListenerPoller.tolerations }}
+      {{- with $.Values.hostListenerPollerShared.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if $.Values.hostListenerPoller.serviceAccountName }}
-      serviceAccountName: {{ $.Values.hostListenerPoller.serviceAccountName }}
+      {{- if $.Values.hostListenerPollerShared.serviceAccountName }}
+      serviceAccountName: {{ $.Values.hostListenerPollerShared.serviceAccountName }}
       {{- end }}
       containers:
         - name: coprocessor-host-listener-poller
-          image: {{ $.Values.hostListenerPoller.image.name }}:{{ $.Values.hostListenerPoller.image.tag }}
+          image: {{ $.Values.hostListenerPollerShared.image.name }}:{{ $.Values.hostListenerPollerShared.image.tag }}
           command: ["host_listener_poller"]
           args:
             - --database-url=$(DATABASE_URL)
             - --url=$(ETHEREUM_RPC_HTTP_URL)
             - --acl-contract-address=$(ACL_CONTRACT_ADDRESS)
             - --tfhe-contract-address=$(FHEVM_EXECUTOR_CONTRACT_ADDRESS)
-            - --health-port={{ $.Values.hostListenerPoller.ports.healthcheck }}
-            - --metrics-addr=0.0.0.0:{{ $.Values.hostListenerPoller.ports.metrics }}
+            - --health-port={{ $.Values.hostListenerPollerShared.ports.healthcheck }}
+            - --metrics-addr=0.0.0.0:{{ $.Values.hostListenerPollerShared.ports.metrics }}
             - --dependent-ops-max-per-chain={{ int $.Values.commonConfig.dependentOpsMaxPerChain }}
-            - --log-level={{ $.Values.hostListenerPoller.args.logLevel }}
-            - --service-name=host-listener-poller-{{ $chain.name }}
-            - --finality-lag={{ $.Values.hostListenerPoller.args.finalityLag }}
-            - --batch-size={{ $.Values.hostListenerPoller.args.batchSize }}
-            - --poll-interval-ms={{ $.Values.hostListenerPoller.args.pollIntervalMs }}
-            - --retry-interval-ms={{ $.Values.hostListenerPoller.args.retryIntervalMs }}
-            - --max-http-retries={{ $.Values.hostListenerPoller.args.maxHttpRetries }}
-            - --rpc-compute-units-per-second={{ $.Values.hostListenerPoller.args.rpcComputeUnitsPerSecond }}
+            - --log-level={{ $.Values.hostListenerPollerShared.args.logLevel }}
+            - --service-name={{ $serviceName }}
+            - --finality-lag={{ $.Values.hostListenerPollerShared.args.finalityLag }}
+            - --batch-size={{ $.Values.hostListenerPollerShared.args.batchSize }}
+            - --poll-interval-ms={{ $.Values.hostListenerPollerShared.args.pollIntervalMs }}
+            - --retry-interval-ms={{ $.Values.hostListenerPollerShared.args.retryIntervalMs }}
+            - --max-http-retries={{ $.Values.hostListenerPollerShared.args.maxHttpRetries }}
+            - --rpc-compute-units-per-second={{ $.Values.hostListenerPollerShared.args.rpcComputeUnitsPerSecond }}
             - --coprocessor-api-key=$(TENANT_API_KEY)
-            {{- with $.Values.hostListenerPoller.extraArgs }}
+            {{- with $.Values.hostListenerPollerShared.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with $chain.hostListenerPoller.extraArgs }}
@@ -80,13 +82,12 @@ spec:
           env:
             - name: DATABASE_URL
               value: {{ $.Values.commonConfig.databaseUrl | quote }}
-            - name: ETHEREUM_RPC_HTTP_URL
-              value: {{ required (printf "chains entry %q: httpUrl is required" $chain.name) $chain.httpUrl | quote }}
+            {{- include "coprocessor.renderChainEnvValue" (dict "name" "ETHEREUM_RPC_HTTP_URL" "value" $chain.httpUrl "valueFrom" $chain.httpUrlValueFrom "fieldName" "httpUrl" "chainName" $chain.name) | nindent 12 }}
             - name: ACL_CONTRACT_ADDRESS
               value: {{ required (printf "chains entry %q: aclContractAddress is required" $chain.name) $chain.aclContractAddress | quote }}
             - name: FHEVM_EXECUTOR_CONTRACT_ADDRESS
               value: {{ required (printf "chains entry %q: fhevmExecutorContractAddress is required" $chain.name) $chain.fhevmExecutorContractAddress | quote }}
-          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerPoller.tracing.enabled }}
+          {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerPollerShared.tracing.enabled }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ $.Values.commonConfig.tracing.endpoint | quote }}
             - name: OTEL_SERVICE_NAME
@@ -97,32 +98,32 @@ spec:
           {{- with $.Values.commonConfig.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with $.Values.hostListenerPoller.env }}
+          {{- with $.Values.hostListenerPollerShared.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with $chain.hostListenerPoller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            {{- range $portName, $portValue := $.Values.hostListenerPoller.ports }}
+            {{- range $portName, $portValue := $.Values.hostListenerPollerShared.ports }}
             - name: {{ $portName }}
               containerPort: {{ $portValue }}
               protocol: TCP
             {{- end }}
           resources:
             requests:
-              cpu: {{ $.Values.hostListenerPoller.resources.requests.cpu | default "100m" }}
-              memory: {{ $.Values.hostListenerPoller.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.hostListenerPollerShared.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.hostListenerPollerShared.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ $.Values.hostListenerPoller.resources.limits.cpu | default "500m" }}
-              memory: {{ $.Values.hostListenerPoller.resources.limits.memory | default "512Mi" }}
-          {{- if and $.Values.hostListenerPoller.probes $.Values.hostListenerPoller.probes.liveness.enabled }}
+              cpu: {{ $.Values.hostListenerPollerShared.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.hostListenerPollerShared.resources.limits.memory | default "512Mi" }}
+          {{- if and $.Values.hostListenerPollerShared.probes $.Values.hostListenerPollerShared.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml (omit $.Values.hostListenerPoller.probes.liveness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerPollerShared.probes.liveness "enabled") | nindent 12 }}
           {{- end }}
-          {{- if and $.Values.hostListenerPoller.probes $.Values.hostListenerPoller.probes.readiness.enabled }}
+          {{- if and $.Values.hostListenerPollerShared.probes $.Values.hostListenerPollerShared.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml (omit $.Values.hostListenerPoller.probes.readiness "enabled") | nindent 12 }}
+            {{- toYaml (omit $.Values.hostListenerPollerShared.probes.readiness "enabled") | nindent 12 }}
           {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-service-monitor.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-service-monitor.yaml
@@ -1,16 +1,21 @@
-{{- if .Values.hostListenerPoller.serviceMonitor.enabled -}}
+{{- range $i, $chain := .Values.chains }}
+{{- if and (($chain.hostListenerPoller).enabled) $.Values.hostListenerPoller.serviceMonitor.enabled }}
+{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: coprocessor-host-listener-poller
-    app.kubernetes.io/name: {{ include "hostListenerPollerName" . }}
-  name: {{ include "hostListenerPollerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
   selector:
     matchLabels:
-      app: coprocessor-host-listener-poller
-      app.kubernetes.io/name: {{ include "hostListenerPollerName" . }}
+      app: {{ $appLabel }}
+      app.kubernetes.io/name: {{ $deploymentName }}
   endpoints:
   - port: metrics
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-service-monitor.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-service-monitor.yaml
@@ -1,7 +1,8 @@
 {{- range $i, $chain := .Values.chains }}
-{{- if and (($chain.hostListenerPoller).enabled) $.Values.hostListenerPoller.serviceMonitor.enabled }}
-{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) (eq $i 0) -}}
+{{- if and (($chain.hostListenerPoller).enabled) $.Values.hostListenerPollerShared.serviceMonitor.enabled }}
+{{- $useLegacyName := $chain.hostListenerPoller.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) $useLegacyName -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-service.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-service.yaml
@@ -1,7 +1,8 @@
 {{- range $i, $chain := .Values.chains }}
 {{- if (($chain.hostListenerPoller).enabled) }}
-{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) (eq $i 0) -}}
+{{- $useLegacyName := $chain.hostListenerPoller.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) $useLegacyName -}}
 ---
 apiVersion: v1
 kind: Service
@@ -13,10 +14,10 @@ metadata:
 spec:
   ports:
     - name: metrics
-      port: {{ $.Values.hostListenerPoller.ports.metrics }}
+      port: {{ $.Values.hostListenerPollerShared.ports.metrics }}
       targetPort: metrics
     - name: healthcheck
-      port: {{ $.Values.hostListenerPoller.ports.healthcheck }}
+      port: {{ $.Values.hostListenerPollerShared.ports.healthcheck }}
       targetPort: healthcheck
   selector:
     app: {{ $appLabel }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-service.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-service.yaml
@@ -1,21 +1,26 @@
-{{- if .Values.hostListenerPoller.enabled }}
+{{- range $i, $chain := .Values.chains }}
+{{- if (($chain.hostListenerPoller).enabled) }}
+{{- $deploymentName := ternary (printf "%s-host-listener-poller" $.Release.Name) (printf "%s-host-listener-poller-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener-poller" (printf "coprocessor-host-listener-poller-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: coprocessor-host-listener-poller
-    app.kubernetes.io/name: {{ include "hostListenerPollerName" . }}
-  name: {{ include "hostListenerPollerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
   ports:
     - name: metrics
-      port: {{ .Values.hostListenerPoller.ports.metrics }}
+      port: {{ $.Values.hostListenerPoller.ports.metrics }}
       targetPort: metrics
     - name: healthcheck
-      port: {{ .Values.hostListenerPoller.ports.healthcheck }}
+      port: {{ $.Values.hostListenerPoller.ports.healthcheck }}
       targetPort: healthcheck
   selector:
-    app: coprocessor-host-listener-poller
-    app.kubernetes.io/name: {{ include "hostListenerPollerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
   type: ClusterIP
+{{- end }}
 {{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-service-monitor.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-service-monitor.yaml
@@ -1,7 +1,8 @@
 {{- range $i, $chain := .Values.chains }}
-{{- if and (($chain.hostListener).enabled) $.Values.hostListener.serviceMonitor.enabled }}
-{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) (eq $i 0) -}}
+{{- if and (($chain.hostListener).enabled) $.Values.hostListenerShared.serviceMonitor.enabled }}
+{{- $useLegacyName := $chain.hostListener.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) $useLegacyName -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/coprocessor/templates/coprocessor-host-listener-service-monitor.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-service-monitor.yaml
@@ -1,16 +1,21 @@
-{{- if .Values.hostListener.serviceMonitor.enabled -}}
+{{- range $i, $chain := .Values.chains }}
+{{- if and (($chain.hostListener).enabled) $.Values.hostListener.serviceMonitor.enabled }}
+{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: coprocessor-host-listener
-    app.kubernetes.io/name: {{ include "hostListenerName" . }}
-  name: {{ include "hostListenerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
   selector:
     matchLabels:
-      app: coprocessor-host-listener
-      app.kubernetes.io/name: {{ include "hostListenerName" . }}
+      app: {{ $appLabel }}
+      app.kubernetes.io/name: {{ $deploymentName }}
   endpoints:
   - port: metrics
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-service.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-service.yaml
@@ -1,21 +1,26 @@
-{{- if .Values.hostListener.enabled }}
+{{- range $i, $chain := .Values.chains }}
+{{- if (($chain.hostListener).enabled) }}
+{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) (eq $i 0) -}}
+{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) (eq $i 0) -}}
+---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: coprocessor-host-listener
-    app.kubernetes.io/name: {{ include "hostListenerName" . }}
-  name: {{ include "hostListenerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
+  name: {{ $deploymentName }}
 spec:
   ports:
     - name: metrics
-      port: {{ .Values.hostListener.ports.metrics }}
+      port: {{ $.Values.hostListener.ports.metrics }}
       targetPort: metrics
     - name: healthcheck
-      port: {{ .Values.hostListener.ports.healthcheck }}
+      port: {{ $.Values.hostListener.ports.healthcheck }}
       targetPort: healthcheck
   selector:
-    app: coprocessor-host-listener
-    app.kubernetes.io/name: {{ include "hostListenerName" . }}
+    app: {{ $appLabel }}
+    app.kubernetes.io/name: {{ $deploymentName }}
   type: ClusterIP
+{{- end }}
 {{- end }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-service.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-service.yaml
@@ -1,7 +1,8 @@
 {{- range $i, $chain := .Values.chains }}
 {{- if (($chain.hostListener).enabled) }}
-{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) (eq $i 0) -}}
-{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) (eq $i 0) -}}
+{{- $useLegacyName := $chain.hostListener.useLegacyName | default false -}}
+{{- $deploymentName := ternary (printf "%s-host-listener" $.Release.Name) (printf "%s-host-listener-%s" $.Release.Name $chain.name) $useLegacyName -}}
+{{- $appLabel := ternary "coprocessor-host-listener" (printf "coprocessor-host-listener-%s" $chain.name) $useLegacyName -}}
 ---
 apiVersion: v1
 kind: Service
@@ -13,10 +14,10 @@ metadata:
 spec:
   ports:
     - name: metrics
-      port: {{ $.Values.hostListener.ports.metrics }}
+      port: {{ $.Values.hostListenerShared.ports.metrics }}
       targetPort: metrics
     - name: healthcheck
-      port: {{ $.Values.hostListener.ports.healthcheck }}
+      port: {{ $.Values.hostListenerShared.ports.healthcheck }}
       targetPort: healthcheck
   selector:
     app: {{ $appLabel }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-validation.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-validation.yaml
@@ -1,0 +1,10 @@
+{{/*
+Validation-only template for host listener migrations.
+This file intentionally renders no Kubernetes resources; it exists to fail fast
+when deprecated top-level listener keys are still used, or when multiple chains
+claim the same unsuffixed legacy resource name.
+*/}}
+{{- include "coprocessor.failIfDeprecatedTopLevelListenerKeysPresent" . }}
+{{- include "coprocessor.failIfMultipleLegacyNameClaims" (dict "root" . "componentKey" "hostListener") }}
+{{- include "coprocessor.failIfMultipleLegacyNameClaims" (dict "root" . "componentKey" "hostListenerPoller") }}
+{{- include "coprocessor.failIfMultipleLegacyNameClaims" (dict "root" . "componentKey" "hostListenerCatchupOnly") }}

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -485,6 +485,38 @@ hostListenerCatchupOnly:
       maxUnavailable: 0
 
 # -----------------------------------------------------------------------------
+# Chains
+# -----------------------------------------------------------------------------
+# Each entry deploys up to three host listener variants for a given chain.
+# Top-level hostListener / hostListenerPoller / hostListenerCatchupOnly values
+# are used as defaults; per-chain fields override or extend them.
+#
+# The first entry preserves the legacy Deployment name (<release>-host-listener)
+# so that an existing single-chain installation can migrate without downtime.
+# Subsequent entries are named <release>-host-listener-<name>.
+#
+# Example:
+# chains:
+#   - name: ethereum
+#     wsUrl: "ws://eth-node:8546"       # required by hostListener + hostListenerCatchupOnly
+#     httpUrl: "http://eth-node:8545"   # required by hostListenerPoller
+#     aclContractAddress: "0x..."
+#     fhevmExecutorContractAddress: "0x..."
+#     hostListener:
+#       enabled: true
+#       extraArgs: []  # appended after top-level hostListener.extraArgs
+#       env: []        # appended after top-level hostListener.env
+#     hostListenerPoller:
+#       enabled: true
+#       extraArgs: []
+#       env: []
+#     hostListenerCatchupOnly:
+#       enabled: true
+#       extraArgs: []
+#       env: []
+chains: []
+
+# -----------------------------------------------------------------------------
 # Gateway Listener
 # -----------------------------------------------------------------------------
 # Processes events from the gateway chain

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -162,12 +162,6 @@ dbMigration:
 # -----------------------------------------------------------------------------
 # Processes blockchain events from the host chain via WebSocket
 hostListener:
-  enabled: false
-  # nameOverride: override the default resource name for this component.
-  # If unset, resources are named <release-name>-<component> (e.g. my-release-tfhe-worker).
-  # Useful when deploying multiple coprocessor instances in the same namespace.
-  nameOverride:
-
   image:
     name: hub.zama.org/zama-protocol/zama-ai/fhevm/coprocessor/host-listener
     tag: v0.11.0
@@ -184,17 +178,16 @@ hostListener:
 
   # Command line arguments for the host listener.
   # The following are injected automatically by the template:
-  #   --database-url, --url, --acl-contract-address, --tfhe-contract-address (from commonConfig)
+  #   --database-url, --url, --acl-contract-address, --tfhe-contract-address (from chains entry)
   #   --health-port (from ports.healthcheck)
   #   --dependent-ops-max-per-chain (from commonConfig.dependentOpsMaxPerChain)
+  #   --service-name=host-listener-<chain.name> (auto-derived from chains entry)
   #   --coprocessor-api-key=$(TENANT_API_KEY)
   # Use extraArgs to pass flags not covered by the fields below.
   args:
     logLevel: INFO
     initialBlockTime: 12        # switches to real block time when data is available
     reorgMaximumDurationInBlocks: 50
-    # New in v0.10
-    serviceName: host-listener
     catchupFinalizationInBlocks: 20  # continuous catchup will wait for block "finalization"
 
   # Additional args appended after all template-injected and structured args.
@@ -272,12 +265,6 @@ hostListener:
 # -----------------------------------------------------------------------------
 # Processes blockchain events from the host chain via HTTP polling
 hostListenerPoller:
-  enabled: false
-  # nameOverride: override the default resource name for this component.
-  # If unset, resources are named <release-name>-<component> (e.g. my-release-tfhe-worker).
-  # Useful when deploying multiple coprocessor instances in the same namespace.
-  nameOverride:
-
   image:
     name: hub.zama.org/zama-protocol/zama-ai/fhevm/coprocessor/host-listener
     tag: v0.11.0
@@ -294,14 +281,14 @@ hostListenerPoller:
 
   # Command line arguments for the host listener poller.
   # The following are injected automatically by the template:
-  #   --database-url, --url, --acl-contract-address, --tfhe-contract-address (from commonConfig)
+  #   --database-url, --url, --acl-contract-address, --tfhe-contract-address (from chains entry)
   #   --health-port (from ports.healthcheck), --metrics-addr (from ports.metrics)
   #   --dependent-ops-max-per-chain (from commonConfig.dependentOpsMaxPerChain)
+  #   --service-name=host-listener-poller-<chain.name> (auto-derived from chains entry)
   #   --coprocessor-api-key=$(TENANT_API_KEY)
   # Use extraArgs to pass flags not covered by the fields below.
   args:
     logLevel: INFO
-    serviceName: host-listener-poller
     finalityLag: 3
     batchSize: 100              # maximum number of blocks to process per iteration
     pollIntervalMs: 6000        # sleep between iterations (half block time ~6s for Ethereum)
@@ -379,12 +366,6 @@ hostListenerPoller:
 # -----------------------------------------------------------------------------
 # Host listener variant that runs only the catchup loop without real-time subscription.
 hostListenerCatchupOnly:
-  enabled: false
-  # nameOverride: override the default resource name for this component.
-  # If unset, resources are named <release-name>-<component> (e.g. my-release-tfhe-worker).
-  # Useful when deploying multiple coprocessor instances in the same namespace.
-  nameOverride:
-
   image:
     name: hub.zama.org/zama-protocol/zama-ai/fhevm/coprocessor/host-listener
     tag: v0.11.0
@@ -402,9 +383,10 @@ hostListenerCatchupOnly:
   # Command line arguments for the host listener catchup only mode.
   # NOTE: onlyCatchupLoop requires endAtBlock to be set.
   # The following are injected automatically by the template:
-  #   --database-url, --url, --acl-contract-address, --tfhe-contract-address (from commonConfig)
+  #   --database-url, --url, --acl-contract-address, --tfhe-contract-address (from chains entry)
   #   --health-port (from ports.healthcheck)
   #   --dependent-ops-max-per-chain (from commonConfig.dependentOpsMaxPerChain)
+  #   --service-name=host-listener-catchup-only-<chain.name> (auto-derived from chains entry)
   #   --coprocessor-api-key=$(TENANT_API_KEY)
   # Use extraArgs to pass flags not covered by the fields below.
   args:
@@ -412,7 +394,6 @@ hostListenerCatchupOnly:
     initialBlockTime: 12
     dependenceCacheSize: 128
     reorgMaximumDurationInBlocks: 50
-    serviceName: host-listener-catchup-only
     catchupFinalizationInBlocks: 20
     # Catchup-only specific parameters
     onlyCatchupLoop: true       # run only the catchup loop, not real-time subscription

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -158,10 +158,19 @@ dbMigration:
   tolerations:
 
 # -----------------------------------------------------------------------------
-# Host Listener
+# Host Listener Shared
 # -----------------------------------------------------------------------------
-# Processes blockchain events from the host chain via WebSocket
-hostListener:
+# Processes blockchain events from the host chain via WebSocket.
+# Shared/default configuration for every chain entry that enables
+# hostListener. This block is the primary source for image, replicas,
+# resources, ports, probes, tracing, scheduling, and structured args.
+# Per-chain hostListener config does not deep-override this block; it only:
+#   - enables the listener for that chain
+#   - provides required chain-specific RPC/contracts via the parent chain entry
+#   - appends env and extraArgs
+#   - may override serviceName
+#   - may claim the unsuffixed legacy resource name via useLegacyName
+hostListenerShared:
   image:
     name: hub.zama.org/zama-protocol/zama-ai/fhevm/coprocessor/host-listener
     tag: v0.11.0
@@ -186,8 +195,9 @@ hostListener:
   # Use extraArgs to pass flags not covered by the fields below.
   args:
     logLevel: INFO
-    initialBlockTime: 12        # switches to real block time when data is available
+    initialBlockTime: 12             # switches to real block time when data is available
     reorgMaximumDurationInBlocks: 50
+    serviceName:                     # optional global override; per-chain hostListener.serviceName takes precedence
     catchupFinalizationInBlocks: 20  # continuous catchup will wait for block "finalization"
 
   # Additional args appended after all template-injected and structured args.
@@ -261,10 +271,19 @@ hostListener:
       maxUnavailable: 0
 
 # -----------------------------------------------------------------------------
-# Host Listener Poller
+# Host Listener Poller Shared
 # -----------------------------------------------------------------------------
 # Processes blockchain events from the host chain via HTTP polling
-hostListenerPoller:
+# Shared/default configuration for every chain entry that enables
+# hostListenerPoller. This block is the primary source for image, replicas,
+# resources, ports, probes, tracing, scheduling, and structured args.
+# Per-chain hostListenerPoller config does not deep-override this block; it only:
+#   - enables the listener for that chain
+#   - provides required chain-specific RPC/contracts via the parent chain entry
+#   - appends env and extraArgs
+#   - may override serviceName
+#   - may claim the unsuffixed legacy resource name via useLegacyName
+hostListenerPollerShared:
   image:
     name: hub.zama.org/zama-protocol/zama-ai/fhevm/coprocessor/host-listener
     tag: v0.11.0
@@ -289,11 +308,12 @@ hostListenerPoller:
   # Use extraArgs to pass flags not covered by the fields below.
   args:
     logLevel: INFO
+    serviceName:                    # optional global override; per-chain hostListenerPoller.serviceName takes precedence
     finalityLag: 3
-    batchSize: 100              # maximum number of blocks to process per iteration
-    pollIntervalMs: 6000        # sleep between iterations (half block time ~6s for Ethereum)
-    retryIntervalMs: 1000       # backoff between retry attempts for RPC/DB failures
-    maxHttpRetries: 45          # maximum HTTP/RPC retry attempts before failing an operation
+    batchSize: 100                  # maximum number of blocks to process per iteration
+    pollIntervalMs: 6000            # sleep between iterations (half block time ~6s for Ethereum)
+    retryIntervalMs: 1000           # backoff between retry attempts for RPC/DB failures
+    maxHttpRetries: 45              # maximum HTTP/RPC retry attempts before failing an operation
     rpcComputeUnitsPerSecond: 1000  # rate limiting budget for RPC calls during block catchup
 
   # Additional args appended after all template-injected and structured args.
@@ -362,10 +382,19 @@ hostListenerPoller:
       maxUnavailable: 0
 
 # -----------------------------------------------------------------------------
-# Host Listener Catchup Only
+# Host Listener Catchup Only Shared
 # -----------------------------------------------------------------------------
 # Host listener variant that runs only the catchup loop without real-time subscription.
-hostListenerCatchupOnly:
+# Shared/default configuration for every chain entry that enables
+# hostListenerCatchupOnly. This block is the primary source for image, replicas,
+# resources, ports, probes, tracing, scheduling, and structured args.
+# Per-chain hostListenerCatchupOnly config does not deep-override this block; it only:
+#   - enables the listener for that chain
+#   - provides required chain-specific RPC/contracts via the parent chain entry
+#   - appends env and extraArgs
+#   - may override serviceName
+#   - may claim the unsuffixed legacy resource name via useLegacyName
+hostListenerCatchupOnlyShared:
   image:
     name: hub.zama.org/zama-protocol/zama-ai/fhevm/coprocessor/host-listener
     tag: v0.11.0
@@ -394,6 +423,7 @@ hostListenerCatchupOnly:
     initialBlockTime: 12
     dependenceCacheSize: 128
     reorgMaximumDurationInBlocks: 50
+    serviceName:                # optional global override; per-chain hostListenerCatchupOnly.serviceName takes precedence
     catchupFinalizationInBlocks: 20
     # Catchup-only specific parameters
     onlyCatchupLoop: true       # run only the catchup loop, not real-time subscription
@@ -469,32 +499,57 @@ hostListenerCatchupOnly:
 # Chains
 # -----------------------------------------------------------------------------
 # Each entry deploys up to three host listener variants for a given chain.
-# Top-level hostListener / hostListenerPoller / hostListenerCatchupOnly values
-# are used as defaults; per-chain fields override or extend them.
+# The top-level hostListenerShared / hostListenerPollerShared / hostListenerCatchupOnlyShared
+# blocks define shared settings used by every enabled chain for that listener
+# type. Chain entries do not deep-merge or override arbitrary top-level fields.
 #
-# The first entry preserves the legacy Deployment name (<release>-host-listener)
-# so that an existing single-chain installation can migrate without downtime.
-# Subsequent entries are named <release>-host-listener-<name>.
+# What each chain entry provides:
+#   - required chain-specific connection values (wsUrl or wsUrlValueFrom,
+#     httpUrl or httpUrlValueFrom, and contracts)
+#   - enabled toggles per listener type
+#   - additive env and extraArgs
+#   - optional serviceName override
+#   - optional useLegacyName flag to keep the unsuffixed legacy Kubernetes name
+#
+# Resource naming:
+#   - By default, resources are named <release>-host-listener-<name>,
+#     <release>-host-listener-poller-<name>, etc.
+#   - Set useLegacyName: true on exactly one chain per listener type to keep the
+#     unsuffixed legacy name (<release>-host-listener, etc.) during migration.
 #
 # Example:
 # chains:
 #   - name: ethereum
-#     wsUrl: "ws://eth-node:8546"       # required by hostListener + hostListenerCatchupOnly
-#     httpUrl: "http://eth-node:8545"   # required by hostListenerPoller
+#     wsUrl: "ws://eth-node:8546"       # required by hostListener + hostListenerCatchupOnly unless wsUrlValueFrom is set
+#     # wsUrlValueFrom:                 # secret/config-backed alternative to wsUrl
+#     #   secretKeyRef:
+#     #     name: rpc
+#     #     key: ethereum-rpc-ws-url
+#     httpUrl: "http://eth-node:8545"   # required by hostListenerPoller unless httpUrlValueFrom is set
+#     # httpUrlValueFrom:
+#     #   secretKeyRef:
+#     #     name: rpc
+#     #     key: ethereum-rpc-url
 #     aclContractAddress: "0x..."
 #     fhevmExecutorContractAddress: "0x..."
 #     hostListener:
 #       enabled: true
-#       extraArgs: []  # appended after top-level hostListener.extraArgs
-#       env: []        # appended after top-level hostListener.env
+#       useLegacyName: false  # set true on exactly one chain to keep the unsuffixed legacy resource names
+#       serviceName:          # optional per-chain override for --service-name
+#       extraArgs: []         # appended after top-level hostListenerShared.extraArgs
+#       env: []               # appended after top-level hostListenerShared.env
 #     hostListenerPoller:
 #       enabled: true
-#       extraArgs: []
-#       env: []
+#       useLegacyName: false
+#       serviceName:
+#       extraArgs: []         # appended after top-level hostListenerPollerShared.extraArgs
+#       env: []               # appended after top-level hostListenerPollerShared.env
 #     hostListenerCatchupOnly:
 #       enabled: true
-#       extraArgs: []
-#       env: []
+#       useLegacyName: false
+#       serviceName:
+#       extraArgs: []         # appended after top-level hostListenerCatchupOnlyShared.extraArgs
+#       env: []               # appended after top-level hostListenerCatchupOnlyShared.env
 chains: []
 
 # -----------------------------------------------------------------------------
@@ -635,22 +690,22 @@ tfheWorker:
   # Use extraArgs to pass flags not covered by the fields below.
   args:
     logLevel: INFO
-    serviceName: tfhe-worker    # service name in OTLP traces
+    serviceName: tfhe-worker       # service name in OTLP traces
     runBgWorker: true
     workerPollingIntervalMs: 10000
-    workItemsBatchSize: 100     # scheduling changed
+    workItemsBatchSize: 100        # scheduling changed
     dependenceChainsPerBatch: 100  # deprecated, to be removed in a future release
     keyCacheSize: 32
-    coprocessorFheThreads: 64   # scheduling changed
-    tokioThreads: 16            # scheduling changed
+    coprocessorFheThreads: 64      # scheduling changed
+    tokioThreads: 16               # scheduling changed
     pgPoolMaxConnections: 10
-    generateFheKeys: false      # unsafe - for testing only, keep false in production
-    dcidTtlSec: 30              # time-to-live (seconds) for dependence chain locks
-    disableDcidLocking: false   # WARNING: may cause multiple workers to process the same DCID concurrently
-    dcidTimesliceSec: 90        # time slice (seconds) for processing a single dependence chain; locks released if exceeded
-    processedDcidTtlSec: 172800  # time-to-live (seconds) for processed dependence chains (default 48h)
-    dcidCleanupIntervalSec: 3600  # interval (seconds) for cleaning up expired DCID locks
-    dcidMaxNoProgressCycles: 2  # worker cycles without progress before releasing
+    generateFheKeys: false         # unsafe - for testing only, keep false in production
+    dcidTtlSec: 30                 # time-to-live (seconds) for dependence chain locks
+    disableDcidLocking: false      # WARNING: may cause multiple workers to process the same DCID concurrently
+    dcidTimesliceSec: 90           # time slice (seconds) for processing a single dependence chain; locks released if exceeded
+    processedDcidTtlSec: 172800    # time-to-live (seconds) for processed dependence chains (default 48h)
+    dcidCleanupIntervalSec: 3600   # interval (seconds) for cleaning up expired DCID locks
+    dcidMaxNoProgressCycles: 2     # worker cycles without progress before releasing
 
   # Additional args appended after all template-injected and structured args.
   extraArgs: []


### PR DESCRIPTION
This PR goes to supporting multi-chain host listeners:
   
  - Updates Host-listener deployments (`host-listener`, `host-listener-poller`, `host-listener-catchup-only`) to iterate over a per-chain config so each chain gets its own `deployment`, `service`, and `ServiceMonitor` for each listener type.   
  - Adds validation (`coprocessor-host-listener-validation.yaml`) to check for the new multi-chain values structure.                                                                                                   
  - Updates `values.yaml` to restructure `host-listener` values to a multi-chain shape.