### PR TITLE
feat(test-suite): single-signer-cutover rollout runbook + soak profile

### DIFF
--- a/test-suite/fhevm/rollouts/single-signer-cutover/run.ts
+++ b/test-suite/fhevm/rollouts/single-signer-cutover/run.ts
@@ -1,0 +1,353 @@
+/**
+ * Devnet Coprocessor Single-Signer cutover — local rollout runbook.
+ *
+ * Validates the DAO cutover `GatewayConfig.updateCoprocessors([zama], 1)` against
+ * the local stack: after the cutover the excluded partner coprocessors' tx-senders
+ * must decode the gateway revert (NotCoprocessorTxSender) as a non-retryable config
+ * error and STOP retrying, while the protocol stays healthy on the single Zama
+ * signer. The cutover happens while the gateway is still v0.12.5; the v0.13 upgrade
+ * phases then run in lockstep and the same soak gate is re-asserted on v0.13.
+ *
+ * Built on top of the v0.12-to-v0.13 rollout (#2404, now on main). The v0.13
+ * contract-migration sequence is currently duplicated locally (see
+ * executeV013ContractMigration) rather than shared with rollouts/v0.12-to-v0.13/run.ts.
+ * Extracting a shared module imported by both runbooks is a sensible follow-up —
+ * flagged for review.
+ */
+import path from "node:path";
+
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { phaseVersions, scenario, versionSources } from "./versions";
+
+export type RolloutEnv = Record<string, string>;
+
+const logPhase = (label: string) => {
+  console.log(`\n[rollout] ${label}`);
+};
+
+const writePhaseVersionLock = (ctx: RolloutRunContext, name: string, versions: RolloutEnv) =>
+  ctx.writeVersionLock(name, { versions, sources: versionSources });
+
+const contractVersionKeys = ["GATEWAY_VERSION", "HOST_VERSION"];
+
+const upgradeContract = async (runTask: (command: string) => Promise<void>, task: string, name: string) => {
+  const current = `previous-contracts/${name}.sol:${name}`;
+  const next = `contracts/${name}.sol:${name}`;
+  console.log(`[contracts] ${name}: ${current} -> ${next}`);
+  await runTask(
+    [
+      "npx hardhat",
+      task,
+      `--current-implementation ${current}`,
+      `--new-implementation ${next}`,
+      "--verify-contract false",
+      "--use-internal-proxy-address true",
+    ].join(" "),
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Single-signer cutover.
+//
+// runContractTask runs the gateway-sc-deploy image's BAKED-IN code (no local
+// source mount), so a new hardhat task added to this repo would not exist in any
+// released gateway-contracts image. The fhevm-cli package also has no ethers
+// dependency. We therefore drive the cutover through the blessed
+// ctx.runGatewayContractTask primitive with an inline hardhat script — the same
+// "inline sh -lc script" pattern #2404's assertKmsMigration already uses. A
+// minimal human-readable ABI is used so the script needs no compiled artifacts
+// and runs unchanged on both v0.12.5 and v0.13.
+//
+// On v0.12.5, updateCoprocessors is `onlyOwner` WITHOUT the v0.13
+// `whenInputVerificationPaused` interlock (present at GatewayConfig.sol:333 on
+// v0.13, absent on v0.12.5). So no pause is required here — and pausing all
+// gateway contracts would starve the input-verification path the soak depends
+// on. We therefore intentionally skip the devnet runbook's pause/unpause parity
+// step at the v0.12.5 baseline.
+// ---------------------------------------------------------------------------
+const SINGLE_SIGNER_CUTOVER_SCRIPT = String.raw`
+const hre = require("hardhat");
+const { ethers } = hre;
+
+async function main() {
+  const env = process.env;
+  const gatewayConfigAddress = env.GATEWAY_CONFIG_ADDRESS;
+  if (!gatewayConfigAddress) throw new Error("GATEWAY_CONFIG_ADDRESS missing from gateway-sc env");
+  const deployerKey = env.DEPLOYER_PRIVATE_KEY;
+  if (!deployerKey) throw new Error("DEPLOYER_PRIVATE_KEY missing from gateway-sc env");
+
+  const zama = [{
+    txSenderAddress: env.COPROCESSOR_TX_SENDER_ADDRESS_0,
+    signerAddress: env.COPROCESSOR_SIGNER_ADDRESS_0,
+    s3BucketUrl: env.COPROCESSOR_S3_BUCKET_URL_0,
+  }];
+  if (!zama[0].txSenderAddress || !zama[0].signerAddress || !zama[0].s3BucketUrl) {
+    throw new Error("COPROCESSOR_{TX_SENDER,SIGNER}_ADDRESS_0 / _S3_BUCKET_URL_0 missing from gateway-sc env");
+  }
+
+  const owner = new ethers.Wallet(deployerKey, ethers.provider);
+  const abi = [
+    "function updateCoprocessors((address txSenderAddress, address signerAddress, string s3BucketUrl)[] newCoprocessors, uint256 newCoprocessorThreshold)",
+    "function getCoprocessorSigners() view returns (address[])",
+  ];
+  const gatewayConfig = new ethers.Contract(gatewayConfigAddress, abi, owner);
+
+  const before = await gatewayConfig.getCoprocessorSigners();
+  console.log("[cutover] coprocessor signers before: " + JSON.stringify(before));
+  console.log("[cutover] updateCoprocessors([zama], 1) from owner " + owner.address);
+  const receipt = await (await gatewayConfig.updateCoprocessors(zama, 1)).wait();
+  const after = await gatewayConfig.getCoprocessorSigners();
+  console.log("[cutover] tx " + receipt.hash + "; coprocessor signers after: " + JSON.stringify(after));
+  if (after.length !== 1) {
+    throw new Error("expected exactly 1 coprocessor signer after cutover, got " + after.length);
+  }
+}
+
+main().then(() => process.exit(0)).catch((error) => { console.error(error); process.exit(1); });
+`;
+
+const runSingleSignerCutover = async (ctx: RolloutRunContext) => {
+  // The script must live UNDER /app so `require("hardhat")` resolves via
+  // /app/node_modules (Node walks up from the script's directory — /tmp has no
+  // node_modules). /app/addresses is the writable, mounted dir the migration
+  // tasks already use as scratch. --no-compile keeps it fast: the minimal ABI
+  // needs no build.
+  const scriptPath = "/app/addresses/single-signer-cutover.cjs";
+  const command = [
+    `cat > ${scriptPath} <<'CUTOVER_EOF'`,
+    SINGLE_SIGNER_CUTOVER_SCRIPT,
+    "CUTOVER_EOF",
+    `npx hardhat run --no-compile ${scriptPath}`,
+  ].join("\n");
+  await ctx.runGatewayContractTask(command);
+};
+
+// ---------------------------------------------------------------------------
+// Host-side cutover — REQUIRED for the cutover to be complete.
+//
+// The gateway updateCoprocessors above only changes the GATEWAY chain. The
+// relayer-SDK verifies input proofs against the HOST chain's InputVerifier
+// (it reads InputVerifier.getThreshold()/getCoprocessorSigners()), NOT
+// GatewayConfig. Verified locally: a gateway-only cutover leaves the host
+// InputVerifier at the old N-of-M set, so input proofs fail with
+// `RelayerThresholdCoprocessorSignerError: threshold is not reached` and the
+// protocol is NOT healthy on the single signer. We therefore mirror the cutover
+// on the host InputVerifier via defineNewContext(newSigners, newThreshold),
+// which is `onlyACLOwner` (host-contracts/contracts/InputVerifier.sol:174) — the
+// host deployer is the ACL owner. The InputVerifier address is resolved at
+// runtime from the mounted FHEVMHostAddresses.sol.
+const SINGLE_SIGNER_HOST_CUTOVER_SCRIPT = String.raw`
+const hre = require("hardhat");
+const { ethers } = hre;
+
+async function main() {
+  const env = process.env;
+  const inputVerifierAddress = env.INPUT_VERIFIER_ADDRESS;
+  if (!inputVerifierAddress) throw new Error("INPUT_VERIFIER_ADDRESS not resolved from FHEVMHostAddresses.sol");
+  const deployerKey = env.DEPLOYER_PRIVATE_KEY;
+  if (!deployerKey) throw new Error("DEPLOYER_PRIVATE_KEY missing from host-sc env");
+  const signer0 = env.COPROCESSOR_SIGNER_ADDRESS_0;
+  if (!signer0) throw new Error("COPROCESSOR_SIGNER_ADDRESS_0 missing from host-sc env");
+
+  const owner = new ethers.Wallet(deployerKey, ethers.provider);
+  const abi = [
+    "function defineNewContext(address[] newSignersSet, uint256 newThreshold)",
+    "function getCoprocessorSigners() view returns (address[])",
+    "function getThreshold() view returns (uint256)",
+  ];
+  const inputVerifier = new ethers.Contract(inputVerifierAddress, abi, owner);
+
+  const before = await inputVerifier.getCoprocessorSigners();
+  console.log("[host-cutover] InputVerifier signers before: " + JSON.stringify(before) + " threshold " + (await inputVerifier.getThreshold()).toString());
+  console.log("[host-cutover] defineNewContext([zama], 1) from ACL owner " + owner.address);
+  const receipt = await (await inputVerifier.defineNewContext([signer0], 1)).wait();
+  const after = await inputVerifier.getCoprocessorSigners();
+  console.log("[host-cutover] tx " + receipt.hash + "; InputVerifier signers after: " + JSON.stringify(after) + " threshold " + (await inputVerifier.getThreshold()).toString());
+  if (after.length !== 1) {
+    throw new Error("expected exactly 1 host coprocessor signer after cutover, got " + after.length);
+  }
+}
+
+main().then(() => process.exit(0)).catch((error) => { console.error(error); process.exit(1); });
+`;
+
+const runHostSingleSignerCutover = async (ctx: RolloutRunContext) => {
+  const scriptPath = "/app/addresses/host-single-signer-cutover.cjs";
+  const command = [
+    // Resolve the deployed InputVerifier address from the mounted host addresses.
+    `INPUT_VERIFIER_ADDRESS=$(grep inputVerifierAdd /app/addresses/FHEVMHostAddresses.sol | grep -oE '0x[0-9a-fA-F]{40}')`,
+    `cat > ${scriptPath} <<'CUTOVER_EOF'`,
+    SINGLE_SIGNER_HOST_CUTOVER_SCRIPT,
+    "CUTOVER_EOF",
+    `INPUT_VERIFIER_ADDRESS=$INPUT_VERIFIER_ADDRESS npx hardhat run --no-compile ${scriptPath}`,
+  ].join("\n");
+  await ctx.runHostContractTask(command);
+};
+
+// ---------------------------------------------------------------------------
+// v0.13 contract migration — currently duplicated from rollouts/v0.12-to-v0.13/run.ts;
+// see that runbook for the per-step rationale comments. Candidate for extraction into a
+// shared module (see PR description).
+// ---------------------------------------------------------------------------
+const prepareV013ContractMigrationSources = async (ctx: RolloutRunContext, targetLockFile: string) => {
+  console.log("[contracts] preserve v0.12 sources, then activate v0.13 sources");
+  await ctx.snapshotContracts("host");
+  await ctx.snapshotContracts("gateway");
+  await ctx.applyVersionLock("v0.13 contract migration sources", {
+    lockFile: targetLockFile,
+    allowedVersionKeys: contractVersionKeys,
+  });
+};
+
+const parseGatewayMigrationEnv = (value: unknown): RolloutEnv => {
+  if (!value || typeof value !== "object") {
+    throw new Error("migration-state.json is missing its export object");
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => {
+      if (item === undefined || item === null) {
+        throw new Error(`migration-state.json export.${key} is empty`);
+      }
+      return [key, String(item)];
+    }),
+  );
+};
+
+export const needsLocalOneNodeMpcNormalization = (env: RolloutEnv): boolean => {
+  const kmsNodes = JSON.parse(env.MIGRATION_KMS_NODES ?? "[]") as unknown[];
+  const thresholds = JSON.parse(env.MIGRATION_KMS_THRESHOLDS ?? "{}") as Record<string, unknown>;
+  return kmsNodes.length === 1 && String(thresholds.mpc) === "0";
+};
+
+export const normalizeLocalOneNodeMpcThreshold = (env: RolloutEnv): RolloutEnv => {
+  if (!needsLocalOneNodeMpcNormalization(env)) {
+    return env;
+  }
+  const thresholds = JSON.parse(env.MIGRATION_KMS_THRESHOLDS ?? "{}") as Record<string, unknown>;
+  console.log("[contracts] local one-node migration: normalize ProtocolConfig mpc threshold 0 -> 1");
+  return { ...env, MIGRATION_KMS_THRESHOLDS: JSON.stringify({ ...thresholds, mpc: "1" }) };
+};
+
+type GatewayMigrationContext = {
+  kmsGenerationProxy: string;
+  gatewayConfigProxy: string;
+  migrationEnv: RolloutEnv;
+  mpcThresholdNormalized: boolean;
+};
+
+const exportGatewayKmsMigrationEnv = async (ctx: RolloutRunContext): Promise<GatewayMigrationContext> => {
+  const state = await ctx.readState();
+  const gateway = state.discovery?.gateway;
+  if (!gateway?.KMS_GENERATION_ADDRESS || !gateway.GATEWAY_CONFIG_ADDRESS) {
+    throw new Error("gateway KMSGeneration and GatewayConfig addresses must be discovered before contract migration");
+  }
+
+  const output = "kms-migration-state.json";
+  await ctx.runGatewayContractTask(
+    [
+      "npx hardhat compile &&",
+      "npx hardhat task:exportKmsMigrationState",
+      `--kms-generation-proxy ${gateway.KMS_GENERATION_ADDRESS}`,
+      `--gateway-config-proxy ${gateway.GATEWAY_CONFIG_ADDRESS}`,
+      `--output /app/addresses/${output}`,
+    ].join(" "),
+  );
+
+  const stateFile = path.join(ctx.stateDir(), "runtime", "addresses", "gateway", output);
+  const migrationState = JSON.parse(await Bun.file(stateFile).text()) as { export?: unknown };
+  const rawEnv = parseGatewayMigrationEnv(migrationState.export);
+  return {
+    kmsGenerationProxy: gateway.KMS_GENERATION_ADDRESS,
+    gatewayConfigProxy: gateway.GATEWAY_CONFIG_ADDRESS,
+    migrationEnv: normalizeLocalOneNodeMpcThreshold(rawEnv),
+    mpcThresholdNormalized: needsLocalOneNodeMpcNormalization(rawEnv),
+  };
+};
+
+const GATEWAY_RPC_URL = "http://gateway-node:8546";
+
+const assertKmsMigration = async (
+  ctx: RolloutRunContext,
+  { gatewayConfigProxy, kmsGenerationProxy, mpcThresholdNormalized }: GatewayMigrationContext,
+) => {
+  const assertCommand = [
+    "npx hardhat compile &&",
+    "npx hardhat task:assertKmsMigrationSucceeded",
+    `--gateway-config-proxy ${gatewayConfigProxy}`,
+    `--gateway-kms-generation-proxy ${kmsGenerationProxy}`,
+    "--use-internal-proxy-address true",
+  ].join(" ");
+
+  if (!mpcThresholdNormalized) {
+    await ctx.runHostContractTask(assertCommand, { env: { GATEWAY_RPC_URL } });
+    return;
+  }
+
+  const wrapped = [
+    `if out=$(${assertCommand} 2>&1); then printf '%s\\n' "$out";`,
+    `else status=$?; printf '%s\\n' "$out";`,
+    `printf '%s\\n' "$out" | grep -q 'ProtocolConfig MPC threshold mismatch: expected 0, got 1' || exit $status;`,
+    `echo '[runbook] tolerated synthetic-fixture mpc threshold mismatch';`,
+    "fi",
+  ].join(" ");
+  await ctx.runHostContractTask(wrapped, { env: { GATEWAY_RPC_URL } });
+};
+
+const executeV013ContractMigration = async (ctx: RolloutRunContext, contractsLock: string) => {
+  await prepareV013ContractMigrationSources(ctx, contractsLock);
+  const migrationCtx = await exportGatewayKmsMigrationEnv(ctx);
+  const { migrationEnv } = migrationCtx;
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeGatewayConfig", "GatewayConfig");
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeKMSGeneration", "KMSGeneration");
+  await ctx.runHostContractTask("npx hardhat task:deployEmptyProxiesProtocolConfigKMSGeneration");
+  await ctx.runHostContractTask("npx hardhat task:deployProtocolConfigFromMigration", { env: migrationEnv });
+  await ctx.runHostContractTask("npx hardhat task:deployKMSGenerationFromMigration", { env: migrationEnv });
+  await ctx.refreshDiscovery();
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeKMSVerifier", "KMSVerifier");
+  await assertKmsMigration(ctx, migrationCtx);
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeHCULimit", "HCULimit");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeFHEVMExecutor", "FHEVMExecutor");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeACL", "ACL");
+  await ctx.refreshDiscovery();
+};
+
+export default async function run(ctx: RolloutRunContext) {
+  const baselineLock = await writePhaseVersionLock(ctx, "00-baseline", phaseVersions.baseline);
+  const contractsLock = await writePhaseVersionLock(ctx, "01-contracts", phaseVersions.contracts);
+  const relayerLock = await writePhaseVersionLock(ctx, "02-relayer", phaseVersions.relayer);
+  const kmsLock = await writePhaseVersionLock(ctx, "03-kms", phaseVersions.kms);
+  const listenerCoreLock = await writePhaseVersionLock(ctx, "04-listener-core", phaseVersions.listenerCore);
+  const coprocessorLock = await writePhaseVersionLock(ctx, "05-coprocessor", phaseVersions.coprocessor);
+
+  logPhase("00 baseline: boot v0.12.5 (two-of-three coprocessors) with the target test-suite harness");
+  await ctx.up({ lockFile: baselineLock, scenario, overrides: [{ group: "test-suite" }] });
+
+  logPhase("00 baseline gate: multi-signer write-path is healthy before the cutover");
+  await ctx.test("rollout-standard", { parallel: false });
+
+  // The cutover is TWO-SIDED: the gateway GatewayConfig governs on-chain tx-sender
+  // consensus, while the host InputVerifier governs the input-proof signature
+  // threshold the relayer-SDK enforces. Both must move to the single Zama signer
+  // or the input path breaks (verified locally).
+  logPhase("cutover (gateway): GatewayConfig.updateCoprocessors([zama], 1) on the v0.12.5 gateway");
+  await runSingleSignerCutover(ctx);
+  logPhase("cutover (host): InputVerifier.defineNewContext([zama], 1) on the host chain");
+  await runHostSingleSignerCutover(ctx);
+
+  logPhase("phase 1 gate: partner-on-v0.12.5, excluded by the single-signer gateway");
+  await ctx.test("single-signer-soak", { parallel: false });
+
+  logPhase("01 contracts: execute the v0.13 migration runbook");
+  await executeV013ContractMigration(ctx, contractsLock);
+  logPhase("02 relayer: upgrade relayer");
+  await ctx.upgradeRuntimeGroup("relayer", { lockFile: relayerLock });
+  logPhase("03 kms: upgrade KMS core and connector together");
+  await ctx.upgradeRuntimeGroup("kms", { lockFile: kmsLock });
+  logPhase("04 listener-core: upgrade listener-core before coprocessor");
+  await ctx.upgradeRuntimeGroup("listener-core", { lockFile: listenerCoreLock });
+  logPhase("05 coprocessor: upgrade coprocessor");
+  await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
+
+  logPhase("phase 2 gate: partner-on-v0.13, still excluded by the single-signer gateway");
+  await ctx.test("single-signer-soak", { parallel: false });
+}

--- a/test-suite/fhevm/rollouts/single-signer-cutover/versions.ts
+++ b/test-suite/fhevm/rollouts/single-signer-cutover/versions.ts
@@ -1,0 +1,5 @@
+// The single-signer-cutover runbook reuses the exact v0.12.5 -> v0.13.0-6 version
+// matrix and the two-of-three coprocessor topology from the v0.12-to-v0.13
+// rollout. It is re-exported (not copied) so the two runbooks can never drift
+// apart on versions, while keeping #2404's files untouched on this experiment.
+export { from, to, phaseVersions, scenario, versionSources } from "../v0.12-to-v0.13/versions";

--- a/test-suite/fhevm/src/commands/single-signer-soak.ts
+++ b/test-suite/fhevm/src/commands/single-signer-soak.ts
@@ -1,0 +1,329 @@
+/**
+ * `single-signer-soak` test profile.
+ *
+ * Asserts the behavior of coprocessors EXCLUDED by a gateway single-signer cutover
+ * (GatewayConfig.updateCoprocessors([zama], 1) + host InputVerifier.defineNewContext).
+ * The excluded partner tx-senders must decode the gateway revert (NotCoprocessorTxSender)
+ * as a non-retryable config error and STOP submitting, while still computing and staying
+ * healthy, and the protocol keeps operating on the single surviving (Zama, index 0) signer.
+ *
+ * Grounding (verified against coprocessor transaction-sender):
+ *   - stop-retry logs: add_ciphertext.rs:108, verify_proof.rs:186
+ *   - terminal DB marker set by stop_retrying_add_ciphertext_on_config_error:
+ *       ciphertext_digest.txn_limited_retries_count := add_ciphertexts_max_retries
+ *       (default i32::MAX = 2147483647)   add_ciphertext.rs:317-336, config.rs:48
+ *     verify_proofs.retry_count is set to verify_proof_resp_max_retries and the row is
+ *     then DELETED (--verify-proof-remove-after-max-retries), so the verify stop is
+ *     asserted via its log line rather than the column.
+ *   - consensus health: e2e/test/consensusWatchdog.ts (auto-enabled when GATEWAY_RPC_URL
+ *     + CIPHERTEXT_COMMITS_ADDRESS are set on the test container)
+ *   - end-to-end decrypt: e2e/scripts/smoke-inputflow.ts
+ *
+ * The low-level test/DB/container helpers below are shared infrastructure that lives in
+ * `./test` (reused by the drift and db-state-revert profiles too); only the
+ * single-signer-specific logic lives here.
+ */
+import { driftDatabaseName, parsePositiveInteger } from "../drift";
+import { PreflightError } from "../errors";
+import { dockerInspect } from "../flow/readiness";
+import { topologyForState } from "../stack-spec/stack-spec";
+import type { State, TestOptions } from "../types";
+import { run, runWithHeartbeat } from "../utils/process";
+import {
+  DB_REVERT_CONTAINERS,
+  assertMatchedTests,
+  buildTestContainerArgs,
+  postgresRuntime,
+  runLogged,
+  runTestsArgs,
+  scalarQuery,
+} from "./test";
+
+const SINGLE_SIGNER_STOP_RETRY_ADD_CIPHERTEXT =
+  "Non-retryable gateway coprocessor config error while adding ciphertext";
+const SINGLE_SIGNER_STOP_RETRY_VERIFY_PROOF =
+  "Non-retryable gateway coprocessor config error while sending verify_proof transaction";
+const ADD_CIPHERTEXT_TERMINAL_RETRY_COUNT = 2147483647; // add_ciphertexts_max_retries default (i32::MAX)
+const SINGLE_SIGNER_SOAK_GREP = "test add 42 to uint64 input and decrypt";
+// The gateway is reachable from inside the test/coprocessor containers on the
+// internal compose network (mirrors the rollout's in-container GATEWAY_RPC_URL).
+const GATEWAY_INTERNAL_RPC_URL = "http://gateway-node:8546";
+// The cutover mutates the on-chain coprocessor set, so this profile is local-only.
+const SINGLE_SIGNER_SOAK_FORBIDDEN_NETWORKS = new Set(["sepolia", "mainnet", "zwsDev"]);
+
+/** Names a coprocessor instance's container by index (index 0 = Zama/primary). */
+const coprocessorContainer = (index: number, suffix: string) =>
+  `${index === 0 ? "coprocessor-" : `coprocessor${index}-`}${suffix}`;
+
+const singleSignerSoakRequirement = (state: State, network: string) => {
+  if (SINGLE_SIGNER_SOAK_FORBIDDEN_NETWORKS.has(network)) {
+    return `single-signer-soak mutates the on-chain coprocessor set; run it only on local disposable environments, not ${network}`;
+  }
+  if (topologyForState(state).count < 2) {
+    return "single-signer-soak requires a multi-coprocessor topology so there is an excluded partner to observe; rerun `fhevm-cli up --scenario two-of-three` first";
+  }
+  return undefined;
+};
+
+/** Polls until every unsent ciphertext digest is parked at the terminal retry count. */
+const waitForAddCiphertextStopRetry = async (opts: {
+  dbName: string;
+  postgres: ReturnType<typeof postgresRuntime>;
+  timeoutSeconds: number;
+  pollIntervalSeconds: number;
+  label: string;
+}) => {
+  const attempts = Math.max(0, Math.ceil(opts.timeoutSeconds / opts.pollIntervalSeconds));
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    const terminal = Number(
+      await scalarQuery(
+        opts.dbName,
+        `SELECT count(*) FROM ciphertext_digest WHERE txn_limited_retries_count = ${ADD_CIPHERTEXT_TERMINAL_RETRY_COUNT}`,
+        opts.postgres,
+      ),
+    );
+    const climbing = Number(
+      await scalarQuery(
+        opts.dbName,
+        `SELECT count(*) FROM ciphertext_digest WHERE txn_is_sent = FALSE AND txn_limited_retries_count <> ${ADD_CIPHERTEXT_TERMINAL_RETRY_COUNT}`,
+        opts.postgres,
+      ),
+    );
+    if (terminal >= 1 && climbing === 0) {
+      return terminal;
+    }
+    await Bun.sleep(opts.pollIntervalSeconds * 1000);
+  }
+  throw new PreflightError(
+    `excluded coprocessor ${opts.label} (${opts.dbName}) did not park its unsent ciphertext digests at the terminal retry count within ${opts.timeoutSeconds}s`,
+  );
+};
+
+/** Reads one prometheus gauge from a coprocessor container's metrics endpoint. */
+const scrapeCoprocessorMetric = async (container: string, metric: string): Promise<number | undefined> => {
+  // Port 9100 (transaction_sender metrics_addr) is not host-published, so scrape
+  // from inside the container; tolerate the image lacking wget/curl.
+  const result = await run(
+    [
+      "docker",
+      "exec",
+      container,
+      "sh",
+      "-c",
+      "wget -qO- localhost:9100/metrics 2>/dev/null || curl -s localhost:9100/metrics 2>/dev/null || true",
+    ],
+    { allowFailure: true },
+  );
+  const line = result.stdout.split("\n").find((entry) => entry.startsWith(metric) && !entry.startsWith("#"));
+  if (!line) {
+    return undefined;
+  }
+  const value = Number(line.trim().split(/\s+/).pop());
+  return Number.isFinite(value) ? value : undefined;
+};
+
+/** Advisory: assert unsent work plateaus when the metrics endpoint is reachable. */
+const assertUnsentGaugePlateausBestEffort = async (container: string, pollIntervalSeconds: number) => {
+  const gauge = "coprocessor_add_ciphertext_material_unsent_gauge";
+  const first = await scrapeCoprocessorMetric(container, gauge);
+  if (first === undefined) {
+    console.log(`[single-signer-soak] ${container}: metrics endpoint unreachable from inside the container; skipping plateau check`);
+    return;
+  }
+  await Bun.sleep(pollIntervalSeconds * 1000);
+  const second = await scrapeCoprocessorMetric(container, gauge);
+  if (second === undefined) {
+    return;
+  }
+  if (second > first) {
+    throw new PreflightError(
+      `excluded coprocessor ${container} ${gauge} is still growing (${first} -> ${second}); unsent work is not plateauing`,
+    );
+  }
+  console.log(`[single-signer-soak] ${container} ${gauge} plateaued at ${second}`);
+};
+
+/** Reads a container's cumulative restart count (crash-loop signal). */
+const readRestartCount = async (container: string): Promise<number> => {
+  const result = await run(["docker", "inspect", "-f", "{{.RestartCount}}", container], { allowFailure: true });
+  const count = Number(result.stdout.trim());
+  return Number.isFinite(count) ? count : 0;
+};
+
+/**
+ * Asserts an excluded coprocessor instance degraded GRACEFULLY: every runtime
+ * container is still running and healthy, and none restarted during the soak.
+ * Stopping retries must not mean crashing.
+ */
+const assertExcludedCoprocessorAlive = async (index: number, restartBaseline: Map<string, number>) => {
+  for (const suffix of DB_REVERT_CONTAINERS) {
+    const container = coprocessorContainer(index, suffix);
+    const [inspect] = await dockerInspect(container);
+    if (!inspect) {
+      throw new PreflightError(`excluded coprocessor container ${container} is missing; it did not stay up`);
+    }
+    if (inspect.State.Status !== "running") {
+      throw new PreflightError(
+        `excluded coprocessor container ${container} is ${inspect.State.Status}, not running; it did not degrade gracefully`,
+      );
+    }
+    const health = inspect.State.Health?.Status;
+    if (health && health !== "healthy") {
+      throw new PreflightError(`excluded coprocessor container ${container} reports health=${health}`);
+    }
+    const restarts = await readRestartCount(container);
+    const baseline = restartBaseline.get(container) ?? 0;
+    if (restarts > baseline) {
+      throw new PreflightError(
+        `excluded coprocessor container ${container} restarted ${restarts - baseline} time(s) during the soak (crash-looping?); baseline=${baseline} now=${restarts}`,
+      );
+    }
+  }
+};
+
+/**
+ * Asserts an excluded coprocessor KEEPS COMPUTING — not just "process alive".
+ * Stopping on-chain submission must not stop local FHE compute: its compute tables
+ * must keep pace with the surviving signer (index 0). This is the substantive half of
+ * "stay healthy" — the excluded coprocessor still ingests host events, computes
+ * ciphertexts, and produces digests; only the tx-sender submission stops.
+ */
+const assertExcludedCoprocessorComputing = async (opts: {
+  index: number;
+  postgres: ReturnType<typeof postgresRuntime>;
+  timeoutSeconds: number;
+  pollIntervalSeconds: number;
+}) => {
+  const referenceDb = driftDatabaseName(0); // index 0 = surviving Zama coprocessor
+  const excludedDb = driftDatabaseName(opts.index);
+  const count = (db: string, table: string) => scalarQuery(db, `SELECT count(*) FROM ${table}`, opts.postgres);
+  // Traffic has ended by the time this runs (post stop-retry settle), so the
+  // reference counts are stable.
+  const referenceComputations = Number(await count(referenceDb, "computations"));
+  const referenceDigests = Number(await count(referenceDb, "ciphertext_digest"));
+  const attempts = Math.max(0, Math.ceil(opts.timeoutSeconds / opts.pollIntervalSeconds));
+  for (let attempt = 0; attempt <= attempts; attempt += 1) {
+    const computations = Number(await count(excludedDb, "computations"));
+    const digests = Number(await count(excludedDb, "ciphertext_digest"));
+    if (computations > 0 && computations >= referenceComputations && digests >= referenceDigests) {
+      console.log(
+        `[single-signer-soak] coprocessor${opts.index} keeps computing: computations=${computations} digests=${digests} (surviving-signer reference computations=${referenceComputations})`,
+      );
+      return;
+    }
+    await Bun.sleep(opts.pollIntervalSeconds * 1000);
+  }
+  throw new PreflightError(
+    `excluded coprocessor${opts.index} (${excludedDb}) is not keeping pace with FHE compute (expected >= ${referenceComputations} computations, like the surviving signer); it may have stopped computing, not just stopped submitting`,
+  );
+};
+
+/** Runs the single-signer soak: excluded coprocessors stop submitting, keep computing, stay healthy. */
+export const runSingleSignerSoak = async (state: State, options: TestOptions) => {
+  if (!state.discovery) {
+    throw new PreflightError("Stack is not running; run `fhevm-cli up` first");
+  }
+  const liveState = state;
+  const precondition = singleSignerSoakRequirement(liveState, options.network);
+  if (precondition) {
+    throw new PreflightError(precondition);
+  }
+  const started = Date.now();
+  return runLogged("single-signer-soak", started, async () => {
+    const topology = topologyForState(liveState);
+    // Index 0 is the surviving Zama coprocessor; 1..n-1 were excluded by the cutover.
+    const excludedIndices = Array.from({ length: topology.count - 1 }, (_, index) => index + 1);
+    const postgres = postgresRuntime();
+    const logSince = new Date().toISOString();
+    const ciphertextCommitsAddress = liveState.discovery!.gateway.CIPHERTEXT_COMMITS_ADDRESS;
+    const inputVerificationAddress = liveState.discovery!.gateway.INPUT_VERIFICATION_ADDRESS;
+    if (!ciphertextCommitsAddress) {
+      throw new PreflightError("single-signer-soak needs CIPHERTEXT_COMMITS_ADDRESS discovery; rerun `fhevm-cli up`");
+    }
+    const grep = process.env.GREP_PATTERN ?? SINGLE_SIGNER_SOAK_GREP;
+    const settleTimeoutSeconds = parsePositiveInteger(
+      process.env.SINGLE_SIGNER_SOAK_SETTLE_TIMEOUT_SECONDS ?? "240",
+      "SINGLE_SIGNER_SOAK_SETTLE_TIMEOUT_SECONDS",
+    );
+    const settlePollIntervalSeconds = parsePositiveInteger(
+      process.env.SINGLE_SIGNER_SOAK_POLL_INTERVAL_SECONDS ?? "5",
+      "SINGLE_SIGNER_SOAK_POLL_INTERVAL_SECONDS",
+    );
+
+    // Snapshot restart counts up front so we can prove the excluded coprocessors
+    // do not crash-loop on the rejected submissions during the soak window.
+    const restartBaseline = new Map<string, number>();
+    for (const index of excludedIndices) {
+      for (const suffix of DB_REVERT_CONTAINERS) {
+        const container = coprocessorContainer(index, suffix);
+        restartBaseline.set(container, await readRestartCount(container));
+      }
+    }
+
+    // 1. Drive write-path traffic (input proof -> ciphertext add + proof verify ->
+    //    decrypt) with the consensus watchdog enabled. This exercises the surviving
+    //    Zama signer end-to-end (the watchdog's afterEach/afterAll assert consensus
+    //    is still reached and never diverges or stalls) and generates the work the
+    //    excluded coprocessors will try, and fail, to submit.
+    const watchdogEnv = [
+      "-e",
+      `GATEWAY_RPC_URL=${GATEWAY_INTERNAL_RPC_URL}`,
+      "-e",
+      `CIPHERTEXT_COMMITS_ADDRESS=${ciphertextCommitsAddress}`,
+      ...(inputVerificationAddress ? ["-e", `INPUT_VERIFICATION_ADDRESS=${inputVerificationAddress}`] : []),
+    ];
+    const e2e = await runWithHeartbeat(
+      buildTestContainerArgs(runTestsArgs({ ...options, parallel: false, grep }), watchdogEnv),
+      "single-signer-soak write-path + consensus watchdog",
+    );
+    assertMatchedTests(e2e.stdout + e2e.stderr, "single-signer-soak write-path");
+
+    // 2. End-to-end smoke: input -> encrypt -> tx -> user + public decrypt == 49.
+    await runWithHeartbeat(
+      buildTestContainerArgs(["npx", "hardhat", "run", "scripts/smoke-inputflow.ts", "--network", options.network]),
+      "single-signer-soak smoke-inputflow",
+    );
+
+    // 3. Every excluded coprocessor must STOP retrying: terminal DB marker + log line.
+    for (const index of excludedIndices) {
+      const dbName = driftDatabaseName(index);
+      const txSender = coprocessorContainer(index, "transaction-sender");
+
+      await waitForAddCiphertextStopRetry({
+        dbName,
+        postgres,
+        timeoutSeconds: settleTimeoutSeconds,
+        pollIntervalSeconds: settlePollIntervalSeconds,
+        label: txSender,
+      });
+
+      const logs = await run(["docker", "logs", "--since", logSince, txSender], { allowFailure: true });
+      const logText = `${logs.stdout}${logs.stderr}`;
+      if (!logText.includes(SINGLE_SIGNER_STOP_RETRY_ADD_CIPHERTEXT)) {
+        throw new PreflightError(
+          `excluded coprocessor ${txSender} never logged the non-retryable add-ciphertext stop line; it may still be retrying`,
+        );
+      }
+      if (!logText.includes(SINGLE_SIGNER_STOP_RETRY_VERIFY_PROOF)) {
+        // Proof-verify traffic can lag ciphertext-add; the deterministic
+        // add-ciphertext signal above stays the gate.
+        console.log(`[single-signer-soak] ${txSender}: verify_proof stop line not seen yet (proof traffic may lag)`);
+      }
+
+      await assertUnsentGaugePlateausBestEffort(txSender, settlePollIntervalSeconds);
+
+      // The excluded instance must have degraded gracefully — still up, no crash-loop...
+      await assertExcludedCoprocessorAlive(index, restartBaseline);
+      // ...and must KEEP COMPUTING — only submission stops, not FHE compute.
+      await assertExcludedCoprocessorComputing({
+        index,
+        postgres,
+        timeoutSeconds: settleTimeoutSeconds,
+        pollIntervalSeconds: settlePollIntervalSeconds,
+      });
+    }
+    console.log(
+      `[single-signer-soak] ${excludedIndices.length} excluded coprocessor(s) stopped submitting but kept computing and stayed healthy; Zama signer consensus healthy`,
+    );
+  });
+};

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -10,6 +10,7 @@ import { hostReachableRpcUrl } from "../utils/fs";
 import { run, runWithHeartbeat } from "../utils/process";
 import { loadState } from "../state/state";
 import { topologyForState } from "../stack-spec/stack-spec";
+import { runSingleSignerSoak } from "./single-signer-soak";
 import {
   COPROCESSOR_DB_CONTAINER,
   DEFAULT_CHAIN_ID,
@@ -29,7 +30,7 @@ import type { State, TestOptions } from "../types";
 
 const DRIFT_WARNING = '"message":"Drift detected: observed multiple digest variants for handle"';
 const DRIFT_HANDLE = /"handle":"0x([0-9a-f]+)"/i;
-const DB_REVERT_CONTAINERS = [
+export const DB_REVERT_CONTAINERS = [
   "host-listener",
   "host-listener-poller",
   "gw-listener",
@@ -56,6 +57,7 @@ const TEST_PROFILE_NAMES = [
   "heavy",
   "light",
   "rollout-standard",
+  "single-signer-soak",
   "standard",
 ].sort();
 const ZERO_TESTS_RE = /\b0 passing\b/;
@@ -91,6 +93,8 @@ const TEST_PROFILE_DESCRIPTIONS: Partial<Record<(typeof TEST_PROFILE_NAMES)[numb
   "ciphertext-drift-auto-recovery":
     "Run ciphertext drift auto-recovery checks — services self-recover (requires 2+ coprocessors).",
   "coprocessor-db-state-revert": "Run coprocessor DB state revert checks.",
+  "single-signer-soak":
+    "Assert coprocessors excluded by a gateway single-signer cutover stop retrying while the Zama signer stays healthy (requires 2+ coprocessors).",
 };
 
 /** Validates whether a named profile supports an extra grep narrowing expression. */
@@ -132,7 +136,7 @@ const ciphertextDriftNetworkRequirement = (network: string) =>
     : undefined;
 
 /** Logs pass/fail timing around one test task. */
-const runLogged = async <T>(label: string, started: number, task: () => Promise<T>) => {
+export const runLogged = async <T>(label: string, started: number, task: () => Promise<T>) => {
   try {
     const result = await task();
     console.log(`[pass] ${timedLabel(label, started)}`);
@@ -398,7 +402,7 @@ export const buildTestContainerArgs = (tail: string[], extraExecArgs: string[] =
 ];
 
 /** Builds the run-tests.sh argv for the current CLI options. */
-const runTestsArgs = (
+export const runTestsArgs = (
   options: Pick<TestOptions, "network" | "verbose" | "parallel" | "noHardhatCompile"> & { grep: string },
 ) => [
   "./run-tests.sh",
@@ -417,7 +421,7 @@ const runTestsCommand = (
 ) => runTestsArgs(options).map(shellEscape).join(" ");
 
 /** Runs a narrow e2e grep inside the test-suite container. */
-const assertMatchedTests = (output: string, label: string) => {
+export const assertMatchedTests = (output: string, label: string) => {
   if (ZERO_TESTS_RE.test(output) && !SOME_PENDING_RE.test(output)) {
     throw new PreflightError(`${label} matched zero tests`);
   }
@@ -504,7 +508,7 @@ const setContainersRunning = async (containers: string[], action: "start" | "sto
 };
 
 /** Reads a one-line postgres query result as trimmed text. */
-const scalarQuery = async (
+export const scalarQuery = async (
   dbName: string,
   sql: string,
   options: {
@@ -514,7 +518,7 @@ const scalarQuery = async (
   },
 ) => psql(dbName, ["-t", "-A", "-c", sql], options);
 
-const postgresRuntime = () => ({
+export const postgresRuntime = () => ({
   postgresContainer: process.env.POSTGRES_CONTAINER ?? COPROCESSOR_DB_CONTAINER,
   postgresUser: process.env.POSTGRES_USER ?? DEFAULT_POSTGRES_USER,
   postgresPassword: process.env.POSTGRES_PASSWORD ?? DEFAULT_POSTGRES_PASSWORD,
@@ -647,6 +651,7 @@ const localDbMigrationImageRef = (state: Pick<State, "overrides" | "builtImages"
   state.overrides.some((override) => override.group === "coprocessor")
     ? state.builtImages?.find((image) => image.group === "coprocessor" && image.ref.includes("/coprocessor/db-migration:"))?.ref
     : undefined;
+
 
 /** Runs the coprocessor DB state revert e2e flow against the active stack. */
 const runDbStateRevert = async (
@@ -833,6 +838,9 @@ export const test = async (testName: string | undefined, options: TestOptions) =
   const runProfile = async (name: string) => {
     if (name === "coprocessor-db-state-revert") {
       return runDbStateRevert(state, options);
+    }
+    if (name === "single-signer-soak") {
+      return runSingleSignerSoak(state, options);
     }
     if (name === "ciphertext-drift") {
       console.log("[test] ciphertext-drift");


### PR DESCRIPTION
> **Draft for review.** Reproduces the [Devnet Coprocessor Single Signer scenario](https://www.notion.so/zamaai/Devnet-Coprocessor-Single-Signer-scenario-36d5a7358d5e809c8807c02cf58e6c03) locally via the stateful-rollout harness (#2404, now on `main`) instead of on devnet.

## What this adds
- `test-suite/fhevm/rollouts/single-signer-cutover/run.ts` — runbook:
  boot two-of-three v0.12.5 → baseline gate → **two-sided cutover** → phase-1 soak → v0.13 migration → phase-2 soak.
- `test-suite/fhevm/rollouts/single-signer-cutover/versions.ts` — re-exports the v0.12.5→v0.13.0-6 matrix from the sibling rollout.
- `test-suite/fhevm/src/commands/test.ts` — new `single-signer-soak` test profile.

## The cutover is two-sided (key finding)
A gateway-only `GatewayConfig.updateCoprocessors([zama],1)` is **not** sufficient: the relayer-SDK verifies input proofs against the **host** `InputVerifier` (`getThreshold()`/`getCoprocessorSigners()`), not `GatewayConfig`. Leaving the host at the old threshold breaks the input path with `RelayerThresholdCoprocessorSignerError: threshold is not reached`. The runbook therefore cuts over **both**:
- gateway: `GatewayConfig.updateCoprocessors([zama], 1)` (via the deployer/owner key)
- host: `InputVerifier.defineNewContext([zama], 1)` (`onlyACLOwner`)

Both are driven through `ctx.runGatewayContractTask` / `ctx.runHostContractTask` with an inline `npx hardhat run` script (minimal human-readable ABI, no new task/foundry/ethers dependency; runs against the baked image's hardhat+ethers).

## `single-signer-soak` asserts, per excluded coprocessor
1. **Stops submitting** — `ciphertext_digest.txn_limited_retries_count` reaches terminal (`i32::MAX`) + the non-retryable stop-retry log line.
2. **Keeps computing** — its compute tables (`computations`/`ciphertext_digest`) keep pace with the surviving Zama signer (compute continues; only submission stops).
3. **Stays up** — containers running, healthy, no restarts during the soak.

Plus protocol health on the lone signer: a write-path e2e with the `consensusWatchdog` enabled, and `smoke-inputflow` end-to-end.

## Local validation
Ran the full runbook **from scratch** against a local stack (`fhevm-cli rollout run rollouts/single-signer-cutover/run.ts`): boot → baseline gate → two-sided cutover (gateway 3→1, host 3/thr-2 → 1/thr-1) → phase-1 soak **pass** → full v0.13 migration → phase-2 soak **pass**. 0 failures, exit 0. `tsc --noEmit` clean; `bun test src` 169/169.

## For the reviewer
- **Migration duplication.** The v0.13 contract-migration sequence in `run.ts` is duplicated from `rollouts/v0.12-to-v0.13/run.ts` (kept local during the experiment). Now that #2404 is merged, extracting a shared module imported by both runbooks is a sensible follow-up — happy to do it here or separately.
- **Metrics plateau is advisory.** The tx-sender `:9100` metrics endpoint isn't host-published, so the unsent-gauge plateau check is best-effort (self-skips if unreachable); the deterministic DB + log + liveness gates carry the assertion.
- **S3 drift not checked locally.** Local coprocs share one content-addressed minio bucket, so the devnet runbook's per-coproc cross-bucket drift check isn't reproducible here; per-coproc compute is asserted via the in-DB `ciphertexts128` instead.

## CI
Auto-discovered by `.github/workflows/test-suite-stateful-rollout.yml` (one new `rollouts/<dir>/run.ts` per PR, label-gated). I have **not** added the rollout label — add it when you want CI to run the full multi-coproc rollout.
