### PR TITLE
fix(coprocessor): missing index for host_chain_blocks_valid

### DIFF
--- a/coprocessor/fhevm-engine/db-migration/migrations/20260513120000_add_host_chain_blocks_valid_block_number_idx.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260513120000_add_host_chain_blocks_valid_block_number_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_host_chain_blocks_valid_block_number
+    ON host_chain_blocks_valid (chain_id, block_number);


### PR DESCRIPTION
Index :
    "blocks_valid_pkey" PRIMARY KEY, btree (chain_id, block_hash)

UPDATE host_chain_blocks_valid
SET block_status = CASE
WHEN block_hash = $2
   THEN 'finalized'
   ELSE 'orphaned'
   END
WHERE block_number = $3 AND chain_id = $1