### PR TITLE
feat(charts/contracts): scJobs list with per-job rendering

### DIFF
--- a/charts/contracts/Chart.yaml
+++ b/charts/contracts/Chart.yaml
@@ -1,6 +1,6 @@
 name: contracts
 description: A helm chart to manage fhevm Smart Contracts Deployment
-version: 0.9.0
+version: 1.0.0
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/contracts/Chart.yaml
+++ b/charts/contracts/Chart.yaml
@@ -1,6 +1,6 @@
 name: contracts
 description: A helm chart to manage fhevm Smart Contracts Deployment
-version: 0.8.2
+version: 0.9.0
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/contracts/README.md
+++ b/charts/contracts/README.md
@@ -22,13 +22,17 @@ Each entry renders to a `Job` named `<release>-<kind>-<name>-<tagSlug>`. Jobs
 share a single PVC (`/app/addresses`) so the OpenZeppelin `.openzeppelin/`
 manifest persists across runs.
 
-After commands finish, the runner script parses `addresses/.env.*` files and
-patches the addresses ConfigMap:
+After commands finish, the runner script parses the entry's `envFile` (a path
+or glob, default `addresses/.env.*`) and patches the addresses ConfigMap:
 
 - `<contract>.address`: written once, never overwritten (proxy addresses are
   immutable across upgrades).
 - `<contract>.version`: overwritten with the Job's `image.tag` for `deploy`
   and `upgrade` kinds only.
+
+If jobs for different contract families share a PVC, set `envFile` to the file
+each image family writes (`addresses/.env.host`, `addresses/.env.gateway`, …)
+so a job never re-stamps another family's `.version` keys with its own tag.
 
 ## Job kinds
 
@@ -66,8 +70,10 @@ ArgoCD considerations:
 
 ## Debugging
 
-Set `scDebug.enabled: true` to spawn a long-running pod with the contracts
-image and the deploy PVC mounted. Use `scDebug.mountMode`:
+Set `scDebug.enabled: true` to spawn a long-running pod with the deploy PVC
+mounted. The pod reuses the image, env, `oldImage` and persistence settings of
+the last enabled `scJobs` entry, so at least one entry is required. Use
+`scDebug.mountMode`:
 
 - `readOnly` (default): live view of the PVC, no write access.
 - `readWrite`: direct read-write mount; reserve for manually fixing PVC contents.
@@ -80,9 +86,3 @@ Exec into the scDebug pod to troubleshoot the contract deployment environment:
 ```bash
 kubectl exec -it sc-deploy-0 -- sh
  ```
-
-## Backward compatibility
-
-Legacy `scDeploy.deployCommands` / `scUpgrade.upgradeCommands` still work,
-synthesized into a single `default` entry (upgrade wins over deploy). Prefer
-`scJobs:` for new configs.

--- a/charts/contracts/README.md
+++ b/charts/contracts/README.md
@@ -1,0 +1,84 @@
+# Contracts Helm Chart
+
+Runs FHEVM smart-contract deployment, upgrade and one-off operational tasks as
+Kubernetes Jobs.
+
+## How it works
+
+Declare each Job as an entry in `scJobs:`:
+
+```yaml
+scJobs:
+  - name: protocol-payment
+    kind: deploy
+    image: { name: ghcr.io/zama-ai/fhevm/gateway-contracts, tag: v0.10.0 }
+    env:
+      - { name: DEPLOYER_PRIVATE_KEY, value: "" }
+    commands:
+      - npx hardhat task:deploySingleContract --name ProtocolPayment
+```
+
+Each entry renders to a `Job` named `<release>-<kind>-<name>-<tagSlug>`. Jobs
+share a single PVC (`/app/addresses`) so the OpenZeppelin `.openzeppelin/`
+manifest persists across runs.
+
+After commands finish, the runner script parses `addresses/.env.*` files and
+patches the addresses ConfigMap:
+
+- `<contract>.address`: written once, never overwritten (proxy addresses are
+  immutable across upgrades).
+- `<contract>.version`: overwritten with the Job's `image.tag` for `deploy`
+  and `upgrade` kinds only.
+
+## Job kinds
+
+| kind      | When to use                                        | 
+|-----------|----------------------------------------------------|
+| `deploy`  | First-time contract deployment                     | 
+| `upgrade` | OpenZeppelin proxy upgrade to a new implementation | 
+| `task`    | One-off operation                                  | 
+
+## Re-run safety
+
+Driven by Job-name uniqueness + the persistent PVC:
+
+- `deploy` / `upgrade`: idempotent in practice. OpenZeppelin reads the existing
+  proxy from the persisted `.openzeppelin/` manifest and skips redeploy.
+- `task`: not idempotent at the chart level. Re-running an ownership transfer
+  or a keygen has on-chain side effects. Don't delete a completed task Job
+  unless you've confirmed it's safe to replay; the live Job acts as its own
+  marker for ArgoCD reconciliation.
+
+ArgoCD considerations:
+
+- Do not delete completed Jobs. With unique per-tag names, the live Job's spec
+  matches the desired spec on every sync, so ArgoCD takes no action. The
+  completed Job is its own sentinel against re-execution.
+- All Jobs are rendered with
+  `argocd.argoproj.io/sync-options: Prune=false` so removing an entry from
+  `scJobs` keeps the historical Job in the cluster. Note: this only protects
+  against source-driven deletion. A manual `kubectl delete job …` will still
+  be re-applied by the next sync.
+
+## Debugging
+
+Set `scDebug.enabled: true` to spawn a long-running pod with the contracts
+image and the deploy PVC mounted. Use `scDebug.mountMode`:
+
+- `readOnly` (default): live view of the PVC, no write access.
+- `readWrite`: direct read-write mount; reserve for manually fixing PVC contents.
+
+Both modes share the PVC's node-level `ReadWriteOnce` lock with running Jobs;
+a Job scheduled to a different node will wait until the debug pod is gone.
+
+Exec into the scDebug pod to troubleshoot the contract deployment environment:
+
+```bash
+kubectl exec -it sc-deploy-0 -- sh
+ ```
+
+## Backward compatibility
+
+Legacy `scDeploy.deployCommands` / `scUpgrade.upgradeCommands` still work,
+synthesized into a single `default` entry (upgrade wins over deploy). Prefer
+`scJobs:` for new configs.

--- a/charts/contracts/README.md
+++ b/charts/contracts/README.md
@@ -59,6 +59,10 @@ ArgoCD considerations:
   `scJobs` keeps the historical Job in the cluster. Note: this only protects
   against source-driven deletion. A manual `kubectl delete job …` will still
   be re-applied by the next sync.
+- Jobs are also rendered with `argocd.argoproj.io/sync-wave: <index>` derived
+  from their position in `scJobs`. ArgoCD applies each wave and waits for the
+  Job to Succeed before starting the next, giving sequential execution within
+  a sync.
 
 ## Debugging
 

--- a/charts/contracts/templates/_helpers.tpl
+++ b/charts/contracts/templates/_helpers.tpl
@@ -13,8 +13,8 @@
 
 {{- /*
   scAllJobs: consolidated Job list emitted as YAML; consumers parse via
-  fromYamlArray. Legacy scDeploy / scUpgrade get synthesized into entries
-  for back-compat, then any explicit .Values.scJobs entries are appended.
+  fromYamlArray. Entries come from .Values.scJobs, skipping any with
+  enabled: false (default true if omitted).
 
   Job entry schema:
     enabled:         bool, default true; set to false to skip the entry
@@ -24,40 +24,22 @@
     oldImage:        { name, tag } source for old contracts (kind=upgrade)
     env:             list of env entries
     commands:        shell commands run in order
-    verifyContracts: bool (deploy only)
+    envFile:         path or glob of address env files to record after the
+                     commands, default "addresses/.env.*"; set it to the file
+                     the job's image family writes (e.g. addresses/.env.host)
+                     so jobs sharing a PVC never re-stamp each other's keys
+    configmap:       { name } overrides the global configmap.name for this job
+    persistence:     merged over the global persistence block for this job
+                     (enabled, mountPath, volumeClaim.name)
 */ -}}
 {{- define "scAllJobs" -}}
 {{- $jobs := list -}}
-{{- if .Values.scUpgrade.enabled -}}
-{{- $jobs = append $jobs (dict
-  "name" "default"
-  "kind" "upgrade"
-  "image" .Values.scDeploy.image
-  "oldImage" .Values.scUpgrade.oldContracts.image
-  "env" (.Values.scDeploy.env | default list)
-  "commands" (.Values.scUpgrade.upgradeCommands | default list)
-) -}}
-{{- else if .Values.scDeploy.enabled -}}
-{{- $jobs = append $jobs (dict
-  "name" "default"
-  "kind" "deploy"
-  "image" .Values.scDeploy.image
-  "env" (.Values.scDeploy.env | default list)
-  "commands" (.Values.scDeploy.deployCommands | default list)
-  "verifyContracts" (.Values.scDeploy.verifyContracts | default false)
-) -}}
-{{- end -}}
-{{- range (.Values.scJobs | default list) -}}
-{{- $jobs = append $jobs . -}}
-{{- end -}}
-{{- /* Filter out entries with enabled: false (default true if omitted) */ -}}
-{{- $filtered := list -}}
-{{- range $j := $jobs -}}
+{{- range $j := (.Values.scJobs | default list) -}}
 {{-   $enabled := true -}}
 {{-   if hasKey $j "enabled" -}}{{- $enabled = $j.enabled -}}{{- end -}}
-{{-   if $enabled -}}{{- $filtered = append $filtered $j -}}{{- end -}}
+{{-   if $enabled -}}{{- $jobs = append $jobs $j -}}{{- end -}}
 {{- end -}}
-{{- $filtered | toYaml -}}
+{{- $jobs | toYaml -}}
 {{- end -}}
 
 {{- /* Job resource name: <release>-<kind>-<name>-<tagSlug>, capped at 63 chars */ -}}

--- a/charts/contracts/templates/_helpers.tpl
+++ b/charts/contracts/templates/_helpers.tpl
@@ -2,13 +2,76 @@
 {{- default .Release.Name .Values.persistence.volumeClaim.name }}
 {{- end -}}
 
-{{- define "scDeployJobName" -}}
-{{- $scDeployJobNameDefault := printf "%s-%s" .Release.Name "deploy" }}
-{{- printf "%s-%s" (default $scDeployJobNameDefault .Values.scDeploy.nameOverride) (.Chart.AppVersion | replace "." "-") | trunc 63 | trimSuffix "-" -}}
+{{- /*
+  scSlug: lowercase, DNS-1123-safe fragment. Image tags like "v0.13.0"
+  become "v0-13-0", which is appended to Job and ConfigMap key names so
+  each (kind, name, tag) combination yields a unique, immutable resource.
+*/ -}}
+{{- define "scSlug" -}}
+{{- regexReplaceAll "[^a-z0-9]+" (lower .) "-" | trimAll "-" -}}
+{{- end -}}
+
+{{- /*
+  scAllJobs: consolidated Job list emitted as YAML; consumers parse via
+  fromYamlArray. Legacy scDeploy / scUpgrade get synthesized into entries
+  for back-compat, then any explicit .Values.scJobs entries are appended.
+
+  Job entry schema:
+    enabled:         bool, default true; set to false to skip the entry
+    name:            short identifier (slug)
+    kind:            deploy | upgrade | task
+    image:           { name, tag } container image
+    oldImage:        { name, tag } source for old contracts (kind=upgrade)
+    env:             list of env entries
+    commands:        shell commands run in order
+    verifyContracts: bool (deploy only)
+*/ -}}
+{{- define "scAllJobs" -}}
+{{- $jobs := list -}}
+{{- if .Values.scUpgrade.enabled -}}
+{{- $jobs = append $jobs (dict
+  "name" "default"
+  "kind" "upgrade"
+  "image" .Values.scDeploy.image
+  "oldImage" .Values.scUpgrade.oldContracts.image
+  "env" (.Values.scDeploy.env | default list)
+  "commands" (.Values.scUpgrade.upgradeCommands | default list)
+) -}}
+{{- else if .Values.scDeploy.enabled -}}
+{{- $jobs = append $jobs (dict
+  "name" "default"
+  "kind" "deploy"
+  "image" .Values.scDeploy.image
+  "env" (.Values.scDeploy.env | default list)
+  "commands" (.Values.scDeploy.deployCommands | default list)
+  "verifyContracts" (.Values.scDeploy.verifyContracts | default false)
+) -}}
+{{- end -}}
+{{- range (.Values.scJobs | default list) -}}
+{{- $jobs = append $jobs . -}}
+{{- end -}}
+{{- /* Filter out entries with enabled: false (default true if omitted) */ -}}
+{{- $filtered := list -}}
+{{- range $j := $jobs -}}
+{{-   $enabled := true -}}
+{{-   if hasKey $j "enabled" -}}{{- $enabled = $j.enabled -}}{{- end -}}
+{{-   if $enabled -}}{{- $filtered = append $filtered $j -}}{{- end -}}
+{{- end -}}
+{{- $filtered | toYaml -}}
+{{- end -}}
+
+{{- /* Job resource name: <release>-<kind>-<name>-<tagSlug>, capped at 63 chars */ -}}
+{{- define "scJobResourceName" -}}
+{{- $tagSlug := include "scSlug" .job.image.tag -}}
+{{- printf "%s-%s-%s-%s" .ctx.Release.Name .job.kind .job.name $tagSlug | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- /* ConfigMap key for the per-job runner script */ -}}
+{{- define "scJobScriptKey" -}}
+{{- printf "run-%s-%s-%s.sh" .job.kind .job.name (include "scSlug" .job.image.tag) -}}
 {{- end -}}
 
 {{- define "scDebugStatefulSetName" -}}
 {{- $scDebugStatefulSetNameDefault := printf "%s-%s" .Release.Name "debug" }}
 {{- default $scDebugStatefulSetNameDefault .Values.scDebug.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-

--- a/charts/contracts/templates/sc-deploy-config.yaml
+++ b/charts/contracts/templates/sc-deploy-config.yaml
@@ -20,7 +20,7 @@ data:
       if ! kubectl get configmap "${cm}" >/dev/null 2>&1; then
         kubectl create configmap "${cm}"
       fi
-      {{- range $k, $v := $.Values.scDeploy.configmap.annotations }}
+      {{- range $k, $v := $.Values.configmap.annotations }}
       kubectl annotate --overwrite configmap "${cm}" {{ $k }}={{ $v | quote }}
       {{- end }}
     }
@@ -41,7 +41,7 @@ data:
       kubectl patch configmap "${cm}" -p="{\"data\": {\"${name}\": \"${value}\"}}"
     }
 
-    CONFIGMAP_NAME="{{ $.Values.scDeploy.configmap.name }}"
+    CONFIGMAP_NAME="{{ (default dict $job.configmap).name | default $.Values.configmap.name }}"
     JOB_KIND="{{ $job.kind }}"
     JOB_VERSION="{{ $job.image.tag }}"
 
@@ -53,7 +53,7 @@ data:
     {{ . | nindent 4 }}
     {{- end }}
 
-    for envfile in addresses/.env.*; do
+    for envfile in {{ $job.envFile | default "addresses/.env.*" }}; do
       echo "---"
       echo "Updating ${CONFIGMAP_NAME} from ${envfile}"
       while IFS= read -r line || [[ -n "$line" ]]; do
@@ -67,9 +67,5 @@ data:
         fi
       done < "${envfile}"
     done
-
-    {{- if and (eq $job.kind "deploy") (default false $job.verifyContracts) }}
-    npx --no-install hardhat verify:verify || true
-    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/contracts/templates/sc-deploy-config.yaml
+++ b/charts/contracts/templates/sc-deploy-config.yaml
@@ -1,3 +1,5 @@
+{{- $jobs := fromYamlArray (include "scAllJobs" .) -}}
+{{- if gt (len $jobs) 0 }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,121 +8,68 @@ metadata:
     app.kubernetes.io/name: {{ .Release.Name }}-config
   name: {{ .Release.Name }}-config
 data:
-  deploy-contracts.sh: |
+{{- range $job := $jobs }}
+{{- $scriptKey := include "scJobScriptKey" (dict "job" $job) }}
+  {{ $scriptKey }}: |
     #!/bin/bash
     set -eo pipefail
-    
+    shopt -s nullglob
+
     create_configmap() {
-      configmap_name="${1}"
-      if [[ -z "$configmap_name" ]]; then
-        echo "error: you must supply a configmap name" 1>&2
-        exit 1
+      local cm="$1"
+      if ! kubectl get configmap "${cm}" >/dev/null 2>&1; then
+        kubectl create configmap "${cm}"
       fi
-      if ! kubectl get configmap ${configmap_name}; then
-        kubectl create configmap ${configmap_name}
-      else
-        echo "skipping: configmap ${configmap_name} already exists" 2>&1
-      fi
-      {{- range $annotationKey, $annotationValue := $.Values.scDeploy.configmap.annotations }}
-      kubectl annotate --overwrite configmap "${configmap_name}" {{ $annotationKey }}={{ $annotationValue | quote }}
+      {{- range $k, $v := $.Values.scDeploy.configmap.annotations }}
+      kubectl annotate --overwrite configmap "${cm}" {{ $k }}={{ $v | quote }}
       {{- end }}
     }
+    # Set key only if missing (used for contract addresses, which must not change on upgrade)
     add_key_to_configmap() {
-      configmap_name="${1}"
-      name="${2}"
-      value="${3}"
-      if [[ -z "$configmap_name" ]]; then
-        echo "error: you must supply a configmap name" 1>&2
-        exit 1
-      fi
-      if [[ -z "$name" ]]; then
-        echo "error: you must supply an item name" 1>&2
-        exit 1
-      fi
-      if [[ -z "$value" ]]; then
-        echo "error: you must supply an item value" 1>&2
-        exit 1
-      fi
-      # Patch configmap to add key if it doesn't already exists
-      configmap_value=$(kubectl get configmap "${configmap_name}" -o jsonpath="{.data['${name//./\\.}']}")
-      if [[ -n "${configmap_value}" ]]; then
-        echo "skipping: ${configmap_name} already contains ${name}:${configmap_value}"
+      local cm="$1" name="$2" value="$3"
+      local current
+      current=$(kubectl get configmap "${cm}" -o jsonpath="{.data['${name//./\\.}']}")
+      if [[ -n "${current}" ]]; then
+        echo "skipping: ${cm} already contains ${name}=${current}"
       else
-        kubectl patch configmap "${configmap_name}" -p="{\"data\": {\"${name}\": \"${value}\"}}"
+        kubectl patch configmap "${cm}" -p="{\"data\": {\"${name}\": \"${value}\"}}"
       fi
     }
-    add_annotation_to_configmap() {
-      configmap_name="${1}"
-      key="${2}"
-      value="${3}"
-      if [[ -z "$configmap_name" ]]; then
-        echo "error: you must supply a configmap name" 1>&2
-        exit 1
-      fi
-      if [[ -z "$key" ]]; then
-        echo "error: you must supply an annotation key" 1>&2
-        exit 1
-      fi
-      if [[ -z "$value" ]]; then
-        echo "error: you must supply an annotation value" 1>&2
-        exit 1
-      fi
+    # Always overwrite (used for per-contract <name>.version)
+    set_key_to_configmap() {
+      local cm="$1" name="$2" value="$3"
+      kubectl patch configmap "${cm}" -p="{\"data\": {\"${name}\": \"${value}\"}}"
     }
-    CONFIGMAP_NAME="{{ .Values.scDeploy.configmap.name }}"
-    echo "creating kubernetes configmap for smart contract configuration outputs"
+
+    CONFIGMAP_NAME="{{ $.Values.scDeploy.configmap.name }}"
+    JOB_KIND="{{ $job.kind }}"
+    JOB_VERSION="{{ $job.image.tag }}"
+
+    echo "ensuring configmap ${CONFIGMAP_NAME} exists"
     create_configmap "${CONFIGMAP_NAME}"
 
-    {{- if .Values.scDeploy.preventRedeployment }}
-    # Prevent smart contract deployment if already done for current version
-    if [[ "$DEPLOYED_SMART_CONTRACTS_VERSION" == "{{ .Values.scDeploy.image.tag }}" ]]; then
-      echo "contracts already deployed with version: ${DEPLOYED_SMART_CONTRACTS_VERSION}, aborting deployment" 1>&2
-      exit 0
-    fi
-    {{- end }}
-
-    echo "executing deploy commands"
-    {{- range .Values.scDeploy.deployCommands }}
+    echo "executing ${JOB_KIND} commands"
+    {{- range $job.commands }}
     {{ . | nindent 4 }}
     {{- end }}
 
     for envfile in addresses/.env.*; do
       echo "---"
-      echo "Updating configmap: ${CONFIGMAP_NAME} for the following contract addresses:"
-
-      # Parse envfile adding a newline at the end if missing
+      echo "Updating ${CONFIGMAP_NAME} from ${envfile}"
       while IFS= read -r line || [[ -n "$line" ]]; do
-        # Use `cut` to split the line at the first `=`
-        # The first part is the key (CONTRACT_NAME) and the second is the value (CONTRACT_ADDRESS)
+        [[ -z "$line" ]] && continue
         CONTRACT_NAME=$(echo "$line" | cut -d'=' -f1)
         CONTRACT_ADDRESS=$(echo "$line" | cut -d'=' -f2)
-
-        # Remove the "_ADDRESS" or  "_CONTRACT_ADDRESS" suffix to get the clean contract name
         CLEAN_NAME=$(echo "${CONTRACT_NAME}" | sed 's/_CONTRACT_ADDRESS\|_ADDRESS//g' | tr '[:upper:]' '[:lower:]')
-        echo "Adding ${CLEAN_NAME}.address=${CONTRACT_ADDRESS}"
         add_key_to_configmap "${CONFIGMAP_NAME}" "${CLEAN_NAME}.address" "${CONTRACT_ADDRESS}"
+        if [[ "${JOB_KIND}" == "deploy" || "${JOB_KIND}" == "upgrade" ]]; then
+          set_key_to_configmap "${CONFIGMAP_NAME}" "${CLEAN_NAME}.version" "${JOB_VERSION}"
+        fi
       done < "${envfile}"
-    done;
+    done
 
-    {{- if .Values.scDeploy.verifyContracts }}
+    {{- if and (eq $job.kind "deploy") (default false $job.verifyContracts) }}
     npx --no-install hardhat verify:verify || true
     {{- end }}
-    echo "adding the current contracts version to the configmap"
-    kubectl patch configmap "${CONFIGMAP_NAME}" -p="{\"data\": {\"contracts.version\": \"{{ .Values.scDeploy.image.tag }}\"}}"
-  upgrade-contracts.sh: |
-    #!/bin/bash
-    set -eo pipefail
-    {{- if .Values.scDeploy.preventRedeployment }}
-    # Prevent smart contract deployment if already done for current version
-    if [[ "$DEPLOYED_SMART_CONTRACTS_VERSION" == "{{ .Values.scDeploy.image.tag }}" ]]; then
-      echo "contracts already deployed with version: ${DEPLOYED_SMART_CONTRACTS_VERSION}, aborting deployment" 1>&2
-      exit 0
-    fi
-    {{- end }}
-
-    echo "executing upgrade commands"
-    {{- range .Values.scUpgrade.upgradeCommands }}
-    {{ . | nindent 4 }}
-    {{- end }}
-    echo "updating the contracts version to the configmap"
-    CONFIGMAP_NAME="{{ .Values.scDeploy.configmap.name }}"
-    kubectl patch configmap "${CONFIGMAP_NAME}" -p="{\"data\": {\"contracts.version\": \"{{ .Values.scDeploy.image.tag }}\"}}"
+{{- end }}
+{{- end }}

--- a/charts/contracts/templates/sc-deploy-job.yaml
+++ b/charts/contracts/templates/sc-deploy-job.yaml
@@ -3,6 +3,7 @@
 {{- range $index, $job := $jobs }}
 {{- $jobName := include "scJobResourceName" (dict "ctx" $ "job" $job) }}
 {{- $scriptKey := include "scJobScriptKey" (dict "job" $job) }}
+{{- $persistence := mergeOverwrite (deepCopy $.Values.persistence) (default dict $job.persistence) }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -24,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if $.Values.persistence.enabled }}
+        {{- if $persistence.enabled }}
         checksum/pvc: {{ include (print $.Template.BasePath "/sc-deploy-pvc.yaml") $ | sha256sum }}
         {{- end }}
         {{- with $.Values.podAnnotations }}
@@ -39,7 +40,7 @@ spec:
     spec:
       serviceAccountName: {{ $.Release.Name }}-config-writer
       securityContext:
-        {{- toYaml $.Values.scDeploy.securityContext | nindent 8 }}
+        {{- toYaml $.Values.securityContext | nindent 8 }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -68,7 +69,7 @@ spec:
           env:
             {{- /* See https://docs.openzeppelin.com/upgrades-plugins/network-files#custom-network-files-location */}}
             - name: MANIFEST_DEFAULT_DIR
-              value: "{{ $.Values.persistence.mountPath }}/.openzeppelin"
+              value: "{{ $persistence.mountPath }}/.openzeppelin"
           {{- with $job.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -80,26 +81,26 @@ spec:
             - mountPath: /app/oldContracts
               name: old-contracts
             {{- end }}
-            {{- if $.Values.persistence.enabled }}
-            - mountPath: {{ $.Values.persistence.mountPath }}
+            {{- if $persistence.enabled }}
+            - mountPath: {{ $persistence.mountPath }}
               name: persistence
             {{- end }}
           resources:
             requests:
-              cpu: {{ $.Values.scDeploy.resources.requests.cpu | default "100m" }}
-              memory: {{ $.Values.scDeploy.resources.requests.memory | default "256Mi" }}
+              cpu: {{ $.Values.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ $.Values.scDeploy.resources.limits.cpu | default "500m" }}
-              memory: {{ $.Values.scDeploy.resources.limits.memory | default "512Mi" }}
+              cpu: {{ $.Values.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.resources.limits.memory | default "512Mi" }}
       volumes:
         - name: config
           configMap:
             name: {{ $.Release.Name }}-config
             defaultMode: 0755
-        {{- if $.Values.persistence.enabled }}
+        {{- if $persistence.enabled }}
         - name: persistence
           persistentVolumeClaim:
-            claimName: {{ include "scVolumeName" $ }}
+            claimName: {{ default $.Release.Name $persistence.volumeClaim.name }}
         {{- end }}
         {{- if eq $job.kind "upgrade" }}
         - name: old-contracts

--- a/charts/contracts/templates/sc-deploy-job.yaml
+++ b/charts/contracts/templates/sc-deploy-job.yaml
@@ -1,114 +1,112 @@
-{{- if or .Values.scDeploy.enabled .Values.scUpgrade.enabled -}}
+{{- $jobs := fromYamlArray (include "scAllJobs" .) -}}
+{{- if gt (len $jobs) 0 -}}
+{{- range $job := $jobs }}
+{{- $jobName := include "scJobResourceName" (dict "ctx" $ "job" $job) }}
+{{- $scriptKey := include "scJobScriptKey" (dict "job" $job) }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
     app: fhevm-sc-deploy
-    app.kubernetes.io/name: {{ include "scDeployJobName" . }}
-  name: {{ include "scDeployJobName" . }}
+    app.kubernetes.io/name: {{ $jobName }}
+    fhevm.zama.ai/job-kind: {{ $job.kind }}
+    fhevm.zama.ai/contracts-version: {{ include "scSlug" $job.image.tag }}
+  annotations:
+    # Keep historical Jobs alive in the cluster even if their entry is later
+    # removed from scJobs. See chart README for the full ArgoCD story.
+    argocd.argoproj.io/sync-options: Prune=false
+  name: {{ $jobName }}
 spec:
   backoffLimit: 0
   template:
     metadata:
       annotations:
-        {{- if .Values.persistence.enabled }}
-        checksum/pvc: {{ include (print $.Template.BasePath "/sc-deploy-pvc.yaml") . | sha256sum }}
+        {{- if $.Values.persistence.enabled }}
+        checksum/pvc: {{ include (print $.Template.BasePath "/sc-deploy-pvc.yaml") $ | sha256sum }}
         {{- end }}
-        {{- with .Values.podAnnotations }}
+        {{- with $.Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- if .Values.persistence.enabled }}
-        checksum/pvc: {{ include (print $.Template.BasePath "/sc-deploy-pvc.yaml") . | sha256sum | trunc 63 }}
-        {{- end }}
-        {{- with .Values.podLabels }}
+        app: fhevm-sc-deploy
+        fhevm.zama.ai/job-kind: {{ $job.kind }}
+        {{- with $.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ .Release.Name }}-config-writer
+      serviceAccountName: {{ $.Release.Name }}-config-writer
       securityContext:
-        {{- toYaml .Values.scDeploy.securityContext | nindent 8 }}
-      {{- with .Values.nodeSelector }}
+        {{- toYaml $.Values.scDeploy.securityContext | nindent 8 }}
+      {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with $.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with $.Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.scUpgrade.enabled }}
+      {{- if eq $job.kind "upgrade" }}
       initContainers:
-      - name: copy-old-contracts
-        image: {{ .Values.scUpgrade.oldContracts.image.name }}:{{ .Values.scUpgrade.oldContracts.image.tag }}
-        command: ["cp", "-r", "/app/contracts/.", "/app/oldContracts"]
-        volumeMounts:
-          - mountPath: /app/oldContracts
-            name: old-contracts
-      containers:
-      - name: upgrade-smart-contracts
-        command: [ "/app/upgrade-contracts.sh" ]
-      {{- else if .Values.scDeploy.enabled }}
-      containers:
-      - name: deploy-smart-contracts
-        command: [ "/app/deploy-contracts.sh" ]
+        - name: copy-old-contracts
+          image: {{ $job.oldImage.name }}:{{ $job.oldImage.tag }}
+          command: ["cp", "-r", "/app/contracts/.", "/app/oldContracts"]
+          volumeMounts:
+            - mountPath: /app/oldContracts
+              name: old-contracts
       {{- end }}
-        image: {{ .Values.scDeploy.image.name }}:{{ .Values.scDeploy.image.tag }}
-        env:
-          - name: DEPLOYED_SMART_CONTRACTS_VERSION
-            valueFrom:
-              configMapKeyRef:
-                name: {{ .Values.scDeploy.configmap.name }}
-                key: contracts.version
-                optional: true
-          {{- /* See https://docs.openzeppelin.com/upgrades-plugins/network-files#custom-network-files-location */}}
-          - name: MANIFEST_DEFAULT_DIR
-            value: "{{ .Values.persistence.mountPath }}/.openzeppelin"
-        {{- if .Values.scDeploy.env }}
-          {{ toYaml .Values.scDeploy.env | nindent 10 }}
-        {{- end }}
-        volumeMounts:
-          - mountPath: /app/deploy-contracts.sh
-            subPath: deploy-contracts.sh
-            name: config
-          - mountPath: /app/upgrade-contracts.sh
-            subPath: upgrade-contracts.sh
-            name: config
-          {{- if .Values.scUpgrade.enabled }}
-          - mountPath: /app/oldContracts
-            name: old-contracts
+      containers:
+        - name: {{ $job.kind }}-smart-contracts
+          image: {{ $job.image.name }}:{{ $job.image.tag }}
+          command: ["/app/run.sh"]
+          env:
+            {{- /* See https://docs.openzeppelin.com/upgrades-plugins/network-files#custom-network-files-location */}}
+            - name: MANIFEST_DEFAULT_DIR
+              value: "{{ $.Values.persistence.mountPath }}/.openzeppelin"
+          {{- with $job.env }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.persistence.enabled }}
-          - mountPath: {{ .Values.persistence.mountPath }}
-            name: persistence
-          {{- end }}
-        resources:
-          requests:
-            cpu: {{ .Values.scDeploy.resources.requests.cpu | default "100m" }}
-            memory: {{ .Values.scDeploy.resources.requests.memory | default "256Mi" }}
-          limits:
-            cpu: {{ .Values.scDeploy.resources.limits.cpu | default "500m" }}
-            memory: {{ .Values.scDeploy.resources.limits.memory | default "512Mi" }}
+          volumeMounts:
+            - mountPath: /app/run.sh
+              subPath: {{ $scriptKey }}
+              name: config
+            {{- if eq $job.kind "upgrade" }}
+            - mountPath: /app/oldContracts
+              name: old-contracts
+            {{- end }}
+            {{- if $.Values.persistence.enabled }}
+            - mountPath: {{ $.Values.persistence.mountPath }}
+              name: persistence
+            {{- end }}
+          resources:
+            requests:
+              cpu: {{ $.Values.scDeploy.resources.requests.cpu | default "100m" }}
+              memory: {{ $.Values.scDeploy.resources.requests.memory | default "256Mi" }}
+            limits:
+              cpu: {{ $.Values.scDeploy.resources.limits.cpu | default "500m" }}
+              memory: {{ $.Values.scDeploy.resources.limits.memory | default "512Mi" }}
       volumes:
-      - name: config
-        configMap:
-          name: {{ .Release.Name }}-config
-          defaultMode: 0755
-      {{- if .Values.persistence.enabled }}
-      - name: persistence
-        persistentVolumeClaim:
-          claimName: {{ include "scVolumeName" . }}
-      {{- end }}
-      {{- if .Values.scUpgrade.enabled }}
-      - name: old-contracts
-        emptyDir: {}
-      {{- end }}
+        - name: config
+          configMap:
+            name: {{ $.Release.Name }}-config
+            defaultMode: 0755
+        {{- if $.Values.persistence.enabled }}
+        - name: persistence
+          persistentVolumeClaim:
+            claimName: {{ include "scVolumeName" $ }}
+        {{- end }}
+        {{- if eq $job.kind "upgrade" }}
+        - name: old-contracts
+          emptyDir: {}
+        {{- end }}
       restartPolicy: Never
       imagePullSecrets:
         - name: registry-credentials
+{{- end }}
 
 ---
 kind: Role

--- a/charts/contracts/templates/sc-deploy-job.yaml
+++ b/charts/contracts/templates/sc-deploy-job.yaml
@@ -1,6 +1,6 @@
 {{- $jobs := fromYamlArray (include "scAllJobs" .) -}}
 {{- if gt (len $jobs) 0 -}}
-{{- range $job := $jobs }}
+{{- range $index, $job := $jobs }}
 {{- $jobName := include "scJobResourceName" (dict "ctx" $ "job" $job) }}
 {{- $scriptKey := include "scJobScriptKey" (dict "job" $job) }}
 ---
@@ -13,9 +13,11 @@ metadata:
     fhevm.zama.ai/job-kind: {{ $job.kind }}
     fhevm.zama.ai/contracts-version: {{ include "scSlug" $job.image.tag }}
   annotations:
-    # Keep historical Jobs alive in the cluster even if their entry is later
-    # removed from scJobs. See chart README for the full ArgoCD story.
+    # Keep completed Jobs alive even if their entry is later removed from scJobs.
     argocd.argoproj.io/sync-options: Prune=false
+    # ArgoCD applies Jobs in wave order, waiting for each to become
+    # Healthy (Job Succeeded) before moving to the next.
+    argocd.argoproj.io/sync-wave: {{ $index | quote }}
   name: {{ $jobName }}
 spec:
   backoffLimit: 0

--- a/charts/contracts/templates/sc-deploy-statefulset.yaml
+++ b/charts/contracts/templates/sc-deploy-statefulset.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.scDebug.enabled }}
+{{- $mountMode := .Values.scDebug.mountMode | default "readOnly" }}
+{{- if not (has $mountMode (list "readOnly" "readWrite")) }}
+{{- fail (printf "scDebug.mountMode must be 'readOnly' or 'readWrite', got %q" $mountMode) }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -48,25 +52,20 @@ spec:
         - name: debug
           image: {{ .Values.scDeploy.image.name }}:{{ .Values.scDeploy.image.tag }}
           command: [ "/bin/bash", "-c", "tail -f /dev/null" ]
-          {{- if .Values.scDeploy.env }}
           env:
-          {{- /* See https://docs.openzeppelin.com/upgrades-plugins/network-files#custom-network-files-location */}}
-          - name: MANIFEST_DEFAULT_DIR
-            value: "/app/addresses/.openzeppelin"
-          {{ toYaml .Values.scDeploy.env | nindent 10 }}
+            {{- /* See https://docs.openzeppelin.com/upgrades-plugins/network-files#custom-network-files-location */}}
+            - name: MANIFEST_DEFAULT_DIR
+              value: "{{ .Values.persistence.mountPath }}/.openzeppelin"
+          {{- with .Values.scDeploy.env }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /app/deploy-contracts.sh
-              subPath: deploy-contracts.sh
-              name: config
-            - mountPath: /app/upgrade-contracts.sh
-              subPath: upgrade-contracts.sh
-              name: config
             - mountPath: /app/oldContracts
               name: old-contracts
             {{- if .Values.persistence.enabled }}
-            - mountPath: /app/addresses
-              name: persistence
+            - mountPath: {{ .Values.persistence.mountPath }}
+              name: addresses
+              readOnly: {{ eq $mountMode "readOnly" }}
             {{- end }}
           resources:
             requests:
@@ -76,17 +75,13 @@ spec:
               cpu: {{ .Values.scDeploy.resources.limits.cpu | default "500m" }}
               memory: {{ .Values.scDeploy.resources.limits.memory | default "512Mi" }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ .Release.Name }}-config
-            defaultMode: 0755
-      {{- if .Values.persistence.enabled }}
-        - name: persistence
-          persistentVolumeClaim:
-            claimName: {{ include "scVolumeName" . }}
-      {{- end }}
         - name: old-contracts
           emptyDir: {}
+        {{- if .Values.persistence.enabled }}
+        - name: addresses
+          persistentVolumeClaim:
+            claimName: {{ include "scVolumeName" . }}
+        {{- end }}
       imagePullSecrets:
         - name: registry-credentials
 {{- end }}

--- a/charts/contracts/templates/sc-deploy-statefulset.yaml
+++ b/charts/contracts/templates/sc-deploy-statefulset.yaml
@@ -3,6 +3,12 @@
 {{- if not (has $mountMode (list "readOnly" "readWrite")) }}
 {{- fail (printf "scDebug.mountMode must be 'readOnly' or 'readWrite', got %q" $mountMode) }}
 {{- end }}
+{{- $jobs := fromYamlArray (include "scAllJobs" .) }}
+{{- if eq (len $jobs) 0 }}
+{{- fail "scDebug.enabled requires at least one enabled scJobs entry: the debug pod reuses the last entry's image and env" }}
+{{- end }}
+{{- $job := last $jobs }}
+{{- $persistence := mergeOverwrite (deepCopy .Values.persistence) (default dict $job.persistence) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -28,7 +34,7 @@ spec:
       {{- end }}
     spec:
       securityContext:
-        {{- toYaml .Values.scDeploy.securityContext | nindent 8 }}
+        {{- toYaml .Values.securityContext | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -41,46 +47,52 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $job.oldImage }}
       initContainers:
         - name: copy-old-contracts
-          image: {{ .Values.scUpgrade.oldContracts.image.name }}:{{ .Values.scUpgrade.oldContracts.image.tag }}
+          image: {{ $job.oldImage.name }}:{{ $job.oldImage.tag }}
           command: ["cp", "-r", "/app/contracts/.", "/app/oldContracts"]
           volumeMounts:
             - mountPath: /app/oldContracts
               name: old-contracts
+      {{- end }}
       containers:
         - name: debug
-          image: {{ .Values.scDeploy.image.name }}:{{ .Values.scDeploy.image.tag }}
+          image: {{ $job.image.name }}:{{ $job.image.tag }}
           command: [ "/bin/bash", "-c", "tail -f /dev/null" ]
           env:
             {{- /* See https://docs.openzeppelin.com/upgrades-plugins/network-files#custom-network-files-location */}}
             - name: MANIFEST_DEFAULT_DIR
-              value: "{{ .Values.persistence.mountPath }}/.openzeppelin"
-          {{- with .Values.scDeploy.env }}
+              value: "{{ $persistence.mountPath }}/.openzeppelin"
+          {{- with $job.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if $job.oldImage }}
             - mountPath: /app/oldContracts
               name: old-contracts
-            {{- if .Values.persistence.enabled }}
-            - mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            {{- if $persistence.enabled }}
+            - mountPath: {{ $persistence.mountPath }}
               name: addresses
               readOnly: {{ eq $mountMode "readOnly" }}
             {{- end }}
           resources:
             requests:
-              cpu: {{ .Values.scDeploy.resources.requests.cpu | default "100m" }}
-              memory: {{ .Values.scDeploy.resources.requests.memory | default "256Mi" }}
+              cpu: {{ .Values.resources.requests.cpu | default "100m" }}
+              memory: {{ .Values.resources.requests.memory | default "256Mi" }}
             limits:
-              cpu: {{ .Values.scDeploy.resources.limits.cpu | default "500m" }}
-              memory: {{ .Values.scDeploy.resources.limits.memory | default "512Mi" }}
+              cpu: {{ .Values.resources.limits.cpu | default "500m" }}
+              memory: {{ .Values.resources.limits.memory | default "512Mi" }}
       volumes:
+        {{- if $job.oldImage }}
         - name: old-contracts
           emptyDir: {}
-        {{- if .Values.persistence.enabled }}
+        {{- end }}
+        {{- if $persistence.enabled }}
         - name: addresses
           persistentVolumeClaim:
-            claimName: {{ include "scVolumeName" . }}
+            claimName: {{ default .Release.Name $persistence.volumeClaim.name }}
         {{- end }}
       imagePullSecrets:
         - name: registry-credentials

--- a/charts/contracts/values.yaml
+++ b/charts/contracts/values.yaml
@@ -13,11 +13,59 @@
 # The chart is shared between gateway and host deployments
 
 # -----------------------------------------------------------------------------
-# Smart Contract Deployment
+# Smart Contracts Jobs
+# -----------------------------------------------------------------------------
+# Declare one entry per Job to run. Each entry produces a uniquely-named Job
+# (`<release>-<kind>-<name>-<tagSlug>`) so re-installs with a new image tag
+# don't collide with prior runs. The legacy scDeploy / scUpgrade blocks below
+# are still honored for back-compat, synthesized into a single default entry
+# of kind=deploy or kind=upgrade.
+#
+# Entry schema:
+#   enabled:         bool, default true; set to false to skip the entry
+#   name:            short slug identifying the job
+#   kind:            deploy | upgrade | task
+#   image:           { name, tag } container image and version
+#   oldImage:        { name, tag } source for old contracts (kind=upgrade only)
+#   env:             list of env entries passed to the container
+#   commands:        shell commands run in order
+#   verifyContracts: bool, runs `hardhat verify:verify` after a deploy
+#
+# Each Job records `<contract>.address` (immutable, skipped if already set)
+# and, for deploy/upgrade kinds, `<contract>.version=<image.tag>` (overwritten
+# on each run) in the configmap named below.
+scJobs: []
+# Example:
+#   - name: protocol-payment
+#     kind: deploy
+#     image:
+#       name: ghcr.io/zama-ai/fhevm/gateway-contracts
+#       tag: v0.10.0
+#     env:
+#       - name: DEPLOYER_PRIVATE_KEY
+#         value: ""
+#       - name: ZAMA_OFT_ADDRESS
+#         value: ""
+#     commands:
+#       - npx hardhat task:setPaymentBridgingContractAddresses
+#       - npx hardhat task:deploySingleContract --name ProtocolPayment
+#   - name: add-pausers
+#     kind: task
+#     image:
+#       name: ghcr.io/zama-ai/fhevm/host-contracts
+#       tag: v0.13.0
+#     env:
+#       - name: DEPLOYER_PRIVATE_KEY
+#         value: ""
+#     commands:
+#       - npx hardhat task:addHostPausers
+
+# -----------------------------------------------------------------------------
+# Smart Contract Deployment (legacy, prefer scJobs)
 # -----------------------------------------------------------------------------
 # Handles initial deployment of all required smart contracts
 scDeploy:
-  enabled: true
+  enabled: false
 
   # Prevent redeployment if already done for current version
   # preventRedeployment: false
@@ -177,7 +225,7 @@ scDeploy:
   verifyContracts: false
 
 # -----------------------------------------------------------------------------
-# Smart Contract Upgrade
+# Smart Contract Upgrade (legacy, prefer scJobs)
 # -----------------------------------------------------------------------------
 # Handles upgrades of existing smart contracts
 scUpgrade:
@@ -242,6 +290,16 @@ scUpgrade:
 scDebug:
   enabled: false
   nameOverride:
+
+  # How the debug pod consumes the deploy PVC:
+  #   readOnly  (default): mount the PVC read-only so the debug pod always
+  #     sees the current state without being able to mutate it.
+  #   readWrite          : mount the PVC read-write. Use sparingly: only when
+  #     you need to edit the PVC contents by hand.
+  # Both modes share the same node-level ReadWriteOnce lock; a contract Job
+  # scheduled to a different node will still wait for the debug pod's node
+  # attachment.
+  mountMode: readOnly
 
 # -----------------------------------------------------------------------------
 # Persistent Storage Configuration

--- a/charts/contracts/values.yaml
+++ b/charts/contracts/values.yaml
@@ -17,9 +17,7 @@
 # -----------------------------------------------------------------------------
 # Declare one entry per Job to run. Each entry produces a uniquely-named Job
 # (`<release>-<kind>-<name>-<tagSlug>`) so re-installs with a new image tag
-# don't collide with prior runs. The legacy scDeploy / scUpgrade blocks below
-# are still honored for back-compat, synthesized into a single default entry
-# of kind=deploy or kind=upgrade.
+# don't collide with prior runs.
 #
 # Entry schema:
 #   enabled:         bool, default true; set to false to skip the entry
@@ -29,11 +27,20 @@
 #   oldImage:        { name, tag } source for old contracts (kind=upgrade only)
 #   env:             list of env entries passed to the container
 #   commands:        shell commands run in order
-#   verifyContracts: bool, runs `hardhat verify:verify` after a deploy
+#   envFile:         path or glob of address env files to record after the
+#                    commands, default "addresses/.env.*"; set it to the file
+#                    the job's image family writes (e.g. addresses/.env.host)
+#                    so jobs sharing a PVC never re-stamp each other's keys
+#   configmap:       { name } overrides the global configmap.name for this job
+#   persistence:     merged over the global persistence block for this job
+#                    (enabled, mountPath, volumeClaim.name); an overridden
+#                    volumeClaim.name must reference an existing PVC, the
+#                    chart only creates the shared one
 #
 # Each Job records `<contract>.address` (immutable, skipped if already set)
 # and, for deploy/upgrade kinds, `<contract>.version=<image.tag>` (overwritten
-# on each run) in the configmap named below.
+# on each run) in the configmap named below (configmap.name), unless the entry
+# sets its own `configmap.name`.
 scJobs: []
 # Example:
 #   - name: protocol-payment
@@ -46,6 +53,7 @@ scJobs: []
 #         value: ""
 #       - name: ZAMA_OFT_ADDRESS
 #         value: ""
+#     envFile: addresses/.env.gateway
 #     commands:
 #       - npx hardhat task:setPaymentBridgingContractAddresses
 #       - npx hardhat task:deploySingleContract --name ProtocolPayment
@@ -61,203 +69,31 @@ scJobs: []
 #       - npx hardhat task:addHostPausers
 
 # -----------------------------------------------------------------------------
-# Smart Contract Deployment (legacy, prefer scJobs)
+# Contract Addresses ConfigMap
 # -----------------------------------------------------------------------------
-# Handles initial deployment of all required smart contracts
-scDeploy:
-  enabled: false
-
-  # Prevent redeployment if already done for current version
-  # preventRedeployment: false
-
-  nameOverride:
-
-  image:
-    name: ghcr.io/zama-ai/fhevm/host-contracts
-    tag: v0.13.0
-
-  # ConfigMap to store deployed contract addresses
-  configmap:
-    name: "sc-addresses"
-    annotations:
-
-  # Environment variables for contract deployment
-  env:
-    # =========================================================================
-    # ==========================  GATEWAY =====================================
-    # =========================================================================
-
-    # Deployer's private key
-    - name: DEPLOYER_PRIVATE_KEY
-      value: ""
-
-    # Pauser set contract address
-    - name: PAUSER_SET_ADDRESS
-      value: ""
-
-    # Number of pausers
-    # Should be set to the number of registered operators, ie `n_kms + n_copro` with `n_kms` the
-    # number of KMS nodes and `n_copro` the number of coprocessors
-    - name: NUM_PAUSERS
-      value: 18
-
-    # Pauser addresses (replace x with sequential number starting from 0 up to NUM_PAUSERS - 1)
-    # Each operator has its own hot wallet address used as pauser
-    - name: PAUSER_ADDRESS_x
-      value: ""
-
-    # =========================================================================
-    # ==========================  HOST    =====================================
-    # =========================================================================
-
-    # Deployer's private key
-    - name: DEPLOYER_PRIVATE_KEY
-      value: ""
-
-    # Pauser set contract address
-    - name: PAUSER_SET_CONTRACT_ADDRESS
-      value: ""
-
-    # Number of pausers
-    # Should be set to the number of registered operators, ie `n_kms + n_copro` with `n_kms` the
-    # number of KMS nodes and `n_copro` the number of coprocessors
-    - name: NUM_PAUSERS
-      value: 18
-
-    # Pauser addresses (replace x with sequential number starting from 0 up to NUM_PAUSERS - 1)
-    # Each operator has its own hot wallet address used as pauser
-    - name: PAUSER_ADDRESS_x
-      value: ""
-
-    # -------------------------------------------------------------------------
-    # ProtocolConfig (KMS node identity, context, thresholds)
-    # -------------------------------------------------------------------------
-    - name: NUM_KMS_NODES
-      value: 13
-
-    # KMS node fields, indexed from 0 up to NUM_KMS_NODES - 1
-    - name: KMS_TX_SENDER_ADDRESS_x
-      value: ""
-
-    - name: KMS_SIGNER_ADDRESS_x
-      value: ""
-
-    - name: KMS_NODE_IP_x
-      value: ""
-
-    - name: KMS_NODE_STORAGE_URL_x
-      value: ""
-
-    - name: PUBLIC_DECRYPTION_THRESHOLD
-      value: 7
-    - name: USER_DECRYPTION_THRESHOLD
-      value: 7
-    - name: KMS_GEN_THRESHOLD
-      value: 7
-    - name: MPC_THRESHOLD
-      value: 3
-
-    # -------------------------------------------------------------------------
-    # KMSVerifier / InputVerifier (references to gateway contracts)
-    # -------------------------------------------------------------------------
-    - name: CHAIN_ID_GATEWAY
-      value: ""
-
-    - name: DECRYPTION_ADDRESS
-      value: ""
-
-    - name: INPUT_VERIFICATION_ADDRESS
-      value: ""
-
-    # -------------------------------------------------------------------------
-    # InputVerifier (coprocessor signer set)
-    # -------------------------------------------------------------------------
-    - name: NUM_COPROCESSORS
-      value: 5
-
-    - name: COPROCESSOR_THRESHOLD
-      value: 3
-
-    # Coprocessor signer addresses, indexed from 0 up to NUM_COPROCESSORS - 1
-    - name: COPROCESSOR_SIGNER_ADDRESS_x
-      value: ""
-
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
-
-  # Security context for container execution
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 10000
-    fsGroup: 10001
-
-  # Deployment commands executed in sequence
-  deployCommands:
-    # =========================================================================
-    # ==========================  GATEWAY =====================================
-    # =========================================================================
-    # Deploy all gateway contracts
-    - npx hardhat task:deployAllGatewayContracts
-
-    # Register host chains in the gateway
-    - npx hardhat task:addHostChainsToGatewayConfig
-
-    # Add pausers to the gateway contracts
-    - npx hardhat task:addGatewayPausers
-
-    # =========================================================================
-    # ==========================  HOST    =====================================
-    # =========================================================================
-    # Deploy all host contracts, including KMSGeneration. KMSGeneration belongs
-    # only on the canonical host chain in the multi-chain model.
-    # See host-contracts/README.md#host-deployment-role.
-    - npx hardhat task:deployAllHostContracts --with-kms-generation true
-
-    # Add pausers to the host contracts
-    - npx hardhat task:addHostPausers
-
-  # Contract verification on block explorers
-  verifyContracts: false
+# ConfigMap where Jobs record deployed contract addresses and versions, unless
+# a scJobs entry sets its own `configmap.name`.
+configmap:
+  name: "sc-addresses"
+  annotations:
 
 # -----------------------------------------------------------------------------
-# Smart Contract Upgrade (legacy, prefer scJobs)
+# Container Runtime Configuration
 # -----------------------------------------------------------------------------
-# Handles upgrades of existing smart contracts
-scUpgrade:
-  enabled: false
+# Shared by all scJobs containers and the scDebug pod
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
 
-  # Configuration for old contracts (used during upgrade process)
-  oldContracts:
-    image:
-      name: ghcr.io/zama-ai/fhevm/host-contracts
-      tag: v0.10.0
-
-  # Note: The upgrade process uses the new contracts image from scDeploy.image
-
-  # Upgrade commands executed during contract upgrade
-  upgradeCommands:
-    # Example upgrade command (uncomment and modify as needed)
-    # - npx hardhat task:upgradeACL
-
-    # =========================================================================
-    # ==========================  GATEWAY =====================================
-    # =========================================================================
-    - npx hardhat task:upgradeGatewayConfig
-
-    - npx hardhat task:upgradeDecryption
-
-    - npx hardhat task:upgradeKMSGeneration
-
-    # =========================================================================
-    # ==========================  HOST    =====================================
-    # =========================================================================
-    - npx hardhat task:upgradeKMSVerifier
-
+# Security context for container execution
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 10000
+  fsGroup: 10001
 
 # -----------------------------------------------------------------------------
 # Node Placement Configuration
@@ -286,7 +122,9 @@ scUpgrade:
 # -----------------------------------------------------------------------------
 # Smart Contract Debugging
 # -----------------------------------------------------------------------------
-# Utilities for debugging smart contract deployments
+# Utilities for debugging smart contract deployments. The debug pod reuses the
+# configuration (image, env, oldImage, persistence) of the last enabled scJobs
+# entry, so enabling it requires at least one entry.
 scDebug:
   enabled: false
   nameOverride:


### PR DESCRIPTION
## Summary

The contracts chart used to template a single deploy/upgrade Job whose name
was fixed per chart release. Bumping the image tag could not be done without
manually deleting the prior Job, and one-off operations (add-pauser, ownership
transfer, keygen, …) had no clean place to live.

This refactor makes `scJobs:` the only way to declare work: each entry renders
as its own uniquely-named Job (`<release>-<kind>-<name>-<tagSlug>`), so
re-installs with a new tag yield new Jobs side-by-side with completed ones
instead of collisions. The legacy `scDeploy` / `scUpgrade` blocks are removed
entirely, hence the 1.0.0 chart version bump (breaking).

## Changes

- New `scJobs:` schema with `kind: deploy | upgrade | task`, an `enabled`
  flag, and an optional `envFile` (path/glob of address files to record,
  default `addresses/.env.*`) so jobs sharing a PVC never re-stamp another
  contract family's `.version` keys. One ConfigMap holds per-job runner
  scripts.
- `configmap`, `resources` and `securityContext` are now top-level values
  shared by all Job containers and the debug pod.
- Addresses ConfigMap stores `<contract>.address` (immutable, skip if set)
  AND `<contract>.version=<image.tag>` per Job. The global `contracts.version`
  key is dropped, since contracts can legitimately run at different versions.
- `scDebug` pod reuses the image/env/oldImage/persistence of the last enabled
  `scJobs` entry (rendering fails with a clear message if none), with
  `mountMode: readOnly | readWrite` (default `readOnly`).
- All Jobs annotated with `argocd.argoproj.io/sync-options: Prune=false` so
  removing an `scJobs` entry preserves the historical Job in-cluster as a
  re-run sentinel, plus `argocd.argoproj.io/sync-wave: <index>` for
  sequential execution in `scJobs` order.
- `verifyContracts` / `hardhat verify:verify` removed; verification should run
  as a dedicated `task` job.
- Chart README added.

## Breaking changes

- `scDeploy` and `scUpgrade` values are no longer honored; migrate to
  `scJobs:` entries. `scDeploy.configmap` moves to the top-level `configmap`,
  `scDeploy.resources`/`securityContext` move to top level.
- `verifyContracts` is gone.

The `values-*.yaml` reference files are intentionally left untouched.