### PR TITLE
fix(common): harden DeepSec security findings

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -496,7 +496,7 @@ jobs:
           fi
 
           # Block responses containing potential secrets
-          if grep -qiE '(ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|github_pat_|sk-ant-|AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY)' /tmp/claude-response-validated.md; then
+          if grep -qiE '((ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{20,}|github_pat_|sk-ant-|AKIA[0-9A-Z]{16}|-----BEGIN (RSA |EC )?PRIVATE KEY)' /tmp/claude-response-validated.md; then
             echo "::error::Response appears to contain secrets — refusing to post"
             echo "Claude's response was blocked because it appeared to contain sensitive data. See [workflow logs](${RUN_URL})." > /tmp/claude-response-validated.md
           fi

--- a/.github/workflows/golden-container-images-docker-build-nodejs.yml
+++ b/.github/workflows/golden-container-images-docker-build-nodejs.yml
@@ -40,12 +40,28 @@ jobs:
         with:
           filters: |
             golden-nodejs:
-              - '.github/workflows/golden-images-docker-build.yml'
+              - '.github/workflows/golden-container-images-docker-build-nodejs.yml'
               - 'golden-container-images/nodejs/**'
+  validate:
+    name: golden-container-images-docker-build-nodejs/validate (bpr)
+    needs: check-changes
+    if: ${{ github.event_name == 'pull_request' && needs.check-changes.outputs.changes-golden-nodejs == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read' # Required to checkout repository code
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+      - name: Build prod image
+        run: docker build --target prod -f golden-container-images/nodejs/Dockerfile golden-container-images/nodejs
+      - name: Build dev image
+        run: docker build --target dev -f golden-container-images/nodejs/Dockerfile golden-container-images/nodejs
+
   build:
     name: golden-container-images-docker-build-nodejs/build
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.changes-golden-nodejs == 'true' || github.event_name == 'release' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
@@ -60,7 +76,7 @@ jobs:
       id-token: 'write' # Required for OIDC authentication
     with:
       working-directory: "."
-      push_image: true
+      push_image: ${{ github.event_name == 'workflow_dispatch' && inputs.push_image }}
       image-name: "fhevm/gci/nodejs"
       docker-file: "./golden-container-images/nodejs/Dockerfile"
       app-cache-dir: "fhevm-golden-nodejs"

--- a/.github/workflows/host-contracts-publish.yml
+++ b/.github/workflows/host-contracts-publish.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   publish:
     name: host-contracts-publish/publish
@@ -52,7 +56,7 @@ jobs:
         run: npm run compile
 
       - name: Publish prerelease to npm
-        if: ${{ inputs.release != 'true' }}
+        if: ${{ !inputs.release }}
         uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
         with:
           package: ./host-contracts/package.json
@@ -62,7 +66,7 @@ jobs:
           access: public
 
       - name: Publish release to npm
-        if: ${{ inputs.release == 'true' }}
+        if: ${{ inputs.release }}
         uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3.1.1
         with:
           package: ./host-contracts/package.json

--- a/.github/workflows/host-contracts-slither-analysis.yml
+++ b/.github/workflows/host-contracts-slither-analysis.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-changes:
     name: host-contracts-slither-analysis/check-changes
@@ -33,7 +37,7 @@ jobs:
     name: host-contracts-slither-analysis/analyze (bpr)
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-host-contracts == 'true' }}
-    runs-on: large_ubuntu_32
+    runs-on: ubuntu-latest
     env:
       HARDHAT_NETWORK: hardhat
     permissions:

--- a/.github/workflows/sdk-rust-sdk-tests.yml
+++ b/.github/workflows/sdk-rust-sdk-tests.yml
@@ -43,7 +43,7 @@ jobs:
   start-runner:
     name: sdk-rust-sdk-tests/start-runner
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.changes-rust-sdk == 'true' }}
+    if: ${{ needs.check-changes.outputs.changes-rust-sdk == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code
@@ -67,6 +67,7 @@ jobs:
   test-rust-sdk:
     name: sdk-rust-sdk-tests/test-rust-sdk (bpr)
     needs: start-runner
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     timeout-minutes: 50
     permissions:
       actions: 'read' # Required to read workflow run information
@@ -110,10 +111,13 @@ jobs:
         with:
           version: "26.x"
 
-      - name: Setup usage of private repo
+      - name: Fetch private dependencies
         env:
           BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
-        run: git config --global url."https://${BLOCKCHAIN_ACTIONS_TOKEN}@github.com".insteadOf ssh://git@github.com
+        run: |
+          git config --global url."https://${BLOCKCHAIN_ACTIONS_TOKEN}@github.com".insteadOf ssh://git@github.com
+          trap 'git config --global --unset-all url."https://${BLOCKCHAIN_ACTIONS_TOKEN}@github.com".insteadOf || true' EXIT
+          cargo fetch
 
       - name: Formatting
         run: cargo fmt -- --check
@@ -122,20 +126,14 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Gen FHE keys
-        env:
-          BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
         run: |
           RUST_BACKTRACE=full cargo run --example keygen
 
       - name: Run Tests
-        env:
-          BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
         run: |
           RUST_BACKTRACE=full cargo test
 
       - name: Run Examples
-        env:
-          BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
         run: |
           bash scripts/run-examples.sh
 

--- a/ci/abi-compat/list.ts
+++ b/ci/abi-compat/list.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { existsSync, mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
@@ -83,7 +83,16 @@ function run(cmd: string, cwd: string) {
 }
 
 function addWorktree(repoRoot: string, path: string, ref: string) {
-  run(`git worktree add --detach "${path}" "${ref}"`, repoRoot);
+  try {
+    execFileSync("git", ["worktree", "add", "--detach", path, ref], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+  } catch (error) {
+    throw new Error(`Command failed in ${repoRoot}: git worktree add --detach ${path} ${ref}\n${formatExecError(error)}`);
+  }
 }
 
 function preparePackage(currentRepoRoot: string, targetRoot: string, baselineRoot: string, pkg: PackageName) {

--- a/ci/upgrade-check/lib.ts
+++ b/ci/upgrade-check/lib.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
@@ -31,8 +31,12 @@ export interface ContractCheckResult {
 }
 
 function execForgeInspect(contract: string, root: string, field: string): string | null {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(contract)) {
+    throw new Error(`Invalid Solidity contract name: ${contract}`);
+  }
+
   try {
-    return execSync(`forge inspect "contracts/${contract}.sol:${contract}" --root "${root}" ${field}`, {
+    return execFileSync("forge", ["inspect", `contracts/${contract}.sol:${contract}`, "--root", root, field], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, NO_COLOR: "1" },

--- a/gateway-contracts/tasks/accounts.ts
+++ b/gateway-contracts/tasks/accounts.ts
@@ -3,35 +3,38 @@ import { HardhatNetworkHDAccountsConfig } from "hardhat/types";
 
 import { NUM_ACCOUNTS } from "../hardhat.config";
 
-// Use this task to get the list of accounts (addresses, private keys, public keys)
-task("get-accounts", "Prints the list of accounts").setAction(async (_, hre) => {
-  // Get signers from hardhat
-  const signers = await hre.ethers.getSigners();
-  const accounts = [];
-  const { mnemonic } = hre.network.config.accounts as HardhatNetworkHDAccountsConfig;
+// Use this task to get the list of accounts.
+task("get-accounts", "Prints the list of accounts")
+  .addFlag("includePrivateKeys", "Print private keys as well as addresses")
+  .setAction(async ({ includePrivateKeys }, hre) => {
+    // Get signers from hardhat
+    const signers = await hre.ethers.getSigners();
+    const accounts = [];
+    const { mnemonic } = hre.network.config.accounts as HardhatNetworkHDAccountsConfig;
 
-  // Get details for specified number of accounts
-  for (let i = 0; i < NUM_ACCOUNTS && i < signers.length; i++) {
-    const signer = signers[i];
-    const address = await signer.getAddress();
-    const phrase = hre.ethers.Mnemonic.fromPhrase(mnemonic);
-    const pathDeployer = "m/44'/60'/0'/0/" + i;
-    const privateKey = hre.ethers.HDNodeWallet.fromMnemonic(phrase, pathDeployer).privateKey;
-    const publicKey = hre.ethers.HDNodeWallet.fromMnemonic(phrase, pathDeployer).publicKey;
+    // Get details for specified number of accounts
+    for (let i = 0; i < NUM_ACCOUNTS && i < signers.length; i++) {
+      const signer = signers[i];
+      const address = await signer.getAddress();
+      const wallet = includePrivateKeys
+        ? hre.ethers.HDNodeWallet.fromMnemonic(hre.ethers.Mnemonic.fromPhrase(mnemonic), "m/44'/60'/0'/0/" + i)
+        : undefined;
 
-    accounts.push({
-      index: i,
-      privateKey: privateKey,
-      publicKey: publicKey,
-      address: address,
+      accounts.push({
+        index: i,
+        privateKey: wallet?.privateKey,
+        publicKey: wallet?.publicKey,
+        address,
+      });
+    }
+    console.info("\nAccount Details:");
+    console.info("================");
+    accounts.forEach(({ index, privateKey, address, publicKey }) => {
+      console.info(`\nAccount ${index}:`);
+      console.info(`Address:     ${address}`);
+      if (includePrivateKeys) {
+        console.info(`Private Key: ${privateKey}`);
+        console.info(`Public Key:  ${publicKey}`);
+      }
     });
-  }
-  console.info("\nAccount Details:");
-  console.info("================");
-  accounts.forEach(({ index, privateKey, address, publicKey }) => {
-    console.info(`\nAccount ${index}:`);
-    console.info(`Address:     ${address}`);
-    console.info(`Private Key: ${privateKey}`);
-    console.info(`Public Key:  ${publicKey}`);
   });
-});

--- a/library-solidity/tasks/taskUtils.ts
+++ b/library-solidity/tasks/taskUtils.ts
@@ -1,12 +1,24 @@
-import { exec as oldExec } from 'child_process';
+import { execFile as oldExecFile } from 'child_process';
 import { task } from 'hardhat/config';
 import { promisify } from 'util';
 
-const exec = promisify(oldExec);
+const execFile = promisify(oldExecFile);
+
+const validateContainerName = (containerName: string) => {
+  if (!/^[a-zA-Z0-9_.-]+$/.test(containerName)) {
+    throw new Error(`Invalid TEST_CONTAINER_NAME: ${containerName}`);
+  }
+};
+
 const getCoin = async (address: string) => {
   const containerName = process.env['TEST_CONTAINER_NAME'] || 'fhevm';
-  const response = await exec(`docker exec -i ${containerName} faucet ${address} | grep height`);
-  const res = JSON.parse(response.stdout);
+  validateContainerName(containerName);
+  const response = await execFile('docker', ['exec', '-i', containerName, 'faucet', address]);
+  const stdout = String(response.stdout);
+  const line = stdout
+    .split('\n')
+    .find((entry) => entry.includes('height'));
+  const res = JSON.parse(line ?? stdout);
   if (res.raw_log.match('account sequence mismatch')) await getCoin(address);
 };
 
@@ -40,7 +52,7 @@ task('task:faucetToPrivate')
 task('task:faucetToAddress')
   .addParam('address', 'The receiver address')
   .setAction(async function (taskArgs, hre) {
-    const receiverAddress = taskArgs.address;
+    const receiverAddress = hre.ethers.getAddress(taskArgs.address);
     if (hre.network.name === 'hardhat') {
       const bal = '0x1000000000000000000000000000000000000000';
       await hre.network.provider.send('hardhat_setBalance', [receiverAddress, bal]);

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -954,6 +954,9 @@ export const test = async (testName: string | undefined, options: TestOptions) =
           postgresPassword: postgres.postgresPassword,
         };
         const hostChainId = process.env.CHAIN_ID ?? "12345";
+        if (!/^\d+$/.test(hostChainId)) {
+          throw new PreflightError(`Invalid CHAIN_ID ${hostChainId}; expected a positive integer`);
+        }
 
         // Snapshot row counts before the revert runs. The gw-listener is
         // still in the grace period (pending status), so this is stable.


### PR DESCRIPTION
## Summary

This PR fixes the manually validated DeepSec findings that were collected in `zama-ai/fhevm-internal#1368`:

- avoid running PR-controlled host-contract Slither code on the self-hosted runner
- avoid exposing `BLOCKCHAIN_ACTIONS_TOKEN` to Rust SDK build/test/example steps
- fix boolean handling in the host-contracts publish workflow
- fix the Node.js golden-image path filter and prevent PR-triggered image pushes
- scrub GitHub App/server tokens from Claude review output
- validate `CHAIN_ID` before using it in test-suite SQL setup
- stop printing gateway contract private keys by default
- replace shell interpolation with argv-based process execution in selected CI/dev scripts
- add missing workflow concurrency stanzas for touched workflows

Closes zama-ai/fhevm-internal#1368

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/host-contracts-slither-analysis.yml .github/workflows/sdk-rust-sdk-tests.yml .github/workflows/host-contracts-publish.yml .github/workflows/golden-container-images-docker-build-nodejs.yml .github/workflows/claude-review.yml`
- `uvx zizmor==1.17.0 --persona pedantic .github/workflows/host-contracts-slither-analysis.yml .github/workflows/sdk-rust-sdk-tests.yml .github/workflows/host-contracts-publish.yml .github/workflows/golden-container-images-docker-build-nodejs.yml .github/workflows/claude-review.yml`
- `test-suite/fhevm/node_modules/.bin/tsc --noEmit --project test-suite/fhevm/tsconfig.json --pretty false`

## Notes

The local pre-commit hook uses the locally installed `zizmor` binary. On this machine that is `zizmor 1.23.1`, which reports newer `secrets-outside-env` warnings in existing workflows. CI is pinned to `zizmor 1.17.0`; the touched workflows pass with that CI-pinned version.
