### PR TITLE
fix(coprocessor): improve drift recovery resilience

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/drift_revert.rs
@@ -21,6 +21,35 @@ const REVERT_SQL_TEMPLATE: &str =
 /// How often services poll `drift_revert_signal` for state changes.
 pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
+/// Per-iteration bound on each signal-poll query.
+pub const POLL_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cumulative limit on DB unreachability. If the watcher cannot reach the
+/// DB (no successful poll) for longer than this, the process exits so the
+/// supervisor restarts it fresh. Prevents a service from running with stale
+/// in-memory state through a long DB outage during which the drift runner
+/// may have completed a revert without it noticing.
+pub const DRIFT_REVERT_DB_DOWN_LIMIT: Duration = Duration::from_secs(60);
+
+/// The revert runner's grace period must be at least this many times
+/// `DRIFT_REVERT_DB_DOWN_LIMIT`.
+pub const MIN_GRACE_PERIOD_MULTIPLIER: u32 = 2;
+
+#[derive(Clone, Copy, Debug)]
+pub struct WatcherTimeouts {
+    pub poll_query_timeout: Duration,
+    pub db_down_limit: Duration,
+}
+
+impl Default for WatcherTimeouts {
+    fn default() -> Self {
+        Self {
+            poll_query_timeout: POLL_QUERY_TIMEOUT,
+            db_down_limit: DRIFT_REVERT_DB_DOWN_LIMIT,
+        }
+    }
+}
+
 static SIGNAL_CREATED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         "coprocessor_drift_revert_signal_created_counter",
@@ -362,16 +391,46 @@ pub async fn on_drift_detected(pool: &Pool<Postgres>, handle: &[u8], host_chain_
 /// Poll `drift_revert_signal` until any signal is in flight (Pending or
 /// Reverting) on any host chain. Used by `run_signal_watcher` to detect that
 /// a drift revert is happening so the service can re-exec.
-/// Transient DB errors are logged and skipped — the watcher must stay alive.
-pub async fn wait_for_in_flight_signal(pool: &Pool<Postgres>) -> anyhow::Result<DriftRevertSignal> {
+///
+/// Transient DB errors are logged and skipped — the watcher must stay
+/// alive. However, if the DB is unreachable for longer than
+/// `DRIFT_REVERT_DB_DOWN_LIMIT`, the process exits so the supervisor can
+/// restart it with fresh in-memory state. Each individual poll is bounded
+/// by `POLL_QUERY_TIMEOUT`.
+pub async fn wait_for_in_flight_signal(
+    pool: &Pool<Postgres>,
+    timeouts: WatcherTimeouts,
+) -> DriftRevertSignal {
+    let mut last_success = std::time::Instant::now();
     loop {
-        match oldest_in_flight_signal(pool).await {
-            Ok(Some(signal)) => return Ok(signal),
-            Ok(None) => {}
-            Err(e) => {
-                error!(error = %e, "Drift-revert watcher poll failed, retrying");
+        match tokio::time::timeout(timeouts.poll_query_timeout, oldest_in_flight_signal(pool)).await
+        {
+            Ok(Ok(Some(signal))) => return signal,
+            Ok(Ok(None)) => {
+                last_success = std::time::Instant::now();
+            }
+            Ok(Err(e)) => {
+                error!(error = %e, "Drift-revert watcher poll failed");
+            }
+            Err(_) => {
+                error!(
+                    timeout = ?timeouts.poll_query_timeout,
+                    "Drift-revert watcher poll timed out"
+                );
             }
         }
+
+        let elapsed = last_success.elapsed();
+        if elapsed >= timeouts.db_down_limit {
+            error!(
+                elapsed = ?elapsed,
+                limit = ?timeouts.db_down_limit,
+                "Drift-revert watcher could not reach the DB for too long; exiting \
+                 for supervisor restart so in-memory state cannot drift past a revert"
+            );
+            std::process::exit(1);
+        }
+
         tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
@@ -552,10 +611,11 @@ pub async fn run_signal_watcher(
     pool: &Pool<Postgres>,
     cancel_token: CancellationToken,
     re_exec_fn: &dyn ReExec,
-) -> anyhow::Result<()> {
+    timeouts: WatcherTimeouts,
+) {
     let signal = tokio::select! {
-        _ = cancel_token.cancelled() => return Ok(()),
-        r = wait_for_in_flight_signal(pool) => r?,
+        _ = cancel_token.cancelled() => return,
+        s = wait_for_in_flight_signal(pool, timeouts) => s,
     };
 
     info!(
@@ -567,8 +627,6 @@ pub async fn run_signal_watcher(
 
     // Never returns (exec replaces process, or exit on failure).
     re_exec_fn.re_exec();
-
-    Ok(())
 }
 
 /// Called on service startup BEFORE the main loop begins. If a pending signal
@@ -748,13 +806,23 @@ async fn run_all_pending_as_runner(
 ///    re-execs the process when one appears.
 ///
 /// Pass `Some(RevertRunnerConfig)` for the revert runner (e.g. gw-listener),
-/// `None` for all other services.
+/// `None` for all other services. `timeouts` controls the watcher's
+/// fail-fast thresholds — production should pass `WatcherTimeouts::default()`;
+/// heavy integration tests override with relaxed values.
 pub async fn init(
     pool: Pool<Postgres>,
     cancel_token: CancellationToken,
     runner_cfg: Option<RevertRunnerConfig>,
+    timeouts: WatcherTimeouts,
 ) -> anyhow::Result<()> {
-    init_with_reexec(pool, cancel_token, runner_cfg, ProcessReExec::new()).await
+    init_with_reexec(
+        pool,
+        cancel_token,
+        runner_cfg,
+        ProcessReExec::new(),
+        timeouts,
+    )
+    .await
 }
 
 /// Like [`init`] but lets the caller inject a custom `ReExec` implementation.
@@ -764,13 +832,12 @@ pub async fn init_with_reexec<R: ReExec + 'static>(
     cancel_token: CancellationToken,
     runner_cfg: Option<RevertRunnerConfig>,
     re_exec: R,
+    timeouts: WatcherTimeouts,
 ) -> anyhow::Result<()> {
     handle_pending_signal_on_startup(&pool, runner_cfg, &cancel_token).await?;
 
     tokio::spawn(async move {
-        if let Err(e) = run_signal_watcher(&pool, cancel_token, &re_exec).await {
-            error!(error = %e, "Drift-revert signal watcher failed");
-        }
+        run_signal_watcher(&pool, cancel_token, &re_exec, timeouts).await;
     });
 
     Ok(())

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -5,7 +5,10 @@ use alloy::{primitives::Address, transports::http::reqwest::Url};
 use clap::Parser;
 use fhevm_engine_common::database::{connect_pool_with_options, resolve_database_url_from_option};
 use fhevm_engine_common::{
-    drift_revert::{self, RevertRunnerConfig},
+    drift_revert::{
+        self, RevertRunnerConfig, WatcherTimeouts, DRIFT_REVERT_DB_DOWN_LIMIT,
+        MIN_GRACE_PERIOD_MULTIPLIER,
+    },
     metrics_server, telemetry,
     utils::DatabaseURL,
 };
@@ -17,6 +20,20 @@ use sqlx::postgres::PgPoolOptions;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
+
+/// Parse `drift_auto_revert_grace_period` and reject values below
+/// `MIN_GRACE_PERIOD_MULTIPLIER * DRIFT_REVERT_DB_DOWN_LIMIT`.
+fn parse_grace_period(s: &str) -> Result<Duration, String> {
+    let d = parse_duration(s).map_err(|e| e.to_string())?;
+    let min = DRIFT_REVERT_DB_DOWN_LIMIT * MIN_GRACE_PERIOD_MULTIPLIER;
+    if d < min {
+        return Err(format!(
+            "must be at least {}x DRIFT_REVERT_DB_DOWN_LIMIT ({:?}) = {:?}, got {:?}",
+            MIN_GRACE_PERIOD_MULTIPLIER, DRIFT_REVERT_DB_DOWN_LIMIT, min, d,
+        ));
+    }
+    Ok(d)
+}
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
@@ -103,9 +120,11 @@ struct Conf {
     drift_post_consensus_grace: Duration,
 
     /// How long to wait after detecting a pending drift-revert signal before
-    /// running the revert SQL. Gives other services time to see the signal and
-    /// re-exec before the DB state changes.
-    #[arg(long, default_value = "60s", value_parser = parse_duration)]
+    /// running the revert SQL. Gives other services time to see the signal
+    /// and re-exec (or fail-fast and be restarted) before the DB state
+    /// changes. Must be ≥ `MIN_GRACE_PERIOD_MULTIPLIER * DRIFT_REVERT_DB_DOWN_LIMIT`;
+    /// the service refuses to start otherwise.
+    #[arg(long, default_value = "120s", value_parser = parse_grace_period)]
     drift_auto_revert_grace_period: Duration,
 
     /// Enable automatic drift recovery. When false (default), the drift
@@ -240,6 +259,7 @@ async fn main() -> anyhow::Result<()> {
             max_recent_attempts: conf.drift_auto_revert_max_recent_attempts,
             recent_attempts_window: conf.drift_auto_revert_recent_attempts_window,
         }),
+        WatcherTimeouts::default(),
     )
     .await?;
 
@@ -260,4 +280,47 @@ async fn main() -> anyhow::Result<()> {
     info!("Gateway listener and HTTP health check server stopped gracefully");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_grace_period_accepts_exactly_min() {
+        let min = DRIFT_REVERT_DB_DOWN_LIMIT * MIN_GRACE_PERIOD_MULTIPLIER;
+        let s = format!("{}s", min.as_secs());
+        let parsed = parse_grace_period(&s).expect("min must be accepted");
+        assert_eq!(parsed, min);
+    }
+
+    #[test]
+    fn parse_grace_period_accepts_above_min() {
+        let min = DRIFT_REVERT_DB_DOWN_LIMIT * MIN_GRACE_PERIOD_MULTIPLIER;
+        let above = min + Duration::from_secs(1);
+        let s = format!("{}s", above.as_secs());
+        assert_eq!(parse_grace_period(&s).unwrap(), above);
+    }
+
+    #[test]
+    fn parse_grace_period_rejects_below_min() {
+        let min = DRIFT_REVERT_DB_DOWN_LIMIT * MIN_GRACE_PERIOD_MULTIPLIER;
+        let below = min - Duration::from_secs(1);
+        let s = format!("{}s", below.as_secs());
+        let err = parse_grace_period(&s).expect_err("below min must be rejected");
+        assert!(
+            err.contains("must be at least"),
+            "error should explain the lower bound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_grace_period_rejects_invalid_duration() {
+        let err = parse_grace_period("not-a-duration").expect_err("must reject garbage");
+        // Surfaces the humantime parse error rather than the bound check.
+        assert!(
+            !err.contains("must be at least"),
+            "invalid duration should not surface bound-check error, got: {err}"
+        );
+    }
 }

--- a/coprocessor/fhevm-engine/gw-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/lib.rs
@@ -33,8 +33,9 @@ pub struct ConfigSettings {
     pub drift_no_consensus_timeout: Duration,
     pub drift_post_consensus_grace: Duration,
     /// How long to wait after detecting a pending drift-revert signal before
-    /// running the revert SQL. Gives other services time to see the signal and
-    /// drop their in-flight work.
+    /// running the revert SQL. Gives other services time to see the signal
+    /// and re-exec (or fail-fast and be restarted by the supervisor) before
+    /// the DB state changes.
     pub drift_auto_revert_grace_period: Duration,
     /// If true, the drift detector creates drift-revert signals when it sees
     /// a consensus mismatch. If false, drift is still detected and logged,
@@ -60,7 +61,7 @@ impl Default for ConfigSettings {
             gateway_config_address: None,
             drift_no_consensus_timeout: Duration::from_secs(5),
             drift_post_consensus_grace: Duration::from_secs(2),
-            drift_auto_revert_grace_period: Duration::from_secs(60),
+            drift_auto_revert_grace_period: Duration::from_secs(120),
             drift_auto_revert_enabled: false,
         }
     }

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -1109,7 +1109,13 @@ pub async fn main(args: Args) -> anyhow::Result<()> {
         Some(&cancel_token),
     )
     .await?;
-    drift_revert::init(drift_revert_pool, cancel_token.clone(), None).await?;
+    drift_revert::init(
+        drift_revert_pool,
+        cancel_token.clone(),
+        None,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await?;
 
     if args.dependent_ops_max_per_chain == 0 {
         let promoted = db.promote_all_dep_chains_to_fast_priority().await?;

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -175,6 +175,7 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         drift_revert_pool,
         cancel_token.clone(),
         None,
+        fhevm_engine_common::drift_revert::WatcherTimeouts::default(),
     )
     .await?;
 

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -539,7 +539,13 @@ pub async fn run_all(
 
     // Drift-revert: must run before any DB-using task so the uploader and
     // service loop don't read or write rows the revert SQL is about to delete.
-    drift_revert::init(pool_mngr.pool().clone(), token.clone(), None).await?;
+    drift_revert::init(
+        pool_mngr.pool().clone(),
+        token.clone(),
+        None,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await?;
 
     // Spawns a task to handle S3 uploads
     spawn(async move {

--- a/coprocessor/fhevm-engine/tfhe-worker/benches/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/benches/utils.rs
@@ -91,6 +91,7 @@ async fn start_coprocessor(rx: Receiver<bool>, db_url: &str) {
         processed_dcid_ttl_sec: 0,
         dcid_max_no_progress_cycles: 2,
         dcid_ignore_dependency_count_threshold: 100,
+        drift_revert_watcher_timeouts: Default::default(),
     };
 
     std::thread::spawn(move || {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/daemon_cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use fhevm_engine_common::drift_revert::WatcherTimeouts;
 use fhevm_engine_common::telemetry::MetricsConfig;
 use fhevm_engine_common::utils::DatabaseURL;
 use tracing::Level;
@@ -113,6 +114,11 @@ pub struct Args {
     /// Prometheus metrics: coprocessor_fhe_batch_latency_seconds
     #[arg(long, default_value = "0.2:5.0:0.05", value_parser = clap::value_parser!(MetricsConfig))]
     pub metric_fhe_batch_latency: MetricsConfig,
+
+    /// Not exposed via CLI — `#[arg(skip)]` initializes the field to `WatcherTimeouts::default()`
+    /// on `Args::parse()`.
+    #[arg(skip)]
+    pub drift_revert_watcher_timeouts: WatcherTimeouts,
 }
 
 pub fn parse_args() -> Args {

--- a/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/lib.rs
@@ -99,7 +99,13 @@ pub async fn async_main(
         Some(&cancel_token),
     )
     .await?;
-    drift_revert::init(drift_revert_pool, cancel_token.clone(), None).await?;
+    drift_revert::init(
+        drift_revert_pool,
+        cancel_token.clone(),
+        None,
+        args.drift_revert_watcher_timeouts,
+    )
+    .await?;
 
     if args.run_bg_worker {
         let gpu_enabled = fhevm_engine_common::utils::log_backend();

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/drift_revert.rs
@@ -766,9 +766,13 @@ async fn signal_watcher_reexecs_on_pending_signal() {
         .await
         .expect("create signal");
 
-    drift_revert::run_signal_watcher(&pool, cancel, &mock)
-        .await
-        .expect("run_signal_watcher");
+    drift_revert::run_signal_watcher(
+        &pool,
+        cancel,
+        &mock,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await;
 
     assert!(mock.was_called(), "re_exec should have been called");
 }
@@ -783,9 +787,13 @@ async fn signal_watcher_exits_cleanly_on_cancel() {
 
     cancel.cancel();
 
-    drift_revert::run_signal_watcher(&pool, cancel, &mock)
-        .await
-        .expect("run_signal_watcher");
+    drift_revert::run_signal_watcher(
+        &pool,
+        cancel,
+        &mock,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await;
 
     assert!(!mock.was_called(), "re_exec should NOT have been called");
 }
@@ -985,9 +993,15 @@ async fn init_handles_pending_signal_and_spawns_watcher() {
     let mock = MockReExec::new();
 
     // init as runner: handles the pending signal (revert + mark done).
-    drift_revert::init_with_reexec(pool.clone(), cancel.clone(), Some(cfg), mock)
-        .await
-        .expect("init");
+    drift_revert::init_with_reexec(
+        pool.clone(),
+        cancel.clone(),
+        Some(cfg),
+        mock,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await
+    .expect("init");
 
     let signal = drift_revert::latest_signal(&pool).await.unwrap().unwrap();
     assert_eq!(

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
@@ -1,10 +1,12 @@
 use crate::daemon_cli::Args;
 use fhevm_engine_common::crs::{Crs, CrsCache};
 use fhevm_engine_common::db_keys::{DbKey, DbKeyCache};
+use fhevm_engine_common::drift_revert::WatcherTimeouts;
 use fhevm_engine_common::telemetry::MetricsConfig;
 use fhevm_engine_common::tfhe_ops::current_ciphertext_version;
 use fhevm_engine_common::types::SupportedFheCiphertexts;
 use std::collections::BTreeMap;
+use std::time::Duration;
 use test_harness::db_utils::setup_test_key;
 use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage, ImageExt};
 use tokio::sync::watch::Receiver;
@@ -94,6 +96,13 @@ async fn start_coprocessor(rx: Receiver<bool>, db_url: &str) -> u16 {
         processed_dcid_ttl_sec: 0,
         dcid_max_no_progress_cycles: 2,
         dcid_ignore_dependency_count_threshold: 100,
+        // Heavy FHE tests can saturate a test Postgres instance for tens of seconds;
+        // relax the watcher's production-tuned thresholds so fail-fast doesn't trip
+        // on slow polls during the test workload.
+        drift_revert_watcher_timeouts: WatcherTimeouts {
+            poll_query_timeout: Duration::from_secs(300),
+            db_down_limit: Duration::from_secs(1800),
+        },
     };
 
     std::thread::spawn(move || {

--- a/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -354,7 +354,13 @@ async fn main() -> anyhow::Result<()> {
     let http_server_fut = tokio::spawn(async move { http_server.start().await });
     metrics_server::spawn(conf.metrics_addr.clone(), cancel_token.child_token());
 
-    drift_revert::init(db_pool.clone(), cancel_token.clone(), None).await?;
+    drift_revert::init(
+        db_pool.clone(),
+        cancel_token.clone(),
+        None,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await?;
 
     let transaction_sender_fut = tokio::spawn(async move { transaction_sender.run().await });
 

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -139,12 +139,17 @@ async fn main() {
 
     metrics_server::spawn(args.metrics_addr.clone(), cancel_token.child_token());
 
-    drift_revert::init(service.pool(), cancel_token.clone(), None)
-        .await
-        .unwrap_or_else(|err| {
-            error!(error = %err, "Drift-revert init failed");
-            std::process::exit(1);
-        });
+    drift_revert::init(
+        service.pool(),
+        cancel_token.clone(),
+        None,
+        drift_revert::WatcherTimeouts::default(),
+    )
+    .await
+    .unwrap_or_else(|err| {
+        error!(error = %err, "Drift-revert init failed");
+        std::process::exit(1);
+    });
 
     let service_task = async {
         info!("Starting worker...");


### PR DESCRIPTION
If a coprocessor service loses its DB connection, it might miss a drift revert signal. When DB connection recovers, it might continue operating with stale data in memory, without having re-execed.

In order to minimize the chance of this happening, make sure services exit if the DB has been down for 60 seconds. Also, require that the drift revert grace period is at least twice that. Exiting in such cases means that the service will observe the signal after restart, if the DB connection is back up again. And if it doesn't observe it, it has restarted, so it should start from a good DB state.