### PR TITLE
Unwrap USDC flow

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -1179,6 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8005eef3a48a9a8cb21b126ae3bb252647e353afe6ef7f19e545177801c841"
 dependencies = [
  "anchor-lang",
+ "spl-associated-token-account-interface",
  "spl-token-2022-interface",
  "spl-token-interface",
 ]

--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -1,5 +1,5 @@
 {
-  "address": "EMhXFu68v61bQV4GrF6ZhZhWNVbH6bHPnTdLtXK8meqn",
+  "address": "4TU1nKdM6cfPRctp5ziwCfDB2VRLaV6yGGgR6KpZGc7C",
   "metadata": {
     "name": "zama_host",
     "version": "0.1.0",
@@ -334,6 +334,19 @@
       ]
     },
     {
+      "name": "FheTernaryOpEvent",
+      "discriminator": [
+        213,
+        15,
+        41,
+        197,
+        234,
+        166,
+        182,
+        95
+      ]
+    },
+    {
       "name": "InputVerifiedEvent",
       "discriminator": [
         72,
@@ -613,6 +626,9 @@
           },
           {
             "name": "Sub"
+          },
+          {
+            "name": "Ge"
           }
         ]
       }
@@ -1052,6 +1068,82 @@
           {
             "name": "fhe_type",
             "type": "u8"
+          },
+          {
+            "name": "result",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FheTernaryOpCode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "IfThenElse"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FheTernaryOpEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "op",
+            "type": {
+              "defined": {
+                "name": "FheTernaryOpCode"
+              }
+            }
+          },
+          {
+            "name": "subject",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "ls",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "ms",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "rs",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "result",

--- a/coprocessor/fhevm-engine/host-listener/src/generated/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/generated/mod.rs
@@ -4,5 +4,5 @@ pub use zama_host_events::{
     anchor_event_discriminator, decode_anchor_cpi_event, AclAllowedEvent,
     AclPublicDecryptAllowedEvent, FheBinaryOpCode, FheBinaryOpEvent,
     FheRandEvent, InputVerifiedEvent, TrivialEncryptEvent, ZamaHostEvent,
-    ANCHOR_EVENT_IX_TAG_LE, EVENT_VERSION,
+    ANCHOR_EVENT_IX_TAG_LE, EVENT_VERSION, FheTernaryOpEvent, FheTernaryOpCode
 };

--- a/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
@@ -6,8 +6,8 @@ use sha2::{Digest, Sha256};
 use sqlx::Error as SqlxError;
 
 use crate::generated::{
-    FheBinaryOpCode, FheBinaryOpEvent, FheRandEvent, TrivialEncryptEvent,
-    ZamaHostEvent,
+    FheBinaryOpCode, FheBinaryOpEvent, FheRandEvent, FheTernaryOpCode, FheTernaryOpEvent,
+    TrivialEncryptEvent, ZamaHostEvent,
 };
 
 use crate::contracts::TfheContract;
@@ -77,6 +77,7 @@ pub fn normalize_solana_events_for_db(
     for (index, event) in host_events.enumerate() {
         let tfhe_event = match event {
             ZamaHostEvent::FheBinaryOp(event) => to_tfhe_event(event),
+            ZamaHostEvent::FheTernaryOp(event) => to_ternary_event(event),
             ZamaHostEvent::TrivialEncrypt(event) => {
                 to_trivial_encrypt_event(event)
             }
@@ -223,6 +224,35 @@ pub fn to_tfhe_event(event: FheBinaryOpEvent) -> Log<TfheContractEvents> {
                 rhs,
                 scalarByte: scalar_byte,
                 result,
+            })
+        }
+        FheBinaryOpCode::Ge => {
+            TfheContractEvents::FheGe(TfheContract::FheGe {
+                caller,
+                lhs: Handle::from(event.lhs),
+                rhs: Handle::from(event.rhs),
+                scalarByte: scalar_byte,
+                result: Handle::from(event.result),
+            })
+        }
+    };
+
+    Log {
+        address: caller,
+        data,
+    }
+}
+
+pub fn to_ternary_event(event: FheTernaryOpEvent) -> Log<TfheContractEvents> {
+    let caller = Address::ZERO;
+    let data = match event.op {
+        FheTernaryOpCode::IfThenElse => {
+            TfheContractEvents::FheIfThenElse(TfheContract::FheIfThenElse {
+                caller,
+                control: Handle::from(event.ls),   // ls = control (BOOL)
+                ifTrue:  Handle::from(event.ms),    // ms = then
+                ifFalse: Handle::from(event.rs),    // rs = else
+                result:  Handle::from(event.result),
             })
         }
     };

--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -6,14 +6,11 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-confidential_token = "5GKzUSfqBSNjoVW83w3xPtTnAe84srZcDTBstpSoBCR4"
-zama_host = "EMhXFu68v61bQV4GrF6ZhZhWNVbH6bHPnTdLtXK8meqn"
-
-[registry]
-url = "https://api.apr.dev"
+confidential_token = "AYevU3R9B94fYWRkiyeecWahoRZwv6jorZsizyheiU7k"
+zama_host = "4TU1nKdM6cfPRctp5ziwCfDB2VRLaV6yGGgR6KpZGc7C"
 
 [provider]
-cluster = "Localnet"
+cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -342,6 +342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8005eef3a48a9a8cb21b126ae3bb252647e353afe6ef7f19e545177801c841"
 dependencies = [
  "anchor-lang",
+ "spl-associated-token-account-interface",
  "spl-token-2022-interface",
  "spl-token-interface",
 ]

--- a/solana/crates/zama-fhe/src/frame.rs
+++ b/solana/crates/zama-fhe/src/frame.rs
@@ -158,6 +158,14 @@ impl<'a, 'info> Builder<'a, 'info> {
         self.binary_op(FheOpcode::Sub, lhs, rhs, output_fhe_type)
     }
 
+    pub fn ge(&mut self, lhs: FrameValue, rhs: FrameValue) -> Result<FrameValue> {
+        self.binary_op(FheOpcode::Ge, lhs, rhs, 0)
+    }
+
+    pub fn if_then_else(&mut self, control: FrameValue, th: FrameValue, el: FrameValue, output_fhe_type: u8) -> Result<FrameValue> {
+        self.ternary_op(FheOpcode::IfThenElse, control, th, el, output_fhe_type)
+    }
+
     pub fn allow(&mut self, value: &FrameValue, allow: DurableAllow<'info>) -> Result<()> {
         let app_account = allow.app_account.key();
         self.authorize_app_account(allow.app_account)?;
@@ -206,6 +214,24 @@ impl<'a, 'info> Builder<'a, 'info> {
         Ok(FrameValue {
             operand: FheOperand::PreviousResult { index: index as u8 },
         })
+    }
+
+    fn ternary_op(
+        &mut self,
+        opcode: FheOpcode,
+        ls: FrameValue,
+        ms: FrameValue,
+        rs: FrameValue,
+        output_fhe_type: u8
+    ) -> Result<FrameValue> {
+        let index = self.steps.len();
+        self.steps.push(FheFrameStep::Operation { 
+            opcode, 
+            operands: vec![ls.operand, ms.operand, rs.operand], 
+            scalar_byte: 0, 
+            output_fhe_type 
+        });
+        Ok(FrameValue { operand: FheOperand::PreviousResult { index: index as u8 } })
     }
 
     fn push_account(&mut self, account: AccountInfo<'info>) -> Result<Pubkey> {

--- a/solana/crates/zama-host-events/build.rs
+++ b/solana/crates/zama-host-events/build.rs
@@ -25,10 +25,10 @@ fn main() {
     let events = idl["events"]
         .as_array()
         .expect("Anchor IDL must contain events");
-    let op_type = types
+    let op_binary_type = types
         .get("FheBinaryOpCode")
         .expect("ZamaHost IDL must define FheBinaryOpCode");
-    let op_variants = op_type["type"]["variants"]
+    let op_binary_variants = op_binary_type["type"]["variants"]
         .as_array()
         .expect("FheBinaryOpCode must be an enum")
         .iter()
@@ -38,6 +38,20 @@ fn main() {
                 .expect("enum variant must have a name")
         })
         .collect::<Vec<_>>();
+
+        let op_ternary_type = types
+            .get("FheTernaryOpCode")
+            .expect("ZamaHost IDL must define FheTernaryOpCode");
+        let op_ternary_variants = op_ternary_type["type"]["variants"]
+            .as_array()
+            .expect("FheTernaryOpCode must be an enum")
+            .iter()
+            .map(|variant| {
+                variant["name"]
+                    .as_str()
+                    .expect("enum variant must have a name")
+            })
+            .collect::<Vec<_>>();
 
     let mut output = String::from(
         r#"// Generated from host-listener/idl/zama_host.json by zama-host-events/build.rs.
@@ -53,7 +67,16 @@ pub const ANCHOR_EVENT_IX_TAG_LE: [u8; 8] = 0x1d9acb512ea545e4_u64.to_le_bytes()
 
     output.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq)]\n");
     output.push_str("pub enum FheBinaryOpCode {\n");
-    for variant in &op_variants {
+    for variant in &op_binary_variants {
+        output.push_str("    ");
+        output.push_str(variant);
+        output.push_str(",\n");
+    }
+    output.push_str("}\n\n");
+
+    output.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq)]\n");
+    output.push_str("pub enum FheTernaryOpCode {\n");
+    for variant in &op_ternary_variants {
         output.push_str("    ");
         output.push_str(variant);
         output.push_str(",\n");
@@ -148,10 +171,23 @@ pub const ANCHOR_EVENT_IX_TAG_LE: [u8; 8] = 0x1d9acb512ea545e4_u64.to_le_bytes()
         "fn read_fhe_binary_op_code(cursor: &mut Cursor<'_>) -> Option<FheBinaryOpCode> {\n",
     );
     output.push_str("    match cursor.read_u8()? {\n");
-    for (index, variant) in op_variants.iter().enumerate() {
+    for (index, variant) in op_binary_variants.iter().enumerate() {
         output.push_str("        ");
         output.push_str(&index.to_string());
         output.push_str(" => Some(FheBinaryOpCode::");
+        output.push_str(variant);
+        output.push_str("),\n");
+    }
+    output.push_str("        _ => None,\n    }\n}\n\n");
+
+    output.push_str(
+        "fn read_fhe_ternary_op_code(cursor: &mut Cursor<'_>) -> Option<FheTernaryOpCode> {\n",
+    );
+    output.push_str("    match cursor.read_u8()? {\n");
+    for (index, variant) in op_ternary_variants.iter().enumerate() {
+        output.push_str("        ");
+        output.push_str(&index.to_string());
+        output.push_str(" => Some(FheTernaryOpCode::");
         output.push_str(variant);
         output.push_str("),\n");
     }
@@ -250,6 +286,7 @@ fn read_expr(idl_type: &Value) -> String {
     if let Some(defined) = idl_type["defined"]["name"].as_str() {
         return match defined {
             "FheBinaryOpCode" => "read_fhe_binary_op_code(&mut cursor)".to_string(),
+            "FheTernaryOpCode" => "read_fhe_ternary_op_code(&mut cursor)".to_string(),
             other => panic!("unsupported IDL defined type {other}"),
         };
     }

--- a/solana/crates/zama-host-events/src/lib.rs
+++ b/solana/crates/zama-host-events/src/lib.rs
@@ -8,6 +8,15 @@ impl FheBinaryOpCode {
         match self {
             Self::Add => 0,
             Self::Sub => 1,
+            Self::Ge  => 14
+        }
+    }
+}
+
+impl FheTernaryOpCode {
+    pub const fn as_u8(self) -> u8 {
+        match self {
+            Self::IfThenElse => 25
         }
     }
 }

--- a/solana/programs/confidential-token/Cargo.toml
+++ b/solana/programs/confidential-token/Cargo.toml
@@ -20,6 +20,6 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build", "zama-fhe/idl-buil
 
 [dependencies]
 anchor-lang = "1.0.2"
-anchor-spl = { version = "1.0.2", default-features = false, features = ["token", "token_2022"] }
+anchor-spl = { version = "1.0.2", default-features = false, features = ["token", "token_2022", "associated_token"] }
 zama-host = { path = "../zama-host", features = ["cpi"] }
 zama-fhe = { path = "../../crates/zama-fhe" }

--- a/solana/programs/confidential-token/src/constant.rs
+++ b/solana/programs/confidential-token/src/constant.rs
@@ -1,0 +1,5 @@
+pub const CONFIDENTIAL_MINT: &[u8] = b"confidential-mint";
+pub const CONFIDENTIAL_TOKEN_ACCOUNT: &[u8] = b"token-account";
+pub const VAULT_AUTHORITY: &[u8] = b"vault-authority";
+pub const FHE_COMPUTE: &[u8] = b"fhe-compute";
+pub const FHE_RAND_COUNTER: &[u8] = b"fhe-rand-counter";

--- a/solana/programs/confidential-token/src/instructions/mod.rs
+++ b/solana/programs/confidential-token/src/instructions/mod.rs
@@ -1,0 +1,3 @@
+mod unwrap_usdc;
+
+pub use unwrap_usdc::*;

--- a/solana/programs/confidential-token/src/instructions/unwrap_usdc.rs
+++ b/solana/programs/confidential-token/src/instructions/unwrap_usdc.rs
@@ -1,0 +1,352 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self as spl_token, Mint as SplMint, Token, TokenAccount, TransferChecked};
+use zama_fhe as fhe;
+use zama_host::{self, program::ZamaHost};
+
+use crate::{
+    APP_EVENT_VERSION, BALANCE_FHE_TYPE, BalanceHandleUpdateReason, BalanceHandleUpdatedEvent,
+    ConfidentialMint, ConfidentialTokenAccount, ConfidentialTokenError, WithdrawalRequestedEvent,
+    balance_acl_subjects, balance_label, balance_nonce_key, constant::{
+        CONFIDENTIAL_MINT, CONFIDENTIAL_TOKEN_ACCOUNT, FHE_COMPUTE, FHE_RAND_COUNTER,
+        VAULT_AUTHORITY,
+    }, durable_acl_handle, fhe_context, token_app_account, withdrawal_label, withdrawal_nonce_key
+};
+
+pub fn request_unwrap_usdc(ctx: Context<RequestUnwrapUsdc>, amount: u64) -> Result<()> {
+    let token_account = &ctx.accounts.token_account;
+    let mint = &ctx.accounts.mint;
+    let compute_signer = mint.compute_signer;
+    let nonce_sequence = token_account.next_balance_nonce_sequence;
+
+    require_keys_eq!(
+        token_account.owner,
+        ctx.accounts.owner.key(),
+        ConfidentialTokenError::OwnerMismatch
+    );
+
+    require_keys_eq!(
+        token_account.mint,
+        mint.key(),
+        ConfidentialTokenError::MintMismatch
+    );
+
+    require_keys_eq!(
+        mint.underlying_mint,
+        ctx.accounts.underlying_mint.key(),
+        ConfidentialTokenError::UnderlyingMintMismatch
+    );
+    require_keys_eq!(
+        ctx.accounts.compute_signer.key(),
+        compute_signer,
+        ConfidentialTokenError::ComputeSignerMismatch
+    );
+    require_keys_eq!(
+        ctx.accounts.current_compute_acl.key(),
+        token_account.balance_acl_record,
+        ConfidentialTokenError::CurrentAclRecordMismatch
+    );
+
+    fhe::execute(
+        fhe_context(
+            &ctx.accounts.owner,
+            &ctx.accounts.zama_event_authority,
+            &ctx.accounts.zama_program,
+            &ctx.accounts.compute_signer,
+            &ctx.accounts.zama_rand_counter,
+            mint.key(),
+            ctx.bumps.compute_signer,
+            &ctx.accounts.system_program,
+        ),
+        |fhe| {
+            let current_balance = fhe.encrypted(fhe::EncryptedValue {
+                handle: token_account.balance_handle,
+                acl_record: ctx.accounts.current_compute_acl.to_account_info(),
+            })?;
+            let amount = fhe.trivial_encrypt_u64(amount, BALANCE_FHE_TYPE)?;
+            let zero = fhe.trivial_encrypt_u64(0, BALANCE_FHE_TYPE)?;
+            let unwrap_allowed = fhe.ge(current_balance, amount.clone())?;
+            let allowed_withdrawal = fhe.if_then_else(unwrap_allowed, amount, zero, BALANCE_FHE_TYPE)?;
+            fhe.allow(
+                &allowed_withdrawal,
+                fhe::DurableAllow {
+                    acl_record: ctx.accounts.output_acl.to_account_info(),
+                    app_account: token_app_account(token_account.to_account_info()),
+                    nonce_key: withdrawal_nonce_key(mint.key(), token_account.key()),
+                    nonce_sequence,
+                    encrypted_value_label: withdrawal_label(),
+                    subjects: balance_acl_subjects(token_account.owner, compute_signer),
+                    public_decrypt: true,
+                },
+            )?;
+            Ok(())
+        },
+    )?;
+    let withdrawal_handle = durable_acl_handle(&ctx.accounts.output_acl.to_account_info())?;
+
+    let token_account = &mut ctx.accounts.token_account;
+    // Record the approved withdrawal as pending; the balance is left untouched
+    // here and is only debited in `finalize_unwrap_usdc`, once the coprocessor
+    // has publicly decrypted this handle.
+    token_account.pending_withdrawal_handle = withdrawal_handle;
+    token_account.pending_withdrawal_acl_record = ctx.accounts.output_acl.key();
+    // PoC simplicity: the withdrawal ACL reuses the balance nonce counter. This
+    // can be split into a dedicated withdrawal nonce space after the PoC.
+    token_account.next_balance_nonce_sequence = nonce_sequence
+        .checked_add(1)
+        .ok_or(ConfidentialTokenError::AclNonceOverflow)?;
+    emit_cpi!(WithdrawalRequestedEvent {
+        version: APP_EVENT_VERSION,
+        mint: mint.key(),
+        owner: token_account.owner,
+        token_account: token_account.key(),
+        withdrawal_handle,
+        withdrawal_acl_record: ctx.accounts.output_acl.key(),
+        nonce_sequence,
+    });
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[event_cpi]
+pub struct RequestUnwrapUsdc<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    #[account(seeds = [CONFIDENTIAL_MINT, underlying_mint.key().as_ref()], bump)]
+    pub mint: Box<Account<'info, ConfidentialMint>>,
+    #[account(mut, seeds = [CONFIDENTIAL_TOKEN_ACCOUNT, mint.key().as_ref(), owner.key().as_ref()], bump)]
+    pub token_account: Box<Account<'info, ConfidentialTokenAccount>>,
+    /// spl mints does not have derivation scheme
+    pub underlying_mint: Box<Account<'info, SplMint>>,
+    /// CHECK: PDA authority for the underlying-token vault.
+    #[account(seeds = [VAULT_AUTHORITY, mint.key().as_ref()], bump)]
+    pub vault_authority: UncheckedAccount<'info>,
+    /// CHECK: Program-controlled compute signer PDA.
+    #[account(seeds = [FHE_COMPUTE, mint.key().as_ref()], bump)]
+    pub compute_signer: UncheckedAccount<'info>,
+    pub current_compute_acl: Box<Account<'info, zama_host::AclRecord>>,
+    /// CHECK: initialized and validated by the Zama host program CPI.
+    #[account(mut)]
+    pub output_acl: UncheckedAccount<'info>,
+    /// CHECK: global Zama host rand counter PDA.
+    #[account(
+        mut,
+        seeds = [FHE_RAND_COUNTER],
+        bump,
+        seeds::program = zama_program.key()
+    )]
+    pub zama_rand_counter: UncheckedAccount<'info>,
+    /// CHECK: Anchor event CPI authority for the Zama host program.
+    pub zama_event_authority: UncheckedAccount<'info>,
+    pub zama_program: Program<'info, ZamaHost>,
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+/// Phase 2 of unwrap: completes a withdrawal whose approved amount has been
+/// publicly decrypted by the coprocessor. Transfers the cleartext amount from
+/// the vault to the user and debits the encrypted balance by the same handle.
+///
+/// PoC: `amount` is the cleartext of `pending_withdrawal_handle`, delivered by
+/// the relayer. It is currently trusted (we only check public-decrypt
+/// eligibility via the ACL record). Production MUST verify a KMS-signed
+/// public-decrypt proof binding `(pending_withdrawal_handle, amount)` — the
+/// analog of EVM `FHE.checkSignatures` — before releasing funds.
+pub fn finalize_unwrap_usdc(ctx: Context<FinalizeUnwrapUsdc>, amount: u64) -> Result<()> {
+    let token_account = &ctx.accounts.token_account;
+    let mint = &ctx.accounts.mint;
+    let compute_signer = mint.compute_signer;
+    let nonce_sequence = token_account.next_balance_nonce_sequence;
+    let old_balance_handle = token_account.balance_handle;
+    let old_balance_acl_record = token_account.balance_acl_record;
+    let pending_withdrawal_handle = token_account.pending_withdrawal_handle;
+
+    require_keys_eq!(
+        token_account.owner,
+        ctx.accounts.owner.key(),
+        ConfidentialTokenError::OwnerMismatch
+    );
+    require_keys_eq!(
+        token_account.mint,
+        mint.key(),
+        ConfidentialTokenError::MintMismatch
+    );
+    require_keys_eq!(
+        mint.underlying_mint,
+        ctx.accounts.underlying_mint.key(),
+        ConfidentialTokenError::UnderlyingMintMismatch
+    );
+    require_keys_eq!(
+        ctx.accounts.compute_signer.key(),
+        compute_signer,
+        ConfidentialTokenError::ComputeSignerMismatch
+    );
+    require_keys_eq!(
+        ctx.accounts.current_compute_acl.key(),
+        token_account.balance_acl_record,
+        ConfidentialTokenError::CurrentAclRecordMismatch
+    );
+
+    // There must be a pending withdrawal, and the supplied ACL record must be it.
+    require!(
+        pending_withdrawal_handle != [0u8; 32],
+        ConfidentialTokenError::NoPendingWithdrawal
+    );
+    require_keys_eq!(
+        ctx.accounts.withdrawal_acl.key(),
+        token_account.pending_withdrawal_acl_record,
+        ConfidentialTokenError::PendingWithdrawalMismatch
+    );
+    // Eligibility: the ACL record must bind the pending handle and be publicly
+    // decryptable. (This is the eligibility half of the KMS check, mirroring
+    // `kms_like_public_decrypt_check` — NOT authenticity of `amount`.)
+    require!(
+        ctx.accounts.withdrawal_acl.handle == pending_withdrawal_handle,
+        ConfidentialTokenError::PendingWithdrawalMismatch
+    );
+    require!(
+        ctx.accounts.withdrawal_acl.public_decrypt,
+        ConfidentialTokenError::PendingWithdrawalMismatch
+    );
+
+    // TODO(PoC hardening): verify a KMS-signed public-decrypt proof binding
+    // (pending_withdrawal_handle, amount) before releasing funds, e.g. by CPI
+    // into a `zama_host::verify_public_decrypt(handle, amount, proof)` primitive.
+    // Until then `amount` is trusted from the caller.
+
+    // Transfer the approved amount from the vault to the user (vault PDA signs).
+    let mint_key = mint.key();
+    let vault_seeds: &[&[u8]] = &[
+        VAULT_AUTHORITY,
+        mint_key.as_ref(),
+        &[ctx.bumps.vault_authority],
+    ];
+    spl_token::transfer_checked(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.key(),
+            TransferChecked {
+                from: ctx.accounts.vault_usdc.to_account_info(),
+                mint: ctx.accounts.underlying_mint.to_account_info(),
+                to: ctx.accounts.user_usdc.to_account_info(),
+                authority: ctx.accounts.vault_authority.to_account_info(),
+            },
+            &[vault_seeds],
+        ),
+        amount,
+        mint.decimals,
+    )?;
+
+    // Debit the encrypted balance by the same (now-revealed) approved withdrawal
+    // handle, so the plaintext transferred equals the encrypted amount debited.
+    fhe::execute(
+        fhe_context(
+            &ctx.accounts.owner,
+            &ctx.accounts.zama_event_authority,
+            &ctx.accounts.zama_program,
+            &ctx.accounts.compute_signer,
+            &ctx.accounts.zama_rand_counter,
+            mint.key(),
+            ctx.bumps.compute_signer,
+            &ctx.accounts.system_program,
+        ),
+        |fhe| {
+            let current_balance = fhe.encrypted(fhe::EncryptedValue {
+                handle: token_account.balance_handle,
+                acl_record: ctx.accounts.current_compute_acl.to_account_info(),
+            })?;
+            let withdrawal = fhe.encrypted(fhe::EncryptedValue {
+                handle: pending_withdrawal_handle,
+                acl_record: ctx.accounts.withdrawal_acl.to_account_info(),
+            })?;
+            let new_balance = fhe.sub(current_balance, withdrawal, BALANCE_FHE_TYPE)?;
+            fhe.allow(
+                &new_balance,
+                fhe::DurableAllow {
+                    acl_record: ctx.accounts.output_acl.to_account_info(),
+                    app_account: token_app_account(token_account.to_account_info()),
+                    nonce_key: balance_nonce_key(mint.key(), token_account.key()),
+                    nonce_sequence,
+                    encrypted_value_label: balance_label(),
+                    subjects: balance_acl_subjects(token_account.owner, compute_signer),
+                    public_decrypt: false,
+                },
+            )?;
+            Ok(())
+        },
+    )?;
+    let new_balance_handle = durable_acl_handle(&ctx.accounts.output_acl.to_account_info())?;
+
+    let token_account = &mut ctx.accounts.token_account;
+    token_account.balance_handle = new_balance_handle;
+    token_account.balance_acl_record = ctx.accounts.output_acl.key();
+    token_account.next_balance_nonce_sequence = nonce_sequence
+        .checked_add(1)
+        .ok_or(ConfidentialTokenError::AclNonceOverflow)?;
+    // Clear the pending withdrawal now that it has been finalized.
+    token_account.pending_withdrawal_handle = [0; 32];
+    token_account.pending_withdrawal_acl_record = Pubkey::default();
+    emit_cpi!(BalanceHandleUpdatedEvent {
+        version: APP_EVENT_VERSION,
+        mint: mint.key(),
+        owner: token_account.owner,
+        token_account: token_account.key(),
+        old_handle: old_balance_handle,
+        old_acl_record: old_balance_acl_record,
+        new_handle: new_balance_handle,
+        new_acl_record: ctx.accounts.output_acl.key(),
+        reason: BalanceHandleUpdateReason::Unwrap,
+    });
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[event_cpi]
+pub struct FinalizeUnwrapUsdc<'info> {
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    #[account(seeds = [CONFIDENTIAL_MINT, underlying_mint.key().as_ref()], bump)]
+    pub mint: Box<Account<'info, ConfidentialMint>>,
+    #[account(mut, seeds = [CONFIDENTIAL_TOKEN_ACCOUNT, mint.key().as_ref(), owner.key().as_ref()], bump)]
+    pub token_account: Box<Account<'info, ConfidentialTokenAccount>>,
+    /// spl mints does not have derivation scheme
+    pub underlying_mint: Box<Account<'info, SplMint>>,
+    #[account(
+        mut,
+        constraint = user_usdc.mint == underlying_mint.key() @ ConfidentialTokenError::UnderlyingMintMismatch,
+        constraint = user_usdc.owner == owner.key() @ ConfidentialTokenError::OwnerMismatch
+    )]
+    pub user_usdc: Box<Account<'info, TokenAccount>>,
+    #[account(
+        mut,
+        constraint = vault_usdc.mint == underlying_mint.key() @ ConfidentialTokenError::UnderlyingMintMismatch,
+        constraint = vault_usdc.owner == vault_authority.key() @ ConfidentialTokenError::VaultAuthorityMismatch
+    )]
+    pub vault_usdc: Box<Account<'info, TokenAccount>>,
+    /// CHECK: PDA authority for the underlying-token vault.
+    #[account(seeds = [VAULT_AUTHORITY, mint.key().as_ref()], bump)]
+    pub vault_authority: UncheckedAccount<'info>,
+    /// CHECK: Program-controlled compute signer PDA.
+    #[account(seeds = [FHE_COMPUTE, mint.key().as_ref()], bump)]
+    pub compute_signer: UncheckedAccount<'info>,
+    pub current_compute_acl: Box<Account<'info, zama_host::AclRecord>>,
+    /// The pending withdrawal ACL record (allowed for public decryption),
+    /// consumed by this instruction.
+    pub withdrawal_acl: Box<Account<'info, zama_host::AclRecord>>,
+    /// CHECK: initialized and validated by the Zama host program CPI.
+    #[account(mut)]
+    pub output_acl: UncheckedAccount<'info>,
+    /// CHECK: global Zama host rand counter PDA.
+    #[account(
+        mut,
+        seeds = [FHE_RAND_COUNTER],
+        bump,
+        seeds::program = zama_program.key()
+    )]
+    pub zama_rand_counter: UncheckedAccount<'info>,
+    /// CHECK: Anchor event CPI authority for the Zama host program.
+    pub zama_event_authority: UncheckedAccount<'info>,
+    pub zama_program: Program<'info, ZamaHost>,
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}

--- a/solana/programs/confidential-token/src/instructions/unwrap_usdc.rs
+++ b/solana/programs/confidential-token/src/instructions/unwrap_usdc.rs
@@ -4,12 +4,15 @@ use zama_fhe as fhe;
 use zama_host::{self, program::ZamaHost};
 
 use crate::{
-    APP_EVENT_VERSION, BALANCE_FHE_TYPE, BalanceHandleUpdateReason, BalanceHandleUpdatedEvent,
-    ConfidentialMint, ConfidentialTokenAccount, ConfidentialTokenError, WithdrawalRequestedEvent,
-    balance_acl_subjects, balance_label, balance_nonce_key, constant::{
+    balance_acl_subjects, balance_label, balance_nonce_key,
+    constant::{
         CONFIDENTIAL_MINT, CONFIDENTIAL_TOKEN_ACCOUNT, FHE_COMPUTE, FHE_RAND_COUNTER,
         VAULT_AUTHORITY,
-    }, durable_acl_handle, fhe_context, token_app_account, withdrawal_label, withdrawal_nonce_key
+    },
+    durable_acl_handle, fhe_context, token_app_account, withdrawal_label, withdrawal_nonce_key,
+    BalanceHandleUpdateReason, BalanceHandleUpdatedEvent, ConfidentialMint,
+    ConfidentialTokenAccount, ConfidentialTokenError, WithdrawalRequestedEvent, APP_EVENT_VERSION,
+    BALANCE_FHE_TYPE,
 };
 
 pub fn request_unwrap_usdc(ctx: Context<RequestUnwrapUsdc>, amount: u64) -> Result<()> {
@@ -46,6 +49,16 @@ pub fn request_unwrap_usdc(ctx: Context<RequestUnwrapUsdc>, amount: u64) -> Resu
         ConfidentialTokenError::CurrentAclRecordMismatch
     );
 
+    require!(
+        token_account.pending_withdrawal_handle == [0u8; 32],
+        ConfidentialTokenError::PendingWithdrawal
+    );
+    require_keys_eq!(
+        Pubkey::default(),
+        token_account.pending_withdrawal_acl_record,
+        ConfidentialTokenError::PendingWithdrawal
+    );
+
     fhe::execute(
         fhe_context(
             &ctx.accounts.owner,
@@ -65,7 +78,8 @@ pub fn request_unwrap_usdc(ctx: Context<RequestUnwrapUsdc>, amount: u64) -> Resu
             let amount = fhe.trivial_encrypt_u64(amount, BALANCE_FHE_TYPE)?;
             let zero = fhe.trivial_encrypt_u64(0, BALANCE_FHE_TYPE)?;
             let unwrap_allowed = fhe.ge(current_balance, amount.clone())?;
-            let allowed_withdrawal = fhe.if_then_else(unwrap_allowed, amount, zero, BALANCE_FHE_TYPE)?;
+            let allowed_withdrawal =
+                fhe.if_then_else(unwrap_allowed, amount, zero, BALANCE_FHE_TYPE)?;
             fhe.allow(
                 &allowed_withdrawal,
                 fhe::DurableAllow {

--- a/solana/programs/confidential-token/src/lib.rs
+++ b/solana/programs/confidential-token/src/lib.rs
@@ -7,7 +7,13 @@ use anchor_spl::token::{self as spl_token, Mint as SplMint, Token, TokenAccount,
 use zama_fhe as fhe;
 use zama_host::{self, program::ZamaHost, AclSubjectEntry};
 
-declare_id!("5GKzUSfqBSNjoVW83w3xPtTnAe84srZcDTBstpSoBCR4");
+mod instructions;
+mod constant;
+
+pub use instructions::*;
+use constant::{CONFIDENTIAL_MINT, CONFIDENTIAL_TOKEN_ACCOUNT};
+
+declare_id!("AYevU3R9B94fYWRkiyeecWahoRZwv6jorZsizyheiU7k");
 
 const BALANCE_FHE_TYPE: u8 = 5;
 const APP_EVENT_VERSION: u8 = 0;
@@ -37,6 +43,8 @@ pub mod confidential_token {
         token_account.balance_handle = [0; 32];
         token_account.balance_acl_record = Pubkey::default();
         token_account.next_balance_nonce_sequence = 1;
+        token_account.pending_withdrawal_handle = [0; 32];
+        token_account.pending_withdrawal_acl_record = Pubkey::default();
         token_account.bump = ctx.bumps.token_account;
         require_keys_eq!(
             ctx.accounts.mint.acl_domain_key,
@@ -347,6 +355,14 @@ pub mod confidential_token {
         Ok(())
     }
 
+    pub fn request_unwrap_usdc(ctx: Context<RequestUnwrapUsdc>, amount: u64) -> Result<()> {
+        instructions::request_unwrap_usdc(ctx, amount)
+    }
+
+    pub fn finalize_unwrap_usdc(ctx: Context<FinalizeUnwrapUsdc>, amount: u64) -> Result<()> {
+        instructions::finalize_unwrap_usdc(ctx, amount)
+    }
+
     /// PoC demo: birth an encrypted random u64 via `fheRand`, durable-allow it for the owner,
     /// and emit an app event the frontend/indexer can consume for a user-decrypt request.
     pub fn poc_demo_confidential_rand(
@@ -418,7 +434,13 @@ pub mod confidential_token {
 pub struct InitializeMint<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
-    #[account(init, payer = authority, space = 8 + ConfidentialMint::SPACE)]
+    #[account(
+        init, 
+        payer = authority, 
+        space = 8 + ConfidentialMint::SPACE, 
+        seeds = [CONFIDENTIAL_MINT, underlying_mint.key().as_ref()], 
+        bump
+    )]
     pub mint: Account<'info, ConfidentialMint>,
     pub underlying_mint: Account<'info, SplMint>,
     pub system_program: Program<'info, System>,
@@ -429,7 +451,9 @@ pub struct InitializeMint<'info> {
 pub struct InitializeTokenAccount<'info> {
     #[account(mut)]
     pub owner: Signer<'info>,
+    #[account(seeds = [CONFIDENTIAL_MINT, underlying_mint.key().as_ref()], bump)]
     pub mint: Account<'info, ConfidentialMint>,
+    pub underlying_mint: Account<'info, SplMint>,
     /// CHECK: Program-controlled compute signer PDA.
     #[account(seeds = [b"fhe-compute", mint.key().as_ref()], bump)]
     pub compute_signer: UncheckedAccount<'info>,
@@ -463,8 +487,13 @@ pub struct InitializeTokenAccount<'info> {
 pub struct WrapUsdc<'info> {
     #[account(mut)]
     pub owner: Signer<'info>,
+    #[account(seeds = [CONFIDENTIAL_MINT, underlying_mint.key().as_ref()], bump)]
     pub mint: Box<Account<'info, ConfidentialMint>>,
-    #[account(mut)]
+    #[account(
+        mut,
+        seeds = [CONFIDENTIAL_TOKEN_ACCOUNT, mint.key().as_ref(), owner.key().as_ref()],
+        bump
+    )]
     pub token_account: Box<Account<'info, ConfidentialTokenAccount>>,
     pub underlying_mint: Box<Account<'info, SplMint>>,
     #[account(
@@ -592,6 +621,10 @@ pub struct ConfidentialTokenAccount {
     pub balance_handle: [u8; 32],
     pub balance_acl_record: Pubkey,
     pub next_balance_nonce_sequence: u64,
+    /// Pending unwrap: the approved-withdrawal handle awaiting coprocessor
+    /// public decryption, consumed by `finalize_unwrap_usdc`. Zeroed when none.
+    pub pending_withdrawal_handle: [u8; 32],
+    pub pending_withdrawal_acl_record: Pubkey,
     pub bump: u8,
 }
 
@@ -619,16 +652,33 @@ pub struct BalanceHandleUpdatedEvent {
     pub reason: BalanceHandleUpdateReason,
 }
 
+/// Emitted by `request_unwrap_usdc`: the approved-withdrawal handle is now
+/// pending coprocessor public decryption. The balance is unchanged at this
+/// point; it is debited in `finalize_unwrap_usdc`.
+#[event]
+pub struct WithdrawalRequestedEvent {
+    pub version: u8,
+    pub mint: Pubkey,
+    pub owner: Pubkey,
+    pub token_account: Pubkey,
+    pub withdrawal_handle: [u8; 32],
+    pub withdrawal_acl_record: Pubkey,
+    pub nonce_sequence: u64,
+}
+
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BalanceHandleUpdateReason {
     Initialize,
     Wrap,
+    Unwrap,
     TransferDebit,
     TransferCredit,
 }
 
 impl ConfidentialTokenAccount {
-    pub const SPACE: usize = 32 + 32 + 32 + 32 + 8 + 1;
+    // owner + mint + balance_handle + balance_acl_record + next_balance_nonce_sequence
+    // + pending_withdrawal_handle + pending_withdrawal_acl_record + bump
+    pub const SPACE: usize = 32 + 32 + 32 + 32 + 8 + 32 + 32 + 1;
 }
 
 #[error_code]
@@ -649,6 +699,10 @@ pub enum ConfidentialTokenError {
     ComputeSignerMismatch,
     #[msg("current ACL record does not match token account state")]
     CurrentAclRecordMismatch,
+    #[msg("no pending withdrawal to finalize")]
+    NoPendingWithdrawal,
+    #[msg("withdrawal ACL record does not match the pending withdrawal")]
+    PendingWithdrawalMismatch,
 }
 
 // Shared constructor for `fhe::Context`; it forwards the host accounts each
@@ -705,8 +759,16 @@ pub fn balance_nonce_key(acl_domain_key: Pubkey, app_account: Pubkey) -> [u8; 32
     nonce_key(acl_domain_key, app_account, balance_label())
 }
 
+pub fn boolean_nonce_key(acl_domain_key: Pubkey, app_account: Pubkey) -> [u8; 32] {
+    nonce_key(acl_domain_key, app_account, boolean_label())
+}
+
 pub fn balance_label() -> [u8; 32] {
     *b"balance_________________________"
+}
+
+pub fn boolean_label() -> [u8; 32] {
+    *b"boolean_________________________"
 }
 
 pub fn rand_label() -> [u8; 32] {
@@ -715,6 +777,18 @@ pub fn rand_label() -> [u8; 32] {
 
 pub fn rand_nonce_key(acl_domain_key: Pubkey, app_account: Pubkey) -> [u8; 32] {
     nonce_key(acl_domain_key, app_account, rand_label())
+}
+
+pub fn wrap_amount_label() -> [u8; 32] {
+    *b"wrap_amount_____________________"
+}
+
+pub fn withdrawal_label() -> [u8; 32] {
+    *b"withdrawal______________________"
+}
+
+pub fn withdrawal_nonce_key(acl_domain_key: Pubkey, app_account: Pubkey) -> [u8; 32] {
+    nonce_key(acl_domain_key, app_account, withdrawal_label())
 }
 
 pub fn nonce_key(

--- a/solana/programs/confidential-token/src/lib.rs
+++ b/solana/programs/confidential-token/src/lib.rs
@@ -251,6 +251,21 @@ pub mod confidential_token {
             to.balance_acl_record,
             ConfidentialTokenError::CurrentAclRecordMismatch
         );
+
+        // PoC simplification: transfers are blocked while the sender has an
+        // unwrap in progress. Otherwise the in-flight withdrawal amount was
+        // computed against a stale balance and finalize_unwrap could release
+        // more than the account still holds.
+        require!(
+            from.pending_withdrawal_handle == [0u8; 32],
+            ConfidentialTokenError::PendingWithdrawal
+        );
+        require_keys_eq!(
+            Pubkey::default(),
+            from.pending_withdrawal_acl_record,
+            ConfidentialTokenError::PendingWithdrawal
+        );
+
         if from.key() == to.key() {
             return Ok(());
         }
@@ -701,6 +716,8 @@ pub enum ConfidentialTokenError {
     CurrentAclRecordMismatch,
     #[msg("no pending withdrawal to finalize")]
     NoPendingWithdrawal,
+    #[msg("pending withdrawal")]
+    PendingWithdrawal,
     #[msg("withdrawal ACL record does not match the pending withdrawal")]
     PendingWithdrawalMismatch,
 }

--- a/solana/programs/zama-host/src/frame.rs
+++ b/solana/programs/zama-host/src/frame.rs
@@ -4,7 +4,8 @@ use crate::acl::{
     assert_canonical_acl_record_data, assert_output_acl_metadata, assert_record_allows_handle,
     create_acl_record_account, deserialize_acl_record, serialize_acl_record, write_acl_record,
 };
-use crate::handles;
+use crate::handles::{FHE_TYPE_BOOL, computed_ternary_handle};
+use crate::{FheTernaryOpCode, FheTernaryOpEvent, handles};
 use crate::{
     AclAllowedEvent, AclPublicDecryptAllowedEvent, FheBinaryOpCode, FheBinaryOpEvent,
     FheFrameAction, FheFrameStep, FheOpcode, FheOperand, FheRandEvent, InputVerifiedEvent,
@@ -26,6 +27,7 @@ pub enum FrameEvent {
     AclAllowed(AclAllowedEvent),
     AclPublicDecryptAllowed(AclPublicDecryptAllowedEvent),
     InputVerified(InputVerifiedEvent),
+    TernaryOp(FheTernaryOpEvent)
 }
 
 #[derive(Clone, Copy)]
@@ -222,6 +224,47 @@ fn execute_operation_step<'info>(
     previous_bank_hash: [u8; 32],
     unix_timestamp: i64,
 ) -> Result<()> {
+    if let Ok(ternary_op) = FheTernaryOpCode::try_from(opcode) {
+        require!(operands.len() == 3, ZamaHostError::InvalidFrameOperands);
+        let ls = resolve_operand(frame, remaining_accounts, &operands[0])?;
+        let ms = resolve_operand(frame, remaining_accounts, &operands[1])?;
+        let rs = resolve_operand(frame, remaining_accounts, &operands[2])?;
+
+        require!(!ls.is_scalar, ZamaHostError::InvalidFrameOperands);
+        require!(!ms.is_scalar, ZamaHostError::InvalidFrameOperands);
+        require!(!rs.is_scalar, ZamaHostError::InvalidFrameOperands);
+
+        require!(scalar_byte == 0, ZamaHostError::InvalidFrameOperands);
+
+        require!(ls.value[30] == FHE_TYPE_BOOL, ZamaHostError::UnsupportedFheType);
+  
+        require!(ms.value[30] == rs.value[30], ZamaHostError::InvalidFrameOperands);
+        require!(ms.value[30] == output_fhe_type, ZamaHostError::InvalidFrameOperands);
+
+        let result = computed_ternary_handle(
+            ternary_op, 
+            ls.value, 
+            ms.value, 
+            rs.value, 
+            output_fhe_type, 
+            SOLANA_POC_CHAIN_ID, 
+            previous_bank_hash, 
+            unix_timestamp
+        );
+
+        frame.push_result(result)?;
+        frame.events.push(FrameEvent::TernaryOp(FheTernaryOpEvent {
+            version: EVENT_VERSION,
+            op: ternary_op,
+            subject: frame.subject.to_bytes(),
+            ls: ls.value,
+            ms: ms.value,
+            rs: rs.value,
+            result,
+        }));
+
+        return Ok(());
+    }
     let binary_op = FheBinaryOpCode::try_from(opcode)?;
     require!(operands.len() == 2, ZamaHostError::InvalidFrameOperands);
     let lhs = resolve_operand(frame, remaining_accounts, &operands[0])?;
@@ -232,6 +275,9 @@ fn execute_operation_step<'info>(
         scalar_byte == u8::from(scalar),
         ZamaHostError::InvalidFrameOperands
     );
+    // TODO: validate the operand FHE type against the opcode (e.g. forbid
+    // arithmetic add/sub on bools / non-integer types) once the PoC settles on
+    // the supported type matrix.
 
     let result = handles::computed_binary_handle(
         binary_op,

--- a/solana/programs/zama-host/src/handles.rs
+++ b/solana/programs/zama-host/src/handles.rs
@@ -2,12 +2,13 @@ use anchor_lang::prelude::*;
 use solana_sha256_hasher::hashv;
 use solana_sysvar::slot_hashes::PodSlotHashes;
 
-use crate::{FheBinaryOpCode, ZamaHostError};
+use crate::{FheBinaryOpCode, FheTernaryOpCode, ZamaHostError};
 
 pub(crate) const COMPUTATION_DOMAIN_SEPARATOR: &[u8] = b"FHE_comp";
 pub(crate) const SEED_DOMAIN_SEPARATOR: &[u8] = b"FHE_seed";
 /// `FHEVMExecutor.Operators.fheRand` enum discriminant on EVM.
 pub(crate) const FHE_RAND_OP: u8 = 26;
+pub(crate) const FHE_TYPE_BOOL: u8 = 0;
 pub(crate) const COMPUTED_HANDLE_MARKER: u8 = 0xff;
 pub(crate) const HANDLE_VERSION: u8 = 0;
 const POC_INPUT_PROOF_DOMAIN_SEPARATOR: &[u8] = b"zama-solana-poc-input-v0";
@@ -50,6 +51,39 @@ pub fn computed_binary_handle(
     .to_bytes();
 
     stamp_computed_handle_tail(&mut result, chain_id, fhe_type);
+    result
+}
+
+pub fn computed_ternary_handle(
+    op: FheTernaryOpCode,
+    ls: [u8; 32],
+    ms: [u8; 32],
+    rs: [u8; 32],
+    fhe_type: u8,
+    chain_id: u64,
+    previous_bank_hash: [u8; 32],
+    unix_timestamp: i64,
+) -> [u8; 32] {
+    let op_byte = [op.as_u8()];
+    let chain_id_bytes = chain_id.to_be_bytes();
+    let timestamp_bytes = unix_timestamp.to_be_bytes();
+    let mut result = hashv(&[
+        COMPUTATION_DOMAIN_SEPARATOR,
+        &op_byte,
+        &ls,
+        &ms,
+        &rs,
+        crate::ID.as_ref(),
+        &chain_id_bytes,
+        &previous_bank_hash,
+        &timestamp_bytes,
+    ])
+    .to_bytes();
+    result[21..32].fill(0);
+    result[21] = COMPUTED_HANDLE_MARKER;
+    result[22..30].copy_from_slice(&chain_id_bytes);
+    result[30] = fhe_type;
+    result[31] = HANDLE_VERSION;
     result
 }
 
@@ -176,7 +210,7 @@ mod tests {
     use crate::FheBinaryOpCode;
 
     #[test]
-    fn computed_handles_are_deterministic() {
+    fn computed_binary_handles_are_deterministic() {
         let lhs = [1_u8; 32];
         let rhs = [2_u8; 32];
         let bank_hash = [0xAB_u8; 32];
@@ -195,6 +229,37 @@ mod tests {
             lhs,
             rhs,
             false,
+            5,
+            12345,
+            bank_hash,
+            1_700_000_000,
+        );
+        assert_eq!(first, second);
+        assert_eq!(first[21], COMPUTED_HANDLE_MARKER);
+        assert_eq!(first[30], 5);
+    }
+
+    #[test]
+    fn computed_ternary_handles_are_deterministic() {
+        let ls = [1_u8; 32];
+        let ms = [2_u8; 32];
+        let rs = [3_u8; 32];
+        let bank_hash = [0xAB_u8; 32];
+        let first = computed_ternary_handle(
+            FheTernaryOpCode::IfThenElse,
+            ls,
+            ms,
+            rs,
+            5,
+            12345,
+            bank_hash,
+            1_700_000_000,
+        );
+        let second = computed_ternary_handle(
+            FheTernaryOpCode::IfThenElse,
+            ls,
+            ms,
+            rs,
             5,
             12345,
             bank_hash,

--- a/solana/programs/zama-host/src/lib.rs
+++ b/solana/programs/zama-host/src/lib.rs
@@ -14,7 +14,7 @@ pub use handles::{
     poc_external_input_proof,
 };
 
-declare_id!("EMhXFu68v61bQV4GrF6ZhZhWNVbH6bHPnTdLtXK8meqn");
+declare_id!("4TU1nKdM6cfPRctp5ziwCfDB2VRLaV6yGGgR6KpZGc7C");
 
 pub const EVENT_VERSION: u8 = 0;
 pub const MAX_ACL_SUBJECTS: usize = 8;
@@ -135,6 +135,7 @@ pub mod zama_host {
                 frame::FrameEvent::AclAllowed(event) => emit_cpi!(event),
                 frame::FrameEvent::AclPublicDecryptAllowed(event) => emit_cpi!(event),
                 frame::FrameEvent::InputVerified(event) => emit_cpi!(event),
+                frame::FrameEvent::TernaryOp(event) => emit_cpi!(event),
             }
         }
 
@@ -225,6 +226,17 @@ pub struct FheBinaryOpEvent {
 }
 
 #[event]
+pub struct FheTernaryOpEvent {
+    pub version: u8,
+    pub op: FheTernaryOpCode,
+    pub subject: [u8; 32],
+    pub ls: [u8; 32],
+    pub ms: [u8; 32],
+    pub rs: [u8; 32],
+    pub result: [u8; 32],
+}
+
+#[event]
 pub struct TrivialEncryptEvent {
     pub version: u8,
     pub subject: [u8; 32],
@@ -271,6 +283,7 @@ pub struct InputVerifiedEvent {
 pub enum FheBinaryOpCode {
     Add,
     Sub,
+    Ge
 }
 
 impl FheBinaryOpCode {
@@ -278,6 +291,20 @@ impl FheBinaryOpCode {
         match self {
             Self::Add => 0,
             Self::Sub => 1,
+            Self::Ge => 14,
+        }
+    }
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FheTernaryOpCode {
+    IfThenElse
+}
+
+impl FheTernaryOpCode {
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Self::IfThenElse => 25
         }
     }
 }
@@ -324,6 +351,18 @@ impl TryFrom<FheOpcode> for FheBinaryOpCode {
         match value {
             FheOpcode::Add => Ok(Self::Add),
             FheOpcode::Sub => Ok(Self::Sub),
+            FheOpcode::Ge  => Ok(Self::Ge),
+            _ => err!(ZamaHostError::UnsupportedFrameOpcode),
+        }
+    }
+}
+
+impl TryFrom<FheOpcode> for FheTernaryOpCode {
+    type Error = Error;
+
+    fn try_from(value: FheOpcode) -> Result<Self> {
+        match value {
+            FheOpcode::IfThenElse => Ok(Self::IfThenElse),
             _ => err!(ZamaHostError::UnsupportedFrameOpcode),
         }
     }

--- a/solana/tests/src/acl.rs
+++ b/solana/tests/src/acl.rs
@@ -26,6 +26,14 @@ pub fn vault_authority_address(program_id: Pubkey, mint: Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"vault-authority", mint.as_ref()], &program_id).0
 }
 
+pub fn confidential_mint_address(program_id: Pubkey, underlying_mint: Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[b"confidential-mint", underlying_mint.as_ref()],
+        &program_id,
+    )
+    .0
+}
+
 pub fn acl_record_address(program_id: Pubkey, nonce_key: [u8; 32], nonce_sequence: u64) -> Pubkey {
     Pubkey::find_program_address(
         &[

--- a/solana/tests/src/cleartext.rs
+++ b/solana/tests/src/cleartext.rs
@@ -7,13 +7,15 @@ use crate::semantic::{BackendError, SemanticBackend};
 use litesvm::types::TransactionMetadata;
 use solana_keccak_hasher::hashv;
 use solana_sdk::pubkey::Pubkey;
-use zama_host_events::{FheBinaryOpCode, FheBinaryOpEvent, FheRandEvent, ZamaHostEvent};
+use zama_host_events::{FheBinaryOpCode, FheBinaryOpEvent, FheTernaryOpEvent, FheTernaryOpCode, FheRandEvent, ZamaHostEvent};
 
 pub type Handle = [u8; 32];
+const FHE_TYPE_BOOL: u8 = 0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ClearValue {
     Uint(u128),
+    Bool(bool)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -65,6 +67,7 @@ impl FheBackend for CleartextBackend {
     fn ingest_zama_host_event(&mut self, event: &ZamaHostEvent) -> Result<(), String> {
         match event {
             ZamaHostEvent::FheBinaryOp(event) => self.ingest_binary_op(event),
+            ZamaHostEvent::FheTernaryOp(event) => self.ingest_ternary_op(event),
             ZamaHostEvent::TrivialEncrypt(event) => {
                 let value = TypedClearValue {
                     fhe_type: event.fhe_type,
@@ -100,6 +103,33 @@ impl CleartextBackend {
         Ok(())
     }
 
+    fn ingest_ternary_op(&mut self, event: &FheTernaryOpEvent) -> Result<(), String> {
+        let ms = self.values.get(&event.ms).copied().ok_or_else(|| "missing ms cleartext value".to_string())?;
+        let rs= self.values.get(&event.rs).copied().ok_or_else(|| "missing rs cleartext value".to_string())?;
+        let ls = self.values.get(&event.ls).copied().ok_or_else(|| "missing ls cleartext value".to_string())?;
+        let value = match event.op {
+            FheTernaryOpCode::IfThenElse => {
+                if ls.fhe_type != FHE_TYPE_BOOL || ms.fhe_type != rs.fhe_type {
+                    return Err("cleartext operand type mismatch".to_string());
+                }
+                let ClearValue::Bool(control) = ls.value else {
+                    return Err("control must be bool".to_string());
+                };
+                
+                if control {
+                    ms
+                } else {
+                    rs
+                }
+            }
+        };
+        self.values.insert(
+            event.result,
+            value,
+        );
+        Ok(())
+    }
+
     fn ingest_binary_op(&mut self, event: &FheBinaryOpEvent) -> Result<(), String> {
         let lhs = self
             .values
@@ -122,23 +152,40 @@ impl CleartextBackend {
             return Err("cleartext operand type mismatch".to_string());
         }
 
-        let ClearValue::Uint(lhs_value) = lhs.value;
-        let ClearValue::Uint(rhs_value) = rhs.value;
-        let result = match event.op {
-            FheBinaryOpCode::Add => lhs_value
-                .checked_add(rhs_value)
-                .ok_or_else(|| "cleartext add overflow".to_string())?,
-            FheBinaryOpCode::Sub => lhs_value
+        let (ClearValue::Uint(lhs_value), ClearValue::Uint(rhs_value)) = (lhs.value, rhs.value) else {
+            return Err("disallowed for arithmetic ops".to_string());
+        };
+        let value = match event.op {
+            FheBinaryOpCode::Add => {
+                let result = lhs_value
+                    .checked_add(rhs_value)
+                    .ok_or_else(|| "cleartext add overflow".to_string())?;
+                TypedClearValue {
+                    fhe_type: lhs.fhe_type,
+                    value: ClearValue::Uint(result),
+                }
+            }
+            FheBinaryOpCode::Sub => {
+                let result = lhs_value
                 .checked_sub(rhs_value)
-                .ok_or_else(|| "cleartext sub underflow".to_string())?,
+                .ok_or_else(|| "cleartext sub underflow".to_string())?;
+                TypedClearValue {
+                    fhe_type: lhs.fhe_type,
+                    value: ClearValue::Uint(result),
+                }
+            }
+            FheBinaryOpCode::Ge => {
+                let result = lhs_value.ge(&rhs_value);
+                TypedClearValue {
+                    fhe_type: 0,
+                    value: ClearValue::Bool(result)
+                }
+            }
         };
 
         self.values.insert(
             event.result,
-            TypedClearValue {
-                fhe_type: lhs.fhe_type,
-                value: ClearValue::Uint(result),
-            },
+            value,
         );
         Ok(())
     }
@@ -193,7 +240,10 @@ impl SemanticBackend for CleartextBackend {
         let Some(value) = self.decrypt_cleartext(handle) else {
             return Err(BackendError::MissingHandle { handle });
         };
-        let ClearValue::Uint(raw) = value.value;
+        let raw = match value.value {
+            ClearValue::Uint(raw) => raw,
+            ClearValue::Bool(_) => return Err(BackendError::UnexpectedType { handle })
+        };
         u64::try_from(raw).map_err(|_| BackendError::UnexpectedType { handle })
     }
 }

--- a/solana/tests/src/events.rs
+++ b/solana/tests/src/events.rs
@@ -7,7 +7,7 @@ use anchor_lang::{AnchorDeserialize, Discriminator, Event};
 use litesvm::types::TransactionMetadata;
 use solana_sdk::pubkey::Pubkey;
 pub use zama_host_events::{
-    decode_anchor_cpi_event, AclAllowedEvent, AclPublicDecryptAllowedEvent, FheBinaryOpEvent,
+    decode_anchor_cpi_event, AclAllowedEvent, AclPublicDecryptAllowedEvent, FheBinaryOpEvent, FheTernaryOpEvent,
     FheRandEvent, InputVerifiedEvent, TrivialEncryptEvent, ZamaHostEvent, ANCHOR_EVENT_IX_TAG_LE,
 };
 
@@ -56,6 +56,7 @@ macro_rules! zama_host_event_filter {
 }
 
 zama_host_event_filter!(binary_op_events, FheBinaryOp, FheBinaryOpEvent);
+zama_host_event_filter!(ternary_op_events, FheTernaryOp, FheTernaryOpEvent);
 zama_host_event_filter!(trivial_encrypt_events, TrivialEncrypt, TrivialEncryptEvent);
 zama_host_event_filter!(fhe_rand_events, FheRand, FheRandEvent);
 zama_host_event_filter!(acl_allowed_events, AclAllowed, AclAllowedEvent);
@@ -73,6 +74,7 @@ pub fn count_tfhe_host_events(events: &[ZamaHostEvent]) -> usize {
             matches!(
                 event,
                 ZamaHostEvent::FheBinaryOp(_)
+                    | ZamaHostEvent::FheTernaryOp(_)
                     | ZamaHostEvent::TrivialEncrypt(_)
                     | ZamaHostEvent::FheRand(_)
             )
@@ -105,6 +107,20 @@ pub fn balance_handle_updated_events(
     program_id: Pubkey,
 ) -> Vec<confidential_token::BalanceHandleUpdatedEvent> {
     collect_cpi_events(meta, account_keys, program_id, decode_token_cpi_event)
+}
+
+fn decode_withdrawal_requested_event(
+    data: &[u8],
+) -> Option<confidential_token::WithdrawalRequestedEvent> {
+    decode_cpi_event::<confidential_token::WithdrawalRequestedEvent>(data)
+}
+
+pub fn withdrawal_requested_events(
+    meta: &TransactionMetadata,
+    account_keys: &[Pubkey],
+    program_id: Pubkey,
+) -> Vec<confidential_token::WithdrawalRequestedEvent> {
+    collect_cpi_events(meta, account_keys, program_id, decode_withdrawal_requested_event)
 }
 
 pub fn max_cpi_depth(meta: &TransactionMetadata) -> u64 {

--- a/solana/tests/src/fixture.rs
+++ b/solana/tests/src/fixture.rs
@@ -12,8 +12,8 @@ use solana_sdk::{
 
 use crate::{
     acl::{
-        balance_acl_record_address, event_authority, rand_counter_address, read_acl_record,
-        token_account_address, vault_authority_address,
+        balance_acl_record_address, confidential_mint_address, event_authority,
+        rand_counter_address, read_acl_record, token_account_address, vault_authority_address,
     },
     programs::{host_program_so_path, svm_with_programs, token_program_so_path},
     transaction::{anchor_ix, send, send_many_with_signers, send_with_signers},
@@ -28,7 +28,7 @@ pub struct TokenFixture {
     pub token_program_id: Pubkey,
     pub alice: Keypair,
     pub bob: Keypair,
-    pub mint: Keypair,
+    pub mint: Pubkey,
     pub underlying_mint: Keypair,
     pub compute_signer: Pubkey,
     pub alice_token: Pubkey,
@@ -62,10 +62,11 @@ pub fn token_fixture() -> TokenFixture {
 
     let alice = svm.create_funded_account(2_000_000_000).unwrap();
     let bob = svm.create_funded_account(1_000_000_000).unwrap();
-    let mint = Keypair::new();
     let underlying_mint = svm.create_token_mint(&alice, 6).unwrap();
+    // The confidential mint is a PDA derived from the underlying SPL mint.
+    let mint = confidential_mint_address(token_program_id, underlying_mint.pubkey());
 
-    let vault_authority = vault_authority_address(token_program_id, mint.pubkey());
+    let vault_authority = vault_authority_address(token_program_id, mint);
     let alice_usdc = svm
         .create_token_account(&underlying_mint.pubkey(), &alice)
         .unwrap();
@@ -92,30 +93,31 @@ pub fn token_fixture() -> TokenFixture {
             token_program_id,
             token::accounts::InitializeMint {
                 authority: alice.pubkey(),
-                mint: mint.pubkey(),
+                mint,
                 underlying_mint: underlying_mint.pubkey(),
                 system_program: system_program::ID,
             },
             token::instruction::InitializeMint {},
         ),
-        &[&alice, &mint],
+        &[&alice],
     )
     .unwrap();
 
-    let compute_signer = token::compute_signer_address(mint.pubkey()).0;
-    let alice_token = token_account_address(token_program_id, mint.pubkey(), alice.pubkey());
-    let bob_token = token_account_address(token_program_id, mint.pubkey(), bob.pubkey());
+    let compute_signer = token::compute_signer_address(mint).0;
+    let alice_token = token_account_address(token_program_id, mint, alice.pubkey());
+    let bob_token = token_account_address(token_program_id, mint, bob.pubkey());
     let alice_current_compute_acl =
-        balance_acl_record_address(host_program_id, mint.pubkey(), alice_token, 0);
+        balance_acl_record_address(host_program_id, mint, alice_token, 0);
     let bob_current_compute_acl =
-        balance_acl_record_address(host_program_id, mint.pubkey(), bob_token, 0);
+        balance_acl_record_address(host_program_id, mint, bob_token, 0);
 
     initialize_confidential_token_account(
         &mut svm,
         token_program_id,
         host_program_id,
         &alice,
-        mint.pubkey(),
+        mint,
+        underlying_mint.pubkey(),
         alice_token,
         compute_signer,
         alice_current_compute_acl,
@@ -126,7 +128,8 @@ pub fn token_fixture() -> TokenFixture {
         token_program_id,
         host_program_id,
         &bob,
-        mint.pubkey(),
+        mint,
+        underlying_mint.pubkey(),
         bob_token,
         compute_signer,
         bob_current_compute_acl,
@@ -165,6 +168,7 @@ fn initialize_confidential_token_account(
     host_program_id: Pubkey,
     owner: &Keypair,
     mint: Pubkey,
+    underlying_mint: Pubkey,
     token_account: Pubkey,
     compute_signer: Pubkey,
     acl_record: Pubkey,
@@ -178,6 +182,7 @@ fn initialize_confidential_token_account(
             token::accounts::InitializeTokenAccount {
                 owner: owner.pubkey(),
                 mint,
+                underlying_mint,
                 compute_signer,
                 token_account,
                 acl_record,

--- a/solana/tests/src/host_events.rs
+++ b/solana/tests/src/host_events.rs
@@ -12,13 +12,14 @@ use crate::{
     host_program_so_path, input_verified_events, kms_like_public_decrypt_check,
     kms_like_user_decrypt_check, label, max_cpi_depth, previous_bank_hash_from_sysvar,
     read_acl_record, read_rand_counter, record_subjects, run_rand_demo_scenario,
-    run_transfer_scenario, run_wrap_scenario, seed_authorizing_acl_record,
+    run_transfer_scenario, run_wrap_scenario, seed_authorizing_acl_record, request_unwrap_usdc_ix,
     seed_transfer_inputs, self_transfer_ix, send, send_many_with_signers, send_with_meta,
     set_previous_slot_hash, signed_confidential_rand_user_decrypt_request,
     signed_current_balance_user_decrypt_request, signed_user_decrypt_request, spl_token_amount,
     svm_with_program, token_account, token_fixture, transfer_ix, transfer_ix_with_amount_proof,
     transfer_ix_with_current_acl, transfer_output_accounts, trivial_encrypt_events, try_send,
-    try_send_with_meta, wrap_output_accounts, wrap_usdc_ix, CleartextBackend, FheBackend,
+    ternary_op_events, try_send_with_meta, withdrawal_requested_events, wrap_output_accounts,
+    wrap_usdc_ix, CleartextBackend, FheBackend,
     FheBinaryOpCode, PublicDecryptHandleEntry, SemanticBackend, TransferExpect,
     TransferOutputAccounts, TransferSetup, TypedClearValue, UserDecryptHandleEntry, WrapSetup,
     DEFAULT_INPUT_NONCE_SEQUENCE, DEFAULT_TEST_PREVIOUS_BANK_HASH,
@@ -26,6 +27,7 @@ use crate::{
 use anchor_lang::AccountSerialize;
 use anchor_litesvm::TestHelpers;
 use confidential_token::{self as token, BalanceHandleUpdateReason};
+use zama_host_events::FheTernaryOpCode;
 use solana_sdk::{
     account::Account,
     pubkey::Pubkey,
@@ -1129,7 +1131,7 @@ fn confidential_transfer_rotates_balance_handles_and_binds_output_acl() {
     assert_balance_acl(
         &fixture.svm,
         output.alice,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.alice_token,
         1,
         new_alice,
@@ -1138,7 +1140,7 @@ fn confidential_transfer_rotates_balance_handles_and_binds_output_acl() {
     assert_balance_acl(
         &fixture.svm,
         output.bob,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.bob_token,
         1,
         new_bob,
@@ -1341,7 +1343,7 @@ fn fhe_execute_wrapper_initialize_creates_balance_acl_via_execute_frame() {
     assert_balance_acl(
         &fixture.svm,
         fixture.alice_current_compute_acl,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.alice_token,
         0,
         fixture.alice_initial,
@@ -1439,12 +1441,75 @@ fn wrap_usdc_escrows_spl_tokens_and_rotates_confidential_balance() {
     assert_balance_acl(
         &fixture.svm,
         output.balance,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.alice_token,
         1,
         new_alice,
         &[fixture.alice.pubkey(), fixture.compute_signer],
     );
+}
+
+/// Production-style `request_unwrap_usdc`: invoke the real instruction and
+/// assert it stages an approved withdrawal (`ge` -> `if_then_else`, publicly
+/// decryptable) without touching the balance.
+#[test]
+fn request_unwrap_usdc_stages_pending_withdrawal() {
+    let mut fixture = token_fixture();
+    let mut cleartext = CleartextBackend::default();
+    // Alice starts with a confidential balance of 125 (seeded by the fixture).
+    cleartext.seed_cleartext(fixture.alice_initial, TypedClearValue::uint64(125));
+
+    // The withdrawal ACL is written at the post-init balance nonce (1) under the
+    // withdrawal label.
+    let nonce_sequence = 1;
+    let amount = 100;
+    let output_acl = acl_record_address(
+        fixture.host_program_id,
+        token::withdrawal_nonce_key(fixture.mint, fixture.alice_token),
+        nonce_sequence,
+    );
+
+    let before = token_account(&fixture.svm, fixture.alice_token);
+    let ix = request_unwrap_usdc_ix(&fixture, output_acl, amount);
+    let (meta, account_keys) = send_with_meta(&mut fixture.svm, &fixture.alice, ix);
+    cleartext
+        .ingest_transaction(&meta, &account_keys, fixture.host_program_id)
+        .unwrap();
+
+    // 1. The affordability check ran as a Ge over the encrypted balance.
+    let binary = binary_op_events(&meta, &account_keys, fixture.host_program_id);
+    assert_eq!(binary.len(), 1);
+    assert_eq!(binary[0].op, FheBinaryOpCode::Ge);
+    assert_eq!(binary[0].lhs, fixture.alice_initial);
+
+    // 2. The approved withdrawal was produced by IfThenElse and written to the
+    //    withdrawal ACL, which is publicly decryptable.
+    let ternary = ternary_op_events(&meta, &account_keys, fixture.host_program_id);
+    assert_eq!(ternary.len(), 1);
+    assert_eq!(ternary[0].op, FheTernaryOpCode::IfThenElse);
+    let withdrawal_record = read_acl_record(&fixture.svm, output_acl).expect("withdrawal ACL");
+    assert_eq!(ternary[0].result, withdrawal_record.handle);
+    assert!(withdrawal_record.public_decrypt);
+
+    // 3. Since 125 >= 100, the approved amount equals the requested amount.
+    assert_eq!(
+        cleartext.decrypt_cleartext(withdrawal_record.handle),
+        Some(TypedClearValue::uint64(amount))
+    );
+
+    // 4. The withdrawal is recorded as pending and the balance is untouched.
+    let after = token_account(&fixture.svm, fixture.alice_token);
+    assert_eq!(after.pending_withdrawal_handle, withdrawal_record.handle);
+    assert_eq!(after.pending_withdrawal_acl_record, output_acl);
+    assert_eq!(after.balance_handle, before.balance_handle);
+    assert_eq!(after.balance_acl_record, before.balance_acl_record);
+
+    // 5. A WithdrawalRequestedEvent is emitted for the relayer / coprocessor.
+    let requested = withdrawal_requested_events(&meta, &account_keys, fixture.token_program_id);
+    assert_eq!(requested.len(), 1);
+    assert_eq!(requested[0].withdrawal_handle, withdrawal_record.handle);
+    assert_eq!(requested[0].withdrawal_acl_record, output_acl);
+    assert_eq!(requested[0].token_account, fixture.alice_token);
 }
 
 #[test]
@@ -1470,7 +1535,7 @@ fn confidential_token_e2e_wrap_transfer_and_decrypts_current_and_historical_bala
     assert_balance_acl(
         &fixture.svm,
         wrap_output.balance,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.alice_token,
         1,
         alice_after_wrap,
@@ -1484,13 +1549,13 @@ fn confidential_token_e2e_wrap_transfer_and_decrypts_current_and_historical_bala
     let transfer_output = TransferOutputAccounts {
         alice: balance_acl_record_address(
             fixture.host_program_id,
-            fixture.mint.pubkey(),
+            fixture.mint,
             fixture.alice_token,
             2,
         ),
         bob: balance_acl_record_address(
             fixture.host_program_id,
-            fixture.mint.pubkey(),
+            fixture.mint,
             fixture.bob_token,
             1,
         ),
@@ -1715,7 +1780,7 @@ fn confidential_transfer_rejects_amount_proof_bound_to_other_context() {
         amount_handle,
         fixture.alice.pubkey(),
         fixture.bob_token,
-        fixture.mint.pubkey(),
+        fixture.mint,
         5,
         zama_host::SOLANA_POC_CHAIN_ID,
     );
@@ -1771,7 +1836,7 @@ fn confidential_transfer_rejects_reused_output_acl_record() {
         alice: fixture.alice_current_compute_acl,
         bob: balance_acl_record_address(
             fixture.host_program_id,
-            fixture.mint.pubkey(),
+            fixture.mint,
             fixture.bob_token,
             1,
         ),
@@ -1968,7 +2033,7 @@ fn confidential_token_e2e_rand_demo_encrypt_compute_and_user_decrypt_request() {
     assert_acl_record(
         &fixture.svm,
         scenario.acl_record,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.alice_token,
         token::rand_label(),
         RAND_NONCE_SEQUENCE,
@@ -2002,7 +2067,7 @@ fn confidential_token_e2e_rand_demo_encrypt_compute_and_user_decrypt_request() {
     assert_eq!(decrypt_request.authorization.user, fixture.alice.pubkey());
     assert_eq!(
         decrypt_request.authorization.allowed_acl_domain_keys,
-        vec![fixture.mint.pubkey()]
+        vec![fixture.mint]
     );
     assert!(kms_like_user_decrypt_check(&fixture.svm, &decrypt_request));
 

--- a/solana/tests/src/instructions.rs
+++ b/solana/tests/src/instructions.rs
@@ -18,7 +18,7 @@ pub fn poc_demo_confidential_rand_ix(
 ) -> (Instruction, Pubkey) {
     let output_acl = rand_acl_record_address(
         fixture.host_program_id,
-        fixture.mint.pubkey(),
+        fixture.mint,
         fixture.alice_token,
         nonce_sequence,
     );
@@ -26,7 +26,7 @@ pub fn poc_demo_confidential_rand_ix(
         fixture.token_program_id,
         token::accounts::PocDemoConfidentialRand {
             owner: fixture.alice.pubkey(),
-            mint: fixture.mint.pubkey(),
+            mint: fixture.mint,
             token_account: fixture.alice_token,
             compute_signer: fixture.compute_signer,
             output_acl,
@@ -49,13 +49,13 @@ pub fn transfer_output_accounts(
     TransferOutputAccounts {
         alice: balance_acl_record_address(
             fixture.host_program_id,
-            fixture.mint.pubkey(),
+            fixture.mint,
             fixture.alice_token,
             nonce_sequence,
         ),
         bob: balance_acl_record_address(
             fixture.host_program_id,
-            fixture.mint.pubkey(),
+            fixture.mint,
             fixture.bob_token,
             nonce_sequence,
         ),
@@ -66,7 +66,7 @@ pub fn wrap_output_accounts(fixture: &TokenFixture, nonce_sequence: u64) -> Wrap
     WrapOutputAccounts {
         balance: balance_acl_record_address(
             fixture.host_program_id,
-            fixture.mint.pubkey(),
+            fixture.mint,
             fixture.alice_token,
             nonce_sequence,
         ),
@@ -92,7 +92,7 @@ pub fn external_input_handle(fixture: &TokenFixture, value: u64, nonce: u64) -> 
         &value.to_be_bytes(),
         fixture.alice.pubkey().as_ref(),
         fixture.alice_token.as_ref(),
-        fixture.mint.pubkey().as_ref(),
+        fixture.mint.as_ref(),
         &nonce.to_be_bytes(),
     ])
     .to_bytes();
@@ -109,7 +109,7 @@ pub fn input_proof(fixture: &TokenFixture, input_handle: [u8; 32]) -> [u8; 32] {
         input_handle.as_ref(),
         fixture.alice.pubkey().as_ref(),
         fixture.alice_token.as_ref(),
-        fixture.mint.pubkey().as_ref(),
+        fixture.mint.as_ref(),
         &[5],
         &zama_host::SOLANA_POC_CHAIN_ID.to_be_bytes(),
     ])
@@ -125,7 +125,7 @@ pub fn self_transfer_ix(
         fixture.token_program_id,
         token::accounts::ConfidentialTransfer {
             owner: fixture.alice.pubkey(),
-            mint: fixture.mint.pubkey(),
+            mint: fixture.mint,
             from_account: fixture.alice_token,
             to_account: fixture.alice_token,
             compute_signer: fixture.compute_signer,
@@ -192,7 +192,7 @@ pub fn transfer_ix_with_amount_proof_and_current_acl(
         fixture.token_program_id,
         token::accounts::ConfidentialTransfer {
             owner: fixture.alice.pubkey(),
-            mint: fixture.mint.pubkey(),
+            mint: fixture.mint,
             from_account: fixture.alice_token,
             to_account: fixture.bob_token,
             compute_signer: fixture.compute_signer,
@@ -225,14 +225,14 @@ pub fn wrap_usdc_ix(
         fixture.token_program_id,
         token::accounts::WrapUsdc {
             owner: fixture.alice.pubkey(),
-            mint: fixture.mint.pubkey(),
+            mint: fixture.mint,
             token_account: fixture.alice_token,
             underlying_mint: fixture.underlying_mint.pubkey(),
             user_usdc: fixture.alice_usdc,
             vault_usdc: fixture.vault_usdc,
             vault_authority: vault_authority_address(
                 fixture.token_program_id,
-                fixture.mint.pubkey(),
+                fixture.mint,
             ),
             compute_signer: fixture.compute_signer,
             current_compute_acl: fixture.alice_current_compute_acl,
@@ -246,5 +246,38 @@ pub fn wrap_usdc_ix(
             program: fixture.token_program_id,
         },
         token::instruction::WrapUsdc { amount },
+    )
+}
+
+pub fn request_unwrap_usdc_ix(
+    fixture: &TokenFixture,
+    output_acl: Pubkey,
+    amount: u64,
+) -> Instruction {
+    use crate::acl::vault_authority_address;
+
+    anchor_ix(
+        fixture.token_program_id,
+        token::accounts::RequestUnwrapUsdc {
+            owner: fixture.alice.pubkey(),
+            mint: fixture.mint,
+            token_account: fixture.alice_token,
+            underlying_mint: fixture.underlying_mint.pubkey(),
+            vault_authority: vault_authority_address(
+                fixture.token_program_id,
+                fixture.mint,
+            ),
+            compute_signer: fixture.compute_signer,
+            current_compute_acl: fixture.alice_current_compute_acl,
+            output_acl,
+            zama_rand_counter: rand_counter_address(fixture.host_program_id),
+            zama_event_authority: event_authority(fixture.host_program_id),
+            zama_program: fixture.host_program_id,
+            token_program: anchor_spl::token::spl_token::id(),
+            system_program: system_program::ID,
+            event_authority: event_authority(fixture.token_program_id),
+            program: fixture.token_program_id,
+        },
+        token::instruction::RequestUnwrapUsdc { amount },
     )
 }

--- a/solana/tests/src/kms.rs
+++ b/solana/tests/src/kms.rs
@@ -40,7 +40,7 @@ pub fn signed_user_decrypt_request(
     signer: &Keypair,
     handles: Vec<UserDecryptHandleEntry>,
 ) -> UserDecryptRequest {
-    signed_user_decrypt_request_with_domains(signer, vec![fixture.mint.pubkey()], handles)
+    signed_user_decrypt_request_with_domains(signer, vec![fixture.mint], handles)
 }
 
 pub fn signed_user_decrypt_request_with_domains(

--- a/solana/tests/src/lib.rs
+++ b/solana/tests/src/lib.rs
@@ -24,9 +24,9 @@ mod util;
 
 pub use acl::{
     acl_record_address, assert_acl_record, assert_balance_acl, balance_acl_record_address,
-    created_acl_count, event_authority, rand_acl_record_address, rand_counter_address,
-    read_acl_record, read_rand_counter, record_subjects, seed_authorizing_acl_record,
-    token_account_address, vault_authority_address,
+    confidential_mint_address, created_acl_count, event_authority, rand_acl_record_address,
+    rand_counter_address, read_acl_record, read_rand_counter, record_subjects,
+    seed_authorizing_acl_record, token_account_address, vault_authority_address,
 };
 pub use cleartext::{
     cleartext_rand_value, ClearValue, CleartextBackend, FheBackend, Handle, TypedClearValue,
@@ -34,10 +34,10 @@ pub use cleartext::{
 pub use events::{
     acl_allowed_events, acl_public_decrypt_allowed_events, balance_handle_updated_events,
     binary_op_events, collect_cpi_events, collect_zama_host_events, count_acl_allowed_events,
-    count_tfhe_host_events, decode_token_cpi_event, fhe_rand_events,
-    input_verified_events, max_cpi_depth, trivial_encrypt_events, AclAllowedEvent,
-    AclPublicDecryptAllowedEvent, FheBinaryOpEvent, FheRandEvent, InputVerifiedEvent,
-    TrivialEncryptEvent, ZamaHostEvent, ANCHOR_EVENT_IX_TAG_LE,
+    count_tfhe_host_events, decode_token_cpi_event, fhe_rand_events, input_verified_events,
+    max_cpi_depth, ternary_op_events, trivial_encrypt_events, withdrawal_requested_events,
+    AclAllowedEvent, AclPublicDecryptAllowedEvent, FheBinaryOpEvent, FheRandEvent,
+    InputVerifiedEvent, TrivialEncryptEvent, ZamaHostEvent, ANCHOR_EVENT_IX_TAG_LE,
 };
 pub use fixture::{
     create_spl_token_account, spl_token_amount, token_account, token_fixture, TokenFixture,
@@ -45,9 +45,9 @@ pub use fixture::{
 };
 pub use host_ix::{allow_for_decryption_ix, execute_frame_ix, label};
 pub use instructions::{
-    external_input_handle, poc_demo_confidential_rand_ix, self_transfer_ix, transfer_ix,
-    transfer_ix_with_amount_proof, transfer_ix_with_current_acl, transfer_output_accounts,
-    wrap_output_accounts, wrap_usdc_ix,
+    external_input_handle, poc_demo_confidential_rand_ix, request_unwrap_usdc_ix, self_transfer_ix,
+    transfer_ix, transfer_ix_with_amount_proof, transfer_ix_with_current_acl,
+    transfer_output_accounts, wrap_output_accounts, wrap_usdc_ix,
 };
 pub use invariants::{
     assert_balance_acl_subjects, assert_no_zama_host_events_on_failure, assert_tfhe_event_count,


### PR DESCRIPTION
## Summary

Implements the `IfThenElse` (cmux) FHE operation end-to-end and uses it to build a
two-phase confidential USDC unwrap (`request` → `finalize`) modelled on the EVM
public-decrypt callback pattern.

## What's included

- **`IfThenElse` op** across the stack: `computed_ternary_handle` + validation in
  `zama-host` (control must be `ebool`, branches must match), `FheTernaryOpEvent`
  emission, the `if_then_else`/`ge` builder API, IDL + generated decoders, and the
  `host-listener` `to_ternary_event` mapping (EVM `FheIfThenElse`). Operand order,
  op byte (`25`), and hashing verified against EVM `fheIfThenElse`.
- **Unwrap flow** in `confidential-token`:
  - `request_unwrap_usdc`: computes `if_then_else(ge(balance, amount), amount, 0)`,
    exposes the approved amount for public decryption, and records it as pending
    (balance untouched).
  - `finalize_unwrap_usdc`: transfers the approved amount vault→user and FHE-debits
    the balance by the same handle. KMS-proof verification is a documented TODO seam
    (cleartext currently trusted from the caller).
- **Tests**: production-style `request_unwrap_usdc` integration test (drives
  `ge`→`if_then_else`), a `computed_ternary_handle` unit test, and a `token_fixture`
  migration to the PDA-based confidential mint.

## Notes / follow-ups

- `finalize` trusts the relayer-supplied cleartext until a `verify_public_decrypt`
  KMS-signature primitive lands in `zama-host`.
