### PR TITLE
ci(hooks): limit zizmor pre-commit to staged lines

### DIFF
--- a/.github/hooks/install.sh
+++ b/.github/hooks/install.sh
@@ -7,7 +7,7 @@ HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GIT_HOOKS_DIR="$(git rev-parse --git-dir)/hooks"
 
 # List of hooks to install
-HOOKS=("commit-msg" "pre-push")
+HOOKS=("commit-msg" "pre-commit" "pre-push")
 
 # Create the hooks directory if it doesn't exist
 mkdir -p "$GIT_HOOKS_DIR"

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+STAGED_WORKFLOWS=()
+while IFS= read -r workflow; do
+  STAGED_WORKFLOWS+=("$workflow")
+done < <(
+  git diff --cached --name-only --diff-filter=ACM |
+    grep -E "^\.github/workflows/.*\.ya?ml$" || true
+)
+
+if [ "${#STAGED_WORKFLOWS[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+command -v zizmor >/dev/null 2>&1 || {
+  echo "ERROR: zizmor is required to check staged GitHub workflow changes."
+  echo "Install it or unstage workflow changes before committing."
+  exit 1
+}
+
+ZIZMOR_JSON="$(mktemp)"
+trap 'rm -f "$ZIZMOR_JSON"' EXIT
+
+set +e
+zizmor --persona pedantic --format json "${STAGED_WORKFLOWS[@]}" >"$ZIZMOR_JSON"
+ZIZMOR_STATUS=$?
+set -e
+
+if [ "$ZIZMOR_STATUS" -eq 0 ]; then
+  echo "zizmor found no findings in staged workflow files."
+  exit 0
+fi
+
+ruby -rjson -e '
+  json_path = ARGV.shift
+  staged_files = ARGV
+
+  def added_lines_for(path)
+    lines = {}
+    current = nil
+
+    diff = IO.popen(["git", "diff", "--cached", "--unified=0", "--", path], &:read)
+    diff.each_line do |line|
+      if (match = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/))
+        start = match[1].to_i
+        count = (match[2] || "1").to_i
+        current = start
+        (start...(start + count)).each { |line_no| lines[line_no] = true }
+      elsif current && line.start_with?("+") && !line.start_with?("+++")
+        current += 1
+      end
+    end
+
+    lines
+  end
+
+  def location_path(location)
+    key = location.dig("symbolic", "key")
+    if key.is_a?(Hash)
+      key.dig("Local", "given_path") || key.dig("Local", "prefix")
+    else
+      key
+    end
+  end
+
+  def primary_location(finding)
+    locations = finding["locations"] || []
+    locations.find { |loc| loc.dig("symbolic", "kind") == "Primary" } || locations.first
+  end
+
+  data = JSON.parse(File.read(json_path))
+  findings = data.is_a?(Hash) ? (data["findings"] || data["results"] || []) : data
+  added_by_file = staged_files.to_h { |file| [file, added_lines_for(file)] }
+
+  introduced = []
+  findings.each do |finding|
+    loc = primary_location(finding)
+    next if loc.nil?
+
+    file = location_path(loc)
+    row = loc.dig("concrete", "location", "start_point", "row")
+    next if file.nil? || row.nil?
+
+    line = row.to_i + 1
+    next unless added_by_file.fetch(file, {}).key?(line)
+
+    introduced << [file, line, finding["ident"], finding["desc"]]
+  end
+
+  if introduced.empty?
+    puts "zizmor reported findings in staged workflow files, but none start on added staged lines."
+    puts "Existing findings should be handled in a dedicated cleanup instead of blocking this commit."
+    exit 0
+  end
+
+  puts "zizmor found findings introduced by added staged workflow lines:"
+  introduced.each do |file, line, ident, desc|
+    puts "- #{file}:#{line}: #{ident}: #{desc}"
+  end
+  exit 1
+' "$ZIZMOR_JSON" "${STAGED_WORKFLOWS[@]}"


### PR DESCRIPTION
## Summary

- add a tracked pre-commit hook to run `zizmor --persona pedantic` on staged GitHub workflow files
- fail the commit only when a `zizmor` finding starts on an added staged line
- install the pre-commit hook from `.github/hooks/install.sh`

## Why

The current local hook runs `zizmor` on whole staged workflow files. When a workflow already has unrelated findings on `main`, a feature PR can be forced to fix security debt it did not introduce. This hook keeps the local check focused on newly added workflow lines and leaves existing findings to dedicated cleanup work.

## Validation

- `bash -n .github/hooks/pre-commit`
- `.github/hooks/pre-commit` with no staged workflow changes
- simulated an unrelated added line in a workflow with existing `zizmor` findings; the hook reported existing findings but did not block
- `git diff --cached --check`

## Follow-up

The full `zizmor 1.23.1 --persona pedantic` report for `origin/main` was documented in zama-ai/fhevm-internal#1381. Security-owned cleanup can use that report without forcing unrelated feature PRs to absorb the findings.
