### PR TITLE
fix(library-solidity): fix codegen to regenerate host contracts idempotently

### DIFF
--- a/library-solidity/codegen/src/hcuLimitGenerator.ts
+++ b/library-solidity/codegen/src/hcuLimitGenerator.ts
@@ -21,6 +21,10 @@ export function generateSolidityHCULimit(priceData: PriceData): string {
    * transaction level, including the maximum number of homomorphic complexity units (HCU) per transaction.
    * @dev The contract is designed to be used with the FHEVMExecutor contract.
   */
+/// @dev This contract was migrated from Ownable2StepUpgradeable to ACLOwnable.
+/// Deployed proxies retain residual \`_owner\` and \`_pendingOwner\` values in the
+/// Ownable2StepUpgradeable EIP-7201 storage namespace. These slots are unused
+/// by ACLOwnable and have no effect on contract behavior.
 /// @custom:security-contact https://github.com/zama-ai/fhevm/blob/main/SECURITY.md
 contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
     /// @notice Returned if the sender is not the FHEVMExecutor.
@@ -86,7 +90,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
     uint256 private constant PATCH_VERSION = 0;
 
     /// @notice FHEVMExecutor address.
-    address private constant fhevmExecutorAddress = fhevmExecutorAdd;
+    address private constant FHEVM_EXECUTOR_ADDRESS = fhevmExecutorAdd;
 
     /// @custom:storage-location erc7201:fhevm.storage.HCULimit
     /// @dev All five uint48 fields pack into a single 256-bit slot (5 × 48 = 240 bits).
@@ -110,12 +114,12 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
     uint64 private constant REINITIALIZER_VERSION = 4;
 
     /// keccak256(abi.encode(uint256(keccak256("fhevm.storage.HCULimit")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant HCULimitStorageLocation =
+    bytes32 private constant HCU_LIMIT_STORAGE_LOCATION =
       0xc13af6c514bff8997f30c90003baa82bd02aad978179d1ce58d85c4319ad6500;
 
     function _getHCULimitStorage() internal pure virtual returns (HCULimitStorage storage $) {
         assembly {
-            $.slot := HCULimitStorageLocation
+            $.slot := HCU_LIMIT_STORAGE_LOCATION
         }
     }
 
@@ -162,7 +166,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
         * @param caller Original caller address from FHEVMExecutor.
          */
          function ${functionName}(FheType resultType, bytes1 scalarByte, bytes32 ct, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
     `;
           break;
@@ -178,7 +182,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
          * @param caller Original dapp caller address from FHEVMExecutor.
          */
          function ${functionName}(FheType resultType, bytes1 scalarByte, bytes32 lhs, bytes32 rhs, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
     `;
           break;
@@ -198,7 +202,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
          * @param caller Original dapp caller address from FHEVMExecutor.
          */
          function ${functionName}(FheType resultType, bytes1 scalarByte, bytes32 lhs, bytes32 /*rhs*/, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
            `;
           break;
@@ -215,7 +219,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
          * @param caller Original dapp caller address from FHEVMExecutor.
          */
         function ${functionName}(FheType resultType, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
     `;
           break;
@@ -228,7 +232,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
         * @param caller Original caller address from FHEVMExecutor.
         */
         function ${functionName}(FheType resultType, bytes32 ct, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
     `;
           break;
@@ -243,7 +247,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
          * @param caller Original dapp caller address from FHEVMExecutor.
          */
         function ${functionName}(FheType resultType, bytes32 lhs, bytes32 rhs, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
     `;
           break;
@@ -258,7 +262,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
          * @param caller Original dapp caller address from FHEVMExecutor.
          */
         function ${functionName}(FheType resultType, bytes32 lhs, bytes32 middle, bytes32 rhs, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 opHCU;
     `;
           break;
@@ -272,7 +276,7 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
          * @param caller Original dapp caller address from FHEVMExecutor.
          */
         function ${functionName}(FheType resultType, bytes32[] calldata values, bytes32 result, address caller) external virtual {
-        if(msg.sender != fhevmExecutorAddress) revert CallerMustBeFHEVMExecutorContract();
+        if(msg.sender != FHEVM_EXECUTOR_ADDRESS) revert CallerMustBeFHEVMExecutorContract();
         uint256 n = values.length;
         uint256 opHCU;
     `;
@@ -570,10 +574,10 @@ contract HCULimit is UUPSUpgradeableEmptyProxy, ACLOwnable {
 
     /**
      * @notice Getter function for the FHEVMExecutor contract address.
-     * @return fhevmExecutorAddress Address of the FHEVMExecutor.
+     * @return FHEVM_EXECUTOR_ADDRESS Address of the FHEVMExecutor.
      */
     function getFHEVMExecutorAddress() public view virtual returns (address) {
-        return fhevmExecutorAddress;
+        return FHEVM_EXECUTOR_ADDRESS;
     }
 
     /**

--- a/library-solidity/codegen/src/templates/Impl.sol-template
+++ b/library-solidity/codegen/src/templates/Impl.sol-template
@@ -235,7 +235,7 @@ interface IInputVerifier {
  */
 library Impl {
     /// keccak256(abi.encode(uint256(keccak256("confidential.storage.config")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant CoprocessorConfigLocation =
+    bytes32 private constant COPROCESSOR_CONFIG_LOCATION =
         0x9e7b61f58c47dc699ac88507c4f5bb9f121c03808c5676a8078fe583e4649700;
 
     /**
@@ -243,7 +243,7 @@ library Impl {
      */
     function getCoprocessorConfig() internal pure returns (CoprocessorConfig storage $) {
         assembly {
-            $.slot := CoprocessorConfigLocation
+            $.slot := COPROCESSOR_CONFIG_LOCATION
         }
     }
 

--- a/library-solidity/lib/Impl.sol
+++ b/library-solidity/lib/Impl.sol
@@ -415,7 +415,7 @@ interface IInputVerifier {
  */
 library Impl {
     /// keccak256(abi.encode(uint256(keccak256("confidential.storage.config")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant CoprocessorConfigLocation =
+    bytes32 private constant COPROCESSOR_CONFIG_LOCATION =
         0x9e7b61f58c47dc699ac88507c4f5bb9f121c03808c5676a8078fe583e4649700;
 
     /**
@@ -423,7 +423,7 @@ library Impl {
      */
     function getCoprocessorConfig() internal pure returns (CoprocessorConfig storage $) {
         assembly {
-            $.slot := CoprocessorConfigLocation
+            $.slot := COPROCESSOR_CONFIG_LOCATION
         }
     }
 


### PR DESCRIPTION
### Summary:

Running `npm run codegen` in host-contracts was producing a diff against the committed contracts because templates were not updated. This pr updates the template to regenerate the same host contracts idempotently.