### PR TITLE
fix(test-suite): backport rollout harness compat shims

### DIFF
--- a/test-suite/e2e/test/compat.ts
+++ b/test-suite/e2e/test/compat.ts
@@ -1,0 +1,28 @@
+const LEGACY_EXTRA_DATA = '0x00';
+
+const isCurrentKmsContextUnavailable = (error: unknown) => {
+  if (!(error instanceof Error)) return false;
+  const messages = [error.message];
+  const { cause } = error as Error & { cause?: unknown };
+  if (cause instanceof Error) {
+    messages.push(cause.message);
+  }
+  return messages.some(
+    (message) =>
+      message.includes('Failed to fetch current KMS context ID') || message.includes('getCurrentKmsContextId'),
+  );
+};
+
+export const getCompatExtraData = async (loadExtraData: () => Promise<string>) => {
+  if (process.env.RELAYER_SDK_FORCE_LEGACY_EXTRA_DATA === 'true') {
+    return LEGACY_EXTRA_DATA;
+  }
+  try {
+    return await loadExtraData();
+  } catch (error) {
+    if (!isCurrentKmsContextUnavailable(error)) {
+      throw error;
+    }
+    return LEGACY_EXTRA_DATA;
+  }
+};

--- a/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
+++ b/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
@@ -66,6 +66,7 @@ describe('Delegated user decryption', function () {
   });
 
   it('test delegated user decryption - smartWallet owner delegates his own EOA to decrypt the smartWallet balance', async function () {
+    this.timeout(10 * 60 * 1000);
     // Bob (smartWallet owner) delegates decryption rights to his own EOA.
     const expirationTimestamp = Math.floor(Date.now() / 1000) + 86400; // 24 hours from now
     const delegateTx = await this.smartWallet
@@ -103,6 +104,7 @@ describe('Delegated user decryption', function () {
   });
 
   it('test delegated user decryption - smartWallet owner delegates a third EOA to decrypt the smartWallet balance', async function () {
+    this.timeout(10 * 60 * 1000);
     // Bob (smartWallet owner) delegates decryption rights to Carol's EOA.
     const expirationTimestamp = Math.floor(Date.now() / 1000) + 86400; // 24 hours from now
     const delegateTx = await this.smartWallet
@@ -140,6 +142,7 @@ describe('Delegated user decryption', function () {
   });
 
   it('test delegated user decryption - smartWallet can execute transference of funds to a third EOA', async function () {
+    this.timeout(10 * 60 * 1000);
     // First, Bob needs to delegate so the smartWallet can initiate transfers.
     const expirationTimestamp = Math.floor(Date.now() / 1000) + 86400;
     const delegateTx = await this.smartWallet
@@ -200,6 +203,9 @@ describe('Delegated user decryption', function () {
       .connect(this.signers.bob)
       .executeTx(txId);
     await executeTx.wait();
+
+    currentBlock = await ethers.provider.getBlockNumber();
+    await waitForBlock(currentBlock + 15);
 
     // Verify the smartWallet balance decreased.
     const smartWalletBalanceAfter = await this.token.balanceOf(this.smartWalletAddress);

--- a/test-suite/e2e/test/instance.ts
+++ b/test-suite/e2e/test/instance.ts
@@ -4,6 +4,7 @@ import { vars } from 'hardhat/config';
 
 import type { Signers } from './signers';
 import { FhevmInstances } from './types';
+import { getCompatExtraData } from './compat';
 
 const defaults = (() => {
   const chainId = network.config.chainId;
@@ -70,7 +71,7 @@ export const createInstances = async (accounts: Signers): Promise<FhevmInstances
 };
 
 export const createInstance = async () => {
-  return createFhevmInstance({
+  const instance = await createFhevmInstance({
     verifyingContractAddressDecryption,
     verifyingContractAddressInputVerification,
     kmsContractAddress: kmsVerifierAddress,
@@ -82,6 +83,10 @@ export const createInstance = async () => {
     chainId: hostChainID,
     ...(auth ? { auth } : {}),
   });
+  return {
+    ...instance,
+    getExtraData: () => getCompatExtraData(() => instance.getExtraData()),
+  };
 };
 
 // Export coprocessor config addresses for smoke tests

--- a/test-suite/e2e/test/utils.ts
+++ b/test-suite/e2e/test/utils.ts
@@ -11,6 +11,13 @@ import hre from 'hardhat';
 import { coprocessorAddress } from './instance';
 import { TypedContractMethod } from '../types/common';
 
+const delegatedUserDecryptRetryMs = Number(process.env.RELAYER_SDK_DELEGATED_USER_DECRYPT_RETRY_MS) || 2_000;
+const delegatedUserDecryptTimeoutMs =
+  Number(process.env.RELAYER_SDK_DELEGATED_USER_DECRYPT_TIMEOUT_MS) || 10 * 60 * 1000;
+
+const isDelegatedDecryptNotReady = (error: unknown) =>
+  error instanceof Error && error.message.includes('Ciphertext not ready for decryption on the gateway chain');
+
 export async function checkIsHardhatSigner(signer: HardhatEthersSigner) {
   const signers: HardhatEthersSigner[] = await hre.ethers.getSigners();
   if (signers.findIndex((s) => s.address === signer.address) === -1) {
@@ -214,18 +221,30 @@ export const delegatedUserDecryptSingleHandle = async (
     eip712.message,
   );
 
-  const result = await instance.delegatedUserDecrypt(
-    handleContractPairs,
-    delegatePrivateKey,
-    delegatePublicKey,
-    delegateSignature.replace('0x', ''),
-    contractAddresses,
-    delegatorAddress,
-    delegateAddress,
-    startTimeStamp,
-    durationDays,
-    extraData,
-  );
+  const deadline = Date.now() + delegatedUserDecryptTimeoutMs;
+  let result;
+  while (true) {
+    try {
+      result = await instance.delegatedUserDecrypt(
+        handleContractPairs,
+        delegatePrivateKey,
+        delegatePublicKey,
+        delegateSignature.replace('0x', ''),
+        contractAddresses,
+        delegatorAddress,
+        delegateAddress,
+        startTimeStamp,
+        durationDays,
+        extraData,
+      );
+      break;
+    } catch (error) {
+      if (!isDelegatedDecryptNotReady(error) || Date.now() + delegatedUserDecryptRetryMs > deadline) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delegatedUserDecryptRetryMs));
+    }
+  }
 
   return result[handle];
 };


### PR DESCRIPTION
## Summary
- backport the rollout harness compat shim for legacy `extraData` when mixed-version stacks do not expose the current KMS context
- retry delegated user decrypt while the ciphertext is still propagating on the gateway chain
- wait for post-`executeTx` propagation before asserting the updated delegated-decrypt balance

## Audit
Excluded on purpose:
- no `@zama-fhe/relayer-sdk` bump or debump; `release/0.12.x` already stays on `^0.5.0-alpha.1`
- no SDK monkey patching
- no paused-gateway assertion widening
- no global public decrypt / input proof timeout inflation
