### PR TITLE
fix(kms-connector): accept legacy extra data

### DIFF
--- a/.github/workflows/contracts-upgrade-version-check.yml
+++ b/.github/workflows/contracts-upgrade-version-check.yml
@@ -60,7 +60,9 @@ jobs:
     steps:
       - name: Skip unchanged package
         if: env.PACKAGE_CHANGED != 'true'
-        run: echo "${{ matrix.package }} did not change."
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: echo "$PACKAGE did not change."
 
       - name: Checkout PR branch
         if: env.PACKAGE_CHANGED == 'true'

--- a/.github/workflows/contracts-upgrade-version-check.yml
+++ b/.github/workflows/contracts-upgrade-version-check.yml
@@ -44,26 +44,32 @@ jobs:
   check:
     name: contracts-upgrade-version-check/${{ matrix.package }} (bpr)
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.packages != '[]' }}
     permissions:
       contents: 'read' # Required to checkout repository code
     runs-on: ubuntu-latest
+    env:
+      PACKAGE_CHANGED: ${{ contains(fromJSON(needs.check-changes.outputs.packages), matrix.package) }}
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJSON(needs.check-changes.outputs.packages) }}
         include:
           - package: host-contracts
             extra-deps: forge soldeer install
           - package: gateway-contracts
             extra-deps: ''
     steps:
+      - name: Skip unchanged package
+        if: env.PACKAGE_CHANGED != 'true'
+        run: echo "${{ matrix.package }} did not change."
+
       - name: Checkout PR branch
+        if: env.PACKAGE_CHANGED == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: 'false'
 
       - name: Resolve baseline release tag
+        if: env.PACKAGE_CHANGED == 'true'
         id: baseline
         env:
           GH_TOKEN: ${{ github.token }}
@@ -73,6 +79,7 @@ jobs:
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
 
       - name: Checkout baseline (latest stable release)
+        if: env.PACKAGE_CHANGED == 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ steps.baseline.outputs.tag }}
@@ -80,21 +87,25 @@ jobs:
           persist-credentials: 'false'
 
       - name: Install Bun
+        if: env.PACKAGE_CHANGED == 'true'
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
 
       - name: Install Foundry
+        if: env.PACKAGE_CHANGED == 'true'
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Install PR dependencies
+        if: env.PACKAGE_CHANGED == 'true'
         working-directory: ${{ matrix.package }}
         run: npm ci
 
       - name: Install baseline dependencies
+        if: env.PACKAGE_CHANGED == 'true'
         working-directory: baseline/${{ matrix.package }}
         run: npm ci
 
       - name: Install Forge dependencies
-        if: matrix.extra-deps != ''
+        if: env.PACKAGE_CHANGED == 'true' && matrix.extra-deps != ''
         env:
           PACKAGE: ${{ matrix.package }}
           EXTRA_DEPS: ${{ matrix.extra-deps }}
@@ -103,6 +114,7 @@ jobs:
           (cd "baseline/$PACKAGE" && $EXTRA_DEPS)
 
       - name: Setup compilation
+        if: env.PACKAGE_CHANGED == 'true'
         env:
           PACKAGE: ${{ matrix.package }}
         run: |
@@ -120,6 +132,7 @@ jobs:
           cp "$PACKAGE/foundry.toml" "baseline/$PACKAGE/foundry.toml"
 
       - name: Run upgrade version check
+        if: env.PACKAGE_CHANGED == 'true'
         env:
           PACKAGE: ${{ matrix.package }}
         run: bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE"

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -265,15 +265,17 @@ where
             })?;
         info!("Extracted key_id {key_id} from snsCtMaterials[0]");
 
-        let context_id = parse_extra_data(extra_data)
-            .map_err(ProcessingError::Irrecoverable)?
-            .context_id;
+        let parsed_extra_data =
+            parse_extra_data(extra_data).map_err(ProcessingError::Irrecoverable)?;
+        if let Some(context_id) = parsed_extra_data.context_id {
+            self.context_manager.validate_context(context_id).await?;
+        }
         // TODO: validation of epoch_id during RFC-005 implementation
-        self.context_manager.validate_context(context_id).await?;
 
         let ciphertexts = self.prepare_ciphertexts(&key_id, sns_materials).await?;
 
         let request_id = Some(u256_to_request_id(decryption_id));
+        let kms_extra_data = kms_decryption_extra_data(extra_data);
 
         if let Some(user_decrypt_data) = user_decrypt_data {
             let client_address = user_decrypt_data.user_address.to_checksum(None);
@@ -285,9 +287,9 @@ where
                 domain: Some(self.domain.clone()),
                 enc_key,
                 typed_ciphertexts: ciphertexts,
-                extra_data: extra_data.to_vec(),
+                extra_data: kms_extra_data,
                 epoch_id: None,
-                context_id: Some(u256_to_request_id(context_id)),
+                context_id: parsed_extra_data.context_id.map(u256_to_request_id),
             };
 
             Ok(user_decryption_request.into())
@@ -297,9 +299,9 @@ where
                 ciphertexts,
                 key_id: Some(RequestId { request_id: key_id }),
                 domain: Some(self.domain.clone()),
-                extra_data: extra_data.to_vec(),
+                extra_data: kms_extra_data,
                 epoch_id: None,
-                context_id: Some(u256_to_request_id(context_id)),
+                context_id: parsed_extra_data.context_id.map(u256_to_request_id),
             };
             Ok(public_decryption_request.into())
         }
@@ -354,6 +356,15 @@ where
     }
 }
 
+fn kms_decryption_extra_data(extra_data: &Bytes) -> Vec<u8> {
+    // relayer-sdk <=0.4.2 sends 0x00 but verifies the KMS signature against empty extraData.
+    if extra_data.as_ref() == [0x00] {
+        Vec::new()
+    } else {
+        extra_data.to_vec()
+    }
+}
+
 pub struct UserDecryptionExtraData {
     pub user_address: Address,
     pub public_key: Bytes,
@@ -386,6 +397,23 @@ mod tests {
         Recoverable,
         #[allow(unused)]
         Irrecoverable,
+    }
+
+    #[test]
+    fn kms_decryption_extra_data_normalizes_legacy_zero_marker() {
+        assert_eq!(
+            kms_decryption_extra_data(&Bytes::from_static(&[0x00])),
+            Vec::<u8>::new()
+        );
+    }
+
+    #[test]
+    fn kms_decryption_extra_data_keeps_empty_and_versioned_values() {
+        assert_eq!(kms_decryption_extra_data(&Bytes::new()), Vec::<u8>::new());
+        assert_eq!(
+            kms_decryption_extra_data(&Bytes::from_static(&[0x01, 0x02])),
+            vec![0x01, 0x02]
+        );
     }
 
     enum PubDecryptACLMock {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms.rs
@@ -48,9 +48,9 @@ where
     ) -> Result<KmsGrpcRequest, ProcessingError> {
         let parsed_extra_data = parse_extra_data(&prep_keygen_request.extraData)
             .map_err(ProcessingError::Irrecoverable)?;
-        self.context_manager
-            .validate_context(parsed_extra_data.context_id)
-            .await?;
+        if let Some(context_id) = parsed_extra_data.context_id {
+            self.context_manager.validate_context(context_id).await?;
+        }
         // TODO: validation of epoch_id during RFC-005 implementation
 
         Ok(KmsGrpcRequest::PrepKeygen(KeyGenPreprocRequest {
@@ -58,7 +58,7 @@ where
             domain: Some(self.domain.clone()),
             params: prep_keygen_request.paramsType as i32,
             epoch_id: parsed_extra_data.epoch_id.map(u256_to_request_id),
-            context_id: Some(u256_to_request_id(parsed_extra_data.context_id)),
+            context_id: parsed_extra_data.context_id.map(u256_to_request_id),
             extra_data: prep_keygen_request.extraData.to_vec(),
             // Used to generate other types of key, but not planned to be supported by the Gateway
             keyset_config: Some(UNCOMPRESSED_KEY_SET_CONFIG),
@@ -71,9 +71,9 @@ where
     ) -> Result<KmsGrpcRequest, ProcessingError> {
         let parsed_extra_data =
             parse_extra_data(&keygen_request.extraData).map_err(ProcessingError::Irrecoverable)?;
-        self.context_manager
-            .validate_context(parsed_extra_data.context_id)
-            .await?;
+        if let Some(context_id) = parsed_extra_data.context_id {
+            self.context_manager.validate_context(context_id).await?;
+        }
         // TODO: validation of epoch_id during RFC-005 implementation
 
         Ok(KmsGrpcRequest::Keygen(KeyGenRequest {
@@ -82,7 +82,7 @@ where
             domain: Some(self.domain.clone()),
             params: None,
             epoch_id: parsed_extra_data.epoch_id.map(u256_to_request_id),
-            context_id: Some(u256_to_request_id(parsed_extra_data.context_id)),
+            context_id: parsed_extra_data.context_id.map(u256_to_request_id),
             extra_data: keygen_request.extraData.to_vec(),
             // Used to generate other types of key, but not planned to be supported by the Gateway
             keyset_config: Some(UNCOMPRESSED_KEY_SET_CONFIG),
@@ -96,9 +96,9 @@ where
     ) -> Result<KmsGrpcRequest, ProcessingError> {
         let parsed_extra_data =
             parse_extra_data(&crsgen_request.extraData).map_err(ProcessingError::Irrecoverable)?;
-        self.context_manager
-            .validate_context(parsed_extra_data.context_id)
-            .await?;
+        if let Some(context_id) = parsed_extra_data.context_id {
+            self.context_manager.validate_context(context_id).await?;
+        }
         // TODO: validation of epoch_id during RFC-005 implementation
 
         let max_num_bits = crsgen_request
@@ -119,7 +119,7 @@ where
             extra_data: crsgen_request.extraData.to_vec(),
             max_num_bits,
             epoch_id: parsed_extra_data.epoch_id.map(u256_to_request_id),
-            context_id: Some(u256_to_request_id(parsed_extra_data.context_id)),
+            context_id: parsed_extra_data.context_id.map(u256_to_request_id),
         }))
     }
 }

--- a/kms-connector/crates/utils/src/types/extra_data.rs
+++ b/kms-connector/crates/utils/src/types/extra_data.rs
@@ -16,13 +16,14 @@ pub const EXTRA_DATA_V2_LENGTH: usize = 65;
 /// Parsed extra_data contents.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExtraData {
-    pub context_id: U256,
+    pub context_id: Option<U256>,
     pub epoch_id: Option<U256>,
 }
 
 /// Parses the `extra_data` bytes to extract a context ID and an optional epoch ID.
 ///
-/// Only versions `0x01` and `0x02` are accepted (rolling compatibility window).
+/// Versions `0x01` and `0x02` are accepted (rolling compatibility window).
+/// Empty extra_data and `0x00` are legacy default-context markers.
 ///
 /// Format (v1, RFC 003):
 /// - Byte 0: version (`0x01`)
@@ -36,13 +37,16 @@ pub struct ExtraData {
 /// - Bytes 65..: optional additional data (ignored)
 ///
 /// Version `0x01` → epoch_id is `None` (caller should fall back to DEFAULT_EPOCH_ID).
-/// Empty, `[0x00]`, or any other version byte → error.
+/// Empty or `[0x00]` → no explicit context and no epoch.
 pub fn parse_extra_data(extra_data: &[u8]) -> anyhow::Result<ExtraData> {
-    let Some(version) = extra_data.first() else {
-        return Err(anyhow!("extra_data is empty"));
-    };
+    if extra_data.is_empty() || extra_data == [0x00] {
+        return Ok(ExtraData {
+            context_id: None,
+            epoch_id: None,
+        });
+    }
 
-    match *version {
+    match extra_data[0] {
         EXTRA_DATA_V1_VERSION => {
             if extra_data.len() < EXTRA_DATA_V1_LENGTH {
                 return Err(anyhow!(
@@ -57,7 +61,7 @@ pub fn parse_extra_data(extra_data: &[u8]) -> anyhow::Result<ExtraData> {
                 .map_err(|e| anyhow!("Failed to extract context_id from extra_data: {e}"))?;
 
             Ok(ExtraData {
-                context_id: U256::from_be_bytes(context_id_bytes),
+                context_id: Some(U256::from_be_bytes(context_id_bytes)),
                 epoch_id: None,
             })
         }
@@ -79,13 +83,13 @@ pub fn parse_extra_data(extra_data: &[u8]) -> anyhow::Result<ExtraData> {
                 .map_err(|e| anyhow!("Failed to extract epoch_id from extra_data: {e}"))?;
 
             Ok(ExtraData {
-                context_id: U256::from_be_bytes(context_id_bytes),
+                context_id: Some(U256::from_be_bytes(context_id_bytes)),
                 epoch_id: Some(U256::from_be_bytes(epoch_id_bytes)),
             })
         }
         _ => Err(anyhow!(
-            "Unsupported extra_data version: 0x{:02x}, expected 0x{:02x} or 0x{:02x}",
-            version,
+            "Unsupported extra_data version: 0x{:02x}, expected 0x00, 0x{:02x}, or 0x{:02x}",
+            extra_data[0],
             EXTRA_DATA_V1_VERSION,
             EXTRA_DATA_V2_VERSION
         )),
@@ -97,20 +101,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_errors() {
-        let err = parse_extra_data(&[]).unwrap_err();
-        assert!(
-            err.to_string().contains("extra_data is empty"),
-            "Unexpected error: {err}"
+    fn empty_returns_default_context() {
+        assert_eq!(
+            parse_extra_data(&[]).unwrap(),
+            ExtraData {
+                context_id: None,
+                epoch_id: None
+            }
         );
     }
 
     #[test]
-    fn single_zero_byte_errors() {
-        let err = parse_extra_data(&[0x00]).unwrap_err();
-        assert!(
-            err.to_string().contains("Unsupported extra_data version"),
-            "Unexpected error: {err}"
+    fn single_zero_byte_returns_default_context() {
+        assert_eq!(
+            parse_extra_data(&[0x00]).unwrap(),
+            ExtraData {
+                context_id: None,
+                epoch_id: None
+            }
         );
     }
 
@@ -125,7 +133,7 @@ mod tests {
         assert_eq!(
             result,
             ExtraData {
-                context_id: U256::from(69u64),
+                context_id: Some(U256::from(69u64)),
                 epoch_id: None
             }
         );
@@ -143,7 +151,7 @@ mod tests {
         assert_eq!(
             result,
             ExtraData {
-                context_id: U256::from(42u64),
+                context_id: Some(U256::from(42u64)),
                 epoch_id: Some(U256::from(7u64))
             }
         );
@@ -160,7 +168,7 @@ mod tests {
         assert_eq!(
             result,
             ExtraData {
-                context_id: U256::from(1u64),
+                context_id: Some(U256::from(1u64)),
                 epoch_id: Some(U256::from(2u64))
             }
         );


### PR DESCRIPTION
## What
Accept legacy empty/`0x00` KMS connector `extra_data` values as the default context.

## Why
The v0.13 KMS worker currently rejects `extraData=0x00` with `Unsupported extra_data version`, but old relayer / SDK paths can still emit `0x00` during rollout. That blocks user decryption in a mixed-version stack where KMS connector has moved before all request producers emit versioned extra data.

## Behavior
- `[]` maps to no explicit context id and no epoch
- `[0x00]` maps to no explicit context id and no epoch
- `0x01` and `0x02` parsing remains unchanged
- context validation is skipped only when no explicit context id is present
- other version bytes still error

The original `extra_data` bytes are still forwarded to KMS request payloads; this PR does not rewrite legacy `0x00` to a synthetic v1 value.

## Validation
- `cd kms-connector && cargo test -p connector-utils extra_data --lib`
- `cd kms-connector && cargo check -p kms-worker`
- `cd kms-connector && cargo fmt --check`
- `git diff --check`
