### PR TITLE
docs(common): update documentation for v0.12.0

### DIFF
--- a/coprocessor/docs/fundamentals/fhevm/coprocessor/fhe_computation.md
+++ b/coprocessor/docs/fundamentals/fhevm/coprocessor/fhe_computation.md
@@ -43,3 +43,13 @@ Note that, for now, we omit the Data Availability (DA) layer. It is still work i
 Since the coprocessor can extract data dependencies from the ingested events, it can use them to execute FHE computations in parallel.
 
 At the time of writing, the Coprocessor uses a simple policy to schedule FHE computation on multiple threads. More optimal policies will be introduced in the future and made configurable.
+
+## Slow Lane for Dependent Operations
+
+When a single chain submits a large burst of FHE operations that all depend on each other (a deep dependency chain), those operations must execute sequentially — they can starve other chains' operations from being processed.
+
+The **slow lane** is a scheduling mechanism that detects chains with an unusually high number of dependent operations per ingested block, and deprioritises them so that independent operations from other chains continue to make progress.
+
+A chain is placed in the slow lane when the number of dependent operations inserted for it in a single block exceeds the `dependentOpsMaxPerChain` threshold. Once the pressure drops, the chain is automatically promoted back to the normal lane.
+
+The slow lane is **disabled by default** (`dependentOpsMaxPerChain: 0`). See [Configuration](../../../getting_started/fhevm/coprocessor/configuration.md#slow-lane) for how to enable it.

--- a/coprocessor/docs/fundamentals/gateway/decryption.md
+++ b/coprocessor/docs/fundamentals/gateway/decryption.md
@@ -23,6 +23,50 @@ We allow explicit decryption requests for any encrypted type. The values are dec
 
 ![](asyncDecrypt.png)
 
+## Interface changes in v0.12.0
+
+> ⚠️ **Breaking changes in v0.12.0** — the `IDecryption` interface has been updated. Off-chain clients and contracts that call these functions must be updated.
+
+### `isUserDecryptionReady`
+
+A new overload without the `userAddress` parameter is now the canonical signature:
+
+```solidity
+// New (canonical) — v0.12.0+
+function isUserDecryptionReady(
+    CtHandleContractPair[] calldata ctHandleContractPairs,
+    bytes calldata extraData
+) external view returns (bool);
+
+// Old (deprecated, kept for backward compatibility)
+function isUserDecryptionReady(
+    address userAddress,           // unused — kept only for ABI backward compatibility
+    CtHandleContractPair[] calldata ctHandleContractPairs,
+    bytes calldata extraData
+) external view returns (bool);
+```
+
+The `userAddress` parameter was not used by the implementation and has been removed from the primary overload. The old signature remains callable but is marked `@custom:deprecated`.
+
+### `isDelegatedUserDecryptionReady`
+
+The `delegationAccounts` parameter has been removed:
+
+```solidity
+// New — v0.12.0+
+function isDelegatedUserDecryptionReady(
+    CtHandleContractPair[] calldata ctHandleContractPairs,
+    bytes calldata extraData
+) external view returns (bool);
+```
+
+### New errors
+
+| Error | Description |
+|---|---|
+| `InvalidExtraDataLength(uint256 length, uint256 minimumLength)` | The `extraData` bytes payload is shorter than required |
+| `UnsupportedExtraDataVersion(uint8 version)` | The version byte in `extraData` is not recognised |
+
 
 
 

--- a/coprocessor/docs/getting_started/fhevm/coprocessor/configuration.md
+++ b/coprocessor/docs/getting_started/fhevm/coprocessor/configuration.md
@@ -38,6 +38,20 @@ Options:
 
 ```
 
+### Slow Lane
+
+The slow lane prevents a single chain's deep dependency burst from starving other chains. Set `dependentOpsMaxPerChain` (Helm) or the equivalent env var to the maximum number of dependent operations allowed per chain per ingested block before the chain is deprioritised:
+
+```yaml
+# charts/coprocessor/values.yaml
+commonConfig:
+  # Max dependent ops per chain per ingested block before slow-lane.
+  # 0 disables slow-lane decisions (default).
+  dependentOpsMaxPerChain: 0
+```
+
+Setting this to `0` disables the slow lane entirely. A recommended starting value for production is `500`; tune upward if legitimate workloads are being throttled. See [Slow Lane](../../../fundamentals/fhevm/coprocessor/fhe_computation.md#slow-lane-for-dependent-operations) for the conceptual overview.
+
 #### Threads
 
 Note that there are two thread pools in the Coprocessor backend:

--- a/coprocessor/docs/getting_started/fhevm/coprocessor/coprocessor_backend.md
+++ b/coprocessor/docs/getting_started/fhevm/coprocessor/coprocessor_backend.md
@@ -17,3 +17,41 @@ The server and the worker can be run as separate processes or as a single proces
 The Coprocessor backend supports **multi-tenancy** in the sense that it can perform FHE computation for separate host blockchains, under different FHE keys.
 
 You can use pre-generated Docker images for the Coprocessor backend node or build them yourself as described in the [README](../../../../fhevm-engine/coprocessor/README.md).
+
+## Reverting to a previous state
+
+If the coprocessor reaches an inconsistent state (e.g. due to a drift detected between the coprocessor's ciphertexts and the expected on-chain state), it can be rolled back to a known-good block and reprocess from there.
+
+> ⚠️ **All coprocessor services must be stopped before running the revert.** The script is destructive: it permanently deletes all data for blocks strictly greater than the target block.
+
+The revert tool ships inside the `db-migration` Docker image as `revert_coprocessor_db_state.sh`.
+
+### Usage
+
+```bash
+# 1. Stop ALL coprocessor services.
+
+# 2. Run the revert against the target block (data for blocks > TO_BLOCK_NUMBER is deleted).
+#    Pass the block *before* the first offending block (i.e. offending_block - 1).
+docker run --rm --network <db-network> \
+  -e DATABASE_URL="postgres://user:pass@db-host:5432/coprocessor" \
+  -e CHAIN_ID=<host-chain-id> \
+  -e TO_BLOCK_NUMBER=<target-block> \
+  ghcr.io/zama-ai/fhevm/coprocessor/db-migration:<version> \
+  "/revert_coprocessor_db_state.sh"
+
+# 3. Restart coprocessor services.
+```
+
+### Environment variables
+
+| Variable | Description |
+|---|---|
+| `DATABASE_URL` | PostgreSQL connection string for the coprocessor database |
+| `CHAIN_ID` | Host chain ID whose state should be reverted |
+| `TO_BLOCK_NUMBER` | Target block number; all data for blocks **strictly greater** than this value is deleted |
+
+### Limitations
+
+- Revert is not possible across a key rotation boundary. If a new FHE key was activated after `TO_BLOCK_NUMBER`, reprocessed computations will use the new key and produce incorrect ciphertexts. In that case, contact Zama support before proceeding.
+- For blocks recorded before the v0.12.0 migration (which added block-number tracking to all relevant tables), revert data may be incomplete.

--- a/coprocessor/docs/references/fhevm_api.md
+++ b/coprocessor/docs/references/fhevm_api.md
@@ -1,1 +1,47 @@
 # FHEVM API specifications
+
+## FHE library (library-solidity)
+
+### `FHE.isPublicDecryptionResultValid`
+
+A view function that verifies the KMS signatures on a public decryption result on-chain, without sending a transaction.
+
+```solidity
+function isPublicDecryptionResultValid(
+    bytes32[] memory handlesList,
+    uint256[] memory decryptedResults,
+    bytes[] memory signatures
+) internal view returns (bool)
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `handlesList` | `bytes32[]` | Ciphertext handles that were decrypted |
+| `decryptedResults` | `uint256[]` | Plaintext values returned by the KMS |
+| `signatures` | `bytes[]` | EIP-712 signatures from KMS nodes |
+
+**Returns** `true` if at least a threshold number of valid KMS signatures are present; `false` otherwise.
+
+> ⚠️ **Use with care**: Unlike `checkSignatures` (non-view), this function does **not** emit an event recording that verification happened on-chain. Prefer `checkSignatures` in state-changing contexts. Use `isPublicDecryptionResultValid` only for read-only checks (e.g. front-end validation, off-chain tooling).
+
+**Example**
+
+```solidity
+bool valid = FHE.isPublicDecryptionResultValid(handles, results, sigs);
+require(valid, "invalid decryption result");
+```
+
+---
+
+### `FHE.fromExternal` — uninitialized handle support
+
+`FHE.fromExternal` now accepts a zero (uninitialized) handle without reverting. A zero handle represents an unset encrypted value and is returned as a zero-valued ciphertext of the requested type. This allows contracts to safely call `fromExternal` on optional or conditionally-set handles without a prior existence check.
+
+```solidity
+// Before v0.12.0: passing a zero inputHandle would revert.
+// From v0.12.0: returns a zero-valued ciphertext of the target type.
+euint64 value = FHE.fromExternal(externalEuint64.wrap(inputHandle), inputProof);
+```
+

--- a/gateway-contracts/docs/getting-started/contracts/gateway_config.md
+++ b/gateway-contracts/docs/getting-started/contracts/gateway_config.md
@@ -44,6 +44,14 @@ The fhevm Gateway has a single KMS, which must be constituted of at least 1 node
 
 Currently, they are set at deployment and it is currently _not_ possible to add or remove a KMS node to the fhevm Gateway later on.
 
+### KMS Context
+
+A **KMS context** groups a set of KMS nodes with their associated FHE key material under a monotonically-increasing numeric identifier (`kmsContextId`). The context ID is stored in `GatewayConfig` and emitted in on-chain events so that all protocol participants can unambiguously identify which key generation round a given decryption belongs to.
+
+> ⚠️ **Breaking change in v0.12.0**: The `UpdateKmsNodes` event has been renamed to `UpdateKmsContext` and now carries an indexed `newContextId` field. The `InitializeGatewayConfig` event also gains an indexed `kmsContextId` field. Any off-chain indexer or listener that filters on these events must be updated.
+
+The initial context ID is set via the `KMS_CONTEXT_ID` environment variable at deployment (see [Environment variables](../deployment/env_variables.md#kms-context-id)). Context IDs must be strictly increasing; attempting to register a context with an ID ≤ the current one reverts with `KmsContextAlreadyRegistered`. A null (zero) context ID always reverts with `InvalidNullKmsContextId`.
+
 ### KMS thresholds
 
 #### MPC threshold

--- a/gateway-contracts/docs/getting-started/deployment/env_variables.md
+++ b/gateway-contracts/docs/getting-started/deployment/env_variables.md
@@ -49,6 +49,7 @@ Here's the complete list of environment variables used for deploying the FHEVM g
 | `USER_DECRYPTION_PRICE`             | Price of a user decryption                 | address       | -                                                                                                   | The price is in $ZAMA base units (using 18 decimals)                             |
 | `ZAMA_OFT_ADDRESS`                  | Address of the ZamaOFT contract            | address       | -                                                                                                   | When using a real environment, the contract should already be deployed.          |
 | `FEES_SENDER_TO_BURNER_ADDRESS`     | Address of the FeesSenderToBurner contract | address       | -                                                                                                   | When using a real environment, the contract should already be deployed.          |
+| `KMS_CONTEXT_ID`                    | Initial KMS context ID                     | uint256       | -                                                                                                   | Must be non-zero. Format: `[0x07 \| counter_1..31]`                              |
 | `DEPLOYER_PRIVATE_KEY`              | Private key for contract deployment        | bytes32       | -                                                                                                   | -                                                                                |
 | `HARDHAT_NETWORK`                   | Network to deploy contracts on             | string        | "hardhat"                                                                                           | Possible values: `hardhat`, `localGateway`, `staging`, `zwsDev`, `testnet`       |
 | `CHAIN_ID_GATEWAY`                  | Chain ID of the gateway network            | uint256       | 31337                                                                                               | It should be consistent with the `HARDHAT_NETWORK` value                         |
@@ -68,6 +69,14 @@ These values are crucial for the FHEVM Gateway protocol and are set in the `Gate
 #### At deployment
 
 The following values are set at deployment.
+
+- KMS Context ID {#kms-context-id}
+
+```bash
+KMS_CONTEXT_ID="3166189940082864718613269121331309980362851143201109172953918312716374638593" # (uint256)
+```
+
+`KMS_CONTEXT_ID` is the initial KMS context identifier. It must be non-zero. The format is `[0x07 | counter_1..31]` (a 32-byte big-endian value whose first byte is `0x07`). See [KMS Context](../contracts/gateway_config.md#kms-context) for details.
 
 - Protocol metadata:
 


### PR DESCRIPTION
## Summary

Pre-release documentation update for v0.12.0. Covers all user-facing changes since v0.11.3 that had no corresponding doc update.

- **Coprocessor — DB state revert runbook**: new operator workflow to roll back a coprocessor to a known-good block when state drift is detected (`db-migration` image, `#2122`)
- **Coprocessor — slow lane**: configuration reference and fundamentals section explaining how the slow lane deprioritises chains with deep dependency bursts (`#1907`)
- **Gateway contracts — KMS context**: new `KMS_CONTEXT_ID` env var, `UpdateKmsNodes` → `UpdateKmsContext` event rename, new `kmsContextId` in `InitializeGatewayConfig`, new errors `InvalidNullKmsContextId` / `KmsContextAlreadyRegistered`
- **Gateway contracts — `IDecryption` breaking changes**: `isUserDecryptionReady` new canonical overload (without `userAddress`), old overload marked deprecated; `isDelegatedUserDecryptionReady` `delegationAccounts` param removed; new errors `InvalidExtraDataLength` / `UnsupportedExtraDataVersion` (`#2137`)
- **library-solidity — `isPublicDecryptionResultValid`**: new view function for off-chain/read-only decryption signature verification (`#1987`)
- **library-solidity — `FHE.fromExternal` uninitialized handles**: documents zero-handle behaviour change (`#1969`)

## Related commits

- `0edd863`: feat(coprocessor): add ability to revert to a previous state (#2122)
- `e1734b9`: feat(coprocessor): slow lane for dependent ops (#1907)
- `aa25e2e`: fix(gateway-contracts): overload `isUserDecryptionReady` with old signature (#2137)
- `2ecbbff`: feat(library-solidity): add view function for validating decryption signatures (#1987)
- `ca9e6eb`: feat(library-solidity): support uninitialized handles in FHE.fromExternal (#1969)

## Test plan
- [ ] Verify GitBook renders correctly (run local preview or check GitBook sync)
- [ ] Confirm SUMMARY.md does not need new entries (no new pages added)
- [ ] No code files modified