### PR TITLE
fix(coprocessor): fail gw-listener on drift rebuild errors

### DIFF
--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -118,17 +118,13 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             self.conf.drift_post_consensus_grace,
             self.conf.drift_auto_revert_enabled,
         );
-        if let Err(e) = self
-            .rebuild_drift_detector(
-                db_pool,
-                &mut drift_detector,
-                progress.earliest_open_ct_commits_block,
-                last_processed_block_num,
-            )
-            .await
-        {
-            error!(error = %e, "Failed to rebuild drift detector; continuing with partial state");
-        }
+        self.rebuild_drift_detector(
+            db_pool,
+            &mut drift_detector,
+            progress.earliest_open_ct_commits_block,
+            last_processed_block_num,
+        )
+        .await?;
 
         let filter_addresses = {
             let mut addrs = vec![self.input_verification_address];


### PR DESCRIPTION
## Summary

- Make gw-listener startup drift-detector rebuild errors bubble out of `run_get_logs` instead of continuing with partial in-memory state.
- This lets the existing outer retry/backoff loop retry recovery and prevents live polling after incomplete rebuild.

## Validation

- `cargo fmt -p gw-listener --check`
- `cargo check -p gw-listener --manifest-path coprocessor/fhevm-engine/Cargo.toml`
- pre-commit hook: cargo check + CI-aligned clippy
