### PR TITLE
fix(kms-connector): make kms-worker KMS-core startup retry env-configurable

### DIFF
--- a/charts/kms-connector/Chart.yaml
+++ b/charts/kms-connector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-connector
 description: A helm chart to distribute and deploy the Zama KMS Connector services
-version: 1.4.2
+version: 1.4.3
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/kms-connector/values.yaml
+++ b/charts/kms-connector/values.yaml
@@ -211,6 +211,40 @@ kmsConnectorKmsWorker:
 
   # Additional environment variables
   env:
+    - name: KMS_CONNECTOR_KMS_CORE_STARTUP_RETRY_NUMBER
+      value: "15"
+    - name: KMS_CONNECTOR_KMS_CORE_STARTUP_RETRY_DELAY
+      value: "4s"
+
+  # Distributed tracing (inherits from commonConfig but can be overridden)
+# -----------------------------------------------------------------------------
+# Communicates with KMS cores to perform cryptographic operations
+kmsConnectorKmsWorker:
+  enabled: true
+  nameOverride:
+
+  image:
+    name: ghcr.io/zama-ai/fhevm/kms-connector/kms-worker
+    tag: v0.10.0
+
+  replicas: 1
+
+  # Component-specific configuration
+  config:
+    # KMS core endpoints for communication
+    kmsCoreEndpoints: "http://kms-core:50051"
+
+    # List of host chain RPC node endpoints, chain ids, and ACL contract addresses
+    hostChains:
+      - url: "http://host-node:8545"
+        chainId: 12345
+        aclAddress: "0x05fD9B5EFE0a996095f42Ed7e77c390810CF660c"
+
+    # Override commonConfig.gatewayUrl if needed
+    # gatewayUrl:
+
+  # Additional environment variables
+  env:
 
   # Distributed tracing (inherits from commonConfig but can be overridden)
   tracing:

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -71,6 +71,12 @@ pub struct Config {
     /// Timeout to connect to a S3 bucket.
     #[serde(with = "humantime_serde", default = "default_s3_connect_timeout")]
     pub s3_connect_timeout: Duration,
+    /// Number of retries when connecting to a KMS Core shard at startup.
+    #[serde(default = "default_kms_core_startup_retry_number")]
+    pub kms_core_startup_retry_number: usize,
+    /// Delay between KMS Core startup connection attempts.
+    #[serde(with = "humantime_serde", default = "default_kms_core_startup_retry_delay")]
+    pub kms_core_startup_retry_delay: Duration,
 
     /// The service name used for tracing.
     #[serde(default = "default_service_name")]
@@ -165,6 +171,14 @@ fn default_s3_connect_timeout() -> Duration {
     Duration::from_secs(3)
 }
 
+fn default_kms_core_startup_retry_number() -> usize {
+    5  // matches the legacy CONNECTION_RETRY_NUMBER constant
+}
+
+fn default_kms_core_startup_retry_delay() -> Duration {
+    Duration::from_secs(2)  // matches the legacy CONNECTION_RETRY_DELAY constant
+}
+
 impl DeserializeConfig for Config {}
 
 // Default implementation for testing purpose
@@ -192,6 +206,8 @@ impl Default for Config {
             max_decryption_attempts: default_max_decryption_attempts(),
             s3_ciphertext_retrieval_retries: default_s3_ciphertext_retrieval_retries(),
             s3_connect_timeout: default_s3_connect_timeout(),
+            kms_core_startup_retry_number: default_kms_core_startup_retry_number(),
+            kms_core_startup_retry_delay: default_kms_core_startup_retry_delay(),
             service_name: default_service_name(),
             task_limit: default_task_limit(),
             monitoring_endpoint: default_monitoring_endpoint(),
@@ -223,6 +239,8 @@ mod tests {
             env::remove_var("KMS_CONNECTOR_MAX_DECRYPTION_ATTEMPTS");
             env::remove_var("KMS_CONNECTOR_S3_CIPHERTEXT_RETRIEVAL_RETRIES");
             env::remove_var("KMS_CONNECTOR_S3_CONNECT_TIMEOUT");
+            env::remove_var("KMS_CONNECTOR_KMS_CORE_STARTUP_RETRY_NUMBER");
+            env::remove_var("KMS_CONNECTOR_KMS_CORE_STARTUP_RETRY_DELAY");
             env::remove_var("KMS_CONNECTOR_SERVICE_NAME");
         }
     }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
@@ -7,10 +7,10 @@ use crate::{
 };
 use alloy::primitives::U256;
 use anyhow::anyhow;
-use connector_utils::{
-    conn::{CONNECTION_RETRY_DELAY, CONNECTION_RETRY_NUMBER},
-    types::{KmsGrpcRequest, KmsGrpcResponse, db::EventType, request_id_to_u256, u256_to_u32},
+use connector_utils::types::{
+    KmsGrpcRequest, KmsGrpcResponse, db::EventType, request_id_to_u256, u256_to_u32,
 };
+use std::time::Duration;
 use kms_grpc::{
     kms::v1::{
         CrsGenRequest, KeyGenPreprocRequest, KeyGenRequest, PublicDecryptionRequest, RequestId,
@@ -48,19 +48,32 @@ impl KmsClient {
     pub async fn connect(config: &Config) -> anyhow::Result<Self> {
         let mut channels = vec![];
         for (i, kms_shard_endpoint) in config.kms_core_endpoints.iter().enumerate() {
-            channels.push(KmsClient::connect_single_shard(i, kms_shard_endpoint).await?);
+            channels.push(
+                KmsClient::connect_single_shard(
+                    i,
+                    kms_shard_endpoint,
+                    config.kms_core_startup_retry_number,
+                    config.kms_core_startup_retry_delay,
+                )
+                .await?,
+            );
         }
 
         Ok(Self::new(channels, config.grpc_request_retries))
     }
 
-    async fn connect_single_shard(shard_id: usize, endpoint: &str) -> anyhow::Result<Channel> {
+    async fn connect_single_shard(
+        shard_id: usize,
+        endpoint: &str,
+        retry_number: usize,
+        retry_delay: Duration,
+    ) -> anyhow::Result<Channel> {
         let grpc_endpoint = Channel::from_shared(endpoint.to_string())
             .map_err(|e| anyhow!("Invalid KMS Core shard endpoint #{shard_id} {endpoint}: {e}"))?;
 
-        for i in 1..=CONNECTION_RETRY_NUMBER {
+        for i in 1..=retry_number {
             info!(
-                "Attempting connection to KMS Core shard #{shard_id}... ({i}/{CONNECTION_RETRY_NUMBER})"
+                "Attempting connection to KMS Core shard #{shard_id}... ({i}/{retry_number})"
             );
 
             match grpc_endpoint.connect().await {
@@ -73,8 +86,8 @@ impl KmsClient {
                 }
             }
 
-            if i != CONNECTION_RETRY_NUMBER {
-                tokio::time::sleep(CONNECTION_RETRY_DELAY).await;
+            if i != retry_number {
+                tokio::time::sleep(retry_delay).await;
             }
         }
 


### PR DESCRIPTION
## Summary

- Promotes `CONNECTION_RETRY_NUMBER` and `CONNECTION_RETRY_DELAY` compile-time constants to two new env-overridable `Config` fields (`kms_core_startup_retry_number`, `kms_core_startup_retry_delay`) on the kms-worker `Config` struct, matching the existing `s3_ciphertext_retrieval_retries` pattern
- Defaults preserved (5 × 2s) — no behavior change for callers without env overrides
- Helm chart (`charts/kms-connector/values.yaml`) sets env vars to 15 × 4s = 60s budget to cover a typical KMS Core 25-container restart window, eliminating crash-loop noise during KMS Core rollouts

Closes zama-ai/fhevm-internal#1420

## Files changed (4)

| File | Change |
|---|---|
| `kms-connector/crates/kms-worker/src/core/config.rs` | Add `kms_core_startup_retry_number` and `kms_core_startup_retry_delay` fields with serde defaults |
| `kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs` | Remove constant imports; pass retry params through `connect_single_shard` |
| `charts/kms-connector/values.yaml` | Set `KMS_CONNECTOR_KMS_CORE_STARTUP_RETRY_NUMBER=15` and `KMS_CONNECTOR_KMS_CORE_STARTUP_RETRY_DELAY=4s` for deployed environments |
| `charts/kms-connector/Chart.yaml` | Bump chart version `1.4.2` → `1.4.3` (required by chart-testing on values.yaml changes) |

## Test plan

- [x] `cargo check -p kms-worker` passes
- [x] Default values unchanged (5 × 2s) — no behavior change for callers without overrides
- [x] Helm chart version bumped (`1.4.2` → `1.4.3`)
- [ ] Post-deploy: kms-worker crash-loops during expected KMS Core rollouts should drop substantially

## Scope

Main only. No backport.