### PR TITLE
fix(test-suite): inject TestInput coprocessor config via constructor + add polygonAmoy

### DIFF
--- a/test-suite/e2e/contracts/smoke/TestInput.sol
+++ b/test-suite/e2e/contracts/smoke/TestInput.sol
@@ -3,10 +3,23 @@
 pragma solidity ^0.8.24;
 
 import "@fhevm/solidity/lib/FHE.sol";
-import {E2ECoprocessorConfig} from "../E2ECoprocessorConfigLocal.sol";
+import {CoprocessorConfig} from "@fhevm/solidity/lib/Impl.sol";
 
-contract TestInput is E2ECoprocessorConfig {
+/// @dev Coprocessor config is injected via the constructor (see fhevm-internal#941), so the
+/// contract is wired to the real on-chain addresses at deploy time instead of the build-time
+/// sed-patch of E2ECoprocessorConfigLocal.
+contract TestInput {
     euint64 public resUint64;
+
+    constructor(address aclAddress, address coprocessorAddress, address kmsVerifierAddress) {
+        FHE.setCoprocessor(
+            CoprocessorConfig({
+                ACLAddress: aclAddress,
+                CoprocessorAddress: coprocessorAddress,
+                KMSVerifierAddress: kmsVerifierAddress
+            })
+        );
+    }
 
     function requestUint64NonTrivial(externalEuint64 inputHandle, bytes calldata inputProof) public {
         resUint64 = FHE.fromExternal(inputHandle, inputProof);

--- a/test-suite/e2e/hardhat.config.ts
+++ b/test-suite/e2e/hardhat.config.ts
@@ -78,6 +78,7 @@ const chainIds = {
   localCoprocessor: 12345,
   staging: 12345,
   zwsDev: 1337,
+  polygonAmoy: 80002,
   sepolia: 11155111,
   mainnet: 1,
   localCoprocessorL1: 123456,
@@ -102,6 +103,7 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
   switch (chain) {
     case 'staging':
     case 'zwsDev':
+    case 'polygonAmoy':
       jsonRpcUrl = process.env.RPC_URL ?? vars.get('RPC_URL', defaultRpcUrl);
       if (shouldWarn && jsonRpcUrl === defaultRpcUrl) {
         console.warn(`WARN: RPC_URL not set for network '${chain}'. Using default: ${defaultRpcUrl}`);
@@ -189,6 +191,7 @@ const config: HardhatUserConfig = {
     },
     staging: getChainConfig('staging'),
     zwsDev: getChainConfig('zwsDev'),
+    polygonAmoy: getChainConfig('polygonAmoy'),
     sepolia: getChainConfig('sepolia'),
     mainnet: getChainConfig('mainnet'),
     localNative: getChainConfig('localNative'),

--- a/test-suite/e2e/test/pausedProtocol/pausedGateway.ts
+++ b/test-suite/e2e/test/pausedProtocol/pausedGateway.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
-import { createInstances } from '../instance';
+import { aclAddress, coprocessorAddress, createInstances, kmsVerifierAddress } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
 const ENFORCED_PAUSE_SELECTOR = '0xd93c0665';
@@ -14,7 +14,9 @@ describe('Paused gateway', function () {
 
     // Initialize TestInput contract.
     const testInputContractFactory = await ethers.getContractFactory('TestInput');
-    this.testInputContract = await testInputContractFactory.connect(this.signers.alice).deploy();
+    this.testInputContract = await testInputContractFactory
+      .connect(this.signers.alice)
+      .deploy(aclAddress, coprocessorAddress, kmsVerifierAddress);
     this.testInputContractAddress = await this.testInputContract.getAddress();
     await this.testInputContract.waitForDeployment();
 

--- a/test-suite/e2e/test/pausedProtocol/pausedHost.ts
+++ b/test-suite/e2e/test/pausedProtocol/pausedHost.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
-import { createInstances } from '../instance';
+import { aclAddress, coprocessorAddress, createInstances, kmsVerifierAddress } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
 const ENFORCED_PAUSE_SELECTOR = '0xd93c0665';
@@ -17,7 +17,9 @@ describe('Paused host', function () {
   it('test paused host user input (allow)', async function () {
     // Initialize TestInput contract.
     const testInputContractFactory = await ethers.getContractFactory('TestInput');
-    const testInputContract = await testInputContractFactory.connect(this.signers.alice).deploy();
+    const testInputContract = await testInputContractFactory
+      .connect(this.signers.alice)
+      .deploy(aclAddress, coprocessorAddress, kmsVerifierAddress);
     const testInputContractAddress = await testInputContract.getAddress();
     await testInputContract.waitForDeployment();
 

--- a/test-suite/e2e/test/userInput/inputFlow.ts
+++ b/test-suite/e2e/test/userInput/inputFlow.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai';
 import { ethers } from 'hardhat';
 
-import { createInstances } from '../instance';
+import { aclAddress, coprocessorAddress, createInstances, kmsVerifierAddress } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
 describe('Input Flow', function () {
@@ -14,7 +14,9 @@ describe('Input Flow', function () {
     const envContractAddress = process.env.TEST_INPUT_CONTRACT_ADDRESS;
     const contractFactory = await ethers.getContractFactory('TestInput');
     if (!envContractAddress) {
-      this.contract = await contractFactory.connect(this.signers.alice).deploy();
+      this.contract = await contractFactory
+        .connect(this.signers.alice)
+        .deploy(aclAddress, coprocessorAddress, kmsVerifierAddress);
       this.contractAddress = await this.contract.getAddress();
       await this.contract.waitForDeployment();
     } else {


### PR DESCRIPTION
## What

Fixes the Polygon Amoy e2e **input-proof revert** (opaque empty `execution reverted`) by removing `TestInput`'s dependency on the runtime-`sed`-patched config.

- **`contracts/smoke/TestInput.sol`** — take `ACL` / `FHEVMExecutor` / `KMSVerifier` via **constructor** (`FHE.setCoprocessor`), dropping the `E2ECoprocessorConfig` inheritance. Same pattern already used by `SmokeTestInput`. (fhevm-internal#941)
- **`test/userInput/inputFlow.ts`**, **`test/pausedProtocol/pausedHost.ts`**, **`test/pausedProtocol/pausedGateway.ts`** — pass the addresses (from `instance.ts`) when deploying `TestInput`.
- **`hardhat.config.ts`** — define `polygonAmoy` (chainId `80002`) natively, so the runtime network-adding `sed` is no longer needed.

Smoke tests are intentionally left untouched.

## Root cause

The deployed `TestInput` carried the **un-substituted placeholder** coprocessor addresses from `E2ECoprocessorConfigLocal.sol` (executor `0xcCAe95…` — no code on Amoy). The gitops address-`sed` patches the source, but `hardhat clean && compile` runs with `HARDHAT_NETWORK=polygonAmoy` set **before** `polygonAmoy` exists in `hardhat.config.ts`, so every hardhat command throws `HH100` and the recompile never happens — the **placeholder-compiled image artifacts** get deployed. `FHE.fromExternal` then calls a code-less executor and the EVM `extcodesize` check reverts with empty data. (The ZK proof, coprocessor, gateway, InputVerifier signer set and ACL were all correct; the same proof verifies against the real executor `0x8a8f…`.)

Constructor injection wires `TestInput` to the real on-chain addresses at deploy time, immune to the `sed`/recompile/`HARDHAT_NETWORK` failure class.

## Validation

Confirmed on Polygon Amoy via the constructor-injected path (`SmokeTestInput`): deploy + `add42ToInput64` (same `FHE.fromExternal` path) mined `status=1`, plus user + public decryption succeeded end-to-end. `TestInput` now uses the identical injection mechanism.

> CI runs lint/compile/typecheck; prepared in a fresh worktree without `node_modules`, so I couldn't run them locally.

## Follow-ups (out of scope)

- Complete fhevm-internal#941 for the remaining `E2ECoprocessorConfig` consumers (UserDecrypt, EncryptedERC20, FHEVMTestSuite*, …), then retire `E2ECoprocessorConfigLocal.sol`.
- gitops: add a Polygon `relayer-e2e-smoke-test` app and drop the address/network `sed`s from the polygon test-suite deploy.


closes https://github.com/zama-ai/fhevm-internal/issues/941