### PR TITLE
test(e2e): add js-sdk smoke profile

### DIFF
--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -57,6 +57,7 @@ jobs:
           - '.github/workflows/test-suite-docker-build.yml'
           - 'test-suite/e2e/**'
           - 'library-solidity/**'
+          - 'sdk/js-sdk/**'
 
   build:
     needs: [is-latest-commit, check-changes]

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=20.19.1-alpine3.21
+ARG NODE_VERSION=22.15.1-alpine3.21
 ARG RELAYER_SDK_VERSION=""
 
 # --- Builder Stage ---
@@ -24,6 +24,7 @@ RUN addgroup -g 10001 fhevm && \
 # Copy only dependency manifests first for better cache reuse
 COPY package.json package-lock.json ./
 COPY library-solidity/package.json ./library-solidity/package.json
+COPY sdk/js-sdk/package.json ./sdk/js-sdk/package.json
 COPY test-suite/e2e/package.json ./test-suite/e2e/
 
 # Install dependencies
@@ -35,7 +36,17 @@ RUN npm ci && \
 
 # Copy sources after deps are cached
 COPY library-solidity ./library-solidity
+COPY sdk/js-sdk ./sdk/js-sdk
 COPY test-suite/e2e ./test-suite/e2e
+
+RUN npm run --workspace @fhevm/sdk build:cjs && \
+    npm run --workspace @fhevm/sdk build:esm && \
+    npm run --workspace @fhevm/sdk build:types && \
+    cd /app/sdk/js-sdk/src && \
+    npm pack --pack-destination /tmp && \
+    rm -rf /app/node_modules/@fhevm/sdk && \
+    mkdir -p /app/node_modules/@fhevm/sdk && \
+    tar -xzf /tmp/fhevm-sdk-*.tgz -C /app/node_modules/@fhevm/sdk --strip-components=1
 
 WORKDIR /app/test-suite/e2e
 

--- a/test-suite/e2e/test/instance.ts
+++ b/test-suite/e2e/test/instance.ts
@@ -34,25 +34,34 @@ const coprocessorAddress = requireEnv(
   'FHEVM_EXECUTOR_CONTRACT_ADDRESS',
 );
 
-const inputAdd = process.env.INPUT_VERIFIER_CONTRACT_ADDRESS || defaults?.inputVerifierContractAddress;
-if (!inputAdd) throw new Error('INPUT_VERIFIER_CONTRACT_ADDRESS is required');
+const inputAdd = requireEnv(
+  process.env.INPUT_VERIFIER_CONTRACT_ADDRESS || defaults?.inputVerifierContractAddress,
+  'INPUT_VERIFIER_CONTRACT_ADDRESS',
+);
 
-const gatewayChainID = Number(process.env.CHAIN_ID_GATEWAY) || defaults?.gatewayChainId;
-if (!gatewayChainID) throw new Error('CHAIN_ID_GATEWAY is required');
+const gatewayChainID = (() => {
+  const value = Number(process.env.CHAIN_ID_GATEWAY) || defaults?.gatewayChainId;
+  if (!value) throw new Error('CHAIN_ID_GATEWAY is required');
+  return value;
+})();
 
-const hostChainID = Number(process.env.CHAIN_ID_HOST) || defaults?.chainId;
-if (!hostChainID) throw new Error('CHAIN_ID_HOST is required');
+const hostChainID = (() => {
+  const value = Number(process.env.CHAIN_ID_HOST) || defaults?.chainId;
+  if (!value) throw new Error('CHAIN_ID_HOST is required');
+  return value;
+})();
 
-const verifyingContractAddressDecryption =
-  process.env.DECRYPTION_ADDRESS || defaults?.verifyingContractAddressDecryption;
-if (!verifyingContractAddressDecryption) throw new Error('DECRYPTION_ADDRESS is required');
+const verifyingContractAddressDecryption = requireEnv(
+  process.env.DECRYPTION_ADDRESS || defaults?.verifyingContractAddressDecryption,
+  'DECRYPTION_ADDRESS',
+);
 
-const verifyingContractAddressInputVerification =
-  process.env.INPUT_VERIFICATION_ADDRESS || defaults?.verifyingContractAddressInputVerification;
-if (!verifyingContractAddressInputVerification) throw new Error('INPUT_VERIFICATION_ADDRESS is required');
+const verifyingContractAddressInputVerification = requireEnv(
+  process.env.INPUT_VERIFICATION_ADDRESS || defaults?.verifyingContractAddressInputVerification,
+  'INPUT_VERIFICATION_ADDRESS',
+);
 
-const relayerUrl = process.env.RELAYER_URL || defaults?.relayerUrl;
-if (!relayerUrl) throw new Error('RELAYER_URL is required');
+const relayerUrl = requireEnv(process.env.RELAYER_URL || defaults?.relayerUrl, 'RELAYER_URL');
 
 // API key is a secret - support hardhat vars for secure storage
 // Auth is optional since internal smoke tests don't go through Kong
@@ -85,4 +94,15 @@ export const createInstance = async () => {
 };
 
 // Export coprocessor config addresses for smoke tests
-export { aclAddress, coprocessorAddress, kmsVerifierAddress };
+export {
+  aclAddress,
+  apiKey,
+  coprocessorAddress,
+  gatewayChainID,
+  hostChainID,
+  inputAdd as inputVerifierAddress,
+  kmsVerifierAddress,
+  relayerUrl,
+  verifyingContractAddressDecryption,
+  verifyingContractAddressInputVerification,
+};

--- a/test-suite/e2e/test/jsSdk/inputFlow.ts
+++ b/test-suite/e2e/test/jsSdk/inputFlow.ts
@@ -1,0 +1,109 @@
+import { createTypedValue } from '@fhevm/sdk/base';
+import { defineFhevmChain } from '@fhevm/sdk/chains';
+import { createFhevmDecryptClient, createFhevmEncryptClient, setFhevmRuntimeConfig } from '@fhevm/sdk/ethers';
+import type { EncryptedValue } from '@fhevm/sdk/types';
+import { expect } from 'chai';
+import { JsonRpcProvider } from 'ethers';
+import { ethers } from 'hardhat';
+import { network } from 'hardhat';
+
+import {
+  aclAddress,
+  apiKey,
+  gatewayChainID,
+  hostChainID,
+  inputVerifierAddress,
+  kmsVerifierAddress,
+  relayerUrl,
+  verifyingContractAddressDecryption,
+  verifyingContractAddressInputVerification,
+} from '../instance';
+import { getSigners, initSigners } from '../signers';
+
+const requireRpcUrl = (): string => {
+  const url = (network.config as { url?: string }).url;
+  if (!url) throw new Error(`network ${network.name} does not expose an RPC URL`);
+  return url;
+};
+
+const e2eFhevmChain = defineFhevmChain({
+  id: hostChainID,
+  fhevm: {
+    contracts: {
+      acl: { address: aclAddress as `0x${string}` },
+      inputVerifier: { address: inputVerifierAddress as `0x${string}` },
+      kmsVerifier: { address: kmsVerifierAddress as `0x${string}` },
+    },
+    relayerUrl,
+    gateway: {
+      id: gatewayChainID,
+      contracts: {
+        decryption: { address: verifyingContractAddressDecryption as `0x${string}` },
+        inputVerification: { address: verifyingContractAddressInputVerification as `0x${string}` },
+      },
+    },
+  },
+});
+
+describe('js-sdk e2e', function () {
+  before(async function () {
+    await initSigners(1);
+    this.signers = await getSigners();
+
+    const contractFactory = await ethers.getContractFactory('TestInput');
+    this.contract = await contractFactory.connect(this.signers.alice).deploy();
+    await this.contract.waitForDeployment();
+    this.contractAddress = await this.contract.getAddress();
+
+    setFhevmRuntimeConfig(apiKey ? { auth: { type: 'ApiKeyHeader', value: apiKey } } : {});
+  });
+
+  it('js-sdk encrypts uint64 input and decrypts computed result', async function () {
+    const sdkProvider = new JsonRpcProvider(requireRpcUrl());
+    const encryptClient = createFhevmEncryptClient({
+      chain: e2eFhevmChain,
+      provider: sdkProvider,
+    });
+    await encryptClient.ready;
+
+    const encryptedInput = await encryptClient.encryptValue({
+      contractAddress: this.contractAddress,
+      userAddress: this.signers.alice.address,
+      value: createTypedValue({ type: 'uint64', value: 7n }),
+    });
+
+    const tx = await this.contract.add42ToInput64(encryptedInput.encryptedValue, encryptedInput.inputProof);
+    const receipt = await tx.wait();
+    expect(receipt?.status).to.equal(1);
+
+    const handle = (await this.contract.resUint64()) as EncryptedValue;
+    const decryptClient = createFhevmDecryptClient({
+      chain: e2eFhevmChain,
+      provider: sdkProvider,
+    });
+    await decryptClient.ready;
+
+    const transportKeypair = await decryptClient.generateTransportKeypair();
+    const signedPermit = await decryptClient.signDecryptionPermit({
+      transportKeypair,
+      contractAddresses: [this.contractAddress],
+      durationDays: 1,
+      startTimestamp: Math.floor(Date.now() / 1000),
+      signerAddress: this.signers.alice.address,
+      signer: this.signers.alice,
+    });
+
+    const decryptedValue = await decryptClient.decryptValue({
+      encryptedValue: handle,
+      contractAddress: this.contractAddress,
+      signedPermit,
+      transportKeypair,
+    });
+    expect(decryptedValue.type).to.equal('uint64');
+    expect(decryptedValue.value).to.equal(49n);
+
+    const publicValue = await decryptClient.readPublicValue({ encryptedValue: handle });
+    expect(publicValue.type).to.equal('uint64');
+    expect(publicValue.value).to.equal(49n);
+  });
+});

--- a/test-suite/fhevm/src/cli.test.ts
+++ b/test-suite/fhevm/src/cli.test.ts
@@ -115,11 +115,13 @@ describe("cli", () => {
     const result = await execCli(["test", "list"]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("standard");
+    expect(result.stdout).toContain("js-sdk - standard");
     expect(result.stdout).toContain("multi-chain-isolation");
     expect(result.stdout).toContain("ciphertext-drift - standard, 2+ coprocessors");
   });
 
-  test("standard suite includes multi-chain isolation coverage", () => {
+  test("standard suite includes client and multi-chain coverage", () => {
+    expect(STANDARD_TEST_PROFILES).toContain("js-sdk");
     expect(STANDARD_TEST_PROFILES).toContain("multi-chain-isolation");
   });
 

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -61,6 +61,7 @@ const TEST_PROFILE_DESCRIPTIONS: Partial<Record<(typeof TEST_PROFILE_NAMES)[numb
   "paused-gateway-contracts": "Run pause-mode checks with gateway contracts paused.",
   "input-proof": "Run basic user input proof coverage.",
   "input-proof-compute-decrypt": "Run compute-and-decrypt input proof coverage.",
+  "js-sdk": "Run SDK package client coverage against the e2e stack.",
   "user-decryption": "Run user decryption coverage.",
   "delegated-user-decryption": "Run delegated user decryption coverage.",
   "public-decryption": "Run async public decryption coverage.",

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -247,6 +247,7 @@ export const TEST_GREP: Record<string, string> = {
     "test paused gateway user input|test paused gateway HTTP public decrypt",
   "input-proof": "test user input uint64",
   "input-proof-compute-decrypt": "test add 42 to uint64 input and decrypt",
+  "js-sdk": "js-sdk encrypts uint64 input and decrypts computed result",
   "user-decryption": "test user decrypt",
   "delegated-user-decryption": "test delegated user decrypt",
   "public-decryption":
@@ -278,6 +279,7 @@ export const STANDARD_TEST_PROFILES = [
   "coprocessor-db-state-revert",
   "input-proof",
   "input-proof-compute-decrypt",
+  "js-sdk",
   "user-decryption",
   "delegated-user-decryption",
   "erc20",


### PR DESCRIPTION
Adds a focused `js-sdk` e2e profile that encrypts a `uint64` input with the packed `@fhevm/sdk`, submits it to the existing `TestInput` contract, then verifies private and public decrypt return `49`.

The profile is included in `standard` so CI exercises SDK client compatibility while still allowing targeted runs with `fhevm-cli test js-sdk`.

The e2e Docker image now uses Node 22, builds the local SDK package, packs `sdk/js-sdk/src`, and extracts that package into `node_modules` so the test covers package exports rather than Vitest source aliases.
