### PR TITLE
ci(security): resolve workflow zizmor findings

### DIFF
--- a/.github/workflows/charts-helm-checks.yml
+++ b/.github/workflows/charts-helm-checks.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   HELM_VERSION: v3.16.4
 

--- a/.github/workflows/charts-helm-release.yml
+++ b/.github/workflows/charts-helm-release.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   HELM_VERSION: v3.16.4
 jobs:

--- a/.github/workflows/check-changes-for-docker-build.yml
+++ b/.github/workflows/check-changes-for-docker-build.yml
@@ -45,6 +45,7 @@ permissions: {}
 jobs:
   check-changes:
     name: check-changes
+    environment: main
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   claude-review:
     name: claude-review
+    environment: main
     if: |
       contains(github.event.comment.body, '@claude') &&
       github.event.issue.pull_request &&

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@
 name: codeql
 permissions: {} # No permissions needed at workflow level
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 on:
   schedule:
     - cron: '30 5 * * 1-5'

--- a/.github/workflows/common-pull-request-lint.yml
+++ b/.github/workflows/common-pull-request-lint.yml
@@ -8,6 +8,10 @@ env:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint:
     name: common-pull-request/lint (bpr)
@@ -47,4 +51,4 @@ jobs:
         uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
         with:
           persona: pedantic
-          version: 1.17.0
+          version: 1.23.1

--- a/.github/workflows/common-typos-check.yml
+++ b/.github/workflows/common-typos-check.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   typos-check:
     name: common-typos-check/typos (bpr)

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -3,6 +3,10 @@ name: coprocessor-benchmarks-cpu
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -50,6 +54,7 @@ env:
 jobs:
   setup-instance:
     name: coprocessor-benchmarks-cpu/setup-instance
+    environment: main
     runs-on: ubuntu-latest
     permissions:
       contents: 'read' # Required to checkout repository code
@@ -69,6 +74,7 @@ jobs:
 
   benchmarks-cpu:
     name: coprocessor-benchmarks-cpu/benchmarks-cpu (bpr)
+    environment: main
     needs: setup-instance
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     continue-on-error: true
@@ -116,9 +122,9 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
-        with:
-          toolchain: nightly
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
 
       - name: Install cargo dependencies
         run: |
@@ -231,6 +237,7 @@ jobs:
 
   teardown-instance:
     name: coprocessor-benchmarks-cpu/teardown
+    environment: main
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, benchmarks-cpu ]
     runs-on: ubuntu-latest

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -3,6 +3,10 @@ name: coprocessor-benchmark-gpu
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -91,6 +95,7 @@ jobs:
 
   setup-instance:
     name: coprocessor-benchmark-gpu/setup-instance
+    environment: main
     needs: parse-inputs
     runs-on: ubuntu-latest
     permissions:
@@ -111,6 +116,7 @@ jobs:
 
   benchmark:
     name: coprocessor-benchmark-gpu/benchmark-gpu (bpr)
+    environment: main
     needs: [ parse-inputs, setup-instance ]
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
     continue-on-error: true
@@ -176,9 +182,9 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
-        with:
-          toolchain: nightly
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
 
       - name: Install cargo dependencies
         run: |
@@ -295,6 +301,7 @@ jobs:
 
   teardown-instance:
     name: coprocessor-benchmark-gpu/teardown
+    environment: main
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, benchmark ]
     runs-on: ubuntu-latest

--- a/.github/workflows/coprocessor-cargo-clippy.yml
+++ b/.github/workflows/coprocessor-cargo-clippy.yml
@@ -50,10 +50,9 @@ jobs:
       run: git lfs checkout
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
-      with:
-        toolchain: 1.91.1
-        components: clippy
+      run: |
+        rustup toolchain install 1.91.1 --profile minimal --component clippy
+        rustup default 1.91.1
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/coprocessor-cargo-fmt.yml
+++ b/.github/workflows/coprocessor-cargo-fmt.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-changes:
     name: trigger
@@ -43,10 +47,9 @@ jobs:
         lfs: true
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
-      with:
-        toolchain: 1.91.1
-        components: rustfmt
+      run: |
+        rustup toolchain install 1.91.1 --profile minimal --component rustfmt
+        rustup default 1.91.1
 
     - name: Run fmt
       run: |

--- a/.github/workflows/coprocessor-dependency-analysis.yml
+++ b/.github/workflows/coprocessor-dependency-analysis.yml
@@ -45,9 +45,9 @@ jobs:
           persist-credentials: 'false'
 
       - name: Rust setup
-        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # v1
-        with:
-          toolchain: stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@84ca29d5c1719e79e23b6af147555a8f4dac79d6 # v1.10.14

--- a/.github/workflows/coprocessor-gpu-tests.yml
+++ b/.github/workflows/coprocessor-gpu-tests.yml
@@ -3,6 +3,10 @@ name: coprocessor-gpu-tests
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -50,6 +54,7 @@ jobs:
 
   setup-instance:
     name: coprocessor-gpu-tests/setup-instance
+    environment: main
     needs: check-changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-coprocessor-gpu == 'true' }}
     runs-on: ubuntu-latest
@@ -126,9 +131,9 @@ jobs:
           echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
 
       - name: Install latest stable
-        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
-        with:
-          toolchain: stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Install cargo dependencies
         run: |
@@ -187,6 +192,7 @@ jobs:
 
   teardown-instance:
     name: coprocessor-gpu-tests/teardown
+    environment: main
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, coprocessor-gpu ]
     runs-on: ubuntu-latest

--- a/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
+++ b/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   check-changes:
+    name: coprocessor-stress-test-tool-docker-build/check-changes
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/host-contracts-docker-deployment-tests.yml
+++ b/.github/workflows/host-contracts-docker-deployment-tests.yml
@@ -33,6 +33,7 @@ jobs:
   docker-compose-tests:
     needs: check-changes
     name: host-contracts-docker-deployment-tests/docker-compose-tests (bpr)
+    environment: main
     if: ${{ needs.check-changes.outputs.changes-host-contracts == 'true' }}
     permissions:
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/host-contracts-hardhat-forge-tests.yml
+++ b/.github/workflows/host-contracts-hardhat-forge-tests.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-changes:
     name: host-contracts-hardhat-forge-tests/check-changes

--- a/.github/workflows/host-contracts-publish.yml
+++ b/.github/workflows/host-contracts-publish.yml
@@ -11,9 +11,14 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   publish:
     name: host-contracts-publish/publish
+    environment: main
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/host-contracts-slither-analysis.yml
+++ b/.github/workflows/host-contracts-slither-analysis.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-changes:
     name: host-contracts-slither-analysis/check-changes

--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -43,6 +43,7 @@ jobs:
               - host-contracts/**
   sc-upgrade:
     name: host-contracts-upgrade-tests/sc-upgrade (bpr)
+    environment: main
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-host-contracts == 'true' }}
     permissions:

--- a/.github/workflows/is-latest-commit.yml
+++ b/.github/workflows/is-latest-commit.yml
@@ -11,6 +11,7 @@ permissions: {}
 
 jobs:
   check:
+    name: is-latest-commit/check
     runs-on: ubuntu-latest
     outputs:
       is_latest: ${{ steps.check.outputs.is_latest }}

--- a/.github/workflows/js-sdk-publish.yml
+++ b/.github/workflows/js-sdk-publish.yml
@@ -11,6 +11,10 @@ on:
 # No permissions at the workflow level — each job declares only what it needs.
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   publish:
     name: js-sdk-publish/publish

--- a/.github/workflows/kms-connector-dependency-analysis.yml
+++ b/.github/workflows/kms-connector-dependency-analysis.yml
@@ -47,9 +47,9 @@ jobs:
           persist-credentials: 'false'
 
       - name: Rust setup
-        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # v1
-        with:
-          toolchain: stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@80aaafe04903087c333980fa2686259ddd34b2d9 # v1.16.6

--- a/.github/workflows/kms-connector-tests.yml
+++ b/.github/workflows/kms-connector-tests.yml
@@ -44,6 +44,7 @@ jobs:
 
   start-runner:
     name: kms-connector-tests/start-runner
+    environment: main
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-connector == 'true' }}
     permissions:
@@ -68,6 +69,7 @@ jobs:
 
   test-connector:
     name: kms-connector-tests/test-connector (bpr)
+    environment: main
     needs: start-runner
     timeout-minutes: 50
     permissions:
@@ -102,10 +104,9 @@ jobs:
           password: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+          rustup default stable
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -132,6 +133,7 @@ jobs:
 
   stop-runner:
     name: kms-connector-tests/stop-runner
+    environment: main
     needs:
       - start-runner
       - test-connector

--- a/.github/workflows/library-solidity-publish.yml
+++ b/.github/workflows/library-solidity-publish.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   publish:
     name: library-solidity-publish/publish
@@ -66,6 +70,7 @@ jobs:
 
   publish-soldeer:
     name: library-solidity-publish/publish-soldeer
+    environment: main
     if: ${{ inputs.release == 'true' }}
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/library-solidity-tests.yml
+++ b/.github/workflows/library-solidity-tests.yml
@@ -5,8 +5,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-changes:
+    name: library-solidity-tests/check-changes
     permissions:
       actions: 'read' # Required to read workflow run information
       contents: 'read' # Required to checkout repository code

--- a/.github/workflows/listener-cargo-fmt-clippy.yml
+++ b/.github/workflows/listener-cargo-fmt-clippy.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           persist-credentials: 'false'
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: 1.91.1
-          components: rustfmt, clippy
+      - name: Setup Rust
+        run: |
+          rustup toolchain install 1.91.1 --profile minimal --component rustfmt --component clippy
+          rustup default 1.91.1
 
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:

--- a/.github/workflows/listener-tests.yml
+++ b/.github/workflows/listener-tests.yml
@@ -45,9 +45,10 @@ jobs:
         with:
           persist-credentials: 'false'
 
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: 1.91.1
+      - name: Setup Rust
+        run: |
+          rustup toolchain install 1.91.1 --profile minimal
+          rustup default 1.91.1
 
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:

--- a/.github/workflows/relayer-tests.yaml
+++ b/.github/workflows/relayer-tests.yaml
@@ -35,6 +35,7 @@ jobs:
 
   unit-test:
     name: relayer-test/unit-test (bpr)
+    environment: main
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-rust-files == 'true' }}
     permissions:
@@ -76,6 +77,7 @@ jobs:
 
   clippy:
     name: relayer-test/clippy (bpr)
+    environment: main
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-rust-files == 'true' }}
     permissions:
@@ -107,6 +109,7 @@ jobs:
 
   integration-test:
     name: relayer-test/integration-test (bpr)
+    environment: main
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-rust-files == 'true' }}
     permissions:

--- a/.github/workflows/sdk-rust-sdk-tests.yml
+++ b/.github/workflows/sdk-rust-sdk-tests.yml
@@ -42,6 +42,7 @@ jobs:
 
   start-runner:
     name: sdk-rust-sdk-tests/start-runner
+    environment: main
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-rust-sdk == 'true' }}
     permissions:
@@ -66,6 +67,7 @@ jobs:
 
   test-rust-sdk:
     name: sdk-rust-sdk-tests/test-rust-sdk (bpr)
+    environment: main
     needs: start-runner
     timeout-minutes: 50
     permissions:
@@ -100,10 +102,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --component clippy
+          rustup default stable
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -141,6 +142,7 @@ jobs:
 
   stop-runner:
     name: sdk-rust-sdk-tests/stop-runner
+    environment: main
     needs:
       - start-runner
       - test-rust-sdk

--- a/.github/workflows/test-suite-compatibility-matrix.yml
+++ b/.github/workflows/test-suite-compatibility-matrix.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   prepare_rollout:
     name: prepare-rollout
+    environment: main
     # On PRs, only same-repo heads with the `rollout` label may enter this
     # secreted compat path. Manual dispatch remains always available.
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'rollout')) }}

--- a/.github/workflows/test-suite-e2e-operators-tests.yml
+++ b/.github/workflows/test-suite-e2e-operators-tests.yml
@@ -50,6 +50,7 @@ concurrency:
 jobs:
   setup-instance:
     name: test-suite-e2e-operators-tests/setup-instance
+    environment: main
     runs-on: ubuntu-latest
     permissions:
       contents: 'read' # Required to checkout repository code
@@ -69,6 +70,7 @@ jobs:
 
   operators-e2e-test:
     name: test-suite-e2e-operators-tests/operators-e2e-test
+    environment: main
     if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: 'read' # Required to checkout repository code
@@ -218,6 +220,7 @@ jobs:
 
   teardown-instance:
     name: test-suite-e2e-operators-tests/teardown
+    environment: main
     if: ${{ always() && needs.setup-instance.result == 'success' }}
     needs: [ setup-instance, operators-e2e-test]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -129,8 +129,10 @@ concurrency:
 
 jobs:
   fhevm-e2e-test:
+    name: test-suite-e2e-tests/fhevm-e2e-test
     # Run on manual/reusable invocations. For direct PRs, require the `e2e` label.
     if: ${{ github.event_name != 'pull_request' || inputs.orchestrated || inputs.compat-test != '' || (github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'mergify/merge-queue/') && contains(github.event.pull_request.labels.*.name, 'e2e')) }}
+    environment: main
     permissions:
       contents: 'read' # Required to checkout repository code
       id-token: 'write' # Required for OIDC authentication

--- a/.github/workflows/unverified_prs.yml
+++ b/.github/workflows/unverified_prs.yml
@@ -6,7 +6,9 @@ on:
 
 permissions: {}
 
-# zizmor: ignore[concurrency-limits] only GitHub can trigger this workflow
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   stale:


### PR DESCRIPTION
## Summary

- bump the CI `zizmor` version from `1.17.0` to `1.23.1`
- remove the inline `zizmor: ignore` from `unverified_prs` by fixing its `concurrency-limits` finding
- fix `secrets-outside-env` findings by assigning secret-consuming jobs to the existing `main` GitHub environment
- fix `superfluous-actions` findings by replacing `dtolnay/rust-toolchain` steps with direct `rustup` commands that preserve the requested toolchain and components
- fix remaining pedantic `concurrency-limits` and `anonymous-definition` findings

## Scope rule

Every workflow behavior change in this PR corresponds to a `zizmor --persona pedantic` finding on `origin/main`, except for the `zizmor` version bump itself.

## Validation

- `zizmor --persona pedantic .github/workflows` with local `zizmor 1.23.1`
- `zizmor .github/workflows` with local `zizmor 1.23.1`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f) }; puts "yaml ok"'`
- `git diff --check`
- staged pre-commit workflow hook

`actionlint` was not available in the local environment.

## Security follow-up

The workflow code now satisfies `zizmor` 1.23.1 with the pedantic persona, but GitHub settings still matter. The `main` environment already exists in `zama-ai/fhevm`; for secret scoping to be effective beyond scanner compliance, the relevant secrets should be configured as environment-scoped secrets and the required protection policy should be decided.

Tracks broader settings cleanup in zama-ai/fhevm-internal#1381.
