### PR TITLE
fix(coprocessor): host-listener, widen WS subscription timeout slack to 5s

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -185,8 +185,10 @@ pub struct Args {
 // TODO: to merge with Levent works
 pub struct InfiniteLogIter {
     url: String,
-    block_time: u64, /* A default value that is refined with real-time
-                      * events data */
+    // Chain block interval (e.g. 12s for Sepolia); combined with a fixed
+    // +5s slack as the WS subscription timeout budget. Not currently
+    // refined at runtime — see fhevm-internal#1382.
+    block_time: u64,
     contract_addresses: Vec<Address>,
     catchup_blocks: Option<(u64, Option<u64>)>, // to do catchup blocks by chunks
     // Option<(from_block, optional to_block)>
@@ -822,7 +824,7 @@ impl InfiniteLogIter {
         // by alloy if not the case, the recheck mechanism ensures it's
         // only extra latency
         match tokio::time::timeout(
-            Duration::from_secs(self.block_time + 2),
+            Duration::from_secs(self.block_time + 5),
             next_opt_event,
         )
         .await


### PR DESCRIPTION
## Summary

- Widens the host-listener WS subscription timeout slack from `+2s` to `+5s` in `InfiniteLogIter` (`cmd/mod.rs`). For Sepolia (block_time=12s) the timeout budget moves from 14s to 17s, comfortably covering observed WS delivery jitter on the deployed RPC tier.
- Replaces a misleading comment on the `block_time` field that claimed runtime refinement which the code does not implement.

Closes zama-ai/fhevm-internal#1382.

## Why

`InfiniteLogIter::block_time` was documented as "A default value that is refined with real-time events data", but no code in the file ever assigns `self.block_time` — the field is initialized once from `args.initial_block_time` and never updated. The WS subscription timeout is therefore a hardcoded `block_time + 2 = 14s` for the Sepolia host chain.

Observed effect on dev and testnet: 376 `"Block timeout, proceed with last block"` WARNs over a 4h window across 6 WS host-listener pods (3 active pods at 14–42/hr; 1 testnet pod at ~7/hr; 3 pods at 0 because they were newly restarted). The fallback path (`find_last_block_and_logs()`) runs HTTP and inserts the block, so no data is lost and `host_chain_blocks_valid` has no gaps — but the rate adds persistent low-grade WARN noise and unnecessary RPC overhead.

The `+2s` slack appears to have been a guess at the time the field was introduced ([PR #178, commit 5ac13348b](https://github.com/zama-ai/fhevm/commit/5ac13348b), 2025-06-09, alloy upgrade). The dropped adaptive-timing TODO is tracked in [fhevm-internal#1382](https://github.com/zama-ai/fhevm-internal/issues/1382) for future revisit; this PR does not implement adaptive timing.

## Test plan

- [x] `cargo fmt --check` (in `coprocessor/fhevm-engine`)
- [x] `cargo check --all-targets`
- [x] `cargo clippy -p host-listener --all-targets -- -W clippy::perf -W clippy::suspicious -W clippy::style -D warnings`
- [x] Existing host-listener tests still build / aren't sensitive to the slack value
- [ ] Post-deploy observation: timeout WARN rate on dev WS pods should drop from 14–42/hr to near 0; verify after the chart picks up a build containing this change

## Scope

Main only — no backport to `release/0.12.x`. This is a code-quality fix; no operational urgency.