### PR TITLE
ci(common): retry docker login and re-tag against GHCR timeouts

### DIFF
--- a/.github/workflows/charts-helm-release.yml
+++ b/.github/workflows/charts-helm-release.yml
@@ -53,15 +53,14 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Install Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 #v4.2.0

--- a/.github/workflows/charts-helm-release.yml
+++ b/.github/workflows/charts-helm-release.yml
@@ -53,7 +53,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/charts-helm-release.yml
+++ b/.github/workflows/charts-helm-release.yml
@@ -53,11 +53,15 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 #v4.2.0

--- a/.github/workflows/check-changes-for-docker-build.yml
+++ b/.github/workflows/check-changes-for-docker-build.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Login to GitHub Container Registry (push only)
         if: inputs.caller-workflow-event-name == 'push'
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/check-changes-for-docker-build.yml
+++ b/.github/workflows/check-changes-for-docker-build.yml
@@ -65,11 +65,15 @@ jobs:
 
       - name: Login to GitHub Container Registry (push only)
         if: inputs.caller-workflow-event-name == 'push'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_READ_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Find latest commit with existing image (push only)
         id: find-latest-image-commit

--- a/.github/workflows/check-changes-for-docker-build.yml
+++ b/.github/workflows/check-changes-for-docker-build.yml
@@ -65,15 +65,14 @@ jobs:
 
       - name: Login to GitHub Container Registry (push only)
         if: inputs.caller-workflow-event-name == 'push'
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_READ_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Find latest commit with existing image (push only)
         id: find-latest-image-commit

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -148,7 +148,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -148,15 +148,14 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -148,11 +148,15 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -204,7 +204,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -204,15 +204,14 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -204,11 +204,15 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -291,7 +291,7 @@ jobs:
   build-db-migration:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.db_migration == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -333,7 +333,7 @@ jobs:
   build-gw-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.gw_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -360,7 +360,7 @@ jobs:
   build-host-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.host_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -387,7 +387,7 @@ jobs:
   build-sns-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.sns_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -414,7 +414,7 @@ jobs:
   build-tfhe-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tfhe_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -441,7 +441,7 @@ jobs:
   build-tx-sender:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tx_sender == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -468,7 +468,7 @@ jobs:
   build-zkproof-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.zkproof_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -291,7 +291,7 @@ jobs:
   build-db-migration:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.db_migration == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -333,7 +333,7 @@ jobs:
   build-gw-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.gw_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -360,7 +360,7 @@ jobs:
   build-host-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.host_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -387,7 +387,7 @@ jobs:
   build-sns-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.sns_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -414,7 +414,7 @@ jobs:
   build-tfhe-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tfhe_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -441,7 +441,7 @@ jobs:
   build-tx-sender:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tx_sender == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -468,7 +468,7 @@ jobs:
   build-zkproof-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.zkproof_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -291,7 +291,7 @@ jobs:
   build-db-migration:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.db_migration == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -333,7 +333,7 @@ jobs:
   build-gw-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.gw_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -360,7 +360,7 @@ jobs:
   build-host-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.host_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -387,7 +387,7 @@ jobs:
   build-sns-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.sns_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -414,7 +414,7 @@ jobs:
   build-tfhe-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tfhe_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -441,7 +441,7 @@ jobs:
   build-tx-sender:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tx_sender == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -468,7 +468,7 @@ jobs:
   build-zkproof-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.zkproof_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
+++ b/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
@@ -41,7 +41,7 @@ jobs:
       needs.check-changes.outputs.changes-coprocessor-stress-test-tool == 'true'
       || github.event_name == 'release'
       || github.event_name == 'workflow_dispatch'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
+++ b/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
@@ -41,7 +41,7 @@ jobs:
       needs.check-changes.outputs.changes-coprocessor-stress-test-tool == 'true'
       || github.event_name == 'release'
       || github.event_name == 'workflow_dispatch'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
+++ b/.github/workflows/coprocessor-stress-test-tool-docker-build.yml
@@ -41,7 +41,7 @@ jobs:
       needs.check-changes.outputs.changes-coprocessor-stress-test-tool == 'true'
       || github.event_name == 'release'
       || github.event_name == 'workflow_dispatch'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/gateway-contracts-deployment-tests.yml
+++ b/.github/workflows/gateway-contracts-deployment-tests.yml
@@ -48,15 +48,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
       - name: Login to Docker Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Build and start Docker services
         working-directory: gateway-contracts

--- a/.github/workflows/gateway-contracts-deployment-tests.yml
+++ b/.github/workflows/gateway-contracts-deployment-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
       - name: Login to Docker Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gateway-contracts-deployment-tests.yml
+++ b/.github/workflows/gateway-contracts-deployment-tests.yml
@@ -48,11 +48,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
       - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and start Docker services
         working-directory: gateway-contracts

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/gateway-contracts-docker-build.yml
+++ b/.github/workflows/gateway-contracts-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/gateway-contracts-upgrade-tests.yml
+++ b/.github/workflows/gateway-contracts-upgrade-tests.yml
@@ -71,11 +71,15 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and start Docker services from previous release
         working-directory: previous-fhevm/gateway-contracts

--- a/.github/workflows/gateway-contracts-upgrade-tests.yml
+++ b/.github/workflows/gateway-contracts-upgrade-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gateway-contracts-upgrade-tests.yml
+++ b/.github/workflows/gateway-contracts-upgrade-tests.yml
@@ -71,15 +71,14 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Build and start Docker services from previous release
         working-directory: previous-fhevm/gateway-contracts

--- a/.github/workflows/gateway-stress-tool-docker-build.yml
+++ b/.github/workflows/gateway-stress-tool-docker-build.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/gateway-stress-tool-docker-build.yml
+++ b/.github/workflows/gateway-stress-tool-docker-build.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/gateway-stress-tool-docker-build.yml
+++ b/.github/workflows/gateway-stress-tool-docker-build.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/golden-container-images-docker-build-nodejs.yml
+++ b/.github/workflows/golden-container-images-docker-build-nodejs.yml
@@ -46,7 +46,7 @@ jobs:
     name: golden-container-images-docker-build-nodejs/build
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-golden-nodejs == 'true' || github.event_name == 'release' }}
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/golden-container-images-docker-build-nodejs.yml
+++ b/.github/workflows/golden-container-images-docker-build-nodejs.yml
@@ -46,7 +46,7 @@ jobs:
     name: golden-container-images-docker-build-nodejs/build
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-golden-nodejs == 'true' || github.event_name == 'release' }}
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/golden-container-images-docker-build-nodejs.yml
+++ b/.github/workflows/golden-container-images-docker-build-nodejs.yml
@@ -46,7 +46,7 @@ jobs:
     name: golden-container-images-docker-build-nodejs/build
     needs: check-changes
     if: ${{ needs.check-changes.outputs.changes-golden-nodejs == 'true' || github.event_name == 'release' }}
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/golden-container-images-docker-build-rust.yml
+++ b/.github/workflows/golden-container-images-docker-build-rust.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   build:
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/golden-container-images-docker-build-rust.yml
+++ b/.github/workflows/golden-container-images-docker-build-rust.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   build:
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/golden-container-images-docker-build-rust.yml
+++ b/.github/workflows/golden-container-images-docker-build-rust.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   build:
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/host-contracts-docker-build.yml
+++ b/.github/workflows/host-contracts-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/host-contracts-docker-deployment-tests.yml
+++ b/.github/workflows/host-contracts-docker-deployment-tests.yml
@@ -47,15 +47,14 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
     - name: Login to Docker Registry
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+      env:
+        GHCR_USERNAME: ${{ github.actor }}
+        GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
       with:
-        action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        attempt_limit: 5
-        attempt_delay: 2000
-        with: |
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_READ_TOKEN }}
+        command: |
+          echo "Logging into ghcr.io..."
+          echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
     - name: Create .env file
       working-directory: host-contracts

--- a/.github/workflows/host-contracts-docker-deployment-tests.yml
+++ b/.github/workflows/host-contracts-docker-deployment-tests.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
     - name: Login to Docker Registry
-      uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+      uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
       env:
         GHCR_USERNAME: ${{ github.actor }}
         GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/host-contracts-docker-deployment-tests.yml
+++ b/.github/workflows/host-contracts-docker-deployment-tests.yml
@@ -47,11 +47,15 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
     - name: Login to Docker Registry
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_READ_TOKEN }}
+        action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        attempt_limit: 5
+        attempt_delay: 2000
+        with: |
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_READ_TOKEN }}
 
     - name: Create .env file
       working-directory: host-contracts

--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -71,11 +71,15 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_READ_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Create .env file
         working-directory: previous-fhevm/host-contracts

--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -71,15 +71,14 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to Docker Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_READ_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Create .env file
         working-directory: previous-fhevm/host-contracts

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -218,7 +218,7 @@ jobs:
   build-db-migration:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.db_migration == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -260,7 +260,7 @@ jobs:
   build-gw-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.gw_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -287,7 +287,7 @@ jobs:
   build-kms-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.kms_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -314,7 +314,7 @@ jobs:
   build-tx-sender:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tx_sender == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -218,7 +218,7 @@ jobs:
   build-db-migration:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.db_migration == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -260,7 +260,7 @@ jobs:
   build-gw-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.gw_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -287,7 +287,7 @@ jobs:
   build-kms-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.kms_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -314,7 +314,7 @@ jobs:
   build-tx-sender:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tx_sender == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/kms-connector-docker-build.yml
+++ b/.github/workflows/kms-connector-docker-build.yml
@@ -218,7 +218,7 @@ jobs:
   build-db-migration:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.db_migration == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -260,7 +260,7 @@ jobs:
   build-gw-listener:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.gw_listener == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -287,7 +287,7 @@ jobs:
   build-kms-worker:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.kms_worker == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:
@@ -314,7 +314,7 @@ jobs:
   build-tx-sender:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.tx_sender == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/kms-connector-tests.yml
+++ b/.github/workflows/kms-connector-tests.yml
@@ -95,7 +95,7 @@ jobs:
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "${GITHUB_ENV}"
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/kms-connector-tests.yml
+++ b/.github/workflows/kms-connector-tests.yml
@@ -95,15 +95,14 @@ jobs:
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "${GITHUB_ENV}"
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_READ_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b

--- a/.github/workflows/kms-connector-tests.yml
+++ b/.github/workflows/kms-connector-tests.yml
@@ -95,11 +95,15 @@ jobs:
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "${GITHUB_ENV}"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_READ_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b

--- a/.github/workflows/listener-docker-build.yml
+++ b/.github/workflows/listener-docker-build.yml
@@ -81,7 +81,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/listener-docker-build.yml
+++ b/.github/workflows/listener-docker-build.yml
@@ -81,7 +81,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/listener-docker-build.yml
+++ b/.github/workflows/listener-docker-build.yml
@@ -81,7 +81,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/re-tag-docker-image.yml
+++ b/.github/workflows/re-tag-docker-image.yml
@@ -66,17 +66,25 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Re-tag docker image
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         env:
           IMAGE_NAME: ${{ inputs.image-name }}
           PREVIOUS_TAG: ${{ needs.prepare-image-tags.outputs.previous-tag }}
           NEW_TAG: ${{ needs.prepare-image-tags.outputs.new-tag }}
-        run: |
-          echo "Creating new tag $NEW_TAG for existing image $IMAGE_NAME:$PREVIOUS_TAG"
-          docker buildx imagetools create "ghcr.io/zama-ai/$IMAGE_NAME:$PREVIOUS_TAG" --tag "ghcr.io/zama-ai/$IMAGE_NAME:$NEW_TAG"
+        with:
+          attempt_limit: 5
+          attempt_delay: 2000
+          command: |
+            echo "Creating new tag $NEW_TAG for existing image $IMAGE_NAME:$PREVIOUS_TAG"
+            docker buildx imagetools create "ghcr.io/zama-ai/$IMAGE_NAME:$PREVIOUS_TAG" --tag "ghcr.io/zama-ai/$IMAGE_NAME:$NEW_TAG"

--- a/.github/workflows/re-tag-docker-image.yml
+++ b/.github/workflows/re-tag-docker-image.yml
@@ -66,25 +66,22 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Re-tag docker image
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
         env:
           IMAGE_NAME: ${{ inputs.image-name }}
           PREVIOUS_TAG: ${{ needs.prepare-image-tags.outputs.previous-tag }}
           NEW_TAG: ${{ needs.prepare-image-tags.outputs.new-tag }}
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
           command: |
             echo "Creating new tag $NEW_TAG for existing image $IMAGE_NAME:$PREVIOUS_TAG"
             docker buildx imagetools create "ghcr.io/zama-ai/$IMAGE_NAME:$PREVIOUS_TAG" --tag "ghcr.io/zama-ai/$IMAGE_NAME:$NEW_TAG"

--- a/.github/workflows/re-tag-docker-image.yml
+++ b/.github/workflows/re-tag-docker-image.yml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
             echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Re-tag docker image
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           IMAGE_NAME: ${{ inputs.image-name }}
           PREVIOUS_TAG: ${{ needs.prepare-image-tags.outputs.previous-tag }}

--- a/.github/workflows/relayer-docker-build.yml
+++ b/.github/workflows/relayer-docker-build.yml
@@ -159,7 +159,7 @@ jobs:
   build-relayer-migrate:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.relayer_migrate == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -201,7 +201,7 @@ jobs:
   build-relayer:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.relayer == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/relayer-docker-build.yml
+++ b/.github/workflows/relayer-docker-build.yml
@@ -159,7 +159,7 @@ jobs:
   build-relayer-migrate:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.relayer_migrate == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -201,7 +201,7 @@ jobs:
   build-relayer:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.relayer == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/relayer-docker-build.yml
+++ b/.github/workflows/relayer-docker-build.yml
@@ -159,7 +159,7 @@ jobs:
   build-relayer-migrate:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.relayer_migrate == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets: &docker_secrets
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -201,7 +201,7 @@ jobs:
   build-relayer:
     needs: build-decisions
     if: always() && needs.build-decisions.outputs.relayer == 'build'
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     permissions: *docker_permissions
     secrets: *docker_secrets
     with:

--- a/.github/workflows/sdk-rust-sdk-tests.yml
+++ b/.github/workflows/sdk-rust-sdk-tests.yml
@@ -93,11 +93,15 @@ jobs:
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "${GITHUB_ENV}"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b

--- a/.github/workflows/sdk-rust-sdk-tests.yml
+++ b/.github/workflows/sdk-rust-sdk-tests.yml
@@ -93,15 +93,14 @@ jobs:
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "${GITHUB_ENV}"
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b

--- a/.github/workflows/sdk-rust-sdk-tests.yml
+++ b/.github/workflows/sdk-rust-sdk-tests.yml
@@ -93,7 +93,7 @@ jobs:
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "${GITHUB_ENV}"
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -78,7 +78,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3ad2e177a5247777349447608ba20f0977a824f # v1.0.7
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -78,7 +78,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -78,7 +78,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@3cf4c2b133947d29e7a313555638621f9ca0345c # v1.0.3
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}

--- a/.github/workflows/test-suite-e2e-operators-tests.yml
+++ b/.github/workflows/test-suite-e2e-operators-tests.yml
@@ -122,11 +122,15 @@ jobs:
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_READ_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/test-suite-e2e-operators-tests.yml
+++ b/.github/workflows/test-suite-e2e-operators-tests.yml
@@ -122,15 +122,14 @@ jobs:
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_READ_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/test-suite-e2e-operators-tests.yml
+++ b/.github/workflows/test-suite-e2e-operators-tests.yml
@@ -122,7 +122,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -177,11 +177,15 @@ jobs:
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_READ_TOKEN }}
+          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+          attempt_limit: 5
+          attempt_delay: 2000
+          with: |
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GHCR_READ_TOKEN }}
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -177,15 +177,14 @@ jobs:
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Login to GitHub Container Registry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
         with:
-          action: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-          attempt_limit: 5
-          attempt_delay: 2000
-          with: |
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GHCR_READ_TOKEN }}
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
       - name: Login to Chainguard Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -177,7 +177,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
 
       - name: Login to GitHub Container Registry
-        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # main
+        uses: zama-ai/ci-templates/.github/actions/retry@f3b6046d0ce6f2eab83353e0fb788bd781be9f2e # v1.0.6
         env:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}


### PR DESCRIPTION
### Summary

- GHCR's token endpoint has been timing out intermittently on docker login and docker buildx imagetools create, with no retry — a single transient blip fails the whole job and blocks Mergify queues.
- Wraps all GHCR calls with `zama-ai/ci-templates/.github/actions/retry@v1.0.6` (5 attempts × 2/4/8/16s exponential backoff)

Related: https://github.com/zama-ai/fhevm-internal/issues/1408