### PR TITLE
feat(kms-connector): erc-1271 signature verification

### DIFF
--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -64,6 +64,13 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # ENV: KMS_CONNECTOR_S3_CONNECT_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
 # s3_connect_timeout = "3s"
 
+# Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
+# Bounds resource use when verifying signatures from smart-account users (Safe, Argent,
+# ERC-4337). 100k is the RFC's suggested starting point; tune up for deep multisig
+# thresholds. (optional, defaults to 100000)
+# ENV: KMS_CONNECTOR_ERC1271_GAS_LIMIT
+# erc1271_gas_limit = 100000
+
 # The maximum number of tasks to process events/responses concurrently (optional, defaults to 1000)
 # ENV: KMS_CONNECTOR_TASK_LIMIT
 # task_limit = 1000

--- a/kms-connector/crates/kms-worker/Cargo.toml
+++ b/kms-connector/crates/kms-worker/Cargo.toml
@@ -35,6 +35,7 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["json-rpc"] }
 connector-utils = { workspace = true, features = ["tests"] }
 mocktail.workspace = true
 rstest.workspace = true

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -69,6 +69,11 @@ pub struct Config {
     #[serde(with = "humantime_serde", default = "default_s3_connect_timeout")]
     pub s3_connect_timeout: Duration,
 
+    /// Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
+    /// Bounded to prevent resource exhaustion from malicious smart-account contracts.
+    #[serde(default = "default_erc1271_gas_limit")]
+    pub erc1271_gas_limit: u64,
+
     /// The service name used for tracing.
     #[serde(default = "default_service_name")]
     pub service_name: String,
@@ -162,6 +167,10 @@ fn default_s3_connect_timeout() -> Duration {
     Duration::from_secs(3)
 }
 
+fn default_erc1271_gas_limit() -> u64 {
+    100_000
+}
+
 impl DeserializeConfig for Config {}
 
 // Default implementation for testing purpose
@@ -188,6 +197,7 @@ impl Default for Config {
             max_decryption_attempts: default_max_decryption_attempts(),
             s3_ciphertext_retrieval_retries: default_s3_ciphertext_retrieval_retries(),
             s3_connect_timeout: default_s3_connect_timeout(),
+            erc1271_gas_limit: default_erc1271_gas_limit(),
             service_name: default_service_name(),
             task_limit: default_task_limit(),
             monitoring_endpoint: default_monitoring_endpoint(),

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -1,13 +1,18 @@
 use crate::core::{
     config::Config,
-    event_processor::{ProcessingError, context::ContextManager, s3::S3Service},
+    event_processor::{
+        ProcessingError,
+        context::ContextManager,
+        s3::S3Service,
+        signature::{compute_user_decrypt_digest, verify_signature},
+    },
 };
 use alloy::{
     consensus::Transaction,
     hex,
     primitives::{Address, Bytes, FixedBytes, U256, map::DefaultHashBuilder},
     providers::Provider,
-    sol_types::SolCall,
+    sol_types::{Eip712Domain, SolCall},
 };
 use anyhow::anyhow;
 use connector_utils::types::{
@@ -45,6 +50,9 @@ pub struct DecryptionProcessor<GP: Provider, HP: Provider, C> {
 
     /// The entity used to collect ciphertexts from S3 buckets.
     s3_service: S3Service<GP>,
+
+    /// Gas cap for the `IERC1271.isValidSignature` static call (RFC-012).
+    erc1271_gas_limit: u64,
 }
 
 impl<GP, HP, C> DecryptionProcessor<GP, HP, C>
@@ -76,6 +84,7 @@ where
             decryption_contract,
             acl_contracts,
             s3_service,
+            erc1271_gas_limit: config.erc1271_gas_limit,
         }
     }
 
@@ -226,13 +235,13 @@ where
     ///
     /// 1. validity window (`startTimestamp <= now <= startTimestamp + durationSeconds`)
     /// 2. `userAddress ∉ allowedContracts` when `allowedContracts` is non-empty
-    /// 3. signature invalidation: `startTimestamp >= ACL.decryptionSignatureInvalidatedBefore(userAddress)`
-    /// 4. per-handle ownership (direct `isAllowed` if `ownerAddress == userAddress`, else
-    ///    `isHandleDelegatedForUserDecryption`)
-    /// 5. per-handle contract allowance (any `isAllowed(handle, c)` for `c ∈ allowedContracts`,
-    ///    no-op in permissive mode)
-    ///
-    /// Note: EIP-712 signature verification (step 1 in RFC016) is deferred to RFC-012 implementation.
+    /// 3. concurrent host-chain checks (one RPC round-trip wave):
+    ///    - EIP-712 signature verification with `ecrecover` → ERC-1271 fallback (RFC-012)
+    ///    - signature invalidation: `startTimestamp >= ACL.decryptionSignatureInvalidatedBefore(userAddress)`
+    ///    - per-handle ownership (direct `isAllowed` if `ownerAddress == userAddress`, else
+    ///      `isHandleDelegatedForUserDecryption`)
+    ///    - per-handle contract allowance (any `isAllowed(handle, c)` for
+    ///      `c ∈ allowedContracts`, no-op in permissive mode)
     #[tracing::instrument(skip_all)]
     pub async fn check_user_decryption_request_v2(
         &self,
@@ -280,28 +289,58 @@ where
                 "No ACL contract config found for chain id {chain_id}"
             ))
         })?;
-        self.inner_invalidation_check_for_user_decryption_v2(
-            acl_contract,
-            payload.userAddress,
-            start,
-        )
-        .await?;
 
-        try_join_all(request.handles.iter().map(|handle_entry| async move {
-            tokio::try_join!(
-                self.inner_ownership_check_for_user_decryption_v2(
-                    acl_contract,
-                    handle_entry,
+        // RFC-012: EIP-712 signature verification with ecrecover → ERC-1271 fallback.
+        // The domain takes name/version/verifyingContract from `self.domain` (already validated
+        // at startup) but substitutes the host `contractsChainId` for the Gateway chain id —
+        // `self.domain` targets KMS gRPC requests, the user-decryption signature targets the
+        // host chain.
+        let domain = Eip712Domain {
+            name: Some(self.domain.name.clone().into()),
+            version: Some(self.domain.version.clone().into()),
+            chain_id: Some(U256::from(chain_id)),
+            verifying_contract: Some(*self.decryption_contract.address()),
+            salt: None,
+        };
+        let digest = compute_user_decrypt_digest(payload, &domain);
+
+        // Signature verification, invalidation, and per-handle ACL checks are all independent
+        // host-chain reads against the same `userAddress`. Fire them concurrently so the
+        // smart-account happy path is faster. `try_join!` short-circuits on the first error, so a
+        // forged request still terminates as soon as `verify_signature` rejects — at the cost of
+        // having issued the in-flight ACL reads.
+        tokio::try_join!(
+            async {
+                verify_signature(
+                    acl_contract.provider(),
                     payload.userAddress,
-                ),
-                self.inner_allowed_contracts_check_for_user_decryption_v2(
-                    acl_contract,
-                    handle_entry.handle,
-                    &payload.allowedContracts,
-                ),
-            )
-        }))
-        .await?;
+                    digest,
+                    payload.signature.as_ref(),
+                    self.erc1271_gas_limit,
+                )
+                .await
+                .map_err(ProcessingError::from)
+            },
+            self.inner_invalidation_check_for_user_decryption_v2(
+                acl_contract,
+                payload.userAddress,
+                start,
+            ),
+            try_join_all(request.handles.iter().map(|handle_entry| async move {
+                tokio::try_join!(
+                    self.inner_ownership_check_for_user_decryption_v2(
+                        acl_contract,
+                        handle_entry,
+                        payload.userAddress,
+                    ),
+                    self.inner_allowed_contracts_check_for_user_decryption_v2(
+                        acl_contract,
+                        handle_entry.handle,
+                        &payload.allowedContracts,
+                    ),
+                )
+            })),
+        )?;
 
         info!(
             "RFC016 ACL check passed for {} handles!",
@@ -581,8 +620,12 @@ impl UserDecryptionExtraData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::event_processor::signature::{
+        ERC1271_MAGIC_VALUE, compute_user_decrypt_digest, default_user_decrypt_domain,
+    };
     use alloy::{
         providers::{ProviderBuilder, mock::Asserter},
+        signers::{SignerSync, local::PrivateKeySigner},
         sol_types::SolValue,
         transports::http::reqwest,
     };
@@ -820,15 +863,46 @@ mod tests {
         }
     }
 
+    /// Builds a `UserDecryptionRequestV2` whose payload carries a valid 65-byte ECDSA signature
+    /// over the EIP-712 digest.
+    ///
+    /// `user_address` and `signing_key` are intentionally decoupled: the EOA-direct case
+    /// passes `signing_key.address()` for both, and the smart-account case passes the
+    /// contract address as `user_address` while `signing_key` plays the role of the wallet's
+    /// owner EOA — its signature recovers to a different address, forcing the ERC-1271
+    /// fallback in `verify_signature`.
+    ///
+    /// The digest is computed against `Config::default().decryption_contract.address` — the
+    /// same gateway address `setup_test_processor` configures the processor with.
     fn make_v2_request(
         sns_ct: &SnsCiphertextMaterial,
         owner_address: Address,
         user_address: Address,
+        signing_key: &PrivateKeySigner,
         allowed_contracts: Vec<Address>,
         start_offset_secs: i64,
         duration_secs: u64,
     ) -> UserDecryptionRequestV2 {
         let start = (Utc::now().timestamp() + start_offset_secs) as u64;
+        let mut payload = UserDecryptionRequestPayload {
+            userAddress: user_address,
+            publicKey: Bytes::from(rand_public_key()),
+            allowedContracts: allowed_contracts,
+            requestValidity: RequestValiditySeconds {
+                startTimestamp: U256::from(start),
+                durationSeconds: U256::from(duration_secs),
+            },
+            extraData: Bytes::default(),
+            signature: Bytes::default(),
+        };
+
+        let chain_id = extract_chain_id_from_handle(sns_ct.ctHandle.as_slice()).unwrap();
+        let gateway_addr = Config::default().decryption_contract.address;
+        let domain = default_user_decrypt_domain(chain_id, gateway_addr);
+        let digest = compute_user_decrypt_digest(&payload, &domain);
+        let sig = signing_key.sign_hash_sync(&digest).unwrap();
+        payload.signature = Bytes::from(sig.as_bytes().to_vec());
+
         UserDecryptionRequestV2 {
             decryptionId: rand_u256(),
             snsCtMaterials: vec![sns_ct.clone()],
@@ -837,17 +911,7 @@ mod tests {
                 contractAddress: rand_address(),
                 ownerAddress: owner_address,
             }],
-            payload: UserDecryptionRequestPayload {
-                userAddress: user_address,
-                publicKey: Bytes::from(rand_public_key()),
-                allowedContracts: allowed_contracts,
-                requestValidity: RequestValiditySeconds {
-                    startTimestamp: U256::from(start),
-                    durationSeconds: U256::from(duration_secs),
-                },
-                extraData: Bytes::default(),
-                signature: Bytes::default(),
-            },
+            payload,
         }
     }
 
@@ -861,12 +925,14 @@ mod tests {
         #[case] expected: ExpectedOutcome,
     ) {
         let sns_ct = rand_sns_ct();
-        let user_address = rand_address();
+        let user_signer = PrivateKeySigner::random();
+        let user_address = user_signer.address();
         let processor = setup_test_processor(Asserter::new(), &sns_ct);
         let request = make_v2_request(
             &sns_ct,
             user_address,
             user_address,
+            &user_signer,
             vec![],
             start_offset_secs,
             duration_secs,
@@ -889,12 +955,14 @@ mod tests {
     #[tokio::test]
     async fn check_user_decryption_request_v2_user_in_allowed_contracts() {
         let sns_ct = rand_sns_ct();
-        let user_address = rand_address();
+        let user_signer = PrivateKeySigner::random();
+        let user_address = user_signer.address();
         let processor = setup_test_processor(Asserter::new(), &sns_ct);
         let request = make_v2_request(
             &sns_ct,
             user_address,
             user_address,
+            &user_signer,
             vec![user_address],
             -3600,
             86400,
@@ -926,7 +994,7 @@ mod tests {
     ) {
         let asserter = Asserter::new();
         let sns_ct = rand_sns_ct();
-        let user_address = rand_address();
+        let user_signer = PrivateKeySigner::random();
         let processor = setup_test_processor(asserter.clone(), &sns_ct);
 
         const START_OFFSET_SECS: i64 = -3600;
@@ -957,8 +1025,9 @@ mod tests {
 
         let request = make_v2_request(
             &sns_ct,
-            user_address,
-            user_address,
+            user_signer.address(),
+            user_signer.address(),
+            &user_signer,
             vec![],
             START_OFFSET_SECS,
             86400,
@@ -1007,7 +1076,8 @@ mod tests {
     ) {
         let asserter = Asserter::new();
         let sns_ct = rand_sns_ct();
-        let user_address = rand_address();
+        let user_signer = PrivateKeySigner::random();
+        let user_address = user_signer.address();
         let processor = setup_test_processor(asserter.clone(), &sns_ct);
 
         let (owner_address, acl_response) = match mock {
@@ -1020,7 +1090,15 @@ mod tests {
             None => asserter.push_failure_msg("transport error"),
         }
 
-        let request = make_v2_request(&sns_ct, owner_address, user_address, vec![], -3600, 86400);
+        let request = make_v2_request(
+            &sns_ct,
+            owner_address,
+            user_address,
+            &user_signer,
+            vec![],
+            -3600,
+            86400,
+        );
         let result = processor.check_user_decryption_request_v2(&request).await;
 
         match expected {
@@ -1054,7 +1132,7 @@ mod tests {
     ) {
         let asserter = Asserter::new();
         let sns_ct = rand_sns_ct();
-        let user_address = rand_address();
+        let user_signer = PrivateKeySigner::random();
         let processor = setup_test_processor(asserter.clone(), &sns_ct);
 
         asserter.push_success(&U256::ZERO.abi_encode()); // invalidation check: not invalidated
@@ -1066,8 +1144,9 @@ mod tests {
 
         let request = make_v2_request(
             &sns_ct,
-            user_address,
-            user_address,
+            user_signer.address(),
+            user_signer.address(),
+            &user_signer,
             vec![rand_address()],
             -3600,
             86400,
@@ -1083,5 +1162,82 @@ mod tests {
                 assert!(matches!(result, Err(ProcessingError::Irrecoverable(_))))
             }
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // RFC-012: signature verification wired into check_user_decryption_request_v2
+    // -------------------------------------------------------------------------
+
+    /// A flipped byte in `payload.signature` makes ecrecover return some other address; with
+    /// no contract code at `userAddress`, the ERC-1271 fallback rejects with Irrecoverable.
+    /// No invalidation/ACL RPC is reached.
+    #[tokio::test]
+    async fn check_user_decryption_request_v2_signature_mismatch() {
+        let asserter = Asserter::new();
+        let sns_ct = rand_sns_ct();
+        let user_signer = PrivateKeySigner::random();
+        let processor = setup_test_processor(asserter.clone(), &sns_ct);
+
+        // STATICCALL to a no-code address returns empty returndata at the EVM level →
+        // `EoaMismatchNoCode` rejection.
+        asserter.push_success(&Bytes::default());
+
+        let mut request = make_v2_request(
+            &sns_ct,
+            user_signer.address(),
+            user_signer.address(),
+            &user_signer,
+            vec![],
+            -3600,
+            86400,
+        );
+        // Flip a byte in the signature
+        let mut sig = request.payload.signature.to_vec();
+        sig[0] ^= 0xFF;
+        request.payload.signature = Bytes::from(sig);
+
+        let result = processor.check_user_decryption_request_v2(&request).await;
+        assert!(matches!(result, Err(ProcessingError::Irrecoverable(_))));
+    }
+
+    /// A smart-account user (Safe-style) whose contract returns the ERC-1271 magic value
+    /// passes the signature check, then the rest of the pipeline (invalidation + ownership)
+    /// proceeds normally.
+    #[tokio::test]
+    async fn check_user_decryption_request_v2_smart_account_accepts() {
+        let asserter = Asserter::new();
+        let sns_ct = rand_sns_ct();
+        let processor = setup_test_processor(asserter.clone(), &sns_ct);
+
+        // Random "smart account" address; no off-chain key controls it, so ecrecover will
+        // never match — verification only succeeds via the ERC-1271 fallback.
+        let smart_account = rand_address();
+        // The wallet's owner EOA: produces real 65-byte signature bytes whose recovered
+        // address is *not* `smart_account`, forcing the ERC-1271 path.
+        let owner = PrivateKeySigner::random();
+        let request = make_v2_request(
+            &sns_ct,
+            smart_account, // owner == userAddress: direct path
+            smart_account,
+            &owner,
+            vec![],
+            -3600,
+            86400,
+        );
+
+        // Mock the host RPC sequence:
+        //   1. isValidSignature → magic value (left-aligned in a 32-byte word)
+        //   2. invalidation → 0
+        //   3. ownership: isAllowed → true
+        let mut magic_word = [0u8; 32];
+        magic_word[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
+        asserter.push_success(&magic_word); // isValidSignature
+        asserter.push_success(&U256::ZERO.abi_encode()); // invalidation
+        asserter.push_success(&true.abi_encode()); // ownership
+
+        processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .unwrap();
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -305,11 +305,11 @@ where
         let digest = compute_user_decrypt_digest(payload, &domain);
 
         // Signature verification, invalidation, and per-handle ACL checks are all independent
-        // host-chain reads against the same `userAddress`. Fire them concurrently so the
-        // smart-account happy path is faster. `try_join!` short-circuits on the first error, so a
-        // forged request still terminates as soon as `verify_signature` rejects — at the cost of
-        // having issued the in-flight ACL reads.
+        // host-chain reads. Fire them concurrently so the smart-account happy path is faster.
+        // `biased;` polls branches in order so tests can deterministically craft the mock-queue
+        // order.
         tokio::try_join!(
+            biased;
             async {
                 verify_signature(
                     acl_contract.provider(),
@@ -328,6 +328,7 @@ where
             ),
             try_join_all(request.handles.iter().map(|handle_entry| async move {
                 tokio::try_join!(
+                    biased;
                     self.inner_ownership_check_for_user_decryption_v2(
                         acl_contract,
                         handle_entry,
@@ -456,7 +457,7 @@ where
         let contract_allowed_call = acl_contract.isAllowed(handle, contract_address);
 
         let (user_allowed, contract_allowed) =
-            tokio::try_join!(user_allowed_call.call(), contract_allowed_call.call())
+            tokio::try_join!(biased; user_allowed_call.call(), contract_allowed_call.call())
                 .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?;
 
         if !user_allowed {
@@ -1116,10 +1117,8 @@ mod tests {
     // Allowed contracts check (direct ownership always passes → 2 RPCs)
     //
     // Two `isAllowed` calls are made concurrently via `tokio::try_join!`. The Asserter
-    // serves responses in FIFO order, but poll ordering between the two futures is not
-    // guaranteed. The test design is robust to either ordering: ownership and contracts
-    // failures are both Recoverable, so swapping which future receives which response
-    // doesn't change the expected outcome.
+    // serves responses in FIFO order, and poll ordering between the two futures is
+    // guaranteed by the `biased` annotation.
     // -------------------------------------------------------------------------
     #[rstest]
     #[case::transport_error(None, ExpectedOutcome::Recoverable)]

--- a/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
@@ -4,6 +4,7 @@ mod kms;
 mod kms_client;
 mod processor;
 pub mod s3;
+mod signature;
 
 pub use context::{ContextManager, DbContextManager};
 pub use decryption::DecryptionProcessor;

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -103,16 +103,18 @@ pub enum ProcessingError {
 }
 
 /// ERC-1271 (RFC-012) signature errors map onto `ProcessingError` so callers can use the `?`
-/// operator: transport blips retry, every deterministic rejection (bad signature, wrong magic,
-/// revert, malformed return) is terminal — the request will never become valid.
+/// operator. Missing code at an EOA is terminal, but smart-account validation can depend on
+/// mutable wallet state, so negative ERC-1271 results are retried through the existing attempt
+/// and validity-window limits.
 impl From<Erc1271Error> for ProcessingError {
     fn from(err: Erc1271Error) -> Self {
         match err {
-            Erc1271Error::Transport(_) => Self::Recoverable(anyhow::Error::new(err)),
-            Erc1271Error::EoaMismatchNoCode(_)
-            | Erc1271Error::EmptySigOnEoa(_)
+            Erc1271Error::EoaMismatchNoCode(_) | Erc1271Error::EmptySigOnEoa(_) => {
+                Self::Irrecoverable(anyhow::Error::new(err))
+            }
+            Erc1271Error::Transport(_)
             | Erc1271Error::WrongMagic(..)
-            | Erc1271Error::Rejected(..) => Self::Irrecoverable(anyhow::Error::new(err)),
+            | Erc1271Error::Rejected(..) => Self::Recoverable(anyhow::Error::new(err)),
         }
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -3,6 +3,7 @@ use crate::core::event_processor::{
     context::ContextManager,
     decryption::{DecryptionProcessor, UserDecryptionExtraData},
     kms::KMSGenerationProcessor,
+    signature::Erc1271Error,
 };
 use alloy::providers::Provider;
 use anyhow::anyhow;
@@ -99,6 +100,21 @@ pub enum ProcessingError {
     Irrecoverable(anyhow::Error),
     #[error("Processing failed: {0}")]
     Recoverable(anyhow::Error),
+}
+
+/// ERC-1271 (RFC-012) signature errors map onto `ProcessingError` so callers can use the `?`
+/// operator: transport blips retry, every deterministic rejection (bad signature, wrong magic,
+/// revert, malformed return) is terminal — the request will never become valid.
+impl From<Erc1271Error> for ProcessingError {
+    fn from(err: Erc1271Error) -> Self {
+        match err {
+            Erc1271Error::Transport(_) => Self::Recoverable(anyhow::Error::new(err)),
+            Erc1271Error::EoaMismatchNoCode(_)
+            | Erc1271Error::EmptySigOnEoa(_)
+            | Erc1271Error::WrongMagic(..)
+            | Erc1271Error::Rejected(..) => Self::Irrecoverable(anyhow::Error::new(err)),
+        }
+    }
 }
 
 impl<GP: Provider, HP: Provider, C: ContextManager> DbEventProcessor<GP, HP, C> {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/signature.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/signature.rs
@@ -1,6 +1,6 @@
 //! RFC-012 EIP-712 signature verification for unified user-decryption requests.
 //!
-//! Implements the `ecrecover` → ERC-1271 fallback specified in RFC12.
+//! Implements the `ecrecover` → ERC-1271 fallback specified in RFC-012.
 //! The EIP-712 typed-data struct is the unified `UserDecryptRequestVerification` from RFC-016
 //! we declare both it and `IERC1271` inline because the unified struct is intentionally
 //! absent from `Decryption.sol` (signature verification is off-chain) and `IERC1271` is not

--- a/kms-connector/crates/kms-worker/src/core/event_processor/signature.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/signature.rs
@@ -1,0 +1,454 @@
+//! RFC-012 EIP-712 signature verification for unified user-decryption requests.
+//!
+//! Implements the `ecrecover` → ERC-1271 fallback specified in RFC12.
+//! The EIP-712 typed-data struct is the unified `UserDecryptRequestVerification` from RFC-016
+//! we declare both it and `IERC1271` inline because the unified struct is intentionally
+//! absent from `Decryption.sol` (signature verification is off-chain) and `IERC1271` is not
+//! part of any in-tree binding.
+
+use IERC1271::isValidSignatureCall;
+use alloy::{
+    primitives::{Address, B256, Bytes, FixedBytes, Signature, U256},
+    providers::Provider,
+    rpc::types::TransactionRequest,
+    sol,
+    sol_types::{Eip712Domain, SolCall, SolStruct},
+    transports::RpcError,
+};
+use fhevm_gateway_bindings::decryption::IDecryption::UserDecryptionRequestPayload;
+use thiserror::Error;
+
+sol! {
+    /// ERC-1271 signature validation interface (OpenZeppelin v5.1).
+    /// Magic value `0x1626ba7e = bytes4(keccak256("isValidSignature(bytes32,bytes)"))`.
+    interface IERC1271 {
+        function isValidSignature(bytes32 hash, bytes signature) external view returns (bytes4 magicValue);
+    }
+
+    /// RFC-016 unified EIP-712 typed-data struct for user-decryption requests.
+    /// Field names and order MUST match the SDK's signing payload exactly.
+    struct UserDecryptRequestVerification {
+        address userAddress;
+        bytes publicKey;
+        address[] allowedContracts;
+        uint256 startTimestamp;
+        uint256 durationSeconds;
+        bytes extraData;
+    }
+}
+
+/// Default EIP-712 domain `name` for the Gateway `Decryption` contract — used by
+/// [`default_user_decrypt_domain`] when the caller has only the contract address.
+//
+// `dead_code` allow: in-tree `DecryptionProcessor` builds its `Eip712Domain` directly from
+// `self.domain` (which carries deployment-specific name/version), so it doesn't go through
+// the default constructor. Kept exposed for downstream consumers that lack an
+// `Eip712DomainMsg` and want the canonical defaults.
+#[allow(dead_code)]
+pub const DEFAULT_DOMAIN_NAME: &str = "Decryption";
+/// Default EIP-712 domain `version` for the Gateway `Decryption` contract.
+#[allow(dead_code)]
+pub const DEFAULT_DOMAIN_VERSION: &str = "1";
+/// ERC-1271 magic return value: `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`.
+pub const ERC1271_MAGIC_VALUE: [u8; 4] = [0x16, 0x26, 0xba, 0x7e];
+
+#[derive(Debug, Error)]
+pub enum Erc1271Error {
+    #[error("ecrecover signer mismatch and userAddress {0} has no contract code on host chain")]
+    EoaMismatchNoCode(Address),
+    #[error("empty signature is only valid for contracts; userAddress {0} has no contract code")]
+    EmptySigOnEoa(Address),
+    #[error("ERC-1271 isValidSignature returned non-magic value {1} for userAddress {0}")]
+    WrongMagic(Address, FixedBytes<4>),
+    #[error(
+        "ERC-1271 isValidSignature reverted or returned malformed data for userAddress {0}: {1}"
+    )]
+    Rejected(Address, String),
+    #[error("RPC transport error during ERC-1271 verification: {0}")]
+    Transport(String),
+}
+
+/// Default `Eip712Domain` builder for callers that only have the host `contractsChainId` and
+/// the Gateway `Decryption` contract address. Uses [`DEFAULT_DOMAIN_NAME`] and
+/// [`DEFAULT_DOMAIN_VERSION`].
+///
+/// Callers that already hold the full domain (name/version may differ per deployment) should
+/// pass their own `Eip712Domain` directly to [`compute_user_decrypt_digest`] instead.
+///
+/// `chain_id` is the host `contractsChainId` (extracted from the handle), **not** the Gateway
+/// chain id used for KMS gRPC requests.
+#[allow(dead_code)] // see `DEFAULT_DOMAIN_NAME` for rationale
+pub fn default_user_decrypt_domain(chain_id: u64, verifying_contract: Address) -> Eip712Domain {
+    Eip712Domain {
+        name: Some(DEFAULT_DOMAIN_NAME.into()),
+        version: Some(DEFAULT_DOMAIN_VERSION.into()),
+        chain_id: Some(U256::from(chain_id)),
+        verifying_contract: Some(verifying_contract),
+        salt: None,
+    }
+}
+
+/// Maps the runtime ABI payload onto the unified EIP-712 signing struct and computes the
+/// EIP-712 digest the user signed, against the supplied `domain`.
+pub fn compute_user_decrypt_digest(
+    payload: &UserDecryptionRequestPayload,
+    domain: &Eip712Domain,
+) -> B256 {
+    UserDecryptRequestVerification::from(payload).eip712_signing_hash(domain)
+}
+
+/// Try to recover the EOA signer address from a 65-byte signature. Returns `None` for any
+/// other length or unparsable signature so the caller can fall through to ERC-1271.
+fn try_ecrecover(digest: &B256, signature: &[u8]) -> Option<Address> {
+    if signature.len() != 65 {
+        return None;
+    }
+    let sig = Signature::from_raw(signature).ok()?;
+    sig.recover_address_from_prehash(digest).ok()
+}
+
+/// Gas-bounded static call to `IERC1271(addr).isValidSignature(digest, signature)`.
+///
+/// Returns `Ok(())` iff returndata length ≥ 32 and the leading bytes4 equals the canonical
+/// magic value `0x1626ba7e`. Otherwise:
+/// - empty returndata → `EmptySigOnEoa` / `EoaMismatchNoCode` (depending on whether the
+///   original signature was empty). At the EVM level, `STATICCALL` to a no-code address
+///   succeeds with empty returndata, so this is the dominant signal that `addr` is an EOA.
+///   A non-compliant fallback that returns empty bytes also lands here — same rejection
+///   outcome, slightly inaccurate error message; not worth a second RPC to disambiguate.
+/// - returndata length 1..32 → `Rejected` (non-compliant ABI return);
+/// - leading bytes don't match magic → `WrongMagic`;
+/// - `isValidSignature` call reverted → `Rejected`;
+/// - any other RPC-layer error → `Transport`.
+async fn check_erc1271_signature<P: Provider>(
+    provider: &P,
+    addr: Address,
+    digest: B256,
+    signature: &[u8],
+    gas_limit: u64,
+) -> Result<(), Erc1271Error> {
+    let call = isValidSignatureCall {
+        hash: digest,
+        signature: Bytes::copy_from_slice(signature),
+    };
+    let tx = TransactionRequest::default()
+        .to(addr)
+        .input(call.abi_encode().into())
+        .gas_limit(gas_limit);
+
+    let returndata = provider.call(tx).await.map_err(|err| match err {
+        RpcError::ErrorResp(e) => {
+            if let Some(revert_data) = e.as_revert_data() {
+                // A revert is interpreted as an invalid signature
+                Erc1271Error::Rejected(
+                    addr,
+                    format!("isValidSignature call reverted: {revert_data}"),
+                )
+            } else {
+                Erc1271Error::Transport(e.to_string())
+            }
+        }
+        _ => Erc1271Error::Transport(err.to_string()),
+    })?;
+
+    if returndata.is_empty() {
+        return Err(if signature.is_empty() {
+            Erc1271Error::EmptySigOnEoa(addr)
+        } else {
+            Erc1271Error::EoaMismatchNoCode(addr)
+        });
+    }
+
+    // Solidity ABI-encodes `bytes4` as a full 32-byte word, left-aligned with zero padding.
+    // A non-compliant fallback function (or a proxy without `isValidSignature`) may return
+    // fewer bytes — RFC-012 and OpenZeppelin's `SignatureChecker` require us to reject those
+    // before pattern-matching the leading bytes.
+    if returndata.len() < 32 {
+        return Err(Erc1271Error::Rejected(
+            addr,
+            format!("returndata length {} < 32", returndata.len()),
+        ));
+    }
+
+    let magic = FixedBytes::<4>::from_slice(&returndata[..4]);
+    if magic.0 == ERC1271_MAGIC_VALUE {
+        Ok(())
+    } else {
+        Err(Erc1271Error::WrongMagic(addr, magic))
+    }
+}
+
+/// Verify the EIP-712 signature on a user-decryption request per RFC-012.
+///
+/// 1. If `signature` is non-empty: try `ecrecover`. If it recovers `claimed_signer`, accept.
+/// 2. Otherwise (empty signature, mismatch, or unparsable signature): static-call
+///    `IERC1271(claimed_signer).isValidSignature(digest, signature)` with a gas cap. Accept
+///    iff the call returns the canonical magic value `0x1626ba7e`. Empty returndata is
+///    interpreted as "no code at `claimed_signer`" — a single RPC handles both the
+///    smart-account path and the EOA-mismatch reject.
+pub async fn verify_signature<P: Provider>(
+    provider: &P,
+    claimed_signer: Address,
+    digest: B256,
+    signature: &[u8],
+    gas_limit: u64,
+) -> Result<(), Erc1271Error> {
+    if !signature.is_empty()
+        && let Some(recovered) = try_ecrecover(&digest, signature)
+        && recovered == claimed_signer
+    {
+        return Ok(());
+    }
+
+    check_erc1271_signature(provider, claimed_signer, digest, signature, gas_limit).await
+}
+
+impl From<&UserDecryptionRequestPayload> for UserDecryptRequestVerification {
+    fn from(value: &UserDecryptionRequestPayload) -> Self {
+        UserDecryptRequestVerification {
+            userAddress: value.userAddress,
+            publicKey: value.publicKey.clone(),
+            allowedContracts: value.allowedContracts.clone(),
+            startTimestamp: value.requestValidity.startTimestamp,
+            durationSeconds: value.requestValidity.durationSeconds,
+            extraData: value.extraData.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        primitives::{Bytes, U256},
+        providers::{ProviderBuilder, mock::Asserter},
+        rpc::json_rpc::ErrorPayload,
+        signers::{SignerSync, local::PrivateKeySigner},
+    };
+    use fhevm_gateway_bindings::decryption::IDecryption::RequestValiditySeconds;
+    use serde_json::value::RawValue;
+    use std::borrow::Cow;
+
+    const TEST_CHAIN_ID: u64 = 12345;
+
+    fn dummy_payload(user_address: Address) -> UserDecryptionRequestPayload {
+        UserDecryptionRequestPayload {
+            userAddress: user_address,
+            publicKey: Bytes::from(vec![1, 2, 3, 4]),
+            allowedContracts: vec![Address::from([0xAB; 20])],
+            requestValidity: RequestValiditySeconds {
+                startTimestamp: U256::from(1_700_000_000_u64),
+                durationSeconds: U256::from(86_400_u64),
+            },
+            extraData: Bytes::from(vec![0x42]),
+            signature: Bytes::default(),
+        }
+    }
+
+    /// Build a (signer, request payload, digest, signature_bytes) tuple where the signature is
+    /// a valid 65-byte ECDSA signature over the EIP-712 digest.
+    fn signed_payload(
+        gateway_addr: Address,
+    ) -> (
+        PrivateKeySigner,
+        UserDecryptionRequestPayload,
+        B256,
+        Vec<u8>,
+    ) {
+        let signer = PrivateKeySigner::random();
+        let payload = dummy_payload(signer.address());
+        let domain = default_user_decrypt_domain(TEST_CHAIN_ID, gateway_addr);
+        let digest = compute_user_decrypt_digest(&payload, &domain);
+        let sig = signer.sign_hash_sync(&digest).unwrap();
+        let bytes = sig.as_bytes().to_vec();
+        assert_eq!(bytes.len(), 65, "ECDSA signature should be 65 bytes");
+        (signer, payload, digest, bytes)
+    }
+
+    fn mock_provider(asserter: Asserter) -> impl Provider {
+        ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_mocked_client(asserter)
+    }
+
+    #[tokio::test]
+    async fn eoa_valid_signature_zero_rpc() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let gateway = Address::from([0xCA; 20]);
+        let (signer, _, digest, sig) = signed_payload(gateway);
+
+        verify_signature(&provider, signer.address(), digest, &sig, 100_000)
+            .await
+            .unwrap();
+
+        // Asserter has no queued responses; if `verify_signature` had made any RPC, the mock
+        // would have returned an error. Reaching `Ok(())` proves the EOA fast path was used.
+    }
+
+    #[tokio::test]
+    async fn eoa_mismatch_no_code_rejects() {
+        // STATICCALL to a no-code address returns success with empty returndata at the EVM
+        // level — that's our "this address is an EOA" signal.
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        // 65 bytes of a "valid-looking but wrong" signature: ecrecover may recover a random
+        // address, which won't match the claimed signer. Any 65 bytes works.
+        let sig = vec![0x11_u8; 65];
+
+        asserter.push_success(&Bytes::default());
+
+        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::EoaMismatchNoCode(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_sig_on_eoa_rejects() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+
+        asserter.push_success(&Bytes::default());
+
+        let err = verify_signature(&provider, claimed, digest, &[], 100_000)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::EmptySigOnEoa(_)));
+    }
+
+    #[tokio::test]
+    async fn erc1271_valid_magic_accepts() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0x11_u8; 65];
+
+        // isValidSignature → magic value (32-byte left-aligned)
+        let mut returndata = [0u8; 32];
+        returndata[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
+        asserter.push_success(&returndata);
+
+        verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn erc1271_wrong_magic_rejects() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0x11_u8; 65];
+
+        // 32 bytes of zeros — wrong magic
+        asserter.push_success(&[0u8; 32]);
+
+        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::WrongMagic(..)));
+    }
+
+    /// Build a JSON-RPC error payload that mimics what an Ethereum node sends when the call
+    /// reverts: a message containing "revert" plus a `data` field whose string value parses
+    /// as hex bytes. This is the shape `ErrorPayload::as_revert_data` looks for.
+    fn revert_payload(revert_data_hex: &str) -> ErrorPayload {
+        let raw = RawValue::from_string(format!("\"{revert_data_hex}\"")).unwrap();
+        ErrorPayload::internal_error_with_message_and_obj(Cow::Borrowed("execution reverted"), raw)
+    }
+
+    #[tokio::test]
+    async fn erc1271_revert_rejects() {
+        // A node's revert response carries hex-encoded revert data in the `data` field; that
+        // pattern is what `as_revert_data` looks for. Treat it as a deterministic rejection.
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0x11_u8; 65];
+
+        asserter.push_failure(revert_payload("0xdeadbeef"));
+
+        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::Rejected(_, _)));
+    }
+
+    #[tokio::test]
+    async fn erc1271_non_revert_rpc_error_maps_to_transport() {
+        // A generic JSON-RPC error with no revert data (rate limit, node syncing, transport
+        // glitch, …) is recoverable — we can't tell whether it's a contract-level rejection.
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0x11_u8; 65];
+
+        asserter.push_failure_msg("rate limit exceeded");
+
+        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::Transport(_)));
+    }
+
+    #[tokio::test]
+    async fn erc1271_short_returndata_rejects() {
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0x11_u8; 65];
+
+        // Only 4 bytes returned — a non-compliant fallback function
+        asserter.push_success(&ERC1271_MAGIC_VALUE);
+
+        let err = verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Erc1271Error::Rejected(_, _)));
+    }
+
+    #[tokio::test]
+    async fn empty_sig_smart_account_accepts() {
+        // Safe `approveHash` flow: empty signature, contract returns magic
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+
+        let mut returndata = [0u8; 32];
+        returndata[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
+        asserter.push_success(&returndata);
+
+        verify_signature(&provider, claimed, digest, &[], 100_000)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn unparsable_signature_falls_through_to_erc1271() {
+        // A 1-byte "signature" cannot be ecrecovered — must fall through to ERC-1271.
+        let asserter = Asserter::new();
+        let provider = mock_provider(asserter.clone());
+        let claimed = Address::from([0xDE; 20]);
+        let digest = B256::from([0u8; 32]);
+        let sig = vec![0xFF_u8];
+
+        let mut returndata = [0u8; 32];
+        returndata[..4].copy_from_slice(&ERC1271_MAGIC_VALUE);
+        asserter.push_success(&returndata);
+
+        verify_signature(&provider, claimed, digest, &sig, 100_000)
+            .await
+            .unwrap();
+    }
+}

--- a/kms-connector/crates/kms-worker/tests/acl.rs
+++ b/kms-connector/crates/kms-worker/tests/acl.rs
@@ -12,7 +12,10 @@ use connector_utils::tests::{
         check_request_failed_in_db, insert_rand_request,
     },
     rand::{rand_digest, rand_sns_ct},
-    setup::{DbInstance, TestInstanceBuilder, init_host_chains_acl_contracts_mock},
+    setup::{
+        DbInstance, TestInstanceBuilder, erc1271_magic_response,
+        init_host_chains_acl_contracts_mock,
+    },
 };
 use kms_worker::core::Config;
 use mocktail::server::MockServer;
@@ -60,13 +63,20 @@ async fn test_decryption_acl_failure(#[case] event_type: TestEventType) -> anyho
     info!("Gateway mock started!");
 
     // Mocking Host chain ACL to DENY decryption.
-    // Per attempt: Public → 1 bool; Legacy user → 2 bools; V2 → 1 U256 (invalidation) + 1 bool.
+    // Per attempt: Public → 1 bool; Legacy user → 2 bools;
+    // V2 → 1 `isValidSignature` (RFC-012) + 1 U256 (invalidation) + 1 bool (ownership, denied).
     let acl_responses = match event_type {
         TestEventType::PublicDecryption => {
             vec![false.abi_encode(); MAX_DECRYPTION_ATTEMPTS as usize]
         }
         TestEventType::UserDecryptionV2 => (0..MAX_DECRYPTION_ATTEMPTS)
-            .flat_map(|_| vec![U256::ZERO.abi_encode(), false.abi_encode()])
+            .flat_map(|_| {
+                vec![
+                    erc1271_magic_response(),
+                    U256::ZERO.abi_encode(),
+                    false.abi_encode(),
+                ]
+            })
             .collect(),
         TestEventType::UserDecryption => {
             vec![false.abi_encode(); 2 * MAX_DECRYPTION_ATTEMPTS as usize]

--- a/kms-connector/crates/kms-worker/tests/attempt_limit.rs
+++ b/kms-connector/crates/kms-worker/tests/attempt_limit.rs
@@ -16,7 +16,7 @@ use connector_utils::{
         rand::{rand_digest, rand_sns_ct},
         setup::{
             DbInstance, S3_CT_DIGEST, S3_CT_HANDLE, S3Instance, TestInstanceBuilder,
-            init_host_chains_acl_contracts_mock,
+            erc1271_magic_response, init_host_chains_acl_contracts_mock,
         },
     },
     types::ProtocolEventKind,
@@ -84,13 +84,20 @@ async fn test_request_processing(#[case] event_type: TestEventType) -> anyhow::R
     info!("Gateway mock started!");
 
     // Mocking Host chain.
-    // Per attempt: Public → 1 bool; Legacy user → 2 bools; V2 → 1 U256 (invalidation) + 1 bool.
+    // Per attempt: Public → 1 bool; Legacy user → 2 bools;
+    // V2 → 1 `isValidSignature` (RFC-012) + 1 U256 (invalidation) + 1 bool (ownership).
     let acl_responses = match event_type {
         TestEventType::PublicDecryption => {
             vec![true.abi_encode(); MAX_DECRYPTION_ATTEMPTS as usize]
         }
         TestEventType::UserDecryptionV2 => (0..MAX_DECRYPTION_ATTEMPTS)
-            .flat_map(|_| vec![U256::ZERO.abi_encode(), true.abi_encode()])
+            .flat_map(|_| {
+                vec![
+                    erc1271_magic_response(),
+                    U256::ZERO.abi_encode(),
+                    true.abi_encode(),
+                ]
+            })
             .collect(),
         TestEventType::UserDecryption => {
             vec![true.abi_encode(); 2 * MAX_DECRYPTION_ATTEMPTS as usize]

--- a/kms-connector/crates/kms-worker/tests/context.rs
+++ b/kms-connector/crates/kms-worker/tests/context.rs
@@ -13,7 +13,8 @@ use connector_utils::tests::{
     },
     rand::{rand_digest, rand_sns_ct},
     setup::{
-        DbInstance, TESTING_KMS_CONTEXT, TestInstanceBuilder, init_host_chains_acl_contracts_mock,
+        DbInstance, TESTING_KMS_CONTEXT, TestInstanceBuilder, erc1271_magic_response,
+        init_host_chains_acl_contracts_mock,
     },
 };
 use kms_worker::core::Config;
@@ -64,13 +65,20 @@ async fn test_decryption_context_not_found(
     info!("Gateway mock started!");
 
     // Mocking Host chain ACL to ALLOW decryption.
-    // Per attempt: Public → 1 bool; Legacy user → 2 bools; V2 → 1 U256 (invalidation) + 1 bool.
+    // Per attempt: Public → 1 bool; Legacy user → 2 bools;
+    // V2 → 1 `isValidSignature` (RFC-012) + 1 U256 (invalidation) + 1 bool (ownership).
     let acl_responses = match event_type {
         TestEventType::PublicDecryption => {
             vec![true.abi_encode(); MAX_DECRYPTION_ATTEMPTS as usize]
         }
         TestEventType::UserDecryptionV2 => (0..MAX_DECRYPTION_ATTEMPTS)
-            .flat_map(|_| vec![U256::ZERO.abi_encode(), true.abi_encode()])
+            .flat_map(|_| {
+                vec![
+                    erc1271_magic_response(),
+                    U256::ZERO.abi_encode(),
+                    true.abi_encode(),
+                ]
+            })
             .collect(),
         TestEventType::UserDecryption => {
             vec![true.abi_encode(); 2 * MAX_DECRYPTION_ATTEMPTS as usize]
@@ -169,10 +177,15 @@ async fn test_decryption_context_invalid(#[case] event_type: TestEventType) -> a
     info!("Gateway mock started!");
 
     // Mocking Host chain ACL to ALLOW decryption (1 attempt only, irrecoverable error).
-    // Per attempt: Public → 1 bool; Legacy user → 2 bools; V2 → 1 U256 (invalidation) + 1 bool.
+    // Per attempt: Public → 1 bool; Legacy user → 2 bools;
+    // V2 → 1 `isValidSignature` (RFC-012) + 1 U256 (invalidation) + 1 bool (ownership).
     let acl_responses = match event_type {
         TestEventType::PublicDecryption => vec![true.abi_encode()],
-        TestEventType::UserDecryptionV2 => vec![U256::ZERO.abi_encode(), true.abi_encode()],
+        TestEventType::UserDecryptionV2 => vec![
+            erc1271_magic_response(),
+            U256::ZERO.abi_encode(),
+            true.abi_encode(),
+        ],
         TestEventType::UserDecryption => vec![true.abi_encode(); 2],
         _ => vec![],
     };

--- a/kms-connector/crates/kms-worker/tests/integration_tests.rs
+++ b/kms-connector/crates/kms-worker/tests/integration_tests.rs
@@ -16,7 +16,7 @@ use connector_utils::{
         rand::{rand_digest, rand_sns_ct},
         setup::{
             DbInstance, S3_CT_DIGEST, S3_CT_HANDLE, S3Instance, TestInstanceBuilder,
-            init_host_chains_acl_contracts_mock,
+            erc1271_magic_response, init_host_chains_acl_contracts_mock,
         },
     },
     types::{
@@ -95,11 +95,18 @@ async fn test_processing_request(
     // Mocking Host chain. ACL call counts per variant:
     //   - Public:            1 `isAllowedForDecryption`
     //   - Legacy user:       2 `isAllowed` (user + contract)
-    //   - RFC016 user (V2):  1 U256 (`decryptionSignatureInvalidatedBefore`) + 1 `isAllowed`
-    //                        (direct ownership path, empty `allowedContracts`)
+    //   - RFC016 user (V2):  1 `isValidSignature` (RFC-012, ERC-1271 fallback — random fixture
+    //                        signature can't ecrecover to userAddress so the call always fires)
+    //                        + 1 U256 (`decryptionSignatureInvalidatedBefore`) + 1 `isAllowed`
+    //                        (direct ownership path, empty `allowedContracts`). All three fire
+    //                        concurrently via `try_join!`, consumed FIFO in poll order.
     let acl_responses = match event_type {
         TestEventType::PublicDecryption => vec![true.abi_encode()],
-        TestEventType::UserDecryptionV2 => vec![U256::ZERO.abi_encode(), true.abi_encode()],
+        TestEventType::UserDecryptionV2 => vec![
+            erc1271_magic_response(),
+            U256::ZERO.abi_encode(),
+            true.abi_encode(),
+        ],
         TestEventType::UserDecryption => vec![true.abi_encode(); 2],
         _ => vec![],
     };

--- a/kms-connector/crates/kms-worker/tests/integration_tests.rs
+++ b/kms-connector/crates/kms-worker/tests/integration_tests.rs
@@ -99,7 +99,8 @@ async fn test_processing_request(
     //                        signature can't ecrecover to userAddress so the call always fires)
     //                        + 1 U256 (`decryptionSignatureInvalidatedBefore`) + 1 `isAllowed`
     //                        (direct ownership path, empty `allowedContracts`). All three fire
-    //                        concurrently via `try_join!`, consumed FIFO in poll order.
+    //                        concurrently via `try_join!`, consumed FIFO in poll order thanks
+    //                        to the `biased` annotation.
     let acl_responses = match event_type {
         TestEventType::PublicDecryption => vec![true.abi_encode()],
         TestEventType::UserDecryptionV2 => vec![

--- a/kms-connector/crates/utils/src/tests/setup/host.rs
+++ b/kms-connector/crates/utils/src/tests/setup/host.rs
@@ -7,6 +7,15 @@ use fhevm_host_bindings::acl::ACL::{self, ACLInstance};
 use std::collections::HashMap;
 use tracing::info;
 
+/// 32-byte ABI-encoded ERC-1271 magic value `0x1626ba7e` (`bytes4` left-aligned in a 32-byte
+/// word). Push as a host-chain mock response to make the RFC-012 `isValidSignature` check pass
+/// in `DecryptionProcessor::check_user_decryption_request_v2`.
+pub fn erc1271_magic_response() -> Vec<u8> {
+    let mut word = vec![0u8; 32];
+    word[..4].copy_from_slice(&[0x16, 0x26, 0xba, 0x7e]);
+    word
+}
+
 /// Inits a mock host chain ACL contracts map.
 ///
 /// Accepts ABI-encoded responses, allowing callers to mix responses with different types.


### PR DESCRIPTION
### Description

Implements RFC-012: moves user-decryption signature verification from `Decryption.sol` to the off-chain KMS Connector and adds an ERC-1271 fallback so smart accounts (Safe, Argent, ERC-4337) can sign without on-chain delegation.

**Flow**: EIP-712 digest → `ecrecover` fast path for EOAs → gas-bounded STATICCALL to `isValidSignature` on the host chain, accepting only the canonical `0x1626ba7e` magic value. Empty signatures bypass `ecrecover` to support Safe's `approveHash`. Configurable `erc1271_gas_limit` (default 100k).

### Skipping the `eth_getCode` pre-check

RFC-012's algorithm prescribes two RPCs in the smart-account branch — `eth_getCode` to detect EOAs, then `isValidSignature`. This PR takes the option proposed in the RFC's Open Question 1 ("Skip or cache `eth_getCode`?") and collapses it to a single RPC: STATICCALL to a no-code address succeeds with empty returndata, which is itself the no-code signal. We classify the result from the returndata alone (`EmptySigOnEoa` / `EoaMismatchNoCode` / `WrongMagic` / `Rejected`).

This way, we can have one RPC instead of two on the smart-account path; zero extra RPCs for EOAs.

Soundness: post-Dencun (EIP-6780) code can't be removed by later `SELFDESTRUCT`, so the only false-positive is a deployed contract with a fallback that returns empty bytes — same rejection outcome, only a slightly less precise error variant. Trade-off acknowledged inline.

Closes https://github.com/zama-ai/fhevm-internal/issues/1329