### PR TITLE
feat: add KMS migration verification script #2469

### DIFF
--- a/gateway-contracts/.env.example
+++ b/gateway-contracts/.env.example
@@ -13,7 +13,6 @@ NEW_OWNER_PRIVATE_KEY="0x7ae52cf0d3011ef7fecbe22d9537aeda1a9e42a0596e8def5d49970
 
 # RPC URL
 RPC_URL="http://127.0.0.1:8757" # (string)
-
 # Protocol
 PROTOCOL_NAME="Protocol" # (string)
 PROTOCOL_WEBSITE="https://protocol.com" # (string)

--- a/gateway-contracts/tasks/exportMigrationState.ts
+++ b/gateway-contracts/tasks/exportMigrationState.ts
@@ -4,9 +4,7 @@ import fs from "fs";
 import { task, types } from "hardhat/config";
 import path from "path";
 
-const KMS_GENERATION_STORAGE_LOCATION = BigInt(
-  calculateERC7201StorageLocation("fhevm_gateway.storage.KMSGeneration"),
-);
+const KMS_GENERATION_STORAGE_LOCATION = BigInt(calculateERC7201StorageLocation("fhevm_gateway.storage.KMSGeneration"));
 
 function storageSlot(offset: bigint): string {
   return toBeHex(KMS_GENERATION_STORAGE_LOCATION + offset, 32);
@@ -86,7 +84,9 @@ async function readKmsStorageState(
     readWord(mappingSlot(activeCrsId, KMS_GENERATION_SLOT.consensusDigest)),
   ]);
 
-  const prepKeygenConsensusDigest = await readWord(mappingSlot(activePrepKeygenId, KMS_GENERATION_SLOT.consensusDigest));
+  const prepKeygenConsensusDigest = await readWord(
+    mappingSlot(activePrepKeygenId, KMS_GENERATION_SLOT.consensusDigest),
+  );
 
   return {
     prepKeygenCounter,
@@ -124,7 +124,6 @@ function buildMigrationEnv(state: Record<string, unknown>): Record<string, unkno
 task("task:exportKmsMigrationState", "Exports Gateway KMSGeneration migration state for the DAO runbook")
   .addParam("kmsGenerationProxy", "Gateway KMSGeneration proxy address")
   .addParam("gatewayConfigProxy", "GatewayConfig proxy address")
-  .addOptionalParam("legacyHostKmsVerifier", "Legacy host KMSVerifier proxy address to record as metadata")
   .addOptionalParam("output", "Output JSON path", "migration-state.json", types.string)
   .addOptionalParam(
     "blockTag",
@@ -135,9 +134,6 @@ task("task:exportKmsMigrationState", "Exports Gateway KMSGeneration migration st
   .setAction(async function (taskArguments, { ethers }) {
     const kmsGenerationAddress = checksumAddress(taskArguments.kmsGenerationProxy, "Gateway KMSGeneration proxy");
     const gatewayConfigAddress = checksumAddress(taskArguments.gatewayConfigProxy, "GatewayConfig proxy");
-    const legacyHostKmsVerifierAddress = taskArguments.legacyHostKmsVerifier
-      ? checksumAddress(taskArguments.legacyHostKmsVerifier, "Legacy host KMSVerifier proxy")
-      : null;
 
     const exportBlockNumber =
       taskArguments.blockTag === undefined ? await ethers.provider.getBlockNumber() : Number(taskArguments.blockTag);
@@ -217,10 +213,10 @@ task("task:exportKmsMigrationState", "Exports Gateway KMSGeneration migration st
     };
 
     const thresholds = {
-      publicDecryption: publicDecryptionThreshold.toString(),
-      userDecryption: userDecryptionThreshold.toString(),
-      kmsGen: kmsGenThreshold.toString(),
-      mpc: mpcThreshold.toString(),
+      publicDecryption: Number(publicDecryptionThreshold),
+      userDecryption: Number(userDecryptionThreshold),
+      kmsGen: Number(kmsGenThreshold),
+      mpc: Number(mpcThreshold),
     };
     const migrationEnv = {
       ...buildMigrationEnv(hostKmsGenerationMigrationState),
@@ -238,7 +234,6 @@ task("task:exportKmsMigrationState", "Exports Gateway KMSGeneration migration st
         exportTimestamp: new Date(Number(exportBlock.timestamp) * 1000).toISOString(),
         gatewayKmsGenerationProxy: kmsGenerationAddress,
         gatewayConfigProxy: gatewayConfigAddress,
-        legacyHostKmsVerifierProxy: legacyHostKmsVerifierAddress,
       },
       export: migrationEnv,
     };

--- a/gateway-contracts/tasks/upgradeContracts.ts
+++ b/gateway-contracts/tasks/upgradeContracts.ts
@@ -1,4 +1,4 @@
-import { Wallet } from "ethers";
+import { Interface, Wallet } from "ethers";
 import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
 
@@ -157,18 +157,44 @@ async function deployImplementationForPreparedUpgrade(
   const newImplementationFactory = await hre.ethers.getContractFactory(newImplementation, deployer);
 
   console.log(`Deploying "${newImplementation}" for prepared upgrade on proxy ${proxyAddress}...`);
-  const implementationAddress = await hre.upgrades.prepareUpgrade(proxyAddress, newImplementationFactory, {
-    kind: "uups",
-  });
+  const implementationAddress = String(
+    await hre.upgrades.prepareUpgrade(proxyAddress, newImplementationFactory, {
+      kind: "uups",
+    }),
+  );
   console.log("New implementation deployed at:", implementationAddress);
 
+  const reinitializeFunctionSignature = getFunctionSignature(reinitializeFunction);
   const reinitializeCalldata = hre.ethers.Interface.from(newImplementationArtifact.abi).encodeFunctionData(
     reinitializeFunction.name,
     reinitializeArgs,
   );
+  const outerCalldata = new Interface([
+    "function upgradeToAndCall(address newImplementation, bytes data) payable",
+  ]).encodeFunctionData("upgradeToAndCall", [implementationAddress, reinitializeCalldata]);
+
+  console.log("proxyAddress:", proxyAddress);
+  console.log("newImplementationAddress:", implementationAddress);
+  console.log("innerFunctionSignature:", reinitializeFunctionSignature);
   console.log(`${reinitializeFunction.name} calldata:`, reinitializeCalldata);
+  console.log("upgradeToAndCall(address,bytes) calldata:", outerCalldata);
   console.log(
-    `To double check, run: cast calldata ${shellQuote(getFunctionSignature(reinitializeFunction))} ${reinitializeArgs
+    "Prepared upgrade artifact:",
+    JSON.stringify(
+      {
+        proxyAddress,
+        newImplementationAddress: implementationAddress,
+        innerFunctionSignature: reinitializeFunctionSignature,
+        decodedArgs: reinitializeArgs,
+        innerCalldata: reinitializeCalldata,
+        outerCalldata,
+      },
+      (_, value: unknown) => (typeof value === "bigint" ? value.toString() : value),
+      2,
+    ),
+  );
+  console.log(
+    `To double check, run: cast calldata ${shellQuote(reinitializeFunctionSignature)} ${reinitializeArgs
       .map((arg) => shellQuote(formatCastArg(arg)))
       .join(" ")}`.trim(),
   );

--- a/host-contracts/.env.example
+++ b/host-contracts/.env.example
@@ -54,6 +54,10 @@ NEW_OWNER_PRIVATE_KEY="0x7ae52cf0d3011ef7fecbe22d9537aeda1a9e42a0596e8def5d49970
 # Migration (only required when running deploy tasks with --migration true)
 # ---------------------------------------------------------------------------
 
+# ProtocolConfig migration: KMS node and threshold state imported from the frozen Gateway config.
+# MIGRATION_KMS_NODES=""      # JSON array from migration-state.json.export.MIGRATION_KMS_NODES
+# MIGRATION_KMS_THRESHOLDS="" # JSON object from migration-state.json.export.MIGRATION_KMS_THRESHOLDS
+
 # KMSGeneration migration: active state imported from the frozen Gateway contract.
 # MIGRATION_PREP_KEYGEN_COUNTER=""
 # MIGRATION_KEY_COUNTER=""
@@ -73,3 +77,6 @@ NEW_OWNER_PRIVATE_KEY="0x7ae52cf0d3011ef7fecbe22d9537aeda1a9e42a0596e8def5d49970
 # MIGRATION_PREP_KEYGEN_PARAMS_TYPE=""  # 0 = Default, 1 = Test
 # MIGRATION_CRS_PARAMS_TYPE=""          # 0 = Default, 1 = Test
 # MIGRATION_CONTEXT_ID=""              # KMS context ID for the migrated state (used by both ProtocolConfig and KMSGeneration). Must be >= KMS_CONTEXT_COUNTER_BASE + 1.
+
+# Required by task:assertKmsMigrationSucceeded — compares the just-migrated host state against the live Gateway snapshot.
+# GATEWAY_RPC_URL=                # JSON-RPC URL of the Gateway chain (env-only; pass Gateway proxy addresses via CLI flags)

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -63,7 +63,7 @@ export async function waitForTaskReady(
   }
 }
 
-async function assertContractMatchesVersionPrefix(
+export async function assertContractMatchesVersionPrefix(
   hre: HardhatRuntimeEnvironment,
   address: string,
   versionPrefix: string,

--- a/host-contracts/tasks/taskMigrate.ts
+++ b/host-contracts/tasks/taskMigrate.ts
@@ -1,8 +1,12 @@
-import { FunctionFragment, Interface, type InterfaceAbi } from 'ethers';
-import { task } from 'hardhat/config';
+import { calculateERC7201StorageLocation } from '@openzeppelin/upgrades-core/dist/utils/erc7201';
+import { AbiCoder, FunctionFragment, Interface, type InterfaceAbi, getAddress, keccak256, toBeHex } from 'ethers';
+import fs from 'fs';
+import { task, types } from 'hardhat/config';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+import path from 'path';
 
 import {
+  assertContractMatchesVersionPrefix,
   deployEmptyUUPS,
   ensureAddressesDirectoryExists,
   readExistingHostEnv,
@@ -11,7 +15,10 @@ import {
 } from './taskDeploy';
 import { buildKMSGenerationInitializeFromMigrationArgs } from './utils/kmsGenerationMigrationEnv';
 import { getRequiredEnvVar } from './utils/loadVariables';
-import { buildProtocolConfigInitializeFromMigrationArgs } from './utils/protocolConfigMigrationEnv';
+import {
+  type ProtocolConfigMigrationKmsNode,
+  buildProtocolConfigInitializeFromMigrationArgs,
+} from './utils/protocolConfigMigrationEnv';
 
 ////////////////////////////////////////////////////////////////////////////////
 // Proposal artifact helpers
@@ -85,6 +92,20 @@ async function prepareDaoUpgrade(
   };
 }
 
+async function verifyPreparedImplementation(
+  hre: HardhatRuntimeEnvironment,
+  data: PreparedDaoUpgrade,
+  contract: string,
+): Promise<void> {
+  console.log('Waiting 2 minutes before contract verification... Please wait...');
+  await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+  await hre.run('verify:verify', {
+    address: data.newImplementationAddress,
+    contract,
+    constructorArguments: [],
+  });
+}
+
 function printPreparedDaoUpgrade(data: PreparedDaoUpgrade): void {
   console.log('proxyAddress:', data.proxyAddress);
   console.log('newImplementationAddress:', data.newImplementationAddress);
@@ -106,6 +127,52 @@ function printPreparedDaoUpgrade(data: PreparedDaoUpgrade): void {
   console.log(
     `Cast command: cast calldata 'upgradeToAndCall(address,bytes)' ${data.newImplementationAddress} ${data.innerCalldata}`,
   );
+}
+
+function assertEqual<T>(label: string, actual: T, expected: NoInfer<T>): void {
+  if (actual !== expected) {
+    throw new Error(`${label} mismatch: expected ${expected}, got ${actual}.`);
+  }
+}
+
+function assertJsonEqual(label: string, actual: unknown, expected: unknown): void {
+  const actualJson = stringifyForProposal(actual);
+  const expectedJson = stringifyForProposal(expected);
+  if (actualJson !== expectedJson) {
+    throw new Error(`${label} mismatch: expected ${expectedJson}, got ${actualJson}.`);
+  }
+}
+
+function normalizeAddresses(addresses: readonly string[]): string[] {
+  return addresses.map((address) => getAddress(address));
+}
+
+type KmsNodeLike = {
+  txSenderAddress: string;
+  signerAddress: string;
+  ipAddress: string;
+  storageUrl: string;
+};
+
+function normalizeKmsNode(node: KmsNodeLike): ProtocolConfigMigrationKmsNode {
+  return {
+    txSenderAddress: getAddress(node.txSenderAddress),
+    signerAddress: getAddress(node.signerAddress),
+    ipAddress: node.ipAddress,
+    storageUrl: node.storageUrl,
+  };
+}
+
+type KeyDigestLike = {
+  keyType: number | bigint;
+  digest: string;
+};
+
+function normalizeKeyDigest(digest: KeyDigestLike): { keyType: number; digest: string } {
+  return {
+    keyType: Number(digest.keyType),
+    digest: digest.digest.toLowerCase(),
+  };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -150,24 +217,34 @@ task('task:deployEmptyProxiesProtocolConfigKMSGeneration').setAction(async funct
 task(
   'task:prepareDeployProtocolConfigFromMigration',
   'Deploys a ProtocolConfig migration implementation and prints DAO upgrade calldata without mutating the proxy',
-).setAction(async function (_, hre) {
-  const parsedEnv = readHostEnv();
-  const proxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
-  // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
-  await hre.run('compile:specific', { contract: 'contracts' });
-  const decodedArgs = buildProtocolConfigInitializeFromMigrationArgs();
-  const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
-  const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
-  const preparedUpgrade = await prepareDaoUpgrade(hre, {
-    proxyAddress,
-    contractName: 'ProtocolConfig',
-    innerFunctionSignature,
-    decodedArgs,
-  });
+)
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function ({ verifyContract }, hre) {
+    const parsedEnv = readHostEnv();
+    const proxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
+    // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
+    await hre.run('compile:specific', { contract: 'contracts' });
+    const decodedArgs = buildProtocolConfigInitializeFromMigrationArgs();
+    const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
+    const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
+    const preparedUpgrade = await prepareDaoUpgrade(hre, {
+      proxyAddress,
+      contractName: 'ProtocolConfig',
+      innerFunctionSignature,
+      decodedArgs,
+    });
 
-  printPreparedDaoUpgrade(preparedUpgrade);
-  return preparedUpgrade;
-});
+    printPreparedDaoUpgrade(preparedUpgrade);
+    if (verifyContract) {
+      await verifyPreparedImplementation(hre, preparedUpgrade, 'contracts/ProtocolConfig.sol:ProtocolConfig');
+    }
+    return preparedUpgrade;
+  });
 
 task(
   'task:deployProtocolConfigFromMigration',
@@ -201,24 +278,34 @@ task(
 task(
   'task:prepareDeployKMSGenerationFromMigration',
   'Deploys a KMSGeneration migration implementation from MIGRATION_* env and prints DAO upgrade calldata without mutating the proxy',
-).setAction(async function (_, hre) {
-  const parsedEnv = readHostEnv();
-  const proxyAddress = parsedEnv.KMS_GENERATION_CONTRACT_ADDRESS;
-  // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
-  await hre.run('compile:specific', { contract: 'contracts' });
-  const decodedArgs = buildKMSGenerationInitializeFromMigrationArgs();
-  const artifact = await hre.artifacts.readArtifact('KMSGeneration');
-  const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
-  const preparedUpgrade = await prepareDaoUpgrade(hre, {
-    proxyAddress,
-    contractName: 'KMSGeneration',
-    innerFunctionSignature,
-    decodedArgs,
-  });
+)
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function ({ verifyContract }, hre) {
+    const parsedEnv = readHostEnv();
+    const proxyAddress = parsedEnv.KMS_GENERATION_CONTRACT_ADDRESS;
+    // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
+    await hre.run('compile:specific', { contract: 'contracts' });
+    const decodedArgs = buildKMSGenerationInitializeFromMigrationArgs();
+    const artifact = await hre.artifacts.readArtifact('KMSGeneration');
+    const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
+    const preparedUpgrade = await prepareDaoUpgrade(hre, {
+      proxyAddress,
+      contractName: 'KMSGeneration',
+      innerFunctionSignature,
+      decodedArgs,
+    });
 
-  printPreparedDaoUpgrade(preparedUpgrade);
-  return preparedUpgrade;
-});
+    printPreparedDaoUpgrade(preparedUpgrade);
+    if (verifyContract) {
+      await verifyPreparedImplementation(hre, preparedUpgrade, 'contracts/KMSGeneration.sol:KMSGeneration');
+    }
+    return preparedUpgrade;
+  });
 
 task(
   'task:deployKMSGenerationFromMigration',
@@ -243,3 +330,352 @@ task(
   });
   console.log('KMSGeneration migration code set successfully at address:', proxyAddress);
 });
+
+////////////////////////////////////////////////////////////////////////////////
+// Post-execution verification
+////////////////////////////////////////////////////////////////////////////////
+
+const HOST_KMS_GENERATION_NAMESPACE = 'fhevm.storage.KMSGeneration';
+const GATEWAY_KMS_GENERATION_NAMESPACE = 'fhevm_gateway.storage.KMSGeneration';
+
+const GATEWAY_CONFIG_VIEW_ABI = [
+  'function getCurrentKmsContextId() view returns (uint256)',
+  'function getKmsTxSendersForContext(uint256 contextId) view returns (address[])',
+  'function getKmsNodeForContext(uint256 contextId, address kmsTxSenderAddress) view returns (tuple(address txSenderAddress, address signerAddress, string ipAddress, string storageUrl))',
+  'function getPublicDecryptionThresholdForContext(uint256 contextId) view returns (uint256)',
+  'function getUserDecryptionThresholdForContext(uint256 contextId) view returns (uint256)',
+  'function getMpcThreshold() view returns (uint256)',
+  'function getKmsGenThreshold() view returns (uint256)',
+];
+
+// Post-migration Gateway KMSGeneration is a view-only frozen stub: only the materials/consensus
+// getters below are exposed. Counters, active IDs and consensus digests are read via storage
+// slots (see KMS_GENERATION_FIELD_OFFSET).
+const GATEWAY_KMS_GENERATION_VIEW_ABI = [
+  'function getConsensusTxSenders(uint256 requestId) view returns (address[])',
+  'function getKeyParamsType(uint256 keyId) view returns (uint8)',
+  'function getCrsParamsType(uint256 crsId) view returns (uint8)',
+  'function getKeyMaterials(uint256 keyId) view returns (string[], tuple(uint8 keyType, bytes digest)[])',
+  'function getCrsMaterials(uint256 crsId) view returns (string[], bytes)',
+];
+
+function assertAddressSetsEqual(label: string, actual: readonly string[], expected: readonly string[]): void {
+  assertEqual(label, normalizeAddresses(actual).sort().join(','), normalizeAddresses(expected).sort().join(','));
+}
+
+// Field offsets within the `KMSGenerationStorage` struct — identical across host
+// (`fhevm.storage.KMSGeneration`) and Gateway (`fhevm_gateway.storage.KMSGeneration`).
+// Mirrors `KMS_GENERATION_SLOT` in `gateway-contracts/tasks/exportMigrationState.ts`.
+const KMS_GENERATION_FIELD_OFFSET = {
+  consensusDigest: 3n,
+  prepKeygenCounter: 4n,
+  keyCounter: 5n,
+  keygenIdPairs: 6n,
+  activeKeyId: 8n,
+  crsCounter: 9n,
+  activeCrsId: 12n,
+} as const;
+
+type StorageProvider = {
+  getStorage: (address: string, slot: string, blockTag?: number | string) => Promise<string>;
+};
+
+function kmsGenerationFieldSlot(namespace: string, offset: bigint): string {
+  return toBeHex(BigInt(calculateERC7201StorageLocation(namespace)) + offset, 32);
+}
+
+function kmsGenerationMappingSlot(namespace: string, offset: bigint, key: bigint): string {
+  const baseSlot = kmsGenerationFieldSlot(namespace, offset);
+  return keccak256(AbiCoder.defaultAbiCoder().encode(['uint256', 'uint256'], [key, baseSlot]));
+}
+
+// Returns a reader bound to one contract (host or Gateway side). Hides the
+// provider/address/namespace/blockTag tuple that's constant for an entire side.
+function makeKmsGenerationStorageReader(
+  provider: StorageProvider,
+  contractAddress: string,
+  namespace: string,
+  blockTag: number | string | undefined,
+) {
+  return {
+    readUint: async (offset: bigint): Promise<bigint> =>
+      BigInt(await provider.getStorage(contractAddress, kmsGenerationFieldSlot(namespace, offset), blockTag)),
+    readMappingUint: async (offset: bigint, key: bigint): Promise<bigint> =>
+      BigInt(await provider.getStorage(contractAddress, kmsGenerationMappingSlot(namespace, offset, key), blockTag)),
+    readMappingBytes32: async (offset: bigint, key: bigint): Promise<string> =>
+      (
+        await provider.getStorage(contractAddress, kmsGenerationMappingSlot(namespace, offset, key), blockTag)
+      ).toLowerCase(),
+  };
+}
+
+task(
+  'task:assertKmsMigrationSucceeded',
+  'Asserts host ProtocolConfig + KMSGeneration + KMSVerifier match the live Gateway snapshot',
+)
+  .addParam('gatewayConfigProxy', 'Gateway GatewayConfig proxy address')
+  .addParam('gatewayKmsGenerationProxy', 'Gateway KMSGeneration proxy address')
+  .addOptionalParam(
+    'gatewayBlockTag',
+    'Gateway block to read at. Defaults to metadata.exportBlockNumber from gateway-contracts/migration-state.json if present; else latest with a warning.',
+    undefined,
+    types.int,
+  )
+  .setAction(async function (taskArgs, hre) {
+    const parsedEnv = readHostEnv();
+    const protocolConfigAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
+    const kmsGenerationAddress = parsedEnv.KMS_GENERATION_CONTRACT_ADDRESS;
+    const kmsVerifierAddress = parsedEnv.KMS_VERIFIER_CONTRACT_ADDRESS;
+
+    const gatewayConfigProxy = getAddress(taskArgs.gatewayConfigProxy);
+    const gatewayKmsGenerationProxy = getAddress(taskArgs.gatewayKmsGenerationProxy);
+
+    // On hardhat the mock Gateway shares the in-process network; everywhere else require the URL.
+    const rpcUrl = hre.network.name === 'hardhat' ? process.env.GATEWAY_RPC_URL : getRequiredEnvVar('GATEWAY_RPC_URL');
+    const gatewayProvider = rpcUrl ? new hre.ethers.JsonRpcProvider(rpcUrl) : hre.ethers.provider;
+
+    let gatewayBlockTag: number | 'latest' = taskArgs.gatewayBlockTag ?? 'latest';
+    if (gatewayBlockTag === 'latest') {
+      const snapshotPath = path.resolve(hre.config.paths.root, '..', 'gateway-contracts', 'migration-state.json');
+      const snapshotBlock = fs.existsSync(snapshotPath)
+        ? (JSON.parse(fs.readFileSync(snapshotPath, 'utf8')) as { metadata?: { exportBlockNumber?: number } }).metadata
+            ?.exportBlockNumber
+        : undefined;
+      // Reject snapshots from a different chain (dev runs against an in-process hardhat node at block 0).
+      if (snapshotBlock !== undefined && snapshotBlock <= (await gatewayProvider.getBlockNumber())) {
+        gatewayBlockTag = snapshotBlock;
+      } else {
+        console.warn(
+          'Gateway block tag defaulting to "latest" — pass --gateway-block-tag for deterministic verification.',
+        );
+      }
+    }
+    const gatewayCallOpts = { blockTag: gatewayBlockTag };
+
+    const gatewayConfig = new hre.ethers.Contract(gatewayConfigProxy, GATEWAY_CONFIG_VIEW_ABI, gatewayProvider);
+    const gatewayKmsGeneration = new hre.ethers.Contract(
+      gatewayKmsGenerationProxy,
+      GATEWAY_KMS_GENERATION_VIEW_ABI,
+      gatewayProvider,
+    );
+
+    const gatewayContextId: bigint = await gatewayConfig.getCurrentKmsContextId(gatewayCallOpts);
+    const gatewayKmsTxSenders: string[] = await gatewayConfig.getKmsTxSendersForContext(
+      gatewayContextId,
+      gatewayCallOpts,
+    );
+    const gatewayRawNodes = await Promise.all(
+      gatewayKmsTxSenders.map((txSender) =>
+        gatewayConfig.getKmsNodeForContext(gatewayContextId, txSender, gatewayCallOpts),
+      ),
+    );
+    const gatewayNodes: ProtocolConfigMigrationKmsNode[] = gatewayRawNodes.map(normalizeKmsNode);
+
+    const [
+      gatewayPublicDecryptionThreshold,
+      gatewayUserDecryptionThreshold,
+      gatewayMpcThreshold,
+      gatewayKmsGenThreshold,
+    ] = (await Promise.all([
+      gatewayConfig.getPublicDecryptionThresholdForContext(gatewayContextId, gatewayCallOpts),
+      gatewayConfig.getUserDecryptionThresholdForContext(gatewayContextId, gatewayCallOpts),
+      gatewayConfig.getMpcThreshold(gatewayCallOpts),
+      gatewayConfig.getKmsGenThreshold(gatewayCallOpts),
+    ])) as [bigint, bigint, bigint, bigint];
+
+    const gatewayKmsStorage = makeKmsGenerationStorageReader(
+      gatewayProvider,
+      gatewayKmsGenerationProxy,
+      GATEWAY_KMS_GENERATION_NAMESPACE,
+      gatewayBlockTag,
+    );
+    const hostKmsStorage = makeKmsGenerationStorageReader(
+      hre.ethers.provider,
+      kmsGenerationAddress,
+      HOST_KMS_GENERATION_NAMESPACE,
+      undefined,
+    );
+
+    const gatewayCounterFields = [
+      'prepKeygenCounter',
+      'keyCounter',
+      'crsCounter',
+      'activeKeyId',
+      'activeCrsId',
+    ] as const;
+    const [gatewayPrepKeygenCounter, gatewayKeyCounter, gatewayCrsCounter, gatewayActiveKeyId, gatewayActiveCrsId] =
+      await Promise.all(gatewayCounterFields.map((f) => gatewayKmsStorage.readUint(KMS_GENERATION_FIELD_OFFSET[f])));
+
+    const gatewayActivePrepKeygenId = await gatewayKmsStorage.readMappingUint(
+      KMS_GENERATION_FIELD_OFFSET.keygenIdPairs,
+      gatewayActiveKeyId,
+    );
+
+    const [
+      gatewayKeyConsensusTxSenders,
+      gatewayCrsConsensusTxSenders,
+      gatewayPrepKeygenConsensusTxSenders,
+      gatewayKeyParamsType,
+      gatewayCrsParamsType,
+    ] = (await Promise.all([
+      gatewayKmsGeneration.getConsensusTxSenders(gatewayActiveKeyId, gatewayCallOpts),
+      gatewayKmsGeneration.getConsensusTxSenders(gatewayActiveCrsId, gatewayCallOpts),
+      gatewayKmsGeneration.getConsensusTxSenders(gatewayActivePrepKeygenId, gatewayCallOpts),
+      gatewayKmsGeneration.getKeyParamsType(gatewayActiveKeyId, gatewayCallOpts),
+      gatewayKmsGeneration.getCrsParamsType(gatewayActiveCrsId, gatewayCallOpts),
+    ])) as [string[], string[], string[], number | bigint, number | bigint];
+
+    const [
+      [gatewayActiveKeyStorageUrls, gatewayActiveKeyDigests],
+      [gatewayActiveCrsStorageUrls, gatewayActiveCrsDigest],
+    ] = (await Promise.all([
+      gatewayKmsGeneration.getKeyMaterials(gatewayActiveKeyId, gatewayCallOpts),
+      gatewayKmsGeneration.getCrsMaterials(gatewayActiveCrsId, gatewayCallOpts),
+    ])) as [[string[], Array<{ keyType: number | bigint; digest: string }>], [string[], string]];
+
+    const gatewaySignerAddresses = gatewayNodes.map((node) => node.signerAddress);
+
+    await assertContractMatchesVersionPrefix(hre, protocolConfigAddress, 'ProtocolConfig');
+    const protocolConfig = await hre.ethers.getContractAt('ProtocolConfig', protocolConfigAddress);
+
+    assertEqual(
+      'ProtocolConfig current KMS context ID',
+      await protocolConfig.getCurrentKmsContextId(),
+      gatewayContextId,
+    );
+    assertEqual(
+      'ProtocolConfig migrated context validity',
+      await protocolConfig.isValidKmsContext(gatewayContextId),
+      true,
+    );
+
+    const sortByTxSender = (nodes: readonly ProtocolConfigMigrationKmsNode[]) =>
+      [...nodes].sort((a, b) => a.txSenderAddress.localeCompare(b.txSenderAddress));
+    const hostNodes = (await protocolConfig.getKmsNodesForContext(gatewayContextId)).map(normalizeKmsNode);
+    assertJsonEqual('ProtocolConfig KMS nodes', sortByTxSender(hostNodes), sortByTxSender(gatewayNodes));
+
+    assertAddressSetsEqual(
+      'ProtocolConfig KMS signers set',
+      await protocolConfig.getKmsSignersForContext(gatewayContextId),
+      gatewaySignerAddresses,
+    );
+
+    assertEqual(
+      'ProtocolConfig public decryption threshold',
+      await protocolConfig.getPublicDecryptionThresholdForContext(gatewayContextId),
+      gatewayPublicDecryptionThreshold,
+    );
+    assertEqual(
+      'ProtocolConfig user decryption threshold',
+      await protocolConfig.getUserDecryptionThresholdForContext(gatewayContextId),
+      gatewayUserDecryptionThreshold,
+    );
+    assertEqual(
+      'ProtocolConfig KMS generation threshold',
+      await protocolConfig.getKmsGenThreshold(),
+      gatewayKmsGenThreshold,
+    );
+    assertEqual('ProtocolConfig MPC threshold', await protocolConfig.getMpcThreshold(), gatewayMpcThreshold);
+
+    await assertContractMatchesVersionPrefix(hre, kmsGenerationAddress, 'KMSGeneration');
+    const kmsGeneration = await hre.ethers.getContractAt('KMSGeneration', kmsGenerationAddress);
+
+    assertEqual('KMSGeneration key counter', await kmsGeneration.getKeyCounter(), gatewayKeyCounter);
+    assertEqual('KMSGeneration CRS counter', await kmsGeneration.getCrsCounter(), gatewayCrsCounter);
+    assertEqual('KMSGeneration active key ID', await kmsGeneration.getActiveKeyId(), gatewayActiveKeyId);
+    assertEqual('KMSGeneration active CRS ID', await kmsGeneration.getActiveCrsId(), gatewayActiveCrsId);
+
+    const [hostActivePrepKeygenId, hostPrepKeygenCounter] = await Promise.all([
+      hostKmsStorage.readMappingUint(KMS_GENERATION_FIELD_OFFSET.keygenIdPairs, gatewayActiveKeyId),
+      hostKmsStorage.readUint(KMS_GENERATION_FIELD_OFFSET.prepKeygenCounter),
+    ]);
+    assertEqual('KMSGeneration active prep keygen ID', hostActivePrepKeygenId, gatewayActivePrepKeygenId);
+    assertEqual('KMSGeneration prep keygen counter', hostPrepKeygenCounter, gatewayPrepKeygenCounter);
+
+    const requestDoneChecks = [
+      { label: 'prep keygen', requestId: gatewayActivePrepKeygenId },
+      { label: 'key', requestId: gatewayActiveKeyId },
+      { label: 'CRS', requestId: gatewayActiveCrsId },
+    ];
+    for (const { label, requestId } of requestDoneChecks) {
+      assertEqual(`KMSGeneration ${label} request done`, await kmsGeneration.isRequestDone(requestId), true);
+    }
+
+    const consensusTxSenderChecks = [
+      { label: 'key', requestId: gatewayActiveKeyId, expectedTxSenders: gatewayKeyConsensusTxSenders },
+      { label: 'CRS', requestId: gatewayActiveCrsId, expectedTxSenders: gatewayCrsConsensusTxSenders },
+      {
+        label: 'prep keygen',
+        requestId: gatewayActivePrepKeygenId,
+        expectedTxSenders: gatewayPrepKeygenConsensusTxSenders,
+      },
+    ];
+    for (const { label, requestId, expectedTxSenders } of consensusTxSenderChecks) {
+      assertJsonEqual(
+        `KMSGeneration ${label} consensus tx senders`,
+        normalizeAddresses(await kmsGeneration.getConsensusTxSenders(requestId)),
+        normalizeAddresses(expectedTxSenders),
+      );
+    }
+
+    const consensusDigestChecks = [
+      { label: 'prep keygen', requestId: gatewayActivePrepKeygenId },
+      { label: 'key', requestId: gatewayActiveKeyId },
+      { label: 'CRS', requestId: gatewayActiveCrsId },
+    ];
+    const consensusDigestPairs = await Promise.all(
+      consensusDigestChecks.map(({ requestId }) =>
+        Promise.all([
+          hostKmsStorage.readMappingBytes32(KMS_GENERATION_FIELD_OFFSET.consensusDigest, requestId),
+          gatewayKmsStorage.readMappingBytes32(KMS_GENERATION_FIELD_OFFSET.consensusDigest, requestId),
+        ]),
+      ),
+    );
+    for (const [i, { label }] of consensusDigestChecks.entries()) {
+      const [hostDigest, gatewayDigest] = consensusDigestPairs[i];
+      assertEqual(`KMSGeneration ${label} consensus digest`, hostDigest, gatewayDigest);
+    }
+
+    assertEqual(
+      'KMSGeneration active key params type',
+      BigInt(await kmsGeneration.getKeyParamsType(gatewayActiveKeyId)),
+      BigInt(gatewayKeyParamsType),
+    );
+    assertEqual(
+      'KMSGeneration active CRS params type',
+      BigInt(await kmsGeneration.getCrsParamsType(gatewayActiveCrsId)),
+      BigInt(gatewayCrsParamsType),
+    );
+
+    const [activeKeyStorageUrls, activeKeyDigests] = await kmsGeneration.getKeyMaterials(gatewayActiveKeyId);
+    assertJsonEqual(
+      'KMSGeneration active key storage URLs',
+      Array.from(activeKeyStorageUrls),
+      gatewayActiveKeyStorageUrls,
+    );
+    assertJsonEqual(
+      'KMSGeneration active key digests',
+      activeKeyDigests.map(normalizeKeyDigest),
+      gatewayActiveKeyDigests.map(normalizeKeyDigest),
+    );
+
+    const [activeCrsStorageUrls, activeCrsDigest] = await kmsGeneration.getCrsMaterials(gatewayActiveCrsId);
+    assertJsonEqual(
+      'KMSGeneration active CRS storage URLs',
+      Array.from(activeCrsStorageUrls),
+      gatewayActiveCrsStorageUrls,
+    );
+    assertEqual('KMSGeneration active CRS digest', activeCrsDigest.toLowerCase(), gatewayActiveCrsDigest.toLowerCase());
+
+    await assertContractMatchesVersionPrefix(hre, kmsVerifierAddress, 'KMSVerifier');
+    const kmsVerifier = await hre.ethers.getContractAt('KMSVerifier', kmsVerifierAddress);
+    assertEqual('KMSVerifier current KMS context ID', await kmsVerifier.getCurrentKmsContextId(), gatewayContextId);
+    assertEqual(
+      'KMSVerifier public decryption threshold',
+      await kmsVerifier.getThreshold(),
+      gatewayPublicDecryptionThreshold,
+    );
+    assertAddressSetsEqual('KMSVerifier KMS signers set', await kmsVerifier.getKmsSigners(), gatewaySignerAddresses);
+
+    console.log('KMS migration verification succeeded.');
+  });

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -1,4 +1,4 @@
-import { Wallet } from 'ethers';
+import { Interface, Wallet } from 'ethers';
 import { task, types } from 'hardhat/config';
 import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types';
 
@@ -124,18 +124,44 @@ async function deployImplementationForPreparedUpgrade(
   const newImplementationFactory = await hre.ethers.getContractFactory(newImplementation, deployer);
 
   console.log(`Deploying "${newImplementation}" for prepared upgrade on proxy ${proxyAddress}...`);
-  const implementationAddress = await hre.upgrades.prepareUpgrade(proxyAddress, newImplementationFactory, {
-    kind: 'uups',
-  });
+  const implementationAddress = String(
+    await hre.upgrades.prepareUpgrade(proxyAddress, newImplementationFactory, {
+      kind: 'uups',
+    }),
+  );
   console.log('New implementation deployed at:', implementationAddress);
 
+  const reinitializeFunctionSignature = getFunctionSignature(reinitializeFunction);
   const reinitializeCalldata = hre.ethers.Interface.from(newImplementationArtifact.abi).encodeFunctionData(
     reinitializeFunction.name,
     reinitializeArgs,
   );
+  const outerCalldata = new Interface([
+    'function upgradeToAndCall(address newImplementation, bytes data) payable',
+  ]).encodeFunctionData('upgradeToAndCall', [implementationAddress, reinitializeCalldata]);
+
+  console.log('proxyAddress:', proxyAddress);
+  console.log('newImplementationAddress:', implementationAddress);
+  console.log('innerFunctionSignature:', reinitializeFunctionSignature);
   console.log(`${reinitializeFunction.name} calldata:`, reinitializeCalldata);
+  console.log('upgradeToAndCall(address,bytes) calldata:', outerCalldata);
   console.log(
-    `To double check, run: cast calldata ${shellQuote(getFunctionSignature(reinitializeFunction))} ${reinitializeArgs
+    'Prepared upgrade artifact:',
+    JSON.stringify(
+      {
+        proxyAddress,
+        newImplementationAddress: implementationAddress,
+        innerFunctionSignature: reinitializeFunctionSignature,
+        decodedArgs: reinitializeArgs,
+        innerCalldata: reinitializeCalldata,
+        outerCalldata,
+      },
+      (_, value: unknown) => (typeof value === 'bigint' ? value.toString() : value),
+      2,
+    ),
+  );
+  console.log(
+    `To double check, run: cast calldata ${shellQuote(reinitializeFunctionSignature)} ${reinitializeArgs
       .map((arg) => shellQuote(formatCastArg(arg)))
       .join(' ')}`.trim(),
   );

--- a/host-contracts/test/mocks/MockGatewayView.sol
+++ b/host-contracts/test/mocks/MockGatewayView.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {KmsNode} from "../../contracts/shared/Structs.sol";
+
+// Test-only mock of the GatewayConfig view surface read by task:assertKmsMigrationSucceeded.
+// State is seeded directly; no governance/access control.
+contract MockGatewayConfigView {
+    uint256 private _currentKmsContextId;
+    mapping(uint256 => address[]) private _kmsTxSendersByContext;
+    mapping(uint256 => mapping(address => KmsNode)) private _kmsNodeByContext;
+    mapping(uint256 => uint256) private _publicDecryptionThresholdByContext;
+    mapping(uint256 => uint256) private _userDecryptionThresholdByContext;
+    uint256 private _mpcThreshold;
+    uint256 private _kmsGenThreshold;
+
+    function seedKmsContext(
+        uint256 contextId,
+        KmsNode[] calldata nodes,
+        uint256 publicDecryptionThreshold,
+        uint256 userDecryptionThreshold,
+        uint256 mpcThreshold,
+        uint256 kmsGenThreshold
+    ) external {
+        _currentKmsContextId = contextId;
+        delete _kmsTxSendersByContext[contextId];
+        for (uint256 i = 0; i < nodes.length; i++) {
+            _kmsTxSendersByContext[contextId].push(nodes[i].txSenderAddress);
+            _kmsNodeByContext[contextId][nodes[i].txSenderAddress] = nodes[i];
+        }
+        _publicDecryptionThresholdByContext[contextId] = publicDecryptionThreshold;
+        _userDecryptionThresholdByContext[contextId] = userDecryptionThreshold;
+        _mpcThreshold = mpcThreshold;
+        _kmsGenThreshold = kmsGenThreshold;
+    }
+
+    function pushPhantomNode(uint256 contextId, KmsNode calldata node) external {
+        _kmsTxSendersByContext[contextId].push(node.txSenderAddress);
+        _kmsNodeByContext[contextId][node.txSenderAddress] = node;
+    }
+
+    function overridePublicDecryptionThreshold(uint256 contextId, uint256 newThreshold) external {
+        _publicDecryptionThresholdByContext[contextId] = newThreshold;
+    }
+
+    function getCurrentKmsContextId() external view returns (uint256) {
+        return _currentKmsContextId;
+    }
+
+    function getKmsTxSendersForContext(uint256 contextId) external view returns (address[] memory) {
+        return _kmsTxSendersByContext[contextId];
+    }
+
+    function getKmsNodeForContext(
+        uint256 contextId,
+        address kmsTxSenderAddress
+    ) external view returns (KmsNode memory) {
+        return _kmsNodeByContext[contextId][kmsTxSenderAddress];
+    }
+
+    function getPublicDecryptionThresholdForContext(uint256 contextId) external view returns (uint256) {
+        return _publicDecryptionThresholdByContext[contextId];
+    }
+
+    function getUserDecryptionThresholdForContext(uint256 contextId) external view returns (uint256) {
+        return _userDecryptionThresholdByContext[contextId];
+    }
+
+    function getMpcThreshold() external view returns (uint256) {
+        return _mpcThreshold;
+    }
+
+    function getKmsGenThreshold() external view returns (uint256) {
+        return _kmsGenThreshold;
+    }
+}
+
+// Test-only mock of the Gateway KMSGeneration view surface. Counters, active IDs and consensus
+// digests are read via eth_getStorageAt, so the ERC-7201 layout below must match production.
+contract MockGatewayKMSGenerationView {
+    struct KeyDigestStorage {
+        uint8 keyType;
+        bytes digest;
+    }
+
+    /// @custom:storage-location erc7201:fhevm_gateway.storage.KMSGeneration
+    /// @dev Field offsets must match `KMSGenerationStorage` in
+    ///      `gateway-contracts/contracts/KMSGeneration.sol` for the offsets read by
+    ///      `task:assertKmsMigrationSucceeded` (3, 4, 5, 6, 8, 9, 12).
+    struct KMSGenerationStorage {
+        uint256 _gap0; //                                offset 0  (kmsHasSignedForResponse)
+        uint256 _gap1; //                                offset 1  (isRequestDone)
+        uint256 _gap2; //                                offset 2  (consensusTxSenderAddresses)
+        mapping(uint256 => bytes32) consensusDigest; //  offset 3
+        uint256 prepKeygenCounter; //                    offset 4
+        uint256 keyCounter; //                           offset 5
+        mapping(uint256 => uint256) keygenIdPairs; //    offset 6
+        uint256 _gap7; //                                offset 7  (keyDigests)
+        uint256 activeKeyId; //                          offset 8
+        uint256 crsCounter; //                           offset 9
+        uint256 _gap10; //                               offset 10 (crsMaxBitLength)
+        uint256 _gap11; //                               offset 11 (crsDigests)
+        uint256 activeCrsId; //                          offset 12
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("fhevm_gateway.storage.KMSGeneration")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant KMS_GENERATION_STORAGE_LOCATION =
+        0x0b8fdb1f0a6356dd20a6cbc6f9668fac23b85f96575d10e333e603faa794ac00;
+
+    mapping(uint256 => address[]) private _consensusTxSendersByRequest;
+    mapping(uint256 => uint8) private _keyParamsType;
+    mapping(uint256 => uint8) private _crsParamsType;
+    mapping(uint256 => string[]) private _keyStorageUrls;
+    mapping(uint256 => KeyDigestStorage[]) private _keyDigests;
+    mapping(uint256 => string[]) private _crsStorageUrls;
+    mapping(uint256 => bytes) private _crsDigest;
+
+    function _getStorage() private pure returns (KMSGenerationStorage storage $) {
+        bytes32 location = KMS_GENERATION_STORAGE_LOCATION;
+        assembly {
+            $.slot := location
+        }
+    }
+
+    function seedKmsGeneration(
+        uint256 prepKeygenCounter,
+        uint256 keyCounter,
+        uint256 crsCounter,
+        uint256 activeKeyId,
+        uint256 activeCrsId,
+        uint256 activePrepKeygenId
+    ) external {
+        KMSGenerationStorage storage $ = _getStorage();
+        $.prepKeygenCounter = prepKeygenCounter;
+        $.keyCounter = keyCounter;
+        $.crsCounter = crsCounter;
+        $.activeKeyId = activeKeyId;
+        $.activeCrsId = activeCrsId;
+        $.keygenIdPairs[activeKeyId] = activePrepKeygenId;
+    }
+
+    function seedConsensusTxSenders(uint256 requestId, address[] calldata txSenders) external {
+        _consensusTxSendersByRequest[requestId] = txSenders;
+    }
+
+    function seedConsensusDigest(uint256 requestId, bytes32 digest) external {
+        _getStorage().consensusDigest[requestId] = digest;
+    }
+
+    function seedKeyMaterials(
+        uint256 keyId,
+        string[] calldata storageUrls,
+        KeyDigestStorage[] calldata digests,
+        uint8 paramsType
+    ) external {
+        delete _keyStorageUrls[keyId];
+        for (uint256 i = 0; i < storageUrls.length; i++) {
+            _keyStorageUrls[keyId].push(storageUrls[i]);
+        }
+        delete _keyDigests[keyId];
+        for (uint256 i = 0; i < digests.length; i++) {
+            _keyDigests[keyId].push(digests[i]);
+        }
+        _keyParamsType[keyId] = paramsType;
+    }
+
+    function seedCrsMaterials(
+        uint256 crsId,
+        string[] calldata storageUrls,
+        bytes calldata digest,
+        uint8 paramsType
+    ) external {
+        delete _crsStorageUrls[crsId];
+        for (uint256 i = 0; i < storageUrls.length; i++) {
+            _crsStorageUrls[crsId].push(storageUrls[i]);
+        }
+        _crsDigest[crsId] = digest;
+        _crsParamsType[crsId] = paramsType;
+    }
+
+    function getConsensusTxSenders(uint256 requestId) external view returns (address[] memory) {
+        return _consensusTxSendersByRequest[requestId];
+    }
+
+    function getKeyParamsType(uint256 keyId) external view returns (uint8) {
+        return _keyParamsType[keyId];
+    }
+
+    function getCrsParamsType(uint256 crsId) external view returns (uint8) {
+        return _crsParamsType[crsId];
+    }
+
+    function getKeyMaterials(uint256 keyId) external view returns (string[] memory, KeyDigestStorage[] memory) {
+        return (_keyStorageUrls[keyId], _keyDigests[keyId]);
+    }
+
+    function getCrsMaterials(uint256 crsId) external view returns (string[] memory, bytes memory) {
+        return (_crsStorageUrls[crsId], _crsDigest[crsId]);
+    }
+}

--- a/host-contracts/test/tasks/migration.ts
+++ b/host-contracts/test/tasks/migration.ts
@@ -99,12 +99,15 @@ describe('Migration prepare tasks', function () {
       applyProtocolConfigMigrationEnv(protocolConfigMigrationEnv);
 
       const implementationSlotBefore = await readImplementationSlot(proxyAddress);
-      const preparedUpgrade = await run('task:prepareDeployProtocolConfigFromMigration');
+      const preparedUpgrade = await run('task:prepareDeployProtocolConfigFromMigration', {
+        verifyContract: false,
+      });
       const implementationSlotAfter = await readImplementationSlot(proxyAddress);
 
       expect(implementationSlotAfter).to.equal(implementationSlotBefore);
 
       const { newImplementationAddress, innerFunctionSignature, innerCalldata, outerCalldata } = preparedUpgrade;
+      expect(preparedUpgrade.proxyAddress).to.equal(proxyAddress);
       const iface = new ethers.Interface([`function ${innerFunctionSignature}`]);
       const decoded = iface.decodeFunctionData('initializeFromMigration', innerCalldata);
 
@@ -115,6 +118,35 @@ describe('Migration prepare tasks', function () {
       expect(decoded[2][0]).to.equal(BigInt(getRequiredEnvVar('PUBLIC_DECRYPTION_THRESHOLD')));
       expect(outerCalldata).to.equal(
         UPGRADE_TO_AND_CALL_INTERFACE.encodeFunctionData('upgradeToAndCall', [newImplementationAddress, innerCalldata]),
+      );
+    });
+
+    it('executes the devnet direct upgrade and initializes ProtocolConfig from migration state', async function () {
+      const proxyAddress = await deployEmptyUUPSProxy(deployer);
+      patchHostEnv('PROTOCOL_CONFIG_CONTRACT_ADDRESS', proxyAddress);
+
+      const migratedContextId = KMS_CONTEXT_COUNTER_BASE + BigInt(4);
+      const protocolConfigMigrationEnv: ProtocolConfigMigrationEnv = {
+        MIGRATION_CONTEXT_ID: migratedContextId.toString(),
+        MIGRATION_KMS_NODES: JSON.stringify(buildKmsNodes()),
+        MIGRATION_KMS_THRESHOLDS: JSON.stringify(buildKmsThresholds()),
+      };
+      applyProtocolConfigMigrationEnv(protocolConfigMigrationEnv);
+
+      const implementationSlotBefore = await readImplementationSlot(proxyAddress);
+      await run('task:deployProtocolConfigFromMigration');
+      const protocolConfig = await ethers.getContractAt('ProtocolConfig', proxyAddress);
+
+      expect(await readImplementationSlot(proxyAddress)).to.not.equal(implementationSlotBefore);
+      expect(await protocolConfig.getVersion()).to.equal('ProtocolConfig v0.1.0');
+      expect(await protocolConfig.getCurrentKmsContextId()).to.equal(migratedContextId);
+      expect(await protocolConfig.getPublicDecryptionThreshold()).to.equal(
+        BigInt(getRequiredEnvVar('PUBLIC_DECRYPTION_THRESHOLD')),
+      );
+
+      const kmsNodes = await protocolConfig.getKmsNodesForContext(migratedContextId);
+      expect(kmsNodes.map((node) => node.txSenderAddress)).to.deep.equal(
+        getKmsTxSenderAddresses(+getRequiredEnvVar('NUM_KMS_NODES')),
       );
     });
   });
@@ -158,7 +190,7 @@ describe('Migration prepare tasks', function () {
         MIGRATION_CRS_PARAMS_TYPE: '0',
         MIGRATION_CONTEXT_ID: contextId.toString(),
       };
-      return { activeKeyId, activeCrsId, consensusTxSenders, migrationEnv };
+      return { activeKeyId, activeCrsId, activePrepKeygenId, consensusTxSenders, migrationEnv };
     }
 
     it('prepares DAO calldata from MIGRATION_* env without mutating the empty proxy implementation', async function () {
@@ -169,12 +201,15 @@ describe('Migration prepare tasks', function () {
       applyKmsGenerationMigrationEnv(migrationEnv);
 
       const implementationSlotBefore = await readImplementationSlot(proxyAddress);
-      const preparedUpgrade = await run('task:prepareDeployKMSGenerationFromMigration');
+      const preparedUpgrade = await run('task:prepareDeployKMSGenerationFromMigration', {
+        verifyContract: false,
+      });
       const implementationSlotAfter = await readImplementationSlot(proxyAddress);
 
       expect(implementationSlotAfter).to.equal(implementationSlotBefore);
 
       const { newImplementationAddress, innerFunctionSignature, innerCalldata, outerCalldata } = preparedUpgrade;
+      expect(preparedUpgrade.proxyAddress).to.equal(proxyAddress);
       const iface = new ethers.Interface([`function ${innerFunctionSignature}`]);
       const decoded = iface.decodeFunctionData('initializeFromMigration', innerCalldata);
 
@@ -185,6 +220,180 @@ describe('Migration prepare tasks', function () {
       expect(outerCalldata).to.equal(
         UPGRADE_TO_AND_CALL_INTERFACE.encodeFunctionData('upgradeToAndCall', [newImplementationAddress, innerCalldata]),
       );
+    });
+
+    it('executes the devnet direct upgrade and initializes KMSGeneration from MIGRATION_* env', async function () {
+      const proxyAddress = await deployEmptyUUPSProxy(deployer);
+      patchHostEnv('KMS_GENERATION_CONTRACT_ADDRESS', proxyAddress);
+
+      const { activeKeyId, activeCrsId, activePrepKeygenId, consensusTxSenders, migrationEnv } =
+        buildKmsGenerationMigrationFixture();
+      applyKmsGenerationMigrationEnv(migrationEnv);
+
+      const implementationSlotBefore = await readImplementationSlot(proxyAddress);
+      await run('task:deployKMSGenerationFromMigration');
+      const kmsGeneration = await ethers.getContractAt('KMSGeneration', proxyAddress);
+
+      expect(await readImplementationSlot(proxyAddress)).to.not.equal(implementationSlotBefore);
+      expect(await kmsGeneration.getVersion()).to.equal('KMSGeneration v0.1.0');
+      expect(await kmsGeneration.getKeyCounter()).to.equal(activeKeyId);
+      expect(await kmsGeneration.getCrsCounter()).to.equal(activeCrsId);
+      expect(await kmsGeneration.getActiveKeyId()).to.equal(activeKeyId);
+      expect(await kmsGeneration.getActiveCrsId()).to.equal(activeCrsId);
+      expect(await kmsGeneration.isRequestDone(activePrepKeygenId)).to.equal(true);
+      expect(await kmsGeneration.isRequestDone(activeKeyId)).to.equal(true);
+      expect(await kmsGeneration.isRequestDone(activeCrsId)).to.equal(true);
+      expect(await kmsGeneration.getConsensusTxSenders(activeKeyId)).to.deep.equal(consensusTxSenders);
+
+      const [, activeKeyDigests] = await kmsGeneration.getKeyMaterials(activeKeyId);
+      const [, activeCrsDigest] = await kmsGeneration.getCrsMaterials(activeCrsId);
+      expect(activeKeyDigests.map((digest) => [Number(digest.keyType), digest.digest])).to.deep.equal([
+        [0, '0xabcdef0123456789'],
+        [1, '0x9876543210fedcba'],
+      ]);
+      expect(activeCrsDigest).to.equal('0xdeadbeefcafe0123');
+    });
+
+    // Deploy a mock Gateway pair on the same hardhat network and seed it with the same values
+    // that populate .env.host, so the assertion task has a real source of truth to compare against.
+    async function deploySeededMockGateway(fixture: ReturnType<typeof buildKmsGenerationMigrationFixture>) {
+      await run('compile:specific', { contract: 'test/mocks/MockGatewayView.sol' });
+      const mockConfig = await (await ethers.getContractFactory('MockGatewayConfigView', deployer)).deploy();
+      const mockKmsGen = await (await ethers.getContractFactory('MockGatewayKMSGenerationView', deployer)).deploy();
+
+      const kmsNodes = buildKmsNodes();
+      const thresholds = buildKmsThresholds();
+      await mockConfig.seedKmsContext(
+        contextId,
+        kmsNodes,
+        thresholds.publicDecryption,
+        thresholds.userDecryption,
+        thresholds.mpc,
+        thresholds.kmsGen,
+      );
+
+      const { activeKeyId, activeCrsId, activePrepKeygenId, consensusTxSenders, migrationEnv } = fixture;
+      const storageUrls = kmsNodes.map((node) => node.storageUrl);
+      // counter == active id is a migration precondition, so seed them as equal here.
+      await mockKmsGen.seedKmsGeneration(
+        activePrepKeygenId,
+        activeKeyId,
+        activeCrsId,
+        activeKeyId,
+        activeCrsId,
+        activePrepKeygenId,
+      );
+      await mockKmsGen.seedConsensusTxSenders(activeKeyId, consensusTxSenders);
+      await mockKmsGen.seedConsensusTxSenders(activeCrsId, consensusTxSenders);
+      await mockKmsGen.seedConsensusTxSenders(activePrepKeygenId, consensusTxSenders);
+      // Seed the consensus digests with the same bytes32 values that flowed into the host via
+      // MIGRATION_* env so the gateway-vs-host digest comparison passes.
+      await mockKmsGen.seedConsensusDigest(activeKeyId, migrationEnv.MIGRATION_KEY_CONSENSUS_DIGEST);
+      await mockKmsGen.seedConsensusDigest(activeCrsId, migrationEnv.MIGRATION_CRS_CONSENSUS_DIGEST);
+      await mockKmsGen.seedConsensusDigest(activePrepKeygenId, migrationEnv.MIGRATION_PREP_KEYGEN_CONSENSUS_DIGEST);
+      await mockKmsGen.seedKeyMaterials(
+        activeKeyId,
+        storageUrls,
+        [
+          { keyType: 0, digest: '0xabcdef0123456789' },
+          { keyType: 1, digest: '0x9876543210fedcba' },
+        ],
+        0,
+      );
+      await mockKmsGen.seedCrsMaterials(activeCrsId, storageUrls, '0xdeadbeefcafe0123', 0);
+
+      return {
+        gatewayConfigAddress: await mockConfig.getAddress(),
+        gatewayKmsGenerationAddress: await mockKmsGen.getAddress(),
+        mockConfig,
+        mockKmsGen,
+        kmsNodes,
+      };
+    }
+
+    async function deployHostMigrationStack() {
+      const protocolConfigProxyAddress = await deployEmptyUUPSProxy(deployer);
+      const kmsGenerationProxyAddress = await deployEmptyUUPSProxy(deployer);
+      const kmsVerifierProxyAddress = await deployEmptyUUPSProxy(deployer);
+
+      patchHostEnv('PROTOCOL_CONFIG_CONTRACT_ADDRESS', protocolConfigProxyAddress);
+      patchHostEnv('KMS_GENERATION_CONTRACT_ADDRESS', kmsGenerationProxyAddress);
+      patchHostEnv('KMS_VERIFIER_CONTRACT_ADDRESS', kmsVerifierProxyAddress);
+
+      const fixture = buildKmsGenerationMigrationFixture();
+      applyKmsGenerationMigrationEnv(fixture.migrationEnv);
+      applyProtocolConfigMigrationEnv({
+        MIGRATION_CONTEXT_ID: contextId.toString(),
+        MIGRATION_KMS_NODES: JSON.stringify(buildKmsNodes()),
+        MIGRATION_KMS_THRESHOLDS: JSON.stringify(buildKmsThresholds()),
+      });
+
+      await run('task:deployProtocolConfigFromMigration');
+      await run('task:deployKMSVerifier');
+      await run('task:deployKMSGenerationFromMigration');
+
+      return fixture;
+    }
+
+    it('asserts the live host migration state matches the live Gateway snapshot', async function () {
+      const fixture = await deployHostMigrationStack();
+      const { gatewayConfigAddress, gatewayKmsGenerationAddress } = await deploySeededMockGateway(fixture);
+
+      await run('task:assertKmsMigrationSucceeded', {
+        gatewayConfigProxy: gatewayConfigAddress,
+        gatewayKmsGenerationProxy: gatewayKmsGenerationAddress,
+      });
+    });
+
+    it('rejects when the Gateway public decryption threshold diverges from the host', async function () {
+      const fixture = await deployHostMigrationStack();
+      const { gatewayConfigAddress, gatewayKmsGenerationAddress, mockConfig } = await deploySeededMockGateway(fixture);
+
+      const hostThreshold = BigInt(getRequiredEnvVar('PUBLIC_DECRYPTION_THRESHOLD'));
+      await (await mockConfig.overridePublicDecryptionThreshold(contextId, hostThreshold + 1n)).wait();
+
+      await expect(
+        run('task:assertKmsMigrationSucceeded', {
+          gatewayConfigProxy: gatewayConfigAddress,
+          gatewayKmsGenerationProxy: gatewayKmsGenerationAddress,
+        }),
+      ).to.be.rejectedWith(/ProtocolConfig public decryption threshold mismatch/);
+    });
+
+    it('rejects when a Gateway consensus digest diverges from the host', async function () {
+      const fixture = await deployHostMigrationStack();
+      const { gatewayConfigAddress, gatewayKmsGenerationAddress, mockKmsGen } = await deploySeededMockGateway(fixture);
+
+      // Flip the key consensus digest on the Gateway side; host keeps the migrated value.
+      await (await mockKmsGen.seedConsensusDigest(fixture.activeKeyId, nonZeroBytes32(0xdead))).wait();
+
+      await expect(
+        run('task:assertKmsMigrationSucceeded', {
+          gatewayConfigProxy: gatewayConfigAddress,
+          gatewayKmsGenerationProxy: gatewayKmsGenerationAddress,
+        }),
+      ).to.be.rejectedWith(/KMSGeneration key consensus digest mismatch/);
+    });
+
+    it('rejects when the Gateway has an extra phantom KMS node not present on the host', async function () {
+      const fixture = await deployHostMigrationStack();
+      const { gatewayConfigAddress, gatewayKmsGenerationAddress, mockConfig } = await deploySeededMockGateway(fixture);
+
+      await (
+        await mockConfig.pushPhantomNode(contextId, {
+          txSenderAddress: '0x000000000000000000000000000000000000beef',
+          signerAddress: '0x000000000000000000000000000000000000cafe',
+          ipAddress: '127.0.0.99',
+          storageUrl: 's3://phantom-bucket',
+        })
+      ).wait();
+
+      await expect(
+        run('task:assertKmsMigrationSucceeded', {
+          gatewayConfigProxy: gatewayConfigAddress,
+          gatewayKmsGenerationProxy: gatewayKmsGenerationAddress,
+        }),
+      ).to.be.rejectedWith(/ProtocolConfig KMS nodes mismatch/);
     });
   });
 
@@ -237,6 +446,20 @@ describe('Migration prepare tasks', function () {
       await expect(run('task:deployKMSVerifier')).to.be.rejectedWith(
         `Cannot deploy KMSVerifier: Contract at ${protocolConfigProxyAddress} does not expose getVersion(); it is not a ProtocolConfig proxy.`,
       );
+
+      expect(await upgrades.erc1967.getImplementationAddress(kmsVerifierProxyAddress)).to.equal(kmsVerifierImplBefore);
+    });
+
+    it('prepares KMSVerifier upgrade calldata without mutating the proxy implementation', async function () {
+      const kmsVerifierProxyAddress = readHostAddress('KMS_VERIFIER_CONTRACT_ADDRESS');
+      const kmsVerifierImplBefore = await upgrades.erc1967.getImplementationAddress(kmsVerifierProxyAddress);
+
+      await run('task:prepareUpgradeKMSVerifier', {
+        currentImplementation: 'contracts/KMSVerifier.sol:KMSVerifier',
+        newImplementation: 'contracts/KMSVerifier.sol:KMSVerifier',
+        useInternalProxyAddress: true,
+        verifyContract: false,
+      });
 
       expect(await upgrades.erc1967.getImplementationAddress(kmsVerifierProxyAddress)).to.equal(kmsVerifierImplBefore);
     });


### PR DESCRIPTION
Backport of #2469, cherry-picked from commit 9f8332e007975cff2388ad9f29071e96b6d69b12 on `release/0.13.x`.

Applied cleanly with no conflicts.