### PR TITLE
feat(listener): block payload to publish full block payload and redis adaptative drain

### DIFF
--- a/listener/crates/consumer/src/client.rs
+++ b/listener/crates/consumer/src/client.rs
@@ -125,6 +125,36 @@ impl ListenerConsumer {
         }
     }
 
+    /// Build a full-block (wildcard) filter command for this consumer.
+    ///
+    /// All address fields are `None`, which the listener interprets as
+    /// "broadcast the entire block": every transaction with every log is
+    /// delivered, letting the consumer parse the chain dynamically.
+    pub fn create_full_block_filter(&self) -> FilterCommand {
+        FilterCommand {
+            consumer_id: self.consumer_id.clone(),
+            from: None,
+            to: None,
+            log_address: None,
+        }
+    }
+
+    /// Register a full-block (wildcard) subscription for this consumer.
+    ///
+    /// After this call the consumer receives the complete [`BlockPayload`]
+    /// (all transactions, all logs) for every block on the chain. Registering
+    /// the same full-block filter again is a no-op on the listener side
+    /// (deduplicated silently).
+    pub async fn register_full_block(&self) -> Result<(), ConsumerError> {
+        self.register_filter(&self.create_full_block_filter()).await
+    }
+
+    /// Remove this consumer's full-block (wildcard) subscription.
+    pub async fn unregister_full_block(&self) -> Result<(), ConsumerError> {
+        self.unregister_filter(&self.create_full_block_filter())
+            .await
+    }
+
     /// Publish a filter removal command to the unwatch topic.
     pub async fn unregister_filter(&self, command: &FilterCommand) -> Result<(), ConsumerError> {
         self.publish_filter_command(command, routing::UNWATCH).await
@@ -505,6 +535,25 @@ mod tests {
             routing::consumer_new_event_routing(consumer_id.into()),
             "catchup and new-event routings must not collide",
         );
+    }
+
+    /// A full-block filter carries no address fields and validates as a
+    /// wildcard subscription tied to this consumer's id. `build()` does not
+    /// open a connection, so this runs without Docker.
+    #[tokio::test]
+    async fn create_full_block_filter_is_wildcard_and_valid() {
+        let broker = Broker::amqp("amqp://user:pass@localhost:5672")
+            .build()
+            .await
+            .unwrap();
+        let consumer = ListenerConsumer::new(&broker, 1, "copro-1-host-eth");
+
+        let mut cmd = consumer.create_full_block_filter();
+        assert_eq!(cmd.consumer_id, "copro-1-host-eth");
+        assert!(cmd.from.is_none());
+        assert!(cmd.to.is_none());
+        assert!(cmd.log_address.is_none());
+        cmd.validate().expect("full-block filter must validate");
     }
 
     /// Locks in the parent/child cancellation contract that `ListenerConsumer`

--- a/listener/crates/consumer/tests/watch_e2e.rs
+++ b/listener/crates/consumer/tests/watch_e2e.rs
@@ -177,6 +177,24 @@ async fn watch_contract_publishes_register_filter() {
 
 #[tokio::test]
 #[ignore = "requires Docker"]
+async fn register_full_block_publishes_wildcard_filter() {
+    // A full-block subscription carries no address fields; it must validate and
+    // round-trip over the broker just like an address-scoped filter.
+    let command = FilterCommand {
+        consumer_id: "gateway".into(),
+        from: None,
+        to: None,
+        log_address: None,
+    };
+
+    let msg =
+        assert_filter_command_roundtrip(routing::WATCH, "watch-e2e-full-block", &command).await;
+    assert_eq!(msg, command);
+    assert!(msg.from.is_none() && msg.to.is_none() && msg.log_address.is_none());
+}
+
+#[tokio::test]
+#[ignore = "requires Docker"]
 async fn unwatch_contract_publishes_unregister_filter() {
     let command = FilterCommand {
         consumer_id: "gateway".into(),

--- a/listener/crates/example/Cargo.toml
+++ b/listener/crates/example/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 name = "example"
 path = "src/main.rs"
 
+[[bin]]
+name = "full_block"
+path = "src/full_block.rs"
+
 [dependencies]
 alloy            = { workspace = true }
 alloy-primitives = { workspace = true }

--- a/listener/crates/example/src/full_block.rs
+++ b/listener/crates/example/src/full_block.rs
@@ -1,0 +1,134 @@
+//! Full-block showcase of the `consumer` library.
+//!
+//! Subscribes to **every** block on the chain by registering a *full-block*
+//! (wildcard) filter — no `from` / `to` / `log_address`. The listener then
+//! publishes the complete `BlockPayload` (all transactions, all logs) to this
+//! consumer, and we print each block so you can verify the feature works.
+//!
+//! This is a downstream-only binary: no RPC, no DB. The `listener_core`
+//! service must be running and pointed at the same broker and `CHAIN_ID`.
+//!
+//! What it does, in order:
+//!  1. Connects to the broker (Redis Streams or RabbitMQ via `BROKER_URL`).
+//!  2. Declares the consumer queue (`full-block.new-event`) so no events are
+//!     lost between filter registration and `consume`.
+//!  3. Publishes a full-block WATCH filter (wildcard, no addresses).
+//!  4. Spawns a live consumer and prints every block it receives.
+//!  5. On Ctrl-C: cancels the flow and unregisters the filter.
+//!
+//! ```bash
+//! BROKER_URL=redis://localhost:6379 CHAIN_ID=1 cargo run -p example --bin full_block
+//! ```
+
+use std::env;
+
+use anyhow::Context;
+use broker::{AckDecision, Broker};
+use consumer::{BlockPayload, ListenerConsumer};
+use tracing::{info, warn};
+
+/// Logical name for this downstream — appears in the routing key
+/// `full-block.new-event` and the WATCH command. Kept distinct from the
+/// `token` example so the two can run side by side without colliding.
+const CONSUMER_ID: &str = "full-block";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    init_tracing();
+
+    // ── 1. Wire-up: broker + ListenerConsumer ──────────────────────────────
+    let broker_url =
+        env::var("BROKER_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let chain_id: u64 = env::var("CHAIN_ID")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+
+    info!(%broker_url, chain_id, consumer_id = CONSUMER_ID, "starting full-block showcase");
+
+    let broker = Broker::from_url(&broker_url)
+        .await
+        .context("connecting to broker")?;
+    let consumer = ListenerConsumer::new(&broker, chain_id, CONSUMER_ID);
+
+    // ── 2. Declare the queue *before* publishing or consuming ──────────────
+    //      Without this, a WATCH published while the queue is missing would
+    //      generate events the broker drops on the floor.
+    consumer.ensure_consumer().await?;
+
+    // ── 3. Register the full-block (wildcard) filter ───────────────────────
+    //      No address fields → the listener broadcasts the entire block.
+    consumer.register_full_block().await?;
+    info!("registered full-block WATCH filter (wildcard: no from/to/log_address)");
+
+    // ── 4. Live consumer — print every block as it arrives ─────────────────
+    let live_handle = tokio::spawn(consumer.consume(|payload, _cancel| async move {
+        print_block(&payload);
+        Ok(AckDecision::Ack)
+    }));
+
+    // ── 5. Wait for Ctrl-C, then shut the flow down cleanly ────────────────
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => info!("ctrl-c — shutting down"),
+        r = live_handle             => warn!(?r, "live consumer exited unexpectedly"),
+    }
+
+    consumer.cancel();
+    if let Err(e) = consumer.unregister_full_block().await {
+        warn!(error = %e, "unregister_full_block failed (filter may linger in DB)");
+    }
+    info!("bye");
+    Ok(())
+}
+
+fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .init();
+}
+
+/// Print a full block: header fields, then every transaction with its logs.
+///
+/// Uses `println!` so the dump is easy to read when verifying the feature,
+/// kept separate from the structured `tracing` lifecycle logs above.
+fn print_block(payload: &BlockPayload) {
+    println!("════════════════════════════════════════════════════════════════");
+    println!(
+        "BLOCK #{} [{:?}]  (chain {})",
+        payload.block_number, payload.flow, payload.chain_id
+    );
+    println!("  hash        : {}", payload.block_hash);
+    println!("  parent hash : {}", payload.parent_hash);
+    println!("  timestamp   : {}", payload.timestamp);
+    println!("  transactions: {}", payload.transactions.len());
+
+    for tx in &payload.transactions {
+        let to = match tx.to {
+            Some(addr) => addr.to_string(),
+            None => "<contract-creation>".to_string(),
+        };
+        println!("  ──────────────────────────────────────────────────────────");
+        println!("  TX #{}  {}", tx.transaction_index, tx.hash);
+        println!("    from : {}", tx.from);
+        println!("    to   : {}", to);
+        println!("    logs : {}", tx.logs.len());
+
+        for log in &tx.logs {
+            println!(
+                "      LOG #{}  addr={}  topics={}",
+                log.log_index,
+                log.address,
+                log.topics.len()
+            );
+            for (i, topic) in log.topics.iter().enumerate() {
+                println!("        topic[{i}] : {topic}");
+            }
+            println!("        data     : {}", log.data);
+        }
+    }
+    println!("════════════════════════════════════════════════════════════════");
+}

--- a/listener/crates/listener_core/.gitignore
+++ b/listener/crates/listener_core/.gitignore
@@ -1,3 +1,4 @@
 target
 .claude
 .env
+config.local.yaml

--- a/listener/crates/shared/broker/src/redis/consumer.rs
+++ b/listener/crates/shared/broker/src/redis/consumer.rs
@@ -549,15 +549,34 @@ impl RedisConsumer {
                     {
                         continue;
                     }
+                    // Only fetch as many as we have free worker slots. This makes
+                    // prefetch_count a true concurrency cap (prefetch=1 => exactly one
+                    // in flight) and bounds the greedy re-poll below. The lock guard is a
+                    // temporary dropped at the `;`, so it is NOT held across the await.
+                    let available = config
+                        .prefetch_count
+                        .saturating_sub(in_flight.lock().await.len());
+                    if available == 0 {
+                        // At capacity — let workers finish; the result branch re-polls
+                        // immediately when a slot frees.
+                        continue;
+                    }
                     match self.xreadgroup(
                         &config.retry.base.stream,
                         &config.retry.base.group_name,
                         &config.retry.base.consumer_name,
-                        config.prefetch_count,
+                        available,
                         ">",
                     ).await {
                         Ok(entries) => {
                             consecutive_conn_errors = 0;
+                            // Adaptive drain: a non-empty read means more may be queued
+                            // right now — re-poll on the next loop iteration without
+                            // waiting for the block_ms heartbeat. An empty read leaves the
+                            // interval untouched, falling back to the block_ms idle cadence.
+                            if !entries.is_empty() {
+                                new_msg_interval.reset_immediately();
+                            }
                             for (stream_id, data) in entries {
                                 let should_dispatch = {
                                     let mut set = in_flight.lock().await;
@@ -809,6 +828,13 @@ impl RedisConsumer {
                             }
                         }
                     }
+
+                    // A worker slot just freed (the `in_flight.remove` happened at the top
+                    // of this branch). Fetch the next message now instead of waiting for the
+                    // block_ms heartbeat — the Redis analog of RMQ's "ack -> server pushes
+                    // next". Harmless while the breaker is open/half-open: the new-message
+                    // branch continues on its CB guard, so no read is issued.
+                    new_msg_interval.reset_immediately();
                 }
 
                 // Worker ended before delivering `ProcessingResult` (panic or send failure).
@@ -823,6 +849,9 @@ impl RedisConsumer {
                             "Worker exited before reporting result, cleared in-flight marker"
                         );
                     }
+                    // A slot may have freed (the worker exited before reporting); re-poll
+                    // immediately rather than waiting for the next block_ms tick.
+                    new_msg_interval.reset_immediately();
                     // If the abnormal exit was the Half-Open probe, clear `probe_in_flight`
                     // so the next pending tick can dispatch a fresh probe. We do NOT call
                     // `record_transient_failure` here — abnormal exit is not necessarily an

--- a/listener/crates/shared/broker/tests/redis_e2e.rs
+++ b/listener/crates/shared/broker/tests/redis_e2e.rs
@@ -1978,6 +1978,187 @@ async fn test_run_recovers_from_worker_panic() {
     );
 }
 
+// ── Adaptive drain: prefetch=1 drains far faster than prefetch_count/block_ms ──
+//
+// With a large block_ms (2s) and a near-instant handler, the pre-adaptive consumer
+// read one message per 2s tick, so draining N messages took ~(N-1)*block_ms. Adaptive
+// drain re-polls immediately after each completion (and after each non-empty read), so
+// draining is bounded by handler latency, not the timer. We assert the whole burst
+// drains in well under the naive timer cost.
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_adaptive_drain_fast_at_prefetch_one() {
+    let url = shared_redis_url().await;
+
+    let stream = "prefetch.adaptive-drain.events";
+    let dead_stream = "prefetch.adaptive-drain.events:dead";
+    let n: u64 = 6;
+    let block_ms: u64 = 2000;
+
+    let config = RedisConsumerConfigBuilder::new()
+        .stream(stream)
+        .group_name("adaptive-drain-group")
+        .consumer_name("consumer-1")
+        .dead_stream(dead_stream)
+        .max_retries(3)
+        // Keep ClaimSweeper out of the test window.
+        .claim_min_idle(Duration::from_secs(30))
+        .claim_interval(Duration::from_secs(10))
+        .prefetch_count(1)
+        .block_ms(block_ms as usize)
+        .build_prefetch()
+        .unwrap();
+
+    let processed = Arc::new(Mutex::new(HashSet::<u64>::new()));
+    let handler = {
+        let processed = processed.clone();
+        AsyncHandlerPayloadOnly::new(move |event: BlockEvent| {
+            let processed = processed.clone();
+            async move {
+                processed.lock().unwrap().insert(event.block_number);
+                Ok::<(), std::convert::Infallible>(())
+            }
+        })
+    };
+
+    let consumer = RedisConsumer::connect(url).await.unwrap();
+    let consumer_handle = tokio::spawn(async move {
+        let _ = consumer.run(config, handler).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let conn = RedisConnectionManager::new(url).await.unwrap();
+    let publisher = RedisPublisher::new(conn);
+    for i in 0..n {
+        publisher
+            .publish(stream, &BlockEvent { block_number: i })
+            .await
+            .unwrap();
+    }
+
+    // Time from "all published" to "all consumed".
+    let start = tokio::time::Instant::now();
+    let deadline = start + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        if processed.lock().unwrap().len() == n as usize {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let elapsed = start.elapsed();
+
+    consumer_handle.abort();
+
+    assert_eq!(
+        processed.lock().unwrap().len(),
+        n as usize,
+        "every published message should be consumed"
+    );
+    // Pre-adaptive cost would be ~(n-1)*block_ms = 10s (one tick per message after the
+    // first). Adaptive drain pays at most ~one block_ms for the first read, then drains
+    // the rest immediately. Half the naive cost is a generous, deterministic ceiling.
+    let naive_timer_cost = Duration::from_millis(block_ms * (n - 1));
+    assert!(
+        elapsed < naive_timer_cost / 2,
+        "adaptive drain should beat the block_ms timer ceiling: elapsed={elapsed:?}, naive={naive_timer_cost:?}"
+    );
+}
+
+// ── Strict concurrency cap: in-flight handlers never exceed prefetch_count ─────
+//
+// With a slow handler and a backlog, the pre-adaptive consumer read prefetch_count new
+// messages every block_ms tick with no capacity check, so in-flight could leak above
+// prefetch_count. The capacity gate caps concurrent handlers at prefetch_count while
+// still draining at full speed.
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_strict_concurrency_cap_under_load() {
+    let url = shared_redis_url().await;
+
+    let stream = "prefetch.strict-cap.events";
+    let dead_stream = "prefetch.strict-cap.events:dead";
+    let prefetch: usize = 3;
+    let n: u64 = 12;
+
+    let config = RedisConsumerConfigBuilder::new()
+        .stream(stream)
+        .group_name("strict-cap-group")
+        .consumer_name("consumer-1")
+        .dead_stream(dead_stream)
+        .max_retries(3)
+        .claim_min_idle(Duration::from_secs(30))
+        .claim_interval(Duration::from_secs(10))
+        .prefetch_count(prefetch)
+        .block_ms(100)
+        .build_prefetch()
+        .unwrap();
+
+    let in_flight = Arc::new(AtomicU32::new(0));
+    let max_in_flight = Arc::new(AtomicU32::new(0));
+    let processed = Arc::new(Mutex::new(HashSet::<u64>::new()));
+
+    let handler = {
+        let in_flight = in_flight.clone();
+        let max_in_flight = max_in_flight.clone();
+        let processed = processed.clone();
+        AsyncHandlerPayloadOnly::new(move |event: BlockEvent| {
+            let in_flight = in_flight.clone();
+            let max_in_flight = max_in_flight.clone();
+            let processed = processed.clone();
+            async move {
+                let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                max_in_flight.fetch_max(cur, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                processed.lock().unwrap().insert(event.block_number);
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+                Ok::<(), std::convert::Infallible>(())
+            }
+        })
+    };
+
+    let consumer = RedisConsumer::connect(url).await.unwrap();
+    let consumer_handle = tokio::spawn(async move {
+        let _ = consumer.run(config, handler).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let conn = RedisConnectionManager::new(url).await.unwrap();
+    let publisher = RedisPublisher::new(conn);
+    for i in 0..n {
+        publisher
+            .publish(stream, &BlockEvent { block_number: i })
+            .await
+            .unwrap();
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while tokio::time::Instant::now() < deadline {
+        if processed.lock().unwrap().len() == n as usize {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    consumer_handle.abort();
+
+    assert_eq!(
+        processed.lock().unwrap().len(),
+        n as usize,
+        "every message should be consumed"
+    );
+    let observed_max = max_in_flight.load(Ordering::SeqCst);
+    assert!(
+        observed_max <= prefetch as u32,
+        "in-flight handlers must never exceed prefetch_count: observed_max={observed_max}, prefetch={prefetch}"
+    );
+    assert!(
+        observed_max >= 2,
+        "test should actually exercise concurrency (observed_max={observed_max})"
+    );
+}
+
 // Helpers for auto-trim assertions.
 async fn redis_xlen(url: &str, stream: &str) -> u64 {
     let client = redis::Client::open(url).unwrap();

--- a/listener/crates/shared/primitives/src/event.rs
+++ b/listener/crates/shared/primitives/src/event.rs
@@ -36,18 +36,19 @@ pub struct FilterCommand {
 }
 
 impl FilterCommand {
-    /// Validate that the command has a non-empty consumer ID and at least one address.
+    /// Validate that the command has a non-empty consumer ID.
     ///
     /// Normalizes `consumer_id` by trimming leading/trailing whitespace so
     /// the stored value is always canonical.
+    ///
+    /// Address fields are all optional. A command with none of `from`, `to`,
+    /// or `log_address` set is a valid **full-block** (wildcard) subscription:
+    /// the consumer receives every transaction and every log of each block.
     #[must_use = "validation result must be checked"]
     pub fn validate(&mut self) -> Result<(), FilterCommandValidationError> {
         self.consumer_id = self.consumer_id.trim().to_owned();
         if self.consumer_id.is_empty() {
             return Err(FilterCommandValidationError::EmptyConsumerId);
-        }
-        if self.from.is_none() && self.to.is_none() && self.log_address.is_none() {
-            return Err(FilterCommandValidationError::MissingContractAddresses);
         }
         Ok(())
     }
@@ -364,16 +365,31 @@ mod tests {
     }
 
     #[test]
-    fn filter_command_rejects_missing_addresses() {
+    fn filter_command_accepts_full_block_wildcard() {
+        // A command with no address fields is a valid full-block subscription:
+        // the consumer receives every transaction and every log.
         let mut cmd = FilterCommand {
-            consumer_id: "gateway".into(),
+            consumer_id: "  gateway  ".into(),
+            from: None,
+            to: None,
+            log_address: None,
+        };
+        cmd.validate().unwrap();
+        assert_eq!(cmd.consumer_id, "gateway");
+    }
+
+    #[test]
+    fn filter_command_rejects_empty_consumer_id_even_when_wildcard() {
+        // Empty consumer_id is still rejected regardless of address fields.
+        let mut cmd = FilterCommand {
+            consumer_id: "   ".into(),
             from: None,
             to: None,
             log_address: None,
         };
         assert_eq!(
             cmd.validate().unwrap_err(),
-            FilterCommandValidationError::MissingContractAddresses,
+            FilterCommandValidationError::EmptyConsumerId,
         );
     }
 


### PR DESCRIPTION
Redis Streams and Rabbitmq message max size are 512MiB max which is quite more than a Full block size.
- Feature for getting full block for delegate consumer to filter events and log on full block.
- Adaptative draining feature for redis to allow faster message consuming at similar pace to rabbitmq.