### PR TITLE
fix(test-suite): fail fast on missing gh package scope

### DIFF
--- a/test-suite/fhevm/README.md
+++ b/test-suite/fhevm/README.md
@@ -62,6 +62,8 @@ Most users should start with `latest-main`.
 
 Use `latest-supported`, network targets, or `sha` when you are reproducing a known supported or deployed bundle rather than validating current mainline behavior.
 
+Live target resolution uses GitHub metadata. For `latest-main`, `sha`, and network targets, install `gh` and authenticate it with package-read access, for example `gh auth refresh -s read:packages`, or provide a `GH_TOKEN` with that scope.
+
 Compat is mainly there to protect those reproduction and cross-era paths. For the common `latest-main` path, the mental model should stay simple: mainline baseline, optional surgical local or CI repo-owned overrides, explicit topology when needed. For the shim/incompatibility decision tree, see `COMPAT.md`.
 
 ## Quick Start

--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -3,7 +3,7 @@ import { writeFile } from "node:fs/promises";
 import { describe, expect, test } from "bun:test";
 
 import { validateBundleCompatibility } from "./compat/compat";
-import { shouldRetryGitHubCliError, shouldStopPackageTagScan } from "./resolve/github";
+import { explainGitHubCliError, shouldRetryGitHubCliError, shouldStopPackageTagScan } from "./resolve/github";
 import {
   SIMPLE_ACL_MIN_SHA,
   SHA_RUNTIME_COMPAT_MIN_SHA,
@@ -152,6 +152,14 @@ describe("resolve", () => {
       ),
     ).toBe(true);
     expect(shouldRetryGitHubCliError("gh: HTTP 404")).toBe(false);
+  });
+
+  test("rewrites missing package scope errors into actionable guidance", () => {
+    expect(
+      explainGitHubCliError(
+        "gh: You need at least read:packages scope to get a package's versions. (HTTP 403)",
+      ),
+    ).toContain("gh auth refresh -s read:packages");
   });
 
   test("stops package tag scans when the requested tag is found", () => {

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -13,10 +13,13 @@ const GH_API_RETRY_DELAY_MS = 1_000;
 const GH_PACKAGE_VERSION_LIMIT = 5_000;
 
 /** Rewrites raw `gh` failures into actionable user-facing guidance. */
-const explainGitHubCliError = (message: string): string => {
+export const explainGitHubCliError = (message: string): string => {
   const lower = message.toLowerCase();
   if (lower.includes("enoent") || lower.includes("not found")) {
     return "GitHub CLI `gh` is required. Install `gh`, authenticate with `gh auth login` or GH_TOKEN, or use `--lock-file` / `--target latest-supported` to avoid GitHub resolution.";
+  }
+  if (lower.includes("read:packages") || lower.includes("scope to get a package") || (lower.includes("http 403") && lower.includes("package"))) {
+    return "GitHub API is missing package-read scope. Run `gh auth refresh -s read:packages`, export GH_TOKEN with `read:packages`, or use `--lock-file` / `--target latest-supported` to avoid GitHub resolution.";
   }
   if (lower.includes("401") || lower.includes("authentication")) {
     return "GitHub API not authenticated. Run `gh auth login`, export GH_TOKEN, or use `--lock-file` / `--target latest-supported` to avoid GitHub resolution.";


### PR DESCRIPTION
## What changed

- rewrites `gh api` package-scope 403 failures into a direct `read:packages` remediation message
- adds a regression test for the missing-scope error mapping
- documents the `gh` package-read requirement for live target resolution

## Why

The new `fhevm-cli` resolver already handled missing `gh`, generic auth failures, rate limits, and timeouts, but a missing `read:packages` scope still surfaced as the raw `gh api` error. This makes the CLI fail fast with an actionable fix.

## Impact

Users hitting GitHub package metadata resolution without `read:packages` are now told exactly how to recover with `gh auth refresh -s read:packages` or a scoped `GH_TOKEN`.

## Validation

- `bun test src/resolve.test.ts`
- `bun run check`
- local dry-run repro with a mocked `gh api` 403 for missing `read:packages`


closes https://github.com/zama-ai/fhevm-internal/issues/1254
