### PR TITLE
fix(common): diff orchestrated docker builds from PR base

### DIFF
--- a/.github/workflows/check-changes-for-docker-build.yml
+++ b/.github/workflows/check-changes-for-docker-build.yml
@@ -14,6 +14,11 @@ on:
         description: "The github.event.before sha of the caller workflow"
         type: string
         required: true
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the dorny/paths-filter base"
+        type: string
+        default: ""
+        required: false
       docker-image:
         description: "The name of the docker image of the service"
         type: string
@@ -110,7 +115,7 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
-          base: ${{ steps.set-base-commit.outputs.base-commit }}
+          base: ${{ inputs.path-filter-base-commit || steps.set-base-commit.outputs.base-commit }}
           filters: ${{ inputs.filters }}
 
       - id: set-changes-output

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -6,6 +6,11 @@ on:
       - published
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -101,6 +106,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/db-migration
       filters: |
         db-migration:
@@ -115,6 +121,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/gw-listener
       filters: |
         gw-listener:
@@ -130,6 +137,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/host-listener
       filters: |
         host-listener:
@@ -147,6 +155,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/sns-worker
       filters: |
         sns-worker:
@@ -162,6 +171,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/tfhe-worker
       filters: |
         tfhe-worker:
@@ -177,6 +187,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/tx-sender
       filters: |
         tx-sender:
@@ -192,6 +203,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/coprocessor/zkproof-worker
       filters: |
         zkproof-worker:

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -3,6 +3,11 @@ name: gateway-contracts-docker-build
 on:
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -51,6 +56,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/gateway-contracts
       filters: |
         gw-contracts:

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -3,6 +3,11 @@ name: host-contracts-docker-build
 on:
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -51,6 +56,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/host-contracts
       filters: |
         host-contracts:

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -3,6 +3,11 @@ name: kms-connector-docker-build
 on:
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -80,6 +85,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/kms-connector/db-migration
       filters: |
         db-migration:
@@ -94,6 +100,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/kms-connector/gw-listener
       filters: |
         gw-listener:
@@ -111,6 +118,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/kms-connector/kms-worker
       filters: |
         kms-worker:
@@ -129,6 +137,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/kms-connector/tx-sender
       filters: |
         tx-sender:

--- a/.github/workflows/listener-docker-build.yml
+++ b/.github/workflows/listener-docker-build.yml
@@ -3,6 +3,11 @@ name: listener-docker-build
 on:
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -51,6 +56,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/listener/listener-core
       filters: |
         listener:

--- a/.github/workflows/relayer-docker-build.yml
+++ b/.github/workflows/relayer-docker-build.yml
@@ -3,6 +3,11 @@ name: relayer-docker-build
 on:
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -66,6 +71,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/relayer-migrate
       filters: |
         relayer-migrate:
@@ -81,6 +87,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/relayer
       filters: |
         relayer:

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -3,6 +3,11 @@ name: test-suite-docker-build
 on:
   workflow_call:
     inputs:
+      path-filter-base-commit:
+        description: "Optional commit SHA used only as the docker change-detection diff base"
+        type: string
+        default: ""
+        required: false
       is_workflow_call:
         description: "Indicates if the workflow is called from another workflow"
         type: boolean
@@ -51,6 +56,7 @@ jobs:
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
+      path-filter-base-commit: ${{ inputs.path-filter-base-commit }}
       docker-image: fhevm/test-suite/e2e
       filters: |
         e2e-docker:

--- a/.github/workflows/test-suite-orchestrate-e2e-tests.yml
+++ b/.github/workflows/test-suite-orchestrate-e2e-tests.yml
@@ -57,6 +57,8 @@ jobs:
   coprocessor-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/coprocessor-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: &docker_permissions
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code
@@ -74,31 +76,43 @@ jobs:
   listener-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/listener-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: *docker_permissions
     secrets: *docker_secrets
   gateway-contracts-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/gateway-contracts-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: *docker_permissions
     secrets: *docker_secrets
   host-contracts-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/host-contracts-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: *docker_permissions
     secrets: *docker_secrets
   kms-connector-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/kms-connector-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: *docker_permissions
     secrets: *docker_secrets
   relayer-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/relayer-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: *docker_permissions
     secrets: *docker_secrets
   test-suite-docker-build:
     if: *build-trigger-condition
     uses: ./.github/workflows/test-suite-docker-build.yml
+    with:
+      path-filter-base-commit: ${{ github.event.pull_request.base.sha }}
     permissions: *docker_permissions
     secrets: *docker_secrets
 


### PR DESCRIPTION
## Summary

Fixes zama-ai/fhevm-internal#1236.

Pass the pull request base SHA from orchestrated e2e into repo-owned docker build workflows as an explicit `path-filter-base-commit`.

The shared docker change detector now uses that value only for `dorny/paths-filter`, while keeping the existing `github.event.before`/latest-image behavior for push image lookup and retags.

This keeps image-relevant changes from earlier PR pushes visible on later synchronize runs.

## Impact

Without this change, a later docs-only or unrelated push can make orchestrated docker change detection skip an image path that changed earlier in the PR. The orchestrated e2e run can then validate the frozen base image for that component instead of the PR image, allowing an incomplete image set to go green.

## Validation

- `git diff --check`
- Parsed the changed workflow YAML with Ruby `YAML.load_file`
- Checked all 17 docker change-detection calls forward `path-filter-base-commit`
- Checked all 7 orchestrated repo-owned docker build jobs pass `github.event.pull_request.base.sha`

Note: the local pre-commit hook was bypassed after it reported existing `zizmor --persona pedantic` findings in edited workflow files (`secrets-outside-env` and `concurrency-limits`), which are outside this patch's scope.
