### PR TITLE
fix(relayer): stop retrying ACL reverts on gas estimation

### DIFF
--- a/.github/workflows/relayer-tests.yaml
+++ b/.github/workflows/relayer-tests.yaml
@@ -173,7 +173,10 @@ jobs:
         run: |
           if ! command -v sqlx &> /dev/null; then
             echo "Installing sqlx-cli..."
-            cargo install sqlx-cli --no-default-features --features postgres
+            # Pin to the same series as the relayer's `sqlx` dependency
+            # (0.8.6 in relayer/Cargo.toml). sqlx-cli 0.9.0 raised its
+            # MSRV to rustc 1.94; rust-toolchain.toml pins 1.91.1.
+            cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres --locked
           else
             echo "sqlx-cli found in cache."
           fi

--- a/relayer/Makefile
+++ b/relayer/Makefile
@@ -74,7 +74,7 @@ _check-cast:
 
 _check-sqlx-cli:
 	@command -v cargo-sqlx >/dev/null 2>&1 || { \
-		echo "$(RED)Error: sqlx-cli not installed. Run: cargo install sqlx-cli --no-default-features --features postgres,rustls$(RESET)"; exit 1; }
+		echo "$(RED)Error: sqlx-cli not installed. Run: cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres,rustls$(RESET)"; exit 1; }
 
 # Validate that a network config exists and has a non-empty private key.
 # Usage: $(MAKE) _check-network-config NET_CONFIG=config/local.testnet.yaml NET_NAME=Testnet

--- a/relayer/docs/DEVELOPMENT.md
+++ b/relayer/docs/DEVELOPMENT.md
@@ -117,7 +117,9 @@ make db-shell       # Open psql shell
 These require `sqlx-cli`:
 
 ```bash
-cargo install sqlx-cli --no-default-features --features postgres,rustls
+# Pinned to the 0.8.x series: sqlx-cli 0.9.0 raised its MSRV to
+# rustc 1.94; rust-toolchain.toml pins 1.91.1.
+cargo install sqlx-cli --version 0.8.6 --no-default-features --features postgres,rustls
 ```
 
 Then:

--- a/relayer/src/gateway/arbitrum/transaction/engine.rs
+++ b/relayer/src/gateway/arbitrum/transaction/engine.rs
@@ -26,12 +26,8 @@ use crate::{
     gateway::arbitrum::{
         parse_private_key,
         transaction::{
-            nonce_manager::NonceManagerNonOptimistic,
-            provider::NonceManagedProvider,
-            selectors::{
-                SELECTOR_ACCOUNT_NOT_ALLOWED_TO_USE_CIPHERTEXT,
-                SELECTOR_CIPHERTEXT_MATERIAL_NOT_READY, SELECTOR_PUBLIC_DECRYPT_NOT_ALLOWED,
-            },
+            nonce_manager::NonceManagerNonOptimistic, provider::NonceManagedProvider,
+            selectors::SELECTOR_CIPHERTEXT_MATERIAL_NOT_READY,
         },
     },
     logging::TxEngineStep,
@@ -317,10 +313,6 @@ impl
                             // NOTE (Nico): This control flow makes the tx engine less generic.
                             if response_error_string
                                 .contains(SELECTOR_CIPHERTEXT_MATERIAL_NOT_READY)
-                                || response_error_string
-                                    .contains(SELECTOR_PUBLIC_DECRYPT_NOT_ALLOWED)
-                                || response_error_string
-                                    .contains(SELECTOR_ACCOUNT_NOT_ALLOWED_TO_USE_CIPHERTEXT)
                             {
                                 // Not passing in loop initial check to get a max retry exceeded fails 1 retry before.
                                 if retries >= self.gas_estimation_max_retries - 1 {

--- a/relayer/src/gateway/arbitrum/transaction/selectors.rs
+++ b/relayer/src/gateway/arbitrum/transaction/selectors.rs
@@ -1,13 +1,9 @@
-// This selectors are useful for revert that should be retried. Due to node provider load balancers,
-// we could have error due to node inconsistent state during gas estimation which we want to retry (readiness check has passed on some state).
-// It could nonetheless introduce some latency due to multiple retries if this never pass, and goes to a failure mode with termination.
+// This selector is useful for reverts that should be retried. Due to node provider load balancers,
+// we could have errors due to node inconsistent state during gas estimation which we want to retry
+// (readiness check has passed on some state). It could nonetheless introduce some latency due to
+// multiple retries if this never passes, and goes to a failure mode with termination.
 // Should not be included in max_retry_exceeded metrics.
 
-/// CiphertextMaterialNotFound(bytes32) - from gateway contracts CiphertextCommits.sol
+/// CiphertextMaterialNotFound(bytes32) - from gateway contracts CiphertextCommits.sol.
+/// Retried during gas estimation because it represents a transient node inconsistency.
 pub const SELECTOR_CIPHERTEXT_MATERIAL_NOT_READY: &str = "0x0666cbdf";
-
-/// PublicDecryptNotAllowed(bytes32) - for ACL readiness check on public decrypt revert.
-pub const SELECTOR_PUBLIC_DECRYPT_NOT_ALLOWED: &str = "0x4331a85d";
-
-/// AccountNotAllowedToUseCiphertext(bytes32,address) - for ACL readiness check on user decrypt revert.
-pub const SELECTOR_ACCOUNT_NOT_ALLOWED_TO_USE_CIPHERTEXT: &str = "0x160a2b4b";


### PR DESCRIPTION
Removes `PublicDecryptNotAllowed` and `AccountNotAllowedToUseCiphertext`
from the retryable gas-estimation reverts: the ACL check is now done
directly on the host chain, not during gas estimation, so only
`CiphertextMaterialNotFound` remains retriable.

See [zama-ai/fhevm-internal#1474][issue] for details.

Follow-up (out of scope): the `RevertedACLSelector` metric now fires
only for `CiphertextMaterialNotFound`; renaming is deferred.

[issue]: https://github.com/zama-ai/fhevm-internal/issues/1474
