### PR TITLE
ci(security): scope e2e registry secrets to environment

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -129,8 +129,10 @@ concurrency:
 
 jobs:
   fhevm-e2e-test:
+    name: test-suite-e2e-tests/fhevm-e2e-test
     # Run on manual/reusable invocations. For direct PRs, require the `e2e` label.
     if: ${{ github.event_name != 'pull_request' || inputs.orchestrated || inputs.compat-test != '' || (github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'mergify/merge-queue/') && contains(github.event.pull_request.labels.*.name, 'e2e')) }}
+    environment: private-registries
     permissions:
       contents: 'read' # Required to checkout repository code
       id-token: 'write' # Required for OIDC authentication


### PR DESCRIPTION
## Summary

- add a stable job name to the e2e workflow job
- bind the e2e workflow job to the `private-registries` GitHub environment
- remove the `zizmor` `secrets-outside-env` finding for the e2e registry credentials without inline suppressions

## Validation

- `zizmor .github/workflows/test-suite-e2e-tests.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-suite-e2e-tests.yml"); puts "yaml ok"'`
- `git diff --check`
- pre-commit hook for staged workflow files

## Follow-up

This PR expects the `private-registries` GitHub environment to be configured with the registry credentials before it is made ready. The broader repo-wide migration is tracked in zama-ai/fhevm-internal#1381.
