### PR TITLE
chore(kms-connector): ethereum chain id for keygen eip712

### DIFF
--- a/charts/kms-connector/Chart.yaml
+++ b/charts/kms-connector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-connector
 description: A helm chart to distribute and deploy the Zama KMS Connector services
-version: 1.4.1
+version: 1.4.2
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/kms-connector/templates/kms-connector-kms-worker-deployment.yaml
+++ b/charts/kms-connector/templates/kms-connector-kms-worker-deployment.yaml
@@ -66,6 +66,8 @@ spec:
               value: {{ .Values.commonConfig.gatewayContractAddresses.decryption | quote }}
             - name: KMS_CONNECTOR_GATEWAY_CONFIG_CONTRACT__ADDRESS
               value: {{ .Values.commonConfig.gatewayContractAddresses.gatewayConfig | quote }}
+            - name: KMS_CONNECTOR_ETHEREUM_CHAIN_ID
+              value: {{ .Values.commonConfig.ethereumChainId | quote }}
             - name: KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS
               value: {{ .Values.commonConfig.gatewayContractAddresses.kmsGeneration | quote }}
           {{- if default .Values.commonConfig.tracing.enabled .Values.kmsConnectorKmsWorker.tracing.enabled }}

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -12,7 +12,7 @@ gateway_url = "http://localhost:8545"
 # ENV: KMS_CONNECTOR_GATEWAY_CHAIN_ID
 gateway_chain_id = 54321
 
-# Chain ID for the Ethereum network (required)
+# Chain ID for the Ethereum-like network; defaults to Sepolia (required)
 # ENV: KMS_CONNECTOR_ETHEREUM_CHAIN_ID
 ethereum_chain_id = 11155111
 

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -12,6 +12,10 @@ gateway_url = "http://localhost:8545"
 # ENV: KMS_CONNECTOR_GATEWAY_CHAIN_ID
 gateway_chain_id = 54321
 
+# Chain ID for the Ethereum network (required)
+# ENV: KMS_CONNECTOR_ETHEREUM_CHAIN_ID
+ethereum_chain_id = 11155111
+
 # List of KMS-core shards gRPC endpoints (required)
 # Format: http://host:port
 # ENV: KMS_CONNECTOR_KMS_CORE_ENDPOINTS
@@ -94,9 +98,9 @@ address = "0x0000000000000000000000000000000000000000"
 # ENV: KMS_CONNECTOR_GATEWAY_CONFIG_CONTRACT__DOMAIN_VERSION
 # domain_version = "1"
 
-# Configuration of the KMSGeneration contract (required)
+# Configuration of the KMSGeneration contract on Ethereum (required)
 [kms_generation_contract]
-# Address of the KMSGeneration contract (required)
+# Address of the KMSGeneration contract on Ethereum (required)
 # Format: hex string with 0x prefix
 # ENV: KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS
 address = "0x0000000000000000000000000000000000000000"

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -38,13 +38,16 @@ pub struct Config {
     pub gateway_url: Url,
     /// The Chain ID of the Gateway.
     pub gateway_chain_id: u64,
-    /// The `Decryption` contract configuration.
+    /// The `Decryption` contract configuration (on Gateway).
     #[serde(deserialize_with = "deserialize_decryption_contract_config")]
     pub decryption_contract: ContractConfig,
-    /// The `GatewayConfig` contract configuration.
+    /// The `GatewayConfig` contract configuration (on Gateway).
     #[serde(deserialize_with = "deserialize_gateway_config_contract_config")]
     pub gateway_config_contract: ContractConfig,
-    /// The `KMSGeneration` contract configuration.
+
+    /// The Chain ID of the Ethereum chain.
+    pub ethereum_chain_id: u64,
+    /// The `KMSGeneration` contract configuration (on Ethereum).
     #[serde(deserialize_with = "deserialize_kms_generation_contract_config")]
     pub kms_generation_contract: ContractConfig,
 
@@ -177,6 +180,7 @@ impl Default for Config {
             gateway_chain_id: 54321,
             decryption_contract: default_decryption_contract_config(),
             gateway_config_contract: default_gateway_config_contract_config(),
+            ethereum_chain_id: 11155111, // Sepolia
             kms_generation_contract: default_kms_generation_contract_config(),
             host_chains: vec![HostChainConfig {
                 url: Url::from_str("http://localhost:8545").unwrap(),
@@ -209,6 +213,7 @@ mod tests {
             env::remove_var("KMS_CONNECTOR_EVENTS_BATCH_SIZE");
             env::remove_var("KMS_CONNECTOR_GATEWAY_URL");
             env::remove_var("KMS_CONNECTOR_GATEWAY_CHAIN_ID");
+            env::remove_var("KMS_CONNECTOR_ETHEREUM_CHAIN_ID");
             env::remove_var("KMS_CONNECTOR_DECRYPTION_CONTRACT__ADDRESS");
             env::remove_var("KMS_CONNECTOR_GATEWAY_CONFIG_CONTRACT__ADDRESS");
             env::remove_var("KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS");
@@ -245,6 +250,7 @@ mod tests {
             env::set_var("KMS_CONNECTOR_EVENTS_BATCH_SIZE", "15");
             env::set_var("KMS_CONNECTOR_GATEWAY_URL", "http://localhost:9545");
             env::set_var("KMS_CONNECTOR_GATEWAY_CHAIN_ID", "31888");
+            env::set_var("KMS_CONNECTOR_ETHEREUM_CHAIN_ID", "31444");
             env::set_var(
                 "KMS_CONNECTOR_DECRYPTION_CONTRACT__ADDRESS",
                 "0x5fbdb2315678afecb367f032d93f642f64180aa3",
@@ -290,6 +296,7 @@ mod tests {
             Url::from_str("http://localhost:9545").unwrap()
         );
         assert_eq!(config.gateway_chain_id, 31888);
+        assert_eq!(config.ethereum_chain_id, 31444);
         assert_eq!(
             config.decryption_contract.address,
             Address::from_str("0x5fbdb2315678afecb367f032d93f642f64180aa3").unwrap()

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms.rs
@@ -28,7 +28,7 @@ where
         let domain = Eip712DomainMsg {
             name: config.kms_generation_contract.domain_name.clone(),
             version: config.kms_generation_contract.domain_version.clone(),
-            chain_id: U256::from(config.gateway_chain_id).to_be_bytes_vec(),
+            chain_id: U256::from(config.ethereum_chain_id).to_be_bytes_vec(),
             verifying_contract: config.kms_generation_contract.address.to_string(),
             salt: None,
         };


### PR DESCRIPTION
Needed to validate the EIP712 of the keygen flow now that `KMSGeneration` contract lives on Ethereum.