### PR TITLE
fix(test-suite): retry GitHub rate limits in resolver

### DIFF
--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -188,7 +188,17 @@ describe("resolve", () => {
   });
 
   test("falls back to X-RateLimit-Reset for rate-limit cooldowns", () => {
-    expect(rateLimitRetryDelayMs({ "x-ratelimit-reset": "180" }, 1, 30_000)).toBe(150_000);
+    expect(rateLimitRetryDelayMs({ "x-ratelimit-remaining": "0", "x-ratelimit-reset": "180" }, 1, 30_000)).toBe(150_000);
+  });
+
+  test("does not use X-RateLimit-Reset when the primary bucket still has room", () => {
+    const random = Math.random;
+    Math.random = () => 0;
+    try {
+      expect(rateLimitRetryDelayMs({ "x-ratelimit-remaining": "42", "x-ratelimit-reset": "180" }, 1, 30_000)).toBe(60_000);
+    } finally {
+      Math.random = random;
+    }
   });
 
   test("rewrites missing package scope errors into actionable guidance", () => {

--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -3,7 +3,13 @@ import { writeFile } from "node:fs/promises";
 import { describe, expect, test } from "bun:test";
 
 import { validateBundleCompatibility } from "./compat/compat";
-import { explainGitHubCliError, shouldRetryGitHubCliError, shouldStopPackageTagScan } from "./resolve/github";
+import {
+  explainGitHubCliError,
+  isRateLimitGitHubCliError,
+  retryDelayMs,
+  shouldRetryGitHubCliError,
+  shouldStopPackageTagScan,
+} from "./resolve/github";
 import {
   SIMPLE_ACL_MIN_SHA,
   SHA_RUNTIME_COMPAT_MIN_SHA,
@@ -155,6 +161,25 @@ describe("resolve", () => {
       ),
     ).toBe(true);
     expect(shouldRetryGitHubCliError("gh: HTTP 404")).toBe(false);
+  });
+
+  test("classifies GitHub rate-limit responses separately", () => {
+    expect(isRateLimitGitHubCliError("gh: HTTP 429 Too Many Requests")).toBe(true);
+    expect(isRateLimitGitHubCliError("gh: API rate limit exceeded for user ID 12345 (HTTP 403)")).toBe(true);
+    expect(isRateLimitGitHubCliError("gh: You have exceeded a secondary rate limit. Please wait a few minutes before you try again. (HTTP 403)")).toBe(true);
+    expect(isRateLimitGitHubCliError("gh: HTTP 503")).toBe(false);
+  });
+
+  test("uses a longer retry delay budget for rate limits", () => {
+    const random = Math.random;
+    Math.random = () => 0;
+    try {
+      expect(retryDelayMs(1, false)).toBe(1_000);
+      expect(retryDelayMs(1, true)).toBe(60_000);
+      expect(retryDelayMs(3, true)).toBe(240_000);
+    } finally {
+      Math.random = random;
+    }
   });
 
   test("rewrites missing package scope errors into actionable guidance", () => {

--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -146,6 +146,9 @@ describe("resolve", () => {
     expect(shouldRetryGitHubCliError("gh: HTTP 503")).toBe(true);
     expect(shouldRetryGitHubCliError("gh: HTTP 502 Bad Gateway")).toBe(true);
     expect(shouldRetryGitHubCliError("gh: HTTP 504 Gateway Timeout")).toBe(true);
+    expect(shouldRetryGitHubCliError("gh: HTTP 429 Too Many Requests")).toBe(true);
+    expect(shouldRetryGitHubCliError("gh: API rate limit exceeded for user ID 12345 (HTTP 403)")).toBe(true);
+    expect(shouldRetryGitHubCliError("gh: You have exceeded a secondary rate limit. Please wait a few minutes before you try again. (HTTP 403)")).toBe(true);
     expect(
       shouldRetryGitHubCliError(
         "gh: No server is currently available to service your request. Sorry about that. Please try resubmitting your request and contact us if the problem persists. (HTTP 503)",

--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -6,6 +6,7 @@ import { validateBundleCompatibility } from "./compat/compat";
 import {
   explainGitHubCliError,
   isRateLimitGitHubCliError,
+  rateLimitRetryDelayMs,
   retryDelayMs,
   shouldRetryGitHubCliError,
   shouldStopPackageTagScan,
@@ -180,6 +181,14 @@ describe("resolve", () => {
     } finally {
       Math.random = random;
     }
+  });
+
+  test("prefers Retry-After for rate-limit cooldowns when available", () => {
+    expect(rateLimitRetryDelayMs({ "retry-after": "90" }, 1, 0)).toBe(90_000);
+  });
+
+  test("falls back to X-RateLimit-Reset for rate-limit cooldowns", () => {
+    expect(rateLimitRetryDelayMs({ "x-ratelimit-reset": "180" }, 1, 30_000)).toBe(150_000);
   });
 
   test("rewrites missing package scope errors into actionable guidance", () => {

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -61,6 +61,18 @@ const retryDelayMs = (attempt: number) => {
   return base + Math.floor(base * GH_API_RETRY_JITTER_RATIO * Math.random());
 };
 
+const retryReason = (message: string) => {
+  const lower = message.toLowerCase();
+  if (lower.includes("secondary rate limit")) return "secondary rate limit";
+  if (lower.includes("rate limit") || /\bhttp 429\b/.test(lower)) return "rate limit";
+  if (/\bhttp 5\d\d\b/.test(lower)) return "GitHub API 5xx";
+  if (lower.includes("timed out") || lower.includes("tls handshake timeout")) return "timeout";
+  if (lower.includes("connection reset") || lower.includes("econnreset")) return "connection reset";
+  if (lower.includes("connection refused")) return "connection refused";
+  if (lower.includes("temporary failure")) return "temporary failure";
+  return "transient GitHub API error";
+};
+
 const runGhApi = async <T>(apiPath: string): Promise<T> => {
   for (let attempt = 1; attempt <= GH_API_RETRIES; attempt += 1) {
     try {
@@ -69,7 +81,11 @@ const runGhApi = async <T>(apiPath: string): Promise<T> => {
     } catch (error) {
       const raw = error instanceof Error ? error.message : String(error);
       if (attempt < GH_API_RETRIES && shouldRetryGitHubCliError(raw)) {
-        await Bun.sleep(retryDelayMs(attempt));
+        const delay = retryDelayMs(attempt);
+        console.log(
+          `[resolve] gh api retry ${attempt}/${GH_API_RETRIES - 1} after ${retryReason(raw)}; waiting ${(delay / 1000).toFixed(1)}s`,
+        );
+        await Bun.sleep(delay);
         continue;
       }
       throw new GitHubApiError(explainGitHubCliError(raw));

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -95,8 +95,9 @@ export const rateLimitRetryDelayMs = (headers: Record<string, string>, attempt: 
   if (Number.isFinite(retryAfter) && retryAfter > 0) {
     return retryAfter * SECOND_MS;
   }
+  const remaining = Number(headers["x-ratelimit-remaining"]);
   const reset = Number(headers["x-ratelimit-reset"]);
-  if (Number.isFinite(reset) && reset > 0) {
+  if (remaining === 0 && Number.isFinite(reset) && reset > 0) {
     return Math.max((reset * SECOND_MS) - now, GH_API_RATE_LIMIT_RETRY_DELAY_MS);
   }
   return retryDelayMs(attempt, true);

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -11,6 +11,8 @@ const GH_API_TIMEOUT_MS = 20_000;
 const GH_API_RETRIES = 7;
 const GH_API_RETRY_DELAY_MS = 1_000;
 const GH_API_RETRY_MAX_DELAY_MS = 16_000;
+const GH_API_RATE_LIMIT_RETRY_DELAY_MS = 60_000;
+const GH_API_RATE_LIMIT_RETRY_MAX_DELAY_MS = 300_000;
 const GH_API_RETRY_JITTER_RATIO = 0.2;
 const GH_PACKAGE_VERSION_LIMIT = 5_000;
 
@@ -36,12 +38,15 @@ export const explainGitHubCliError = (message: string): string => {
 };
 
 /** Runs `gh api` and parses its JSON payload with CLI-specific error handling. */
+export const isRateLimitGitHubCliError = (message: string) => {
+  const lower = message.toLowerCase();
+  return lower.includes("secondary rate limit") || lower.includes("rate limit") || /\bhttp 429\b/.test(lower);
+};
+
 export const shouldRetryGitHubCliError = (message: string) => {
   const lower = message.toLowerCase();
   return (
-    lower.includes("rate limit") ||
-    lower.includes("secondary rate limit") ||
-    /\bhttp 429\b/.test(lower) ||
+    isRateLimitGitHubCliError(message) ||
     lower.includes("connection refused") ||
     lower.includes("timed out") ||
     lower.includes("tls handshake timeout") ||
@@ -56,8 +61,10 @@ export const shouldRetryGitHubCliError = (message: string) => {
   );
 };
 
-const retryDelayMs = (attempt: number) => {
-  const base = Math.min(GH_API_RETRY_DELAY_MS * 2 ** (attempt - 1), GH_API_RETRY_MAX_DELAY_MS);
+export const retryDelayMs = (attempt: number, rateLimited = false) => {
+  const initialDelay = rateLimited ? GH_API_RATE_LIMIT_RETRY_DELAY_MS : GH_API_RETRY_DELAY_MS;
+  const maxDelay = rateLimited ? GH_API_RATE_LIMIT_RETRY_MAX_DELAY_MS : GH_API_RETRY_MAX_DELAY_MS;
+  const base = Math.min(initialDelay * 2 ** (attempt - 1), maxDelay);
   return base + Math.floor(base * GH_API_RETRY_JITTER_RATIO * Math.random());
 };
 
@@ -81,7 +88,7 @@ const runGhApi = async <T>(apiPath: string): Promise<T> => {
     } catch (error) {
       const raw = error instanceof Error ? error.message : String(error);
       if (attempt < GH_API_RETRIES && shouldRetryGitHubCliError(raw)) {
-        const delay = retryDelayMs(attempt);
+        const delay = retryDelayMs(attempt, isRateLimitGitHubCliError(raw));
         console.log(
           `[resolve] gh api retry ${attempt}/${GH_API_RETRIES - 1} after ${retryReason(raw)}; waiting ${(delay / 1000).toFixed(1)}s`,
         );

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -8,8 +8,10 @@ const FHEVM_REPO = "zama-ai/fhevm";
 const GITOPS_REPO = "zama-zws/gitops";
 const GH_OWNER = "zama-ai";
 const GH_API_TIMEOUT_MS = 20_000;
-const GH_API_RETRIES = 5;
+const GH_API_RETRIES = 7;
 const GH_API_RETRY_DELAY_MS = 1_000;
+const GH_API_RETRY_MAX_DELAY_MS = 16_000;
+const GH_API_RETRY_JITTER_RATIO = 0.2;
 const GH_PACKAGE_VERSION_LIMIT = 5_000;
 
 /** Rewrites raw `gh` failures into actionable user-facing guidance. */
@@ -37,6 +39,9 @@ export const explainGitHubCliError = (message: string): string => {
 export const shouldRetryGitHubCliError = (message: string) => {
   const lower = message.toLowerCase();
   return (
+    lower.includes("rate limit") ||
+    lower.includes("secondary rate limit") ||
+    /\bhttp 429\b/.test(lower) ||
     lower.includes("connection refused") ||
     lower.includes("timed out") ||
     lower.includes("tls handshake timeout") ||
@@ -51,6 +56,11 @@ export const shouldRetryGitHubCliError = (message: string) => {
   );
 };
 
+const retryDelayMs = (attempt: number) => {
+  const base = Math.min(GH_API_RETRY_DELAY_MS * 2 ** (attempt - 1), GH_API_RETRY_MAX_DELAY_MS);
+  return base + Math.floor(base * GH_API_RETRY_JITTER_RATIO * Math.random());
+};
+
 const runGhApi = async <T>(apiPath: string): Promise<T> => {
   for (let attempt = 1; attempt <= GH_API_RETRIES; attempt += 1) {
     try {
@@ -59,7 +69,7 @@ const runGhApi = async <T>(apiPath: string): Promise<T> => {
     } catch (error) {
       const raw = error instanceof Error ? error.message : String(error);
       if (attempt < GH_API_RETRIES && shouldRetryGitHubCliError(raw)) {
-        await Bun.sleep(GH_API_RETRY_DELAY_MS * 2 ** (attempt - 1));
+        await Bun.sleep(retryDelayMs(attempt));
         continue;
       }
       throw new GitHubApiError(explainGitHubCliError(raw));

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -15,6 +15,7 @@ const GH_API_RATE_LIMIT_RETRY_DELAY_MS = 60_000;
 const GH_API_RATE_LIMIT_RETRY_MAX_DELAY_MS = 300_000;
 const GH_API_RETRY_JITTER_RATIO = 0.2;
 const GH_PACKAGE_VERSION_LIMIT = 5_000;
+const SECOND_MS = 1_000;
 
 /** Rewrites raw `gh` failures into actionable user-facing guidance. */
 export const explainGitHubCliError = (message: string): string => {
@@ -68,6 +69,39 @@ export const retryDelayMs = (attempt: number, rateLimited = false) => {
   return base + Math.floor(base * GH_API_RETRY_JITTER_RATIO * Math.random());
 };
 
+type GhHttpResponse = {
+  headers: Record<string, string>;
+  body: string;
+};
+
+const parseGhHttpResponse = (text: string): GhHttpResponse => {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const [rawHeaders = "", ...bodyParts] = normalized.split("\n\n");
+  const headers = Object.fromEntries(
+    rawHeaders
+      .split("\n")
+      .slice(1)
+      .map((line) => {
+        const index = line.indexOf(":");
+        return index < 0 ? undefined : [line.slice(0, index).trim().toLowerCase(), line.slice(index + 1).trim()] as const;
+      })
+      .filter((entry): entry is readonly [string, string] => Boolean(entry)),
+  );
+  return { headers, body: bodyParts.join("\n\n").trim() };
+};
+
+export const rateLimitRetryDelayMs = (headers: Record<string, string>, attempt: number, now = Date.now()) => {
+  const retryAfter = Number(headers["retry-after"]);
+  if (Number.isFinite(retryAfter) && retryAfter > 0) {
+    return retryAfter * SECOND_MS;
+  }
+  const reset = Number(headers["x-ratelimit-reset"]);
+  if (Number.isFinite(reset) && reset > 0) {
+    return Math.max((reset * SECOND_MS) - now, GH_API_RATE_LIMIT_RETRY_DELAY_MS);
+  }
+  return retryDelayMs(attempt, true);
+};
+
 const retryReason = (message: string) => {
   const lower = message.toLowerCase();
   if (lower.includes("secondary rate limit")) return "secondary rate limit";
@@ -82,21 +116,23 @@ const retryReason = (message: string) => {
 
 const runGhApi = async <T>(apiPath: string): Promise<T> => {
   for (let attempt = 1; attempt <= GH_API_RETRIES; attempt += 1) {
-    try {
-      const result = await run(["gh", "api", apiPath], { timeoutMs: GH_API_TIMEOUT_MS });
-      return JSON.parse(result.stdout) as T;
-    } catch (error) {
-      const raw = error instanceof Error ? error.message : String(error);
-      if (attempt < GH_API_RETRIES && shouldRetryGitHubCliError(raw)) {
-        const delay = retryDelayMs(attempt, isRateLimitGitHubCliError(raw));
+    const result = await run(["gh", "api", apiPath, "-i"], { timeoutMs: GH_API_TIMEOUT_MS, allowFailure: true });
+    if (result.code === 0) {
+      return JSON.parse(parseGhHttpResponse(result.stdout).body) as T;
+    }
+    const raw = [result.stderr, parseGhHttpResponse(result.stdout).body].filter(Boolean).join("\n").trim() || result.stdout.trim();
+    if (attempt < GH_API_RETRIES && shouldRetryGitHubCliError(raw)) {
+        const response = parseGhHttpResponse(result.stdout);
+        const delay = isRateLimitGitHubCliError(raw)
+          ? rateLimitRetryDelayMs(response.headers, attempt)
+          : retryDelayMs(attempt, false);
         console.log(
           `[resolve] gh api retry ${attempt}/${GH_API_RETRIES - 1} after ${retryReason(raw)}; waiting ${(delay / 1000).toFixed(1)}s`,
         );
         await Bun.sleep(delay);
         continue;
-      }
-      throw new GitHubApiError(explainGitHubCliError(raw));
     }
+    throw new GitHubApiError(explainGitHubCliError(raw));
   }
   throw new GitHubApiError("GitHub metadata lookup failed");
 };


### PR DESCRIPTION
## Summary
- retry GitHub rate-limit responses in the fhevm resolver instead of failing immediately
- increase retry attempts and use capped exponential backoff with light jitter
- extend resolver tests to cover 429 and rate-limit 403 responses

## Verification
- `bun test src/resolve.test.ts`
- `bun run check`
