### PR TITLE
fix(coprocessor): add (chain_id, block_number) index on host_chain_blocks_valid

### DIFF
--- a/coprocessor/fhevm-engine/db-migration/migrations/20260513120000_add_block_number_index_on_host_chain_blocks_valid.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260513120000_add_block_number_index_on_host_chain_blocks_valid.sql
@@ -1,19 +1,8 @@
--- Completes the sibling-pattern coverage from migration
--- 20260319120000_add_block_number_for_state_revert.sql, which added
--- (host_chain_id, block_number) indexes to `computations`,
--- `pbs_computations`, and `allowed_handles` but missed
--- `host_chain_blocks_valid`. This table is filtered by
--- (chain_id, block_number) in `update_block_as_finalized`
--- (host-listener/src/database/tfhe_event_propagate.rs); the index
--- supports that access pattern.
---
--- Built transactionally (no CONCURRENTLY): the table is small enough
--- on current deployments (~1.36M rows on testnet, ~230k on dev) that
--- the brief ACCESS EXCLUSIVE lock during build is sub-second on dev
--- and well under 10s on testnet — within the listener's WS subscription
--- timeout budget. If/when this table approaches mainnet scale
--- (multi-million rows), prefer pre-creating with CONCURRENTLY via the
--- `precreate_index` helper in `initialize_db.sh` before applying.
+-- Add (chain_id, block_number) index on host_chain_blocks_valid.
+-- Mirrors the pattern from 20260319120000_add_block_number_for_state_revert.sql
+-- which added analogous indexes to sibling tables (computations,
+-- pbs_computations, allowed_handles) but missed this one.
+-- Used by update_block_as_finalized.
 
 CREATE INDEX IF NOT EXISTS idx_host_chain_blocks_valid_block_number
 ON host_chain_blocks_valid (chain_id, block_number);

--- a/coprocessor/fhevm-engine/db-migration/migrations/20260513120000_add_block_number_index_on_host_chain_blocks_valid.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260513120000_add_block_number_index_on_host_chain_blocks_valid.sql
@@ -1,0 +1,19 @@
+-- Completes the sibling-pattern coverage from migration
+-- 20260319120000_add_block_number_for_state_revert.sql, which added
+-- (host_chain_id, block_number) indexes to `computations`,
+-- `pbs_computations`, and `allowed_handles` but missed
+-- `host_chain_blocks_valid`. This table is filtered by
+-- (chain_id, block_number) in `update_block_as_finalized`
+-- (host-listener/src/database/tfhe_event_propagate.rs); the index
+-- supports that access pattern.
+--
+-- Built transactionally (no CONCURRENTLY): the table is small enough
+-- on current deployments (~1.36M rows on testnet, ~230k on dev) that
+-- the brief ACCESS EXCLUSIVE lock during build is sub-second on dev
+-- and well under 10s on testnet — within the listener's WS subscription
+-- timeout budget. If/when this table approaches mainnet scale
+-- (multi-million rows), prefer pre-creating with CONCURRENTLY via the
+-- `precreate_index` helper in `initialize_db.sh` before applying.
+
+CREATE INDEX IF NOT EXISTS idx_host_chain_blocks_valid_block_number
+ON host_chain_blocks_valid (chain_id, block_number);


### PR DESCRIPTION
## Summary

Adds the missing `(chain_id, block_number)` index on `host_chain_blocks_valid`. Completes the sibling-pattern coverage from migration [`20260319120000_add_block_number_for_state_revert.sql`](https://github.com/zama-ai/fhevm/blob/main/coprocessor/fhevm-engine/db-migration/migrations/20260319120000_add_block_number_for_state_revert.sql), which added analogous indexes to `computations`, `pbs_computations`, and `allowed_handles` but missed this one.

Closes zama-ai/fhevm-internal#1383.

## Why

`host_chain_blocks_valid` is filtered by `(chain_id, block_number)` in `update_block_as_finalized` (`host-listener/src/database/tfhe_event_propagate.rs`); the only existing index is the PK on `(chain_id, block_hash)`, so the access pattern goes through a sequential scan. Extending the existing sibling-table index pattern here is consistency / code-quality hygiene.

This PR is **not framed as fixing slowness** — the originally hypothesized "slow scan on growing table" framing in [fhevm-internal#1369](https://github.com/zama-ai/fhevm-internal/issues/1369) was disproved by direct measurement (dev table is *smaller* than testnet's but was the symptomatic one; the SELECT equivalent runs in 49 ms with 100% buffer cache hits). #1369 was closed not-planned; this PR addresses only the schema gap, separately.

## Build mode: plain (non-concurrent)

Plain `CREATE INDEX IF NOT EXISTS`. The build holds a `SHARE` lock on the table, which **blocks concurrent writes but does not block reads**. At the sizes I measured directly:

- dev: 230k rows, 22 MB heap → sub-second write-blocking window
- testnet: 1.36M rows, 217 MB heap → estimated under 10s write-blocking window

This matches the team convention used in `20260319120000` and the half-dozen other recent index migrations in the directory — atomic, retry-safe, idempotent via `IF NOT EXISTS`.

## Test plan

- [x] Migration filename follows existing convention (`YYYYMMDDhhmmss_<descriptive>.sql`)
- [x] Idempotent via `IF NOT EXISTS`
- [x] No Rust files staged → pre-commit hook correctly skipped cargo check/clippy
- [ ] CI to verify migration applies cleanly (sqlx will run it on every test DB)
- [ ] Post-deploy: index visible via `\d host_chain_blocks_valid`

## Scope

Main only — no backport to `release/0.12.x`. Sibling-pattern hygiene; no operational urgency.