### PR TITLE
feat(gateway-contracts): add enable/disable/remove host chain hardhat tasks

### DIFF
--- a/gateway-contracts/docs/getting-started/deployment/local_deploy.md
+++ b/gateway-contracts/docs/getting-started/deployment/local_deploy.md
@@ -41,6 +41,28 @@ This:
 - deploys the contracts through the `deployAllGatewayContracts` task found in [deploy.ts](../../../tasks/deployment/contracts.ts)
 - adds the host chains to the `GatewayConfig` contract through the `addHostChainsToGatewayConfig` task found in [addHostChains.ts](../../../tasks/addHostChains.ts)
 
+## Manage host chains
+
+Once a host chain is registered, its lifecycle is managed through three owner-only tasks found in
+[manageHostChains.ts](../../../tasks/manageHostChains.ts). Each task signs with `DEPLOYER_PRIVATE_KEY`
+and resolves the `GatewayConfig` address the same way as `addHostChainsToGatewayConfig` — from the
+`GATEWAY_CONFIG_ADDRESS` env var by default, or from the `addresses/` directory when
+`--use-internal-proxy-address true` is passed (local / CI flow):
+
+```bash
+# Disable a registered host chain (it stays registered but is flagged disabled)
+npx hardhat task:disableHostChainOnGatewayConfig --chain-id <id>
+
+# Re-enable a previously disabled host chain
+npx hardhat task:enableHostChainOnGatewayConfig --chain-id <id>
+
+# Remove a host chain entirely (it must be disabled first)
+npx hardhat task:removeHostChainOnGatewayConfig --chain-id <id>
+```
+
+Each task runs a pre-flight check (chain registered / disabled state) so the operator gets a clean
+error before submitting a transaction that would otherwise revert on-chain.
+
 ## Run tests
 
 Run all tests on the local network:

--- a/gateway-contracts/hardhat.config.ts
+++ b/gateway-contracts/hardhat.config.ts
@@ -17,6 +17,7 @@ import "./tasks/blockExplorerVerify";
 import "./tasks/deployment";
 import "./tasks/exportMigrationState";
 import "./tasks/getters";
+import "./tasks/manageHostChains";
 import "./tasks/mockedTokenFund";
 import "./tasks/ownership";
 import "./tasks/pauseContracts";

--- a/gateway-contracts/tasks/manageHostChains.ts
+++ b/gateway-contracts/tasks/manageHostChains.ts
@@ -1,0 +1,119 @@
+import { task, types } from "hardhat/config";
+
+import { getRequiredEnvVar, loadGatewayAddresses } from "./utils";
+
+// Host chain lifecycle tasks for the GatewayConfig contract.
+//
+// `addHostChain` already has a dedicated task (see `addHostChains.ts`). These tasks close the
+// symmetry by exposing the three remaining owner-only host chain operations: disable, enable and
+// remove. They mirror the conventions of `addHostChains.ts`:
+//   - `--use-internal-proxy-address` (default `false`) picks up `GATEWAY_CONFIG_ADDRESS` either from
+//     env (operator / gitops flow) or from `addresses/.env.gateway` (local / CI flow).
+//   - `DEPLOYER_PRIVATE_KEY` from env signs the transaction (the deployer owns GatewayConfig).
+
+// Resolves the GatewayConfig contract connected to the deployer wallet, applying the same
+// address-resolution rules as `addHostChains.ts`.
+async function loadGatewayConfig(hre: any, useInternalProxyAddress: boolean) {
+  await hre.run("compile:specific", { contract: "contracts" });
+
+  const deployerPrivateKey = getRequiredEnvVar("DEPLOYER_PRIVATE_KEY");
+  const deployer = new hre.ethers.Wallet(deployerPrivateKey).connect(hre.ethers.provider);
+
+  if (useInternalProxyAddress) {
+    loadGatewayAddresses();
+  }
+  const proxyAddress = getRequiredEnvVar("GATEWAY_CONFIG_ADDRESS");
+
+  const gatewayConfig = await hre.ethers.getContractAt("GatewayConfig", proxyAddress, deployer);
+  return { gatewayConfig, proxyAddress };
+}
+
+// Disable a registered host chain. The chain stays registered but is flagged as disabled.
+task("task:disableHostChainOnGatewayConfig")
+  .addParam("chainId", "The chain ID of the host chain to disable", undefined, types.string)
+  .addParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .setAction(async function ({ chainId, useInternalProxyAddress }, hre) {
+    const { gatewayConfig, proxyAddress } = await loadGatewayConfig(hre, useInternalProxyAddress);
+
+    // Pre-flight: surface a clean error before submitting a tx that would revert on-chain.
+    if (!(await gatewayConfig.isHostChainRegistered(chainId))) {
+      throw new Error(`Host chain ${chainId} is not registered in GatewayConfig at ${proxyAddress}.`);
+    }
+    if (await gatewayConfig.isHostChainDisabled(chainId)) {
+      throw new Error(`Host chain ${chainId} is already disabled in GatewayConfig at ${proxyAddress}.`);
+    }
+
+    console.log(`Disabling host chain ${chainId} in GatewayConfig contract:`, proxyAddress, "\n");
+    const tx = await gatewayConfig.disableHostChain(chainId);
+    await tx.wait();
+
+    console.log(`Emitted DisableHostChain(${chainId}) (tx: ${tx.hash})`);
+    console.log("Host chain disabled!");
+  });
+
+// Re-enable a previously disabled host chain.
+task("task:enableHostChainOnGatewayConfig")
+  .addParam("chainId", "The chain ID of the host chain to enable", undefined, types.string)
+  .addParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .setAction(async function ({ chainId, useInternalProxyAddress }, hre) {
+    const { gatewayConfig, proxyAddress } = await loadGatewayConfig(hre, useInternalProxyAddress);
+
+    // Pre-flight: surface a clean error before submitting a tx that would revert on-chain.
+    if (!(await gatewayConfig.isHostChainRegistered(chainId))) {
+      throw new Error(`Host chain ${chainId} is not registered in GatewayConfig at ${proxyAddress}.`);
+    }
+    if (!(await gatewayConfig.isHostChainDisabled(chainId))) {
+      throw new Error(`Host chain ${chainId} is already enabled in GatewayConfig at ${proxyAddress}.`);
+    }
+
+    console.log(`Enabling host chain ${chainId} in GatewayConfig contract:`, proxyAddress, "\n");
+    const tx = await gatewayConfig.enableHostChain(chainId);
+    await tx.wait();
+
+    console.log(`Emitted EnableHostChain(${chainId}) (tx: ${tx.hash})`);
+    console.log("Host chain enabled!");
+  });
+
+// Remove a host chain entirely. The chain must be disabled first, mirroring the on-chain
+// `HostChainNotDisabled` guard, so the operator gets a clean error before submitting.
+task("task:removeHostChainOnGatewayConfig")
+  .addParam("chainId", "The chain ID of the host chain to remove", undefined, types.string)
+  .addParam(
+    "useInternalProxyAddress",
+    "If proxy address from the /addresses directory should be used",
+    false,
+    types.boolean,
+  )
+  .setAction(async function ({ chainId, useInternalProxyAddress }, hre) {
+    const { gatewayConfig, proxyAddress } = await loadGatewayConfig(hre, useInternalProxyAddress);
+
+    // Pre-flight: surface a clean error before submitting a tx that would revert on-chain.
+    if (!(await gatewayConfig.isHostChainRegistered(chainId))) {
+      throw new Error(`Host chain ${chainId} is not registered in GatewayConfig at ${proxyAddress}.`);
+    }
+    // Mirror the on-chain `HostChainNotDisabled` check (GatewayConfig.sol): a chain must be disabled
+    // before it can be removed, so removal cannot pull a chain out from under in-flight requests.
+    if (!(await gatewayConfig.isHostChainDisabled(chainId))) {
+      throw new Error(
+        `Host chain ${chainId} must be disabled before removal. ` +
+          `Run task:disableHostChainOnGatewayConfig --chain-id ${chainId} first.`,
+      );
+    }
+
+    console.log(`Removing host chain ${chainId} from GatewayConfig contract:`, proxyAddress, "\n");
+    const tx = await gatewayConfig.removeHostChain(chainId);
+    await tx.wait();
+
+    console.log(`Emitted RemoveHostChain(${chainId}) (tx: ${tx.hash})`);
+    console.log("Host chain removed!");
+  });

--- a/gateway-contracts/test/tasks/hostChains.ts
+++ b/gateway-contracts/test/tasks/hostChains.ts
@@ -1,0 +1,107 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import hre from "hardhat";
+
+import { GatewayConfig } from "../../typechain-types";
+import { loadTestVariablesFixture } from "../utils";
+
+// Asserts that the given promise rejects with an error message containing `substring`.
+// Used for the tasks' pre-flight checks, which throw plain JS errors (not contract reverts).
+async function expectTaskToThrow(promise: Promise<unknown>, substring: string) {
+  let threw = false;
+  try {
+    await promise;
+  } catch (error) {
+    threw = true;
+    expect((error as Error).message).to.include(substring);
+  }
+  expect(threw, `Expected task to throw containing "${substring}"`).to.eq(true);
+}
+
+describe("Host chain management tasks", function () {
+  let gatewayConfig: GatewayConfig;
+  let registeredChainId: number;
+  // A chain ID that is guaranteed not to be registered by the test setup.
+  const unregisteredChainId = 999999;
+
+  before(async function () {
+    const fixtureData = await loadFixture(loadTestVariablesFixture);
+    gatewayConfig = fixtureData.gatewayConfig;
+    // The test setup registers the host chains via `task:addHostChainsToGatewayConfig`.
+    registeredChainId = fixtureData.chainIds[0];
+  });
+
+  it("Should start with a registered, enabled host chain", async function () {
+    expect(await gatewayConfig.isHostChainRegistered(registeredChainId)).to.eq(true);
+    expect(await gatewayConfig.isHostChainDisabled(registeredChainId)).to.eq(false);
+  });
+
+  it("Should disable a host chain", async function () {
+    await hre.run("task:disableHostChainOnGatewayConfig", {
+      chainId: registeredChainId.toString(),
+      useInternalProxyAddress: true,
+    });
+    expect(await gatewayConfig.isHostChainDisabled(registeredChainId)).to.eq(true);
+    expect(await gatewayConfig.isHostChainRegistered(registeredChainId)).to.eq(true);
+  });
+
+  it("Should reject disabling an already-disabled host chain", async function () {
+    await expectTaskToThrow(
+      hre.run("task:disableHostChainOnGatewayConfig", {
+        chainId: registeredChainId.toString(),
+        useInternalProxyAddress: true,
+      }),
+      "already disabled",
+    );
+  });
+
+  it("Should reject removing an unregistered host chain", async function () {
+    await expectTaskToThrow(
+      hre.run("task:removeHostChainOnGatewayConfig", {
+        chainId: unregisteredChainId.toString(),
+        useInternalProxyAddress: true,
+      }),
+      "not registered",
+    );
+  });
+
+  it("Should enable a disabled host chain", async function () {
+    await hre.run("task:enableHostChainOnGatewayConfig", {
+      chainId: registeredChainId.toString(),
+      useInternalProxyAddress: true,
+    });
+    expect(await gatewayConfig.isHostChainDisabled(registeredChainId)).to.eq(false);
+  });
+
+  it("Should reject enabling an already-enabled host chain", async function () {
+    await expectTaskToThrow(
+      hre.run("task:enableHostChainOnGatewayConfig", {
+        chainId: registeredChainId.toString(),
+        useInternalProxyAddress: true,
+      }),
+      "already enabled",
+    );
+  });
+
+  it("Should reject removing an enabled (not-disabled) host chain", async function () {
+    await expectTaskToThrow(
+      hre.run("task:removeHostChainOnGatewayConfig", {
+        chainId: registeredChainId.toString(),
+        useInternalProxyAddress: true,
+      }),
+      "must be disabled before removal",
+    );
+  });
+
+  it("Should remove a host chain after it has been disabled", async function () {
+    await hre.run("task:disableHostChainOnGatewayConfig", {
+      chainId: registeredChainId.toString(),
+      useInternalProxyAddress: true,
+    });
+    await hre.run("task:removeHostChainOnGatewayConfig", {
+      chainId: registeredChainId.toString(),
+      useInternalProxyAddress: true,
+    });
+    expect(await gatewayConfig.isHostChainRegistered(registeredChainId)).to.eq(false);
+  });
+});


### PR DESCRIPTION
Closes #2714.

## What

Adds the three operator-facing host chain lifecycle tasks to `gateway-contracts`, mirroring the existing `task:addHostChainsToGatewayConfig` and closing the symmetry with `addHostChain`:

| Solidity function | New hardhat task |
|---|---|
| `disableHostChain(uint256)` | `task:disableHostChainOnGatewayConfig --chain-id <id>` |
| `enableHostChain(uint256)` | `task:enableHostChainOnGatewayConfig --chain-id <id>` |
| `removeHostChain(uint256)` | `task:removeHostChainOnGatewayConfig --chain-id <id>` |

Each task:
- accepts `--use-internal-proxy-address` (default `false`) — resolves `GATEWAY_CONFIG_ADDRESS` from env (operator / gitops flow) or from `addresses/.env.gateway` (local / CI flow), exactly like `addHostChains.ts`;
- signs with `DEPLOYER_PRIVATE_KEY` (the deployer owns `GatewayConfig`);
- runs an **upfront pre-flight check** using the `isHostChainRegistered` / `isHostChainDisabled` getters, so the operator gets a clean error *before* submitting a tx that would revert on-chain;
- surfaces the emitted event (`DisableHostChain` / `EnableHostChain` / `RemoveHostChain`) in the logs.

`removeHostChainOnGatewayConfig` mirrors the on-chain `HostChainNotDisabled` guard (`GatewayConfig.sol`): it refuses to submit unless the chain is already disabled, pointing the operator at the disable task first.

## Files

- `tasks/manageHostChains.ts` — the three tasks (one file, like `pauseContracts.ts` groups related tasks).
- `hardhat.config.ts` — registers the new task module.
- `docs/getting-started/deployment/local_deploy.md` — new "Manage host chains" section.
- `test/tasks/hostChains.ts` — task tests (happy paths + every pre-flight rejection).

## Tests

`make test` — full suite green, **351 passing**, including 8 new tests covering disable → reject-double-disable → reject-remove-unregistered → enable → reject-double-enable → reject-remove-while-enabled → disable+remove.

## Notes / deviations from the issue

- **Doc location:** the acceptance criteria said "document in `gateway-contracts/README.md` next to `task:addHostChainsToGatewayConfig`", but that task is **not** documented in the README — its actual doc home is `docs/getting-started/deployment/local_deploy.md`. Documented the new tasks there instead, next to where `addHostChainsToGatewayConfig` is referenced.
- **No Solidity changed** → rust bindings / selectors / mocks / SPDX integrity checks are unaffected. The contract functions and the `isHostChainDisabled` getter already exist on `feature/0.13.1`.
- Targets `feature/0.13.1` per the 0.13.1 patch scope.

Draft pending review.