### PR TITLE
fix(coprocessor): suppress drift alerts during gw-listener replay

### DIFF
--- a/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
@@ -124,6 +124,14 @@ impl DriftDetector {
         self.replaying = replaying;
     }
 
+    pub(crate) fn finish_replay(&mut self) {
+        self.open_handles.clear();
+        self.deferred_drift_detected = 0;
+        self.deferred_consensus_timeout = 0;
+        self.deferred_missing_submission = 0;
+        self.replaying = false;
+    }
+
     pub(crate) fn set_current_expected_senders(&mut self, expected_senders: Vec<Address>) {
         self.current_expected_senders = expected_senders;
     }
@@ -556,6 +564,9 @@ impl DriftDetector {
     /// Finalize a normal log-polling batch: check deferred consensus results,
     /// alert on completed-without-consensus handles, and evict stale handles.
     pub(crate) async fn end_of_batch(&mut self, db_pool: &Pool<Postgres>) -> anyhow::Result<()> {
+        if self.replaying {
+            return Ok(());
+        }
         self.refresh_pending_consensus_checks(db_pool).await?;
         self.finalize_completed_without_consensus();
         self.evict_stale(Instant::now());
@@ -1485,6 +1496,42 @@ mod tests {
 
         detector.flush_metrics();
 
+        assert_eq!(detector.deferred_drift_detected, 0);
+        assert_eq!(detector.deferred_consensus_timeout, 0);
+        assert_eq!(detector.deferred_missing_submission, 0);
+    }
+
+    #[test]
+    fn finish_replay_drops_replayed_state_without_emitting_metrics() {
+        let mut detector = detector();
+        let handle = FixedBytes::from([7u8; 32]);
+        let senders = senders();
+
+        detector.set_replaying(true);
+        submit_digest_event_and_drift_check(
+            &mut detector,
+            handle,
+            [8u8; 32],
+            [9u8; 32],
+            senders[0],
+            10,
+        );
+        submit_digest_event_and_drift_check(
+            &mut detector,
+            handle,
+            [10u8; 32],
+            [11u8; 32],
+            senders[1],
+            11,
+        );
+        detector.deferred_drift_detected = 1;
+        detector.deferred_consensus_timeout = 2;
+        detector.deferred_missing_submission = 3;
+
+        detector.finish_replay();
+
+        assert!(!detector.replaying);
+        assert!(detector.open_handles.is_empty());
         assert_eq!(detector.deferred_drift_detected, 0);
         assert_eq!(detector.deferred_consensus_timeout, 0);
         assert_eq!(detector.deferred_missing_submission, 0);

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -175,18 +175,18 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
             self.conf.drift_no_consensus_timeout,
             self.conf.drift_post_consensus_grace,
         );
-        if replay_from_block.is_none() {
-            if let Err(e) = self
-                .rebuild_drift_detector(
-                    db_pool,
-                    &mut drift_detector,
-                    progress.earliest_open_ct_commits_block,
-                    last_processed_block_num,
-                )
-                .await
-            {
-                error!(error = %e, "Failed to rebuild drift detector; continuing with partial state");
-            }
+        if replay_from_block.is_some() {
+            drift_detector.set_replaying(true);
+        } else if let Err(e) = self
+            .rebuild_drift_detector(
+                db_pool,
+                &mut drift_detector,
+                progress.earliest_open_ct_commits_block,
+                last_processed_block_num,
+            )
+            .await
+        {
+            error!(error = %e, "Failed to rebuild drift detector; continuing with partial state");
         }
 
         let filter_addresses = {
@@ -350,6 +350,7 @@ impl<P: Provider<Ethereum> + Clone + 'static, A: AwsS3Interface + Clone + 'stati
                         if to_block == current_block {
                             info!("Replay finished");
                             *replay_from_block = None;
+                            drift_detector.finish_replay();
                         } else {
                             // if an error happens replay will restart here
                             *replay_from_block = Some(to_block as i64 + 1);


### PR DESCRIPTION
## Summary

- put the drift detector in replay mode when `--replay-from-block` is active
- skip normal end-of-batch drift finalization while replaying old gateway logs
- drop replay-built drift state and deferred counters before live polling resumes

## Scope

This is a narrow `release/0.12.x` backport for the operator replay path. The goal is to prevent historical `CiphertextCommits` logs from re-emitting high-severity drift alerts/metrics during manual replay.

It does not introduce durable drift alert idempotency. That belongs in a separate main-branch design because replay/report-once semantics across restarts need a persisted drift identity, not only an in-memory replay flag.

## Testing

- `cargo test -p gw-listener finish_replay_drops_replayed_state_without_emitting_metrics --lib`
- `cargo check -p gw-listener`
