### PR TITLE
ci(charts): lint chart versions against the PR base branch [0.13.x]

### DIFF
--- a/.github/workflows/charts-helm-checks.yml
+++ b/.github/workflows/charts-helm-checks.yml
@@ -83,4 +83,18 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --config .github/config/ct.yaml
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Compare chart versions against the branch this change targets, not a
+          # hardcoded main: PRs use the base branch (main or release/*), pushes
+          # use the branch that was pushed. Without this, backport PRs to
+          # release/* are checked against main and fail when main's chart version
+          # has moved ahead of the release line.
+          if [ -n "${GITHUB_BASE_REF}" ]; then
+            TARGET_BRANCH="${GITHUB_BASE_REF}"
+          else
+            TARGET_BRANCH="${GITHUB_REF_NAME}"
+          fi
+          ct lint --config .github/config/ct.yaml --target-branch "${TARGET_BRANCH}"


### PR DESCRIPTION
Backport of #2684 to `release/0.13.x`.

## Summary

`charts-helm-checks` runs `ct lint` with the hardcoded `target-branch: main` from `.github/config/ct.yaml`, so chart version checks always compare against **main** regardless of the PR's actual base. Backports to `release/0.13.x` therefore fail as soon as main's chart version is ahead of the release line — even for charts they don't touch (e.g. `coprocessor 0.13.0` on main vs `0.12.1` on `release/0.13.x`).

This passes `--target-branch` to `ct lint` from `github.base_ref` (PRs) with a `github.ref_name` fallback (push events), so charts are checked against the branch they target.

Once this lands, the host-contracts multi-chain backport #2657 passes the chart check without carrying its own copy of the fix.

## Test plan

- [x] Verified on #2657 that the same change turns `charts-helm-checks/test (bpr)` green.
- [ ] CI green here.

Made with [Cursor](https://cursor.com)