### PR TITLE
docs(relayer): document admin endpoint security

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -4862,9 +4862,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -176,7 +176,9 @@ GET  /admin/config
 POST /admin/config
 ```
 
-Controlled by `enable_admin_endpoint` (returns `403 Forbidden` when disabled). Supports runtime tuning of throttler TPS and retry-after fields.
+Controlled by `enable_admin_endpoint` (returns `403 Forbidden` when disabled). Supports runtime tuning of throttler TPS and retry-after fields. Primarily intended for testing and benchmarking.
+
+> **Note.** These endpoints are disabled by default and intentionally have no application-level authentication. When enabling them, restrict reachability via network-level controls — bind `http.endpoint` to loopback or an internal subnet, or place the endpoint behind an authentication layer.
 
 ## Observability
 

--- a/relayer/docs/SELF_HOSTING.md
+++ b/relayer/docs/SELF_HOSTING.md
@@ -116,9 +116,16 @@ Key operator-tunable fields in the config file:
 | `storage.cron.user_decrypt_expiry`              | Retention for user decrypt records        | `7d`           |
 | `storage.cron.input_proof_expiry`               | Retention for input proof records         | `7d`           |
 | `http.retry_after.max_seconds`                  | Max Retry-After header value              | `300`          |
-| `http.enable_admin_endpoint`                    | Enable runtime config via `/admin/config` | `false`        |
+| `http.enable_admin_endpoint`                    | Enable runtime config via `/admin/config` (see security note below) | `false`        |
 
 Configuration is hierarchical: YAML file -> environment variables (`APP_` prefix, `__` nesting) -> CLI args.
+
+### Admin endpoint security
+
+`/admin/config` is primarily intended for testing and benchmarking. It is disabled by default and intentionally has no application-level authentication. When enabling it, restrict reachability via network-level controls:
+
+- bind `http.endpoint` to loopback (`127.0.0.1:3000`) or an internal-only subnet, or
+- place the endpoint behind an authentication layer.
 
 ## Monitoring
 


### PR DESCRIPTION
Documents the `/admin/config` security model in the relayer README and self-hosting guide.

Refs zama-ai/fhevm-internal#1325 (see issue for details).