### PR TITLE
fix: use github token for fhevm cli GH API calls

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -120,7 +120,7 @@ jobs:
       id-token: 'write' # Required for OIDC authentication
       packages: 'read' # Required to read GitHub packages/container registry
     env:
-      GH_TOKEN: ${{ secrets.GHCR_READ_TOKEN || github.token }}
+      GH_TOKEN: ${{ github.token }}
       BUILD: ${{ inputs.orchestrated && 'false' || github.event_name == 'pull_request' && 'true' || inputs.build && 'true' || 'false' }}
       COPROCESSOR_DB_MIGRATION_VERSION: ${{ inputs.coprocessor-db-migration-version }}
       COPROCESSOR_HOST_LISTENER_VERSION: ${{ inputs.coprocessor-host-listener-version }}


### PR DESCRIPTION
## Summary
Use the job-scoped `github.token` for `gh api` calls in the reusable test-suite e2e workflow.

## Why
Merge queue was reaching `./fhevm-cli up --target latest-main` and failing during live GitHub package resolution with:

`GitHub API is missing package-read scope.`

The job already grants `packages: read` to `GITHUB_TOKEN`, but the workflow exported `GH_TOKEN` from `GHCR_READ_TOKEN`, so `gh api` was not using the job token.

## Change
Set `GH_TOKEN: ${{ github.token }}` in `.github/workflows/test-suite-e2e-tests.yml`.

Docker login still uses `GHCR_READ_TOKEN`, so registry authentication behavior for image pulls is unchanged.

## Testing
Not run locally. This should be verified by rerunning the merge-queue e2e job.
