### PR TITLE
chore(kms-connector): make healthcheck calls concurrently

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2769,7 +2769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3505,7 +3505,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4869,7 +4869,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4906,9 +4906,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5334,7 +5334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6175,7 +6175,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/kms-connector/crates/gw-listener/src/monitoring/health.rs
+++ b/kms-connector/crates/gw-listener/src/monitoring/health.rs
@@ -34,23 +34,16 @@ impl<GP: Provider, EP: Provider> State<GP, EP> {
 
 impl<GP: Provider, EP: Provider> Healthcheck for State<GP, EP> {
     async fn healthcheck(&self) -> actix_web::HttpResponse {
+        let (db_res, gw_res, eth_res) = tokio::join!(
+            database_healthcheck(&self.db_pool, self.healthcheck_timeout),
+            rpc_node_healthcheck(&self.gateway_provider, self.healthcheck_timeout, "Gateway"),
+            rpc_node_healthcheck(&self.ethereum_provider, self.healthcheck_timeout, "Ethereum"),
+        );
+
         let mut errors = vec![];
-        let database_connected =
-            database_healthcheck(&self.db_pool, self.healthcheck_timeout, &mut errors).await;
-        let gateway_connected = rpc_node_healthcheck(
-            &self.gateway_provider,
-            self.healthcheck_timeout,
-            "Gateway",
-            &mut errors,
-        )
-        .await;
-        let ethereum_connected = rpc_node_healthcheck(
-            &self.ethereum_provider,
-            self.healthcheck_timeout,
-            "Ethereum",
-            &mut errors,
-        )
-        .await;
+        let database_connected = db_res.map_err(|e| errors.push(e)).is_ok();
+        let gateway_connected = gw_res.map_err(|e| errors.push(e)).is_ok();
+        let ethereum_connected = eth_res.map_err(|e| errors.push(e)).is_ok();
 
         let (status_code, healthy) = if errors.is_empty() {
             (StatusCode::OK, true)

--- a/kms-connector/crates/gw-listener/src/monitoring/health.rs
+++ b/kms-connector/crates/gw-listener/src/monitoring/health.rs
@@ -37,7 +37,11 @@ impl<GP: Provider, EP: Provider> Healthcheck for State<GP, EP> {
         let (db_res, gw_res, eth_res) = tokio::join!(
             database_healthcheck(&self.db_pool, self.healthcheck_timeout),
             rpc_node_healthcheck(&self.gateway_provider, self.healthcheck_timeout, "Gateway"),
-            rpc_node_healthcheck(&self.ethereum_provider, self.healthcheck_timeout, "Ethereum"),
+            rpc_node_healthcheck(
+                &self.ethereum_provider,
+                self.healthcheck_timeout,
+                "Ethereum"
+            ),
         );
 
         let mut errors = vec![];

--- a/kms-connector/crates/kms-worker/src/monitoring/health.rs
+++ b/kms-connector/crates/kms-worker/src/monitoring/health.rs
@@ -40,7 +40,7 @@ impl<P: Provider> State<P> {
 
 impl<P: Provider> Healthcheck for State<P> {
     async fn healthcheck(&self) -> actix_web::HttpResponse {
-        let (db_res, gw_res, kms_healtcheck_results) = tokio::join!(
+        let (db_res, gw_res, kms_healthcheck_results) = tokio::join!(
             database_healthcheck(&self.db_pool, self.healthcheck_timeout),
             rpc_node_healthcheck(&self.provider, self.healthcheck_timeout, "Gateway"),
             self.kms_health_client.check(self.healthcheck_timeout),
@@ -51,7 +51,7 @@ impl<P: Provider> Healthcheck for State<P> {
         let gateway_connected = gw_res.map_err(|e| errors.push(e)).is_ok();
 
         let mut kms_core_connected = true;
-        for (i, kms_shard_connected) in kms_healtcheck_results.iter().enumerate() {
+        for (i, kms_shard_connected) in kms_healthcheck_results.iter().enumerate() {
             match kms_shard_connected {
                 Ok(Ok(_)) => (),
                 Ok(Err(e)) => {

--- a/kms-connector/crates/kms-worker/src/monitoring/health.rs
+++ b/kms-connector/crates/kms-worker/src/monitoring/health.rs
@@ -40,19 +40,17 @@ impl<P: Provider> State<P> {
 
 impl<P: Provider> Healthcheck for State<P> {
     async fn healthcheck(&self) -> actix_web::HttpResponse {
+        let (db_res, gw_res, kms_healtcheck_results) = tokio::join!(
+            database_healthcheck(&self.db_pool, self.healthcheck_timeout),
+            rpc_node_healthcheck(&self.provider, self.healthcheck_timeout, "Gateway"),
+            self.kms_health_client.check(self.healthcheck_timeout),
+        );
+
         let mut errors = vec![];
-        let database_connected =
-            database_healthcheck(&self.db_pool, self.healthcheck_timeout, &mut errors).await;
-        let gateway_connected = rpc_node_healthcheck(
-            &self.provider,
-            self.healthcheck_timeout,
-            "Gateway",
-            &mut errors,
-        )
-        .await;
+        let database_connected = db_res.map_err(|e| errors.push(e)).is_ok();
+        let gateway_connected = gw_res.map_err(|e| errors.push(e)).is_ok();
 
         let mut kms_core_connected = true;
-        let kms_healtcheck_results = self.kms_health_client.check(self.healthcheck_timeout).await;
         for (i, kms_shard_connected) in kms_healtcheck_results.iter().enumerate() {
             match kms_shard_connected {
                 Ok(Ok(_)) => (),

--- a/kms-connector/crates/tx-sender/src/monitoring/health.rs
+++ b/kms-connector/crates/tx-sender/src/monitoring/health.rs
@@ -34,23 +34,16 @@ impl State {
 
 impl Healthcheck for State {
     async fn healthcheck(&self) -> actix_web::HttpResponse {
+        let (db_res, gw_res, eth_res) = tokio::join!(
+            database_healthcheck(&self.db_pool, self.healthcheck_timeout),
+            rpc_node_healthcheck(&self.gateway_provider, self.healthcheck_timeout, "Gateway"),
+            rpc_node_healthcheck(&self.ethereum_provider, self.healthcheck_timeout, "Ethereum"),
+        );
+
         let mut errors = vec![];
-        let database_connected =
-            database_healthcheck(&self.db_pool, self.healthcheck_timeout, &mut errors).await;
-        let gateway_connected = rpc_node_healthcheck(
-            &self.gateway_provider,
-            self.healthcheck_timeout,
-            "Gateway",
-            &mut errors,
-        )
-        .await;
-        let ethereum_connected = rpc_node_healthcheck(
-            &self.ethereum_provider,
-            self.healthcheck_timeout,
-            "Ethereum",
-            &mut errors,
-        )
-        .await;
+        let database_connected = db_res.map_err(|e| errors.push(e)).is_ok();
+        let gateway_connected = gw_res.map_err(|e| errors.push(e)).is_ok();
+        let ethereum_connected = eth_res.map_err(|e| errors.push(e)).is_ok();
 
         let (status_code, healthy) = if errors.is_empty() {
             (StatusCode::OK, true)

--- a/kms-connector/crates/tx-sender/src/monitoring/health.rs
+++ b/kms-connector/crates/tx-sender/src/monitoring/health.rs
@@ -37,7 +37,11 @@ impl Healthcheck for State {
         let (db_res, gw_res, eth_res) = tokio::join!(
             database_healthcheck(&self.db_pool, self.healthcheck_timeout),
             rpc_node_healthcheck(&self.gateway_provider, self.healthcheck_timeout, "Gateway"),
-            rpc_node_healthcheck(&self.ethereum_provider, self.healthcheck_timeout, "Ethereum"),
+            rpc_node_healthcheck(
+                &self.ethereum_provider,
+                self.healthcheck_timeout,
+                "Ethereum"
+            ),
         );
 
         let mut errors = vec![];

--- a/kms-connector/crates/utils/src/monitoring/health.rs
+++ b/kms-connector/crates/utils/src/monitoring/health.rs
@@ -24,22 +24,15 @@ pub fn default_healthcheck_timeout() -> Duration {
 
 /// Performs the database healthcheck.
 ///
-/// Stores the potential error in the `errors` vector.
+/// Returns `Ok(())` on success, or an `Err` containing a formatted error message on failure.
 pub async fn database_healthcheck(
     db_pool: &Pool<Postgres>,
     timeout: Duration,
-    errors: &mut Vec<String>,
-) -> bool {
+) -> Result<(), String> {
     match tokio::time::timeout(timeout, db_pool.acquire()).await {
-        Ok(Ok(_)) => true,
-        Ok(Err(e)) => {
-            errors.push(format!("Database connection failed: {e}"));
-            false
-        }
-        Err(e) => {
-            errors.push(format!("Database connection timed out: {e}"));
-            false
-        }
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(format!("Database connection failed: {e}")),
+        Err(e) => Err(format!("Database connection timed out: {e}")),
     }
 }
 
@@ -47,23 +40,16 @@ pub async fn database_healthcheck(
 ///
 /// Uses `eth_blockNumber` for this.
 ///
-/// Stores the potential error in the `errors` vector.
+/// Returns `Ok(())` on success, or an `Err` containing a formatted error message on failure.
 pub async fn rpc_node_healthcheck<P: Provider>(
     provider: P,
     timeout: Duration,
     chain_name: &str,
-    errors: &mut Vec<String>,
-) -> bool {
+) -> Result<(), String> {
     match tokio::time::timeout(timeout, provider.get_block_number()).await {
-        Ok(Ok(_)) => true,
-        Ok(Err(e)) => {
-            errors.push(format!("{chain_name} connection failed: {e}"));
-            false
-        }
-        Err(e) => {
-            errors.push(format!("{chain_name} connection timed out: {e}"));
-            false
-        }
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(format!("{chain_name} connection failed: {e}")),
+        Err(e) => Err(format!("{chain_name} connection timed out: {e}")),
     }
 }
 


### PR DESCRIPTION
Pretty much everything is described in the PR title and the issue below :slightly_smiling_face:.
Healthcheck calls in kms-connector services used to be sequential. Now they are done concurrently.

Closes https://github.com/zama-ai/fhevm-internal/issues/1262