### PR TITLE
fix(test-suite): inject TestInput coprocessor config via constructor + add polygonAmoy [0.13.x]

### DIFF
--- a/test-suite/e2e/contracts/smoke/TestInput.sol
+++ b/test-suite/e2e/contracts/smoke/TestInput.sol
@@ -3,10 +3,23 @@
 pragma solidity ^0.8.24;
 
 import "@fhevm/solidity/lib/FHE.sol";
-import {E2ECoprocessorConfig} from "../E2ECoprocessorConfigLocal.sol";
+import {CoprocessorConfig} from "@fhevm/solidity/lib/Impl.sol";
 
-contract TestInput is E2ECoprocessorConfig {
+/// @dev Coprocessor config is injected via the constructor (see fhevm-internal#941), so the
+/// contract is wired to the real on-chain addresses at deploy time instead of the build-time
+/// sed-patch of E2ECoprocessorConfigLocal.
+contract TestInput {
     euint64 public resUint64;
+
+    constructor(address aclAddress, address coprocessorAddress, address kmsVerifierAddress) {
+        FHE.setCoprocessor(
+            CoprocessorConfig({
+                ACLAddress: aclAddress,
+                CoprocessorAddress: coprocessorAddress,
+                KMSVerifierAddress: kmsVerifierAddress
+            })
+        );
+    }
 
     function requestUint64NonTrivial(externalEuint64 inputHandle, bytes calldata inputProof) public {
         resUint64 = FHE.fromExternal(inputHandle, inputProof);

--- a/test-suite/e2e/hardhat.config.ts
+++ b/test-suite/e2e/hardhat.config.ts
@@ -78,6 +78,7 @@ const chainIds = {
   localCoprocessor: 12345,
   staging: 12345,
   zwsDev: 1337,
+  polygonAmoy: 80002,
   sepolia: 11155111,
   mainnet: 1,
   localCoprocessorL1: 123456,
@@ -102,6 +103,7 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
   switch (chain) {
     case 'staging':
     case 'zwsDev':
+    case 'polygonAmoy':
       jsonRpcUrl = process.env.RPC_URL ?? vars.get('RPC_URL', defaultRpcUrl);
       if (shouldWarn && jsonRpcUrl === defaultRpcUrl) {
         console.warn(`WARN: RPC_URL not set for network '${chain}'. Using default: ${defaultRpcUrl}`);
@@ -189,6 +191,7 @@ const config: HardhatUserConfig = {
     },
     staging: getChainConfig('staging'),
     zwsDev: getChainConfig('zwsDev'),
+    polygonAmoy: getChainConfig('polygonAmoy'),
     sepolia: getChainConfig('sepolia'),
     mainnet: getChainConfig('mainnet'),
     localNative: getChainConfig('localNative'),

--- a/test-suite/e2e/test/pausedProtocol/pausedGateway.ts
+++ b/test-suite/e2e/test/pausedProtocol/pausedGateway.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
-import { createInstances } from '../instance';
+import { aclAddress, coprocessorAddress, createInstances, kmsVerifierAddress } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
 const ENFORCED_PAUSE_SELECTOR = '0xd93c0665';
@@ -14,7 +14,9 @@ describe('Paused gateway', function () {
 
     // Initialize TestInput contract.
     const testInputContractFactory = await ethers.getContractFactory('TestInput');
-    this.testInputContract = await testInputContractFactory.connect(this.signers.alice).deploy();
+    this.testInputContract = await testInputContractFactory
+      .connect(this.signers.alice)
+      .deploy(aclAddress, coprocessorAddress, kmsVerifierAddress);
     this.testInputContractAddress = await this.testInputContract.getAddress();
     await this.testInputContract.waitForDeployment();
 

--- a/test-suite/e2e/test/pausedProtocol/pausedHost.ts
+++ b/test-suite/e2e/test/pausedProtocol/pausedHost.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
-import { createInstances } from '../instance';
+import { aclAddress, coprocessorAddress, createInstances, kmsVerifierAddress } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
 const ENFORCED_PAUSE_SELECTOR = '0xd93c0665';
@@ -17,7 +17,9 @@ describe('Paused host', function () {
   it('test paused host user input (allow)', async function () {
     // Initialize TestInput contract.
     const testInputContractFactory = await ethers.getContractFactory('TestInput');
-    const testInputContract = await testInputContractFactory.connect(this.signers.alice).deploy();
+    const testInputContract = await testInputContractFactory
+      .connect(this.signers.alice)
+      .deploy(aclAddress, coprocessorAddress, kmsVerifierAddress);
     const testInputContractAddress = await testInputContract.getAddress();
     await testInputContract.waitForDeployment();
 

--- a/test-suite/e2e/test/userInput/inputFlow.ts
+++ b/test-suite/e2e/test/userInput/inputFlow.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai';
 import { ethers } from 'hardhat';
 
-import { createInstances } from '../instance';
+import { aclAddress, coprocessorAddress, createInstances, kmsVerifierAddress } from '../instance';
 import { getSigners, initSigners } from '../signers';
 
 describe('Input Flow', function () {
@@ -14,7 +14,9 @@ describe('Input Flow', function () {
     const envContractAddress = process.env.TEST_INPUT_CONTRACT_ADDRESS;
     const contractFactory = await ethers.getContractFactory('TestInput');
     if (!envContractAddress) {
-      this.contract = await contractFactory.connect(this.signers.alice).deploy();
+      this.contract = await contractFactory
+        .connect(this.signers.alice)
+        .deploy(aclAddress, coprocessorAddress, kmsVerifierAddress);
       this.contractAddress = await this.contract.getAddress();
       await this.contract.waitForDeployment();
     } else {


### PR DESCRIPTION
Backport of #2668 to `release/0.13.x` (clean cherry-pick — **identical `git patch-id`** `1af2157b…`).

Fixes the Polygon Amoy e2e input-proof revert: the deployed `TestInput` carried the un-substituted placeholder coprocessor addresses from `E2ECoprocessorConfigLocal.sol` (executor `0xcCAe95…`, no code) because the address-`sed` + recompile silently failed (`HARDHAT_NETWORK=polygonAmoy` before `polygonAmoy` is in `hardhat.config.ts` → `HH100`), so `FHE.fromExternal` called a code-less executor and reverted with empty data.

- `TestInput.sol`: take ACL/executor/KMS via constructor (`FHE.setCoprocessor`), dropping the `E2ECoprocessorConfig`/sed dependency.
- `inputFlow.ts`, `pausedProtocol/{pausedHost,pausedGateway}.ts`: pass addresses from `instance.ts` at deploy.
- `hardhat.config.ts`: define `polygonAmoy` (80002) natively.

See #2668 for full root-cause analysis and on-chain validation. Refs: fhevm-internal#941