### PR TITLE
fix(contracts): scope upgrade check matrix and add diagnostics

### DIFF
--- a/.github/workflows/contracts-upgrade-version-check.yml
+++ b/.github/workflows/contracts-upgrade-version-check.yml
@@ -17,15 +17,15 @@ jobs:
   check-changes:
     name: contracts-upgrade-version-check/check-changes
     permissions:
-      contents: 'read' # Required to checkout repository code
-      pull-requests: 'read' # Required to read pull request for paths-filter
+      contents: "read" # Required to checkout repository code
+      pull-requests: "read" # Required to read pull request for paths-filter
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: 'false'
+          persist-credentials: "false"
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
@@ -46,22 +46,18 @@ jobs:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.packages != '[]' }}
     permissions:
-      contents: 'read' # Required to checkout repository code
+      contents: "read" # Required to checkout repository code
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         package: ${{ fromJSON(needs.check-changes.outputs.packages) }}
-        include:
-          - package: host-contracts
-            extra-deps: forge soldeer install
-          - package: gateway-contracts
-            extra-deps: ''
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: 'false'
+          fetch-depth: 0
+          persist-credentials: "false"
 
       - name: Resolve baseline release tag
         id: baseline
@@ -77,7 +73,7 @@ jobs:
         with:
           ref: ${{ steps.baseline.outputs.tag }}
           path: baseline
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
@@ -93,14 +89,11 @@ jobs:
         working-directory: baseline/${{ matrix.package }}
         run: npm ci
 
-      - name: Install Forge dependencies
-        if: matrix.extra-deps != ''
-        env:
-          PACKAGE: ${{ matrix.package }}
-          EXTRA_DEPS: ${{ matrix.extra-deps }}
+      - name: Install host Forge dependencies
+        if: matrix.package == 'host-contracts'
         run: |
-          (cd "$PACKAGE" && $EXTRA_DEPS)
-          (cd "baseline/$PACKAGE" && $EXTRA_DEPS)
+          (cd host-contracts && forge soldeer install)
+          (cd baseline/host-contracts && forge soldeer install)
 
       - name: Setup compilation
         env:
@@ -122,4 +115,5 @@ jobs:
       - name: Run upgrade version check
         env:
           PACKAGE: ${{ matrix.package }}
+          UPGRADE_CHECK_BASE_REF: ${{ steps.baseline.outputs.tag }}
         run: bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE"

--- a/ci/upgrade-check/check.ts
+++ b/ci/upgrade-check/check.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 // Checks that upgradeable contracts have proper version bumps when bytecode changes.
 // Usage: bun ci/upgrade-check/check.ts <baseline-pkg-dir> <pr-pkg-dir>
+import { execFileSync } from "child_process";
+import { basename } from "path";
 
 import { collectUpgradeVersionResults } from "./lib";
 
@@ -12,6 +14,46 @@ if (!baselineDir || !prDir) {
 
 const results = collectUpgradeVersionResults(baselineDir, prDir);
 let errors = 0;
+
+function printCommits(title: string, baseRef: string, targetRef: string, paths: string[]) {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const format = repo ? `- %h %s (https://github.com/${repo}/commit/%H)` : "- %h %s";
+  let output = "";
+
+  try {
+    output = execFileSync("git", ["log", `--format=${format}`, `${baseRef}..${targetRef}`, "--", ...paths], {
+      encoding: "utf-8",
+      env: { ...process.env, NO_COLOR: "1" },
+    }).trim();
+  } catch (error) {
+    const stderr = error instanceof Error && "stderr" in error ? String(error.stderr).trim() : "";
+    output = stderr || "git log failed";
+  }
+
+  console.log(title);
+  console.log(output || "- none");
+}
+
+function printDiagnostics(contract: string) {
+  const baseRef = process.env.UPGRADE_CHECK_BASE_REF;
+  if (!baseRef) return;
+
+  const targetRef = process.env.UPGRADE_CHECK_TARGET_REF ?? process.env.GITHUB_SHA ?? "HEAD";
+  const pkg = basename(prDir);
+  console.log(`Diagnostics for ${contract}:`);
+  console.log(`Baseline ref: ${baseRef}`);
+  console.log(`Target ref: ${targetRef}`);
+  printCommits("Non-exhaustive candidate commits touching the direct contract source:", baseRef, targetRef, [
+    `${pkg}/contracts/${contract}.sol`,
+  ]);
+  printCommits("Non-exhaustive candidate commits touching package build/config files:", baseRef, targetRef, [
+    `${pkg}/foundry.toml`,
+    `${pkg}/hardhat.config.ts`,
+    `${pkg}/package.json`,
+    `${pkg}/package-lock.json`,
+    `${pkg}/remappings.txt`,
+  ]);
+}
 
 for (const result of results) {
   console.log(`::group::Checking ${result.name}`);
@@ -30,6 +72,9 @@ for (const result of results) {
     for (const error of result.errors) {
       console.error(`::error::${error}`);
       errors++;
+    }
+    if (result.errors.length > 0) {
+      printDiagnostics(result.name);
     }
   } finally {
     console.log("::endgroup::");


### PR DESCRIPTION
## Summary

- scopes `contracts-upgrade-version-check` matrix rows to the packages selected by `check-changes`
- keeps host-only Forge setup behind a host package condition instead of using matrix `include`
- adds failure diagnostics that print candidate commits touching the failed contract source and package build/config files between the baseline tag and target SHA

## Validation

- `npx prettier --check ci/upgrade-check/check.ts .github/workflows/contracts-upgrade-version-check.yml`
- `git diff --check`
- YAML parse check for `.github/workflows/contracts-upgrade-version-check.yml`
- locally reproduced the PR #2364 gateway failure against `v0.12.3`; diagnostics pointed at `ed5c787ca feat(gateway-contracts): unify user decryption (#2329)`
