### PR TITLE
fix(test-suite): run input proof on shared networks

### DIFF
--- a/test-suite/e2e/test/userInput/inputFlow.ts
+++ b/test-suite/e2e/test/userInput/inputFlow.ts
@@ -4,9 +4,6 @@ import { ethers } from 'hardhat';
 import { createInstances } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
-const CIPHERTEXT_DRIFT_FORBIDDEN_NETWORKS = new Set(['sepolia', 'mainnet', 'zwsDev']);
-const activeNetwork = () => process.env.NETWORK ?? process.env.HARDHAT_NETWORK ?? '';
-
 describe('Input Flow', function () {
   before(async function () {
     await initSigners(2);
@@ -28,10 +25,6 @@ describe('Input Flow', function () {
   });
 
   it('test user input uint64 (non-trivial)', async function () {
-    if (CIPHERTEXT_DRIFT_FORBIDDEN_NETWORKS.has(activeNetwork())) {
-      this.skip();
-    }
-
     const encryptedAmount = await this.instances.alice.encryptUint64({
       value: 18446744073709550042n,
       contractAddress: this.contractAddress,


### PR DESCRIPTION
## Summary

Remove the live/shared-network skip from the plain input proof e2e test.

## Root cause

The guard was added to protect intentional ciphertext drift runs from shared/live networks, but it was placed inside `test user input uint64 (non-trivial)`. That test is the normal `input-proof` smoke path and does not install the drift SQL trigger. The drift profile already has a CLI preflight guard where drift injection is actually enabled.

## Impact

`input-proof` now runs on `sepolia`, `mainnet`, and `zwsDev` instead of being reported as skipped. The dedicated `ciphertext-drift` profile remains blocked on those networks.

## Validation

- Inspected the profile mappings and confirmed `input-proof` maps to `test user input uint64` while drift profiles default to `test add 42 to uint64 input and decrypt`.
- `npm run tsc` in `test-suite/e2e` could not run because `tsc` is not installed in this worktree.
