### PR TITLE
fix(test-suite): show local build in fhevm-cli output

### DIFF
--- a/test-suite/fhevm/src/flow.test.ts
+++ b/test-suite/fhevm/src/flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  displayedBundle,
   multiChainCoprocessorUpgradeTargets,
   preflightPorts,
   resumeRepairStep,
@@ -9,7 +10,7 @@ import {
 } from "./flow/up-flow";
 import { assertContractTaskStackRunning } from "./flow/contracts";
 import { envPath, hostChainAddressesPath, kmsCoreConfigPath } from "./layout";
-import type { State } from "./types";
+import { OVERRIDE_GROUPS, type State } from "./types";
 
 const completeState = (): State => ({
   target: "latest-main",
@@ -308,5 +309,15 @@ describe("runtime helpers", () => {
 
   test("resume hint is suppressed for equals-form fresh-stack flags", () => {
     expect(shouldShowResumeHint(["up", "--target=sha", "--sha=badbad"])).toBe(false);
+  });
+
+  test("displayedBundle prints local build for repo-owned versions under full build", () => {
+    const state = completeState();
+    state.overrides = OVERRIDE_GROUPS.map((group) => ({ group }));
+    const bundle = displayedBundle(state.versions, state.overrides);
+    expect(bundle.env.GATEWAY_VERSION).toBe("LOCAL BUILD");
+    expect(bundle.env.RELAYER_VERSION).toBe("LOCAL BUILD");
+    expect(bundle.env.TEST_SUITE_VERSION).toBe("LOCAL BUILD");
+    expect(bundle.env.CORE_VERSION).toBe("v0.13.10-rc.3");
   });
 });

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -25,7 +25,7 @@ import {
   RpcError,
   SchemaGuardError,
 } from "../errors";
-import { describeBundle } from "../resolve/target";
+import { describeBundle, REPO_KEYS } from "../resolve/target";
 import {
   ADDRESS_DIR,
   COMPOSE_OUT_DIR,
@@ -72,7 +72,7 @@ import type {
   VersionBundle,
   VersionTarget,
 } from "../types";
-import { STEP_NAMES } from "../types";
+import { OVERRIDE_GROUPS, STEP_NAMES } from "../types";
 import {
   exists,
   hostReachableMaterialUrl,
@@ -255,7 +255,26 @@ const overrideWarnings = (overrides: LocalOverride[], target?: string) => {
 };
 
 /** Prints the resolved version bundle in compact or detailed form. */
-const printBundle = (bundle: VersionBundle, options?: { detailed?: boolean }) => {
+const fullBuildActive = (overrides: LocalOverride[]) =>
+  OVERRIDE_GROUPS.every((group) => overrides.some((item) => item.group === group));
+
+/** Rewrites displayed repo-owned versions to match the effective runtime source under `--build`. */
+export const displayedBundle = (
+  bundle: VersionBundle,
+  overrides: LocalOverride[],
+) =>
+  !fullBuildActive(overrides)
+    ? bundle
+    : {
+        ...bundle,
+        env: Object.fromEntries(
+          Object.entries(bundle.env).map(([key, value]) => [key, REPO_KEYS.has(key) ? "LOCAL BUILD" : value]),
+        ),
+      };
+
+/** Prints the resolved version bundle in compact or detailed form. */
+const printBundle = (state: Pick<State, "versions" | "overrides">, options?: { detailed?: boolean }) => {
+  const bundle = displayedBundle(state.versions, state.overrides);
   console.log(`[resolve] ${bundle.lockName}`);
   if (options?.detailed) {
     console.log(describeBundle(bundle));
@@ -461,7 +480,7 @@ export const runStep = async (state: State, step: StepName) => {
       await preflight(state, true, state.requiresGitHub ?? true);
       break;
     case "resolve":
-      printBundle(state.versions, { detailed: true });
+      printBundle(state, { detailed: true });
       break;
     case "generate":
       await generateRuntime(state, stackSpecForState(state));
@@ -903,7 +922,7 @@ export const upDryRun = async (options: Omit<UpOptions, "dryRun">) => {
     state.scenarioSourcePath ??= state.scenario?.sourcePath;
     ensureResumeOptions(state, options);
     await preflight(state, false, state.requiresGitHub);
-    printBundle(state.versions, { detailed: true });
+    printBundle(state, { detailed: true });
     printPlan(state, options.fromStep ?? startStep(state, options));
     console.log("[dry-run] resume preview uses persisted state only; no runtime state or containers were changed");
     return;
@@ -915,7 +934,7 @@ export const upDryRun = async (options: Omit<UpOptions, "dryRun">) => {
   await assertSchemaCompatibility(bundle, options.overrides, scenario, options.allowSchemaMismatch);
   const state = previewStateFromBundle(options, bundle, scenario);
   await preflight(state, false, state.requiresGitHub);
-  printBundle(state.versions, { detailed: true });
+  printBundle(state, { detailed: true });
   printPlan(state, options.fromStep);
   console.log("[dry-run] preflight passed; no runtime state or containers were changed");
 };


### PR DESCRIPTION
## Summary
Make `fhevm-cli up --build` print repo-owned component versions as `LOCAL BUILD` instead of the baseline lock tag, so the log reflects what will actually run.
Keep companion versions such as `CORE_VERSION` unchanged.
Add a focused test for the displayed bundle output.

Internal issue: https://github.com/zama-ai/fhevm-internal/issues/1291
