### PR TITLE
fix(host-contracts): per-contract verify tasks tolerate "Already Verified"

### DIFF
--- a/host-contracts/tasks/blockExplorerVerify.ts
+++ b/host-contracts/tasks/blockExplorerVerify.ts
@@ -1,8 +1,27 @@
 import { task, types } from 'hardhat/config';
-import type { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types';
+import type { HardhatRuntimeEnvironment, RunTaskFunction, TaskArguments } from 'hardhat/types';
 
 import { formatError } from './utils/formatError';
 import { getRequiredEnvVar, loadHostAddresses } from './utils/loadVariables';
+
+// Verifies a single contract on the block explorer, skipping the benign "already verified" response.
+//
+// `@nomicfoundation/hardhat-verify` rethrows "Already Verified" as a hard error — for the auto-matched
+// ERC1967 proxy, and for the deterministic implementation when a prior deploy already verified it.
+// When a per-contract `task:verify*` is called straight from a deploy script (the gitops sc-deploy
+// pattern), that error combines with `set -eo pipefail` to abort the whole deploy. Genuine failures
+// (bad API key, explorer down, bytecode mismatch) are rethrown unchanged.
+export async function verifyContract(run: RunTaskFunction, address: string): Promise<void> {
+  try {
+    await run('verify:verify', { address, constructorArguments: [] });
+  } catch (error) {
+    if (/already verified/i.test(formatError(error))) {
+      console.log(`${address} is already verified — skipping.`);
+    } else {
+      throw error;
+    }
+  }
+}
 
 task('task:verifyACL')
   .addOptionalParam(
@@ -17,14 +36,8 @@ task('task:verifyACL')
     }
     const proxyAddress = getRequiredEnvVar('ACL_CONTRACT_ADDRESS');
     const implementationACLAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationACLAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationACLAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyFHEVMExecutor')
@@ -40,14 +53,8 @@ task('task:verifyFHEVMExecutor')
     }
     const proxyAddress = getRequiredEnvVar('FHEVM_EXECUTOR_CONTRACT_ADDRESS');
     const implementationFHEVMExecutorAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationFHEVMExecutorAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationFHEVMExecutorAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyKMSVerifier')
@@ -63,14 +70,8 @@ task('task:verifyKMSVerifier')
     }
     const proxyAddress = getRequiredEnvVar('KMS_VERIFIER_CONTRACT_ADDRESS');
     const implementationKMSVerifierAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationKMSVerifierAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationKMSVerifierAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyInputVerifier')
@@ -86,14 +87,8 @@ task('task:verifyInputVerifier')
     }
     const proxyAddress = getRequiredEnvVar('INPUT_VERIFIER_CONTRACT_ADDRESS');
     const implementationInputVerifierAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationInputVerifierAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationInputVerifierAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyHCULimit')
@@ -109,14 +104,8 @@ task('task:verifyHCULimit')
     }
     const proxyAddress = getRequiredEnvVar('HCU_LIMIT_CONTRACT_ADDRESS');
     const implementationHCULimitAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationHCULimitAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationHCULimitAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyPauserSet')
@@ -131,10 +120,7 @@ task('task:verifyPauserSet')
       loadHostAddresses();
     }
     const implementationPauserSetAddress = getRequiredEnvVar('PAUSER_SET_CONTRACT_ADDRESS');
-    await run('verify:verify', {
-      address: implementationPauserSetAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationPauserSetAddress);
   });
 
 task('task:verifyProtocolConfig')
@@ -150,14 +136,8 @@ task('task:verifyProtocolConfig')
     }
     const proxyAddress = getRequiredEnvVar('PROTOCOL_CONFIG_CONTRACT_ADDRESS');
     const implementationProtocolConfigAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationProtocolConfigAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationProtocolConfigAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyKMSGeneration')
@@ -173,14 +153,8 @@ task('task:verifyKMSGeneration')
     }
     const proxyAddress = getRequiredEnvVar('KMS_GENERATION_CONTRACT_ADDRESS');
     const implementationKMSGenerationAddress = await upgrades.erc1967.getImplementationAddress(proxyAddress);
-    await run('verify:verify', {
-      address: implementationKMSGenerationAddress,
-      constructorArguments: [],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationKMSGenerationAddress);
+    await verifyContract(run, proxyAddress);
   });
 
 // Verify tasks deployed on every host chain (canonical and secondary).

--- a/host-contracts/test/tasks/blockExplorerVerify.ts
+++ b/host-contracts/test/tasks/blockExplorerVerify.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+
+import { verifyContract } from '../../tasks/blockExplorerVerify';
+
+describe('verifyContract', function () {
+  it('forwards the address to the verify:verify subtask on success', async function () {
+    const calls: Array<{ name: string; args: any }> = [];
+    const fakeRun = async (name: string, args: any) => {
+      calls.push({ name, args });
+    };
+
+    await verifyContract(fakeRun as any, '0xdeadbeef');
+
+    expect(calls).to.have.length(1);
+    expect(calls[0].name).to.eq('verify:verify');
+    expect(calls[0].args.address).to.eq('0xdeadbeef');
+    expect(calls[0].args.constructorArguments).to.deep.eq([]);
+  });
+
+  it('swallows the proxy "Already Verified" error (hardhat-verify casing)', async function () {
+    const fakeRun = async () => {
+      throw new Error('Failed to verify ERC1967Proxy contract at 0x1dD3c231: Already Verified');
+    };
+
+    // Should resolve without throwing.
+    await verifyContract(fakeRun as any, '0x1dD3c231');
+  });
+
+  it('swallows a lowercase "already verified" error (implementation re-verify)', async function () {
+    const fakeRun = async () => {
+      throw new Error('Contract source code already verified');
+    };
+
+    await verifyContract(fakeRun as any, '0xabc');
+  });
+
+  it('rethrows a genuine verification failure', async function () {
+    const fakeRun = async () => {
+      throw new Error('Invalid API Key');
+    };
+
+    let threw = false;
+    try {
+      await verifyContract(fakeRun as any, '0xabc');
+    } catch (error) {
+      threw = true;
+      expect(String(error)).to.include('Invalid API Key');
+    }
+    expect(threw, 'expected a genuine failure to be rethrown').to.eq(true);
+  });
+});


### PR DESCRIPTION
Closes #2717. **Stacked on #2657** (multi-chain deploy split), which already adds the `formatError` helper and best-effort wrapping for the *bulk* verify tasks (`verifyCanonicalHost` / `verifySecondaryHost`).

## Problem

The individual per-contract `task:verify*` (e.g. `task:verifyACL`) still call `verify:verify` raw. When a deploy script invokes them directly — the gitops sc-deploy pattern, where each verify runs right after its deploy — `@nomicfoundation/hardhat-verify` rethrows the explorer's "Already Verified" response as a hard error. Combined with `set -eo pipefail` in the chart `run.sh`, that aborts the whole deploy chain. Hit while rolling out `polygonAmoy` on `zws-dev`.

## Fix

Reuse #2657's `formatError` tool and add one small helper:

```ts
export async function verifyContract(run: RunTaskFunction, address: string): Promise<void> {
  try {
    await run('verify:verify', { address, constructorArguments: [] });
  } catch (error) {
    if (/already verified/i.test(formatError(error))) {
      console.log(`${address} is already verified — skipping.`);
    } else {
      throw error;
    }
  }
}
```

Every per-contract verify call (impl + proxy, all 8 tasks) is routed through it. Only the benign "already verified" case is swallowed (case-insensitive — the proxy returns `Already Verified`, the deterministic impl can return lowercase `already verified` on re-runs); genuine failures (bad API key, explorer down, bytecode mismatch) still throw.

## Tests

Unit tests drive the helper with a fake `run`: forward-through on success, swallow proxy + impl already-verified, rethrow `Invalid API Key`. **4 passing.** No Solidity touched → integrity gates unaffected.

Targets `elias/backport-2626-release-0.13.x` (#2657) so it lands on the refactored file; both are 0.13.1. Draft pending review.