### PR TITLE
ci(charts): lint chart versions against the PR base branch

### DIFF
--- a/.github/workflows/charts-helm-checks.yml
+++ b/.github/workflows/charts-helm-checks.yml
@@ -83,4 +83,18 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --config .github/config/ct.yaml
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Compare chart versions against the branch this change targets, not a
+          # hardcoded main: PRs use the base branch (main or release/*), pushes
+          # use the branch that was pushed. Without this, backport PRs to
+          # release/* are checked against main and fail when main's chart version
+          # has moved ahead of the release line.
+          if [ -n "${GITHUB_BASE_REF}" ]; then
+            TARGET_BRANCH="${GITHUB_BASE_REF}"
+          else
+            TARGET_BRANCH="${GITHUB_REF_NAME}"
+          fi
+          ct lint --config .github/config/ct.yaml --target-branch "${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary

The `charts-helm-checks` job runs `ct lint` with the hardcoded `target-branch: main` from `.github/config/ct.yaml`. That means the chart version-increment check always compares a PR's charts against **main**, regardless of the branch the PR actually targets.

This breaks any backport PR to a `release/*` branch the moment main's chart version moves ahead of the release line — even for charts the PR never touches. Concrete example on the 0.13 backport #2657: `ct` sees `coprocessor 0.13.0 (main) → 0.12.1 (release/0.13.x)` and reports a forbidden downgrade, failing the check.

## Change

Pass `--target-branch` to `ct lint`, derived from the event:

- **Pull requests** → `github.base_ref` (the branch being merged into — `main` or `release/*`).
- **Push events** → `github.ref_name` (the branch that was pushed).

So each change is version-checked against the branch it actually targets. Normal PRs to `main` are unaffected (base ref is `main`); backports are now checked against their release branch.

`list-changed` still uses the config's `target-branch` (it only gates *whether* lint runs); the pass/fail now comes from `lint` against the correct base.

## Test plan

- [x] Validated on #2657: with this change, `charts-helm-checks/test (bpr)` goes from failing to passing, because the untouched `coprocessor` chart is no longer compared against main and `contracts` reads as a valid bump against `release/0.13.x`.
- [ ] CI green on this PR (base `main`, no chart changes → check skips, behavior unchanged for main).

## Follow-up

- Backport to `release/0.13.x` so existing and future backports benefit (separate PR).

Made with [Cursor](https://cursor.com)