### PR TITLE
ci(common): add docs-only mergify queue rule that skips e2e gate

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,19 @@
 queue_rules:
+  # Docs-only PRs (every changed file lives under docs/) skip the e2e gate.
+  # Mergify evaluates queue rules in order, so this must come before `main`.
+  # Aggressive batching — no e2e to amortize, so don't make docs PRs wait.
+  - name: docs-only
+    batch_size: 1
+    batch_max_wait_time: 1m
+    checks_timeout: 12h
+    merge_method: squash
+    update_method: rebase
+    merge_conditions: []
+    queue_conditions:
+      - base = main
+      - label!=do-not-merge
+      - -files~=^(?!docs/)
+
   - name: main
     batch_size: 3
     batch_max_wait_time: 1h


### PR DESCRIPTION
## Summary

Adds a new Mergify queue rule, `docs-only`, that bypasses the `run-e2e-tests / fhevm-e2e-test` gate when every changed file in a PR lives under `docs/`. Uses aggressive batching (`batch_size: 1`, `batch_max_wait_time: 1m`) so docs PRs don't sit waiting for a batch to fill — there's no e2e to amortize across batch members.

## Why

Docs-only PRs currently sit in the merge queue waiting on the full e2e suite:

- Each queue attempt takes 30+ minutes of CI time.
- The e2e setup has been intermittently failing on **unrelated infra issues** (most recently `gateway-deploy-mocked-zama-oft: manifest unknown` — a missing GHCR image tag), bouncing approved docs PRs out of the queue.
- Example: [#2290](https://github.com/zama-ai/fhevm/pull/2290) has been approved with all review threads resolved for 2+ days but is still blocked.

A `docs/**`-only diff cannot affect runtime behavior, so gating it on the full e2e suite adds latency and noise without protection.

## How

`.mergify.yml` gains a new queue rule placed **before** the existing `main` rule:

\`\`\`yaml
- name: docs-only
  batch_size: 1
  batch_max_wait_time: 1m
  ...
  merge_conditions: []
  queue_conditions:
    - base = main
    - label!=do-not-merge
    - -files~=^(?!docs/)
\`\`\`

- Mergify evaluates queue rules in order, so a PR where every changed file matches `docs/**` matches `docs-only` first and skips the e2e gate.
- Anything touching code outside `docs/` falls through to the existing `main` rule unchanged.
- GitHub branch-protection requirements (approvals, resolved review threads, lint, abi-compat, etc.) are enforced independently of Mergify and continue to apply to all PRs, including docs-only ones.
- The aggressive batching (`batch_size: 1`, `batch_max_wait_time: 1m`) means a docs PR is merged as soon as queue conditions are met — there's no point holding it back to batch with another docs PR when there's no expensive check to amortize.

## Test plan

- [x] Mergify configuration check (\`Configuration changed\`) passes on this PR.
- [ ] After merge, verify that an approved docs-only PR (e.g. #2290) progresses through the new \`docs-only\` queue without hitting the e2e merge condition.
- [ ] Verify that a non-docs PR still routes through the \`main\` queue and still requires \`check-success = run-e2e-tests / fhevm-e2e-test\`.