### PR TITLE
docs(common): align natspec

### DIFF
--- a/gateway-contracts/contracts/interfaces/IDecryption.sol
+++ b/gateway-contracts/contracts/interfaces/IDecryption.sol
@@ -330,7 +330,8 @@ interface IDecryption {
     ) external;
 
     /**
-     * @notice Indicates if handles are ready to be decrypted publicly.
+     * @notice Indicates if ciphertext material exists for public decryption.
+     * @dev Checks only ciphertext-material availability. ACL checks happen off-chain in the KMS.
      * @param ctHandles The ciphertext handles.
      * @param extraData Generic bytes metadata for versioned payloads. First byte is for the version.
      */
@@ -340,7 +341,8 @@ interface IDecryption {
     ) external view returns (bool);
 
     /**
-     * @notice Indicates if handles are ready to be decrypted by a user.
+     * @notice Indicates if ciphertext material exists for user decryption.
+     * @dev Checks only ciphertext-material availability. ACL checks happen off-chain in the KMS.
      * @param ctHandleContractPairs The ciphertext handles with associated contract addresses.
      * @param extraData Generic bytes metadata for versioned payloads. First byte is for the version.
      */
@@ -350,7 +352,8 @@ interface IDecryption {
     ) external view returns (bool);
 
     /**
-     * @notice Indicates if handles are ready to be decrypted by a user.
+     * @notice Indicates if ciphertext material exists for user decryption.
+     * @dev Checks only ciphertext-material availability. ACL checks happen off-chain in the KMS.
      * @param userAddress The user's address (unused, kept for backward compatibility).
      * @param ctHandleContractPairs The ciphertext handles with associated contract addresses.
      * @param extraData Generic bytes metadata for versioned payloads. First byte is for the version.
@@ -363,7 +366,8 @@ interface IDecryption {
     ) external view returns (bool);
 
     /**
-     * @notice Indicates if the handles are ready to be decrypted by the delegate address in delegation accounts.
+     * @notice Indicates if ciphertext material exists for delegated user decryption.
+     * @dev Checks only ciphertext-material availability. ACL checks happen off-chain in the KMS.
      * @param ctHandleContractPairs The ciphertext handles with associated contract addresses.
      * @param extraData Generic bytes metadata for versioned payloads. First byte is for the version.
      */

--- a/host-contracts/contracts/KMSVerifier.sol
+++ b/host-contracts/contracts/KMSVerifier.sol
@@ -133,7 +133,10 @@ contract KMSVerifier is UUPSUpgradeableEmptyProxy, EIP712UpgradeableCrossChain, 
      * @param handlesList       The list of handles, which where requested to be decrypted.
      * @param decryptedResult   A bytes array representing the abi-encoding of all requested decrypted values.
      * @param decryptionProof   Decryption proof containing KMS signatures and extra data.
-     * @return isVerified       true if enough provided signatures are valid, false otherwise.
+     * @return isVerified       true if enough unique provided signatures are valid, false otherwise.
+     * @dev                     Reverts on malformed proof or extraData, invalid context, missing or below-threshold
+     *                          signatures, failed recovery, or an unregistered signer. Returns false only when the
+     *                          unique valid signer threshold is not reached.
      */
     function verifyDecryptionEIP712KMSSignatures(
         bytes32[] memory handlesList,

--- a/host-contracts/contracts/ProtocolConfig.sol
+++ b/host-contracts/contracts/ProtocolConfig.sol
@@ -42,7 +42,7 @@ contract ProtocolConfig is IProtocolConfig, UUPSUpgradeableEmptyProxy, ACLOwnabl
         mapping(uint256 contextId => mapping(address => bool)) isKmsSignerForContext;
         /// @notice KmsNode by tx sender per context.
         mapping(uint256 contextId => mapping(address => KmsNode)) kmsNodeByTxSenderForContext;
-        /// @notice Signer addresses per context (for ordered iteration).
+        /// @notice Signer addresses per context, in insertion order.
         mapping(uint256 contextId => address[]) kmsSignerAddressesForContext;
         /// @notice Public decryption threshold per context.
         mapping(uint256 contextId => uint256) publicDecryptionThresholdForContext;

--- a/host-contracts/lib/FHE.sol
+++ b/host-contracts/lib/FHE.sol
@@ -9880,7 +9880,6 @@ library FHE {
     ///                       `abiEncodedCleartexts`
     /// @return true if the signatures verification succeeds, false otherwise
     /// @dev Private low-level function used to verify the KMS signatures.
-    ///      Warning: this function never reverts, its boolean return value must be checked.
     ///      The decryptionProof is the numSigners + kmsSignatures + extraData (1 + 65*numSigners + extraData bytes)
     ///      Only static native solidity types for clear values are supported, so `abiEncodedCleartexts` is the concatenation of all clear values appended to 32 bytes.
     /// @dev Reverts if any of the following conditions are met by the underlying KMS verifier:

--- a/library-solidity/codegen/src/templates/FHE.sol-template
+++ b/library-solidity/codegen/src/templates/FHE.sol-template
@@ -673,7 +673,6 @@ library FHE {
     ///                       `abiEncodedCleartexts`
     /// @return true if the signatures verification succeeds, false otherwise
     /// @dev Private low-level function used to verify the KMS signatures.
-    ///      Warning: this function never reverts, its boolean return value must be checked.
     ///      The decryptionProof is the numSigners + kmsSignatures + extraData (1 + 65*numSigners + extraData bytes)
     ///      Only static native solidity types for clear values are supported, so `abiEncodedCleartexts` is the concatenation of all clear values appended to 32 bytes.
     /// @dev Reverts if any of the following conditions are met by the underlying KMS verifier:

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -9880,7 +9880,6 @@ library FHE {
     ///                       `abiEncodedCleartexts`
     /// @return true if the signatures verification succeeds, false otherwise
     /// @dev Private low-level function used to verify the KMS signatures.
-    ///      Warning: this function never reverts, its boolean return value must be checked.
     ///      The decryptionProof is the numSigners + kmsSignatures + extraData (1 + 65*numSigners + extraData bytes)
     ///      Only static native solidity types for clear values are supported, so `abiEncodedCleartexts` is the concatenation of all clear values appended to 32 bytes.
     /// @dev Reverts if any of the following conditions are met by the underlying KMS verifier:


### PR DESCRIPTION
## Summary
- Clarify KMS verifier revert behavior in NatSpec
- Clarify decryption readiness checks as ciphertext-material checks only
- Remove the contradictory non-reverting warning from FHE wrapper docs

Links https://github.com/zama-ai/fhevm-internal/issues/1372