### PR TITLE
docs(host-contracts): clarify initializeFromMigration seeds from GatewayConfig

### DIFF
--- a/host-contracts/contracts/ProtocolConfig.sol
+++ b/host-contracts/contracts/ProtocolConfig.sol
@@ -96,7 +96,7 @@ contract ProtocolConfig is IProtocolConfig, UUPSUpgradeableEmptyProxy, ACLOwnabl
 
     /**
      * @notice Migration initializer: seeds the migrated context from the existing GatewayConfig state.
-     * @dev GatewayConfig mirrors KMSVerifier per RFC-013 and carries the extra KMS node fields
+     * @dev GatewayConfig mirrors KMSVerifier per RFC-003 and carries the extra KMS node fields
      *      needed for the migration.
      * @param existingContextId The currnet context ID. The counter is seeded to
      *        `existingContextId - 1` so that `_defineKmsContext` increments to the exact

--- a/host-contracts/contracts/ProtocolConfig.sol
+++ b/host-contracts/contracts/ProtocolConfig.sol
@@ -95,9 +95,11 @@ contract ProtocolConfig is IProtocolConfig, UUPSUpgradeableEmptyProxy, ACLOwnabl
     }
 
     /**
-     * @notice Migration initializer: seeds the migrated context from an existing KMSVerifier state.
-     * @param existingContextId The context ID from the old KMSVerifier to preserve. The counter is
-     *        seeded to `existingContextId - 1` so that `_defineKmsContext` increments to the exact
+     * @notice Migration initializer: seeds the migrated context from the existing GatewayConfig state.
+     * @dev GatewayConfig mirrors KMSVerifier per RFC-013 and carries the extra KMS node fields
+     *      needed for the migration.
+     * @param existingContextId The currnet context ID. The counter is seeded to
+     *        `existingContextId - 1` so that `_defineKmsContext` increments to the exact
      *        old ID, preserving context continuity for downstream readers.
      * @param existingKmsNodes The existing KMS node set to migrate.
      * @param existingThresholds The existing thresholds to migrate.


### PR DESCRIPTION
Migration reads from GatewayConfig (which mirrors KMSVerifier per RFC-003), not KMSVerifier directly. Fix NatSpec to match.

Closes zama-ai/fhevm-internal#1380