### PR TITLE
feat(host-contracts): add file-based prepareUpgrade flows

### DIFF
--- a/.github/workflows/gateway-contracts-upgrade-tests.yml
+++ b/.github/workflows/gateway-contracts-upgrade-tests.yml
@@ -116,6 +116,77 @@ jobs:
           cp -r ../../previous-fhevm/gateway-contracts/contracts ./previous-contracts
           docker cp deploy-gateway-contracts:/app/addresses ./
 
+      - name: Run prepare-only upgrades
+        working-directory: current-fhevm/gateway-contracts
+        run: |
+          set -euo pipefail
+          source addresses/.env.gateway
+          PREPARED=0
+          SKIPPED=0
+
+          for name in $(jq -r '.[]' upgrade-manifest.json); do
+            if [ ! -f "contracts/${name}.sol" ]; then
+              echo "::error::$name listed in upgrade-manifest.json but contracts/${name}.sol not found"
+              exit 1
+            fi
+
+            if [ ! -f "previous-contracts/${name}.sol" ]; then
+              echo "Skipping prepare-only check for $name (not present in previous release)"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            old_ver=$(sed -n 's/.*REINITIALIZER_VERSION[[:space:]]*=[[:space:]]*\([0-9]*\).*/\1/p' \
+              "previous-contracts/${name}.sol")
+            new_ver=$(sed -n 's/.*REINITIALIZER_VERSION[[:space:]]*=[[:space:]]*\([0-9]*\).*/\1/p' \
+              "contracts/${name}.sol")
+            if [ -z "$old_ver" ]; then
+              echo "::error::Failed to parse REINITIALIZER_VERSION from previous-contracts/${name}.sol"
+              exit 1
+            fi
+            if [ -z "$new_ver" ]; then
+              echo "::error::Failed to parse REINITIALIZER_VERSION from contracts/${name}.sol"
+              exit 1
+            fi
+
+            if [ "$old_ver" = "$new_ver" ]; then
+              echo "Skipping prepare-only check for $name (reinitializer unchanged: $old_ver)"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            case "$name" in
+              GatewayConfig) proxy_address="$GATEWAY_CONFIG_ADDRESS" ;;
+              Decryption) proxy_address="$DECRYPTION_ADDRESS" ;;
+              CiphertextCommits) proxy_address="$CIPHERTEXT_COMMITS_ADDRESS" ;;
+              InputVerification) proxy_address="$INPUT_VERIFICATION_ADDRESS" ;;
+              KMSGeneration) proxy_address="$KMS_GENERATION_ADDRESS" ;;
+              *)
+                echo "::error::Unsupported gateway upgrade manifest entry: $name"
+                exit 1
+                ;;
+            esac
+
+            echo "::group::Preparing $name (reinitializer $old_ver → $new_ver)"
+            before_impl=$(cast implementation "$proxy_address" --rpc-url "$RPC_URL")
+
+            npx hardhat "task:prepareUpgrade${name}" \
+              --current-implementation "previous-contracts/${name}.sol:${name}" \
+              --new-implementation "contracts/${name}.sol:${name}" \
+              --use-internal-proxy-address true \
+              --verify-contract false
+
+            after_impl=$(cast implementation "$proxy_address" --rpc-url "$RPC_URL")
+            test "$before_impl" = "$after_impl"
+            echo "::endgroup::"
+            PREPARED=$((PREPARED + 1))
+          done
+
+          echo "::notice::Prepare-upgrade summary: $PREPARED prepared, $SKIPPED skipped"
+          if [ "$PREPARED" -eq 0 ]; then
+            echo "::warning::No contracts needed preparing — consider bumping UPGRADE_FROM_TAG"
+          fi
+
       - name: Run contract upgrades
         working-directory: current-fhevm/gateway-contracts
         run: |

--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -120,26 +120,77 @@ jobs:
           cp -r ../../previous-fhevm/host-contracts/contracts ./previous-contracts
           docker cp fhevm-sc-deploy:/app/addresses ./
 
-      # The regular upgrade loop below only exercises task:upgrade<Contract>, which upgrades the proxy in place.
-      # We also rely on task:prepareUpgradeFHEVMExecutor operationally to deploy a new implementation without
-      # mutating the proxy. This smoke step covers that prepare-only path and guards against regressions where
-      # the task stops deploying correctly or accidentally upgrades the proxy instead of just preparing it.
-      - name: Smoke test prepare-only FHEVMExecutor deployment
+      - name: Run prepare-only upgrades
         working-directory: current-fhevm/host-contracts
         run: |
           set -euo pipefail
           source addresses/.env.host
 
-          before_impl=$(cast implementation "$FHEVM_EXECUTOR_CONTRACT_ADDRESS" --rpc-url "$RPC_URL")
+          PREPARED=0
+          SKIPPED=0
 
-          npx hardhat task:prepareUpgradeFHEVMExecutor \
-            --current-implementation previous-contracts/FHEVMExecutor.sol:FHEVMExecutor \
-            --new-implementation contracts/FHEVMExecutor.sol:FHEVMExecutor \
-            --use-internal-proxy-address true \
-            --verify-contract false
+          for name in $(jq -r '.[]' upgrade-manifest.json); do
+            if [ ! -f "contracts/${name}.sol" ]; then
+              echo "::error::$name listed in upgrade-manifest.json but contracts/${name}.sol not found"
+              exit 1
+            fi
 
-          after_impl=$(cast implementation "$FHEVM_EXECUTOR_CONTRACT_ADDRESS" --rpc-url "$RPC_URL")
-          test "$before_impl" = "$after_impl"
+            if [ ! -f "previous-contracts/${name}.sol" ]; then
+              echo "Skipping prepare-only check for $name (not present in previous release)"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            old_ver=$(sed -n 's/.*REINITIALIZER_VERSION[[:space:]]*=[[:space:]]*\([0-9]*\).*/\1/p' \
+              "previous-contracts/${name}.sol")
+            new_ver=$(sed -n 's/.*REINITIALIZER_VERSION[[:space:]]*=[[:space:]]*\([0-9]*\).*/\1/p' \
+              "contracts/${name}.sol")
+            if [ -z "$old_ver" ]; then
+              echo "::error::Failed to parse REINITIALIZER_VERSION from previous-contracts/${name}.sol"
+              exit 1
+            fi
+            if [ -z "$new_ver" ]; then
+              echo "::error::Failed to parse REINITIALIZER_VERSION from contracts/${name}.sol"
+              exit 1
+            fi
+
+            if [ "$old_ver" = "$new_ver" ]; then
+              echo "Skipping prepare-only check for $name (reinitializer unchanged: $old_ver)"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            case "$name" in
+              ACL) proxy_address="$ACL_CONTRACT_ADDRESS" ;;
+              FHEVMExecutor) proxy_address="$FHEVM_EXECUTOR_CONTRACT_ADDRESS" ;;
+              KMSVerifier) proxy_address="$KMS_VERIFIER_CONTRACT_ADDRESS" ;;
+              InputVerifier) proxy_address="$INPUT_VERIFIER_CONTRACT_ADDRESS" ;;
+              HCULimit) proxy_address="$HCU_LIMIT_CONTRACT_ADDRESS" ;;
+              *)
+                echo "::error::Unsupported host upgrade manifest entry: $name"
+                exit 1
+                ;;
+            esac
+
+            echo "::group::Preparing $name (reinitializer $old_ver → $new_ver)"
+            before_impl=$(cast implementation "$proxy_address" --rpc-url "$RPC_URL")
+
+            npx hardhat "task:prepareUpgrade${name}" \
+              --current-implementation "previous-contracts/${name}.sol:${name}" \
+              --new-implementation "contracts/${name}.sol:${name}" \
+              --use-internal-proxy-address true \
+              --verify-contract false
+
+            after_impl=$(cast implementation "$proxy_address" --rpc-url "$RPC_URL")
+            test "$before_impl" = "$after_impl"
+            echo "::endgroup::"
+            PREPARED=$((PREPARED + 1))
+          done
+
+          echo "::notice::Prepare-upgrade summary: $PREPARED prepared, $SKIPPED skipped"
+          if [ "$PREPARED" -eq 0 ]; then
+            echo "::warning::No contracts needed preparing — consider bumping UPGRADE_FROM_TAG"
+          fi
 
       - name: Run contract upgrades
         working-directory: current-fhevm/host-contracts

--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -128,13 +128,12 @@ jobs:
         working-directory: current-fhevm/host-contracts
         run: |
           set -euo pipefail
-          git fetch --depth=1 origin "refs/tags/${UPGRADE_FROM_TAG}:refs/tags/${UPGRADE_FROM_TAG}"
           source addresses/.env.host
 
           before_impl=$(cast implementation "$FHEVM_EXECUTOR_CONTRACT_ADDRESS" --rpc-url "$RPC_URL")
 
           npx hardhat task:prepareUpgradeFHEVMExecutor \
-            --upgrade-from-ref "$UPGRADE_FROM_TAG" \
+            --current-implementation previous-contracts/FHEVMExecutor.sol:FHEVMExecutor \
             --new-implementation contracts/FHEVMExecutor.sol:FHEVMExecutor \
             --use-internal-proxy-address true \
             --verify-contract false

--- a/gateway-contracts/tasks/upgradeContracts.ts
+++ b/gateway-contracts/tasks/upgradeContracts.ts
@@ -8,12 +8,37 @@ const REINITIALIZE_FUNCTION_PREFIX = "reinitializeV"; // Prefix for reinitialize
 
 // This file defines generic tasks that can be used to upgrade the implementation of already deployed contracts.
 
+type AbiFunction = {
+  type?: string;
+  name?: string;
+  inputs?: { type?: string }[];
+};
+
 function getImplementationDirectory(input: string): string {
   const colonIndex = input.lastIndexOf("/");
   if (colonIndex !== -1) {
     return input.substring(0, colonIndex);
   }
   return input;
+}
+
+function getReinitializeFunction(abi: AbiFunction[]) {
+  return abi.find((item) => item.type === "function" && item.name?.includes(REINITIALIZE_FUNCTION_PREFIX));
+}
+
+function getFunctionSignature(fn: AbiFunction): string {
+  return `${fn.name}(${(fn.inputs ?? []).map((input) => input.type).join(",")})`;
+}
+
+function formatCastArg(arg: unknown): string {
+  if (Array.isArray(arg)) {
+    return `[${arg.map(formatCastArg).join(",")}]`;
+  }
+  return String(arg);
+}
+
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
 // Upgrades the implementation of the proxy
@@ -40,9 +65,10 @@ async function upgradeCurrentToNew(
 
   // Get reinitialize function from the new implementation artifact
   const newImplementationArtifact = await hre.artifacts.readArtifact(newImplementation);
-  const reinitializeFunction = newImplementationArtifact.abi.find(
-    (item) => item.type === "function" && item.name.includes(REINITIALIZE_FUNCTION_PREFIX),
-  );
+  const reinitializeFunction = getReinitializeFunction(newImplementationArtifact.abi);
+  if (!reinitializeFunction?.name) {
+    throw new Error(`No reinitialize function found in ${newImplementation}`);
+  }
 
   // Prepare the new implementation factory and execute the upgrade by calling the reinitialize function
   const newImplementationFactory = await hre.ethers.getContractFactory(newImplementation, deployer);
@@ -106,6 +132,58 @@ async function checkImplementationArtifacts(
   }
 }
 
+async function deployImplementationForPreparedUpgrade(
+  proxyAddress: string,
+  expectedArtifactName: string,
+  currentImplementation: string,
+  newImplementation: string,
+  verifyContract: boolean,
+  hre: HardhatRuntimeEnvironment,
+  reinitializeArgs: unknown[] = [],
+): Promise<void> {
+  await compileImplementations(currentImplementation, newImplementation, hre);
+  await checkImplementationArtifacts(expectedArtifactName, currentImplementation, newImplementation, hre);
+
+  const deployerPrivateKey = getRequiredEnvVar("DEPLOYER_PRIVATE_KEY");
+  const deployer = new Wallet(deployerPrivateKey).connect(hre.ethers.provider);
+  const currentImplementationFactory = await hre.ethers.getContractFactory(currentImplementation, deployer);
+  await hre.upgrades.forceImport(proxyAddress, currentImplementationFactory);
+
+  const newImplementationArtifact = await hre.artifacts.readArtifact(newImplementation);
+  const reinitializeFunction = getReinitializeFunction(newImplementationArtifact.abi);
+  if (!reinitializeFunction?.name) {
+    throw new Error(`No reinitialize function found in ${newImplementation}`);
+  }
+  const newImplementationFactory = await hre.ethers.getContractFactory(newImplementation, deployer);
+
+  console.log(`Deploying "${newImplementation}" for prepared upgrade on proxy ${proxyAddress}...`);
+  const implementationAddress = await hre.upgrades.prepareUpgrade(proxyAddress, newImplementationFactory, {
+    kind: "uups",
+  });
+  console.log("New implementation deployed at:", implementationAddress);
+
+  const reinitializeCalldata = hre.ethers.Interface.from(newImplementationArtifact.abi).encodeFunctionData(
+    reinitializeFunction.name,
+    reinitializeArgs,
+  );
+  console.log(`${reinitializeFunction.name} calldata:`, reinitializeCalldata);
+  console.log(
+    `To double check, run: cast calldata ${shellQuote(getFunctionSignature(reinitializeFunction))} ${reinitializeArgs
+      .map((arg) => shellQuote(formatCastArg(arg)))
+      .join(" ")}`.trim(),
+  );
+
+  if (verifyContract) {
+    console.log("Waiting 2 minutes before contract verification... Please wait...");
+    await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+    await hre.run("verify:verify", {
+      address: implementationAddress,
+      contract: newImplementation,
+      constructorArguments: [],
+    });
+  }
+}
+
 // Helper to perform a standard upgrade: compile, check artifacts, load address, upgrade
 async function upgradeContract(
   contractName: string,
@@ -124,6 +202,29 @@ async function upgradeContract(
 
   await upgradeCurrentToNew(
     proxyAddress,
+    taskArgs.currentImplementation,
+    taskArgs.newImplementation,
+    taskArgs.verifyContract,
+    hre,
+    reinitializeArgs,
+  );
+}
+
+async function prepareUpgradeContract(
+  contractName: string,
+  addressEnvVar: string,
+  taskArgs: TaskArguments,
+  hre: HardhatRuntimeEnvironment,
+  reinitializeArgs: unknown[] = [],
+) {
+  if (taskArgs.useInternalProxyAddress) {
+    loadGatewayAddresses();
+  }
+  const proxyAddress = getRequiredEnvVar(addressEnvVar);
+
+  await deployImplementationForPreparedUpgrade(
+    proxyAddress,
+    contractName,
     taskArgs.currentImplementation,
     taskArgs.newImplementation,
     taskArgs.verifyContract,
@@ -157,6 +258,31 @@ task("task:upgradeCiphertextCommits")
     await upgradeContract("CiphertextCommits", "CIPHERTEXT_COMMITS_ADDRESS", taskArgs, hre);
   });
 
+task("task:prepareUpgradeCiphertextCommits")
+  .addParam(
+    "currentImplementation",
+    "The currently deployed implementation solidity contract path and name, eg: contracts/CiphertextCommits.sol:CiphertextCommits",
+  )
+  .addParam(
+    "newImplementation",
+    "The new implementation solidity contract path and name, eg: contracts/CiphertextCommits.sol:CiphertextCommits",
+  )
+  .addOptionalParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    "verifyContract",
+    "Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)",
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract("CiphertextCommits", "CIPHERTEXT_COMMITS_ADDRESS", taskArgs, hre);
+  });
+
 task("task:upgradeDecryption")
   .addParam(
     "currentImplementation",
@@ -180,6 +306,31 @@ task("task:upgradeDecryption")
   )
   .setAction(async function (taskArgs: TaskArguments, hre) {
     await upgradeContract("Decryption", "DECRYPTION_ADDRESS", taskArgs, hre);
+  });
+
+task("task:prepareUpgradeDecryption")
+  .addParam(
+    "currentImplementation",
+    "The currently deployed implementation solidity contract path and name, eg: contracts/Decryption.sol:Decryption",
+  )
+  .addParam(
+    "newImplementation",
+    "The new implementation solidity contract path and name, eg: contracts/Decryption.sol:Decryption",
+  )
+  .addOptionalParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    "verifyContract",
+    "Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)",
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract("Decryption", "DECRYPTION_ADDRESS", taskArgs, hre);
   });
 
 task("task:upgradeGatewayConfig")
@@ -208,6 +359,32 @@ task("task:upgradeGatewayConfig")
     await upgradeContract("GatewayConfig", "GATEWAY_CONFIG_ADDRESS", taskArgs, hre, [kmsContextId]);
   });
 
+task("task:prepareUpgradeGatewayConfig")
+  .addParam(
+    "currentImplementation",
+    "The currently deployed implementation solidity contract path and name, eg: contracts/GatewayConfig.sol:GatewayConfig",
+  )
+  .addParam(
+    "newImplementation",
+    "The new implementation solidity contract path and name, eg: contracts/GatewayConfig.sol:GatewayConfig",
+  )
+  .addOptionalParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    "verifyContract",
+    "Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)",
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    const kmsContextId = getRequiredEnvVar("KMS_CONTEXT_ID");
+    await prepareUpgradeContract("GatewayConfig", "GATEWAY_CONFIG_ADDRESS", taskArgs, hre, [kmsContextId]);
+  });
+
 task("task:upgradeKMSGeneration")
   .addParam(
     "currentImplementation",
@@ -233,6 +410,31 @@ task("task:upgradeKMSGeneration")
     await upgradeContract("KMSGeneration", "KMS_GENERATION_ADDRESS", taskArgs, hre);
   });
 
+task("task:prepareUpgradeKMSGeneration")
+  .addParam(
+    "currentImplementation",
+    "The currently deployed implementation solidity contract path and name, eg: contracts/KMSGeneration.sol:KMSGeneration",
+  )
+  .addParam(
+    "newImplementation",
+    "The new implementation solidity contract path and name, eg: contracts/KMSGeneration.sol:KMSGeneration",
+  )
+  .addOptionalParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    "verifyContract",
+    "Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)",
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract("KMSGeneration", "KMS_GENERATION_ADDRESS", taskArgs, hre);
+  });
+
 task("task:upgradeInputVerification")
   .addParam(
     "currentImplementation",
@@ -256,4 +458,29 @@ task("task:upgradeInputVerification")
   )
   .setAction(async function (taskArgs: TaskArguments, hre) {
     await upgradeContract("InputVerification", "INPUT_VERIFICATION_ADDRESS", taskArgs, hre);
+  });
+
+task("task:prepareUpgradeInputVerification")
+  .addParam(
+    "currentImplementation",
+    "The currently deployed implementation solidity contract path and name, eg: contracts/InputVerification.sol:InputVerification",
+  )
+  .addParam(
+    "newImplementation",
+    "The new implementation solidity contract path and name, eg: contracts/InputVerification.sol:InputVerification",
+  )
+  .addOptionalParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    "verifyContract",
+    "Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)",
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract("InputVerification", "INPUT_VERIFICATION_ADDRESS", taskArgs, hre);
   });

--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -59,14 +59,14 @@ Then run:
 ```bash
 npx hardhat task:prepareUpgradeFHEVMExecutor \
   --network sepolia \
-  --upgrade-from-ref v0.11.1 \
+  --current-implementation previous-contracts/FHEVMExecutor.sol:FHEVMExecutor \
   --new-implementation contracts/FHEVMExecutor.sol:FHEVMExecutor \
   --verify-contract true
 ```
 
 Notes:
 - `--network` selects where the implementation deployment transaction is sent.
-- `--upgrade-from-ref` is only used to load the old implementation source for OZ validation.
+- `--current-implementation` points to the old implementation source available on disk.
 - `--new-implementation` comes from your current checkout.
 - if you want the proxy address from `addresses/.env.host`, add `--use-internal-proxy-address true`
 - the task runs `hardhat clean` before recompiling so the implementation is not built from stale

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -1,7 +1,4 @@
 import { Wallet } from 'ethers';
-import fs from 'fs';
-import path from 'path';
-import { execFileSync } from 'child_process';
 import { task, types } from 'hardhat/config';
 import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types';
 
@@ -11,6 +8,12 @@ const REINITIALIZE_FUNCTION_PREFIX = 'reinitializeV'; // Prefix for reinitialize
 
 // This file defines generic tasks that can be used to upgrade the implementation of already deployed contracts.
 
+type AbiFunction = {
+  type?: string;
+  name?: string;
+  inputs?: { type?: string }[];
+};
+
 function getImplementationDirectory(input: string): string {
   const colonIndex = input.lastIndexOf('/');
   if (colonIndex !== -1) {
@@ -19,34 +22,23 @@ function getImplementationDirectory(input: string): string {
   return input;
 }
 
-function materializeContractsFromGit(gitRef: string, relativeDir: string) {
-  const repoRoot = path.resolve(__dirname, '../..');
-  const absoluteDir = path.resolve(__dirname, '..', relativeDir);
-  fs.mkdirSync(absoluteDir, { recursive: true });
+function getReinitializeFunction(abi: AbiFunction[]) {
+  return abi.find((item) => item.type === 'function' && item.name?.includes(REINITIALIZE_FUNCTION_PREFIX));
+}
 
-  execFileSync(
-    'sh',
-    [
-      '-c',
-      'git archive --format=tar "$1" '
-        + 'host-contracts/contracts/FHEVMExecutor.sol '
-        + 'host-contracts/contracts/ACL.sol '
-        + 'host-contracts/contracts/HCULimit.sol '
-        + 'host-contracts/contracts/FHEEvents.sol '
-        + 'host-contracts/contracts/ACLEvents.sol '
-        + 'host-contracts/contracts/interfaces/IPauserSet.sol '
-        + 'host-contracts/contracts/shared '
-        + '| tar -x -C "$2" --strip-components=2',
-      'sh',
-      gitRef,
-      absoluteDir,
-    ],
-    { cwd: repoRoot },
-  );
+function getFunctionSignature(fn: AbiFunction): string {
+  return `${fn.name}(${(fn.inputs ?? []).map((input) => input.type).join(',')})`;
+}
 
-  return {
-    cleanup: () => fs.rmSync(absoluteDir, { recursive: true, force: true }),
-  };
+function formatCastArg(arg: unknown): string {
+  if (Array.isArray(arg)) {
+    return `[${arg.map(formatCastArg).join(',')}]`;
+  }
+  return String(arg);
+}
+
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
 async function upgradeCurrentToNew(
@@ -72,9 +64,10 @@ async function upgradeCurrentToNew(
 
   // Get reinitialize function from the new implementation artifact
   const newImplementationArtifact = await hre.artifacts.readArtifact(newImplementation);
-  const reinitializeFunction = newImplementationArtifact.abi.find(
-    (item) => item.type === 'function' && item.name.includes(REINITIALIZE_FUNCTION_PREFIX),
-  );
+  const reinitializeFunction = getReinitializeFunction(newImplementationArtifact.abi);
+  if (!reinitializeFunction?.name) {
+    throw new Error(`No reinitialize function found in ${newImplementation}`);
+  }
 
   // Prepare the new implementation factory and execute the upgrade by calling the reinitialize function
   const newImplementationFactory = await hre.ethers.getContractFactory(newImplementation, deployer);
@@ -106,12 +99,15 @@ async function deployImplementationForPreparedUpgrade(
   newImplementation: string,
   verifyContract: boolean,
   hre: HardhatRuntimeEnvironment,
+  reinitializeArgs: unknown[] = [],
+  forceClean = false,
 ): Promise<void> {
-  // FHEVMExecutor pulls in generated host addresses, so force a clean rebuild to avoid
-  // reusing artifacts compiled against another environment.
-  await hre.run('clean');
-  await hre.run('compile:specific', { contract: getImplementationDirectory(currentImplementation) });
-  await hre.run('compile:specific', { contract: getImplementationDirectory(newImplementation) });
+  if (forceClean) {
+    // FHEVMExecutor pulls in generated host addresses, so force a clean rebuild to avoid
+    // reusing artifacts compiled against another environment.
+    await hre.run('clean');
+  }
+  await compileImplementations(currentImplementation, newImplementation, hre);
 
   await checkImplementationArtifacts(expectedArtifactName, currentImplementation, newImplementation, hre);
 
@@ -121,9 +117,10 @@ async function deployImplementationForPreparedUpgrade(
   await hre.upgrades.forceImport(proxyAddress, currentImplementationFactory);
 
   const newImplementationArtifact = await hre.artifacts.readArtifact(newImplementation);
-  const reinitializeFunction = newImplementationArtifact.abi.find(
-    (item) => item.type === 'function' && item.name.includes(REINITIALIZE_FUNCTION_PREFIX),
-  );
+  const reinitializeFunction = getReinitializeFunction(newImplementationArtifact.abi);
+  if (!reinitializeFunction?.name) {
+    throw new Error(`No reinitialize function found in ${newImplementation}`);
+  }
   const newImplementationFactory = await hre.ethers.getContractFactory(newImplementation, deployer);
 
   console.log(`Deploying "${newImplementation}" for prepared upgrade on proxy ${proxyAddress}...`);
@@ -134,9 +131,14 @@ async function deployImplementationForPreparedUpgrade(
 
   const reinitializeCalldata = hre.ethers.Interface.from(newImplementationArtifact.abi).encodeFunctionData(
     reinitializeFunction.name,
-    [],
+    reinitializeArgs,
   );
   console.log(`${reinitializeFunction.name} calldata:`, reinitializeCalldata);
+  console.log(
+    `To double check, run: cast calldata ${shellQuote(getFunctionSignature(reinitializeFunction))} ${reinitializeArgs
+      .map((arg) => shellQuote(formatCastArg(arg)))
+      .join(' ')}`.trim(),
+  );
 
   if (verifyContract) {
     console.log('Waiting 2 minutes before contract verification... Please wait...');
@@ -214,6 +216,31 @@ async function upgradeContract(
   );
 }
 
+async function prepareUpgradeContract(
+  contractName: string,
+  addressEnvVar: string,
+  taskArgs: TaskArguments,
+  hre: HardhatRuntimeEnvironment,
+  reinitializeArgs: unknown[] = [],
+  forceClean = false,
+) {
+  if (taskArgs.useInternalProxyAddress) {
+    loadHostAddresses();
+  }
+  const proxyAddress = getRequiredEnvVar(addressEnvVar);
+
+  await deployImplementationForPreparedUpgrade(
+    proxyAddress,
+    contractName,
+    taskArgs.currentImplementation,
+    taskArgs.newImplementation,
+    taskArgs.verifyContract,
+    hre,
+    reinitializeArgs,
+    forceClean,
+  );
+}
+
 task('task:upgradeACL')
   .addParam(
     'currentImplementation',
@@ -266,8 +293,8 @@ task('task:upgradeFHEVMExecutor')
 
 task('task:prepareUpgradeFHEVMExecutor')
   .addParam(
-    'upgradeFromRef',
-    'Git ref used to materialize the implementation currently deployed behind the proxy, eg: v0.11.1',
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/FHEVMExecutor.sol:FHEVMExecutor',
   )
   .addParam(
     'newImplementation',
@@ -285,29 +312,34 @@ task('task:prepareUpgradeFHEVMExecutor')
     true,
     types.boolean,
   )
-  .setAction(
-    async function ({ upgradeFromRef, newImplementation, useInternalProxyAddress, verifyContract }: TaskArguments, hre) {
-      const generatedCurrentImplementation = materializeContractsFromGit(upgradeFromRef, 'generated-upgrade-from-contracts');
-      const currentImplementation = 'generated-upgrade-from-contracts/FHEVMExecutor.sol:FHEVMExecutor';
-      if (useInternalProxyAddress) {
-        loadHostAddresses();
-      }
-      const proxyAddress = getRequiredEnvVar('FHEVM_EXECUTOR_CONTRACT_ADDRESS');
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract('FHEVMExecutor', 'FHEVM_EXECUTOR_CONTRACT_ADDRESS', taskArgs, hre, [], true);
+  });
 
-      try {
-        await deployImplementationForPreparedUpgrade(
-          proxyAddress,
-          'FHEVMExecutor',
-          currentImplementation,
-          newImplementation,
-          verifyContract,
-          hre,
-        );
-      } finally {
-        generatedCurrentImplementation.cleanup();
-      }
-    },
-  );
+task('task:prepareUpgradeACL')
+  .addParam(
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/ACL.sol:ACL',
+  )
+  .addParam(
+    'newImplementation',
+    'The new implementation solidity contract path and name, eg: contracts/ACL.sol:ACL',
+  )
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract('ACL', 'ACL_CONTRACT_ADDRESS', taskArgs, hre);
+  });
 
 task('task:upgradeKMSVerifier')
   .addParam(
@@ -334,6 +366,31 @@ task('task:upgradeKMSVerifier')
     await upgradeContract('KMSVerifier', 'KMS_VERIFIER_CONTRACT_ADDRESS', taskArgs, hre);
   });
 
+task('task:prepareUpgradeKMSVerifier')
+  .addParam(
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/KMSVerifier.sol:KMSVerifier',
+  )
+  .addParam(
+    'newImplementation',
+    'The new implementation solidity contract path and name, eg: contracts/KMSVerifier.sol:KMSVerifier',
+  )
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract('KMSVerifier', 'KMS_VERIFIER_CONTRACT_ADDRESS', taskArgs, hre);
+  });
+
 task('task:upgradeInputVerifier')
   .addParam(
     'currentImplementation',
@@ -356,10 +413,6 @@ task('task:upgradeInputVerifier')
     types.boolean,
   )
   .setAction(async function (taskArgs: TaskArguments, hre) {
-    if (taskArgs.useInternalProxyAddress) {
-      loadHostAddresses();
-    }
-
     const initialSigners: string[] = [];
     const numSigners = getRequiredEnvVar('NUM_COPROCESSORS');
     for (let idx = 0; idx < +numSigners; idx++) {
@@ -368,6 +421,41 @@ task('task:upgradeInputVerifier')
     const coprocessorThreshold = getRequiredEnvVar('COPROCESSOR_THRESHOLD');
 
     await upgradeContract('InputVerifier', 'INPUT_VERIFIER_CONTRACT_ADDRESS', taskArgs, hre, [
+      initialSigners,
+      coprocessorThreshold,
+    ]);
+  });
+
+task('task:prepareUpgradeInputVerifier')
+  .addParam(
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/InputVerifier.sol:InputVerifier',
+  )
+  .addParam(
+    'newImplementation',
+    'The new implementation solidity contract path and name, eg: contracts/InputVerifier2.sol:InputVerifier',
+  )
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    const initialSigners: string[] = [];
+    const numSigners = getRequiredEnvVar('NUM_COPROCESSORS');
+    for (let idx = 0; idx < +numSigners; idx++) {
+      initialSigners.push(getRequiredEnvVar(`COPROCESSOR_SIGNER_ADDRESS_${idx}`));
+    }
+    const coprocessorThreshold = getRequiredEnvVar('COPROCESSOR_THRESHOLD');
+
+    await prepareUpgradeContract('InputVerifier', 'INPUT_VERIFIER_CONTRACT_ADDRESS', taskArgs, hre, [
       initialSigners,
       coprocessorThreshold,
     ]);
@@ -414,6 +502,53 @@ task('task:upgradeHCULimit')
   )
   .setAction(async function (taskArgs: TaskArguments, hre) {
     await upgradeContract('HCULimit', 'HCU_LIMIT_CONTRACT_ADDRESS', taskArgs, hre, [
+      BigInt(taskArgs.hcuCapPerBlock),
+      BigInt(taskArgs.maxHcuDepthPerTx),
+      BigInt(taskArgs.maxHcuPerTx),
+    ]);
+  });
+
+task('task:prepareUpgradeHCULimit')
+  .addParam(
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/HCULimit.sol:HCULimit',
+  )
+  .addParam(
+    'newImplementation',
+    'The new implementation solidity contract path and name, eg: contracts/HCULimit.sol:HCULimit',
+  )
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'hcuCapPerBlock',
+    'Global HCU cap per block passed to reinitializeV2 (default: uint48 max)',
+    '281474976710655',
+    types.string,
+  )
+  .addOptionalParam(
+    'maxHcuDepthPerTx',
+    'Max sequential HCU depth per transaction (default: 5000000)',
+    '5000000',
+    types.string,
+  )
+  .addOptionalParam(
+    'maxHcuPerTx',
+    'Max total HCU per transaction (default: 20000000)',
+    '20000000',
+    types.string,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract('HCULimit', 'HCU_LIMIT_CONTRACT_ADDRESS', taskArgs, hre, [
       BigInt(taskArgs.hcuCapPerBlock),
       BigInt(taskArgs.maxHcuDepthPerTx),
       BigInt(taskArgs.maxHcuPerTx),


### PR DESCRIPTION
## Summary

This refactors the host and gateway upgrade tasks to support the GitOps/governance upgrade flow described in `zama-ai/fhevm-internal#1264`.

The main changes are:
- remove the git-based `prepareUpgradeFHEVMExecutor` flow and hard-cut it to file-based `currentImplementation` / `newImplementation` inputs
- add reusable prepared-upgrade helpers for host and gateway tasks
- add the missing `prepareUpgrade*` variants for host and gateway contracts
- encode and print reinitializer calldata, including argful cases such as `InputVerifier`, `HCULimit`, and `GatewayConfig`
- print a matching `cast calldata ...` command to let humans double-check the ABI encoding before building the DAO proposal

## Why

After proxy ownership is transferred to governance, the deployer can no longer call `upgradeProxy()` directly on testnet/mainnet.

Infra needs a `prepareUpgrade` flow that:
- works in Kubernetes/GitOps jobs without a `.git` checkout
- deploys the new implementation without touching the proxy
- prints the implementation address and reinitializer calldata needed for the governance proposal

## Validation

Validation performed in this checkout:
- static review of the task coverage and removal of `upgradeFromRef` / `git archive` from the prepare-upgrade path
- local `cast calldata` sanity checks for representative argful reinitializers

Validation not performed in this checkout:
- Hardhat task execution, because `node_modules` are not installed in this worktree
- Prettier, for the same dependency reason

closes https://github.com/zama-ai/fhevm-internal/issues/1264
