### PR TITLE
feat(coprocessor): automatic drift recovery via revert

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -99,8 +99,8 @@ on:
         default: ""
         type: string
       scenario:
-        description: "Deployment scenario (e.g. two-of-two, two-of-two-multi-chain)"
-        default: "two-of-two"
+        description: "Deployment scenario (e.g. two-of-three, two-of-three-multi-chain)"
+        default: "two-of-three"
         type: string
       test-profile:
         description: "Named test profile to run instead of the default standard suite"
@@ -152,7 +152,7 @@ jobs:
       RELAYER_VERSION: ${{ inputs.relayer-version }}
       CORE_VERSION: ${{ inputs.kms-core-version }}
       ORCHESTRATED: ${{ inputs.orchestrated && 'true' || 'false' }}
-      SCENARIO: ${{ inputs.scenario || 'two-of-two' }}
+      SCENARIO: ${{ inputs.scenario || 'two-of-three' }}
       TEST_PROFILE: ${{ inputs.test-profile || 'standard' }}
     runs-on: large_ubuntu_32
     steps:
@@ -374,18 +374,18 @@ jobs:
             echo "::endgroup::"
           }
           snapshot_logs "Relayer Logs" fhevm-relayer
-          snapshot_logs "SNS Worker Logs" coprocessor-sns-worker "Selected 0 rows to process"
-          snapshot_logs "Transaction Sender Logs (filtered)" coprocessor-transaction-sender "Selected 0 rows to process"
-          snapshot_logs "Host Listener" coprocessor-host-listener
-          snapshot_logs "Gateway Listener" coprocessor-gw-listener
-          snapshot_logs "ZKProof Worker" coprocessor-zkproof-worker
-          snapshot_logs "TFHE Worker" coprocessor-tfhe-worker
-          snapshot_logs "Coprocessor 2 - Host Listener" coprocessor1-host-listener
-          snapshot_logs "Coprocessor 2 - Gateway Listener" coprocessor1-gw-listener
-          snapshot_logs "Coprocessor 2 - SNS Worker" coprocessor1-sns-worker "Selected 0 rows to process"
-          snapshot_logs "Coprocessor 2 - Transaction Sender (filtered)" coprocessor1-transaction-sender "Selected 0 rows to process"
-          snapshot_logs "Coprocessor 2 - ZKProof Worker" coprocessor1-zkproof-worker
-          snapshot_logs "Coprocessor 2 - TFHE Worker" coprocessor1-tfhe-worker
+          # Iterate over all running coprocessor instances (primary is "coprocessor-",
+          # additional instances are "coprocessorN-" where N>=1).
+          for container in $(docker ps --format '{{.Names}}' | grep -E '^coprocessor[0-9]*-gw-listener$' | sort); do
+            prefix="${container%-gw-listener}"
+            label="${prefix}"
+            snapshot_logs "${label} - Host Listener" "${prefix}-host-listener"
+            snapshot_logs "${label} - Gateway Listener" "${prefix}-gw-listener"
+            snapshot_logs "${label} - SNS Worker" "${prefix}-sns-worker" "Selected 0 rows to process"
+            snapshot_logs "${label} - Transaction Sender (filtered)" "${prefix}-transaction-sender" "Selected 0 rows to process"
+            snapshot_logs "${label} - ZKProof Worker" "${prefix}-zkproof-worker"
+            snapshot_logs "${label} - TFHE Worker" "${prefix}-tfhe-worker"
+          done
 
       - name: Cleanup
         working-directory: test-suite/fhevm

--- a/.github/workflows/test-suite-orchestrate-e2e-tests.yml
+++ b/.github/workflows/test-suite-orchestrate-e2e-tests.yml
@@ -205,5 +205,5 @@ jobs:
       lock-artifact-name: ${{ needs.create-e2e-tests-input.outputs.lock-artifact-name }}
       relayer-migrate-version: ${{ needs.create-e2e-tests-input.outputs.relayer-migrate-version }}
       relayer-version: ${{ needs.create-e2e-tests-input.outputs.relayer-version }}
-      scenario: ${{ startsWith(github.base_ref, 'release/') && 'two-of-two' || 'two-of-two-multi-chain' }}
+      scenario: ${{ startsWith(github.base_ref, 'release/') && 'two-of-three' || 'two-of-three-multi-chain' }}
       test-suite-version: ${{ needs.create-e2e-tests-input.outputs.test-suite-version }}

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -6610,7 +6610,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.31",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/coprocessor/fhevm-engine/db-migration/migrations/20260414120000_add_drift_revert_signal.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260414120000_add_drift_revert_signal.sql
@@ -14,3 +14,8 @@ CREATE TABLE IF NOT EXISTS drift_revert_signal (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+CREATE INDEX IF NOT EXISTS drift_revert_signal_host_chain_status_idx
+    ON drift_revert_signal (host_chain_id, status);
+CREATE INDEX IF NOT EXISTS drift_revert_signal_status_idx
+    ON drift_revert_signal (status);

--- a/coprocessor/fhevm-engine/db-migration/migrations/20260414120000_add_drift_revert_signal.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260414120000_add_drift_revert_signal.sql
@@ -1,0 +1,16 @@
+-- Table used by the auto drift recovery mechanism.
+-- When the gw-listener detects a ciphertext drift, it writes a row here.
+-- All coprocessor services poll this table and coordinate a revert + restart/re-exec.
+-- Past rows serve as an audit trail and prevent repeated auto-reverts
+-- for the same host chain.
+
+CREATE TABLE IF NOT EXISTS drift_revert_signal (
+    id BIGSERIAL PRIMARY KEY,
+    host_chain_id BIGINT NOT NULL,
+    -- The host chain block where drift was observed (the "offending" block).
+    offending_host_block_number BIGINT NOT NULL,
+    -- The status of the signal itself - whether it is pending, etc.
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -1,0 +1,479 @@
+//! Auto drift recovery: shared coordination logic.
+//!
+//! When the gw-listener detects ciphertext drift, it writes a row to
+//! `drift_revert_signal`. All coprocessor services poll that table and
+//! re-exec themselves when a signal appears. On startup, all fresh
+//! processes check for a pending signal:
+//!  * gw-listener runs the revert SQL,
+//!  * other services wait until it's done, then all proceed normally
+
+use std::time::Duration;
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{Pool, Postgres, Row};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+const REVERT_SQL_TEMPLATE: &str =
+    include_str!("../../db-migration/db-scripts/revert_coprocessor_db_state.sql");
+
+/// How often services poll `drift_revert_signal` for state changes.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignalStatus {
+    Pending,
+    Reverting,
+    Done,
+    Failed(String),
+}
+
+impl SignalStatus {
+    fn as_db_str(&self) -> String {
+        match self {
+            Self::Pending => "pending".to_owned(),
+            Self::Reverting => "reverting".to_owned(),
+            Self::Done => "done".to_owned(),
+            Self::Failed(reason) => format!("failed: {reason}"),
+        }
+    }
+
+    fn from_db_str(s: &str) -> Self {
+        match s {
+            "pending" => Self::Pending,
+            "reverting" => Self::Reverting,
+            "done" => Self::Done,
+            other => Self::Failed(other.strip_prefix("failed: ").unwrap_or(other).to_owned()),
+        }
+    }
+
+    pub fn is_in_flight(&self) -> bool {
+        matches!(self, Self::Pending | Self::Reverting)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DriftRevertSignal {
+    pub id: i64,
+    pub host_chain_id: i64,
+    pub offending_host_block_number: i64,
+    pub status: SignalStatus,
+}
+
+/// Create a new drift revert signal.
+/// Returns `Some(id)` if created, `None` if there's already an in-flight
+/// revert for this host chain.
+pub async fn create_revert_signal(
+    pool: &Pool<Postgres>,
+    host_chain_id: i64,
+    offending_host_block_number: i64,
+) -> anyhow::Result<Option<i64>> {
+    let row = sqlx::query(
+        "INSERT INTO drift_revert_signal (host_chain_id, offending_host_block_number, status) \
+         SELECT $1, $2, $3 \
+         WHERE NOT EXISTS ( \
+             SELECT 1 FROM drift_revert_signal \
+             WHERE host_chain_id = $1 AND (status = $3 OR status = $4) \
+         ) \
+         RETURNING id",
+    )
+    .bind(host_chain_id)
+    .bind(offending_host_block_number)
+    .bind(SignalStatus::Pending.as_db_str())
+    .bind(SignalStatus::Reverting.as_db_str())
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        Some(r) => {
+            let id: i64 = r.get("id");
+            Ok(Some(id))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Fetch the latest signal row, if any.
+pub async fn latest_signal(pool: &Pool<Postgres>) -> anyhow::Result<Option<DriftRevertSignal>> {
+    let row = sqlx::query(
+        "SELECT id, host_chain_id, offending_host_block_number, status \
+         FROM drift_revert_signal ORDER BY id DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|r| {
+        let status_str: String = r.get("status");
+        DriftRevertSignal {
+            id: r.get("id"),
+            host_chain_id: r.get("host_chain_id"),
+            offending_host_block_number: r.get("offending_host_block_number"),
+            status: SignalStatus::from_db_str(&status_str),
+        }
+    }))
+}
+
+/// Update the status of a signal row.
+pub async fn update_signal_status(
+    pool: &Pool<Postgres>,
+    signal_id: i64,
+    status: &SignalStatus,
+) -> anyhow::Result<()> {
+    sqlx::query("UPDATE drift_revert_signal SET status = $1, updated_at = NOW() WHERE id = $2")
+        .bind(status.as_db_str())
+        .bind(signal_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Called by the drift detector when it detects a ciphertext drift for a
+/// given handle. Looks up the host chain block where the drifted computation
+/// originated and creates a revert signal so all services can coordinate.
+///
+/// Transient failures (DB errors) are logged and swallowed so they don't
+/// cascade into the drift detector — the next detection cycle will retry.
+pub async fn on_drift_detected(pool: &Pool<Postgres>, handle: &[u8], host_chain_id: i64) {
+    // Byte 21 is 0xff for compute outputs; inputs encode the ciphertext index
+    // in the proof (0x00..=0xfe). Input drift is out of scope for auto-recovery.
+    if handle.len() != 32 || handle[21] != 0xff {
+        warn!(
+            host_chain_id,
+            "Drifted handle is a ZK input; auto-recovery is not supported for input handles"
+        );
+        return;
+    }
+
+    let host_block: Option<i64> = match sqlx::query_scalar(
+        "SELECT block_number FROM computations \
+         WHERE output_handle = $1 AND host_chain_id = $2 \
+         LIMIT 1",
+    )
+    .bind(handle)
+    .bind(host_chain_id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            error!(error = %e, host_chain_id, "Failed to look up computation for drifted handle");
+            return;
+        }
+    };
+
+    let Some(block) = host_block else {
+        error!(
+            host_chain_id,
+            "Cannot create revert signal: no computation found for drifted handle"
+        );
+        return;
+    };
+
+    match create_revert_signal(pool, host_chain_id, block).await {
+        Ok(Some(id)) => {
+            info!(
+                host_chain_id,
+                block, id, "Drift revert signal created successfully"
+            );
+        }
+        Ok(None) => {
+            warn!(
+                host_chain_id,
+                block, "Drift revert signal already in flight, skipping creation"
+            );
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to create drift revert signal");
+        }
+    }
+}
+
+/// Poll `drift_revert_signal` until a signal is in flight (status Pending or
+/// Reverting). Used by `run_signal_watcher` in non-revert-runner services to
+/// detect that a drift revert is happening so they can re-exec.
+pub async fn wait_for_in_flight_signal(pool: &Pool<Postgres>) -> anyhow::Result<DriftRevertSignal> {
+    loop {
+        if let Some(signal) = latest_signal(pool).await? {
+            if signal.status.is_in_flight() {
+                return Ok(signal);
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Poll until the latest signal reaches a terminal status.
+/// Used by non-gw-listener services to wait for the revert to finish.
+/// On `Failed`, logs the reason and returns `Ok(())` — the service continues
+/// startup despite a failed revert (operator can investigate via logs).
+pub async fn wait_for_revert_done(pool: &Pool<Postgres>) -> anyhow::Result<()> {
+    loop {
+        if let Some(signal) = latest_signal(pool).await? {
+            match &signal.status {
+                SignalStatus::Done => return Ok(()),
+                SignalStatus::Failed(reason) => {
+                    error!(
+                        signal_id = signal.id,
+                        host_chain_id = signal.host_chain_id,
+                        reason = %reason,
+                        "Drift revert failed; continuing service startup regardless"
+                    );
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Prepare the revert SQL by replacing psql-specific syntax with concrete
+/// parameter values so the script can be executed via sqlx as raw SQL.
+fn prepare_revert_sql(chain_id: i64, to_block_number: i64) -> String {
+    REVERT_SQL_TEMPLATE
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            // Strip psql directives
+            !trimmed.starts_with("\\set")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .replace(":'chain_id'", &chain_id.to_string())
+        .replace(":'to_block_number'", &to_block_number.to_string())
+}
+
+/// Execute the revert SQL script against the database.
+///
+/// `to_block = max(1, offending_host_block_number - 1)` — we subtract 1
+/// because the script reverts everything strictly greater than `to_block`,
+/// and we want the offending block itself gone. If ciphertexts from earlier
+/// blocks also drifted (due to out-of-order processing), the drift detector
+/// will catch them eventually in subsequent rounds.
+pub async fn execute_revert(
+    pool: &Pool<Postgres>,
+    host_chain_id: i64,
+    offending_host_block_number: i64,
+) -> anyhow::Result<()> {
+    let to_block_number = (offending_host_block_number - 1).max(1);
+
+    info!(
+        host_chain_id,
+        offending_host_block_number, to_block_number, "Starting DB state revert"
+    );
+
+    let sql = prepare_revert_sql(host_chain_id, to_block_number);
+    sqlx::raw_sql(&sql).execute(pool).await?;
+
+    info!(host_chain_id, to_block_number, "DB state revert completed");
+    Ok(())
+}
+
+/// Trait for re-exec behavior, allowing tests to substitute a mock.
+pub trait ReExec: Send + Sync {
+    fn re_exec(&self);
+}
+
+pub struct ProcessReExec;
+
+impl ProcessReExec {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ProcessReExec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReExec for ProcessReExec {
+    fn re_exec(&self) {
+        use std::os::unix::process::CommandExt;
+
+        let exe = match std::env::current_exe() {
+            Ok(exe) => exe,
+            Err(e) => {
+                error!(error = %e, "Failed to resolve executable path for re-exec, exiting");
+                std::process::exit(1);
+            }
+        };
+        let args: Vec<String> = std::env::args().collect();
+
+        info!(?exe, ?args, "Re-execing process for drift recovery");
+
+        let err = std::process::Command::new(&exe).args(&args[1..]).exec();
+
+        // exec() only returns on error — process may be in a broken state, exit immediately.
+        error!(error = %err, "re-exec failed, exiting");
+        std::process::exit(1);
+    }
+}
+
+pub struct RevertRunnerConfig {
+    /// How long to wait after detecting a pending signal at startup before
+    /// running the revert SQL. Gives other services time to also re-exec.
+    pub grace_period: Duration,
+}
+
+/// Watch for a pending drift-revert signal during normal service operation.
+/// When a signal is detected → re-exec immediately. The re-execed process is
+/// responsible for handling the revert (via `handle_pending_signal_on_startup`).
+///
+/// Services run this alongside their main loop. Exits cleanly if the cancel
+/// token fires (e.g., SIGTERM). On success, this never returns (re-exec
+/// replaces the process).
+pub async fn run_signal_watcher(
+    pool: &Pool<Postgres>,
+    cancel_token: CancellationToken,
+    re_exec_fn: &dyn ReExec,
+) -> anyhow::Result<()> {
+    let signal = tokio::select! {
+        _ = cancel_token.cancelled() => return Ok(()),
+        r = wait_for_in_flight_signal(pool) => r?,
+    };
+
+    info!(
+        signal_id = signal.id,
+        host_chain_id = signal.host_chain_id,
+        offending_host_block_number = signal.offending_host_block_number,
+        "Drift revert signal detected, re-execing"
+    );
+
+    // Never returns (exec replaces process, or exit on failure).
+    re_exec_fn.re_exec();
+
+    Ok(())
+}
+
+/// Called on service startup BEFORE the main loop begins. If a pending signal
+/// exists, handles it: the revert runner (gw-listener) waits a grace period
+/// then runs the revert SQL and marks it done; waiters (other services) block
+/// until the signal is done. Returns when it's safe for the service to
+/// proceed with normal operation.
+///
+/// - `runner_cfg`: `Some` for the revert runner (gw-listener), `None` for all
+///   other services (they just wait for the runner to finish).
+pub async fn handle_pending_signal_on_startup(
+    pool: &Pool<Postgres>,
+    runner_cfg: Option<RevertRunnerConfig>,
+) -> anyhow::Result<()> {
+    let Some(signal) = latest_signal(pool).await? else {
+        return Ok(());
+    };
+
+    match &signal.status {
+        SignalStatus::Done => Ok(()),
+        SignalStatus::Pending | SignalStatus::Reverting => {
+            let is_revert_runner = runner_cfg.is_some();
+            info!(
+                signal_id = signal.id,
+                host_chain_id = signal.host_chain_id,
+                offending_host_block_number = signal.offending_host_block_number,
+                is_revert_runner,
+                status = signal.status.as_db_str(),
+                "Found pending drift revert signal on startup"
+            );
+
+            if let Some(cfg) = runner_cfg {
+                // Grace period: give other services time to re-exec too.
+                info!(grace_period = ?cfg.grace_period, "Waiting grace period before revert");
+                tokio::time::sleep(cfg.grace_period).await;
+
+                update_signal_status(pool, signal.id, &SignalStatus::Reverting).await?;
+
+                if let Err(e) = execute_revert(
+                    pool,
+                    signal.host_chain_id,
+                    signal.offending_host_block_number,
+                )
+                .await
+                {
+                    error!(error = %e, "Drift revert failed");
+                    update_signal_status(pool, signal.id, &SignalStatus::Failed(e.to_string()))
+                        .await?;
+                    return Err(e);
+                }
+
+                // Test-only hook: keep status=reverting for a few seconds so
+                // E2E tests can observe the DB state after the revert ran but
+                // before services resume. Production leaves the env var unset.
+                if let Ok(secs) = std::env::var("DRIFT_REVERT_TEST_HOLD_SECS") {
+                    if let Ok(secs) = secs.parse::<u64>() {
+                        if secs > 0 {
+                            info!(
+                                hold_secs = secs,
+                                "Holding reverting status for test observation"
+                            );
+                            tokio::time::sleep(Duration::from_secs(secs)).await;
+                        }
+                    }
+                }
+
+                update_signal_status(pool, signal.id, &SignalStatus::Done).await?;
+                info!("Drift revert complete, resuming normal operation");
+            } else {
+                wait_for_revert_done(pool).await?;
+                info!("Drift revert complete, resuming normal operation");
+            }
+
+            Ok(())
+        }
+        SignalStatus::Failed(reason) => {
+            // A previous auto-revert attempt failed. The DB may still contain
+            // drifted data — operator intervention is required (manual revert
+            // or other remediation). We proceed normally so the service stays
+            // up, but flag the condition prominently.
+            error!(
+                signal_id = signal.id,
+                host_chain_id = signal.host_chain_id,
+                reason = reason,
+                "Latest drift revert signal has failed status — manual intervention required, proceeding anyway"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Initialize drift-revert handling for a service. Call once at startup,
+/// before the main loop begins.
+///
+/// 1. If a pending signal exists, handles it (runner runs the revert,
+///    waiters block until done).
+/// 2. Spawns a background watcher that polls for future signals and
+///    re-execs the process when one appears.
+///
+/// Pass `Some(RevertRunnerConfig)` for the revert runner (e.g. gw-listener),
+/// `None` for all other services.
+pub async fn init(
+    database_url: &str,
+    cancel_token: CancellationToken,
+    runner_cfg: Option<RevertRunnerConfig>,
+) -> anyhow::Result<()> {
+    init_with_reexec(database_url, cancel_token, runner_cfg, ProcessReExec::new()).await
+}
+
+/// Like [`init`] but lets the caller inject a custom `ReExec` implementation.
+/// Primarily used by tests to swap in a mock.
+pub async fn init_with_reexec<R: ReExec + 'static>(
+    database_url: &str,
+    cancel_token: CancellationToken,
+    runner_cfg: Option<RevertRunnerConfig>,
+    re_exec: R,
+) -> anyhow::Result<()> {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(database_url)
+        .await?;
+
+    handle_pending_signal_on_startup(&pool, runner_cfg).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = run_signal_watcher(&pool, cancel_token, &re_exec).await {
+            error!(error = %e, "Drift-revert signal watcher failed");
+        }
+    });
+
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -536,7 +536,7 @@ pub async fn handle_pending_signal_on_startup(
     }
 
     if let Some(cfg) = runner_cfg {
-        run_all_pending_as_runner(pool, &cfg).await
+        run_all_pending_as_runner(pool, &cfg, cancel_token).await
     } else {
         wait_for_revert_done(pool, cancel_token).await
     }
@@ -568,7 +568,9 @@ async fn count_recent_done_signals(
 async fn run_all_pending_as_runner(
     pool: &Pool<Postgres>,
     cfg: &RevertRunnerConfig,
+    cancel_token: &CancellationToken,
 ) -> anyhow::Result<()> {
+    let mut waited_grace = false;
     while let Some(signal) = oldest_in_flight_signal(pool).await? {
         info!(
             signal_id = signal.id,
@@ -609,8 +611,14 @@ async fn run_all_pending_as_runner(
         // Only wait it once per process startup — if we're on the 2nd signal,
         // services have already had time to re-exec during the first revert.
         if matches!(signal.status, SignalStatus::Pending) {
-            info!(grace_period = ?cfg.grace_period, "Waiting grace period before revert");
-            tokio::time::sleep(cfg.grace_period).await;
+            if !waited_grace {
+                info!(grace_period = ?cfg.grace_period, "Waiting grace period before revert");
+                tokio::select! {
+                    _ = cancel_token.cancelled() => return Ok(()),
+                    _ = tokio::time::sleep(cfg.grace_period) => {}
+                }
+                waited_grace = true;
+            }
             update_signal_status(pool, signal.id, &SignalStatus::Reverting).await?;
         }
 

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -7,8 +7,10 @@
 //!  * gw-listener runs the revert SQL,
 //!  * other services wait until it's done, then all proceed normally
 
+use std::sync::LazyLock;
 use std::time::Duration;
 
+use prometheus::{register_int_counter_vec, IntCounterVec};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{Pool, Postgres, Row};
 use tokio_util::sync::CancellationToken;
@@ -19,6 +21,33 @@ const REVERT_SQL_TEMPLATE: &str =
 
 /// How often services poll `drift_revert_signal` for state changes.
 pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+static SIGNAL_CREATED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "coprocessor_drift_revert_signal_created_counter",
+        "Number of drift-revert signals created (one per detected consensus drift that required a revert)",
+        &["host_chain_id"]
+    )
+    .unwrap()
+});
+
+static REVERT_SUCCESS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "coprocessor_drift_revert_success_counter",
+        "Number of drift reverts that ran successfully (SQL completed and signal marked Done)",
+        &["host_chain_id"]
+    )
+    .unwrap()
+});
+
+static REVERT_FAILURE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "coprocessor_drift_revert_failure_counter",
+        "Number of drift reverts that failed during SQL execution (signal marked Failed)",
+        &["host_chain_id"]
+    )
+    .unwrap()
+});
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SignalStatus {
@@ -62,7 +91,8 @@ pub struct DriftRevertSignal {
 
 /// Create a new drift revert signal.
 /// Returns `Some(id)` if created, `None` if there's already an in-flight
-/// revert for this host chain.
+/// revert for this host chain. Multiple chains can have concurrent in-flight
+/// signals; the runner processes them one at a time (oldest first).
 pub async fn create_revert_signal(
     pool: &Pool<Postgres>,
     host_chain_id: i64,
@@ -93,7 +123,7 @@ pub async fn create_revert_signal(
     }
 }
 
-/// Fetch the latest signal row, if any.
+/// Fetch the latest signal row (by id), if any.
 pub async fn latest_signal(pool: &Pool<Postgres>) -> anyhow::Result<Option<DriftRevertSignal>> {
     let row = sqlx::query(
         "SELECT id, host_chain_id, offending_host_block_number, status \
@@ -101,16 +131,36 @@ pub async fn latest_signal(pool: &Pool<Postgres>) -> anyhow::Result<Option<Drift
     )
     .fetch_optional(pool)
     .await?;
+    Ok(row.map(signal_from_row))
+}
 
-    Ok(row.map(|r| {
-        let status_str: String = r.get("status");
-        DriftRevertSignal {
-            id: r.get("id"),
-            host_chain_id: r.get("host_chain_id"),
-            offending_host_block_number: r.get("offending_host_block_number"),
-            status: SignalStatus::from_db_str(&status_str),
-        }
-    }))
+/// Fetch the oldest in-flight (Pending or Reverting) signal, if any. The
+/// runner processes signals in this order so no chain's drift is dropped
+/// when multiple chains report drift concurrently.
+pub async fn oldest_in_flight_signal(
+    pool: &Pool<Postgres>,
+) -> anyhow::Result<Option<DriftRevertSignal>> {
+    let row = sqlx::query(
+        "SELECT id, host_chain_id, offending_host_block_number, status \
+         FROM drift_revert_signal \
+         WHERE status = $1 OR status = $2 \
+         ORDER BY id ASC LIMIT 1",
+    )
+    .bind(SignalStatus::Pending.as_db_str())
+    .bind(SignalStatus::Reverting.as_db_str())
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(signal_from_row))
+}
+
+fn signal_from_row(r: sqlx::postgres::PgRow) -> DriftRevertSignal {
+    let status_str: String = r.get("status");
+    DriftRevertSignal {
+        id: r.get("id"),
+        host_chain_id: r.get("host_chain_id"),
+        offending_host_block_number: r.get("offending_host_block_number"),
+        status: SignalStatus::from_db_str(&status_str),
+    }
 }
 
 /// Update the status of a signal row.
@@ -171,6 +221,9 @@ pub async fn on_drift_detected(pool: &Pool<Postgres>, handle: &[u8], host_chain_
 
     match create_revert_signal(pool, host_chain_id, block).await {
         Ok(Some(id)) => {
+            SIGNAL_CREATED_COUNTER
+                .with_label_values(&[&host_chain_id.to_string()])
+                .inc();
             info!(
                 host_chain_id,
                 block, id, "Drift revert signal created successfully"
@@ -188,42 +241,66 @@ pub async fn on_drift_detected(pool: &Pool<Postgres>, handle: &[u8], host_chain_
     }
 }
 
-/// Poll `drift_revert_signal` until a signal is in flight (status Pending or
-/// Reverting). Used by `run_signal_watcher` in non-revert-runner services to
-/// detect that a drift revert is happening so they can re-exec.
+/// Poll `drift_revert_signal` until any signal is in flight (Pending or
+/// Reverting) on any host chain. Used by `run_signal_watcher` to detect that
+/// a drift revert is happening so the service can re-exec.
+/// Transient DB errors are logged and skipped — the watcher must stay alive.
 pub async fn wait_for_in_flight_signal(pool: &Pool<Postgres>) -> anyhow::Result<DriftRevertSignal> {
     loop {
-        if let Some(signal) = latest_signal(pool).await? {
-            if signal.status.is_in_flight() {
-                return Ok(signal);
+        match oldest_in_flight_signal(pool).await {
+            Ok(Some(signal)) => return Ok(signal),
+            Ok(None) => {}
+            Err(e) => {
+                error!(error = %e, "Drift-revert watcher poll failed, retrying");
             }
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 
-/// Poll until the latest signal reaches a terminal status.
-/// Used by non-gw-listener services to wait for the revert to finish.
-/// On `Failed`, logs the reason and returns `Ok(())` — the service continues
-/// startup despite a failed revert (operator can investigate via logs).
-pub async fn wait_for_revert_done(pool: &Pool<Postgres>) -> anyhow::Result<()> {
+/// Poll until there are no in-flight (Pending or Reverting) signals across
+/// any host chain, or until `cancel_token` fires. Used by non-runner services
+/// to wait for all pending reverts to finish on startup.
+///
+/// Returns an error if at any point the latest signal transitions to `Failed`
+/// — the waiter must not let the service start on a DB where recovery failed.
+pub async fn wait_for_revert_done(
+    pool: &Pool<Postgres>,
+    cancel_token: &CancellationToken,
+) -> anyhow::Result<()> {
+    match oldest_in_flight_signal(pool).await? {
+        None => return Ok(()),
+        Some(signal) => info!(
+            signal_id = signal.id,
+            host_chain_id = signal.host_chain_id,
+            status = signal.status.as_db_str(),
+            "Waiting for drift revert to complete"
+        ),
+    }
     loop {
+        if cancel_token.is_cancelled() {
+            return Ok(());
+        }
+        // Abort if the revert failed while we were waiting.
         if let Some(signal) = latest_signal(pool).await? {
-            match &signal.status {
-                SignalStatus::Done => return Ok(()),
-                SignalStatus::Failed(reason) => {
-                    error!(
-                        signal_id = signal.id,
-                        host_chain_id = signal.host_chain_id,
-                        reason = %reason,
-                        "Drift revert failed; continuing service startup regardless"
-                    );
-                    return Ok(());
-                }
-                _ => {}
+            if let SignalStatus::Failed(reason) = &signal.status {
+                error!(
+                    signal_id = signal.id,
+                    host_chain_id = signal.host_chain_id,
+                    reason,
+                    "Drift revert transitioned to Failed while waiting"
+                );
+                anyhow::bail!("drift revert signal {} is Failed: {reason}", signal.id);
             }
         }
-        tokio::time::sleep(POLL_INTERVAL).await;
+        if oldest_in_flight_signal(pool).await?.is_none() {
+            info!("Drift revert complete, resuming normal operation");
+            return Ok(());
+        }
+        tokio::select! {
+            _ = cancel_token.cancelled() => return Ok(()),
+            _ = tokio::time::sleep(POLL_INTERVAL) => {}
+        }
     }
 }
 
@@ -355,85 +432,106 @@ pub async fn run_signal_watcher(
 ///
 /// - `runner_cfg`: `Some` for the revert runner (gw-listener), `None` for all
 ///   other services (they just wait for the runner to finish).
+/// - `cancel_token`: exits the wait early on shutdown.
+///
+/// Returns an error if the latest signal is `Failed` — the service must not
+/// serve traffic on a DB where drift recovery failed. Operator must either
+/// re-drive the signal (Failed → Pending) or acknowledge it (Failed → Done)
+/// before the service can start.
 pub async fn handle_pending_signal_on_startup(
     pool: &Pool<Postgres>,
     runner_cfg: Option<RevertRunnerConfig>,
+    cancel_token: &CancellationToken,
 ) -> anyhow::Result<()> {
-    let Some(signal) = latest_signal(pool).await? else {
-        return Ok(());
-    };
-
-    match &signal.status {
-        SignalStatus::Done => Ok(()),
-        SignalStatus::Pending | SignalStatus::Reverting => {
-            let is_revert_runner = runner_cfg.is_some();
-            info!(
-                signal_id = signal.id,
-                host_chain_id = signal.host_chain_id,
-                offending_host_block_number = signal.offending_host_block_number,
-                is_revert_runner,
-                status = signal.status.as_db_str(),
-                "Found pending drift revert signal on startup"
-            );
-
-            if let Some(cfg) = runner_cfg {
-                // Grace period: give other services time to re-exec too.
-                info!(grace_period = ?cfg.grace_period, "Waiting grace period before revert");
-                tokio::time::sleep(cfg.grace_period).await;
-
-                update_signal_status(pool, signal.id, &SignalStatus::Reverting).await?;
-
-                if let Err(e) = execute_revert(
-                    pool,
-                    signal.host_chain_id,
-                    signal.offending_host_block_number,
-                )
-                .await
-                {
-                    error!(error = %e, "Drift revert failed");
-                    update_signal_status(pool, signal.id, &SignalStatus::Failed(e.to_string()))
-                        .await?;
-                    return Err(e);
-                }
-
-                // Test-only hook: keep status=reverting for a few seconds so
-                // E2E tests can observe the DB state after the revert ran but
-                // before services resume. Production leaves the env var unset.
-                if let Ok(secs) = std::env::var("DRIFT_REVERT_TEST_HOLD_SECS") {
-                    if let Ok(secs) = secs.parse::<u64>() {
-                        if secs > 0 {
-                            info!(
-                                hold_secs = secs,
-                                "Holding reverting status for test observation"
-                            );
-                            tokio::time::sleep(Duration::from_secs(secs)).await;
-                        }
-                    }
-                }
-
-                update_signal_status(pool, signal.id, &SignalStatus::Done).await?;
-                info!("Drift revert complete, resuming normal operation");
-            } else {
-                wait_for_revert_done(pool).await?;
-                info!("Drift revert complete, resuming normal operation");
-            }
-
-            Ok(())
-        }
-        SignalStatus::Failed(reason) => {
-            // A previous auto-revert attempt failed. The DB may still contain
-            // drifted data — operator intervention is required (manual revert
-            // or other remediation). We proceed normally so the service stays
-            // up, but flag the condition prominently.
+    if let Some(signal) = latest_signal(pool).await? {
+        if let SignalStatus::Failed(reason) = &signal.status {
             error!(
                 signal_id = signal.id,
                 host_chain_id = signal.host_chain_id,
-                reason = reason,
-                "Latest drift revert signal has failed status — manual intervention required, proceeding anyway"
+                reason,
+                "Refusing to start: latest drift revert is Failed — operator must investigate \
+                 (mark Failed → Pending to retry, or Failed → Done to acknowledge)"
             );
-            Ok(())
+            anyhow::bail!("drift revert signal {} is Failed: {reason}", signal.id);
         }
     }
+
+    if let Some(cfg) = runner_cfg {
+        run_all_pending_as_runner(pool, &cfg).await
+    } else {
+        wait_for_revert_done(pool, cancel_token).await
+    }
+}
+
+/// Runner path: process all in-flight signals (oldest first) until none remain.
+/// Multiple chains may have concurrent drifts; each gets its own revert run.
+async fn run_all_pending_as_runner(
+    pool: &Pool<Postgres>,
+    cfg: &RevertRunnerConfig,
+) -> anyhow::Result<()> {
+    while let Some(signal) = oldest_in_flight_signal(pool).await? {
+        info!(
+            signal_id = signal.id,
+            host_chain_id = signal.host_chain_id,
+            offending_host_block_number = signal.offending_host_block_number,
+            status = signal.status.as_db_str(),
+            "Found pending drift revert signal on startup"
+        );
+
+        // Grace period: give other services time to re-exec too.
+        // Only wait it once per process startup — if we're on the 2nd signal,
+        // services have already had time to re-exec during the first revert.
+        if matches!(signal.status, SignalStatus::Pending) {
+            info!(grace_period = ?cfg.grace_period, "Waiting grace period before revert");
+            tokio::time::sleep(cfg.grace_period).await;
+            update_signal_status(pool, signal.id, &SignalStatus::Reverting).await?;
+        }
+
+        if let Err(e) = execute_revert(
+            pool,
+            signal.host_chain_id,
+            signal.offending_host_block_number,
+        )
+        .await
+        {
+            REVERT_FAILURE_COUNTER
+                .with_label_values(&[&signal.host_chain_id.to_string()])
+                .inc();
+            // Mark Failed and bail — we must not let the service start on a
+            // DB where drift recovery failed. Operator intervention required
+            // (mark Failed → Pending to retry, or Failed → Done to acknowledge).
+            error!(
+                error = %e,
+                signal_id = signal.id,
+                host_chain_id = signal.host_chain_id,
+                "Drift revert failed"
+            );
+            update_signal_status(pool, signal.id, &SignalStatus::Failed(e.to_string())).await?;
+            return Err(e);
+        }
+
+        // Test-only hook: keep status=reverting for a few seconds so E2E
+        // tests can observe the DB state after the revert ran but before
+        // services resume. Production leaves the env var unset.
+        if let Ok(secs) = std::env::var("DRIFT_REVERT_TEST_HOLD_SECS") {
+            if let Ok(secs) = secs.parse::<u64>() {
+                if secs > 0 {
+                    info!(
+                        hold_secs = secs,
+                        "Holding reverting status for test observation"
+                    );
+                    tokio::time::sleep(Duration::from_secs(secs)).await;
+                }
+            }
+        }
+
+        update_signal_status(pool, signal.id, &SignalStatus::Done).await?;
+        REVERT_SUCCESS_COUNTER
+            .with_label_values(&[&signal.host_chain_id.to_string()])
+            .inc();
+        info!(signal_id = signal.id, "Drift revert complete");
+    }
+    Ok(())
 }
 
 /// Initialize drift-revert handling for a service. Call once at startup,
@@ -467,7 +565,7 @@ pub async fn init_with_reexec<R: ReExec + 'static>(
         .connect(database_url)
         .await?;
 
-    handle_pending_signal_on_startup(&pool, runner_cfg).await?;
+    handle_pending_signal_on_startup(&pool, runner_cfg, &cancel_token).await?;
 
     tokio::spawn(async move {
         if let Err(e) = run_signal_watcher(&pool, cancel_token, &re_exec).await {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -24,7 +24,8 @@ pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
 static SIGNAL_CREATED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         "coprocessor_drift_revert_signal_created_counter",
-        "Number of drift-revert signals created (one per detected consensus drift that required a revert)",
+        "Number of drift-revert signal recordings (one per detected consensus drift; \
+         includes both new signals and existing pending signals lowered to an earlier block)",
         &["host_chain_id"]
     )
     .unwrap()
@@ -106,23 +107,49 @@ pub struct DriftRevertSignal {
     pub status: SignalStatus,
 }
 
-/// Create a new drift revert signal.
-/// Returns `Some(id)` if created, `None` if there's already an in-flight
-/// revert for this host chain. Multiple chains can have concurrent in-flight
-/// signals; the runner processes them one at a time (oldest first).
+/// Record a drift revert signal for `host_chain_id`. Atomically:
+///   - INSERT a new Pending signal if no in-flight signal exists for this chain.
+///   - Else, if a Pending signal exists pointing at a later block, lower its
+///     `offending_host_block_number` to the new (earlier) value.
+///   - Else (Reverting or Pending already at earlier-or-equal
+///     block) no-op.
+///
+/// Lowering matters because drifts can be observed out of host-block order.
+/// The runner commits to whatever block is set when the grace period ends, so
+/// lowering during the grace window pulls the revert target back to the
+/// earliest known drift.
+///
+/// In practice the `lower` branch only fires in the original gw-listener
+/// process, between signal creation and re-exec.
+/// After re-exec, the new process runs the revert during `init` before the
+/// drift detector restarts, meaning this function cannot be called.
+///
+/// Returns `Some(id)` for either action (created or lowered), `None` for
+/// no-op.
 pub async fn create_revert_signal(
     pool: &Pool<Postgres>,
     host_chain_id: i64,
     offending_host_block_number: i64,
 ) -> anyhow::Result<Option<i64>> {
     let row = sqlx::query(
-        "INSERT INTO drift_revert_signal (host_chain_id, offending_host_block_number, status) \
-         SELECT $1, $2, $3 \
-         WHERE NOT EXISTS ( \
-             SELECT 1 FROM drift_revert_signal \
-             WHERE host_chain_id = $1 AND (status = $3 OR status = $4) \
+        "WITH ins AS ( \
+            INSERT INTO drift_revert_signal (host_chain_id, offending_host_block_number, status) \
+            SELECT $1, $2, $3 \
+            WHERE NOT EXISTS ( \
+                SELECT 1 FROM drift_revert_signal \
+                WHERE host_chain_id = $1 AND (status = $3 OR status = $4) \
+            ) \
+            RETURNING id \
+         ), upd AS ( \
+            UPDATE drift_revert_signal \
+            SET offending_host_block_number = $2, updated_at = NOW() \
+            WHERE host_chain_id = $1 \
+              AND status = $3 \
+              AND offending_host_block_number > $2 \
+              AND NOT EXISTS (SELECT 1 FROM ins) \
+            RETURNING id \
          ) \
-         RETURNING id",
+         SELECT id FROM ins UNION ALL SELECT id FROM upd",
     )
     .bind(host_chain_id)
     .bind(offending_host_block_number)
@@ -131,13 +158,7 @@ pub async fn create_revert_signal(
     .fetch_optional(pool)
     .await?;
 
-    match row {
-        Some(r) => {
-            let id: i64 = r.get("id");
-            Ok(Some(id))
-        }
-        None => Ok(None),
-    }
+    Ok(row.map(|r| r.get("id")))
 }
 
 /// Fetch the latest signal row (by id), if any.
@@ -255,9 +276,8 @@ pub async fn on_drift_detected(pool: &Pool<Postgres>, handle: &[u8], host_chain_
     }
 
     let host_block: Option<i64> = match sqlx::query_scalar(
-        "SELECT block_number FROM computations \
-         WHERE output_handle = $1 AND host_chain_id = $2 \
-         LIMIT 1",
+        "SELECT MIN(block_number) FROM computations \
+         WHERE output_handle = $1 AND host_chain_id = $2",
     )
     .bind(handle)
     .bind(host_chain_id)
@@ -286,17 +306,18 @@ pub async fn on_drift_detected(pool: &Pool<Postgres>, handle: &[u8], host_chain_
                 .inc();
             info!(
                 host_chain_id,
-                block, id, "Drift revert signal created successfully"
+                block, id, "Drift revert signal recorded (created or lowered to earlier block)"
             );
         }
         Ok(None) => {
             warn!(
                 host_chain_id,
-                block, "Drift revert signal already in flight, skipping creation"
+                block,
+                "Drift revert signal not recorded: revert already in flight or pending at earlier block"
             );
         }
         Err(e) => {
-            error!(error = %e, "Failed to create drift revert signal");
+            error!(error = %e, "Failed to record drift revert signal");
         }
     }
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -49,6 +49,17 @@ static REVERT_FAILURE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+static TOO_MANY_ATTEMPTS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "coprocessor_drift_revert_too_many_attempts_counter",
+        "Number of times the revert runner refused to revert because too many \
+         successful reverts already happened in the recent window — indicates a \
+         deterministic loop where reverts succeed but drift keeps recurring",
+        &["host_chain_id"]
+    )
+    .unwrap()
+});
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SignalStatus {
     Pending,
@@ -57,13 +68,15 @@ pub enum SignalStatus {
     Failed(String),
 }
 
+const FAILED_DB_PREFIX: &str = "failed: ";
+
 impl SignalStatus {
-    fn as_db_str(&self) -> String {
+    pub fn as_db_str(&self) -> String {
         match self {
             Self::Pending => "pending".to_owned(),
             Self::Reverting => "reverting".to_owned(),
             Self::Done => "done".to_owned(),
-            Self::Failed(reason) => format!("failed: {reason}"),
+            Self::Failed(reason) => format!("{FAILED_DB_PREFIX}{reason}"),
         }
     }
 
@@ -72,12 +85,17 @@ impl SignalStatus {
             "pending" => Self::Pending,
             "reverting" => Self::Reverting,
             "done" => Self::Done,
-            other => Self::Failed(other.strip_prefix("failed: ").unwrap_or(other).to_owned()),
+            other => Self::Failed(
+                other
+                    .strip_prefix(FAILED_DB_PREFIX)
+                    .unwrap_or(other)
+                    .to_owned(),
+            ),
         }
     }
 
-    pub fn is_in_flight(&self) -> bool {
-        matches!(self, Self::Pending | Self::Reverting)
+    fn failed_like_pattern() -> String {
+        format!("{FAILED_DB_PREFIX}%")
     }
 }
 
@@ -146,6 +164,49 @@ pub async fn oldest_in_flight_signal(
          WHERE status = $1 OR status = $2 \
          ORDER BY id ASC LIMIT 1",
     )
+    .bind(SignalStatus::Pending.as_db_str())
+    .bind(SignalStatus::Reverting.as_db_str())
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(signal_from_row))
+}
+
+/// Fetch the most recent Failed signal across any host chain.
+pub async fn latest_failed_signal(
+    pool: &Pool<Postgres>,
+) -> anyhow::Result<Option<DriftRevertSignal>> {
+    let row = sqlx::query(
+        "SELECT id, host_chain_id, offending_host_block_number, status
+         FROM drift_revert_signal
+         WHERE status LIKE $1
+         ORDER BY id DESC LIMIT 1",
+    )
+    .bind(SignalStatus::failed_like_pattern())
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(signal_from_row))
+}
+
+/// Fetch the signal that should block service startup, in priority order:
+///   1. Most recent Failed signal — caller must bail.
+///   2. Oldest in-flight (Pending or Reverting) — caller must wait.
+///   3. None — caller can proceed.
+async fn blocking_signal(pool: &Pool<Postgres>) -> anyhow::Result<Option<DriftRevertSignal>> {
+    let row = sqlx::query(
+        "SELECT id, host_chain_id, offending_host_block_number, status FROM (
+            (SELECT 1 AS priority, id, host_chain_id, offending_host_block_number, status
+             FROM drift_revert_signal
+             WHERE status LIKE $1
+             ORDER BY id DESC LIMIT 1)
+            UNION ALL
+            (SELECT 2 AS priority, id, host_chain_id, offending_host_block_number, status
+             FROM drift_revert_signal
+             WHERE status = $2 OR status = $3
+             ORDER BY id ASC LIMIT 1)
+         ) sq
+         ORDER BY priority ASC LIMIT 1",
+    )
+    .bind(SignalStatus::failed_like_pattern())
     .bind(SignalStatus::Pending.as_db_str())
     .bind(SignalStatus::Reverting.as_db_str())
     .fetch_optional(pool)
@@ -262,46 +323,54 @@ pub async fn wait_for_in_flight_signal(pool: &Pool<Postgres>) -> anyhow::Result<
 /// any host chain, or until `cancel_token` fires. Used by non-runner services
 /// to wait for all pending reverts to finish on startup.
 ///
-/// Returns an error if at any point the latest signal transitions to `Failed`
-/// — the waiter must not let the service start on a DB where recovery failed.
+/// Returns an error if any host chain has an unresolved `Failed` signal at
+/// any point — the waiter must not let the service start on a DB where any
+/// chain's revert failed.
 pub async fn wait_for_revert_done(
     pool: &Pool<Postgres>,
     cancel_token: &CancellationToken,
 ) -> anyhow::Result<()> {
-    match oldest_in_flight_signal(pool).await? {
-        None => return Ok(()),
-        Some(signal) => info!(
-            signal_id = signal.id,
-            host_chain_id = signal.host_chain_id,
-            status = signal.status.as_db_str(),
-            "Waiting for drift revert to complete"
-        ),
-    }
+    let Some(signal) = blocking_signal(pool).await? else {
+        return Ok(());
+    };
+    bail_if_failed(
+        &signal,
+        "Unresolved Failed drift revert signal — refusing to start",
+    )?;
+    info!(
+        signal_id = signal.id,
+        host_chain_id = signal.host_chain_id,
+        status = signal.status.as_db_str(),
+        "Waiting for drift revert to complete"
+    );
+
     loop {
-        if cancel_token.is_cancelled() {
-            return Ok(());
-        }
-        // Abort if the revert failed while we were waiting.
-        if let Some(signal) = latest_signal(pool).await? {
-            if let SignalStatus::Failed(reason) = &signal.status {
-                error!(
-                    signal_id = signal.id,
-                    host_chain_id = signal.host_chain_id,
-                    reason,
-                    "Drift revert transitioned to Failed while waiting"
-                );
-                anyhow::bail!("drift revert signal {} is Failed: {reason}", signal.id);
-            }
-        }
-        if oldest_in_flight_signal(pool).await?.is_none() {
-            info!("Drift revert complete, resuming normal operation");
-            return Ok(());
-        }
         tokio::select! {
             _ = cancel_token.cancelled() => return Ok(()),
             _ = tokio::time::sleep(POLL_INTERVAL) => {}
         }
+        match blocking_signal(pool).await? {
+            None => {
+                info!("Drift revert complete, resuming normal operation");
+                return Ok(());
+            }
+            Some(s) => bail_if_failed(&s, "Drift revert reached Failed state while waiting")?,
+        }
     }
+}
+
+/// Logs and bails if `signal` has `Failed` status. No-op otherwise.
+fn bail_if_failed(signal: &DriftRevertSignal, message: &str) -> anyhow::Result<()> {
+    if let SignalStatus::Failed(reason) = &signal.status {
+        error!(
+            signal_id = signal.id,
+            host_chain_id = signal.host_chain_id,
+            reason,
+            "{message}"
+        );
+        anyhow::bail!("drift revert signal {} is Failed: {reason}", signal.id);
+    }
+    Ok(())
 }
 
 /// Prepare the revert SQL by replacing psql-specific syntax with concrete
@@ -392,6 +461,14 @@ pub struct RevertRunnerConfig {
     /// How long to wait after detecting a pending signal at startup before
     /// running the revert SQL. Gives other services time to also re-exec.
     pub grace_period: Duration,
+    /// Maximum number of successful reverts allowed for a host chain within
+    /// `recent_attempts_window`. Once exceeded, the next signal is marked
+    /// `Failed` with reason "too many recent attempts" instead of running
+    /// another (likely futile) revert. Catches deterministic recovery loops
+    /// where each revert succeeds but the underlying drift recurs.
+    pub max_recent_attempts: u32,
+    /// Time window over which `max_recent_attempts` is counted.
+    pub recent_attempts_window: Duration,
 }
 
 /// Watch for a pending drift-revert signal during normal service operation.
@@ -443,17 +520,19 @@ pub async fn handle_pending_signal_on_startup(
     runner_cfg: Option<RevertRunnerConfig>,
     cancel_token: &CancellationToken,
 ) -> anyhow::Result<()> {
-    if let Some(signal) = latest_signal(pool).await? {
-        if let SignalStatus::Failed(reason) = &signal.status {
-            error!(
-                signal_id = signal.id,
-                host_chain_id = signal.host_chain_id,
-                reason,
-                "Refusing to start: latest drift revert is Failed — operator must investigate \
-                 (mark Failed → Pending to retry, or Failed → Done to acknowledge)"
-            );
-            anyhow::bail!("drift revert signal {} is Failed: {reason}", signal.id);
-        }
+    if let Some(signal) = latest_failed_signal(pool).await? {
+        let reason = match &signal.status {
+            SignalStatus::Failed(r) => r.as_str(),
+            _ => "unknown",
+        };
+        error!(
+            signal_id = signal.id,
+            host_chain_id = signal.host_chain_id,
+            reason,
+            "Refusing to start: an unresolved Failed drift revert signal exists — operator \
+             must investigate (mark Failed → Pending to retry, or Failed → Done to acknowledge)"
+        );
+        anyhow::bail!("drift revert signal {} is Failed: {reason}", signal.id);
     }
 
     if let Some(cfg) = runner_cfg {
@@ -461,6 +540,27 @@ pub async fn handle_pending_signal_on_startup(
     } else {
         wait_for_revert_done(pool, cancel_token).await
     }
+}
+
+/// Counts successful reverts (status = Done) for `host_chain_id` within the
+/// recent `window`.
+async fn count_recent_done_signals(
+    pool: &Pool<Postgres>,
+    host_chain_id: i64,
+    window: Duration,
+) -> anyhow::Result<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM drift_revert_signal \
+         WHERE host_chain_id = $1 \
+           AND status = $2 \
+           AND updated_at > NOW() - make_interval(secs => $3)",
+    )
+    .bind(host_chain_id)
+    .bind(SignalStatus::Done.as_db_str())
+    .bind(window.as_secs() as i64)
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
 }
 
 /// Runner path: process all in-flight signals (oldest first) until none remain.
@@ -477,6 +577,33 @@ async fn run_all_pending_as_runner(
             status = signal.status.as_db_str(),
             "Found pending drift revert signal on startup"
         );
+
+        // Refuse to retry if too many successful reverts already happened on
+        // this chain in the recent window — drift keeps recurring, the revert
+        // alone isn't fixing it. Mark Failed and bail; operator must investigate.
+        let recent_dones =
+            count_recent_done_signals(pool, signal.host_chain_id, cfg.recent_attempts_window)
+                .await?;
+        if recent_dones >= cfg.max_recent_attempts as i64 {
+            let reason = format!(
+                "too many recent attempts: {recent_dones} successful reverts on chain {} \
+                 in the last {}s (threshold {})",
+                signal.host_chain_id,
+                cfg.recent_attempts_window.as_secs(),
+                cfg.max_recent_attempts,
+            );
+            error!(
+                signal_id = signal.id,
+                host_chain_id = signal.host_chain_id,
+                reason = %reason,
+                "Refusing to revert: too many recent attempts on this chain"
+            );
+            update_signal_status(pool, signal.id, &SignalStatus::Failed(reason.clone())).await?;
+            TOO_MANY_ATTEMPTS_COUNTER
+                .with_label_values(&[&signal.host_chain_id.to_string()])
+                .inc();
+            return Err(anyhow::anyhow!(reason));
+        }
 
         // Grace period: give other services time to re-exec too.
         // Only wait it once per process startup — if we're on the 2nd signal,

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -411,17 +411,30 @@ fn prepare_revert_sql(chain_id: i64, to_block_number: i64) -> String {
 
 /// Execute the revert SQL script against the database.
 ///
-/// `to_block = max(1, offending_host_block_number - 1)` — we subtract 1
-/// because the script reverts everything strictly greater than `to_block`,
-/// and we want the offending block itself gone. If ciphertexts from earlier
-/// blocks also drifted (due to out-of-order processing), the drift detector
-/// will catch them eventually in subsequent rounds.
+/// `to_block = offending_host_block_number - 1` — we subtract 1 because the
+/// script reverts everything strictly greater than `to_block`, and we want the
+/// offending block itself gone. If ciphertexts from earlier blocks also
+/// drifted (due to out-of-order processing), the drift detector will catch
+/// them eventually in subsequent rounds.
+///
+/// Refuses to revert when `offending <= 1`: the SQL script rejects
+/// `to_block <= 0`, and clamping to `to_block = 1` would silently leave
+/// block 1's drifted state in place (the SQL only deletes blocks `> to_block`).
+/// Drift on block 1 is realistic only on fresh chains / test environments and
+/// requires operator intervention to wipe the chain explicitly.
 pub async fn execute_revert(
     pool: &Pool<Postgres>,
     host_chain_id: i64,
     offending_host_block_number: i64,
 ) -> anyhow::Result<()> {
-    let to_block_number = (offending_host_block_number - 1).max(1);
+    if offending_host_block_number <= 1 {
+        anyhow::bail!(
+            "refusing auto-revert for offending block {offending_host_block_number} on \
+             chain {host_chain_id}: cannot delete block <= 1 via the revert script — \
+             operator must wipe the chain manually"
+        );
+    }
+    let to_block_number = offending_host_block_number - 1;
 
     info!(
         host_chain_id,

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -11,7 +11,6 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use prometheus::{register_int_counter_vec, IntCounterVec};
-use sqlx::postgres::PgPoolOptions;
 use sqlx::{Pool, Postgres, Row};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -680,26 +679,21 @@ async fn run_all_pending_as_runner(
 /// Pass `Some(RevertRunnerConfig)` for the revert runner (e.g. gw-listener),
 /// `None` for all other services.
 pub async fn init(
-    database_url: &str,
+    pool: Pool<Postgres>,
     cancel_token: CancellationToken,
     runner_cfg: Option<RevertRunnerConfig>,
 ) -> anyhow::Result<()> {
-    init_with_reexec(database_url, cancel_token, runner_cfg, ProcessReExec::new()).await
+    init_with_reexec(pool, cancel_token, runner_cfg, ProcessReExec::new()).await
 }
 
 /// Like [`init`] but lets the caller inject a custom `ReExec` implementation.
 /// Primarily used by tests to swap in a mock.
 pub async fn init_with_reexec<R: ReExec + 'static>(
-    database_url: &str,
+    pool: Pool<Postgres>,
     cancel_token: CancellationToken,
     runner_cfg: Option<RevertRunnerConfig>,
     re_exec: R,
 ) -> anyhow::Result<()> {
-    let pool = PgPoolOptions::new()
-        .max_connections(1)
-        .connect(database_url)
-        .await?;
-
     handle_pending_signal_on_startup(&pool, runner_cfg, &cancel_token).await?;
 
     tokio::spawn(async move {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/lib.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chain_id;
 pub mod crs;
 pub mod database;
 pub mod db_keys;
+pub mod drift_revert;
 #[cfg(feature = "gpu")]
 pub mod gpu_memory;
 pub mod healthz_server;

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -120,7 +120,14 @@ struct Conf {
     /// running the revert SQL. Gives other services time to see the signal and
     /// re-exec before the DB state changes.
     #[arg(long, default_value = "60s", value_parser = parse_duration)]
-    drift_revert_grace_period: Duration,
+    drift_auto_revert_grace_period: Duration,
+
+    /// Enable automatic drift recovery. When false (default), the drift
+    /// detector still runs and logs drift, but no revert signal is created
+    /// and no automatic recovery kicks in. Opt-in while the feature rolls out.
+    /// Also readable from `DRIFT_AUTO_REVERT_ENABLED` env var.
+    #[arg(long, env = "DRIFT_AUTO_REVERT_ENABLED", default_value_t = false)]
+    drift_auto_revert_enabled: bool,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -198,7 +205,8 @@ async fn main() -> anyhow::Result<()> {
         gateway_config_address: conf.gateway_config_address,
         drift_no_consensus_timeout: conf.drift_no_consensus_timeout,
         drift_post_consensus_grace: conf.drift_post_consensus_grace,
-        drift_revert_grace_period: conf.drift_revert_grace_period,
+        drift_auto_revert_grace_period: conf.drift_auto_revert_grace_period,
+        drift_auto_revert_enabled: conf.drift_auto_revert_enabled,
     };
 
     let gw_listener = std::sync::Arc::new(GatewayListener::new(
@@ -231,7 +239,7 @@ async fn main() -> anyhow::Result<()> {
         config.database_url.as_str(),
         cancel_token.clone(),
         Some(RevertRunnerConfig {
-            grace_period: config.drift_revert_grace_period,
+            grace_period: config.drift_auto_revert_grace_period,
         }),
     )
     .await?;

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -128,6 +128,16 @@ struct Conf {
     /// Also readable from `DRIFT_AUTO_REVERT_ENABLED` env var.
     #[arg(long, env = "DRIFT_AUTO_REVERT_ENABLED", default_value_t = false)]
     drift_auto_revert_enabled: bool,
+
+    /// Maximum number of successful reverts allowed for a host chain within
+    /// `--drift-auto-revert-recent-attempts-window` before refusing further
+    /// reverts. Catches loops where each revert succeeds but drift recurs.
+    #[arg(long, default_value_t = 2)]
+    drift_auto_revert_max_recent_attempts: u32,
+
+    /// Time window over which `--drift-auto-revert-max-recent-attempts` is counted.
+    #[arg(long, default_value = "30m", value_parser = parse_duration)]
+    drift_auto_revert_recent_attempts_window: Duration,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -240,6 +250,8 @@ async fn main() -> anyhow::Result<()> {
         cancel_token.clone(),
         Some(RevertRunnerConfig {
             grace_period: config.drift_auto_revert_grace_period,
+            max_recent_attempts: conf.drift_auto_revert_max_recent_attempts,
+            recent_attempts_window: conf.drift_auto_revert_recent_attempts_window,
         }),
     )
     .await?;

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::{primitives::Address, transports::http::reqwest::Url};
 use clap::Parser;
-use fhevm_engine_common::database::resolve_database_url_from_option;
+use fhevm_engine_common::database::{connect_pool_with_options, resolve_database_url_from_option};
 use fhevm_engine_common::{
     drift_revert::{self, RevertRunnerConfig},
     metrics_server, telemetry,
@@ -14,6 +14,7 @@ use gw_listener::gw_listener::GatewayListener;
 use gw_listener::http_server::HttpServer;
 use gw_listener::ConfigSettings;
 use humantime::parse_duration;
+use sqlx::postgres::PgPoolOptions;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
@@ -243,9 +244,16 @@ async fn main() -> anyhow::Result<()> {
         "Starting HTTP health check server"
     );
 
+    let (db_pool, _pool_refresh_handle) = connect_pool_with_options(
+        &config.database_url,
+        PgPoolOptions::new().max_connections(config.database_pool_size),
+        Some(&cancel_token),
+    )
+    .await?;
+
     // gw-listener is the revert runner — it runs the revert SQL if pending.
     drift_revert::init(
-        config.database_url.as_str(),
+        db_pool.clone(),
         cancel_token.clone(),
         Some(RevertRunnerConfig {
             grace_period: config.drift_auto_revert_grace_period,
@@ -255,7 +263,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    let gw_listener_fut = tokio::spawn(async move { gw_listener.run().await });
+    let gw_listener_fut = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     let gw_listener_res = gw_listener_fut.await;
     let http_server_res = http_server_fut.await;

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -5,6 +5,11 @@ use alloy::{primitives::Address, transports::http::reqwest::Url};
 use clap::Parser;
 use fhevm_engine_common::database::resolve_database_url_from_option;
 use fhevm_engine_common::{metrics_server, telemetry, utils::DatabaseURL};
+use fhevm_engine_common::{
+    drift_revert::{self, RevertRunnerConfig},
+    metrics_server, telemetry,
+    utils::DatabaseURL,
+};
 use gw_listener::aws_s3::AwsS3Client;
 use gw_listener::gw_listener::GatewayListener;
 use gw_listener::http_server::HttpServer;
@@ -110,6 +115,12 @@ struct Conf {
     /// coprocessors to submit their ciphertext material. Wall-clock duration.
     #[arg(long, default_value = "5m", value_parser = parse_duration, requires = "ciphertext_commits_address")]
     drift_post_consensus_grace: Duration,
+
+    /// How long to wait after detecting a pending drift-revert signal before
+    /// running the revert SQL. Gives other services time to see the signal and
+    /// re-exec before the DB state changes.
+    #[arg(long, default_value = "60s", value_parser = parse_duration)]
+    drift_revert_grace_period: Duration,
 }
 
 fn install_signal_handlers(cancel_token: CancellationToken) -> anyhow::Result<()> {
@@ -187,19 +198,17 @@ async fn main() -> anyhow::Result<()> {
         gateway_config_address: conf.gateway_config_address,
         drift_no_consensus_timeout: conf.drift_no_consensus_timeout,
         drift_post_consensus_grace: conf.drift_post_consensus_grace,
+        drift_revert_grace_period: conf.drift_revert_grace_period,
     };
 
-    let gw_listener = GatewayListener::new(
+    let gw_listener = std::sync::Arc::new(GatewayListener::new(
         conf.input_verification_address,
         conf.kms_generation_address,
         config.clone(),
         cancel_token.clone(),
         provider.clone(),
         aws_s3_client.clone(),
-    );
-
-    // Wrap the GatewayListener in an Arc
-    let gw_listener = std::sync::Arc::new(gw_listener);
+    ));
 
     let http_server = HttpServer::new(
         gw_listener.clone(),
@@ -209,17 +218,25 @@ async fn main() -> anyhow::Result<()> {
 
     install_signal_handlers(cancel_token.clone())?;
 
+    let http_server_fut = tokio::spawn(async move { http_server.start().await });
+    metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
+
     info!(
         health_check_port = conf.health_check_port,
         "Starting HTTP health check server"
     );
 
-    // Run both services in parallel. Here we assume that if gw listener stops without an error, HTTP server should also stop.
-    let gw_listener_fut = tokio::spawn(async move { gw_listener.run().await });
-    let http_server_fut = tokio::spawn(async move { http_server.start().await });
+    // gw-listener is the revert runner — it runs the revert SQL if pending.
+    drift_revert::init(
+        config.database_url.as_str(),
+        cancel_token.clone(),
+        Some(RevertRunnerConfig {
+            grace_period: config.drift_revert_grace_period,
+        }),
+    )
+    .await?;
 
-    // Start the metrics server.
-    metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
+    let gw_listener_fut = tokio::spawn(async move { gw_listener.run().await });
 
     let gw_listener_res = gw_listener_fut.await;
     let http_server_res = http_server_fut.await;

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -4,7 +4,6 @@ use alloy::providers::{ProviderBuilder, WsConnect};
 use alloy::{primitives::Address, transports::http::reqwest::Url};
 use clap::Parser;
 use fhevm_engine_common::database::resolve_database_url_from_option;
-use fhevm_engine_common::{metrics_server, telemetry, utils::DatabaseURL};
 use fhevm_engine_common::{
     drift_revert::{self, RevertRunnerConfig},
     metrics_server, telemetry,

--- a/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
@@ -338,6 +338,14 @@ impl DriftDetector {
                 "Drift detected: local digest does not match consensus"
             );
             self.deferred_drift_detected += 1;
+
+            // Auto drift recovery: signal that a revert is needed.
+            fhevm_engine_common::drift_revert::on_drift_detected(
+                db_pool,
+                handle.as_slice(),
+                chain_id_from_handle(handle),
+            )
+            .await;
         }
 
         let Some(state) = self.open_handles.get_mut(&handle) else {
@@ -1568,6 +1576,135 @@ mod tests {
             .unwrap();
 
         assert_eq!(detector.deferred_drift_detected, 1);
+    }
+
+    // Set up host_chains + transactions + computations so that
+    // `on_drift_detected`'s block lookup succeeds for a compute-output handle
+    // at the given chain id and block. Returns the constructed handle bytes.
+    async fn setup_computation_for_recovery(
+        pool: &Pool<Postgres>,
+        chain_id: i64,
+        block_number: i64,
+    ) -> [u8; 32] {
+        // Compute-output handle (byte 21 = 0xff) carrying chain_id.
+        let mut handle = [0xAA; 32];
+        handle[21] = 0xff;
+        handle[22..30].copy_from_slice(&(chain_id as u64).to_be_bytes());
+
+        sqlx::query(
+            "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+             VALUES ($1, 'test', '0x1')",
+        )
+        .bind(chain_id)
+        .execute(pool)
+        .await
+        .unwrap();
+        let txn_id: Vec<u8> = vec![0xBB; 32];
+        sqlx::query("INSERT INTO transactions (id, chain_id, block_number) VALUES ($1, $2, $3)")
+            .bind(&txn_id)
+            .bind(chain_id)
+            .bind(block_number)
+            .execute(pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO computations (output_handle, dependencies, fhe_operation, is_scalar, \
+             transaction_id, host_chain_id, block_number) \
+             VALUES ($1, ARRAY[]::bytea[], 1, false, $2, $3, $4)",
+        )
+        .bind(handle.as_slice())
+        .bind(&txn_id)
+        .bind(chain_id)
+        .bind(block_number)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        handle
+    }
+
+    #[tokio::test]
+    #[serial(db)]
+    async fn consensus_mismatch_creates_revert_signal() {
+        let (pool, _inst) = setup_db().await;
+
+        let chain_id: i64 = 12345;
+        let block: i64 = 42;
+        let handle = setup_computation_for_recovery(&pool, chain_id, block).await;
+
+        let local_ct = [0xBB; 32];
+        let local_ct128 = [0xCC; 32];
+        let consensus_ct_mismatch = [0xFF; 32];
+
+        insert_ciphertext_digest(
+            &pool,
+            chain_id,
+            [0u8; 32],
+            &handle,
+            &local_ct,
+            &local_ct128,
+            0,
+        )
+        .await
+        .unwrap();
+
+        let mut detector = detector();
+        detector
+            .handle_consensus(
+                make_consensus_event(
+                    FixedBytes::from(handle),
+                    FixedBytes::from(consensus_ct_mismatch),
+                    FixedBytes::from(local_ct128),
+                    senders(),
+                ),
+                context(10),
+                &pool,
+            )
+            .await
+            .unwrap();
+
+        let signal = fhevm_engine_common::drift_revert::latest_signal(&pool)
+            .await
+            .unwrap()
+            .expect("consensus mismatch should create a revert signal");
+        assert_eq!(signal.host_chain_id, chain_id);
+        assert_eq!(signal.offending_host_block_number, block);
+    }
+
+    #[tokio::test]
+    #[serial(db)]
+    async fn consensus_match_does_not_create_revert_signal() {
+        let (pool, _inst) = setup_db().await;
+
+        let handle = setup_computation_for_recovery(&pool, 12345, 42).await;
+        let local_ct = [0xBB; 32];
+        let local_ct128 = [0xCC; 32];
+        insert_ciphertext_digest(&pool, 12345, [0u8; 32], &handle, &local_ct, &local_ct128, 0)
+            .await
+            .unwrap();
+
+        let mut detector = detector();
+        detector
+            .handle_consensus(
+                make_consensus_event(
+                    FixedBytes::from(handle),
+                    FixedBytes::from(local_ct),
+                    FixedBytes::from(local_ct128),
+                    senders(),
+                ),
+                context(10),
+                &pool,
+            )
+            .await
+            .unwrap();
+
+        let signal = fhevm_engine_common::drift_revert::latest_signal(&pool)
+            .await
+            .unwrap();
+        assert!(
+            signal.is_none(),
+            "matching consensus should not create a revert signal"
+        );
     }
 
     #[tokio::test]

--- a/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
@@ -91,6 +91,7 @@ pub(crate) struct DriftDetector {
     local_node_id: String,
     drift_no_consensus_timeout: Duration,
     drift_post_consensus_grace: Duration,
+    auto_revert_enabled: bool,
     deferred_drift_detected: u64,
     deferred_consensus_timeout: u64,
     deferred_missing_submission: u64,
@@ -102,6 +103,7 @@ impl DriftDetector {
         expected_senders: Vec<Address>,
         drift_no_consensus_timeout: Duration,
         drift_post_consensus_grace: Duration,
+        auto_revert_enabled: bool,
     ) -> Self {
         Self {
             current_expected_senders: expected_senders,
@@ -109,6 +111,7 @@ impl DriftDetector {
             local_node_id: std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_owned()),
             drift_no_consensus_timeout,
             drift_post_consensus_grace,
+            auto_revert_enabled,
             deferred_drift_detected: 0,
             deferred_consensus_timeout: 0,
             deferred_missing_submission: 0,
@@ -339,13 +342,14 @@ impl DriftDetector {
             );
             self.deferred_drift_detected += 1;
 
-            // Auto drift recovery: signal that a revert is needed.
-            fhevm_engine_common::drift_revert::on_drift_detected(
-                db_pool,
-                handle.as_slice(),
-                chain_id_from_handle(handle),
-            )
-            .await;
+            if self.auto_revert_enabled {
+                fhevm_engine_common::drift_revert::on_drift_detected(
+                    db_pool,
+                    handle.as_slice(),
+                    chain_id_from_handle(handle),
+                )
+                .await;
+            }
         }
 
         let Some(state) = self.open_handles.get_mut(&handle) else {
@@ -698,10 +702,12 @@ mod tests {
         let digest_b = FixedBytes::from([0x66; 32]);
         let digest_128 = FixedBytes::from([0x77; 32]);
         let base = Instant::now();
+        let auto_revert_enabled = false;
         let mut detector = DriftDetector::new(
             vec![sender_a, sender_b, sender_c],
             Duration::from_secs(50),
             Duration::from_secs(10),
+            auto_revert_enabled,
         );
 
         detector.set_replaying(true);
@@ -829,7 +835,23 @@ mod tests {
     }
 
     fn detector() -> DriftDetector {
-        DriftDetector::new(senders(), Duration::from_secs(5), Duration::from_secs(2))
+        let auto_revert_enabled = false;
+        DriftDetector::new(
+            senders(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+            auto_revert_enabled,
+        )
+    }
+
+    fn detector_with_auto_revert() -> DriftDetector {
+        let auto_revert_enabled = true;
+        DriftDetector::new(
+            senders(),
+            Duration::from_secs(5),
+            Duration::from_secs(2),
+            auto_revert_enabled,
+        )
     }
 
     fn make_consensus_state(
@@ -1648,7 +1670,7 @@ mod tests {
         .await
         .unwrap();
 
-        let mut detector = detector();
+        let mut detector = detector_with_auto_revert();
         detector
             .handle_consensus(
                 make_consensus_event(
@@ -1683,7 +1705,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut detector = detector();
+        let mut detector = detector_with_auto_revert();
         detector
             .handle_consensus(
                 make_consensus_event(

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -4,7 +4,7 @@ use alloy::eips::BlockId;
 use alloy::rpc::types::Filter;
 use alloy::sol_types::SolEventInterface;
 use alloy::{network::Ethereum, primitives::Address, providers::Provider, rpc::types::Log};
-use fhevm_engine_common::database::{connect_options_for_database_url, connect_pool_with_options};
+use fhevm_engine_common::database::connect_options_for_database_url;
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::utils::to_hex;
 use futures_util::future::join_all;
@@ -88,19 +88,13 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
         }
     }
 
-    pub async fn run(&self) -> anyhow::Result<()> {
+    pub async fn run(&self, db_pool: Pool<Postgres>) -> anyhow::Result<()> {
         info!(
             conf = ?self.conf,
             self.input_verification_address = %self.input_verification_address,
             self.kms_generation_address = %self.kms_generation_address,
             "Starting Gateway Listener",
         );
-        let (db_pool, _pool_refresh_handle) = connect_pool_with_options(
-            &self.conf.database_url,
-            PgPoolOptions::new().max_connections(self.conf.database_pool_size),
-            Some(&self.cancel_token),
-        )
-        .await?;
 
         let get_logs_handle = {
             let s = self.clone();

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -176,6 +176,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             expected_senders,
             self.conf.drift_no_consensus_timeout,
             self.conf.drift_post_consensus_grace,
+            self.conf.drift_auto_revert_enabled,
         );
         if replay_from_block.is_none() {
             if let Err(e) = self

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -57,6 +57,10 @@ pub struct ConfigSettings {
     pub gateway_config_address: Option<Address>,
     pub drift_no_consensus_timeout: Duration,
     pub drift_post_consensus_grace: Duration,
+    /// How long to wait after detecting a pending drift-revert signal before
+    /// running the revert SQL. Gives other services time to see the signal and
+    /// drop their in-flight work.
+    pub drift_revert_grace_period: Duration,
 }
 
 /// Default is used by unit tests only. Production defaults come from
@@ -81,6 +85,7 @@ impl Default for ConfigSettings {
             gateway_config_address: None,
             drift_no_consensus_timeout: Duration::from_secs(5),
             drift_post_consensus_grace: Duration::from_secs(2),
+            drift_revert_grace_period: Duration::from_secs(60),
         }
     }
 }

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -60,11 +60,13 @@ pub struct ConfigSettings {
     /// How long to wait after detecting a pending drift-revert signal before
     /// running the revert SQL. Gives other services time to see the signal and
     /// drop their in-flight work.
-    pub drift_revert_grace_period: Duration,
+    pub drift_auto_revert_grace_period: Duration,
+    /// If true, the drift detector creates drift-revert signals when it sees
+    /// a consensus mismatch. If false, drift is still detected and logged,
+    /// but no signal is created.
+    pub drift_auto_revert_enabled: bool,
 }
 
-/// Default is used by unit tests only. Production defaults come from
-/// the CLI arg definitions in `bin/gw_listener.rs` (e.g. `--drift-no-consensus-timeout 5m`).
 impl Default for ConfigSettings {
     fn default() -> Self {
         Self {
@@ -85,7 +87,8 @@ impl Default for ConfigSettings {
             gateway_config_address: None,
             drift_no_consensus_timeout: Duration::from_secs(5),
             drift_post_consensus_grace: Duration::from_secs(2),
-            drift_revert_grace_period: Duration::from_secs(60),
+            drift_auto_revert_grace_period: Duration::from_secs(60),
+            drift_auto_revert_enabled: false,
         }
     }
 }

--- a/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/coprocessor/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -202,7 +202,8 @@ async fn verify_proof_request_inserted_into_db() -> anyhow::Result<()> {
         aws_s3_client.clone(),
     );
 
-    let run_handle = tokio::spawn(async move { gw_listener.run().await });
+    let db_pool = env.db_pool.clone();
+    let run_handle = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     let contract_address = PrivateKeySigner::random().address();
     let user_address = PrivateKeySigner::random().address();
@@ -484,7 +485,8 @@ async fn keygen_ok_simple() -> anyhow::Result<()> {
         aws_s3_client.clone(),
     );
 
-    let listener = tokio::spawn(async move { gw_listener.run().await });
+    let db_pool = env.db_pool.clone();
+    let listener = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     assert!(has_not_public_key(&env.db_pool.clone(), key_id).await?);
     assert!(has_not_server_key(&env.db_pool.clone(), key_id).await?);
@@ -585,7 +587,8 @@ async fn keygen_ok_catchup_gen(positive: bool) -> anyhow::Result<()> {
         provider.clone(),
         aws_s3_client.clone(),
     );
-    let listener = tokio::spawn(async move { gw_listener.run().await });
+    let db_pool = env.db_pool.clone();
+    let listener = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     assert!(has_public_key(&env.db_pool.clone(), key_id).await?);
     assert!(has_server_key(&env.db_pool.clone(), key_id).await?);
@@ -633,7 +636,8 @@ async fn keygen_compromised_key() -> anyhow::Result<()> {
         aws_s3_client.clone(),
     );
 
-    let result = tokio::spawn(async move { gw_listener.run().await });
+    let db_pool = env.db_pool.clone();
+    let result = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     assert!(has_not_public_key(&env.db_pool.clone(), key_id).await?);
     assert!(has_not_server_key(&env.db_pool.clone(), key_id).await?);
@@ -693,7 +697,8 @@ async fn keygen_bad_key_or_bucket() -> anyhow::Result<()> {
         aws_s3_client.clone(),
     );
 
-    let listener = tokio::spawn(async move { gw_listener.run().await });
+    let db_pool = env.db_pool.clone();
+    let listener = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     assert!(has_not_public_key(&env.db_pool.clone(), key_id).await?);
     assert!(has_not_server_key(&env.db_pool.clone(), key_id).await?);
@@ -751,7 +756,8 @@ async fn keygen_only_public_or_server_key() -> anyhow::Result<()> {
         aws_s3_client.clone(),
     );
 
-    let listener = tokio::spawn(async move { gw_listener.run().await });
+    let db_pool = env.db_pool.clone();
+    let listener = tokio::spawn(async move { gw_listener.run(db_pool).await });
 
     assert!(has_not_public_key(&env.db_pool.clone(), key_id).await?);
     assert!(has_not_server_key(&env.db_pool.clone(), key_id).await?);

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use fhevm_engine_common::drift_revert;
 use fhevm_engine_common::healthz_server::HttpServer as HealthHttpServer;
 use fhevm_engine_common::types::BlockchainProvider;
 use fhevm_engine_common::utils::{DatabaseURL, HeartBeat};
@@ -1039,6 +1040,7 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
 
     let mut log_iter = InfiniteLogIter::new(&args);
     let chain_id = log_iter.get_chain_id().await?;
+
     info!(chain_id = %chain_id, "Chain ID");
     if args.database_url.as_str().is_empty() {
         error!("Database URL is required");
@@ -1047,6 +1049,31 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
     let mut db =
         Database::new(&args.database_url, chain_id, args.dependence_cache_size)
             .await?;
+
+    let health_check = HealthCheck {
+        blockchain_timeout_tick: log_iter.tick_timeout.clone(),
+        blockchain_tick: log_iter.tick_block.clone(),
+        blockchain_provider: log_iter.provider.clone(),
+        database_pool: db.pool.clone(),
+        database_tick: db.tick.clone(),
+    };
+
+    let cancel_token = CancellationToken::new();
+
+    // Start health check before drift-revert init so the service stays
+    // healthy while waiting for a revert to complete.
+    let health_check_server = HealthHttpServer::new(
+        Arc::new(health_check),
+        args.health_port,
+        cancel_token.clone(),
+    );
+    tokio::spawn(async move { health_check_server.start().await });
+
+    // Drift-revert: must run before any DB state reads so we don't read
+    // pre-revert state.
+    drift_revert::init(args.database_url.as_str(), cancel_token.clone(), None)
+        .await?;
+
     if args.dependent_ops_max_per_chain == 0 {
         let promoted = db.promote_all_dep_chains_to_fast_priority().await?;
         if promoted > 0 {
@@ -1056,21 +1083,6 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
             );
         }
     }
-
-    let health_check = HealthCheck {
-        blockchain_timeout_tick: log_iter.tick_timeout.clone(),
-        blockchain_tick: log_iter.tick_block.clone(),
-        blockchain_provider: log_iter.provider.clone(),
-        database_pool: db.pool.clone(),
-        database_tick: db.tick.clone(),
-    };
-    let cancel_token = CancellationToken::new();
-    let health_check_server = HealthHttpServer::new(
-        Arc::new(health_check),
-        args.health_port,
-        cancel_token.clone(),
-    );
-    tokio::spawn(async move { health_check_server.start().await });
 
     if log_iter.start_at_block.is_none() {
         log_iter.start_at_block = db

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -1075,8 +1075,12 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
 
     // Drift-revert: must run before any DB state reads so we don't read
     // pre-revert state.
-    drift_revert::init(args.database_url.as_str(), cancel_token.clone(), None)
-        .await?;
+    drift_revert::init(
+        db.pool.read().await.clone(),
+        cancel_token.clone(),
+        None,
+    )
+    .await?;
 
     if args.dependent_ops_max_per_chain == 0 {
         let promoted = db.promote_all_dep_chains_to_fast_priority().await?;

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -1067,7 +1067,11 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         args.health_port,
         cancel_token.clone(),
     );
-    tokio::spawn(async move { health_check_server.start().await });
+    tokio::spawn(async move {
+        if let Err(err) = health_check_server.start().await {
+            error!(error = %err, "Health check server failed");
+        }
+    });
 
     // Drift-revert: must run before any DB state reads so we don't read
     // pre-revert state.

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -17,10 +17,12 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use fhevm_engine_common::database::connect_pool_with_options;
 use fhevm_engine_common::drift_revert;
 use fhevm_engine_common::healthz_server::HttpServer as HealthHttpServer;
 use fhevm_engine_common::types::BlockchainProvider;
 use fhevm_engine_common::utils::{DatabaseURL, HeartBeat};
+use sqlx::postgres::PgPoolOptions;
 
 use crate::database::ingest::{
     ingest_block_logs, update_finalized_blocks, BlockLogs, IngestOptions,
@@ -1075,12 +1077,13 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
 
     // Drift-revert: must run before any DB state reads so we don't read
     // pre-revert state.
-    drift_revert::init(
-        db.pool.read().await.clone(),
-        cancel_token.clone(),
-        None,
+    let (drift_revert_pool, _pool_refresh_handle) = connect_pool_with_options(
+        &args.database_url,
+        PgPoolOptions::new().max_connections(1),
+        Some(&cancel_token),
     )
     .await?;
+    drift_revert::init(drift_revert_pool, cancel_token.clone(), None).await?;
 
     if args.dependent_ops_max_per_chain == 0 {
         let promoted = db.promote_all_dep_chains_to_fast_priority().await?;

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -15,8 +15,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use fhevm_engine_common::chain_id::ChainId;
+use fhevm_engine_common::database::connect_pool_with_options;
 use fhevm_engine_common::healthz_server::HttpServer as HealthHttpServer;
 use fhevm_engine_common::utils::{DatabaseURL, HeartBeat};
+use sqlx::postgres::PgPoolOptions;
 
 use crate::cmd::block_history::BlockSummary;
 use crate::database::ingest::{ingest_block_logs, BlockLogs, IngestOptions};
@@ -153,8 +155,16 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         }
     });
 
+    // Drift-revert: must run before any DB state reads so we don't read
+    // pre-revert state.
+    let (drift_revert_pool, _pool_refresh_handle) = connect_pool_with_options(
+        &config.database_url,
+        PgPoolOptions::new().max_connections(1),
+        Some(&cancel_token),
+    )
+    .await?;
     fhevm_engine_common::drift_revert::init(
-        db.pool.read().await.clone(),
+        drift_revert_pool,
         cancel_token.clone(),
         None,
     )

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -141,11 +141,11 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         database_pool: db.pool.clone(),
         database_tick: db.tick.clone(),
     };
-    let health_check_cancel_token = CancellationToken::new();
+    let cancel_token = CancellationToken::new();
     let health_check_server = HealthHttpServer::new(
         Arc::new(health_check),
         config.health_port,
-        health_check_cancel_token.clone(),
+        cancel_token.clone(),
     );
     tokio::spawn(async move {
         if let Err(err) = health_check_server.start().await {
@@ -155,7 +155,7 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
 
     fhevm_engine_common::drift_revert::init(
         config.database_url.as_str(),
-        health_check_cancel_token.clone(),
+        cancel_token.clone(),
         None,
     )
     .await?;

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -133,6 +133,33 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         config.dependence_cache_size,
     )
     .await?;
+
+    let health_check = HealthCheck {
+        blockchain_timeout_tick: blockchain_timeout_tick.clone(),
+        blockchain_tick: blockchain_tick.clone(),
+        blockchain_provider: blockchain_provider.clone(),
+        database_pool: db.pool.clone(),
+        database_tick: db.tick.clone(),
+    };
+    let health_check_cancel_token = CancellationToken::new();
+    let health_check_server = HealthHttpServer::new(
+        Arc::new(health_check),
+        config.health_port,
+        health_check_cancel_token.clone(),
+    );
+    tokio::spawn(async move {
+        if let Err(err) = health_check_server.start().await {
+            error!(error = %err, "Health check server failed");
+        }
+    });
+
+    fhevm_engine_common::drift_revert::init(
+        config.database_url.as_str(),
+        health_check_cancel_token.clone(),
+        None,
+    )
+    .await?;
+
     if config.dependent_ops_max_per_chain == 0 {
         let promoted = db.promote_all_dep_chains_to_fast_priority().await?;
         if promoted > 0 {
@@ -157,25 +184,6 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
                 .context("initial last_caught_up_block cannot be negative")?
         }
     };
-
-    let health_check = HealthCheck {
-        blockchain_timeout_tick: blockchain_timeout_tick.clone(),
-        blockchain_tick: blockchain_tick.clone(),
-        blockchain_provider: blockchain_provider.clone(),
-        database_pool: db.pool.clone(),
-        database_tick: db.tick.clone(),
-    };
-    let health_check_cancel_token = CancellationToken::new();
-    let health_check_server = HealthHttpServer::new(
-        Arc::new(health_check),
-        config.health_port,
-        health_check_cancel_token.clone(),
-    );
-    tokio::spawn(async move {
-        if let Err(err) = health_check_server.start().await {
-            error!(error = %err, "Health check server failed");
-        }
-    });
 
     info!(
         chain_id = %chain_id,

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -154,7 +154,7 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
     });
 
     fhevm_engine_common::drift_revert::init(
-        config.database_url.as_str(),
+        db.pool.read().await.clone(),
         cancel_token.clone(),
         None,
     )

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -403,7 +403,6 @@ pub async fn run_computation_loop(
     events_tx: InternalEvents,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let port = conf.health_checks.port;
-    let db_url = conf.db.url.clone();
 
     let service = Arc::new(
         SwitchNSquashService::create(
@@ -430,7 +429,7 @@ pub async fn run_computation_loop(
         anyhow::Ok(())
     });
 
-    drift_revert::init(db_url.as_str(), token.clone(), None).await?;
+    drift_revert::init(pool_mngr.pool().clone(), token.clone(), None).await?;
 
     // Run the main service loop
     service.run(pool_mngr).await;

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -37,7 +37,6 @@ use tokio::{
         mpsc::{self, Sender},
         RwLock,
     },
-    task,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
@@ -393,52 +392,6 @@ impl UploadJob {
     }
 }
 
-/// Runs the SnS worker loop
-pub async fn run_computation_loop(
-    pool_mngr: &PostgresPoolManager,
-    conf: Config,
-    tx: Sender<UploadJob>,
-    token: CancellationToken,
-    client: Arc<Client>,
-    events_tx: InternalEvents,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let port = conf.health_checks.port;
-
-    let service = Arc::new(
-        SwitchNSquashService::create(
-            pool_mngr,
-            conf,
-            tx,
-            token.child_token(),
-            client,
-            events_tx.clone(),
-        )
-        .await?,
-    );
-
-    // Start health check server
-    let healthz = healthz_server::HttpServer::new(service.clone(), port, token.child_token());
-    task::spawn(async move {
-        if let Err(err) = healthz.start().await {
-            error!(
-                task = "health_check",
-                error = %err,
-                "Error while running server"
-            );
-        }
-        anyhow::Ok(())
-    });
-
-    drift_revert::init(pool_mngr.pool().clone(), token.clone(), None).await?;
-
-    // Run the main service loop
-    service.run(pool_mngr).await;
-    token.cancel();
-
-    info!("Worker stopped");
-    Ok(())
-}
-
 /// Runs the uploader loop
 pub async fn run_uploader_loop(
     pool_mngr: &PostgresPoolManager,
@@ -555,6 +508,42 @@ pub async fn run_all(
         );
     }
 
+    // Build the service.
+    // create() is a pure struct constructor — no DB or
+    // S3 calls — so it's safe to run before drift_revert::init.
+    let service = Arc::new(
+        SwitchNSquashService::create(
+            &pool_mngr,
+            conf.clone(),
+            uploads_tx,
+            token.child_token(),
+            client,
+            events_tx.clone(),
+        )
+        .await?,
+    );
+
+    // Start health check BEFORE drift_revert::init so the orchestrator sees us as alive.
+    let healthz = healthz_server::HttpServer::new(
+        service.clone(),
+        conf.health_checks.port,
+        token.child_token(),
+    );
+    spawn(async move {
+        if let Err(err) = healthz.start().await {
+            error!(
+                task = "health_check",
+                error = %err,
+                "Error while running server"
+            );
+        }
+        anyhow::Ok(())
+    });
+
+    // Drift-revert: must run before any DB-using task so the uploader and
+    // service loop don't read or write rows the revert SQL is about to delete.
+    drift_revert::init(pool_mngr.pool().clone(), token.clone(), None).await?;
+
     // Spawns a task to handle S3 uploads
     spawn(async move {
         if let Err(err) = run_uploader_loop(&pg_mngr, &conf, jobs_rx, tx, s3, is_ready).await {
@@ -562,16 +551,10 @@ pub async fn run_all(
         }
     });
 
-    // Run the main computation loop
-    // This will handle the PBS computations
-    let conf = config.clone();
-    let token = parent_token.child_token();
+    // Run the main service loop
+    service.run(&pool_mngr).await;
+    token.cancel();
 
-    if let Err(err) =
-        run_computation_loop(&pool_mngr, conf, uploads_tx, token, client, events_tx).await
-    {
-        error!(error = %err, "SnS worker failed");
-    }
-
+    info!("Worker stopped");
     Ok(())
 }

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -21,6 +21,7 @@ use aws_sdk_s3::{config::Builder, Client};
 use fhevm_engine_common::{
     chain_id::ChainId,
     db_keys::DbKeyId,
+    drift_revert,
     healthz_server::{self},
     metrics_server,
     pg_pool::{PostgresPoolManager, ServiceError},
@@ -402,6 +403,7 @@ pub async fn run_computation_loop(
     events_tx: InternalEvents,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let port = conf.health_checks.port;
+    let db_url = conf.db.url.clone();
 
     let service = Arc::new(
         SwitchNSquashService::create(
@@ -427,6 +429,8 @@ pub async fn run_computation_loop(
         }
         anyhow::Ok(())
     });
+
+    drift_revert::init(db_url.as_str(), token.clone(), None).await?;
 
     // Run the main service loop
     service.run(pool_mngr).await;

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -1,5 +1,4 @@
 use ::tracing::{error, info};
-use fhevm_engine_common::database::resolve_database_url_from_option;
 use fhevm_engine_common::keys::{FhevmKeys, SerializedFhevmKeys};
 use fhevm_engine_common::{drift_revert, healthz_server, metrics_server, telemetry};
 use tokio_util::sync::CancellationToken;
@@ -102,10 +101,6 @@ pub async fn async_main(
             args.clone(),
             health_check.clone(),
         ));
-    }
-
-    if set.is_empty() {
-        panic!("No tasks specified to run");
     }
 
     while let Some(res) = set.join_next().await {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -1,6 +1,8 @@
 use ::tracing::{error, info};
+use fhevm_engine_common::database::{connect_pool_with_options, resolve_database_url_from_option};
 use fhevm_engine_common::keys::{FhevmKeys, SerializedFhevmKeys};
 use fhevm_engine_common::{drift_revert, healthz_server, metrics_server, telemetry};
+use sqlx::postgres::PgPoolOptions;
 use tokio_util::sync::CancellationToken;
 
 use std::sync::{Once, OnceLock};
@@ -64,7 +66,7 @@ pub async fn async_main(
     let cancel_token = CancellationToken::new();
     info!(target: "async_main", args = ?args, "Starting runtime with args");
 
-    let database_url = args.database_url.clone().unwrap_or_default();
+    let database_url = resolve_database_url_from_option(args.database_url.clone())?;
 
     let health_check = health_check::HealthCheck::new(database_url.clone());
 
@@ -91,7 +93,13 @@ pub async fn async_main(
         Ok(())
     });
 
-    drift_revert::init(database_url.as_str(), cancel_token.clone(), None).await?;
+    let (drift_revert_pool, _pool_refresh_handle) = connect_pool_with_options(
+        &database_url,
+        PgPoolOptions::new().max_connections(1),
+        Some(&cancel_token),
+    )
+    .await?;
+    drift_revert::init(drift_revert_pool, cancel_token.clone(), None).await?;
 
     if args.run_bg_worker {
         let gpu_enabled = fhevm_engine_common::utils::log_backend();

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -1,7 +1,7 @@
 use ::tracing::{error, info};
 use fhevm_engine_common::database::resolve_database_url_from_option;
 use fhevm_engine_common::keys::{FhevmKeys, SerializedFhevmKeys};
-use fhevm_engine_common::{healthz_server, metrics_server, telemetry};
+use fhevm_engine_common::{drift_revert, healthz_server, metrics_server, telemetry};
 use tokio_util::sync::CancellationToken;
 
 use std::sync::{Once, OnceLock};
@@ -65,10 +65,35 @@ pub async fn async_main(
     let cancel_token = CancellationToken::new();
     info!(target: "async_main", args = ?args, "Starting runtime with args");
 
-    let database_url = resolve_database_url_from_option(args.database_url.clone())?;
-    let health_check = health_check::HealthCheck::new(database_url);
+    let database_url = args.database_url.clone().unwrap_or_default();
+
+    let health_check = health_check::HealthCheck::new(database_url.clone());
 
     let mut set = JoinSet::new();
+    let metrics_addr = args.metrics_addr.clone();
+    if let Some(fut) = metrics_server::metrics_future(metrics_addr, cancel_token.child_token()) {
+        set.spawn(async {
+            fut.await;
+            Ok(())
+        });
+    }
+
+    info!(target: "async_main", "Start health check server");
+    let health_check_cancel_token = CancellationToken::new();
+    let health_check_server = healthz_server::HttpServer::new(
+        std::sync::Arc::new(health_check.clone()),
+        args.health_check_port,
+        health_check_cancel_token,
+    );
+    set.spawn(async move {
+        if let Err(e) = health_check_server.start().await {
+            error!(target: "async_main", error = %e, "Health check server failed");
+        }
+        Ok(())
+    });
+
+    drift_revert::init(database_url.as_str(), cancel_token.clone(), None).await?;
+
     if args.run_bg_worker {
         let gpu_enabled = fhevm_engine_common::utils::log_backend();
         info!(target: "async_main", gpu_enabled,  "Initializing background worker");
@@ -79,28 +104,9 @@ pub async fn async_main(
         ));
     }
 
-    let metrics_addr = args.metrics_addr.clone();
-    if let Some(fut) = metrics_server::metrics_future(metrics_addr, cancel_token.child_token()) {
-        set.spawn(async {
-            fut.await;
-            Ok(())
-        });
-    }
-
     if set.is_empty() {
         panic!("No tasks specified to run");
     }
-
-    info!(target: "async_main", "Start health check server");
-    let health_check_cancel_token = CancellationToken::new();
-    let health_check_server = healthz_server::HttpServer::new(
-        std::sync::Arc::new(health_check.clone()),
-        args.health_check_port,
-        health_check_cancel_token,
-    );
-    let Ok(()) = health_check_server.start().await else {
-        panic!("Failed to start health check server");
-    };
 
     while let Some(res) = set.join_next().await {
         if let Err(e) = res {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -1,0 +1,376 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use fhevm_engine_common::drift_revert::{self, ReExec, RevertRunnerConfig, SignalStatus};
+use serial_test::serial;
+use sqlx::PgPool;
+use test_harness::instance::{setup_test_db, ImportMode};
+use tokio_util::sync::CancellationToken;
+
+const CHAIN_A: i64 = 100;
+
+async fn setup_chain_and_computation(pool: &PgPool, chain_id: i64, block_number: i64) -> Vec<u8> {
+    sqlx::query(
+        "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+         VALUES ($1, 'test', '0x1')",
+    )
+    .bind(chain_id)
+    .execute(pool)
+    .await
+    .expect("insert host_chain");
+
+    // Byte 21 = 0xff marks a compute output (see host-contracts FHEVMExecutor.sol).
+    let mut handle: Vec<u8> = vec![0xAA; 32];
+    handle[21] = 0xff;
+    let txn_id: Vec<u8> = vec![0xBB; 32];
+
+    sqlx::query("INSERT INTO transactions (id, chain_id, block_number) VALUES ($1, $2, $3)")
+        .bind(&txn_id)
+        .bind(chain_id)
+        .bind(block_number)
+        .execute(pool)
+        .await
+        .expect("insert transaction");
+
+    sqlx::query(
+        "INSERT INTO computations (output_handle, dependencies, fhe_operation, is_scalar, \
+         transaction_id, host_chain_id, block_number) \
+         VALUES ($1, ARRAY[]::bytea[], 1, false, $2, $3, $4)",
+    )
+    .bind(&handle)
+    .bind(&txn_id)
+    .bind(chain_id)
+    .bind(block_number)
+    .execute(pool)
+    .await
+    .expect("insert computation");
+
+    handle
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn on_drift_detected_creates_signal_with_correct_block() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    let block = 42;
+    let handle = setup_chain_and_computation(&pool, CHAIN_A, block).await;
+
+    drift_revert::on_drift_detected(&pool, &handle, CHAIN_A).await;
+
+    let signal = drift_revert::latest_signal(&pool)
+        .await
+        .expect("latest_signal")
+        .expect("should have a signal");
+
+    assert_eq!(signal.host_chain_id, CHAIN_A);
+    assert_eq!(signal.offending_host_block_number, block);
+    assert_eq!(signal.status, SignalStatus::Pending);
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn on_drift_detected_no_signal_when_handle_not_found() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    let unknown_handle: Vec<u8> = vec![0xFF; 32];
+
+    drift_revert::on_drift_detected(&pool, &unknown_handle, CHAIN_A).await;
+
+    let signal = drift_revert::latest_signal(&pool)
+        .await
+        .expect("latest_signal");
+    assert!(
+        signal.is_none(),
+        "should not create a signal for unknown handle"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn on_drift_detected_skips_for_input_handle() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    // Byte 21 != 0xff → ZK input handle.
+    let mut input_handle: Vec<u8> = vec![0xAA; 32];
+    input_handle[21] = 0x01;
+
+    drift_revert::on_drift_detected(&pool, &input_handle, CHAIN_A).await;
+
+    let signal = drift_revert::latest_signal(&pool)
+        .await
+        .expect("latest_signal");
+    assert!(
+        signal.is_none(),
+        "should not create a signal for ZK input handles"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn on_drift_detected_skips_when_in_flight() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    let handle = setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+
+    drift_revert::on_drift_detected(&pool, &handle, CHAIN_A).await;
+
+    let result = drift_revert::create_revert_signal(&pool, CHAIN_A, 20)
+        .await
+        .expect("second call");
+    assert!(result.is_none(), "should skip when in-flight");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn on_drift_detected_allows_new_signal_after_done() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    let handle = setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+
+    drift_revert::on_drift_detected(&pool, &handle, CHAIN_A).await;
+
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    drift_revert::update_signal_status(&pool, signal.id, &SignalStatus::Done)
+        .await
+        .unwrap();
+
+    let second_id = drift_revert::create_revert_signal(&pool, CHAIN_A, 20)
+        .await
+        .expect("second call after done")
+        .expect("should allow new signal after done");
+
+    assert_ne!(
+        second_id, signal.id,
+        "new signal should have a different id"
+    );
+
+    let latest = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(latest.id, second_id);
+    assert_eq!(latest.offending_host_block_number, 20);
+    assert_eq!(latest.status, SignalStatus::Pending);
+}
+
+struct MockReExec {
+    called: Arc<Mutex<bool>>,
+}
+
+impl MockReExec {
+    fn new() -> Self {
+        Self {
+            called: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    fn was_called(&self) -> bool {
+        *self.called.lock().unwrap()
+    }
+}
+
+impl ReExec for MockReExec {
+    fn re_exec(&self) {
+        *self.called.lock().unwrap() = true;
+    }
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn signal_watcher_reexecs_on_pending_signal() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    let cancel = CancellationToken::new();
+    let mock = MockReExec::new();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .expect("create signal");
+
+    drift_revert::run_signal_watcher(&pool, cancel, &mock)
+        .await
+        .expect("run_signal_watcher");
+
+    assert!(mock.was_called(), "re_exec should have been called");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn signal_watcher_exits_cleanly_on_cancel() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    let cancel = CancellationToken::new();
+    let mock = MockReExec::new();
+
+    cancel.cancel();
+
+    drift_revert::run_signal_watcher(&pool, cancel, &mock)
+        .await
+        .expect("run_signal_watcher");
+
+    assert!(!mock.was_called(), "re_exec should NOT have been called");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn handle_pending_signal_runner_marks_done() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 50).await;
+
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 50)
+        .await
+        .expect("create signal");
+
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+    };
+
+    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg))
+        .await
+        .expect("handle_pending_signal_on_startup");
+
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(signal.status, SignalStatus::Done);
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn handle_pending_signal_waiter_blocks_until_done() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 50).await;
+
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 50)
+        .await
+        .expect("create signal");
+
+    let waiter = {
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            drift_revert::handle_pending_signal_on_startup(&pool, None)
+                .await
+                .expect("waiter");
+        })
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(!waiter.is_finished(), "waiter should be blocking");
+
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    drift_revert::update_signal_status(&pool, signal.id, &SignalStatus::Done)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(3), waiter)
+        .await
+        .expect("waiter should finish within timeout")
+        .expect("waiter task should succeed");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn execute_revert_deletes_computations_after_offending_block() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    // Set up blocks 1..=10 with one computation each.
+    sqlx::query(
+        "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+         VALUES ($1, 'test', '0x1')",
+    )
+    .bind(CHAIN_A)
+    .execute(&pool)
+    .await
+    .expect("insert host_chain");
+
+    for block in 1..=10 {
+        let handle: Vec<u8> = vec![block as u8; 32];
+        let txn_id: Vec<u8> = vec![block as u8 + 100; 32];
+        sqlx::query("INSERT INTO transactions (id, chain_id, block_number) VALUES ($1, $2, $3)")
+            .bind(&txn_id)
+            .bind(CHAIN_A)
+            .bind(block)
+            .execute(&pool)
+            .await
+            .expect("insert transaction");
+        sqlx::query(
+            "INSERT INTO computations (output_handle, dependencies, fhe_operation, is_scalar, \
+             transaction_id, host_chain_id, block_number) \
+             VALUES ($1, ARRAY[]::bytea[], 1, false, $2, $3, $4)",
+        )
+        .bind(&handle)
+        .bind(&txn_id)
+        .bind(CHAIN_A)
+        .bind(block)
+        .execute(&pool)
+        .await
+        .expect("insert computation");
+    }
+
+    // Drift detected at block 7 → revert target = 6 (offending - 1).
+    drift_revert::execute_revert(&pool, CHAIN_A, 7)
+        .await
+        .expect("execute_revert");
+
+    let remaining: Vec<i64> = sqlx::query_scalar(
+        "SELECT block_number FROM computations WHERE host_chain_id = $1 ORDER BY block_number",
+    )
+    .bind(CHAIN_A)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        remaining,
+        (1..=6i64).collect::<Vec<_>>(),
+        "should keep blocks 1..=6"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn init_handles_pending_signal_and_spawns_watcher() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    let cancel = CancellationToken::new();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 50).await;
+
+    // Insert a pending signal, then mark it done so the runner path completes.
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 50)
+        .await
+        .expect("create signal");
+
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+    };
+
+    let mock = MockReExec::new();
+
+    // init as runner: handles the pending signal (revert + mark done).
+    drift_revert::init_with_reexec(db.db_url(), cancel.clone(), Some(cfg), mock)
+        .await
+        .expect("init");
+
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(
+        signal.status,
+        SignalStatus::Done,
+        "init should have run the revert"
+    );
+
+    // Spawn a new pending signal — the background watcher should pick it up
+    // and call re_exec (MockReExec). We can't easily observe that from here
+    // since the watcher owns the mock, so we just verify init didn't error
+    // and the first signal was handled correctly.
+
+    // Clean up: cancel the watcher so the background task exits.
+    cancel.cancel();
+}

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -838,7 +838,7 @@ async fn init_handles_pending_signal_and_spawns_watcher() {
     let mock = MockReExec::new();
 
     // init as runner: handles the pending signal (revert + mark done).
-    drift_revert::init_with_reexec(db.db_url(), cancel.clone(), Some(cfg), mock)
+    drift_revert::init_with_reexec(pool.clone(), cancel.clone(), Some(cfg), mock)
         .await
         .expect("init");
 

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -9,6 +9,17 @@ use tokio_util::sync::CancellationToken;
 
 const CHAIN_A: i64 = 100;
 
+/// Builds a `RevertRunnerConfig` for tests. Defaults pin the attempts
+/// thresholds high enough that they never trip incidentally; tests for the
+/// breaker itself override `max_recent_attempts` / `recent_attempts_window`.
+fn runner_cfg(grace_period: Duration) -> RevertRunnerConfig {
+    RevertRunnerConfig {
+        grace_period,
+        max_recent_attempts: 100,
+        recent_attempts_window: Duration::from_secs(3600),
+    }
+}
+
 async fn setup_chain_and_computation(pool: &PgPool, chain_id: i64, block_number: i64) -> Vec<u8> {
     sqlx::query(
         "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
@@ -179,9 +190,7 @@ async fn runner_processes_concurrent_signals_from_multiple_chains() {
         .expect("should create B");
     assert!(id_b > id_a, "B should have a newer id than A");
 
-    let cfg = RevertRunnerConfig {
-        grace_period: Duration::from_millis(10),
-    };
+    let cfg = runner_cfg(Duration::from_millis(10));
     let cancel = CancellationToken::new();
     drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
         .await
@@ -194,8 +203,9 @@ async fn runner_processes_concurrent_signals_from_multiple_chains() {
             .await
             .unwrap();
     assert_eq!(rows.len(), 2, "both signals should remain as audit trail");
+    let done = SignalStatus::Done.as_db_str();
     for (id, status) in &rows {
-        assert_eq!(status, "done", "signal {id} should be Done");
+        assert_eq!(status, &done, "signal {id} should be Done");
     }
 }
 
@@ -218,14 +228,154 @@ async fn runner_refuses_on_failed_latest() {
     setup_failed_signal(&pool).await;
 
     let cancel = CancellationToken::new();
-    let cfg = RevertRunnerConfig {
-        grace_period: Duration::from_millis(10),
-    };
+    let cfg = runner_cfg(Duration::from_millis(10));
     let result = drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel).await;
     assert!(
         result.is_err(),
         "runner startup must refuse while latest signal is Failed"
     );
+}
+
+/// Inserts `count` signals on `host_chain_id` already in `Done` state to
+/// represent recent successful reverts.
+async fn insert_done_signals(pool: &PgPool, host_chain_id: i64, count: u32) {
+    for _ in 0..count {
+        sqlx::query(
+            "INSERT INTO drift_revert_signal (host_chain_id, offending_host_block_number, status) \
+             VALUES ($1, 1, $2)",
+        )
+        .bind(host_chain_id)
+        .bind(SignalStatus::Done.as_db_str())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn runner_marks_failed_when_too_many_recent_attempts() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+    insert_done_signals(&pool, CHAIN_A, 3).await;
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+        max_recent_attempts: 3,
+        recent_attempts_window: Duration::from_secs(3600),
+    };
+    let cancel = CancellationToken::new();
+    let err = drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
+        .await
+        .expect_err("runner must refuse when too many recent attempts");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("too many recent attempts"),
+        "error should mention too-many-attempts, got: {msg}"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn runner_too_many_attempts_isolates_per_chain() {
+    const CHAIN_B: i64 = 200;
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    // Many recent dones on B should NOT block reverts on A.
+    sqlx::query(
+        "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+         VALUES ($1, 'test-b', '0x2')",
+    )
+    .bind(CHAIN_B)
+    .execute(&pool)
+    .await
+    .unwrap();
+    insert_done_signals(&pool, CHAIN_B, 5).await;
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+        max_recent_attempts: 3,
+        recent_attempts_window: Duration::from_secs(3600),
+    };
+    let cancel = CancellationToken::new();
+    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
+        .await
+        .expect("runner should process A despite B having many recent attempts");
+
+    // Chain A's signal must now be Done (runner processed it).
+    let chain_a_status: String = sqlx::query_scalar(
+        "SELECT status FROM drift_revert_signal WHERE host_chain_id = $1 ORDER BY id DESC LIMIT 1",
+    )
+    .bind(CHAIN_A)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(chain_a_status, SignalStatus::Done.as_db_str());
+
+    // Revert SQL ran on chain A: the block-10 computation we seeded was past
+    // the revert target (block 9) and must be gone.
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM computations WHERE host_chain_id = $1")
+            .bind(CHAIN_A)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        remaining, 0,
+        "chain A's computation should have been reverted"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn runner_too_many_attempts_ignores_old_dones_outside_window() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+
+    // 5 Done signals on chain A, but with updated_at 2 hours in the past —
+    // outside any reasonable recent window. The runner should NOT count them.
+    for _ in 0..5 {
+        sqlx::query(
+            "INSERT INTO drift_revert_signal \
+             (host_chain_id, offending_host_block_number, status, updated_at) \
+             VALUES ($1, 1, $2, NOW() - INTERVAL '2 hours')",
+        )
+        .bind(CHAIN_A)
+        .bind(SignalStatus::Done.as_db_str())
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Threshold of 3 within a 1-hour window. Old Dones don't count → runner proceeds.
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+        max_recent_attempts: 3,
+        recent_attempts_window: Duration::from_secs(3600),
+    };
+    let cancel = CancellationToken::new();
+    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
+        .await
+        .expect("runner must not trip when historical Dones are outside the window");
 }
 
 #[tokio::test]
@@ -294,9 +444,7 @@ async fn runner_resumes_from_reverting_status_without_grace_period() {
 
     // Grace period is set very large; if the runner incorrectly waits it,
     // the test should complete in under a second anyway — we assert it did.
-    let cfg = RevertRunnerConfig {
-        grace_period: Duration::from_secs(30),
-    };
+    let cfg = runner_cfg(Duration::from_secs(30));
     let cancel = CancellationToken::new();
     let started = std::time::Instant::now();
     drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
@@ -374,6 +522,96 @@ async fn waiter_waits_until_all_chains_done() {
         .expect("waiter task should succeed");
 }
 
+#[tokio::test]
+#[serial(db)]
+async fn waiter_bails_when_revert_fails_during_wait() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+    let id = drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let cancel = CancellationToken::new();
+    let waiter = {
+        let pool = pool.clone();
+        let cancel = cancel.clone();
+        tokio::spawn(async move {
+            drift_revert::handle_pending_signal_on_startup(&pool, None, &cancel).await
+        })
+    };
+
+    // Let the waiter enter its poll loop, then transition the signal to Failed.
+    tokio::time::sleep(drift_revert::POLL_INTERVAL * 2).await;
+    drift_revert::update_signal_status(&pool, id, &SignalStatus::Failed("simulated".to_owned()))
+        .await
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(3), waiter)
+        .await
+        .expect("waiter should finish within timeout")
+        .expect("task should not panic");
+    let err = result.expect_err("waiter must bail when signal becomes Failed during wait");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Failed") && msg.contains("simulated"),
+        "error should reference Failed status with reason, got: {msg}"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn waiter_bails_on_old_failed_even_when_newer_is_done() {
+    const CHAIN_B: i64 = 200;
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+    sqlx::query(
+        "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+         VALUES ($1, 'test-b', '0x2')",
+    )
+    .bind(CHAIN_B)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Older signal on chain A: Failed.
+    let id_a = drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+    let reason_marker = "older-chain-a-marker";
+    drift_revert::update_signal_status(
+        &pool,
+        id_a,
+        &SignalStatus::Failed(reason_marker.to_owned()),
+    )
+    .await
+    .unwrap();
+
+    // Newer signal on chain B: Done.
+    sqlx::query(
+        "INSERT INTO drift_revert_signal (host_chain_id, offending_host_block_number, status) \
+         VALUES ($1, 1, $2)",
+    )
+    .bind(CHAIN_B)
+    .bind(SignalStatus::Done.as_db_str())
+    .execute(&pool)
+    .await
+    .unwrap();
+    // The `blocking_signal` query prioritizes Failed → bails.
+    let cancel = CancellationToken::new();
+    let result = drift_revert::handle_pending_signal_on_startup(&pool, None, &cancel).await;
+    let err = result.expect_err("waiter must bail despite newer Done signal masking older Failed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Failed") && msg.contains(reason_marker),
+        "error should reference the older Failed signal, got: {msg}"
+    );
+}
+
 struct MockReExec {
     called: Arc<Mutex<bool>>,
 }
@@ -446,9 +684,7 @@ async fn handle_pending_signal_runner_marks_done() {
         .await
         .expect("create signal");
 
-    let cfg = RevertRunnerConfig {
-        grace_period: Duration::from_millis(10),
-    };
+    let cfg = runner_cfg(Duration::from_millis(10));
 
     let cancel = CancellationToken::new();
     drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
@@ -597,9 +833,7 @@ async fn init_handles_pending_signal_and_spawns_watcher() {
         .await
         .expect("create signal");
 
-    let cfg = RevertRunnerConfig {
-        grace_period: Duration::from_millis(10),
-    };
+    let cfg = runner_cfg(Duration::from_millis(10));
 
     let mock = MockReExec::new();
 

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -20,9 +20,11 @@ async fn setup_chain_and_computation(pool: &PgPool, chain_id: i64, block_number:
     .expect("insert host_chain");
 
     // Byte 21 = 0xff marks a compute output (see host-contracts FHEVMExecutor.sol).
-    let mut handle: Vec<u8> = vec![0xAA; 32];
+    // Other bytes are seeded from chain_id so multi-chain tests don't collide.
+    let seed = chain_id as u8;
+    let mut handle: Vec<u8> = vec![seed; 32];
     handle[21] = 0xff;
-    let txn_id: Vec<u8> = vec![0xBB; 32];
+    let txn_id: Vec<u8> = vec![seed.wrapping_add(1); 32];
 
     sqlx::query("INSERT INTO transactions (id, chain_id, block_number) VALUES ($1, $2, $3)")
         .bind(&txn_id)
@@ -156,6 +158,222 @@ async fn on_drift_detected_allows_new_signal_after_done() {
     assert_eq!(latest.status, SignalStatus::Pending);
 }
 
+#[tokio::test]
+#[serial(db)]
+async fn runner_processes_concurrent_signals_from_multiple_chains() {
+    const CHAIN_B: i64 = 200;
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    // Two chains with their own in-flight signals (pre-existing, e.g. created
+    // right before the process crashed and got re-execed).
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+    setup_chain_and_computation(&pool, CHAIN_B, 20).await;
+    let id_a = drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .expect("signal A")
+        .expect("should create A");
+    let id_b = drift_revert::create_revert_signal(&pool, CHAIN_B, 20)
+        .await
+        .expect("signal B")
+        .expect("should create B");
+    assert!(id_b > id_a, "B should have a newer id than A");
+
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+    };
+    let cancel = CancellationToken::new();
+    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
+        .await
+        .expect("runner should process both signals");
+
+    // Both signals should now be marked Done.
+    let rows: Vec<(i64, String)> =
+        sqlx::query_as("SELECT id, status FROM drift_revert_signal ORDER BY id ASC")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    assert_eq!(rows.len(), 2, "both signals should remain as audit trail");
+    for (id, status) in &rows {
+        assert_eq!(status, "done", "signal {id} should be Done");
+    }
+}
+
+async fn setup_failed_signal(pool: &PgPool) {
+    setup_chain_and_computation(pool, CHAIN_A, 10).await;
+    let id = drift_revert::create_revert_signal(pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+    drift_revert::update_signal_status(pool, id, &SignalStatus::Failed("simulated".to_owned()))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn runner_refuses_on_failed_latest() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    setup_failed_signal(&pool).await;
+
+    let cancel = CancellationToken::new();
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_millis(10),
+    };
+    let result = drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel).await;
+    assert!(
+        result.is_err(),
+        "runner startup must refuse while latest signal is Failed"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn waiter_refuses_on_failed_latest() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+    setup_failed_signal(&pool).await;
+
+    let cancel = CancellationToken::new();
+    let result = drift_revert::handle_pending_signal_on_startup(&pool, None, &cancel).await;
+    assert!(
+        result.is_err(),
+        "waiter startup must refuse while latest signal is Failed"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn runner_resumes_from_reverting_status_without_grace_period() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    // Insert host_chain and a couple of blocks of computations.
+    sqlx::query(
+        "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+         VALUES ($1, 'test', '0x1')",
+    )
+    .bind(CHAIN_A)
+    .execute(&pool)
+    .await
+    .unwrap();
+    for block in 1..=5i64 {
+        let handle: Vec<u8> = vec![block as u8; 32];
+        let txn_id: Vec<u8> = vec![block as u8 + 100; 32];
+        sqlx::query("INSERT INTO transactions (id, chain_id, block_number) VALUES ($1, $2, $3)")
+            .bind(&txn_id)
+            .bind(CHAIN_A)
+            .bind(block)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO computations (output_handle, dependencies, fhe_operation, is_scalar, \
+             transaction_id, host_chain_id, block_number) \
+             VALUES ($1, ARRAY[]::bytea[], 1, false, $2, $3, $4)",
+        )
+        .bind(&handle)
+        .bind(&txn_id)
+        .bind(CHAIN_A)
+        .bind(block)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    // Signal for offending block 3 — target will be block 2.
+    let id = drift_revert::create_revert_signal(&pool, CHAIN_A, 3)
+        .await
+        .unwrap()
+        .unwrap();
+    // Simulate a prior runner crashing after marking Reverting but before Done.
+    drift_revert::update_signal_status(&pool, id, &SignalStatus::Reverting)
+        .await
+        .unwrap();
+
+    // Grace period is set very large; if the runner incorrectly waits it,
+    // the test should complete in under a second anyway — we assert it did.
+    let cfg = RevertRunnerConfig {
+        grace_period: Duration::from_secs(30),
+    };
+    let cancel = CancellationToken::new();
+    let started = std::time::Instant::now();
+    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
+        .await
+        .expect("runner should resume");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "runner should skip grace period for Reverting status, took {elapsed:?}"
+    );
+
+    // Signal marked Done.
+    let latest = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(latest.status, SignalStatus::Done);
+
+    // Revert SQL ran idempotently — blocks > 2 are gone.
+    let remaining: Vec<i64> = sqlx::query_scalar(
+        "SELECT block_number FROM computations WHERE host_chain_id = $1 ORDER BY block_number",
+    )
+    .bind(CHAIN_A)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining, vec![1_i64, 2]);
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn waiter_waits_until_all_chains_done() {
+    const CHAIN_B: i64 = 200;
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+    setup_chain_and_computation(&pool, CHAIN_B, 20).await;
+    let id_a = drift_revert::create_revert_signal(&pool, CHAIN_A, 10)
+        .await
+        .unwrap()
+        .unwrap();
+    let id_b = drift_revert::create_revert_signal(&pool, CHAIN_B, 20)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let waiter = {
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            let cancel = CancellationToken::new();
+            drift_revert::handle_pending_signal_on_startup(&pool, None, &cancel)
+                .await
+                .expect("waiter");
+        })
+    };
+
+    // Marking only the newer chain's signal Done must NOT unblock the waiter
+    // — the older (A) signal is still in-flight. We wait 3 * POLL_INTERVAL to
+    // ensure the waiter has polled multiple times after B=Done and still
+    // didn't return.
+    drift_revert::update_signal_status(&pool, id_b, &SignalStatus::Done)
+        .await
+        .unwrap();
+    tokio::time::sleep(drift_revert::POLL_INTERVAL * 3).await;
+    assert!(
+        !waiter.is_finished(),
+        "waiter must not return while chain A signal is still in-flight"
+    );
+
+    drift_revert::update_signal_status(&pool, id_a, &SignalStatus::Done)
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(3), waiter)
+        .await
+        .expect("waiter should finish after both signals are Done")
+        .expect("waiter task should succeed");
+}
+
 struct MockReExec {
     called: Arc<Mutex<bool>>,
 }
@@ -232,7 +450,8 @@ async fn handle_pending_signal_runner_marks_done() {
         grace_period: Duration::from_millis(10),
     };
 
-    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg))
+    let cancel = CancellationToken::new();
+    drift_revert::handle_pending_signal_on_startup(&pool, Some(cfg), &cancel)
         .await
         .expect("handle_pending_signal_on_startup");
 
@@ -255,15 +474,14 @@ async fn handle_pending_signal_waiter_blocks_until_done() {
     let waiter = {
         let pool = pool.clone();
         tokio::spawn(async move {
-            drift_revert::handle_pending_signal_on_startup(&pool, None)
+            let cancel = CancellationToken::new();
+            drift_revert::handle_pending_signal_on_startup(&pool, None, &cancel)
                 .await
                 .expect("waiter");
         })
     };
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    assert!(!waiter.is_finished(), "waiter should be blocking");
-
+    // Signal starts as Pending; only transition to Done should let the waiter finish.
     let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
     drift_revert::update_signal_status(&pool, signal.id, &SignalStatus::Done)
         .await
@@ -271,7 +489,38 @@ async fn handle_pending_signal_waiter_blocks_until_done() {
 
     tokio::time::timeout(Duration::from_secs(3), waiter)
         .await
-        .expect("waiter should finish within timeout")
+        .expect("waiter should finish within timeout after status=done")
+        .expect("waiter task should succeed");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn handle_pending_signal_waiter_exits_on_cancel() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 50).await;
+    drift_revert::create_revert_signal(&pool, CHAIN_A, 50)
+        .await
+        .expect("create signal");
+
+    let cancel = CancellationToken::new();
+    let waiter = {
+        let pool = pool.clone();
+        let cancel = cancel.clone();
+        tokio::spawn(async move {
+            drift_revert::handle_pending_signal_on_startup(&pool, None, &cancel)
+                .await
+                .expect("waiter");
+        })
+    };
+
+    // Signal stays Pending — the only way the waiter can finish is if
+    // cancellation actually unblocks it.
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(3), waiter)
+        .await
+        .expect("waiter should exit within timeout after cancel")
         .expect("waiter task should succeed");
 }
 

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -939,6 +939,35 @@ async fn execute_revert_deletes_computations_after_offending_block() {
 
 #[tokio::test]
 #[serial(db)]
+async fn execute_revert_refuses_when_offending_block_le_1() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO host_chains (chain_id, name, acl_contract_address) \
+         VALUES ($1, 'test', '0x1')",
+    )
+    .bind(CHAIN_A)
+    .execute(&pool)
+    .await
+    .expect("insert host_chain");
+
+    let err = drift_revert::execute_revert(&pool, CHAIN_A, 1)
+        .await
+        .expect_err("must refuse for offending == 1");
+    assert!(
+        err.to_string().contains("cannot delete block <= 1"),
+        "unexpected error: {err}"
+    );
+
+    // offending == 0 / negative are equally invalid.
+    drift_revert::execute_revert(&pool, CHAIN_A, 0)
+        .await
+        .expect_err("must refuse for offending == 0");
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn init_handles_pending_signal_and_spawns_watcher() {
     let db = setup_test_db(ImportMode::None).await.expect("setup db");
     let pool = PgPool::connect(db.db_url()).await.unwrap();

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -84,6 +84,53 @@ async fn on_drift_detected_creates_signal_with_correct_block() {
 
 #[tokio::test]
 #[serial(db)]
+async fn on_drift_detected_picks_earliest_block_for_duplicate_handle() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    let earliest = 30;
+    let later = 70;
+
+    // Seed host_chain + computation at the later block first, then add a
+    // second computation row with the same handle at the earlier block.
+    let handle = setup_chain_and_computation(&pool, CHAIN_A, later).await;
+
+    let dup_txn_id: Vec<u8> = vec![0xEE; 32];
+    sqlx::query("INSERT INTO transactions (id, chain_id, block_number) VALUES ($1, $2, $3)")
+        .bind(&dup_txn_id)
+        .bind(CHAIN_A)
+        .bind(earliest)
+        .execute(&pool)
+        .await
+        .expect("insert duplicate transaction");
+    sqlx::query(
+        "INSERT INTO computations (output_handle, dependencies, fhe_operation, is_scalar, \
+         transaction_id, host_chain_id, block_number) \
+         VALUES ($1, ARRAY[]::bytea[], 1, false, $2, $3, $4)",
+    )
+    .bind(&handle)
+    .bind(&dup_txn_id)
+    .bind(CHAIN_A)
+    .bind(earliest)
+    .execute(&pool)
+    .await
+    .expect("insert duplicate computation");
+
+    drift_revert::on_drift_detected(&pool, &handle, CHAIN_A).await;
+
+    let signal = drift_revert::latest_signal(&pool)
+        .await
+        .expect("latest_signal")
+        .expect("should have a signal");
+
+    assert_eq!(
+        signal.offending_host_block_number, earliest,
+        "must pick the earliest block so the revert wipes all duplicates"
+    );
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn on_drift_detected_no_signal_when_handle_not_found() {
     let db = setup_test_db(ImportMode::None).await.expect("setup db");
     let pool = PgPool::connect(db.db_url()).await.unwrap();
@@ -136,6 +183,77 @@ async fn on_drift_detected_skips_when_in_flight() {
         .await
         .expect("second call");
     assert!(result.is_none(), "should skip when in-flight");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn create_revert_signal_lowers_pending_to_earlier_block() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+
+    // First detection: signal at block 120. Drifts arriving in computation-
+    // finish order (not host-block order) is the realistic case.
+    let first_id = drift_revert::create_revert_signal(&pool, CHAIN_A, 120)
+        .await
+        .expect("first call")
+        .expect("should create signal");
+
+    // Earlier drift detected later — must pull the existing pending signal
+    // back to 110 so the runner reverts far enough to wipe both.
+    let second_id = drift_revert::create_revert_signal(&pool, CHAIN_A, 110)
+        .await
+        .expect("second call")
+        .expect("should report lowered signal");
+
+    assert_eq!(
+        second_id, first_id,
+        "lowering must reuse the existing signal id, not create a new row"
+    );
+
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(signal.id, second_id);
+    assert_eq!(signal.offending_host_block_number, 110);
+    assert_eq!(signal.status, SignalStatus::Pending);
+
+    // A subsequent detection at a later block must NOT raise the signal back.
+    let third = drift_revert::create_revert_signal(&pool, CHAIN_A, 130)
+        .await
+        .expect("third call");
+    assert!(third.is_none(), "later block must not raise the target");
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(signal.id, second_id);
+    assert_eq!(signal.offending_host_block_number, 110);
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn create_revert_signal_does_not_lower_reverting_signal() {
+    let db = setup_test_db(ImportMode::None).await.expect("setup db");
+    let pool = PgPool::connect(db.db_url()).await.unwrap();
+
+    setup_chain_and_computation(&pool, CHAIN_A, 10).await;
+
+    let id = drift_revert::create_revert_signal(&pool, CHAIN_A, 120)
+        .await
+        .expect("create")
+        .expect("should create");
+
+    // Once the runner has committed (Reverting), an earlier drift detection
+    // must NOT change the in-flight target — the runner is past convergence.
+    drift_revert::update_signal_status(&pool, id, &SignalStatus::Reverting)
+        .await
+        .unwrap();
+
+    let result = drift_revert::create_revert_signal(&pool, CHAIN_A, 110)
+        .await
+        .expect("second call");
+    assert!(result.is_none(), "must not lower a Reverting signal");
+
+    let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
+    assert_eq!(signal.offending_host_block_number, 120);
+    assert_eq!(signal.status, SignalStatus::Reverting);
 }
 
 #[tokio::test]

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod dependence_chain;
+mod drift_revert;
 mod errors;
 mod event_helpers;
 mod health_check;

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -244,9 +244,6 @@ async fn main() -> anyhow::Result<()> {
     let cancel_token = CancellationToken::new();
     install_signal_handlers(cancel_token.clone())?;
 
-    let db_url = conf.database_url.clone().unwrap_or_default();
-    let db_url = db_url.as_str();
-
     // Try to get the chain ID until cancelled.
     let chain_id = tokio::select! {
         chain_id = get_chain_id(
@@ -357,7 +354,7 @@ async fn main() -> anyhow::Result<()> {
     let http_server_fut = tokio::spawn(async move { http_server.start().await });
     metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
 
-    drift_revert::init(db_url, cancel_token.clone(), None).await?;
+    drift_revert::init(db_pool.clone(), cancel_token.clone(), None).await?;
 
     let transaction_sender_fut = tokio::spawn(async move { transaction_sender.run().await });
 

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -14,6 +14,7 @@ use anyhow::Context;
 use aws_config::BehaviorVersion;
 use clap::{Parser, ValueEnum};
 use fhevm_engine_common::database::{connect_pool_with_options, resolve_database_url_from_option};
+use fhevm_engine_common::drift_revert;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
@@ -243,6 +244,9 @@ async fn main() -> anyhow::Result<()> {
     let cancel_token = CancellationToken::new();
     install_signal_handlers(cancel_token.clone())?;
 
+    let db_url = conf.database_url.clone().unwrap_or_default();
+    let db_url = db_url.as_str();
+
     // Try to get the chain ID until cancelled.
     let chain_id = tokio::select! {
         chain_id = get_chain_id(
@@ -350,12 +354,12 @@ async fn main() -> anyhow::Result<()> {
         "Transaction sender and HTTP health check server starting"
     );
 
-    // Run both services in parallel. Here we assume that if transaction sender stops without an error, HTTP server should also stop.
-    let transaction_sender_fut = tokio::spawn(async move { transaction_sender.run().await });
     let http_server_fut = tokio::spawn(async move { http_server.start().await });
-
-    // Start metrics server.
     metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
+
+    drift_revert::init(db_url, cancel_token.clone(), None).await?;
+
+    let transaction_sender_fut = tokio::spawn(async move { transaction_sender.run().await });
 
     // Start gauge update routine.
     spawn_gauge_update_routine(

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -1,7 +1,9 @@
 use clap::{command, Parser};
 use fhevm_engine_common::database::resolve_database_url_from_option;
 use fhevm_engine_common::telemetry::{self, MetricsConfig};
-use fhevm_engine_common::{healthz_server::HttpServer, metrics_server, utils::DatabaseURL};
+use fhevm_engine_common::{
+    drift_revert, healthz_server::HttpServer, metrics_server, utils::DatabaseURL,
+};
 use humantime::parse_duration;
 use std::{sync::Arc, time::Duration};
 use tokio::{join, task};
@@ -109,7 +111,9 @@ async fn main() {
     };
 
     let cancel_token = CancellationToken::new();
-    let Some(service) = ZkProofService::create(conf, cancel_token.child_token()).await else {
+
+    let Some(service) = ZkProofService::create(conf.clone(), cancel_token.child_token()).await
+    else {
         error!("Failed to create zkproof service");
         std::process::exit(1);
     };
@@ -133,8 +137,14 @@ async fn main() {
         anyhow::Ok(())
     });
 
-    // Start metrics server
     metrics_server::spawn(args.metrics_addr.clone(), cancel_token.child_token());
+
+    drift_revert::init(conf.database_url.as_str(), cancel_token.clone(), None)
+        .await
+        .unwrap_or_else(|err| {
+            error!(error = %err, "Drift-revert init failed");
+            std::process::exit(1);
+        });
 
     let service_task = async {
         info!("Starting worker...");

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -139,7 +139,7 @@ async fn main() {
 
     metrics_server::spawn(args.metrics_addr.clone(), cancel_token.child_token());
 
-    drift_revert::init(conf.database_url.as_str(), cancel_token.clone(), None)
+    drift_revert::init(service.pool(), cancel_token.clone(), None)
         .await
         .unwrap_or_else(|err| {
             error!(error = %err, "Drift-revert init failed");

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -112,6 +112,10 @@ impl ZkProofService {
         })
     }
 
+    pub fn pool(&self) -> PgPool {
+        self.pool_mngr.pool().clone()
+    }
+
     pub async fn run(&self) -> Result<(), ExecutionError> {
         execute_verify_proofs_loop(
             self.pool_mngr.clone(),

--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -137,6 +137,22 @@ Note that recommendations assume a smoke test that runs transactions/requests at
  - **Type**: Histogram
  - **Description**: Block distance between the consensus event and seeing all expected submissions for a handle. Diagnostic metric for understanding on-chain completion latency; the grace window is wall-clock based and configured via `--drift-post-consensus-grace`. Bucket boundaries: 0, 1, 2, 3, 5, 8, 13, 21, 34.
 
+#### Metric Name: `coprocessor_drift_revert_signal_created_counter`
+ - **Type**: Counter (labeled by `host_chain_id`)
+ - **Description**: Number of drift-revert signals created, per host chain. Each signal represents one detected consensus drift that triggered the auto-recovery mechanism. Emitted by gw-listener only.
+ - **Alarm**: Any non-zero increase is unusual — drift should be rare.
+    - **Recommendation**: alarm on `increase(counter[5m]) > 0`.
+
+#### Metric Name: `coprocessor_drift_revert_success_counter`
+ - **Type**: Counter (labeled by `host_chain_id`)
+ - **Description**: Number of drift reverts that completed successfully per host chain (SQL ran to completion and signal marked Done). Emitted by gw-listener only.
+
+#### Metric Name: `coprocessor_drift_revert_failure_counter`
+ - **Type**: Counter (labeled by `host_chain_id`)
+ - **Description**: Number of drift reverts that failed during SQL execution per host chain (signal marked Failed). Recovery did not complete and operator intervention may be required. Emitted by gw-listener only.
+ - **Alarm**: Any non-zero increase.
+    - **Recommendation**: alarm on `increase(counter[1m]) > 0`.
+
 ### zkproof-worker
 
 Metrics for zkproof-worker are to be added in future releases, if/when needed. Currently, the transaction-sender handles ZK proof related metrics, please see its section.

--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -153,6 +153,12 @@ Note that recommendations assume a smoke test that runs transactions/requests at
  - **Alarm**: Any non-zero increase.
     - **Recommendation**: alarm on `increase(counter[1m]) > 0`.
 
+#### Metric Name: `coprocessor_drift_revert_too_many_attempts_counter`
+ - **Type**: Counter (labeled by `host_chain_id`)
+ - **Description**: Number of times the revert runner refused to revert because too many successful reverts already happened in the recent window for this host chain. Indicates a deterministic loop where reverts succeed but drift keeps recurring (e.g. a tfhe-worker bug). The signal is marked Failed and the service refuses to start until an operator intervenes. Emitted by gw-listener only.
+ - **Alarm**: Any non-zero increase.
+    - **Recommendation**: alarm on `increase(counter[1m]) > 0`.
+
 ### zkproof-worker
 
 Metrics for zkproof-worker are to be added in future releases, if/when needed. Currently, the transaction-sender handles ZK proof related metrics, please see its section.

--- a/test-suite/e2e/test/consensusWatchdog.ts
+++ b/test-suite/e2e/test/consensusWatchdog.ts
@@ -38,6 +38,7 @@ interface PendingProof {
 
 interface CiphertextPollResult {
   pendingHandles: Map<string, PendingHandle>;
+  resolvedHandles: Set<string>;
   resolvedHandleDelta: number;
   divergences: string[];
   divergenceKeys: Set<string>;
@@ -45,6 +46,7 @@ interface CiphertextPollResult {
 
 interface ProofPollResult {
   pendingProofs: Map<string, PendingProof>;
+  resolvedProofs: Set<string>;
   resolvedProofDelta: number;
   divergences: string[];
   divergenceKeys: Set<string>;
@@ -56,6 +58,10 @@ export class ConsensusWatchdog {
   private inputVerification: ethers.Contract | null;
   private pendingHandles = new Map<string, PendingHandle>();
   private pendingProofs = new Map<string, PendingProof>();
+  // Handles/proofs that already reached consensus. Late submissions for these
+  // must be ignored, since the contract only emits one consensus event per handle.
+  private resolvedHandles = new Set<string>();
+  private resolvedProofs = new Set<string>();
   private resolvedHandleCount = 0;
   private resolvedProofCount = 0;
   private divergences: string[] = [];
@@ -115,6 +121,7 @@ export class ConsensusWatchdog {
           ? this.pollInputVerificationEvents(fromBlock, toBlock)
           : Promise.resolve<ProofPollResult>({
               pendingProofs: this.clonePendingProofs(),
+              resolvedProofs: new Set(this.resolvedProofs),
               resolvedProofDelta: 0,
               divergences: [],
               divergenceKeys: new Set(this.divergenceKeys),
@@ -123,6 +130,8 @@ export class ConsensusWatchdog {
 
       this.pendingHandles = ciphertextResult.pendingHandles;
       this.pendingProofs = proofResult.pendingProofs;
+      this.resolvedHandles = ciphertextResult.resolvedHandles;
+      this.resolvedProofs = proofResult.resolvedProofs;
       this.resolvedHandleCount += ciphertextResult.resolvedHandleDelta;
       this.resolvedProofCount += proofResult.resolvedProofDelta;
       this.divergences.push(...ciphertextResult.divergences, ...proofResult.divergences);
@@ -149,6 +158,7 @@ export class ConsensusWatchdog {
     ]);
 
     const pendingHandles = this.clonePendingHandles();
+    const resolvedHandles = new Set(this.resolvedHandles);
     const divergences: string[] = [];
     const divergenceKeys = new Set(this.divergenceKeys);
     let resolvedHandleDelta = 0;
@@ -160,6 +170,8 @@ export class ConsensusWatchdog {
       const ciphertextDigest = log.args[2] as string;
       const snsCiphertextDigest = log.args[3] as string;
       const coprocessor = log.args[4] as string;
+
+      if (resolvedHandles.has(ctHandle)) continue;
 
       if (!pendingHandles.has(ctHandle)) {
         pendingHandles.set(ctHandle, {
@@ -178,12 +190,13 @@ export class ConsensusWatchdog {
     for (const event of consensuses) {
       const log = event as ethers.EventLog;
       const ctHandle = log.args[0] as string;
+      resolvedHandles.add(ctHandle);
       if (pendingHandles.delete(ctHandle)) {
         resolvedHandleDelta++;
       }
     }
 
-    return { pendingHandles, resolvedHandleDelta, divergences, divergenceKeys };
+    return { pendingHandles, resolvedHandles, resolvedHandleDelta, divergences, divergenceKeys };
   }
 
   private async pollInputVerificationEvents(fromBlock: number, toBlock: number): Promise<ProofPollResult> {
@@ -201,6 +214,7 @@ export class ConsensusWatchdog {
     ]);
 
     const pendingProofs = this.clonePendingProofs();
+    const resolvedProofs = new Set(this.resolvedProofs);
     const divergences: string[] = [];
     const divergenceKeys = new Set(this.divergenceKeys);
     let resolvedProofDelta = 0;
@@ -210,6 +224,8 @@ export class ConsensusWatchdog {
       const zkProofId = String(log.args[0]);
       const ctHandles = log.args[1] as string[];
       const coprocessor = log.args[3] as string;
+
+      if (resolvedProofs.has(zkProofId)) continue;
 
       if (!pendingProofs.has(zkProofId)) {
         pendingProofs.set(zkProofId, {
@@ -227,12 +243,13 @@ export class ConsensusWatchdog {
     for (const event of consensuses) {
       const log = event as ethers.EventLog;
       const zkProofId = String(log.args[0]);
+      resolvedProofs.add(zkProofId);
       if (pendingProofs.delete(zkProofId)) {
         resolvedProofDelta++;
       }
     }
 
-    return { pendingProofs, resolvedProofDelta, divergences, divergenceKeys };
+    return { pendingProofs, resolvedProofs, resolvedProofDelta, divergences, divergenceKeys };
   }
 
   private checkCiphertextDivergence(

--- a/test-suite/fhevm/scenarios/two-of-three-multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/two-of-three-multi-chain.yaml
@@ -1,0 +1,14 @@
+version: 1
+kind: coprocessor-consensus
+name: Two Of Three Multi Chain
+description: 3 coprocessors with threshold 2 across two host chains — enables consensus mismatch detection (for drift auto-recovery) plus multi-chain coverage.
+hostChains:
+  - key: host
+    chainId: "12345"
+    rpcPort: 8545
+  - key: chain-b
+    chainId: "67890"
+    rpcPort: 8547
+topology:
+  count: 3
+  threshold: 2

--- a/test-suite/fhevm/scenarios/two-of-three.yaml
+++ b/test-suite/fhevm/scenarios/two-of-three.yaml
@@ -1,0 +1,7 @@
+version: 1
+kind: coprocessor-consensus
+name: Two Of Three
+description: 3 coprocessors with threshold 2 — enables consensus mismatch detection
+topology:
+  count: 3
+  threshold: 2

--- a/test-suite/fhevm/src/cli.test.ts
+++ b/test-suite/fhevm/src/cli.test.ts
@@ -116,7 +116,8 @@ describe("cli", () => {
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("standard");
     expect(result.stdout).toContain("multi-chain-isolation");
-    expect(result.stdout).toContain("ciphertext-drift - standard, 2+ coprocessors");
+    expect(result.stdout).toContain("ciphertext-drift - 2+ coprocessors");
+    expect(result.stdout).toContain("ciphertext-drift-auto-recovery - standard");
   });
 
   test("standard suite includes multi-chain isolation coverage", () => {

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -834,7 +834,7 @@ export const test = async (testName: string | undefined, options: TestOptions) =
         const faultyInstanceIndex = parseDriftInstanceIndex(process.env.FAULTY_INSTANCE_INDEX ?? "1");
         const driftInjectTimeoutSeconds = parsePositiveInteger(process.env.DRIFT_INJECT_TIMEOUT_SECONDS ?? "180", "DRIFT_INJECT_TIMEOUT_SECONDS");
         const driftInjectPollIntervalSeconds = parsePositiveInteger(process.env.DRIFT_INJECT_POLL_INTERVAL_SECONDS ?? "2", "DRIFT_INJECT_POLL_INTERVAL_SECONDS");
-        const driftAlertTimeoutSeconds = parsePositiveInteger(process.env.DRIFT_ALERT_TIMEOUT_SECONDS ?? "180", "DRIFT_ALERT_TIMEOUT_SECONDS");
+        const driftAlertTimeoutSeconds = parsePositiveInteger(process.env.DRIFT_ALERT_TIMEOUT_SECONDS ?? "360", "DRIFT_ALERT_TIMEOUT_SECONDS");
         const driftAlertPollIntervalSeconds = parsePositiveInteger(process.env.DRIFT_ALERT_POLL_INTERVAL_SECONDS ?? "2", "DRIFT_ALERT_POLL_INTERVAL_SECONDS");
         const grepPattern = process.env.GREP_PATTERN ?? "test add 42 to uint64 input and decrypt";
         const injector = injectCiphertextDrift({
@@ -887,7 +887,7 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           "DRIFT_INJECT_POLL_INTERVAL_SECONDS",
         );
         const driftAlertTimeoutSeconds = parsePositiveInteger(
-          process.env.DRIFT_ALERT_TIMEOUT_SECONDS ?? "180",
+          process.env.DRIFT_ALERT_TIMEOUT_SECONDS ?? "360",
           "DRIFT_ALERT_TIMEOUT_SECONDS",
         );
         const driftAlertPollIntervalSeconds = parsePositiveInteger(

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -793,10 +793,6 @@ export const test = async (testName: string | undefined, options: TestOptions) =
     return undefined;
   };
 
-  const ciphertextDriftSkipReason = () =>
-    ciphertextDriftNetworkRequirement(options.network) ??
-    (state.scenario.topology.count < 2 ? "topology has fewer than 2 coprocessors" : ciphertextDriftRequirement());
-
   const ciphertextDriftAutoRecoverySkipReason = () =>
     ciphertextDriftNetworkRequirement(options.network) ??
     (state.scenario.topology.count < 3 ||
@@ -941,6 +937,16 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           `[drift-auto-recovery] drift detected in ${warning.container} for handle 0x${injectedHandleHex}`,
         );
 
+        // Cross-check that drift was visible on chain (≥2 distinct digests
+        // across the AddCiphertextMaterial submissions). Folded in from the
+        // former `ciphertext-drift` profile so this single test covers both
+        // detection and recovery.
+        const ciphertextCommitsAddress = state.discovery!.gateway.CIPHERTEXT_COMMITS_ADDRESS;
+        if (ciphertextCommitsAddress) {
+          const gatewayRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.gateway.http);
+          await assertOnChainDivergence(gatewayRpcUrl, ciphertextCommitsAddress, injectedHandleHex);
+        }
+
         const dbOptions = {
           instanceIndex: faultyInstanceIndex,
           postgresContainer: postgres.postgresContainer,
@@ -1065,13 +1071,6 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           const skipReason = multiChainIsolationSkipReason();
           if (skipReason) {
             console.log(`[test] skipping multi-chain-isolation: ${skipReason}`);
-            continue;
-          }
-        }
-        if (profile === "ciphertext-drift") {
-          const skipReason = ciphertextDriftSkipReason();
-          if (skipReason) {
-            console.log(`[test] skipping ciphertext-drift: ${skipReason}`);
             continue;
           }
         }

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -47,7 +47,7 @@ const CIPHERTEXT_DRIFT_FORBIDDEN_NETWORKS = new Set(["sepolia", "mainnet", "zwsD
 const timedLabel = (label: string, started: number) =>
   `${label} (${Math.round((Date.now() - started) / 1000)}s)`;
 
-const TEST_PROFILE_NAMES = [...Object.keys(TEST_GREP), "ciphertext-drift", "coprocessor-db-state-revert", "heavy", "light", "standard"].sort();
+const TEST_PROFILE_NAMES = [...Object.keys(TEST_GREP), "ciphertext-drift", "ciphertext-drift-auto-recovery", "coprocessor-db-state-revert", "heavy", "light", "standard"].sort();
 const ZERO_TESTS_RE = /\b0 passing\b/;
 const PAUSE_PROFILE_SCOPE: Record<string, string> = {
   "paused-host-contracts": "host",
@@ -74,6 +74,8 @@ const TEST_PROFILE_DESCRIPTIONS: Partial<Record<(typeof TEST_PROFILE_NAMES)[numb
   "negative-acl": "Run negative ACL scenarios.",
   "multi-chain-isolation": "Run multi-chain state isolation coverage.",
   "ciphertext-drift": "Run ciphertext drift detection checks (requires 2+ coprocessors).",
+  "ciphertext-drift-auto-recovery":
+    "Run ciphertext drift auto-recovery checks — services self-recover (requires 2+ coprocessors).",
   "coprocessor-db-state-revert": "Run coprocessor DB state revert checks.",
 };
 
@@ -282,6 +284,87 @@ const assertOnChainDivergence = async (
     throw new PreflightError(`on-chain AddCiphertextMaterial events show identical digests — drift not visible on chain`);
   }
   console.log(`[drift] on-chain divergence confirmed: ${logs.length} submissions with ${unique.size} distinct digest(s)`);
+};
+
+type DriftRevertDbOptions = {
+  instanceIndex: number;
+  postgresContainer: string;
+  postgresUser: string;
+  postgresPassword: string;
+};
+
+/** Counts computations rows for the host chain (coprocessor DB). */
+const countComputations = async (dbOptions: DriftRevertDbOptions, hostChainId: string) => {
+  const dbName = driftDatabaseName(dbOptions.instanceIndex);
+  const value = await psql(
+    dbName,
+    ["-t", "-A", "-c", `SELECT COUNT(*) FROM computations WHERE host_chain_id = ${hostChainId};`],
+    dbOptions,
+  );
+  return Number(value);
+};
+
+/** Polls `computations` row count until it reaches `target` — signals that
+ * the host-listener has caught up with blocks re-processed after a revert. */
+const waitForComputationsCatchup = async (
+  options: DriftRevertDbOptions & {
+    hostChainId: string;
+    target: number;
+    timeoutSeconds: number;
+    pollIntervalSeconds: number;
+  },
+) => {
+  const attempts = Math.max(0, Math.ceil(options.timeoutSeconds / options.pollIntervalSeconds));
+  let lastCount = -1;
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    lastCount = await countComputations(options, options.hostChainId);
+    if (lastCount >= options.target) {
+      return lastCount;
+    }
+    if (attempt === attempts) {
+      throw new PreflightError(
+        `timed out waiting for computations to catch up: have ${lastCount}, need >= ${options.target}`,
+      );
+    }
+    await Bun.sleep(options.pollIntervalSeconds * 1000);
+  }
+  return lastCount;
+};
+
+/** Polls drift_revert_signal until the latest row reaches a given status. */
+const waitForDriftRevertStatus = async (
+  options: DriftRevertDbOptions & {
+    targetStatus: "reverting" | "done";
+    timeoutSeconds: number;
+    pollIntervalSeconds: number;
+  },
+) => {
+  const dbName = driftDatabaseName(options.instanceIndex);
+  const attempts = Math.max(0, Math.ceil(options.timeoutSeconds / options.pollIntervalSeconds));
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    const status = await psql(
+      dbName,
+      ["-t", "-A", "-c", "SELECT status FROM drift_revert_signal ORDER BY id DESC LIMIT 1;"],
+      options,
+    );
+    if (status === options.targetStatus) {
+      return;
+    }
+    // "done" is also acceptable when waiting for "reverting" — we may have
+    // missed the transition if our polling was slower than the hold.
+    if (options.targetStatus === "reverting" && status === "done") {
+      return;
+    }
+    if (status.startsWith("failed")) {
+      throw new PreflightError(`drift_revert_signal transitioned to status=${status}`);
+    }
+    if (attempt === attempts) {
+      throw new PreflightError(
+        `timed out waiting for drift_revert_signal to reach status=${options.targetStatus} in ${dbName} (last status: ${status || "<none>"})`,
+      );
+    }
+    await Bun.sleep(options.pollIntervalSeconds * 1000);
+  }
 };
 
 /** Builds the `docker exec` argv used to run tests inside the test-suite container. */
@@ -695,9 +778,31 @@ export const test = async (testName: string | undefined, options: TestOptions) =
     return undefined;
   };
 
+  // Auto-recovery requires consensus mismatch detection — the gateway must be
+  // able to reach consensus while a minority dissents. This means threshold
+  // must be strictly less than count (e.g., 2-of-3).
+  const ciphertextDriftAutoRecoveryRequirement = () => {
+    const base = ciphertextDriftRequirement();
+    if (base) {
+      return base;
+    }
+    const topology = topologyForState(state);
+    if (topology.threshold >= topology.count) {
+      return "ciphertext-drift-auto-recovery requires a topology where threshold < count (e.g. 2-of-3); rerun `fhevm-cli up --scenario two-of-three` first";
+    }
+    return undefined;
+  };
+
   const ciphertextDriftSkipReason = () =>
     ciphertextDriftNetworkRequirement(options.network) ??
     (state.scenario.topology.count < 2 ? "topology has fewer than 2 coprocessors" : ciphertextDriftRequirement());
+
+  const ciphertextDriftAutoRecoverySkipReason = () =>
+    ciphertextDriftNetworkRequirement(options.network) ??
+    (state.scenario.topology.count < 3 ||
+      state.scenario.topology.threshold >= state.scenario.topology.count
+      ? "topology does not support consensus mismatch detection (needs threshold < count, e.g. 2-of-3)"
+      : ciphertextDriftAutoRecoveryRequirement());
 
   const multiChainIsolationRequirement = () =>
     state.scenario.hostChains.length > 1
@@ -731,7 +836,7 @@ export const test = async (testName: string | undefined, options: TestOptions) =
         const driftInjectPollIntervalSeconds = parsePositiveInteger(process.env.DRIFT_INJECT_POLL_INTERVAL_SECONDS ?? "2", "DRIFT_INJECT_POLL_INTERVAL_SECONDS");
         const driftAlertTimeoutSeconds = parsePositiveInteger(process.env.DRIFT_ALERT_TIMEOUT_SECONDS ?? "180", "DRIFT_ALERT_TIMEOUT_SECONDS");
         const driftAlertPollIntervalSeconds = parsePositiveInteger(process.env.DRIFT_ALERT_POLL_INTERVAL_SECONDS ?? "2", "DRIFT_ALERT_POLL_INTERVAL_SECONDS");
-        const grepPattern = process.env.GREP_PATTERN ?? "test user input uint64 \\(non-trivial\\)";
+        const grepPattern = process.env.GREP_PATTERN ?? "test add 42 to uint64 input and decrypt";
         const injector = injectCiphertextDrift({
           instanceIndex: faultyInstanceIndex,
           timeoutSeconds: driftInjectTimeoutSeconds,
@@ -760,6 +865,147 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           const gatewayRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.gateway.http);
           await assertOnChainDivergence(gatewayRpcUrl, ciphertextCommitsAddress, injectedHandleHex);
         }
+      });
+    }
+    if (name === "ciphertext-drift-auto-recovery") {
+      console.log("[test] ciphertext-drift-auto-recovery");
+      const started = Date.now();
+      const precondition = ciphertextDriftAutoRecoveryRequirement();
+      if (precondition) {
+        throw new PreflightError(precondition);
+      }
+      return runLogged("ciphertext-drift-auto-recovery", started, async () => {
+        const postgres = postgresRuntime();
+        const logSince = new Date().toISOString();
+        const faultyInstanceIndex = parseDriftInstanceIndex(process.env.FAULTY_INSTANCE_INDEX ?? "1");
+        const driftInjectTimeoutSeconds = parsePositiveInteger(
+          process.env.DRIFT_INJECT_TIMEOUT_SECONDS ?? "180",
+          "DRIFT_INJECT_TIMEOUT_SECONDS",
+        );
+        const driftInjectPollIntervalSeconds = parsePositiveInteger(
+          process.env.DRIFT_INJECT_POLL_INTERVAL_SECONDS ?? "2",
+          "DRIFT_INJECT_POLL_INTERVAL_SECONDS",
+        );
+        const driftAlertTimeoutSeconds = parsePositiveInteger(
+          process.env.DRIFT_ALERT_TIMEOUT_SECONDS ?? "180",
+          "DRIFT_ALERT_TIMEOUT_SECONDS",
+        );
+        const driftAlertPollIntervalSeconds = parsePositiveInteger(
+          process.env.DRIFT_ALERT_POLL_INTERVAL_SECONDS ?? "2",
+          "DRIFT_ALERT_POLL_INTERVAL_SECONDS",
+        );
+        const driftRecoveryTimeoutSeconds = parsePositiveInteger(
+          process.env.DRIFT_RECOVERY_TIMEOUT_SECONDS ?? "300",
+          "DRIFT_RECOVERY_TIMEOUT_SECONDS",
+        );
+        const driftRecoveryPollIntervalSeconds = parsePositiveInteger(
+          process.env.DRIFT_RECOVERY_POLL_INTERVAL_SECONDS ?? "2",
+          "DRIFT_RECOVERY_POLL_INTERVAL_SECONDS",
+        );
+        // Must target a test that produces a compute output (byte 21 = 0xff).
+        // The drift injector only corrupts compute-output handles, because
+        // input drift is out of scope for auto-recovery.
+        const grepPattern = process.env.GREP_PATTERN ?? "test add 42 to uint64 input and decrypt";
+
+        const injector = injectCiphertextDrift({
+          instanceIndex: faultyInstanceIndex,
+          timeoutSeconds: driftInjectTimeoutSeconds,
+          pollIntervalSeconds: driftInjectPollIntervalSeconds,
+          postgresContainer: postgres.postgresContainer,
+          postgresUser: postgres.postgresUser,
+          postgresPassword: postgres.postgresPassword,
+        });
+
+        // Run the e2e tests that trigger the drift. This run may surface
+        // errors due to the drift itself — we tolerate that and verify
+        // recovery in the next step.
+        await runWithHeartbeat(
+          buildTestContainerArgs(
+            runTestsArgs({ ...options, parallel: false, grep: grepPattern }),
+            ["-e", "GATEWAY_RPC_URL="],
+          ),
+          "test ciphertext-drift-auto-recovery (initial run)",
+        ).catch((error) => {
+          console.log(
+            `[drift-auto-recovery] initial test run failed (expected due to drift): ${formatCliError(error) ?? "unknown error"}`,
+          );
+        });
+
+        const injectedHandleHex = await injector;
+        const warning = await waitForDriftWarning(injectedHandleHex, {
+          since: logSince,
+          timeoutSeconds: driftAlertTimeoutSeconds,
+          pollIntervalSeconds: driftAlertPollIntervalSeconds,
+        });
+        console.log(
+          `[drift-auto-recovery] drift detected in ${warning.container} for handle 0x${injectedHandleHex}`,
+        );
+
+        const dbOptions = {
+          instanceIndex: faultyInstanceIndex,
+          postgresContainer: postgres.postgresContainer,
+          postgresUser: postgres.postgresUser,
+          postgresPassword: postgres.postgresPassword,
+        };
+        const hostChainId = process.env.CHAIN_ID ?? "12345";
+
+        // Snapshot row counts before the revert runs. The gw-listener is
+        // still in the grace period (pending status), so this is stable.
+        const computationsBefore = await countComputations(dbOptions, hostChainId);
+        console.log(`[drift-auto-recovery] computations before revert: ${computationsBefore}`);
+
+        // Wait for the revert to actually run (status transitions to
+        // "reverting" and the SQL completes). DRIFT_REVERT_TEST_HOLD_SECS
+        // (defaulted in generated env) keeps status=reverting for ~15s so
+        // we have a window to query the post-SQL state.
+        await waitForDriftRevertStatus({
+          ...dbOptions,
+          targetStatus: "reverting",
+          timeoutSeconds: driftRecoveryTimeoutSeconds,
+          pollIntervalSeconds: driftRecoveryPollIntervalSeconds,
+        });
+
+        // Snapshot counts while status=reverting. Services are still blocked
+        // waiting for status=done, so no new writes are racing.
+        const computationsAfterRevert = await countComputations(dbOptions, hostChainId);
+        console.log(`[drift-auto-recovery] computations after revert: ${computationsAfterRevert}`);
+        if (computationsAfterRevert >= computationsBefore) {
+          throw new PreflightError(
+            `drift revert did not delete any computations (before=${computationsBefore}, after=${computationsAfterRevert})`,
+          );
+        }
+
+        // Wait for the revert to finish.
+        await waitForDriftRevertStatus({
+          ...dbOptions,
+          targetStatus: "done",
+          timeoutSeconds: driftRecoveryTimeoutSeconds,
+          pollIntervalSeconds: driftRecoveryPollIntervalSeconds,
+        });
+
+        // Wait for host-listener to re-process the reverted blocks so the
+        // follow-up test isn't racing against catchup.
+        const caughtUp = await waitForComputationsCatchup({
+          ...dbOptions,
+          hostChainId,
+          target: computationsBefore,
+          timeoutSeconds: driftRecoveryTimeoutSeconds,
+          pollIntervalSeconds: driftRecoveryPollIntervalSeconds,
+        });
+        console.log(`[drift-auto-recovery] revert completed; computations caught up to ${caughtUp} (>= ${computationsBefore}); re-running tests to verify recovery`);
+
+        // Re-run the e2e tests to verify the services have fully recovered.
+        const followUp = await runWithHeartbeat(
+          buildTestContainerArgs(
+            runTestsArgs({ ...options, parallel: false, grep: grepPattern }),
+            ["-e", "GATEWAY_RPC_URL="],
+          ),
+          "test ciphertext-drift-auto-recovery (post-recovery)",
+        );
+        assertMatchedTests(
+          followUp.stdout + followUp.stderr,
+          "test ciphertext-drift-auto-recovery (post-recovery)",
+        );
       });
     }
     if (name === "multi-chain-isolation") {
@@ -833,6 +1079,13 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           const skipReason = dbStateRevertSkipReason();
           if (skipReason) {
             console.log(`[test] skipping coprocessor-db-state-revert: ${skipReason}`);
+            continue;
+          }
+        }
+        if (profile === "ciphertext-drift-auto-recovery") {
+          const skipReason = ciphertextDriftAutoRecoverySkipReason();
+          if (skipReason) {
+            console.log(`[test] skipping ciphertext-drift-auto-recovery: ${skipReason}`);
             continue;
           }
         }

--- a/test-suite/fhevm/src/drift.ts
+++ b/test-suite/fhevm/src/drift.ts
@@ -31,7 +31,8 @@ BEGIN
   IF NEW.txn_is_sent = FALSE
      AND NEW.ciphertext IS NOT NULL
      AND NEW.ciphertext128 IS NOT NULL
-     AND (OLD.ciphertext IS NULL OR OLD.ciphertext128 IS NULL) THEN
+     AND (OLD.ciphertext IS NULL OR OLD.ciphertext128 IS NULL)
+     AND EXISTS (SELECT 1 FROM computations WHERE output_handle = NEW.handle) THEN
     NEW.ciphertext := set_byte(NEW.ciphertext, 0, get_byte(NEW.ciphertext, 0) # 1);
 
     UPDATE drift_injection_state

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -72,6 +72,10 @@ const applyBaseRuntimeEnv = (
   const crsKeyId = state.discovery?.actualCrsKeyId ?? state.discovery?.crsKeyId ?? predictedCrsId();
 
   envs["coprocessor"].DATABASE_URL = `postgresql://${envs.database.POSTGRES_USER}:${envs.database.POSTGRES_PASSWORD}@${POSTGRES_HOST}/coprocessor`;
+  // Test-only: hold drift-revert signal in "reverting" state briefly so e2e
+  // tests can observe the post-revert DB state before services resume.
+  // No-op when no drift revert is in progress.
+  envs["coprocessor"].DRIFT_REVERT_TEST_HOLD_SECS = "15";
   envs["coprocessor"].TENANT_API_KEY = DEFAULT_TENANT_API_KEY;
   envs["coprocessor"].COPROCESSOR_API_KEY = DEFAULT_TENANT_API_KEY;
   envs["coprocessor"].AWS_ENDPOINT_URL = state.discovery?.endpoints.minioExternal ?? MINIO_INTERNAL_URL;

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -72,6 +72,8 @@ const applyBaseRuntimeEnv = (
   const crsKeyId = state.discovery?.actualCrsKeyId ?? state.discovery?.crsKeyId ?? predictedCrsId();
 
   envs["coprocessor"].DATABASE_URL = `postgresql://${envs.database.POSTGRES_USER}:${envs.database.POSTGRES_PASSWORD}@${POSTGRES_HOST}/coprocessor`;
+  // E2E tests opt into automatic drift revert. Set via env (not CLI flag).
+  envs["coprocessor"].DRIFT_AUTO_REVERT_ENABLED = "true";
   // Test-only: hold drift-revert signal in "reverting" state briefly so e2e
   // tests can observe the post-revert DB state before services resume.
   // No-op when no drift revert is in progress.

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -288,6 +288,7 @@ export const STANDARD_TEST_PROFILES = [
   "multi-chain-isolation",
   "hcu-block-cap",
   "ciphertext-drift",
+  "ciphertext-drift-auto-recovery",
 ] as const;
 
 /** Heavy suites are the slowest and most stateful CI checks. */

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -287,7 +287,10 @@ export const STANDARD_TEST_PROFILES = [
   "random-subset",
   "multi-chain-isolation",
   "hcu-block-cap",
-  "ciphertext-drift",
+  // Covers both drift detection (incl. an on-chain divergence cross-check folded
+  // in from the former `ciphertext-drift` profile) and full auto-recovery.
+  // `ciphertext-drift` is still registered as a profile for on-demand runs but
+  // is omitted from the standard suite to avoid leaving a corrupted DB.
   "ciphertext-drift-auto-recovery",
 ] as const;
 


### PR DESCRIPTION
Try to resolve a state drift when a minotiry of coprocessors are drifting, meaning that the revert only triggers if a conensus on a ciphertext has been reached.

The coprocessor state revert script is run when a drift is detected. It works by separating services into two categories:
 * runner - gw-listener
 * non-runners - all other services

When a drift is detected for a ciphertext, we determine the host chain and the block ID to revert to and insert a signal into the DB with this data. When observing this signal, all services re-exec and replace themselves with a new instance and then:
 * the gw-listener waits for a grace period before running the state revert script
 * all services (including gw-listener) wait until revert completes and continue executing normally

In this commit, we also add support for 2 out of 3 coprocessors for E2E tests.

We also recognize that, as of now, we can only recover from a state drift due to computations being bad. For input proofs, we can't recover as revert only works based on host chain and block ID and if an input ciphertext is not used on a host chain, we won't observe a drift. For that, we change the drift injector such that it only inserts drifts for computation handles.