### PR TITLE
fix(test-suite): run input proof on shared networks

### DIFF
--- a/test-suite/e2e/test/userInput/inputFlow.ts
+++ b/test-suite/e2e/test/userInput/inputFlow.ts
@@ -4,9 +4,6 @@ import { ethers } from 'hardhat';
 import { createInstances } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
-const CIPHERTEXT_DRIFT_FORBIDDEN_NETWORKS = new Set(['sepolia', 'mainnet', 'zwsDev']);
-const activeNetwork = () => process.env.NETWORK ?? process.env.HARDHAT_NETWORK ?? '';
-
 describe('Input Flow', function () {
   before(async function () {
     await initSigners(2);
@@ -28,10 +25,6 @@ describe('Input Flow', function () {
   });
 
   it('test user input uint64 (non-trivial)', async function () {
-    if (CIPHERTEXT_DRIFT_FORBIDDEN_NETWORKS.has(activeNetwork())) {
-      this.skip();
-    }
-
     const encryptedAmount = await this.instances.alice.encryptUint64({
       value: 18446744073709550042n,
       contractAddress: this.contractAddress,


### PR DESCRIPTION
Backport of #2607 to release/0.13.x.

Original merge commit: ce5539366bd6549a13984e93012154e84936b6cd
Backport commit: 6e5f5c57e27803bc732233f685b6c2a0a516ced7

Validation:
- Inspected the backport diff against origin/release/0.13.x; it only removes the network skip from test-suite/e2e/test/userInput/inputFlow.ts.
- Attempted npm run tsc in test-suite/e2e, but dependencies are not installed in this worktree (tsc: command not found).
