### PR TITLE
fix(coprocessor): suppress drift alerts during gw-listener replay

### DIFF
--- a/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
@@ -564,6 +564,9 @@ impl DriftDetector {
     /// Finalize a normal log-polling batch: check deferred consensus results,
     /// alert on completed-without-consensus handles, and evict stale handles.
     pub(crate) async fn end_of_batch(&mut self, db_pool: &Pool<Postgres>) -> anyhow::Result<()> {
+        if self.replaying {
+            return Ok(());
+        }
         self.refresh_pending_consensus_checks(db_pool).await?;
         self.finalize_completed_without_consensus();
         self.evict_stale(Instant::now());
@@ -985,6 +988,35 @@ mod tests {
 
         assert_eq!(detector.deferred_drift_detected, 1);
         assert!(detector.open_handles.get(&handle).unwrap().drift_reported);
+    }
+
+    #[tokio::test]
+    async fn end_of_batch_is_noop_while_replaying() {
+        let mut detector = detector();
+        let handle = FixedBytes::from([12u8; 32]);
+        let senders = senders();
+        let base = Instant::now();
+
+        detector.set_replaying(true);
+        for sender in senders {
+            submit_at(
+                &mut detector,
+                handle,
+                [13u8; 32],
+                [14u8; 32],
+                sender,
+                10,
+                base,
+            );
+        }
+
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://test:test@localhost:5432/test")
+            .unwrap();
+        detector.end_of_batch(&pool).await.unwrap();
+
+        assert!(detector.open_handles.contains_key(&handle));
+        assert_eq!(detector.deferred_consensus_timeout, 0);
     }
 
     #[test]

--- a/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/drift_detector.rs
@@ -123,6 +123,11 @@ impl DriftDetector {
         self.replaying = replaying;
     }
 
+    #[cfg(test)]
+    pub(crate) fn is_replaying(&self) -> bool {
+        self.replaying
+    }
+
     pub(crate) fn set_current_expected_senders(&mut self, expected_senders: Vec<Address>) {
         self.current_expected_senders = expected_senders;
     }

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -311,8 +311,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             from_block,
             to_block, "Rebuilding drift detector from persisted watermark"
         );
-        drift_detector.set_replaying(true);
-
+        let mut replay = ReplayGuard::new(drift_detector);
         let mut batch_from = from_block;
         while batch_from <= to_block {
             let batch_to = std::cmp::min(
@@ -344,10 +343,10 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
 
             for log in logs {
                 if log.address() == ciphertext_commits_address {
-                    self.process_ciphertext_commits_log(drift_detector, log, batch_to, db_pool)
+                    self.process_ciphertext_commits_log(replay.detector(), log, batch_to, db_pool)
                         .await?;
                 } else if Some(log.address()) == self.conf.gateway_config_address {
-                    self.process_gateway_config_log(drift_detector, log)?;
+                    self.process_gateway_config_log(replay.detector(), log)?;
                 } else {
                     error!(log = ?log, "Unexpected log address while rebuilding drift detector");
                 }
@@ -355,7 +354,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
 
             batch_from = batch_to.saturating_add(1);
         }
-        drift_detector.set_replaying(false);
+        drop(replay);
         drift_detector.end_of_rebuild(db_pool).await?;
         drift_detector.flush_metrics();
         Ok(())
@@ -603,5 +602,67 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
                 error_details.join("; "),
             )
         }
+    }
+}
+
+struct ReplayGuard<'a> {
+    detector: &'a mut DriftDetector,
+}
+
+impl<'a> ReplayGuard<'a> {
+    fn new(detector: &'a mut DriftDetector) -> Self {
+        detector.set_replaying(true);
+        Self { detector }
+    }
+
+    fn detector(&mut self) -> &mut DriftDetector {
+        self.detector
+    }
+}
+
+impl Drop for ReplayGuard<'_> {
+    fn drop(&mut self) {
+        self.detector.set_replaying(false);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{providers::ProviderBuilder, transports::mock::Asserter};
+
+    #[tokio::test]
+    async fn rebuild_error_clears_replay_mode() {
+        let mut conf = ConfigSettings {
+            ciphertext_commits_address: Some(Address::from([1; 20])),
+            ..ConfigSettings::default()
+        };
+        conf.get_logs_block_batch_size = 1;
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("get_logs failed");
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let listener = GatewayListener::new(
+            Address::from([2; 20]),
+            conf.clone(),
+            CancellationToken::new(),
+            provider,
+        );
+        let mut detector = DriftDetector::new(
+            Vec::new(),
+            conf.drift_no_consensus_timeout,
+            conf.drift_post_consensus_grace,
+            conf.drift_auto_revert_enabled,
+        );
+        let pool = PgPoolOptions::new()
+            .connect_lazy("postgres://test:test@localhost:5432/test")
+            .unwrap();
+
+        let result = listener
+            .rebuild_drift_detector(&pool, &mut detector, Some(1), Some(1))
+            .await;
+
+        assert!(result.is_err());
+        assert!(!detector.is_replaying());
     }
 }


### PR DESCRIPTION
## Summary

- skip end-of-batch drift finalization while replay mode is active

## Why this differs from `release/0.12.x`

The `release/0.12.x` PR contains extra code because that branch still has the operator-triggered gw-listener replay path:

- `--replay-from-block`
- alias `--catchup-kms-generation-from-block`
- `--replay-skip-verify-proof`
- `replay_from_block` state passed through `run_get_logs`

That path rewinds `last_processed_block_num` and reprocesses old gateway logs through the normal polling loop. Without that branch-specific handling, historical `CiphertextCommits` logs can reach `DriftDetector::end_of_batch` as if they were live logs.

On `main`, the explicit replay CLI path was removed by #2347 (`refactor(coprocessor): remove key generation listening from gw-listener`). The remaining replay on `main` is startup drift-detector rebuild from `earliest_open_ct_commits_block` to `last_processed_block_num`, with a separate `end_of_rebuild` finalization point. Therefore this PR only hardens the shared `end_of_batch` invariant.

## Behavioral equivalence with `release/0.12.x`

The intended common effect is: historical gateway log replay must not emit live drift alerts during normal batch finalization.

- On `release/0.12.x`, #2431 applies that behavior to both startup rebuild replay and explicit `--replay-from-block` replay.
- On `main`, explicit `--replay-from-block` replay no longer exists, so this PR applies the shared `end_of_batch` replay guard only.

## Testing

- `cargo test -p gw-listener end_of_batch_is_noop_while_replaying --lib`
- `cargo check -p gw-listener`
- pre-commit: `cargo fmt`, cargo check, clippy
