### PR TITLE
feat(coprocessor): add upgrade orchestrator service for blue-green upgrades

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -2409,6 +2409,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "coproc-mngr"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "chrono",
+ "clap",
+ "fhevm-engine-common",
+ "hex",
+ "humantime",
+ "prometheus",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha3",
+ "sqlx",
+ "strum 0.26.3",
+ "test-harness",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6610,7 +6637,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.31",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "sns-worker",
     "transaction-sender",
     "zkproof-worker",
+    "coproc-mngr",
     "test-harness",
     "stress-test-generator",
 ]

--- a/coprocessor/fhevm-engine/coproc-mngr/Cargo.toml
+++ b/coprocessor/fhevm-engine/coproc-mngr/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "coproc-mngr"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "coproc-mngr"
+path = "src/bin/coproc_mngr.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+hex = { workspace = true }
+humantime = { workspace = true }
+prometheus = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha3 = { workspace = true }
+sqlx = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+fhevm-engine-common = { path = "../fhevm-engine-common" }
+
+[dev-dependencies]
+serial_test = { workspace = true }
+test-harness = { path = "../test-harness" }

--- a/coprocessor/fhevm-engine/coproc-mngr/README.md
+++ b/coprocessor/fhevm-engine/coproc-mngr/README.md
@@ -1,0 +1,97 @@
+# coproc-mngr
+
+Upgrade orchestrator for the FHEVM coprocessor stack. Implements the FSM and
+signaling described in [RFC-021-blue-green-upgrad] 
+§ `coproc-mngr`.
+
+What works today:
+
+- LISTENs on the `event_upgrade` channel; falls back to polling
+  `upgrade_events` on a configurable interval.
+- Drives the GCS FSM `OFFLINE -> SNAPSHOTTING -> REPLAYING -> READY -> SIGNALING`
+  on `proposedUpgrade`.
+- Drives the BCS FSM `LIVE -> DRAINING -> STOPPED` and the GCS FSM
+  `SIGNALING -> CUTTING_OVER -> LIVE` on `CoprocUpgraded`.
+- Inserts a row into `signal_ready_pending` carrying the (placeholder)
+  `stateCommitment`. The future tx-sender SignalReady op will drain it.
+- Per-stage `pg_notify` on
+  `event_coproc_mngr_{snapshot_start,replay_start,dry_run_on,dry_run_off,signal_ready,bcs_drain,gcs_promote}`.
+- DB-persisted FSM in `service_state` with restart-safe transitions.
+
+Explicitly **out of scope** for v1:
+
+- Real `stateCommitment` derivation (fixed zero-hash placeholder).
+- Submitting `signalReady` on-chain (handed off via `signal_ready_pending`,
+  but no consumer yet).
+- Any handling in other services. They will read `pg_notify` channels in
+  follow-up iterations.
+
+`pg_dump | pg_restore` against the snapshot table set is implemented and runs during the `OFFLINE -> SNAPSHOTTING` transition. The BCS DB pool is opened only for the readiness check that precedes it, and is dropped immediately after. `pg_dump` and `pg_restore` are spawned as child processes via `tokio::process::Command` and pipe-linked at the OS level (no in-memory buffering); both are spawned with `kill_on_drop(true)` so a cancelled coproc-mngr does not leak them.
+
+## Tables introduced
+
+See migration `20260430120000_create_coproc_mngr_tables.sql`:
+
+- `service_state` - per-stack FSM. Bootstrapped with `BCS=LIVE`, `GCS=OFFLINE`.
+- `upgrade_events` - ingress queue. The future gw-listener routing path
+  inserts `proposedUpgrade` / `CoprocUpgraded` rows here. Trigger fires
+  `NOTIFY event_upgrade`.
+- `signal_ready_pending` - coproc-mngr -> tx-sender handoff.
+
+## Testing manually
+
+Until gw-listener writes to `upgrade_events` automatically, you can drive
+the FSM by inserting rows yourself:
+
+```sql
+INSERT INTO upgrade_events
+    (kind, proposal_id, version, snapshot_block, eval_block, block_number, transaction_hash)
+VALUES
+    ('proposedUpgrade',
+     decode('aabb...','hex'),
+     'v0.8.0',
+     100, 105,
+     12345, decode('cc...','hex'));
+```
+
+The trigger fires `NOTIFY event_upgrade`; coproc-mngr picks it up and runs
+the full GCS lifecycle, ending in SIGNALING.
+
+To trigger cutover:
+
+```sql
+INSERT INTO upgrade_events
+    (kind, proposal_id, state_commitment, block_number, transaction_hash)
+VALUES
+    ('CoprocUpgraded',
+     decode('aabb...','hex'),
+     decode('0000000000000000000000000000000000000000000000000000000000000000','hex'),
+     12350, decode('dd...','hex'));
+```
+
+The same coproc-mngr instance handles both BCS-drain and GCS-promotion paths
+based on which `service_state` rows look non-trivial.
+
+## CLI
+
+```
+coproc-mngr \
+    --database-url postgres://.../greencs \
+    --bcs-database-url postgres://.../bluecs   \ 
+    --upgrade-event-channel event_upgrade      \
+    --poll-interval 10s                        \
+    --readiness-timeout 30m                    \
+    --readiness-poll-interval 5s               \
+    --health-check-port 8080                   \
+    --metrics-addr 0.0.0.0:9100
+```
+
+## Metrics
+
+Exposed on the `--metrics-addr` HTTP server (Prometheus text format):
+
+- `coproc_mngr_inbound_event_total` - events dispatched.
+- `coproc_mngr_inbound_notification_total` - NOTIFYs received.
+- `coproc_mngr_inbound_poll_total` - polling-fallback ticks.
+- `coproc_mngr_event_success_total{stage}` - successful handler stages.
+- `coproc_mngr_event_fail_total{reason}` - handler failures.

--- a/coprocessor/fhevm-engine/coproc-mngr/src/bin/coproc_mngr.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/bin/coproc_mngr.rs
@@ -1,0 +1,116 @@
+use std::time::Duration;
+
+use clap::Parser;
+use coproc_mngr::{run, ConfigSettings};
+use fhevm_engine_common::utils::DatabaseURL;
+use humantime::parse_duration;
+use tokio::signal::unix::{signal, SignalKind};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, Level};
+
+#[derive(Parser, Debug, Clone)]
+#[command(version, about = "FHEVM coprocessor upgrade orchestrator")]
+struct Conf {
+    /// GCS Postgres URL.
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: DatabaseURL,
+
+    #[arg(long, default_value_t = 8)]
+    database_pool_size: u32,
+
+    /// BCS Postgres URL. Currently only logged; reserved for the
+    /// SNAPSHOTTING phase in a later iteration.
+    #[arg(long, env = "BCS_DATABASE_URL")]
+    bcs_database_url: Option<DatabaseURL>,
+
+    /// Inbound NOTIFY channel coproc-mngr LISTENs on. Must match the
+    /// trigger fired by `upgrade_events_notify_trigger` (default
+    /// `event_upgrade`).
+    #[arg(long, default_value = "event_upgrade")]
+    upgrade_event_channel: String,
+
+    /// Polling fallback interval if no NOTIFY arrives.
+    #[arg(long, default_value = "10s", value_parser = parse_duration)]
+    poll_interval: Duration,
+
+    /// How long to wait for "fully settled" before giving up on a proposal.
+    #[arg(long, default_value = "30m", value_parser = parse_duration)]
+    readiness_timeout: Duration,
+
+    /// Backoff between readiness checks.
+    #[arg(long, default_value = "5s", value_parser = parse_duration)]
+    readiness_poll_interval: Duration,
+
+    #[arg(long, default_value_t = 8080)]
+    health_check_port: u16,
+
+    #[arg(long, default_value = "0.0.0.0:9100")]
+    metrics_addr: Option<String>,
+
+    #[arg(long, value_parser = clap::value_parser!(Level), default_value_t = Level::INFO)]
+    log_level: Level,
+
+    /// OTel service name.
+    #[arg(long, env = "OTEL_SERVICE_NAME", default_value = "coproc-mngr")]
+    service_name: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Conf::parse();
+    init_tracing(args.log_level);
+
+    let cancel = CancellationToken::new();
+    spawn_signal_handler(cancel.clone());
+
+    let conf = ConfigSettings {
+        database_url: args.database_url,
+        database_pool_size: args.database_pool_size,
+        bcs_database_url: args.bcs_database_url,
+        upgrade_event_channel: args.upgrade_event_channel,
+        poll_interval: args.poll_interval,
+        readiness_timeout: args.readiness_timeout,
+        readiness_poll_interval: args.readiness_poll_interval,
+        health_check_port: args.health_check_port,
+        metrics_addr: args.metrics_addr,
+    };
+
+    info!(service = %args.service_name, "coproc-mngr starting up");
+
+    if let Err(err) = run(conf, cancel).await {
+        error!(error = %err, "coproc-mngr exited with error");
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn init_tracing(level: Level) {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(level)
+        .with_target(true)
+        .try_init();
+}
+
+fn spawn_signal_handler(cancel: CancellationToken) {
+    tokio::spawn(async move {
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                error!(error = %e, "failed to install SIGTERM handler");
+                return;
+            }
+        };
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                error!(error = %e, "failed to install SIGINT handler");
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigterm.recv() => info!("SIGTERM"),
+            _ = sigint.recv()  => info!("SIGINT"),
+        }
+        cancel.cancel();
+    });
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/commitment.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/commitment.rs
@@ -1,0 +1,112 @@
+//! `stateCommitment` derivation.
+//!
+//! For the upgrade round to succeed, every operator must compute the same
+//! commitment over the work GCS replayed in `(snapshotBlock, evalBlock]`.
+//! That commitment is the keccak256 of every output handle that finished
+//! computing in that range, concatenated with the originating block hash,
+//! sorted deterministically.
+//!
+//! Sort order is `(block_hash, output_handle)`. Both fields are byte arrays;
+//! Postgres' `bytea` ordering is lexicographic, which is what we want.
+//!
+//! Schema dependencies (already present, no migration needed):
+//! - `computations.output_handle`, `computations.block_number`,
+//!   `computations.host_chain_id`, `computations.is_completed`
+//! - `host_chain_blocks_valid.(chain_id, block_number, block_hash)`
+
+use anyhow::{Context, Result};
+use sha3::{Digest, Keccak256};
+use sqlx::{PgPool, Row};
+use tracing::info;
+
+/// Compute keccak256 over `(block_hash || output_handle)` for every
+/// completed compute output produced in `(snapshot_block, eval_block]`,
+/// sorted by `(block_hash, output_handle)`.
+///
+/// Returns the 32-byte digest. An empty range (no rows) returns
+/// `keccak256(<empty>) = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
+pub async fn compute_state_commitment(
+    pool: &PgPool,
+    snapshot_block: i64,
+    eval_block: i64,
+) -> Result<[u8; 32]> {
+    let rows = sqlx::query(
+        r#"
+        SELECT c.output_handle, h.block_hash
+        FROM   computations c
+        JOIN   host_chain_blocks_valid h
+          ON   h.chain_id     = c.host_chain_id
+         AND   h.block_number = c.block_number
+        WHERE  c.block_number >  $1
+          AND  c.block_number <= $2
+          AND  c.is_completed  = TRUE
+        ORDER  BY h.block_hash, c.output_handle
+        "#,
+    )
+    .bind(snapshot_block)
+    .bind(eval_block)
+    .fetch_all(pool)
+    .await
+    .context("compute_state_commitment: SELECT computations JOIN host_chain_blocks_valid")?;
+
+    let mut hasher = Keccak256::new();
+    let mut count: usize = 0;
+    for row in &rows {
+        let block_hash: Vec<u8> = row.try_get("block_hash")?;
+        let output_handle: Vec<u8> = row.try_get("output_handle")?;
+        hasher.update(&block_hash);
+        hasher.update(&output_handle);
+        count += 1;
+    }
+    let digest: [u8; 32] = hasher.finalize().into();
+
+    info!(
+        snapshot_block,
+        eval_block,
+        handle_count = count,
+        commitment = %hex::encode(digest),
+        "Computed stateCommitment"
+    );
+    Ok(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use sha3::{Digest, Keccak256};
+
+    /// keccak256 of an empty byte string. Sanity check that our hasher
+    /// produces the canonical value the docstring references.
+    #[test]
+    fn empty_keccak256() {
+        let digest: [u8; 32] = Keccak256::new().finalize().into();
+        assert_eq!(
+            hex::encode(digest),
+            "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+        );
+    }
+
+    /// Order matters: swapping two rows produces a different commitment.
+    #[test]
+    fn order_sensitive() {
+        let a = [0x11_u8; 32];
+        let b = [0x22_u8; 32];
+        let h1 = [0xaa_u8; 32];
+        let h2 = [0xbb_u8; 32];
+
+        let mut k1 = Keccak256::new();
+        k1.update(a);
+        k1.update(h1);
+        k1.update(b);
+        k1.update(h2);
+
+        let mut k2 = Keccak256::new();
+        k2.update(b);
+        k2.update(h2);
+        k2.update(a);
+        k2.update(h1);
+
+        let d1: [u8; 32] = k1.finalize().into();
+        let d2: [u8; 32] = k2.finalize().into();
+        assert_ne!(d1, d2);
+    }
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/config.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/config.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use fhevm_engine_common::utils::DatabaseURL;
+
+#[derive(Clone, Debug)]
+pub struct ConfigSettings {
+    /// GCS Postgres URL. coproc-mngr is hosted on the GCS instance.
+    pub database_url: DatabaseURL,
+
+    /// Pool size for the GCS DB connection.
+    pub database_pool_size: u32,
+
+    /// BCS Postgres URL. Currently only logged - opened in a future iteration
+    /// during the SNAPSHOTTING phase to run `pg_dump` and dropped immediately
+    /// after.
+    pub bcs_database_url: Option<DatabaseURL>,
+
+    /// Inbound Postgres NOTIFY channel that the (future) gw-listener fires
+    /// after inserting into `upgrade_events`.
+    pub upgrade_event_channel: String,
+
+    /// Polling fallback for the inbound listener. If the LISTEN connection
+    /// drops or no NOTIFYs arrive, the loop scans `upgrade_events` for
+    /// unhandled rows on this interval.
+    pub poll_interval: Duration,
+
+    /// How long the readiness predicate (BCS settled at snapshotBlock) is
+    /// retried before giving up and marking the proposal failed.
+    pub readiness_timeout: Duration,
+
+    /// Backoff between readiness checks while waiting for BCS to settle.
+    pub readiness_poll_interval: Duration,
+
+    /// Health-check HTTP port.
+    pub health_check_port: u16,
+
+    /// Prometheus metrics bind address. None disables the metrics server.
+    pub metrics_addr: Option<String>,
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/handlers/coproc_upgraded.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/handlers/coproc_upgraded.rs
@@ -1,0 +1,167 @@
+//! Handler: `CoprocUpgraded` event -> drive both BCS and GCS through cutover.
+//!
+//! This handler runs against either DB. On the BCS DB it transitions
+//! `LIVE -> DRAINING -> STOPPED`. On the GCS DB it transitions
+//! `SIGNALING -> CUTTING_OVER -> LIVE`. We pick the side by reading the
+//! `service_state` row that's already in a non-trivial state.
+
+use anyhow::{anyhow, Context, Result};
+use sqlx::PgPool;
+use tracing::{info, warn};
+
+use crate::config::ConfigSettings;
+use crate::handlers::UpgradeEvent;
+use crate::metrics::UPGRADE_EVENT_SUCCESS_COUNTER;
+use crate::notify;
+use crate::state::{read_state, transition, BcsState, FsmState, GcsState, StackRole};
+
+pub async fn handle(pool: &PgPool, _conf: &ConfigSettings, ev: &UpgradeEvent) -> Result<()> {
+    let bcs = read_state(pool, StackRole::BCS).await?;
+    let gcs = read_state(pool, StackRole::GCS).await?;
+    info!(
+        bcs = bcs.state.as_str(),
+        gcs = gcs.state.as_str(),
+        "CoprocUpgraded received"
+    );
+
+    match (bcs.state, gcs.state) {
+        // GCS side: we were the SIGNALING party; promote to LIVE.
+        (_, FsmState::Gcs(GcsState::SIGNALING)) => promote_gcs(pool, ev).await,
+        // BCS side: we were LIVE; drain.
+        (FsmState::Bcs(BcsState::LIVE), FsmState::Gcs(GcsState::OFFLINE)) => {
+            drain_bcs(pool, ev).await
+        }
+        // Idempotent: already done. Log and move on.
+        (FsmState::Bcs(BcsState::STOPPED), _) | (_, FsmState::Gcs(GcsState::LIVE)) => {
+            warn!(
+                bcs = bcs.state.as_str(),
+                gcs = gcs.state.as_str(),
+                "CoprocUpgraded already applied, idempotent skip"
+            );
+            Ok(())
+        }
+        _ => Err(anyhow!(
+            "CoprocUpgraded received in unexpected state combo: bcs={}, gcs={}",
+            bcs.state.as_str(),
+            gcs.state.as_str()
+        )),
+    }
+}
+
+async fn drain_bcs(pool: &PgPool, ev: &UpgradeEvent) -> Result<()> {
+    // BCS LIVE -> DRAINING. In v1 this is a transition + notify only;
+    // BCS workers don't yet listen on `event_coproc_mngr_bcs_drain`, so
+    // they continue running. Real drain semantics land in a later
+    // iteration.
+    transition_with_notify(
+        pool,
+        StackRole::BCS,
+        FsmState::Bcs(BcsState::LIVE),
+        FsmState::Bcs(BcsState::DRAINING),
+        ev,
+        Some(notify::CHAN_BCS_DRAIN),
+    )
+    .await?;
+    info!("PLACEHOLDER: would wait for BCS in-flight queues to drain");
+
+    // BCS DRAINING -> STOPPED.
+    transition_with_notify(
+        pool,
+        StackRole::BCS,
+        FsmState::Bcs(BcsState::DRAINING),
+        FsmState::Bcs(BcsState::STOPPED),
+        ev,
+        None,
+    )
+    .await?;
+
+    UPGRADE_EVENT_SUCCESS_COUNTER
+        .with_label_values(&["CoprocUpgraded.bcs_drain"])
+        .inc();
+    Ok(())
+}
+
+async fn promote_gcs(pool: &PgPool, ev: &UpgradeEvent) -> Result<()> {
+    // GCS SIGNALING -> CUTTING_OVER (notify gcs_promote so future tx-sender
+    // flips dry-run flags).
+    transition_with_notify(
+        pool,
+        StackRole::GCS,
+        FsmState::Gcs(GcsState::SIGNALING),
+        FsmState::Gcs(GcsState::CUTTING_OVER),
+        ev,
+        Some(notify::CHAN_GCS_PROMOTE),
+    )
+    .await?;
+    info!("PLACEHOLDER: would catch up GCS from evalBlock to head + flip dry-run off");
+    notify_only(pool, notify::CHAN_DRY_RUN_OFF, ev).await?;
+
+    // GCS CUTTING_OVER -> LIVE.
+    transition_with_notify(
+        pool,
+        StackRole::GCS,
+        FsmState::Gcs(GcsState::CUTTING_OVER),
+        FsmState::Gcs(GcsState::LIVE),
+        ev,
+        None,
+    )
+    .await?;
+
+    UPGRADE_EVENT_SUCCESS_COUNTER
+        .with_label_values(&["CoprocUpgraded.gcs_promote"])
+        .inc();
+    Ok(())
+}
+
+async fn transition_with_notify(
+    pool: &PgPool,
+    role: StackRole,
+    from: FsmState,
+    to: FsmState,
+    ev: &UpgradeEvent,
+    channel: Option<&str>,
+) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    transition(
+        &mut tx,
+        role,
+        from,
+        to,
+        Some(&ev.proposal_id),
+        ev.version.as_deref(),
+        ev.snapshot_block,
+        ev.eval_block,
+        ev.state_commitment.as_deref(),
+    )
+    .await
+    .with_context(|| format!("transition {} -> {}", from.as_str(), to.as_str()))?;
+    if let Some(chan) = channel {
+        let payload = serde_json::json!({
+            "proposal_id": hex::encode(&ev.proposal_id),
+            "to": to.as_str(),
+        })
+        .to_string();
+        notify::pg_notify(&mut tx, chan, &payload).await?;
+    }
+    tx.commit().await?;
+    info!(
+        proposal_id = %hex::encode(&ev.proposal_id),
+        role = role.as_ref(),
+        from = from.as_str(),
+        to = to.as_str(),
+        notify_channel = channel.unwrap_or("(none)"),
+        "FSM transition committed"
+    );
+    Ok(())
+}
+
+async fn notify_only(pool: &PgPool, channel: &str, ev: &UpgradeEvent) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    let payload = serde_json::json!({
+        "proposal_id": hex::encode(&ev.proposal_id),
+    })
+    .to_string();
+    notify::pg_notify(&mut tx, channel, &payload).await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/handlers/mod.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/handlers/mod.rs
@@ -1,0 +1,95 @@
+pub mod coproc_upgraded;
+pub mod proposed_upgrade;
+
+use anyhow::Result;
+use sqlx::{PgPool, Row};
+use tracing::{info, warn};
+
+use crate::config::ConfigSettings;
+
+/// One row in `upgrade_events` that the dispatcher saw via NOTIFY or polling.
+#[derive(Clone, Debug)]
+pub struct UpgradeEvent {
+    pub id: i64,
+    pub kind: EventKind,
+    pub proposal_id: Vec<u8>,
+    pub version: Option<String>,
+    pub snapshot_block: Option<i64>,
+    pub eval_block: Option<i64>,
+    pub state_commitment: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EventKind {
+    ProposedUpgrade,
+    CoprocUpgraded,
+}
+
+impl EventKind {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "proposedUpgrade" => Some(Self::ProposedUpgrade),
+            "CoprocUpgraded" => Some(Self::CoprocUpgraded),
+            _ => None,
+        }
+    }
+}
+
+pub async fn dispatch(pool: &PgPool, conf: &ConfigSettings, ev: UpgradeEvent) -> Result<()> {
+    info!(
+        kind = ?ev.kind,
+        proposal_id = %hex::encode(&ev.proposal_id),
+        "Handling upgrade event"
+    );
+    let res = match ev.kind {
+        EventKind::ProposedUpgrade => proposed_upgrade::handle(pool, conf, &ev).await,
+        EventKind::CoprocUpgraded => coproc_upgraded::handle(pool, conf, &ev).await,
+    };
+    if let Err(ref e) = res {
+        warn!(error = format!("{e:#}").as_str(), "handler returned error");
+    }
+    mark_handled(pool, ev.id).await?;
+    res
+}
+
+async fn mark_handled(pool: &PgPool, id: i64) -> Result<()> {
+    sqlx::query("UPDATE upgrade_events SET handled = TRUE WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn fetch_unhandled(pool: &PgPool, limit: i64) -> Result<Vec<UpgradeEvent>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT id, kind, proposal_id, version, snapshot_block, eval_block, state_commitment
+        FROM   upgrade_events
+        WHERE  handled = FALSE
+        ORDER  BY created_at ASC
+        LIMIT  $1
+        "#,
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for r in rows {
+        let kind_raw: String = r.try_get("kind")?;
+        let Some(kind) = EventKind::parse(&kind_raw) else {
+            warn!(kind = %kind_raw, "unknown upgrade_events.kind, skipping");
+            continue;
+        };
+        out.push(UpgradeEvent {
+            id: r.try_get("id")?,
+            kind,
+            proposal_id: r.try_get("proposal_id")?,
+            version: r.try_get("version")?,
+            snapshot_block: r.try_get("snapshot_block")?,
+            eval_block: r.try_get("eval_block")?,
+            state_commitment: r.try_get("state_commitment")?,
+        });
+    }
+    Ok(out)
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/handlers/proposed_upgrade.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/handlers/proposed_upgrade.rs
@@ -1,0 +1,366 @@
+//! Handler: `proposedUpgrade` event -> drive GCS through OFFLINE -> SNAPSHOTTING
+//! -> REPLAYING -> READY -> SIGNALING.
+//!
+//! In this iteration each "do the work" step is a `pg_notify` plus a state
+//! transition. The actual workers (host-listener, sns-worker, tx-sender) do
+//! not yet listen on these channels, so the side-effects are observability
+//! only. The state machine itself runs to completion regardless.
+
+use std::process::Stdio;
+
+use anyhow::{anyhow, bail, Context, Result};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use tokio::process::Command;
+use tokio::time::{sleep, Instant};
+use tracing::{info, warn};
+
+/// Table set duplicated from BCS DB into GCS DB at `snapshotBlock`. Matches
+/// the snapshot list in RFC-021 § Database Migrations Isolation. Kept in
+/// code so changes are deliberate and code-reviewed.
+const SNAPSHOT_TABLES: &[&str] = &[
+    "ciphertexts",
+    "ciphertext_digest",
+    "keys",
+    "host_chain_blocks_valid",
+    "gw_listener_last_block",
+    "host_listener_poller_state",
+];
+
+use crate::commitment;
+use crate::config::ConfigSettings;
+use crate::handlers::UpgradeEvent;
+use crate::metrics::{
+    UPGRADE_EVENT_FAIL_COUNTER, UPGRADE_EVENT_SUCCESS_COUNTER,
+};
+use crate::notify;
+use crate::readiness;
+use crate::state::{transition, FsmState, GcsState, StackRole};
+
+pub async fn handle(pool: &PgPool, conf: &ConfigSettings, ev: &UpgradeEvent) -> Result<()> {
+    let snapshot_block = ev
+        .snapshot_block
+        .ok_or_else(|| anyhow!("proposedUpgrade missing snapshotBlock"))?;
+    let eval_block = ev
+        .eval_block
+        .ok_or_else(|| anyhow!("proposedUpgrade missing evalBlock"))?;
+    let version = ev
+        .version
+        .clone()
+        .ok_or_else(|| anyhow!("proposedUpgrade missing version"))?;
+
+    if eval_block <= snapshot_block {
+        bail!("evalBlock ({eval_block}) must be > snapshotBlock ({snapshot_block})");
+    }
+
+    info!(
+        snapshot_block,
+        eval_block,
+        version = %version,
+        "Driving GCS through proposedUpgrade lifecycle"
+    );
+
+    // 1. Wait until BCS is fully settled at snapshotBlock. The check runs
+    // against the BCS DB (read-only). The pool is opened here and closed
+    // as soon as the predicate passes; coproc-mngr does not hold an open
+    // BCS connection outside this window.
+    {
+        let bcs_pool = open_bcs_pool(conf)
+            .await
+            .context("opening BCS DB pool for snapshotBlock readiness check")?;
+        wait_for_settled(&bcs_pool, snapshot_block, conf).await?;
+        bcs_pool.close().await;
+    }
+
+    // 2. OFFLINE -> SNAPSHOTTING (+ pg_notify snapshot_start), then run
+    // the actual pg_dump | pg_restore. If the snapshot fails, the FSM
+    // stays in SNAPSHOTTING and the operator must drop the GCS DB and
+    // re-issue the proposal (per RFC-021 § Database Migrations Isolation).
+    transition_with_notify(
+        pool,
+        FsmState::Gcs(GcsState::OFFLINE),
+        FsmState::Gcs(GcsState::SNAPSHOTTING),
+        ev,
+        notify::CHAN_SNAPSHOT_START,
+    )
+    .await?;
+    run_pg_dump_restore(conf)
+        .await
+        .context("pg_dump | pg_restore from BCS into GCS")?;
+
+    // 3. SNAPSHOTTING -> REPLAYING (+ pg_notify replay_start + dry_run_on).
+    transition_with_notify(
+        pool,
+        FsmState::Gcs(GcsState::SNAPSHOTTING),
+        FsmState::Gcs(GcsState::REPLAYING),
+        ev,
+        notify::CHAN_REPLAY_START,
+    )
+    .await?;
+    notify_only(pool, notify::CHAN_DRY_RUN_ON, ev).await?;
+    info!(
+        snapshot_block,
+        eval_block,
+        "PLACEHOLDER: would instruct host-listener to replay (snapshotBlock, evalBlock]"
+    );
+
+    // 4. REPLAYING -> READY once GCS reaches evalBlock and is settled.
+    // No-op in v1 because nothing is actually replaying. The wait loop
+    // exits immediately when the predicate is trivially true on an empty
+    // GCS DB.
+    wait_for_settled(pool, eval_block, conf).await?;
+
+    transition_with_notify_payload(
+        pool,
+        FsmState::Gcs(GcsState::REPLAYING),
+        FsmState::Gcs(GcsState::READY),
+        ev,
+        None,
+        None,
+    )
+    .await?;
+
+    // 5. Compute stateCommitment over the GCS-replayed handles in
+    // (snapshotBlock, evalBlock] and insert into signal_ready_pending.
+    let state_commitment = commitment::compute_state_commitment(
+        pool,
+        snapshot_block,
+        eval_block,
+    )
+    .await
+    .context("computing stateCommitment")?;
+    info!(
+        proposal_id = %hex::encode(&ev.proposal_id),
+        version = %version,
+        state_commitment = %hex::encode(state_commitment),
+        "stateCommitment ready"
+    );
+    insert_signal_ready_pending(pool, ev, &version, &state_commitment).await?;
+
+    // 6. READY -> SIGNALING (+ pg_notify signal_ready).
+    transition_with_notify_payload(
+        pool,
+        FsmState::Gcs(GcsState::READY),
+        FsmState::Gcs(GcsState::SIGNALING),
+        ev,
+        Some(&state_commitment),
+        Some(notify::CHAN_SIGNAL_READY),
+    )
+    .await?;
+
+    UPGRADE_EVENT_SUCCESS_COUNTER
+        .with_label_values(&["proposedUpgrade"])
+        .inc();
+    info!("proposedUpgrade lifecycle reached SIGNALING - awaiting CoprocUpgraded");
+    Ok(())
+}
+
+async fn wait_for_settled(pool: &PgPool, block: i64, conf: &ConfigSettings) -> Result<()> {
+    let deadline = Instant::now() + conf.readiness_timeout;
+    loop {
+        let r = readiness::check_settled_at(pool, block).await?;
+        if r.fully_settled() {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            UPGRADE_EVENT_FAIL_COUNTER
+                .with_label_values(&["readiness_timeout"])
+                .inc();
+            bail!("readiness timeout waiting for block {block} to settle: {r:?}");
+        }
+        warn!(?r, block, "not yet settled, sleeping");
+        sleep(conf.readiness_poll_interval).await;
+    }
+}
+
+async fn transition_with_notify(
+    pool: &PgPool,
+    from: FsmState,
+    to: FsmState,
+    ev: &UpgradeEvent,
+    channel: &str,
+) -> Result<()> {
+    transition_with_notify_payload(pool, from, to, ev, None, Some(channel)).await
+}
+
+async fn notify_only(pool: &PgPool, channel: &str, ev: &UpgradeEvent) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    let payload = serde_json::json!({
+        "proposal_id": hex::encode(&ev.proposal_id),
+    })
+    .to_string();
+    notify::pg_notify(&mut tx, channel, &payload).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+async fn transition_with_notify_payload(
+    pool: &PgPool,
+    from: FsmState,
+    to: FsmState,
+    ev: &UpgradeEvent,
+    state_commitment: Option<&[u8]>,
+    channel: Option<&str>,
+) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    transition(
+        &mut tx,
+        StackRole::GCS,
+        from,
+        to,
+        Some(&ev.proposal_id),
+        ev.version.as_deref(),
+        ev.snapshot_block,
+        ev.eval_block,
+        state_commitment,
+    )
+    .await
+    .with_context(|| format!("transition {} -> {}", from.as_str(), to.as_str()))?;
+
+    if let Some(chan) = channel {
+        let payload = serde_json::json!({
+            "proposal_id": hex::encode(&ev.proposal_id),
+            "to": to.as_str(),
+        })
+        .to_string();
+        notify::pg_notify(&mut tx, chan, &payload).await?;
+    }
+
+    tx.commit().await?;
+    info!(
+        proposal_id = %hex::encode(&ev.proposal_id),
+        from = from.as_str(),
+        to = to.as_str(),
+        notify_channel = channel.unwrap_or("(none)"),
+        "FSM transition committed"
+    );
+    Ok(())
+}
+
+async fn insert_signal_ready_pending(
+    pool: &PgPool,
+    ev: &UpgradeEvent,
+    version: &str,
+    state_commitment: &[u8],
+) -> Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO signal_ready_pending (proposal_id, state_commitment, version)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (proposal_id) DO NOTHING
+        "#,
+    )
+    .bind(&ev.proposal_id)
+    .bind(state_commitment)
+    .bind(version)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Open a read-only-intent pool against the BCS DB. The caller is expected
+/// to .close() the pool as soon as the check completes; coproc-mngr does
+/// not hold a long-lived BCS connection.
+async fn open_bcs_pool(conf: &crate::config::ConfigSettings) -> Result<PgPool> {
+    let url = conf
+        .bcs_database_url
+        .as_ref()
+        .ok_or_else(|| anyhow!("--bcs-database-url is required to handle proposedUpgrade"))?;
+    PgPoolOptions::new()
+        .max_connections(2)
+        .connect(url.as_str())
+        .await
+        .context("connect BCS DB")
+}
+
+/// Run `pg_dump --data-only --format=custom <snapshot tables> <BCS_URL>`
+/// piped into `pg_restore --data-only --dbname=<GCS_URL>`.
+///
+/// The schema on GCS is assumed to already exist (db-migration applied
+/// independently). We only copy data for the snapshot table set. Both
+/// processes are spawned with `kill_on_drop(true)` so that a cancelled
+/// coproc-mngr cleans them up rather than leaking processes.
+///
+/// On any error: the GCS DB may be in a partially-populated state. Recovery
+/// per RFC-021 is to drop the GCS DB and reissue the proposal; coproc-mngr
+/// itself does not attempt cleanup.
+async fn run_pg_dump_restore(conf: &crate::config::ConfigSettings) -> Result<()> {
+    let bcs_url = conf
+        .bcs_database_url
+        .as_ref()
+        .ok_or_else(|| anyhow!("--bcs-database-url is required for pg_dump"))?;
+    let gcs_url = &conf.database_url;
+
+    info!(
+        snapshot_tables = ?SNAPSHOT_TABLES,
+        "Starting pg_dump | pg_restore from BCS into GCS"
+    );
+    let started_at = Instant::now();
+
+    // pg_dump: read from BCS, emit custom-format archive to stdout.
+    let mut dump = {
+        let mut cmd = Command::new("pg_dump");
+        cmd.args([
+            "--format=custom",
+            "--no-owner",
+            "--no-acl",
+            "--data-only",
+        ]);
+        for t in SNAPSHOT_TABLES {
+            cmd.arg(format!("--table={t}"));
+        }
+        cmd.arg(bcs_url.as_str())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .context("spawning pg_dump")?
+    };
+
+    let dump_stdout: Stdio = dump
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("pg_dump stdout pipe missing"))?
+        .try_into()
+        .context("converting pg_dump stdout to Stdio")?;
+
+    // pg_restore: read custom-format archive on stdin, write to GCS.
+    let restore = Command::new("pg_restore")
+        .args(["--no-owner", "--no-acl", "--data-only", "--dbname"])
+        .arg(gcs_url.as_str())
+        .stdin(dump_stdout)
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("spawning pg_restore")?;
+
+    // Both must run concurrently; pg_dump only finishes once pg_restore has
+    // drained its stdout, and pg_restore only finishes once pg_dump has
+    // closed it.
+    let (dump_out, restore_out) =
+        tokio::join!(dump.wait_with_output(), restore.wait_with_output());
+    let dump_out = dump_out.context("waiting on pg_dump")?;
+    let restore_out = restore_out.context("waiting on pg_restore")?;
+
+    if !dump_out.status.success() {
+        bail!(
+            "pg_dump failed (exit={}): {}",
+            dump_out.status,
+            String::from_utf8_lossy(&dump_out.stderr).trim()
+        );
+    }
+    if !restore_out.status.success() {
+        bail!(
+            "pg_restore failed (exit={}): {}",
+            restore_out.status,
+            String::from_utf8_lossy(&restore_out.stderr).trim()
+        );
+    }
+
+    info!(
+        elapsed_ms = started_at.elapsed().as_millis() as u64,
+        "pg_dump | pg_restore completed"
+    );
+    Ok(())
+}
+

--- a/coprocessor/fhevm-engine/coproc-mngr/src/lib.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/lib.rs
@@ -1,0 +1,34 @@
+//! `coproc-mngr` - upgrade orchestrator service for the FHEVM coprocessor stack.
+//!
+//! See `tech-spec/rfcs/021-blue-green-upgrade.md` § `coproc-mngr`.
+//!
+//! ## What it does
+//!
+//! - LISTENs on the Postgres `event_upgrade` channel.
+//! - Drains rows from `upgrade_events` (written by the future gw-listener
+//!   routing path; manually inserted in this iteration for testing).
+//! - Drives the per-stack FSM in `service_state`.
+//! - Emits `pg_notify` on per-stage channels to coordinate the other services.
+//!   In this first iteration **nothing else listens on these channels** - see
+//!   the RFC for the consumer-side rollout plan.
+//!
+//! ## What it does NOT do (yet)
+//!
+//! - Run `pg_dump` of the BCS DB into the GCS DB (logged as a placeholder).
+//! - Submit `signalReady` on-chain (just inserts a row into
+//!   `signal_ready_pending`; tx-sender will pick it up in a later iteration).
+//! - Compute a real `stateCommitment` (a placeholder zero-hash is written).
+//! - Talk to BCS DB at all (the `bcs_database_url` CLI flag is accepted but
+//!   only logged; no cross-DB connection is opened).
+
+pub mod commitment;
+pub mod config;
+pub mod handlers;
+pub mod metrics;
+pub mod notify;
+pub mod readiness;
+pub mod service;
+pub mod state;
+
+pub use config::ConfigSettings;
+pub use service::run;

--- a/coprocessor/fhevm-engine/coproc-mngr/src/metrics.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/metrics.rs
@@ -1,0 +1,46 @@
+use prometheus::{
+    register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec,
+};
+use std::sync::LazyLock;
+
+pub static INBOUND_EVENT_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coproc_mngr_inbound_event_total",
+        "Total upgrade_events rows dispatched"
+    )
+    .unwrap()
+});
+
+pub static INBOUND_NOTIFICATION_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coproc_mngr_inbound_notification_total",
+        "Total `event_upgrade` NOTIFYs received"
+    )
+    .unwrap()
+});
+
+pub static INBOUND_POLL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "coproc_mngr_inbound_poll_total",
+        "Total polling-fallback ticks"
+    )
+    .unwrap()
+});
+
+pub static UPGRADE_EVENT_SUCCESS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "coproc_mngr_event_success_total",
+        "Successfully handled upgrade events, by stage label",
+        &["stage"]
+    )
+    .unwrap()
+});
+
+pub static UPGRADE_EVENT_FAIL_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "coproc_mngr_event_fail_total",
+        "Upgrade event handler failures, by reason label",
+        &["reason"]
+    )
+    .unwrap()
+});

--- a/coprocessor/fhevm-engine/coproc-mngr/src/notify.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/notify.rs
@@ -1,0 +1,48 @@
+//! Outbound `pg_notify` channels.
+//!
+//! In this iteration the only consumer of these notifies is *future* code in
+//! `host-listener`, `sns-worker`, `tx-sender`, etc. coproc-mngr emits them in
+//! the same Postgres transaction that commits the FSM transition; if the
+//! transition is rolled back, the notify is too. (Postgres semantics: NOTIFY
+//! payloads are buffered until COMMIT.)
+
+use anyhow::Result;
+use sqlx::{Postgres, Transaction};
+
+/// Signal: the BCS is fully settled; consumers should treat the snapshot as
+/// frozen and prepare for replay. Currently no consumer.
+pub const CHAN_SNAPSHOT_START: &str = "event_coproc_mngr_snapshot_start";
+
+/// Signal: GCS host-listener should ingest blocks `(snapshotBlock, evalBlock]`
+/// in polling mode.
+pub const CHAN_REPLAY_START: &str = "event_coproc_mngr_replay_start";
+
+/// Signal: tx-sender should suppress AddCipher/VerifyProof and enable
+/// SignalReady (dry-run mode).
+pub const CHAN_DRY_RUN_ON: &str = "event_coproc_mngr_dry_run_on";
+
+/// Signal: tx-sender should re-enable AddCipher/VerifyProof and disable
+/// SignalReady (live-run mode).
+pub const CHAN_DRY_RUN_OFF: &str = "event_coproc_mngr_dry_run_off";
+
+/// Signal: a new row exists in `signal_ready_pending` for tx-sender to drain.
+pub const CHAN_SIGNAL_READY: &str = "event_coproc_mngr_signal_ready";
+
+/// Signal: BCS services should drain in-flight work and stop.
+pub const CHAN_BCS_DRAIN: &str = "event_coproc_mngr_bcs_drain";
+
+/// Signal: GCS should promote to LIVE - flip dry-run flags off.
+pub const CHAN_GCS_PROMOTE: &str = "event_coproc_mngr_gcs_promote";
+
+pub async fn pg_notify(
+    tx: &mut Transaction<'_, Postgres>,
+    channel: &str,
+    payload: &str,
+) -> Result<()> {
+    sqlx::query("SELECT pg_notify($1, $2)")
+        .bind(channel)
+        .bind(payload)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/readiness.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/readiness.rs
@@ -1,0 +1,72 @@
+//! Readiness predicates for "the coprocessor stack is fully settled at
+//! block N." Used in two places:
+//!
+//! 1. Before triggering `pg_dump`, the BCS must be settled at `snapshotBlock`.
+//! 2. Before transitioning REPLAYING -> READY, the GCS must be settled at
+//!    `evalBlock`.
+//!
+//! The same predicate set works for both: every compute output through the
+//! given block has finished, every Allow-event SNS row is complete, and the
+//! ciphertext registration tx has been submitted.
+//!
+//! The function takes whichever pool the caller wants to check against:
+//! the `proposedUpgrade` handler passes a transient BCS pool for
+//! `snapshotBlock`, and the GCS pool for `evalBlock`. The schema requirements
+//! (`computations.block_number`, `pbs_computations.block_number`,
+//! `ciphertext_digest.txn_is_sent`) are identical on both DBs.
+
+use anyhow::{Context, Result};
+use sqlx::{PgPool, Row};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Readiness {
+    pub compute_done: bool,
+    pub sns_done: bool,
+    pub tx_done: bool,
+}
+
+impl Readiness {
+    pub fn fully_settled(&self) -> bool {
+        self.compute_done && self.sns_done && self.tx_done
+    }
+}
+
+pub async fn check_settled_at(pool: &PgPool, block_number: i64) -> Result<Readiness> {
+    let row = sqlx::query(
+        r#"
+        SELECT
+            NOT EXISTS (
+                SELECT 1 FROM computations
+                WHERE  block_number IS NOT NULL
+                  AND  block_number <= $1
+                  AND  is_completed = FALSE
+            ) AS compute_done,
+
+            NOT EXISTS (
+                SELECT 1 FROM pbs_computations
+                WHERE  block_number IS NOT NULL
+                  AND  block_number <= $1
+                  AND  is_completed = FALSE
+            ) AS sns_done,
+
+            NOT EXISTS (
+                SELECT 1
+                FROM   ciphertext_digest cd
+                JOIN   computations c ON c.output_handle = cd.handle
+                WHERE  c.block_number IS NOT NULL
+                  AND  c.block_number <= $1
+                  AND  cd.txn_is_sent = FALSE
+            ) AS tx_done
+        "#,
+    )
+    .bind(block_number)
+    .fetch_one(pool)
+    .await
+    .context("readiness check query")?;
+
+    Ok(Readiness {
+        compute_done: row.try_get("compute_done")?,
+        sns_done: row.try_get("sns_done")?,
+        tx_done: row.try_get("tx_done")?,
+    })
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/service.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/service.rs
@@ -1,0 +1,118 @@
+//! Main daemon loop. LISTENs on `event_upgrade`, drains unhandled rows from
+//! `upgrade_events`, dispatches to per-event handlers.
+//!
+//! Cancellation: a single tokio CancellationToken stops the inbound LISTEN
+//! and lets in-flight handlers finish their current SQL transaction before
+//! exiting cleanly.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use sqlx::postgres::{PgListener, PgPoolOptions};
+use sqlx::PgPool;
+use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+use crate::config::ConfigSettings;
+use crate::handlers;
+use crate::metrics::{
+    INBOUND_EVENT_COUNTER, INBOUND_NOTIFICATION_COUNTER, INBOUND_POLL_COUNTER,
+};
+
+const DRAIN_BATCH_SIZE: i64 = 16;
+
+pub async fn run(conf: ConfigSettings, cancel: CancellationToken) -> Result<()> {
+    let pool = connect(&conf).await?;
+    info!(
+        database_url = %conf.database_url.as_str(),
+        bcs_database_url = ?conf.bcs_database_url.as_ref().map(|u| u.as_str().to_string()),
+        upgrade_event_channel = %conf.upgrade_event_channel,
+        "coproc-mngr starting"
+    );
+
+    // Drain anything left over from a previous run. Restart-safe.
+    drain_unhandled(&pool, &conf).await;
+
+    let mut listener = PgListener::connect_with(&pool)
+        .await
+        .context("PgListener connect")?;
+    listener
+        .listen(&conf.upgrade_event_channel)
+        .await
+        .with_context(|| format!("LISTEN {}", conf.upgrade_event_channel))?;
+    info!(channel = %conf.upgrade_event_channel, "Subscribed to upgrade events");
+
+    let mut poll = interval(conf.poll_interval);
+    poll.tick().await; // burn the immediate tick
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("Cancellation requested, shutting down");
+                return Ok(());
+            }
+            recv = listener.try_recv() => {
+                match recv {
+                    Ok(Some(_n)) => {
+                        INBOUND_NOTIFICATION_COUNTER.inc();
+                        drain_unhandled(&pool, &conf).await;
+                    }
+                    Ok(None) => {
+                        warn!("Listener connection closed; reconnecting");
+                        listener = match PgListener::connect_with(&pool).await {
+                            Ok(l) => l,
+                            Err(e) => {
+                                error!(error = %e, "Listener reconnect failed; backing off");
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                continue;
+                            }
+                        };
+                        if let Err(e) = listener.listen(&conf.upgrade_event_channel).await {
+                            error!(error = %e, "Re-LISTEN failed");
+                        }
+                    }
+                    Err(e) => {
+                        error!(error = %e, "try_recv error");
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                }
+            }
+            _ = poll.tick() => {
+                INBOUND_POLL_COUNTER.inc();
+                drain_unhandled(&pool, &conf).await;
+            }
+        }
+    }
+}
+
+async fn drain_unhandled(pool: &PgPool, conf: &ConfigSettings) {
+    let evs = match handlers::fetch_unhandled(pool, DRAIN_BATCH_SIZE).await {
+        Ok(v) => v,
+        Err(e) => {
+            error!(error = %e, "fetch_unhandled failed");
+            return;
+        }
+    };
+    if evs.is_empty() {
+        return;
+    }
+    info!(count = evs.len(), "Dispatching upgrade events");
+    INBOUND_EVENT_COUNTER.inc_by(evs.len() as u64);
+    for ev in evs {
+        if let Err(e) = handlers::dispatch(pool, conf, ev).await {
+            // Errors in handlers are already logged; row is still marked
+            // handled to prevent infinite re-dispatch. Operator alerts
+            // off the prometheus counter UPGRADE_EVENT_FAIL_COUNTER.
+            error!(error = format!("{e:#}").as_str(), "handler dispatch failed");
+        }
+    }
+}
+
+async fn connect(conf: &ConfigSettings) -> Result<PgPool> {
+    PgPoolOptions::new()
+        .max_connections(conf.database_pool_size)
+        .connect(conf.database_url.as_str())
+        .await
+        .context("PgPool connect")
+}

--- a/coprocessor/fhevm-engine/coproc-mngr/src/state.rs
+++ b/coprocessor/fhevm-engine/coproc-mngr/src/state.rs
@@ -1,0 +1,203 @@
+//! FSM persisted in the `service_state` table.
+//!
+//! Two rows exist on every coprocessor DB instance, one per stack role.
+//! Only the row matching this DB's actual role is mutated. (BCS DB only
+//! transitions BCS states; GCS DB only transitions GCS states.)
+//!
+//! Every transition is committed in the same SQL transaction as the
+//! corresponding side effect (a pg_notify, an INSERT into
+//! `signal_ready_pending`, etc.) so a crash mid-transition is atomic from
+//! the system's point of view: either both happen or neither.
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Postgres, Row, Transaction};
+use strum::{AsRefStr, Display, EnumString};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Display, EnumString, AsRefStr, Serialize, Deserialize)]
+#[strum(serialize_all = "UPPERCASE")]
+pub enum StackRole {
+    BCS,
+    GCS,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Display, EnumString, AsRefStr, Serialize, Deserialize)]
+pub enum BcsState {
+    LIVE,
+    DRAINING,
+    STOPPED,
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Display, EnumString, AsRefStr, Serialize, Deserialize)]
+pub enum GcsState {
+    OFFLINE,
+    SNAPSHOTTING,
+    REPLAYING,
+    READY,
+    SIGNALING,
+    CUTTING_OVER,
+    LIVE,
+}
+
+/// What state a row can be in. The same column holds either set.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FsmState {
+    Bcs(BcsState),
+    Gcs(GcsState),
+}
+
+impl FsmState {
+    pub fn parse(role: StackRole, raw: &str) -> Result<Self> {
+        match role {
+            StackRole::BCS => Ok(FsmState::Bcs(
+                raw.parse().map_err(|_| anyhow!("invalid BCS state: {raw}"))?,
+            )),
+            StackRole::GCS => Ok(FsmState::Gcs(
+                raw.parse().map_err(|_| anyhow!("invalid GCS state: {raw}"))?,
+            )),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FsmState::Bcs(BcsState::LIVE) => "LIVE",
+            FsmState::Bcs(BcsState::DRAINING) => "DRAINING",
+            FsmState::Bcs(BcsState::STOPPED) => "STOPPED",
+            FsmState::Gcs(GcsState::OFFLINE) => "OFFLINE",
+            FsmState::Gcs(GcsState::SNAPSHOTTING) => "SNAPSHOTTING",
+            FsmState::Gcs(GcsState::REPLAYING) => "REPLAYING",
+            FsmState::Gcs(GcsState::READY) => "READY",
+            FsmState::Gcs(GcsState::SIGNALING) => "SIGNALING",
+            FsmState::Gcs(GcsState::CUTTING_OVER) => "CUTTING_OVER",
+            FsmState::Gcs(GcsState::LIVE) => "LIVE",
+        }
+    }
+}
+
+/// Validate a transition. Encodes the allowed edges of the FSM.
+pub fn is_legal_transition(from: FsmState, to: FsmState) -> bool {
+    match (from, to) {
+        // BCS lifecycle on CoprocUpgraded.
+        (FsmState::Bcs(BcsState::LIVE), FsmState::Bcs(BcsState::DRAINING)) => true,
+        (FsmState::Bcs(BcsState::DRAINING), FsmState::Bcs(BcsState::STOPPED)) => true,
+
+        // GCS lifecycle on proposedUpgrade through to LIVE.
+        (FsmState::Gcs(GcsState::OFFLINE), FsmState::Gcs(GcsState::SNAPSHOTTING)) => true,
+        (FsmState::Gcs(GcsState::SNAPSHOTTING), FsmState::Gcs(GcsState::REPLAYING)) => true,
+        (FsmState::Gcs(GcsState::REPLAYING), FsmState::Gcs(GcsState::READY)) => true,
+        (FsmState::Gcs(GcsState::READY), FsmState::Gcs(GcsState::SIGNALING)) => true,
+        (FsmState::Gcs(GcsState::SIGNALING), FsmState::Gcs(GcsState::CUTTING_OVER)) => true,
+        (FsmState::Gcs(GcsState::CUTTING_OVER), FsmState::Gcs(GcsState::LIVE)) => true,
+
+        _ => false,
+    }
+}
+
+/// One row of `service_state`.
+#[derive(Clone, Debug)]
+pub struct ServiceStateRow {
+    pub stack_role: StackRole,
+    pub state: FsmState,
+    pub proposal_id: Option<Vec<u8>>,
+    pub version: Option<String>,
+    pub snapshot_block: Option<i64>,
+    pub eval_block: Option<i64>,
+    pub state_commitment: Option<Vec<u8>>,
+}
+
+pub async fn read_state(pool: &PgPool, role: StackRole) -> Result<ServiceStateRow> {
+    let row = sqlx::query(
+        r#"
+        SELECT state,
+               proposal_id,
+               version,
+               snapshot_block,
+               eval_block,
+               state_commitment
+        FROM service_state
+        WHERE stack_role = $1
+        "#,
+    )
+    .bind(role.as_ref())
+    .fetch_one(pool)
+    .await
+    .with_context(|| format!("read_state({role:?})"))?;
+
+    let state_raw: String = row.try_get("state")?;
+    Ok(ServiceStateRow {
+        stack_role: role,
+        state: FsmState::parse(role, &state_raw)?,
+        proposal_id: row.try_get("proposal_id")?,
+        version: row.try_get("version")?,
+        snapshot_block: row.try_get("snapshot_block")?,
+        eval_block: row.try_get("eval_block")?,
+        state_commitment: row.try_get("state_commitment")?,
+    })
+}
+
+/// Atomically advance the FSM. The caller must already have validated the
+/// transition with `is_legal_transition`; this function re-checks under the
+/// row's `FOR UPDATE` lock to handle racing writers.
+pub async fn transition(
+    tx: &mut Transaction<'_, Postgres>,
+    role: StackRole,
+    expected_from: FsmState,
+    to: FsmState,
+    proposal_id: Option<&[u8]>,
+    version: Option<&str>,
+    snapshot_block: Option<i64>,
+    eval_block: Option<i64>,
+    state_commitment: Option<&[u8]>,
+) -> Result<()> {
+    if !is_legal_transition(expected_from, to) {
+        return Err(anyhow!(
+            "illegal transition {} -> {}",
+            expected_from.as_str(),
+            to.as_str()
+        ));
+    }
+
+    let cur = sqlx::query(
+        r#"SELECT state FROM service_state WHERE stack_role = $1 FOR UPDATE"#,
+    )
+    .bind(role.as_ref())
+    .fetch_one(&mut **tx)
+    .await?;
+
+    let cur_raw: String = cur.try_get("state")?;
+    let cur_state = FsmState::parse(role, &cur_raw)?;
+    if cur_state != expected_from {
+        return Err(anyhow!(
+            "concurrent transition: expected {} but row is {}",
+            expected_from.as_str(),
+            cur_state.as_str()
+        ));
+    }
+
+    sqlx::query(
+        r#"
+        UPDATE service_state
+        SET    state            = $2,
+               proposal_id      = COALESCE($3, proposal_id),
+               version          = COALESCE($4, version),
+               snapshot_block   = COALESCE($5, snapshot_block),
+               eval_block       = COALESCE($6, eval_block),
+               state_commitment = COALESCE($7, state_commitment),
+               updated_at       = NOW()
+        WHERE  stack_role = $1
+        "#,
+    )
+    .bind(role.as_ref())
+    .bind(to.as_str())
+    .bind(proposal_id)
+    .bind(version)
+    .bind(snapshot_block)
+    .bind(eval_block)
+    .bind(state_commitment)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}

--- a/coprocessor/fhevm-engine/db-migration/migrations/20260430120000_create_coproc_mngr_tables.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260430120000_create_coproc_mngr_tables.sql
@@ -1,0 +1,113 @@
+-- Tables and triggers used by the `coproc-mngr` upgrade-orchestrator service.
+--
+-- See RFC-021. This migration only introduces the storage + signaling
+-- mechanisms; the consuming services (host-listener, sns-worker, tx-sender)
+-- are unchanged in this iteration. coproc-mngr emits pg_notify on the
+-- channels listed below; nothing acts on them yet.
+
+-- ----------------------------------------------------------------------------
+-- service_state: per-stack FSM persistence (BCS row + GCS row).
+--
+-- A single Postgres instance only ever hosts one of {BCS, GCS}, so we keep
+-- one row per `stack_role`. The `state` column drives every transition in the
+-- coproc-mngr; it is the single source of truth for "where is the upgrade
+-- right now?". Restart-safe because every transition is committed before the
+-- corresponding outbound pg_notify is emitted.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS service_state (
+    stack_role        TEXT        PRIMARY KEY
+                                  CHECK (stack_role IN ('BCS', 'GCS')),
+    state             TEXT        NOT NULL
+                                  CHECK (state IN (
+                                      -- BCS lifecycle
+                                      'LIVE', 'DRAINING', 'STOPPED',
+                                      -- GCS lifecycle
+                                      'OFFLINE', 'SNAPSHOTTING', 'REPLAYING',
+                                      'READY', 'SIGNALING', 'CUTTING_OVER'
+                                  )),
+    proposal_id       BYTEA       NULL,
+    version           TEXT        NULL,
+    snapshot_block    BIGINT      NULL CHECK (snapshot_block >= 0),
+    eval_block        BIGINT      NULL CHECK (eval_block >= 0),
+    state_commitment  BYTEA       NULL,
+    last_error        TEXT        NULL,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Bootstrap: a brand-new BCS deployment is LIVE; any GCS is OFFLINE.
+INSERT INTO service_state (stack_role, state)
+VALUES ('BCS', 'LIVE')
+ON CONFLICT (stack_role) DO NOTHING;
+
+INSERT INTO service_state (stack_role, state)
+VALUES ('GCS', 'OFFLINE')
+ON CONFLICT (stack_role) DO NOTHING;
+
+-- ----------------------------------------------------------------------------
+-- upgrade_events: ingress queue from the (future) gw-listener routing path.
+--
+-- gw-listener will eventually decode `proposedUpgrade` / `CoprocUpgraded`
+-- events and INSERT a row here. coproc-mngr LISTENs on `event_upgrade` and
+-- drains the queue. ON CONFLICT (proposal_id, kind) DO NOTHING makes
+-- replay safe.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS upgrade_events (
+    id                BIGSERIAL   PRIMARY KEY,
+    kind              TEXT        NOT NULL
+                                  CHECK (kind IN ('proposedUpgrade', 'CoprocUpgraded')),
+    proposal_id       BYTEA       NOT NULL,
+    version           TEXT        NULL,
+    snapshot_block    BIGINT      NULL CHECK (snapshot_block >= 0),
+    eval_block        BIGINT      NULL CHECK (eval_block >= 0),
+    state_commitment  BYTEA       NULL,
+    block_number      BIGINT      NOT NULL,
+    transaction_hash  BYTEA       NOT NULL,
+    log_index         BIGINT      NULL,
+    handled           BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    UNIQUE (proposal_id, kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_upgrade_events_unhandled
+    ON upgrade_events (created_at)
+    WHERE handled = FALSE;
+
+-- Trigger: fires `event_upgrade` per insert. coproc-mngr LISTENs and
+-- pulls unhandled rows.
+CREATE OR REPLACE FUNCTION notify_upgrade_event()
+    RETURNS trigger AS $$
+BEGIN
+    NOTIFY event_upgrade;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS upgrade_events_notify_trigger ON upgrade_events;
+CREATE TRIGGER upgrade_events_notify_trigger
+    AFTER INSERT
+    ON upgrade_events
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION notify_upgrade_event();
+
+-- ----------------------------------------------------------------------------
+-- signal_ready_pending: coproc-mngr -> tx-sender handoff.
+--
+-- coproc-mngr writes a row here when GCS reaches READY and the
+-- stateCommitment has been computed. The (future) tx-sender SignalReady op
+-- reads `txn_is_sent = FALSE` rows, submits `signalReady(proposalId, commitment)`
+-- to the Gateway, and flips the flag.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS signal_ready_pending (
+    proposal_id       BYTEA       PRIMARY KEY,
+    state_commitment  BYTEA       NOT NULL,
+    version           TEXT        NOT NULL,
+    txn_is_sent       BOOLEAN     NOT NULL DEFAULT FALSE,
+    txn_hash          BYTEA       NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_signal_ready_pending_unsent
+    ON signal_ready_pending (created_at)
+    WHERE txn_is_sent = FALSE;


### PR DESCRIPTION
 
  Introduces `coproc-mngr`, a new long-running service - one per coprocessor
  party - that owns the upgrade lifecycle FSM described in RFC-021. It
  listens on the Postgres `event_upgrade` channel, drives the per-stack
  state machine on `proposedUpgrade` / `CoprocUpgraded` events, and
  coordinates the other services through `pg_notify` and a small set of
  new tables.