### PR TITLE
feat(test-suite): add native runner and binary replace

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -110,6 +110,10 @@ on:
         description: "Named test profile to run instead of the default standard suite"
         default: "standard"
         type: string
+      test-runner:
+        description: "Test runner backend used by fhevm-cli test"
+        default: "docker"
+        type: string
   workflow_call:
     secrets:
       GHCR_READ_TOKEN:
@@ -159,6 +163,7 @@ jobs:
       ORCHESTRATED: ${{ inputs.orchestrated && 'true' || 'false' }}
       SCENARIO: ${{ inputs.scenario || 'two-of-three-multi-chain' }}
       TEST_PROFILE: ${{ inputs.test-profile || 'standard' }}
+      TEST_RUNNER: ${{ inputs.test-runner || 'docker' }}
     runs-on: large_ubuntu_32
     steps:
       - name: Checkout code
@@ -172,6 +177,16 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+
+      - name: Setup Node.js
+        if: ${{ env.TEST_RUNNER == 'native' }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: 20.x
+
+      - name: Install native e2e deps
+        if: ${{ env.TEST_RUNNER == 'native' }}
+        run: npm ci --workspace test-suite/e2e --include-workspace-root=false
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
@@ -353,7 +368,8 @@ jobs:
       - name: Selected e2e suite
         working-directory: test-suite/fhevm
         run: |
-          ./fhevm-cli test "$TEST_PROFILE"
+          args=("$TEST_PROFILE")
+          ./fhevm-cli test "${args[@]}" --runner "$TEST_RUNNER"
 
       - name: Host listener consumer only test without drift-revert tests
         if: ${{ inputs.test-profile == '' || inputs.test-profile == 'standard' }}
@@ -362,7 +378,7 @@ jobs:
           trap 'docker start coprocessor-host-listener coprocessor-host-listener-poller>/dev/null 2>&1 || true' EXIT
           docker stop coprocessor-host-listener coprocessor-host-listener-poller
           for TEST in input-proof input-proof-compute-decrypt user-decryption delegated-user-decryption erc20 public-decrypt-http-ebool public-decrypt-http-mixed; do
-            ./fhevm-cli test $TEST
+            ./fhevm-cli test "$TEST" --runner "$TEST_RUNNER"
           done
           docker start coprocessor-host-listener coprocessor-host-listener-poller
           trap - EXIT
@@ -373,7 +389,8 @@ jobs:
         run: |
           trap 'docker start coprocessor-host-listener coprocessor-host-listener-consumer>/dev/null 2>&1 || true' EXIT
           docker stop coprocessor-host-listener coprocessor-host-listener-consumer
-          ./fhevm-cli test erc20
+          args=(erc20)
+          ./fhevm-cli test "${args[@]}" --runner "$TEST_RUNNER"
           docker start coprocessor-host-listener coprocessor-host-listener-consumer
           trap - EXIT
 

--- a/test-suite/e2e/hardhat.config.ts
+++ b/test-suite/e2e/hardhat.config.ts
@@ -12,14 +12,53 @@ const DEFAULT_NETWORK = 'staging';
 task('compile:specific', 'Compiles only the specified contract')
   .addParam('contract', "The contract's path")
   .setAction(async ({ contract }, hre) => {
-    // Adjust the configuration to include only the specified contract
+    const originalSources = hre.config.paths.sources;
     hre.config.paths.sources = contract;
-
-    await hre.run('compile');
+    try {
+      await hre.run('compile');
+    } finally {
+      hre.config.paths.sources = originalSources;
+    }
   });
 
 const dotenvConfigPath: string = process.env.DOTENV_CONFIG_PATH || './.env';
 dotenv.config({ path: resolve(__dirname, dotenvConfigPath) });
+
+// Native runner: the relayer returns MinIO URLs using Docker hostnames because
+// that is what runtime containers need. The host-side SDK process has to fetch
+// the same material through the published MinIO port.
+if (process.env.FHEVM_NATIVE_RUNNER === 'true') {
+  const originalFetch = globalThis.fetch;
+  const nativeMaterialUrl = (href: string) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(href);
+    } catch {
+      return undefined;
+    }
+    if (
+      parsed.protocol !== 'http:' ||
+      parsed.port !== '9000' ||
+      !(/^[a-z][a-z0-9-]*$/i.test(parsed.hostname) || /^\d+\.\d+\.\d+\.\d+$/.test(parsed.hostname))
+    ) {
+      return undefined;
+    }
+    parsed.hostname = 'localhost';
+    return parsed.toString();
+  };
+
+  globalThis.fetch = (input, init) => {
+    const href = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    const rewritten = nativeMaterialUrl(href);
+    if (!rewritten) {
+      return originalFetch(input, init);
+    }
+    if (input instanceof Request) {
+      return originalFetch(new Request(rewritten, input), init);
+    }
+    return originalFetch(rewritten, init);
+  };
+}
 
 const defaultMnemonic =
   'adapt mosquito move limb mobile illegal tree voyage juice mosquito burger raise father hope layer';

--- a/test-suite/fhevm/README.md
+++ b/test-suite/fhevm/README.md
@@ -78,6 +78,7 @@ bun test
 ./fhevm-cli up --target latest-supported
 ./fhevm-cli up --target latest-main --build --dry-run
 ./fhevm-cli test erc20
+./fhevm-cli test input-proof --runner native
 ./fhevm-cli clean
 ```
 
@@ -88,7 +89,7 @@ bun test
 - `up --scenario <name-or-file>` applies an explicit coprocessor consensus scenario on top of the resolved bundle
 - `up --override coprocessor` is the fast local-dev shorthand for a one-instance local coprocessor scenario
 - `scenario list` prints the bundled scenario presets with their intent
-- `test` runs against the current stack and may recompile contracts through Hardhat by default. Pass `--no-hardhat-compile` to skip that step. `--parallel` runs tests in parallel (auto for `operators`). `test light` is the tiny smoke lane (`input-proof` + `erc20`), `test standard` runs the default CI lane including db revert and drift, `test multi-chain-isolation` is the dedicated multi-chain coverage lane, and `test heavy` is the operators lane
+- `test` runs against the current stack and may recompile contracts through Hardhat by default. Pass `--runner native` to run the checked-out `test-suite/e2e` workspace directly; Docker remains the default runner. Pass `--no-hardhat-compile` to skip that step. `--parallel` runs tests in parallel (auto for `operators`). `test light` is the tiny smoke lane (`input-proof` + `erc20`), `test standard` runs the default CI lane including db revert and drift, `test multi-chain-isolation` is the dedicated multi-chain coverage lane, and `test heavy` is the operators lane
 - `logs` follows container output; `--no-follow` prints the tail and exits
 - `pause` / `unpause` pauses or unpauses host or gateway contracts
 - `down` stops the stack, prunes `.fhevm/runtime`, and keeps resumable `.fhevm/state`
@@ -355,6 +356,9 @@ When changing runtime flags, env contracts, target semantics, or external compan
 ./fhevm-cli test standard
 ./fhevm-cli test heavy
 ./fhevm-cli test operators
+./fhevm-cli test input-proof --runner native
+./fhevm-cli replace list
+./fhevm-cli replace coprocessor:tfhe-worker --local-build
 ./fhevm-cli test --grep "oversized shift/rotate" --verbose
 ./fhevm-cli pause host
 ./fhevm-cli unpause host
@@ -370,8 +374,22 @@ Use `--override` to run local code for one repo-owned group on top of an otherwi
 Important:
 
 - by default, the stack uses the published `test-suite` image
-- local e2e test changes are not picked up unless you use `--override test-suite` or `--build`
-- if you are validating newly added or edited tests in this branch, prefer `--override test-suite` for a surgical local test-suite rebuild
+- local e2e test changes are picked up fastest with `./fhevm-cli test <profile> --runner native`
+- Docker-runner e2e test changes still require `--override test-suite` or `--build`
+- if you are validating newly added or edited tests in the test-suite image path, prefer `--override test-suite` for a surgical local test-suite rebuild
+
+### Fast local e2e iteration
+
+Use the native test runner when editing TypeScript tests in `test-suite/e2e`:
+
+```sh
+npm ci --workspace test-suite/e2e --include-workspace-root=false
+cd test-suite/fhevm
+./fhevm-cli up
+./fhevm-cli test input-proof --runner native
+```
+
+The stack still runs in Docker. Only `test-suite/e2e/run-tests.sh` and Hardhat run from the checked-out workspace, so edits and debug logs are picked up on the next test command without rebuilding or copying into the test-suite container.
 
 Use `--build` when you want the whole local workspace on the active baseline. On topology-only scenario runs, `--build` also applies local coprocessor images to inherited scenario instances. If a scenario explicitly pins coprocessor source, overlapping explicit coprocessor overrides fail fast instead.
 `--build` cannot be combined with `--override`.
@@ -468,6 +486,36 @@ If a runtime override is already active and you only want to rebuild and restart
 ```
 
 `upgrade` only supports active runtime override groups: `coprocessor`, `kms-connector`, and `test-suite`. It is a runtime rebuild/restart command, not a live schema migration command. For schema-coupled groups (`coprocessor`, `kms-connector`), if local DB migrations changed, `upgrade` fails fast and asks you to do a fresh `fhevm-cli up` instead of rerunning the initializer on a live database.
+
+## Replace Runtime Binaries
+
+Use `replace` for a narrow debug loop when the running stack should keep its current env, config, database state, and Docker image. With `--local-build`, the CLI runs a cached Linux Cargo build, copies the resulting binary into matching running containers, and restarts only those containers. Without `--local-build`, it copies an already-built binary from the default path.
+
+```sh
+./fhevm-cli replace list
+./fhevm-cli replace coprocessor:tfhe-worker --local-build
+./fhevm-cli replace coprocessor:tfhe-worker --local-build --build-profile release
+./fhevm-cli replace coprocessor:tfhe-worker
+./fhevm-cli replace coprocessor:tfhe-worker coprocessor:zkproof-worker
+./fhevm-cli replace kms-connector:gw-listener --binary ../../kms-connector/target/release/gw-listener
+```
+
+Valid targets:
+
+- `coprocessor:host-listener`
+- `coprocessor:host-listener-poller`
+- `coprocessor:host-listener-consumer`
+- `coprocessor:gw-listener`
+- `coprocessor:tfhe-worker`
+- `coprocessor:sns-worker`
+- `coprocessor:transaction-sender`
+- `coprocessor:zkproof-worker`
+- `kms-connector:gw-listener`
+- `kms-connector:kms-worker`
+- `kms-connector:tx-sender`
+- `listener-core:publisher`
+
+`replace --local-build` owns a maintained target catalog: Cargo workspace, package, binary name, container path, and matching running containers. Builds run inside Docker's Linux VM with Cargo registry, git, and target caches under `.fhevm/runtime/replace-build`. The default build profile is `dev` for fast iteration; pass `--build-profile release` for optimized binaries. It does not rerender Compose, run migrations, or change versions. Use `upgrade` or a fresh `up --override ...` when env contracts, runtime args, dependencies, migrations, or image contents changed.
 
 ## Dropped Convenience Commands
 

--- a/test-suite/fhevm/src/cli.test.ts
+++ b/test-suite/fhevm/src/cli.test.ts
@@ -1,17 +1,29 @@
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import { describe, expect, test } from "bun:test";
-import { DEFAULT_GATEWAY_RPC_PORT, DEFAULT_HOST_RPC_PORT, MINIO_PORT, STANDARD_TEST_PROFILES, TEST_SUITE_CONTAINER } from "./layout";
 import {
   buildTestContainerArgs,
   dbRevertDeleteExpectations,
   dbRevertTargetBlock,
   keyBootstrapLogArgs,
+  nativeTestEnv,
+  parseTestRunner,
+  prepareNativeTestEnv,
   validateNamedProfileGrep,
   waitForKeyBootstrap,
 } from "./commands/test";
+import { readEnvFile } from "./utils/fs";
+import { REPLACE_TARGET_NAMES, parseBuildProfile, replaceBuildBinary, replaceBuildTargetDir, replaceTargetsForState } from "./commands/replace";
 import { resumeOptionConflicts, shouldShowResumeHint } from "./flow/up-flow";
 import { resolveLogsFollow } from "./cli";
+import {
+  DEFAULT_GATEWAY_RPC_PORT,
+  DEFAULT_HOST_RPC_PORT,
+  envPath,
+  MINIO_PORT,
+  STANDARD_TEST_PROFILES,
+  TEST_SUITE_CONTAINER,
+} from "./layout";
 import { withTempStateDir } from "./test-state";
 import { testDefaultScenario } from "./test-fixtures";
 import type { State } from "./types";
@@ -109,6 +121,7 @@ describe("cli", () => {
     expect(result.code).toBe(0);
     expect(output).toContain("fhevm-cli test");
     expect(output).toContain("[TESTNAME]");
+    expect(output).toContain("--runner");
   });
 
   test("lists bundled test profiles", async () => {
@@ -122,6 +135,56 @@ describe("cli", () => {
 
   test("standard suite includes multi-chain isolation coverage", () => {
     expect(STANDARD_TEST_PROFILES).toContain("multi-chain-isolation");
+  });
+
+  test("parses test runner backends", () => {
+    expect(parseTestRunner(undefined)).toBe("docker");
+    expect(parseTestRunner("docker")).toBe("docker");
+    expect(parseTestRunner("native")).toBe("native");
+    expect(() => parseTestRunner("container")).toThrow("Unsupported test runner container");
+  });
+
+  test("rejects invalid test runner before listing profiles", async () => {
+    const result = await execCli(["test", "list", "--runner", "container"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Unsupported test runner container");
+  });
+
+  test("rewrites generated test env URLs for native runs", () => {
+    expect(
+      nativeTestEnv({
+        RPC_URL: "http://host-node:8545",
+        GATEWAY_RPC_URL: "http://gateway-node:8546",
+        RELAYER_URL: "http://fhevm-relayer:3000/v2",
+        HOST_CHAIN_1_RPC_URL: "http://host-node-1:8547",
+        APP_KEYURL__CRS__URL: "http://minio:9000/kms-public/foo/CRS/bar",
+        MAINNET_ETH_RPC_URL: "http://mainnet.example",
+      }),
+    ).toEqual({
+      RPC_URL: "http://localhost:8545",
+      GATEWAY_RPC_URL: "http://localhost:8546",
+      RELAYER_URL: "http://localhost:3000/v2",
+      HOST_CHAIN_1_RPC_URL: "http://localhost:8547",
+      APP_KEYURL__CRS__URL: "http://localhost:9000/kms-public/foo/CRS/bar",
+      MAINNET_ETH_RPC_URL: "http://mainnet.example",
+    });
+  });
+
+  test("native runner writes a host-reachable env and returns it as spawn vars", async () => {
+    await withTempStateDir(async () => {
+      await mkdir(path.dirname(envPath("test-suite")), { recursive: true });
+      await writeFile(envPath("test-suite"), "RPC_URL=http://host-node:8545\nMAINNET_ETH_RPC_URL=http://mainnet.example\n");
+      await expect(prepareNativeTestEnv()).resolves.toEqual({
+        RPC_URL: "http://localhost:8545",
+        MAINNET_ETH_RPC_URL: "http://mainnet.example",
+        DOTENV_CONFIG_PATH: envPath("test-suite.native"),
+        FHEVM_NATIVE_RUNNER: "true",
+      });
+      await expect(readEnvFile(envPath("test-suite.native"))).resolves.toEqual({
+        MAINNET_ETH_RPC_URL: "http://mainnet.example",
+        RPC_URL: "http://localhost:8545",
+      });
+    });
   });
 
   test("lists bundled scenarios", async () => {
@@ -186,6 +249,93 @@ describe("cli", () => {
     expect(output).toContain("[SERVICE]");
     expect(output).toContain("--no-follow");
     expect(output).toContain("first running fhevm container");
+  });
+
+  test("prints replace help with valid targets", async () => {
+    const result = await execCli(["replace", "--help"]);
+    const output = normalizeCliOutput(result.stdout);
+    expect(result.code).toBe(0);
+    expect(output).toContain("fhevm-cli replace");
+    expect(output).toContain("coprocessor:tfhe-worker");
+    expect(output).toContain("kms-connector:gw-listener");
+    expect(output).toContain("listener-core:publisher");
+    expect(output).toContain("--local-build");
+    expect(output).toContain("--build-profile");
+  });
+
+  test("lists replace targets without a running stack", async () => {
+    const result = await execCli(["replace", "list"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("coprocessor:tfhe-worker");
+    expect(result.stdout).toContain("default binary: coprocessor/fhevm-engine/target/release/tfhe_worker");
+    expect(result.stdout).toContain("local build: cached Linux cargo build for package tfhe-worker");
+    expect(result.stdout).toContain("kms-connector:tx-sender");
+    expect(result.stdout).toContain("listener-core:publisher");
+  });
+
+  test("parses replace build profiles", () => {
+    expect(parseBuildProfile(undefined)).toBe("dev");
+    expect(parseBuildProfile("release")).toBe("release");
+    expect(parseBuildProfile("profiling.local")).toBe("profiling.local");
+    expect(() => parseBuildProfile("../release")).toThrow("Invalid build profile");
+    expect(() => parseBuildProfile("--release")).toThrow("Invalid build profile");
+  });
+
+  test("rejects combining replace --binary with --local-build", async () => {
+    const result = await execCli(["replace", "coprocessor:tfhe-worker", "--binary", "/tmp/tfhe_worker", "--local-build"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("--binary cannot be combined with --local-build");
+  });
+
+  test("rejects replace --build-profile without --local-build", async () => {
+    const result = await execCli(["replace", "coprocessor:tfhe-worker", "--build-profile", "release"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("--build-profile can only be used with --local-build");
+  });
+
+  test("accepts several replace targets at the CLI boundary", async () => {
+    const result = await execCli(["replace", "coprocessor:tfhe-worker", "coprocessor:zkproof-worker"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("replace requires persisted stack state");
+    expect(result.stderr).not.toContain("Unexpected positional argument");
+  });
+
+  test("maps replace targets onto active topology containers", () => {
+    const state = bootstrappedState();
+    state.scenario = testDefaultScenario({
+      topology: { count: 2, threshold: 1 },
+      hostChains: [
+        { key: "host", chainId: "12345", rpcPort: 8545 },
+        { key: "side", chainId: "12346", rpcPort: 8547 },
+      ],
+    });
+    expect(replaceTargetsForState(state, "coprocessor:tfhe-worker").containers).toEqual([
+      "coprocessor-tfhe-worker",
+      "coprocessor1-tfhe-worker",
+    ]);
+    expect(replaceTargetsForState(state, "coprocessor:tfhe-worker").localBuild.package).toBe("tfhe-worker");
+    expect(replaceTargetsForState(state, "coprocessor:host-listener").containers).toEqual([
+      "coprocessor-host-listener",
+      "coprocessor1-host-listener",
+      "coprocessor-host-listener-side",
+      "coprocessor1-host-listener-side",
+    ]);
+    expect(REPLACE_TARGET_NAMES).toContain("kms-connector:kms-worker");
+    expect(replaceTargetsForState(state, "listener-core:publisher").containers).toEqual([
+      "listener-publisher-for-anvil",
+    ]);
+  });
+
+  test("local replace builds share one cargo target cache per workspace", () => {
+    const state = bootstrappedState();
+    const tfhe = replaceTargetsForState(state, "coprocessor:tfhe-worker").localBuild;
+    const zkproof = replaceTargetsForState(state, "coprocessor:zkproof-worker").localBuild;
+    const kmsWorker = replaceTargetsForState(state, "kms-connector:kms-worker").localBuild;
+
+    expect(replaceBuildTargetDir(tfhe)).toBe(replaceBuildTargetDir(zkproof));
+    expect(replaceBuildTargetDir(tfhe)).not.toBe(replaceBuildTargetDir(kmsWorker));
+    expect(replaceBuildBinary(tfhe, "dev")).toContain("replace-build/coprocessor/target/debug/tfhe_worker");
+    expect(replaceBuildBinary(tfhe, "release")).toContain("replace-build/coprocessor/target/release/tfhe_worker");
   });
 
   test("prints clean help with keep-images semantics", async () => {

--- a/test-suite/fhevm/src/cli.ts
+++ b/test-suite/fhevm/src/cli.ts
@@ -3,9 +3,10 @@
  */
 import { defineCommand, renderUsage, runCommand } from "citty";
 
-import { formatCliError, PreflightError } from "./errors";
+import { REPLACE_TARGET_NAMES, replace } from "./commands/replace";
 import { printRolloutMatrix, rollout, rolloutStep } from "./commands/rollout";
-import { listTestProfiles, test } from "./commands/test";
+import { listTestProfiles, parseTestRunner, test } from "./commands/test";
+import { formatCliError, PreflightError } from "./errors";
 import { resolveBundle } from "./resolve/bundle-store";
 import { STEP_NAMES } from "./types";
 import {
@@ -55,6 +56,11 @@ const commandOptionForms = async (cmd: CliCommand) => {
 
 const commandPositionalCount = async (cmd: CliCommand) =>
   Object.values(await commandArgs(cmd)).filter((arg) => arg.type === "positional").length;
+
+const commandAcceptsExtraPositionals = async (cmd: CliCommand) => {
+  const args = await commandArgs(cmd);
+  return args.targets?.type === "positional";
+};
 
 const positionalTokens = async (cmd: CliCommand, rawArgs: string[]) => {
   const args = await commandArgs(cmd);
@@ -152,7 +158,7 @@ const validateKnownArgs = async (cmd: CliCommand, rawArgs: string[]): Promise<vo
   }
   const positionals = await positionalTokens(cmd, rawArgs);
   const allowedPositionals = await commandPositionalCount(cmd);
-  if (positionals.length > allowedPositionals) {
+  if (!(await commandAcceptsExtraPositionals(cmd)) && positionals.length > allowedPositionals) {
     throw new PreflightError(`Unexpected positional argument ${positionals[allowedPositionals]}`);
   }
 };
@@ -241,6 +247,27 @@ const root = defineCommand({
         await upgrade(asString(args.group));
       },
     }),
+    replace: defineCommand({
+      meta: { name: "replace", description: "Build or copy local binaries into running stack containers and restart them." },
+      args: {
+        targets: {
+          type: "positional",
+          description: `Target to replace, or list. Valid: ${REPLACE_TARGET_NAMES.join(", ")}.`,
+          required: false,
+        },
+        binary: { type: "string", description: "Binary path to copy. Only valid with one target; otherwise default target paths are used." },
+        "local-build": { type: "boolean", description: "Run a cached Linux Cargo build before copying the built binary." },
+        "build-profile": { type: "string", description: "Cargo build profile for --local-build. Default: dev. Use release for optimized binaries." },
+      },
+      async run({ args }) {
+        const targets = (args._ as string[] | undefined)?.length ? (args._ as string[]) : asString(args.targets) ? [asString(args.targets)!] : [];
+        await replace(targets, {
+          binary: asString(args.binary),
+          localBuild: asBool(args["local-build"]),
+          buildProfile: asString(args["build-profile"]),
+        });
+      },
+    }),
     resolve: defineCommand({
       meta: { name: "resolve", description: "Resolve a version target and print the resulting lock path." },
       args: {
@@ -288,17 +315,19 @@ const root = defineCommand({
       },
     }),
     test: defineCommand({
-      meta: { name: "test", description: "Run e2e tests inside the fhevm test-suite container." },
+      meta: { name: "test", description: "Run e2e tests with the fhevm test-suite runner." },
       args: {
         testName: { type: "positional", description: "Named test profile to run.", required: false },
         grep: { type: "string", description: "Custom grep pattern passed through to the e2e runner." },
         network: { type: "string", description: "Hardhat network passed to the test suite.", default: "staging" },
+        runner: { type: "string", description: "Test runner backend: docker or native.", default: "docker" },
         verbose: { type: "boolean", description: "Enable verbose output from the test command." },
         "no-hardhat-compile": { type: "boolean", description: "Skip the Hardhat compilation step inside the test runner." },
         parallel: { type: "boolean", description: "Run supported test suites in parallel." },
       },
       async run({ args }) {
         const testName = asString(args.testName);
+        const runner = parseTestRunner(asString(args.runner));
         if (testName === "list") {
           listTestProfiles();
           return;
@@ -306,6 +335,7 @@ const root = defineCommand({
         await test(testName, {
           grep: asString(args.grep),
           network: asString(args.network) ?? "staging",
+          runner,
           verbose: asBool(args.verbose),
           noHardhatCompile: asBool(args["no-hardhat-compile"]),
           parallel: args.parallel === undefined ? undefined : asBool(args.parallel),

--- a/test-suite/fhevm/src/commands/replace.ts
+++ b/test-suite/fhevm/src/commands/replace.ts
@@ -1,0 +1,401 @@
+/**
+ * Hot-swaps locally built binaries into running stack containers for debug loops.
+ */
+import path from "node:path";
+
+import { PreflightError } from "../errors";
+import { PROJECT, REPO_ROOT, RUNTIME_DIR, defaultHostChainKey, hostChainSuffix } from "../layout";
+import { dockerInspect, postBootHealthGate, waitForContainer } from "../flow/readiness";
+import { loadState } from "../state/state";
+import { topologyForState } from "../stack-spec/stack-spec";
+import type { State } from "../types";
+import { ensureDir, exists } from "../utils/fs";
+import { run, runWithHeartbeat } from "../utils/process";
+
+type LocalBuild = {
+  workspaceId: string;
+  binaryName: string;
+  cwd: string;
+  package: string;
+  env?: Record<string, string>;
+};
+
+type ReplaceTarget = {
+  key: string;
+  description: string;
+  defaultBinary: string;
+  containerPath: string;
+  localBuild: LocalBuild;
+  containers: (state: State) => string[];
+};
+
+const LINUX_RUST_IMAGE =
+  "ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0@sha256:5c561870f4cc043ff53f415e986ffdbc1099541e5f2a3e487e40858f88f0d67f";
+const CONTAINER_REPO_ROOT = "/workspace/fhevm";
+const CONTAINER_BUILD_HOME = "/tmp/fhevm-replace-home";
+
+const coprocessorPrefix = (index: number) => (index === 0 ? "coprocessor-" : `coprocessor${index}-`);
+
+const coprocessorRuntimeContainers = (suffix: string) => (state: State) =>
+  Array.from({ length: topologyForState(state).count }, (_, index) => `${coprocessorPrefix(index)}${suffix}`);
+
+const coprocessorChainContainers = (suffix: string) => (state: State) => {
+  const defaultKey = defaultHostChainKey(state.scenario.hostChains);
+  const chains = state.scenario.hostChains.length ? state.scenario.hostChains : [{ key: defaultKey }];
+  return chains.flatMap((chain) => {
+    const chainSuffix = hostChainSuffix(chain.key, defaultKey);
+    return Array.from({ length: topologyForState(state).count }, (_, index) => `${coprocessorPrefix(index)}${suffix}${chainSuffix}`);
+  });
+};
+
+const coprocessorBuild = (packageName: string, binaryName: string): LocalBuild => ({
+  workspaceId: "coprocessor",
+  binaryName,
+  cwd: path.join(REPO_ROOT, "coprocessor", "fhevm-engine"),
+  package: packageName,
+  env: { SQLX_OFFLINE: "true", BUILD_ID: "local" },
+});
+
+const kmsConnectorBuild = (packageName: string, binaryName: string): LocalBuild => ({
+  workspaceId: "kms-connector",
+  binaryName,
+  cwd: path.join(REPO_ROOT, "kms-connector"),
+  package: packageName,
+});
+
+const listenerCoreBuild = (): LocalBuild => ({
+  workspaceId: "listener-core",
+  binaryName: "listener_core",
+  cwd: path.join(REPO_ROOT, "listener"),
+  package: "listener_core",
+  env: { SQLX_OFFLINE: "true" },
+});
+
+export const REPLACE_TARGETS: ReplaceTarget[] = [
+  {
+    key: "coprocessor:host-listener",
+    description: "Replace host-listener binaries on every active host chain and coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/host_listener",
+    containerPath: "/usr/local/bin/host_listener",
+    localBuild: coprocessorBuild("host-listener", "host_listener"),
+    containers: coprocessorChainContainers("host-listener"),
+  },
+  {
+    key: "coprocessor:host-listener-poller",
+    description: "Replace host-listener-poller binaries on every active host chain and coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/host_listener_poller",
+    containerPath: "/usr/local/bin/host_listener_poller",
+    localBuild: coprocessorBuild("host-listener", "host_listener_poller"),
+    containers: coprocessorChainContainers("host-listener-poller"),
+  },
+  {
+    key: "coprocessor:host-listener-consumer",
+    description: "Replace host-listener-consumer binaries on every active coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/host_listener_consumer",
+    containerPath: "/usr/local/bin/host_listener_consumer",
+    localBuild: coprocessorBuild("host-listener", "host_listener_consumer"),
+    containers: coprocessorRuntimeContainers("host-listener-consumer"),
+  },
+  {
+    key: "coprocessor:gw-listener",
+    description: "Replace gateway-listener binaries on every active coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/gw_listener",
+    containerPath: "/usr/local/bin/gw_listener",
+    localBuild: coprocessorBuild("gw-listener", "gw_listener"),
+    containers: coprocessorRuntimeContainers("gw-listener"),
+  },
+  {
+    key: "coprocessor:tfhe-worker",
+    description: "Replace TFHE worker binaries on every active coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/tfhe_worker",
+    containerPath: "/usr/local/bin/tfhe_worker",
+    localBuild: coprocessorBuild("tfhe-worker", "tfhe_worker"),
+    containers: coprocessorRuntimeContainers("tfhe-worker"),
+  },
+  {
+    key: "coprocessor:sns-worker",
+    description: "Replace SNS worker binaries on every active coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/sns_worker",
+    containerPath: "/usr/local/bin/sns_worker",
+    localBuild: coprocessorBuild("sns-worker", "sns_worker"),
+    containers: coprocessorRuntimeContainers("sns-worker"),
+  },
+  {
+    key: "coprocessor:transaction-sender",
+    description: "Replace transaction-sender binaries on every active coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/transaction_sender",
+    containerPath: "/usr/local/bin/transaction_sender",
+    localBuild: coprocessorBuild("transaction-sender", "transaction_sender"),
+    containers: coprocessorRuntimeContainers("transaction-sender"),
+  },
+  {
+    key: "coprocessor:zkproof-worker",
+    description: "Replace ZK proof worker binaries on every active coprocessor instance.",
+    defaultBinary: "coprocessor/fhevm-engine/target/release/zkproof_worker",
+    containerPath: "/usr/local/bin/zkproof_worker",
+    localBuild: coprocessorBuild("zkproof-worker", "zkproof_worker"),
+    containers: coprocessorRuntimeContainers("zkproof-worker"),
+  },
+  {
+    key: "kms-connector:gw-listener",
+    description: "Replace the KMS connector gateway listener binary.",
+    defaultBinary: "kms-connector/target/release/gw-listener",
+    containerPath: "/app/kms-connector/bin/gw-listener",
+    localBuild: kmsConnectorBuild("gw-listener", "gw-listener"),
+    containers: () => ["kms-connector-gw-listener"],
+  },
+  {
+    key: "kms-connector:kms-worker",
+    description: "Replace the KMS connector KMS worker binary.",
+    defaultBinary: "kms-connector/target/release/kms-worker",
+    containerPath: "/app/kms-connector/bin/kms-worker",
+    localBuild: kmsConnectorBuild("kms-worker", "kms-worker"),
+    containers: () => ["kms-connector-kms-worker"],
+  },
+  {
+    key: "kms-connector:tx-sender",
+    description: "Replace the KMS connector transaction sender binary.",
+    defaultBinary: "kms-connector/target/release/tx-sender",
+    containerPath: "/app/kms-connector/bin/tx-sender",
+    localBuild: kmsConnectorBuild("tx-sender", "tx-sender"),
+    containers: () => ["kms-connector-tx-sender"],
+  },
+  {
+    key: "listener-core:publisher",
+    description: "Replace the listener-core publisher binary.",
+    defaultBinary: "listener/target/release/listener_core",
+    containerPath: "/app/listener_core",
+    localBuild: listenerCoreBuild(),
+    containers: () => ["listener-publisher-for-anvil"],
+  },
+];
+
+export const REPLACE_TARGET_NAMES = REPLACE_TARGETS.map((target) => target.key);
+
+const targetByName = new Map(REPLACE_TARGETS.map((target) => [target.key, target] as const));
+
+const dockerProjectContainers = async () => {
+  const result = await run(
+    ["docker", "ps", "--filter", `label=com.docker.compose.project=${PROJECT}`, "--format", "{{.Names}}"],
+    { allowFailure: true },
+  );
+  if (result.code !== 0) {
+    throw new PreflightError(`Docker unavailable: ${result.stderr.trim() || "docker ps failed"}`);
+  }
+  return new Set(result.stdout.split("\n").map((name) => name.trim()).filter(Boolean));
+};
+
+export const replaceTargetsForState = (state: State, name: string) => {
+  const target = targetByName.get(name);
+  if (!target) {
+    throw new PreflightError(`Unknown replace target ${name}. Valid: ${REPLACE_TARGET_NAMES.join(", ")}`);
+  }
+  return {
+    ...target,
+    binary: path.join(REPO_ROOT, target.defaultBinary),
+    containers: target.containers(state),
+  };
+};
+
+/** Prints the replace target catalog, optionally with active-stack container names. */
+export const listReplaceTargets = async () => {
+  const state = await loadState();
+  for (const target of REPLACE_TARGETS) {
+    console.log(target.key);
+    console.log(`  ${target.description}`);
+    console.log(`  default binary: ${target.defaultBinary}`);
+    console.log(`  local build: cached Linux cargo build for package ${target.localBuild.package}`);
+    console.log(`  container path: ${target.containerPath}`);
+    if (state) {
+      console.log(`  containers: ${target.containers(state).join(", ")}`);
+    }
+  }
+};
+
+const waitForRestart = async (container: string) => {
+  const [inspect] = await dockerInspect(container);
+  await waitForContainer(container, inspect?.State.Health ? "healthy" : "running");
+};
+
+const cargoProfileArgs = (profile: string) => {
+  if (profile === "dev") return [];
+  if (profile === "release") return ["--release"];
+  return ["--profile", profile];
+};
+
+const cargoProfileDir = (profile: string) => (profile === "dev" ? "debug" : profile);
+
+export const parseBuildProfile = (profile: string | undefined) => {
+  const value = profile ?? "dev";
+  if (/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    return value;
+  }
+  throw new PreflightError(
+    `Invalid build profile ${value}; expected an alphanumeric name followed by letters, digits, dot, underscore, or dash`,
+  );
+};
+
+const replaceBuildRoot = (build: Pick<LocalBuild, "workspaceId">) =>
+  path.join(RUNTIME_DIR, "replace-build", build.workspaceId);
+
+export const replaceBuildTargetDir = (build: Pick<LocalBuild, "workspaceId">) =>
+  path.join(replaceBuildRoot(build), "target");
+
+export const replaceBuildBinary = (build: LocalBuild, profile: string) =>
+  path.join(replaceBuildTargetDir(build), cargoProfileDir(profile), build.binaryName);
+
+const dockerUserArgs = () =>
+  typeof process.getuid === "function" && typeof process.getgid === "function"
+    ? ["--user", `${process.getuid()}:${process.getgid()}`]
+    : [];
+
+const containerImagePlatform = async (container: string) => {
+  const containerImage = (
+    await run(["docker", "inspect", "--format", "{{.Image}}", container])
+  ).stdout.trim();
+  if (!containerImage) {
+    throw new PreflightError(`Could not resolve image id for ${container}`);
+  }
+  const platform = (
+    await run(["docker", "image", "inspect", "--format", "{{.Os}}/{{.Architecture}}", containerImage])
+  ).stdout.trim();
+  if (!platform.startsWith("linux/")) {
+    throw new PreflightError(`replace --local-build only supports Linux runtime containers; ${container} uses ${platform}`);
+  }
+  return platform;
+};
+
+const replacementPlatform = async (containers: string[]) => {
+  const platforms = new Set<string>();
+  for (const container of containers) {
+    platforms.add(await containerImagePlatform(container));
+  }
+  if (platforms.size !== 1) {
+    throw new PreflightError(`replace --local-build expected one runtime platform, got ${[...platforms].join(", ")}`);
+  }
+  return [...platforms][0];
+};
+
+const runLocalBuilds = async (
+  plans: Array<{ containers: string[]; localBuild: LocalBuild }>,
+  profile: string,
+) => {
+  const builds = new Map<string, LocalBuild>();
+  for (const plan of plans) {
+    builds.set(`${plan.localBuild.workspaceId}:${plan.localBuild.package}`, plan.localBuild);
+  }
+  const platform = await replacementPlatform(plans.flatMap((plan) => plan.containers));
+  const cacheRoot = path.join(RUNTIME_DIR, "replace-build", "cargo");
+  const homeRoot = path.join(RUNTIME_DIR, "replace-build", "home");
+  await Promise.all([
+    ensureDir(path.join(cacheRoot, "registry")),
+    ensureDir(path.join(cacheRoot, "git")),
+    ensureDir(homeRoot),
+    ...[...builds.values()].map((build) => ensureDir(replaceBuildTargetDir(build))),
+  ]);
+  for (const build of builds.values()) {
+    const workspace = path.relative(REPO_ROOT, build.cwd);
+    const label = `build ${build.package} (${profile}, ${platform})`;
+    const env = build.env ?? {};
+    console.log(`[replace] ${label}`);
+    await runWithHeartbeat(
+      [
+        "docker",
+        "run",
+        "--rm",
+        "--platform",
+        platform,
+        ...dockerUserArgs(),
+        "--mount",
+        `type=bind,source=${REPO_ROOT},target=${CONTAINER_REPO_ROOT},readonly`,
+        "-v",
+        `${path.join(cacheRoot, "registry")}:/usr/local/cargo/registry`,
+        "-v",
+        `${path.join(cacheRoot, "git")}:/usr/local/cargo/git`,
+        "-v",
+        `${homeRoot}:${CONTAINER_BUILD_HOME}`,
+        "-v",
+        `${replaceBuildTargetDir(build)}:${path.posix.join(CONTAINER_REPO_ROOT, workspace, "target")}`,
+        "-w",
+        path.posix.join(CONTAINER_REPO_ROOT, workspace),
+        "-e",
+        `HOME=${CONTAINER_BUILD_HOME}`,
+        "-e",
+        `GIT_CONFIG_GLOBAL=${path.posix.join(CONTAINER_BUILD_HOME, ".gitconfig")}`,
+        ...Object.entries(env).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
+        LINUX_RUST_IMAGE,
+        "sh",
+        "-lc",
+        `git config --global --add safe.directory ${CONTAINER_REPO_ROOT} && cargo build ${cargoProfileArgs(profile).join(" ")} -p ${build.package}`,
+      ],
+      label,
+    );
+  }
+};
+
+/** Replaces selected running service binaries and restarts the affected containers. */
+export const replace = async (
+  names: string[],
+  options: { binary?: string; localBuild?: boolean; buildProfile?: string } = {},
+) => {
+  if (!names.length || (names.length === 1 && names[0] === "list")) {
+    await listReplaceTargets();
+    return;
+  }
+  if (options.binary && names.length !== 1) {
+    throw new PreflightError("--binary can only be used with one replace target");
+  }
+  if (options.binary && options.localBuild) {
+    throw new PreflightError("--binary cannot be combined with --local-build");
+  }
+  if (options.buildProfile && !options.localBuild) {
+    throw new PreflightError("--build-profile can only be used with --local-build");
+  }
+  const buildProfile = parseBuildProfile(options.buildProfile);
+  const state = await loadState();
+  if (!state) {
+    throw new PreflightError("replace requires persisted stack state; run `fhevm-cli up` first");
+  }
+  const running = await dockerProjectContainers();
+  if (!running.size) {
+    throw new PreflightError("replace requires a running stack; run `fhevm-cli up --resume` first");
+  }
+  const plans = names.map((name) => {
+    const plan = replaceTargetsForState(state, name);
+    const binary = options.binary
+      ? path.resolve(options.binary)
+      : options.localBuild
+        ? replaceBuildBinary(plan.localBuild, buildProfile)
+        : plan.binary;
+    const containers = plan.containers.filter((container) => running.has(container));
+    if (!containers.length) {
+      throw new PreflightError(`No running containers found for ${name}; run \`fhevm-cli replace list\``);
+    }
+    return { ...plan, name, binary, containers };
+  });
+  if (options.localBuild) {
+    await runLocalBuilds(plans, buildProfile);
+  }
+  for (const plan of plans) {
+    if (!(await exists(plan.binary))) {
+      throw new PreflightError(
+        `Missing binary for ${plan.name}: expected ${plan.binary}\nBuild it first or rerun \`fhevm-cli replace ${plan.name} --local-build\``,
+      );
+    }
+  }
+  const restarted = new Set<string>();
+  for (const plan of plans) {
+    console.log(`[replace] ${plan.name}`);
+    for (const container of plan.containers) {
+      console.log(`[replace] copy ${plan.binary} -> ${container}:${plan.containerPath}`);
+      await run(["docker", "cp", plan.binary, `${container}:${plan.containerPath}`]);
+    }
+    console.log(`[replace] restart ${plan.containers.join(", ")}`);
+    await run(["docker", "restart", ...plan.containers]);
+    await Promise.all(plan.containers.map(waitForRestart));
+    plan.containers.forEach((container) => restarted.add(container));
+  }
+  if (restarted.size) {
+    await postBootHealthGate([...restarted]);
+  }
+};

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -1,12 +1,13 @@
 /**
  * Runs named e2e test profiles, standard/heavy CI suites, and topology-specific test flows.
  */
+import path from "node:path";
 import { compatPolicyForState, supportsCoprocessorDbStateRevert } from "../compat/compat";
 import { DRIFT_CLEANUP_SQL, DRIFT_INSTALL_SQL, driftDatabaseName, parseDriftInstanceIndex, parsePositiveInteger } from "../drift";
 import { PreflightError, formatCliError } from "../errors";
 import { dockerInspect } from "../flow/readiness";
-import { pause, shellEscape, unpause } from "../flow/up-flow";
-import { hostReachableRpcUrl } from "../utils/fs";
+import { pause, unpause } from "../flow/up-flow";
+import { hostReachableMaterialUrl, hostReachableRpcUrl, readEnvFile, writeEnvFile } from "../utils/fs";
 import { run, runWithHeartbeat } from "../utils/process";
 import { loadState } from "../state/state";
 import { topologyForState } from "../stack-spec/stack-spec";
@@ -16,9 +17,11 @@ import {
   DEFAULT_POSTGRES_DB,
   DEFAULT_POSTGRES_PASSWORD,
   DEFAULT_POSTGRES_USER,
+  envPath,
   HEAVY_TEST_PROFILES,
   LIGHT_TEST_PROFILES,
   POSTGRES_HOST,
+  REPO_ROOT,
   STANDARD_TEST_PROFILES,
   TEST_GREP,
   TEST_PARALLEL,
@@ -42,6 +45,10 @@ const KEY_BOOTSTRAP_LOG = /Fetched keyset/;
 const KEY_BOOTSTRAP_PROFILES = new Set(["input-proof", "input-proof-compute-decrypt"]);
 // Intentional ciphertext drift must never run on shared/live networks.
 const CIPHERTEXT_DRIFT_FORBIDDEN_NETWORKS = new Set(["sepolia", "mainnet", "zwsDev"]);
+const TEST_RUNNERS = new Set(["docker", "native"]);
+const NATIVE_TEST_URL_ENV = /^(RPC_URL|GATEWAY_RPC_URL|RELAYER_URL|HOST_CHAIN_\d+_RPC_URL)$/;
+const NATIVE_MATERIAL_URL_ENV = /^(APP_KEYURL__|KMS_.*_KEY$|.*_MATERIAL_URL$)/;
+const TEST_SUITE_E2E_DIR = path.join(REPO_ROOT, "test-suite", "e2e");
 
 /** Formats a progress label with elapsed wall-clock time. */
 const timedLabel = (label: string, started: number) =>
@@ -87,6 +94,15 @@ export const validateNamedProfileGrep = (testName: string | undefined, grep: str
   if (testName && grep && !(testName in TEST_GREP)) {
     throw new PreflightError(`\`fhevm-cli test ${testName}\` does not accept \`--grep\`; use either a named profile or a custom grep`);
   }
+};
+
+/** Parses the test runner backend while keeping docker as the compatibility default. */
+export const parseTestRunner = (runner: string | undefined): NonNullable<TestOptions["runner"]> => {
+  const value = runner ?? "docker";
+  if (TEST_RUNNERS.has(value)) {
+    return value as NonNullable<TestOptions["runner"]>;
+  }
+  throw new PreflightError(`Unsupported test runner ${value}. Valid: docker, native`);
 };
 
 /** Combines a named profile grep with an extra narrowing grep expression. */
@@ -397,28 +413,86 @@ const runTestsArgs = (
   options.grep,
 ].filter(Boolean);
 
-/** Builds a shell-safe run-tests.sh command string. */
-const runTestsCommand = (
-  options: Pick<TestOptions, "network" | "verbose" | "parallel" | "noHardhatCompile"> & { grep: string },
-) => runTestsArgs(options).map(shellEscape).join(" ");
+/** Rewrites generated container URLs so run-tests.sh can run from the workspace. */
+export const nativeTestEnv = (env: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(env).map(([key, value]) => {
+      if (NATIVE_TEST_URL_ENV.test(key)) {
+        return [key, hostReachableRpcUrl(value)];
+      }
+      if (NATIVE_MATERIAL_URL_ENV.test(key)) {
+        return [key, hostReachableMaterialUrl(value)];
+      }
+      return [key, value];
+    }),
+  );
 
-/** Runs a narrow e2e grep inside the test-suite container. */
+const testExecEnv = (extraExecArgs: string[]) => {
+  const env: Record<string, string> = {};
+  for (let index = 0; index < extraExecArgs.length; index += 1) {
+    if (extraExecArgs[index] !== "-e" && extraExecArgs[index] !== "--env") {
+      continue;
+    }
+    const assignment = extraExecArgs[index + 1];
+    index += 1;
+    if (!assignment) {
+      continue;
+    }
+    const separator = assignment.indexOf("=");
+    const key = separator < 0 ? assignment : assignment.slice(0, separator);
+    env[key] = separator < 0 ? "" : assignment.slice(separator + 1);
+  }
+  return env;
+};
+
+/** Materializes a host-reachable copy of the test-suite env and returns it as spawn env vars. */
+export const prepareNativeTestEnv = async (): Promise<Record<string, string>> => {
+  const containerEnv = envPath("test-suite");
+  let rewritten: Record<string, string>;
+  try {
+    rewritten = nativeTestEnv(await readEnvFile(containerEnv));
+  } catch {
+    throw new PreflightError(
+      `native test runner requires generated test-suite env at ${containerEnv}; run \`fhevm-cli up\` first`,
+    );
+  }
+  const hostEnv = envPath("test-suite.native");
+  await writeEnvFile(hostEnv, rewritten);
+  return { ...rewritten, DOTENV_CONFIG_PATH: hostEnv, FHEVM_NATIVE_RUNNER: "true" };
+};
+
+/** Runs a narrow e2e grep with the selected test runner backend. */
+const runE2e = async (
+  options: Pick<TestOptions, "network" | "verbose" | "parallel" | "noHardhatCompile" | "runner"> & { grep: string },
+  label: string,
+  extraExecArgs: string[] = [],
+) => {
+  if ((options.runner ?? "docker") === "docker") {
+    return runWithHeartbeat(buildTestContainerArgs(runTestsArgs(options), extraExecArgs), label);
+  }
+  const env = {
+    ...(await prepareNativeTestEnv()),
+    npm_config_update_notifier: "false",
+    NPM_CONFIG_UPDATE_NOTIFIER: "false",
+    ...testExecEnv(extraExecArgs),
+  };
+  return runWithHeartbeat(runTestsArgs(options), label, { cwd: TEST_SUITE_E2E_DIR, env });
+};
+
+/** Asserts a narrow e2e grep selected at least one test. */
 const assertMatchedTests = (output: string, label: string) => {
   if (ZERO_TESTS_RE.test(output) && !SOME_PENDING_RE.test(output)) {
     throw new PreflightError(`${label} matched zero tests`);
   }
 };
 
-/** Runs a narrow e2e grep inside the test-suite container. */
+/** Runs a named e2e grep with the selected test runner backend. */
 const runNamedE2e = async (
-  options: Pick<TestOptions, "network" | "noHardhatCompile">,
+  options: Pick<TestOptions, "network" | "noHardhatCompile" | "runner">,
   grep: string,
   label: string,
 ) => {
-  const result = await runWithHeartbeat(
-    buildTestContainerArgs(runTestsArgs({ ...options, verbose: false, parallel: false, grep })),
-    label,
-  );
+  const result = await runE2e({ ...options, verbose: false, parallel: false, grep }, label);
   assertMatchedTests(result.stdout + result.stderr, label);
 };
 
@@ -752,6 +826,7 @@ export const test = async (testName: string | undefined, options: TestOptions) =
     listTestProfiles();
     return;
   }
+  options = { ...options, runner: parseTestRunner(options.runner) };
   if (testName && !TEST_PROFILE_NAMES.includes(testName)) {
     throw new PreflightError(`Unknown test profile ${testName}. Valid: ${TEST_PROFILE_NAMES.join(", ")}`);
   }
@@ -844,12 +919,10 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           postgresUser: postgres.postgresUser,
           postgresPassword: postgres.postgresPassword,
         });
-        const result = await runWithHeartbeat(
-          buildTestContainerArgs(
-            runTestsArgs({ ...options, parallel: false, grep: grepPattern }),
-            ["-e", "GATEWAY_RPC_URL="],
-          ),
+        const result = await runE2e(
+          { ...options, parallel: false, grep: grepPattern },
           "test ciphertext-drift",
+          ["-e", "GATEWAY_RPC_URL="],
         );
         assertMatchedTests(result.stdout + result.stderr, "test ciphertext-drift");
         const injectedHandleHex = await injector;
@@ -918,12 +991,10 @@ export const test = async (testName: string | undefined, options: TestOptions) =
         // Run the e2e tests that trigger the drift. This run may surface
         // errors due to the drift itself — we tolerate that and verify
         // recovery in the next step.
-        await runWithHeartbeat(
-          buildTestContainerArgs(
-            runTestsArgs({ ...options, parallel: false, grep: grepPattern }),
-            ["-e", "GATEWAY_RPC_URL="],
-          ),
+        await runE2e(
+          { ...options, parallel: false, grep: grepPattern },
           "test ciphertext-drift-auto-recovery (initial run)",
+          ["-e", "GATEWAY_RPC_URL="],
         ).catch((error) => {
           console.log(
             `[drift-auto-recovery] initial test run failed (expected due to drift): ${formatCliError(error) ?? "unknown error"}`,
@@ -1004,12 +1075,10 @@ export const test = async (testName: string | undefined, options: TestOptions) =
         console.log(`[drift-auto-recovery] revert completed; computations caught up to ${caughtUp} (>= ${computationsBefore}); re-running tests to verify recovery`);
 
         // Re-run the e2e tests to verify the services have fully recovered.
-        const followUp = await runWithHeartbeat(
-          buildTestContainerArgs(
-            runTestsArgs({ ...options, parallel: false, grep: grepPattern }),
-            ["-e", "GATEWAY_RPC_URL="],
-          ),
+        const followUp = await runE2e(
+          { ...options, parallel: false, grep: grepPattern },
           "test ciphertext-drift-auto-recovery (post-recovery)",
+          ["-e", "GATEWAY_RPC_URL="],
         );
         assertMatchedTests(
           followUp.stdout + followUp.stderr,
@@ -1034,12 +1103,11 @@ export const test = async (testName: string | undefined, options: TestOptions) =
       const grep = narrowedProfileGrep(filter, options.grep);
       console.log(`[test] ${name} (${options.network})`);
       const started = Date.now();
-      const command = runTestsCommand({ ...options, parallel: shouldParallel, grep });
       return runLogged(name, started, async () => {
         if (KEY_BOOTSTRAP_PROFILES.has(name)) {
           await waitForKeyBootstrap(state);
         }
-        const result = await runWithHeartbeat(buildTestContainerArgs(["sh", "-lc", command]), `test ${name}`);
+        const result = await runE2e({ ...options, parallel: shouldParallel, grep }, `test ${name}`);
         assertMatchedTests(result.stdout + result.stderr, `test ${name}`);
       });
     };
@@ -1136,11 +1204,11 @@ export const test = async (testName: string | undefined, options: TestOptions) =
   }
 
   if (options.grep) {
+    const grep = options.grep;
     console.log(`[test] custom (${options.network})`);
     const started = Date.now();
-    const command = runTestsCommand({ ...options, grep: options.grep });
     await runLogged("custom", started, async () => {
-      const result = await runWithHeartbeat(buildTestContainerArgs(["sh", "-lc", command]), "test custom");
+      const result = await runE2e({ ...options, grep }, "test custom");
       assertMatchedTests(result.stdout + result.stderr, "test custom");
     });
     return;

--- a/test-suite/fhevm/src/types.ts
+++ b/test-suite/fhevm/src/types.ts
@@ -178,4 +178,5 @@ export type TestOptions = {
   verbose: boolean;
   noHardhatCompile: boolean;
   parallel?: boolean;
+  runner?: "docker" | "native";
 };


### PR DESCRIPTION
## Summary

This PR adds two related test-suite developer workflows:

1. `fhevm-cli test --runner native` runs the checked-out `test-suite/e2e` workspace directly against an existing Docker stack, while keeping Docker as the default runner.
2. `fhevm-cli replace` hot-swaps selected Rust service binaries into running stack containers for a narrower debug loop.

## Native e2e runner

- Adds `--runner docker|native` to `fhevm-cli test`; `docker` remains the default.
- Reuses `test-suite/e2e/run-tests.sh` for the native path instead of duplicating e2e execution logic.
- Rewrites generated Docker DNS URLs to host-reachable localhost endpoints for native execution.
- Pins `DOTENV_CONFIG_PATH` to the generated CLI env so stale local e2e dotfiles do not leak into native runs.
- Adds a fetch-time MinIO URL rewrite for the relayer SDK path that reads object URLs such as `http://minio:9000/...` off-chain.

## Binary replace command

- Adds `fhevm-cli replace` for copying local service binaries into matching running containers and restarting only those containers.
- Supports `replace --local-build`, which runs a cached Linux Cargo build in Docker's Linux VM.
- Stores Cargo registry, git, and target caches under `.fhevm/runtime/replace-build`.
- Supports `--build-profile dev|release`; `dev` is the default for fast iteration.
- Supports `--binary <path>` as the explicit prebuilt-binary escape hatch.
- Does not rerender Compose, run migrations, change versions, or alter stack state beyond the targeted container restart.

## CI smoke

When the e2e workflow already runs in the normal non-compat/non-orchestrated path, it now also runs a small native `input-proof` smoke.

The PR-trigger gate is unchanged: direct same-repo PRs still need the `e2e` label for this workflow to run.

## Validation

- `bun run check`
- `bun test src/cli.test.ts`
- `bun test src`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-suite-e2e-tests.yml"); puts "yaml ok"'`
- `./fhevm-cli replace --help && ./fhevm-cli test --help`

Refs zama-ai/fhevm-internal#1346
