### PR TITLE
fix(test-suite): use receipt block number in reorg isolation test

### DIFF
--- a/test-suite/e2e/test/multiChain/multiChainIsolation.ts
+++ b/test-suite/e2e/test/multiChain/multiChainIsolation.ts
@@ -211,9 +211,9 @@ describe('Multi-Chain State Isolation', function () {
         to: this.signersB.bob.address,
         value: ethers.parseEther('0.1'),
       });
-      await transferB.wait();
+      const receiptB = await transferB.wait();
 
-      const chainBBlockDuring = await providerB.getBlockNumber();
+      const chainBBlockDuring = receiptB!.blockNumber;
       expect(chainBBlockDuring).to.be.greaterThan(chainBBlockBefore);
 
       const reverted = await evmRevert(ethers.provider, snapshotId);


### PR DESCRIPTION
### Summary

Fixes a flaky multichain test where `evm_revert` on Chain A does not affect Chain B state would intermittently fail because `providerB.getBlockNumber()` can return a cached pre-transaction block number before ethers.js's internal polling interval fires. Replace it with the block number from the transaction receipt, which is always accurate.