### PR TITLE
fix(coprocessor): exit workers on fatal DB connection loss so k8s restarts them

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -11,8 +11,6 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Instrument};
 
-const CODE_DEADLOCK_DETECTED: &str = "40P01";
-
 /// True if the DB connection is lost/unusable, so we should exit and let k8s
 /// restart us rather than retry on a dead pool.
 pub fn is_fatal_connection_error(err: &sqlx::Error) -> bool {
@@ -217,21 +215,17 @@ impl PostgresPoolManager {
 
             match operation(self.pool.clone(), ct.clone()).await {
                 Ok(()) => return Ok(()),
-                // Retry deadlocks; everything else (lost connection, auth
-                // rejection) is fatal, so the caller exits and k8s restarts us.
-                Err(ServiceError::Database(sqlx::Error::Database(ref db_err)))
-                    if db_err.code().as_deref() == Some(CODE_DEADLOCK_DETECTED) =>
-                {
-                    error!(error=%db_err, "Transient DB error (deadlock); retrying...");
-                    cancellable_sleep(&ct, backoff_delay).await;
-                }
-                Err(ServiceError::Database(sqlx::Error::PoolTimedOut)) => {
-                    error!("Timed out waiting for a DB pool connection; retrying...");
-                    cancellable_sleep(&ct, self.params.retry_db_conn_interval).await;
-                }
                 Err(err) => {
-                    error!(error=%err, "Fatal DB error; not retrying");
-                    return Err(err);
+                    // Exit only on a lost connection (k8s gives us a fresh pool);
+                    // retry everything else.
+                    if let ServiceError::Database(db_err) = &err {
+                        if is_fatal_connection_error(db_err) {
+                            error!(error=%err, "Fatal DB connection error; not retrying");
+                            return Err(err);
+                        }
+                    }
+                    error!(error=%err, "Transient DB error; retrying...");
+                    cancellable_sleep(&ct, backoff_delay).await;
                 }
             }
         }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -11,8 +11,6 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Instrument};
 
-const CODE_DEADLOCK_DETECTED: &str = "40P01";
-
 /// True if the DB connection is lost/unusable, so we should exit and let k8s
 /// restart us rather than retry on a dead pool.
 pub fn is_fatal_connection_error(err: &sqlx::Error) -> bool {
@@ -218,25 +216,15 @@ impl PostgresPoolManager {
             match operation(self.pool.clone(), ct.clone()).await {
                 Ok(()) => return Ok(()),
                 Err(err) => {
-                    // Retry transient DB errors; exit on a lost connection or a
-                    // non-DB error so k8s restarts the service.
+                    // Only a lost connection is fatal (a restart gives a fresh
+                    // pool); retry everything else.
                     if let ServiceError::Database(db_err) = &err {
                         if is_fatal_connection_error(db_err) {
                             error!(error=%err, "Fatal DB connection error; not retrying");
                             return Err(err);
                         }
-                        // Retry deadlocks; other DB errors won't recover by retrying.
-                        if let sqlx::Error::Database(pg) = db_err {
-                            if pg.code().as_deref() != Some(CODE_DEADLOCK_DETECTED) {
-                                error!(error=%err, "Non-transient DB error; not retrying");
-                                return Err(err);
-                            }
-                        }
-                    } else {
-                        error!(error=%err, "Internal error; not retrying");
-                        return Err(err);
                     }
-                    error!(error=%err, "DB error; retrying...");
+                    error!(error=%err, "Service error; retrying...");
                     cancellable_sleep(&ct, backoff_delay).await;
                 }
             }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -11,6 +11,8 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Instrument};
 
+const CODE_DEADLOCK_DETECTED: &str = "40P01";
+
 /// True if the DB connection is lost/unusable, so we should exit and let k8s
 /// restart us rather than retry on a dead pool.
 pub fn is_fatal_connection_error(err: &sqlx::Error) -> bool {
@@ -222,6 +224,13 @@ impl PostgresPoolManager {
                         if is_fatal_connection_error(db_err) {
                             error!(error=%err, "Fatal DB connection error; not retrying");
                             return Err(err);
+                        }
+                        // Retry deadlocks; other DB errors won't recover by retrying.
+                        if let sqlx::Error::Database(pg) = db_err {
+                            if pg.code().as_deref() != Some(CODE_DEADLOCK_DETECTED) {
+                                error!(error=%err, "Non-transient DB error; not retrying");
+                                return Err(err);
+                            }
                         }
                     } else {
                         error!(error=%err, "Internal error; not retrying");

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -224,7 +224,7 @@ impl PostgresPoolManager {
                             return Err(err);
                         }
                     }
-                    error!(error=%err, "Transient DB error; retrying...");
+                    error!(error=%err, "Service error; retrying...");
                     cancellable_sleep(&ct, backoff_delay).await;
                 }
             }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -13,6 +13,29 @@ use tracing::{error, info, Instrument};
 
 const CODE_DEADLOCK_DETECTED: &str = "40P01";
 
+/// True if the DB connection is lost/unusable, so we should exit and let k8s
+/// restart us rather than retry on a dead pool.
+pub fn is_fatal_connection_error(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Io(_)
+        | sqlx::Error::Tls(_)
+        | sqlx::Error::Protocol(_)
+        | sqlx::Error::PoolClosed
+        | sqlx::Error::WorkerCrashed => true,
+        sqlx::Error::Database(db) => db.code().as_deref().is_some_and(fatal_connection_sqlstate),
+        _ => false,
+    }
+}
+
+/// Postgres SQLSTATEs for a dead connection/session (e.g. 28000, the auth
+/// rejection from the RDS failover). Deadlock (40P01) is excluded, it's retryable.
+fn fatal_connection_sqlstate(code: &str) -> bool {
+    matches!(
+        code,
+        "28000" | "28P01" | "08006" | "08001" | "08004" | "57P01" | "53300"
+    )
+}
+
 #[derive(Clone)]
 pub struct PostgresPoolManager {
     pool: Pool<Postgres>,
@@ -123,11 +146,15 @@ impl PostgresPoolManager {
     ///     let handle = db.spawn_with_db_retry(op, "my_task").await;
     ///
     ///     // Wait for the task to finish (or let it run in background)
-    ///     handle.await.unwrap();
+    ///     handle.await.unwrap()?;
     ///     Ok(())
     /// }
     /// ```
-    pub async fn spawn_with_db_retry<F, Fut>(&self, op: F, name: &str) -> JoinHandle<()>
+    pub async fn spawn_with_db_retry<F, Fut>(
+        &self,
+        op: F,
+        name: &str,
+    ) -> JoinHandle<Result<(), ServiceError>>
     where
         F: Fn(Pool<Postgres>, CancellationToken) -> Fut + Send + 'static,
         Fut: Future<Output = Result<(), ServiceError>> + Send + 'static,
@@ -135,19 +162,14 @@ impl PostgresPoolManager {
         let pool_mngr = self.clone();
         let fut = pool_mngr.run_with_db_retry(op);
 
-        tokio::spawn(
-            async move {
-                let _ = fut.await;
-            }
-            .instrument(Self::span(name)),
-        )
+        tokio::spawn(fut.instrument(Self::span(name)))
     }
 
     /// Calls run_with_db_retry on the specific JoinSet
     pub async fn spawn_join_set_with_db_retry<F, Fut>(
         &self,
         op: F,
-        join_set: &mut JoinSet<()>,
+        join_set: &mut JoinSet<Result<(), ServiceError>>,
         name: &str,
     ) -> AbortHandle
     where
@@ -157,12 +179,7 @@ impl PostgresPoolManager {
         let pool_mngr = self.clone();
         let fut = pool_mngr.run_with_db_retry(op);
 
-        join_set.spawn(
-            async move {
-                let _ = fut.await;
-            }
-            .instrument(Self::span(name)),
-        )
+        join_set.spawn(fut.instrument(Self::span(name)))
     }
 
     /// Run the given closure with a database pool, retrying on transient errors.
@@ -188,7 +205,6 @@ impl PostgresPoolManager {
         Fut: Future<Output = Result<(), ServiceError>>,
     {
         let ct = self.cancel_token.child_token();
-        let retry_delay = self.params.retry_db_conn_interval;
         let mut backoff_delay = self.params.retry_db_conn_interval;
 
         loop {
@@ -199,41 +215,24 @@ impl PostgresPoolManager {
 
             backoff_delay = std::cmp::min(backoff_delay * 2, Duration::from_secs(60));
 
-            if let Err(err) = operation(self.pool.clone(), ct.clone()).await {
-                error!(error=%err, "service failure; retrying...");
-                match err {
-                    ServiceError::Database(sqlx::Error::PoolTimedOut) => {
-                        // PoolTimedOut is considered a transient error; retry after sleeping.
-                        cancellable_sleep(&ct, retry_delay).await;
-                    }
-                    ServiceError::Database(
-                        sqlx::Error::Io(_) | sqlx::Error::Protocol(_) | sqlx::Error::Tls(_),
-                    ) => {
-                        // IO, Protocol, and TLS errors are usually transient (e.g., network issues)
-                        cancellable_sleep(&ct, backoff_delay).await;
-                    }
-                    ServiceError::Database(sqlx::Error::Database(ref db_err)) => {
-                        // Only retry on transient database errors (deadlock, etc.)
-                        let code = db_err.code().unwrap_or("".into());
-                        if code == CODE_DEADLOCK_DETECTED {
-                            error!(error=%err, code=%code, "Transient DB error; retrying...");
-                        } else {
-                            error!(error=%db_err, code=%code, "Non-transient DB error; not retrying");
-                            return Err(err);
-                        }
-                    }
-                    ServiceError::Database(other) => {
-                        error!(error=%other, "Non-transient DB error; longer backoff");
-                        cancellable_sleep(&ct, backoff_delay).await;
-                    }
-                    _ => {
-                        // Non-database errors are returned immediately.
-                        error!(error = %err, "unrecoverable error, a restart required");
-                        return Err(err);
-                    }
+            match operation(self.pool.clone(), ct.clone()).await {
+                Ok(()) => return Ok(()),
+                // Retry deadlocks; everything else (lost connection, auth
+                // rejection) is fatal, so the caller exits and k8s restarts us.
+                Err(ServiceError::Database(sqlx::Error::Database(ref db_err)))
+                    if db_err.code().as_deref() == Some(CODE_DEADLOCK_DETECTED) =>
+                {
+                    error!(error=%db_err, "Transient DB error (deadlock); retrying...");
+                    cancellable_sleep(&ct, backoff_delay).await;
                 }
-            } else {
-                return Ok(());
+                Err(ServiceError::Database(sqlx::Error::PoolTimedOut)) => {
+                    error!("Timed out waiting for a DB pool connection; retrying...");
+                    cancellable_sleep(&ct, self.params.retry_db_conn_interval).await;
+                }
+                Err(err) => {
+                    error!(error=%err, "Fatal DB error; not retrying");
+                    return Err(err);
+                }
             }
         }
     }
@@ -308,5 +307,40 @@ async fn cancellable_sleep(cancel_token: &CancellationToken, duration: Duration)
         _ = sleep(duration) => {
             // Sleep completed
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlstate_classification() {
+        for code in [
+            "28000", "28P01", "08006", "08001", "08004", "57P01", "53300",
+        ] {
+            assert!(fatal_connection_sqlstate(code), "{code} should be fatal");
+        }
+        // Deadlock is retryable; ordinary errors and unknown codes are not fatal.
+        for code in ["40P01", "23505", "23503", ""] {
+            assert!(
+                !fatal_connection_sqlstate(code),
+                "{code} should not be fatal"
+            );
+        }
+    }
+
+    #[test]
+    fn error_variant_classification() {
+        assert!(is_fatal_connection_error(&sqlx::Error::PoolClosed));
+        assert!(is_fatal_connection_error(&sqlx::Error::WorkerCrashed));
+        assert!(is_fatal_connection_error(&sqlx::Error::Io(
+            std::io::Error::other("boom")
+        )));
+        assert!(is_fatal_connection_error(&sqlx::Error::Protocol(
+            "bad".into()
+        )));
+        assert!(!is_fatal_connection_error(&sqlx::Error::PoolTimedOut));
+        assert!(!is_fatal_connection_error(&sqlx::Error::RowNotFound));
     }
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -216,15 +216,18 @@ impl PostgresPoolManager {
             match operation(self.pool.clone(), ct.clone()).await {
                 Ok(()) => return Ok(()),
                 Err(err) => {
-                    // Exit only on a lost connection (k8s gives us a fresh pool);
-                    // retry everything else.
+                    // Retry transient DB errors; exit on a lost connection or a
+                    // non-DB error so k8s restarts the service.
                     if let ServiceError::Database(db_err) = &err {
                         if is_fatal_connection_error(db_err) {
                             error!(error=%err, "Fatal DB connection error; not retrying");
                             return Err(err);
                         }
+                    } else {
+                        error!(error=%err, "Internal error; not retrying");
+                        return Err(err);
                     }
-                    error!(error=%err, "Service error; retrying...");
+                    error!(error=%err, "DB error; retrying...");
                     cancellable_sleep(&ct, backoff_delay).await;
                 }
             }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -43,6 +43,17 @@ impl Drop for TracerProviderGuard {
     }
 }
 
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+
+/// Flush buffered OTLP spans; call before `std::process::exit`.
+pub fn flush() {
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(err) = provider.force_flush() {
+            warn!(error = %err, "Failed to flush OTLP tracer provider");
+        }
+    }
+}
+
 pub static HOST_TXN_LATENCY_CONFIG: OnceLock<MetricsConfig> = OnceLock::new();
 pub(crate) static HOST_TXN_LATENCY_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
     register_histogram(
@@ -94,6 +105,7 @@ pub fn init_json_subscriber(
     let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
     base.with(telemetry_layer).try_init()?;
     opentelemetry::global::set_tracer_provider(trace_provider.clone());
+    let _ = TRACER_PROVIDER.set(trace_provider.clone());
     Ok(Some(TracerProviderGuard::new(trace_provider)))
 }
 

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -39,7 +39,7 @@ pub(crate) async fn spawn_resubmit_task(
     jobs_tx: mpsc::Sender<UploadJob>,
     client: Arc<aws_sdk_s3::Client>,
     is_ready: Arc<AtomicBool>,
-) -> Result<JoinHandle<()>, ExecutionError> {
+) -> Result<JoinHandle<Result<(), ServiceError>>, ExecutionError> {
     let op = move |pool, token| {
         let client = client.clone();
         let is_ready = is_ready.clone();
@@ -63,7 +63,7 @@ pub(crate) async fn spawn_uploader(
     rx: Arc<RwLock<mpsc::Receiver<UploadJob>>>,
     client: Arc<aws_sdk_s3::Client>,
     is_ready: Arc<AtomicBool>,
-) -> Result<JoinHandle<()>, ExecutionError> {
+) -> Result<JoinHandle<Result<(), ServiceError>>, ExecutionError> {
     let op = move |pool, token| {
         let client = client.clone();
         let is_ready = is_ready.clone();

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -9,7 +9,7 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use bytesize::ByteSize;
 use fhevm_engine_common::chain_id::ChainId;
-use fhevm_engine_common::pg_pool::{PostgresPoolManager, ServiceError};
+use fhevm_engine_common::pg_pool::{is_fatal_connection_error, PostgresPoolManager, ServiceError};
 use fhevm_engine_common::{telemetry, utils::to_hex};
 use futures::future::join_all;
 use opentelemetry::trace::{Status, TraceContextExt};
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::select;
 use tokio::sync::{mpsc, RwLock, Semaphore};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, error_span, info, warn, Instrument};
@@ -89,7 +89,7 @@ async fn run_uploader_loop(
     pool: Pool<Postgres>,
     conf: S3Config,
 ) -> Result<(), ExecutionError> {
-    let mut ongoing_upload_tasks: Vec<JoinHandle<()>> = Vec::new();
+    let mut ongoing_upload_tasks: JoinSet<Result<(), ExecutionError>> = JoinSet::new();
     let max_concurrent_uploads = conf.max_concurrent_uploads as usize;
     let semaphore = Arc::new(Semaphore::new(max_concurrent_uploads));
     let mut jobs_rx = jobs_rx.write().await;
@@ -171,8 +171,6 @@ async fn run_uploader_loop(
 
                 debug!(handle = hex::encode(&item.handle), "Received task, handle");
 
-                // Cleanup completed tasks
-                ongoing_upload_tasks.retain(|h| !h.is_finished());
                 // Check if we have reached the max concurrent uploads
                 if ongoing_upload_tasks.len() >= max_concurrent_uploads {
                     warn!({target = "worker", action = "review", max_concurrent_uploads = max_concurrent_uploads},
@@ -191,18 +189,20 @@ async fn run_uploader_loop(
                 let conf = conf.clone();
                 let ready_flag = is_ready.clone();
 
-                // Spawn a new task to upload the ciphertexts
-                let h = tokio::spawn(async move {
+                // Spawn an upload. A lost connection is returned so the loop
+                // fails fast; other failures are best-effort (resubmit retries).
+                ongoing_upload_tasks.spawn(async move {
                     // Cross-boundary: spawned task; restore the OTel context
                     // that was captured when the upload item was created.
                     let upload_span = error_span!("upload_s3");
                     upload_span.set_parent(item.span.context());
-                    match upload_ciphertexts(trx, item, &client, &conf)
+                    let result = upload_ciphertexts(trx, item, &client, &conf)
                         .instrument(upload_span.clone())
-                        .await
-                    {
+                        .await;
+                    let outcome = match result {
                         Ok(()) => {
                             AWS_UPLOAD_SUCCESS_COUNTER.inc();
+                            Ok(())
                         }
                         Err(err) => {
                             if let ExecutionError::S3TransientError(_) = err {
@@ -216,25 +216,35 @@ async fn run_uploader_loop(
                                 .span()
                                 .set_status(Status::error(err.to_string()));
                             AWS_UPLOAD_FAILURE_COUNTER.inc();
+                            // Only a lost connection is fatal; retry the rest.
+                            match &err {
+                                ExecutionError::DbError(e) if is_fatal_connection_error(e) => {
+                                    Err(err)
+                                }
+                                _ => Ok(()),
+                            }
                         }
-                    }
+                    };
                     drop(upload_span);
                     drop(permit);
+                    outcome
                 });
-
-                ongoing_upload_tasks.push(h);
             },
+            // Drain finished uploads; exit if one lost the connection.
+            Some(joined) = ongoing_upload_tasks.join_next() => {
+                if let Ok(Err(err)) = joined {
+                    return Err(err);
+                }
+            }
             _ = token.cancelled() => {
-                // Cleanup completed tasks
-                ongoing_upload_tasks.retain(|h| !h.is_finished());
-
                 info!("Waiting for all uploads to finish...");
-                for handle in ongoing_upload_tasks {
-                    if let Err(err) = handle.await {
-                        error!(error = %err, "Failed to join upload task");
+                while let Some(joined) = ongoing_upload_tasks.join_next().await {
+                    match joined {
+                        Ok(Err(err)) => error!(error = %err, "Upload task failed during shutdown"),
+                        Err(err) => error!(error = %err, "Failed to join upload task"),
+                        Ok(Ok(())) => {}
                     }
                 }
-
                 return Ok(())
             }
         }

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -82,6 +82,7 @@ async fn main() {
         .await
         .unwrap_or_else(|err| {
             error!(error = %err, "Error running SNS worker");
+            telemetry::flush();
             std::process::exit(1);
         });
 }

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -145,7 +145,7 @@ impl SwitchNSquashService {
         })
     }
 
-    pub async fn run(&self, pool_mngr: &PostgresPoolManager) {
+    pub async fn run(&self, pool_mngr: &PostgresPoolManager) -> Result<(), ServiceError> {
         let keys_cache: Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>> = Arc::new(RwLock::new(
             lru::LruCache::new(NonZeroUsize::new(10).unwrap()),
         ));
@@ -172,7 +172,7 @@ impl SwitchNSquashService {
             }
         };
 
-        let _ = pool_mngr.blocking_with_db_retry(op, "sns").await;
+        pool_mngr.blocking_with_db_retry(op, "sns").await
     }
 }
 
@@ -267,8 +267,19 @@ pub(crate) async fn run_loop(
 
         select! {
             _ = token.cancelled() => return Ok(()),
-            n = listener.try_recv() => {
-                info!( notification = ?n, "Received notification");
+            notification = listener.try_recv() => {
+                match notification? {
+                    Some(notification) => {
+                        info!(notification = ?notification, "Received notification");
+                    }
+                    None => {
+                        return Err(sqlx::Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "postgres LISTEN connection lost",
+                        ))
+                        .into());
+                    }
+                }
             },
             _ = polling_ticker.tick() => {
                 debug!( "Polling timeout, rechecking for tasks");

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -273,11 +273,9 @@ pub(crate) async fn run_loop(
                         info!(notification = ?notification, "Received notification");
                     }
                     None => {
-                        return Err(sqlx::Error::Io(std::io::Error::new(
-                            std::io::ErrorKind::BrokenPipe,
-                            "postgres LISTEN connection lost",
-                        ))
-                        .into());
+                        // sqlx already reconnected the LISTEN connection; keep going.
+                        warn!("postgres LISTEN connection reset; reconnected");
+                        continue;
                     }
                 }
             },

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -28,7 +28,6 @@ use fhevm_engine_common::{
     types::FhevmError,
     utils::{to_hex, DatabaseURL},
 };
-use futures::join;
 use sqlx::{Postgres, Transaction};
 use thiserror::Error;
 use tokio::{
@@ -436,7 +435,7 @@ pub async fn run_uploader_loop(
     let (is_ready_res, _) = check_is_ready(&client, conf).await;
     is_ready.store(is_ready_res, Ordering::Release);
 
-    let handle_resubmit = spawn_resubmit_task(
+    let mut handle_resubmit = spawn_resubmit_task(
         pool_mngr,
         conf.clone(),
         tx.clone(),
@@ -445,10 +444,16 @@ pub async fn run_uploader_loop(
     )
     .await?;
 
-    let handle_uploader = spawn_uploader(pool_mngr, conf.clone(), rx, client, is_ready).await?;
-    let (resubmit_res, uploader_res) = join!(handle_resubmit, handle_uploader);
-    resubmit_res??;
-    uploader_res??;
+    let mut handle_uploader = spawn_uploader(pool_mngr, conf.clone(), rx, client, is_ready).await?;
+
+    // Return when either task ends; abort the other and propagate its result.
+    let res = tokio::select! {
+        r = &mut handle_resubmit => r,
+        r = &mut handle_uploader => r,
+    };
+    handle_resubmit.abort();
+    handle_uploader.abort();
+    res??;
 
     info!("Uploader stopped");
     Ok(())

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -446,7 +446,9 @@ pub async fn run_uploader_loop(
     .await?;
 
     let handle_uploader = spawn_uploader(pool_mngr, conf.clone(), rx, client, is_ready).await?;
-    let _res = join!(handle_resubmit, handle_uploader);
+    let (resubmit_res, uploader_res) = join!(handle_resubmit, handle_uploader);
+    resubmit_res??;
+    uploader_res??;
 
     info!("Uploader stopped");
     Ok(())
@@ -587,8 +589,13 @@ pub async fn run_all(
     });
 
     // Run the main service loop
-    service.run(&pool_mngr).await;
+    let result = service.run(&pool_mngr).await;
     token.cancel();
+
+    if let Err(err) = result {
+        error!(error = %err, "SNS worker exited with a fatal error");
+        return Err(err.into());
+    }
 
     info!("Worker stopped");
     Ok(())

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -581,20 +581,23 @@ pub async fn run_all(
     )
     .await?;
 
-    // Spawns a task to handle S3 uploads
-    spawn(async move {
-        if let Err(err) = run_uploader_loop(&pg_mngr, &conf, jobs_rx, tx, s3, is_ready).await {
-            error!(error = %err, "Failed to run the upload-worker");
-        }
-    });
+    // Keep the uploader's handle so its failure exits the process too.
+    let uploader =
+        spawn(async move { run_uploader_loop(&pg_mngr, &conf, jobs_rx, tx, s3, is_ready).await });
 
-    // Run the main service loop
-    let result = service.run(&pool_mngr).await;
+    // Exit if either the service loop or the uploader fails.
+    let result: Result<(), Box<dyn std::error::Error + Send + Sync>> = tokio::select! {
+        res = service.run(&pool_mngr) => res.map_err(Into::into),
+        res = uploader => match res {
+            Ok(inner) => inner,
+            Err(join_err) => Err(join_err.into()),
+        },
+    };
     token.cancel();
 
     if let Err(err) = result {
         error!(error = %err, "SNS worker exited with a fatal error");
-        return Err(err.into());
+        return Err(err);
     }
 
     info!("Worker stopped");

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -74,6 +74,12 @@ pub async fn run_tfhe_worker(
         // here we log the errors and make sure we retry
         if let Err(cycle_error) = tfhe_worker_cycle(&args, worker_id, health_check.clone()).await {
             WORKER_ERRORS_COUNTER.inc();
+            if let Some(db_err) = cycle_error.downcast_ref::<sqlx::Error>() {
+                if fhevm_engine_common::pg_pool::is_fatal_connection_error(db_err) {
+                    error!(target: "tfhe_worker", error = %db_err, "Fatal DB connection error; exiting for k8s restart");
+                    std::process::exit(1);
+                }
+            }
             error!(target: "tfhe_worker", { error = cycle_error }, "Error in background worker, retrying shortly");
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
@@ -121,9 +127,20 @@ async fn tfhe_worker_cycle(
         // only if previous iteration had no work done do the wait
         if !immediately_poll_more_work {
             tokio::select! {
-                _ = listener.try_recv() => {
-                    WORK_ITEMS_NOTIFICATIONS_COUNTER.inc();
-                    info!(target: "tfhe_worker", "Received work_available notification from postgres");
+                notification = listener.try_recv() => {
+                    match notification? {
+                        Some(_) => {
+                            WORK_ITEMS_NOTIFICATIONS_COUNTER.inc();
+                            info!(target: "tfhe_worker", "Received work_available notification from postgres");
+                        }
+                        None => {
+                            return Err(sqlx::Error::Io(std::io::Error::new(
+                                std::io::ErrorKind::BrokenPipe,
+                                "postgres LISTEN connection lost",
+                            ))
+                            .into());
+                        }
+                    }
                 },
                 _ = tokio::time::sleep(tokio::time::Duration::from_millis(args.worker_polling_interval_ms)) => {
                     WORK_ITEMS_POLL_COUNTER.inc();

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -77,6 +77,7 @@ pub async fn run_tfhe_worker(
             if let Some(db_err) = cycle_error.downcast_ref::<sqlx::Error>() {
                 if fhevm_engine_common::pg_pool::is_fatal_connection_error(db_err) {
                     error!(target: "tfhe_worker", error = %db_err, "Fatal DB connection error; exiting for k8s restart");
+                    fhevm_engine_common::telemetry::flush();
                     std::process::exit(1);
                 }
             }

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -2,7 +2,6 @@ use crate::dependence_chain::{self};
 use crate::types::CoprocessorError;
 use fhevm_engine_common::database::{connect_pool_with_options, resolve_database_url_from_option};
 use fhevm_engine_common::db_keys::DbKeyCache;
-use fhevm_engine_common::pg_pool::is_fatal_connection_error;
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::tfhe_ops::check_fhe_operand_types;
 use fhevm_engine_common::types::{FhevmError, Handle, SupportedFheCiphertexts};
@@ -75,30 +74,24 @@ pub async fn run_tfhe_worker(
         // here we log the errors and make sure we retry
         if let Err(cycle_error) = tfhe_worker_cycle(&args, worker_id, health_check.clone()).await {
             WORKER_ERRORS_COUNTER.inc();
-            if has_fatal_db_error(cycle_error.as_ref()) {
+            if cycle_error.is_fatal_connection() {
                 error!(target: "tfhe_worker", error = %cycle_error, "Fatal DB connection error; exiting for k8s restart");
                 fhevm_engine_common::telemetry::flush();
                 std::process::exit(1);
             }
-            error!(target: "tfhe_worker", { error = cycle_error }, "Error in background worker, retrying shortly");
+            error!(target: "tfhe_worker", { error = %cycle_error }, "Error in background worker, retrying shortly");
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
     }
-}
-
-fn has_fatal_db_error(err: &(dyn std::error::Error + 'static)) -> bool {
-    std::iter::successors(Some(err), |e| e.source()).any(|e| {
-        e.downcast_ref::<sqlx::Error>()
-            .is_some_and(is_fatal_connection_error)
-    })
 }
 
 async fn tfhe_worker_cycle(
     args: &crate::daemon_cli::Args,
     worker_id: Uuid,
     health_check: crate::health_check::HealthCheck,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let db_url = resolve_database_url_from_option(args.database_url.clone())?;
+) -> Result<(), CoprocessorError> {
+    let db_url = resolve_database_url_from_option(args.database_url.clone())
+        .map_err(|e| CoprocessorError::Other(e.into()))?;
     let (pool, _pool_refresh_handle) = connect_pool_with_options(
         &db_url,
         sqlx::postgres::PgPoolOptions::new().max_connections(args.pg_pool_max_connections),
@@ -106,7 +99,8 @@ async fn tfhe_worker_cycle(
     )
     .await?;
 
-    let db_key_cache = DbKeyCache::new(args.key_cache_size)?;
+    let db_key_cache =
+        DbKeyCache::new(args.key_cache_size).map_err(|e| CoprocessorError::Other(e.into()))?;
     let mut listener = PgListener::connect_with(&pool).await?;
     listener.listen("work_available").await?;
 
@@ -126,7 +120,10 @@ async fn tfhe_worker_cycle(
 
     #[cfg(feature = "bench")]
     {
-        let _ = db_key_cache.fetch_latest_from_pool(&pool).await?;
+        let _ = db_key_cache
+            .fetch_latest_from_pool(&pool)
+            .await
+            .map_err(|e| CoprocessorError::Other(e.into()))?;
     }
     let mut immediately_poll_more_work = false;
     let mut no_progress_cycles = 0;
@@ -268,7 +265,7 @@ async fn tfhe_worker_cycle(
 async fn query_ciphertexts<'a>(
     cts_to_query: &[Vec<u8>],
     trx: &mut sqlx::Transaction<'a, Postgres>,
-) -> Result<HashMap<Vec<u8>, (i16, Vec<u8>)>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<HashMap<Vec<u8>, (i16, Vec<u8>)>, CoprocessorError> {
     // TODO: select all the ciphertexts where they're contained in the tuples
     let ciphertexts_rows = query!(
         "
@@ -300,8 +297,7 @@ async fn query_for_work<'a>(
     trx: &mut sqlx::Transaction<'a, Postgres>,
     deps_chain_mngr: &mut dependence_chain::LockMngr,
     no_progress_cycles: &mut u32,
-) -> Result<(Vec<ComponentNode>, PrimitiveDateTime, bool), Box<dyn std::error::Error + Send + Sync>>
-{
+) -> Result<(Vec<ComponentNode>, PrimitiveDateTime, bool), CoprocessorError> {
     let s_dcid = tracing::info_span!(
         "query_dependence_chain",
         dependence_chain_id = tracing::field::Empty
@@ -322,7 +318,7 @@ async fn query_for_work<'a>(
                 }
             }
         };
-        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(result)
+        Ok::<_, CoprocessorError>(result)
     }
     .instrument(s_dcid.clone())
     .await?;
@@ -441,8 +437,7 @@ WHERE c.transaction_id IN (
                         inputs.push(DFGTaskInput::Dependence(dh.clone()));
                     }
                 }
-                check_fhe_operand_types(w.fhe_operation.into(), &this_comp_inputs, &is_scalar_op_vec)
-                    .map_err(CoprocessorError::FhevmError)?;
+                check_fhe_operand_types(w.fhe_operation.into(), &this_comp_inputs, &is_scalar_op_vec)?;
                 ops.push(DFGOp {
                     output_handle: w.output_handle.clone(),
                     fhe_op,
@@ -456,10 +451,11 @@ WHERE c.transaction_id IN (
                     earliest_schedule_order = w.schedule_order;
                 }
             }
-            let (mut components, _) = build_component_nodes(ops, transaction_id)?;
+            let (mut components, _) = build_component_nodes(ops, transaction_id)
+                .map_err(|e| CoprocessorError::Other(e.into()))?;
             transactions.append(&mut components);
         }
-        Ok::<_, Box<dyn std::error::Error + Send + Sync>>((transactions, earliest_schedule_order))
+        Ok::<_, CoprocessorError>((transactions, earliest_schedule_order))
     }
     .instrument(s_prep)
     .await?;
@@ -473,7 +469,7 @@ async fn build_transaction_graph_and_execute<'a>(
     health_check: &crate::health_check::HealthCheck,
     trx: &mut sqlx::Transaction<'a, Postgres>,
     dcid_mngr: &dependence_chain::LockMngr,
-) -> Result<DFComponentGraph, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<DFComponentGraph, CoprocessorError> {
     let mut tx_graph = DFComponentGraph::default();
     if let Err(e) = tx_graph.build(txs) {
         // If we had an error while building the graph, we don't
@@ -492,16 +488,18 @@ async fn build_transaction_graph_and_execute<'a>(
         }
     }
     for (handle, (ct_type, mut ct)) in ciphertext_map.into_iter() {
-        tx_graph.add_input(
-            &handle,
-            &DFGTxInput::Compressed((
-                CompressedCiphertext {
-                    ct_type,
-                    ct_bytes: std::mem::take(&mut ct),
-                },
-                true,
-            )),
-        )?;
+        tx_graph
+            .add_input(
+                &handle,
+                &DFGTxInput::Compressed((
+                    CompressedCiphertext {
+                        ct_type,
+                        ct_bytes: std::mem::take(&mut ct),
+                    },
+                    true,
+                )),
+            )
+            .map_err(|e| CoprocessorError::Other(e.into()))?;
     }
     // Resolve deferred cross-transaction dependences: edges whose
     // handle was fetched from DB are dropped (data already available),
@@ -517,7 +515,8 @@ async fn build_transaction_graph_and_execute<'a>(
         let keys = match db_key_cache.fetch_latest(trx.as_mut()).await {
             Ok(k) => k,
             Err(err) => {
-                // Preserve the typed sqlx::Error so `has_fatal_db_error` can find it.
+                // Extract the sqlx error from anyhow so it classifies as a
+                // fatal connection (fail fast) instead of looking like missing keys.
                 let cerr: CoprocessorError = match err.downcast::<sqlx::Error>() {
                     Ok(sqlx_err) => sqlx_err.into(),
                     Err(other) => CoprocessorError::MissingKeys {
@@ -527,7 +526,7 @@ async fn build_transaction_graph_and_execute<'a>(
                 error!(target: "tfhe_worker", { error = %cerr }, "failed to fetch latest key");
                 telemetry::set_current_span_error(&cerr);
                 WORKER_ERRORS_COUNTER.inc();
-                return Err(cerr.into());
+                return Err(cerr);
             }
         };
 
@@ -542,8 +541,11 @@ async fn build_transaction_graph_and_execute<'a>(
             keys.gpu_sks.clone(),
             health_check.activity_heartbeat.clone(),
         );
-        sched.schedule().await?;
-        Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
+        sched
+            .schedule()
+            .await
+            .map_err(|e| CoprocessorError::Other(e.into()))?;
+        Ok::<(), CoprocessorError>(())
     }
     .instrument(s_compute)
     .await?;
@@ -555,7 +557,7 @@ async fn upload_transaction_graph_results<'a>(
     tx_graph: &mut DFComponentGraph,
     trx: &mut sqlx::Transaction<'a, Postgres>,
     deps_mngr: &mut dependence_chain::LockMngr,
-) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<bool, CoprocessorError> {
     // Get computation results
     let graph_results = tx_graph.get_results();
     let mut handles_to_update = vec![];
@@ -652,7 +654,7 @@ async fn upload_transaction_graph_results<'a>(
             let _ = sqlx::query!("SELECT pg_notify($1, '')", EVENT_CIPHERTEXT_COMPUTED)
                 .execute(trx.as_mut())
                 .await?;
-            Ok::<u64, Box<dyn std::error::Error + Send + Sync>>(cts_inserted)
+            Ok::<u64, CoprocessorError>(cts_inserted)
         }
         .instrument(s_insert)
         .await?;
@@ -680,7 +682,7 @@ async fn upload_transaction_graph_results<'a>(
                 error!(target: "tfhe_worker", { error = %err }, "error while updating computations as completed");
                 err
             })?.rows_affected();
-            Ok::<u64, Box<dyn std::error::Error + Send + Sync>>(comp_updated)
+            Ok::<u64, CoprocessorError>(comp_updated)
         }
         .instrument(s_update)
         .await?;
@@ -696,7 +698,7 @@ async fn set_computation_error<'a>(
     cerr: &(dyn std::error::Error + Send + Sync),
     trx: &mut sqlx::Transaction<'a, Postgres>,
     deps_mngr: &mut dependence_chain::LockMngr,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(), CoprocessorError> {
     WORKER_ERRORS_COUNTER.inc();
     let err_string = cerr.to_string();
     error!(target: "tfhe_worker", error = %err_string, output_handle = %format!("0x{}", hex::encode(output_handle)), "error while processing work item");

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -2,6 +2,7 @@ use crate::dependence_chain::{self};
 use crate::types::CoprocessorError;
 use fhevm_engine_common::database::{connect_pool_with_options, resolve_database_url_from_option};
 use fhevm_engine_common::db_keys::DbKeyCache;
+use fhevm_engine_common::pg_pool::is_fatal_connection_error;
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::tfhe_ops::check_fhe_operand_types;
 use fhevm_engine_common::types::{FhevmError, Handle, SupportedFheCiphertexts};
@@ -74,17 +75,22 @@ pub async fn run_tfhe_worker(
         // here we log the errors and make sure we retry
         if let Err(cycle_error) = tfhe_worker_cycle(&args, worker_id, health_check.clone()).await {
             WORKER_ERRORS_COUNTER.inc();
-            if let Some(db_err) = cycle_error.downcast_ref::<sqlx::Error>() {
-                if fhevm_engine_common::pg_pool::is_fatal_connection_error(db_err) {
-                    error!(target: "tfhe_worker", error = %db_err, "Fatal DB connection error; exiting for k8s restart");
-                    fhevm_engine_common::telemetry::flush();
-                    std::process::exit(1);
-                }
+            if has_fatal_db_error(cycle_error.as_ref()) {
+                error!(target: "tfhe_worker", error = %cycle_error, "Fatal DB connection error; exiting for k8s restart");
+                fhevm_engine_common::telemetry::flush();
+                std::process::exit(1);
             }
             error!(target: "tfhe_worker", { error = cycle_error }, "Error in background worker, retrying shortly");
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
     }
+}
+
+fn has_fatal_db_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    std::iter::successors(Some(err), |e| e.source()).any(|e| {
+        e.downcast_ref::<sqlx::Error>()
+            .is_some_and(is_fatal_connection_error)
+    })
 }
 
 async fn tfhe_worker_cycle(
@@ -511,8 +517,12 @@ async fn build_transaction_graph_and_execute<'a>(
         let keys = match db_key_cache.fetch_latest(trx.as_mut()).await {
             Ok(k) => k,
             Err(err) => {
-                let cerr = CoprocessorError::MissingKeys {
-                    reason: err.to_string(),
+                // Preserve the typed sqlx::Error so `has_fatal_db_error` can find it.
+                let cerr: CoprocessorError = match err.downcast::<sqlx::Error>() {
+                    Ok(sqlx_err) => sqlx_err.into(),
+                    Err(other) => CoprocessorError::MissingKeys {
+                        reason: other.to_string(),
+                    },
                 };
                 error!(target: "tfhe_worker", { error = %cerr }, "failed to fetch latest key");
                 telemetry::set_current_span_error(&cerr);

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -135,11 +135,8 @@ async fn tfhe_worker_cycle(
                             info!(target: "tfhe_worker", "Received work_available notification from postgres");
                         }
                         None => {
-                            return Err(sqlx::Error::Io(std::io::Error::new(
-                                std::io::ErrorKind::BrokenPipe,
-                                "postgres LISTEN connection lost",
-                            ))
-                            .into());
+                            // sqlx already reconnected the LISTEN connection; poll for work.
+                            warn!(target: "tfhe_worker", "postgres LISTEN connection reset; reconnected");
                         }
                     }
                 },

--- a/coprocessor/fhevm-engine/tfhe-worker/src/types.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/types.rs
@@ -1,12 +1,22 @@
+use fhevm_engine_common::pg_pool::is_fatal_connection_error;
 use fhevm_engine_common::types::FhevmError;
 use scheduler::dfg::types::SchedulerError;
 
 #[derive(Debug)]
 pub enum CoprocessorError {
     DbError(sqlx::Error),
+    FatalConnection(sqlx::Error),
     SchedulerError(SchedulerError),
     FhevmError(FhevmError),
     MissingKeys { reason: String },
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl CoprocessorError {
+    // True if this is a lost DB connection error.
+    pub fn is_fatal_connection(&self) -> bool {
+        matches!(self, Self::FatalConnection(_))
+    }
 }
 
 impl std::fmt::Display for CoprocessorError {
@@ -14,6 +24,9 @@ impl std::fmt::Display for CoprocessorError {
         match self {
             Self::DbError(dbe) => {
                 write!(f, "Coprocessor db error: {:?}", dbe)
+            }
+            Self::FatalConnection(dbe) => {
+                write!(f, "Fatal DB connection error: {:?}", dbe)
             }
             Self::SchedulerError(se) => {
                 write!(f, "Coprocessor scheduler error: {:?}", se)
@@ -24,27 +37,40 @@ impl std::fmt::Display for CoprocessorError {
             Self::MissingKeys { reason } => {
                 write!(f, "Missing keys: {}", reason)
             }
+            Self::Other(e) => {
+                write!(f, "Coprocessor error: {:?}", e)
+            }
         }
     }
 }
 
-impl std::error::Error for CoprocessorError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::DbError(e) => Some(e),
-            Self::SchedulerError(_) | Self::FhevmError(_) | Self::MissingKeys { .. } => None,
-        }
-    }
-}
+impl std::error::Error for CoprocessorError {}
 
 impl From<sqlx::Error> for CoprocessorError {
     fn from(err: sqlx::Error) -> Self {
-        CoprocessorError::DbError(err)
+        // Classify once, here at the source, while the error is still typed.
+        if is_fatal_connection_error(&err) {
+            CoprocessorError::FatalConnection(err)
+        } else {
+            CoprocessorError::DbError(err)
+        }
     }
 }
 
 impl From<SchedulerError> for CoprocessorError {
     fn from(err: SchedulerError) -> Self {
         CoprocessorError::SchedulerError(err)
+    }
+}
+
+impl From<FhevmError> for CoprocessorError {
+    fn from(err: FhevmError) -> Self {
+        CoprocessorError::FhevmError(err)
+    }
+}
+
+impl From<Box<dyn std::error::Error + Send + Sync>> for CoprocessorError {
+    fn from(err: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        CoprocessorError::Other(err)
     }
 }

--- a/coprocessor/fhevm-engine/tfhe-worker/src/types.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/types.rs
@@ -28,7 +28,14 @@ impl std::fmt::Display for CoprocessorError {
     }
 }
 
-impl std::error::Error for CoprocessorError {}
+impl std::error::Error for CoprocessorError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DbError(e) => Some(e),
+            Self::SchedulerError(_) | Self::FhevmError(_) | Self::MissingKeys { .. } => None,
+        }
+    }
+}
 
 impl From<sqlx::Error> for CoprocessorError {
     fn from(err: sqlx::Error) -> Self {

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -153,15 +153,13 @@ async fn main() {
 
     let service_task = async move {
         info!("Starting worker...");
-        if let Err(err) = service.run().await {
-            error!(error = %err, "Worker failed");
-        }
+        service.run().await
     };
 
     // Either task returning means the service can't process work; crash so k8s restarts the service.
     tokio::select! {
-        _ = http_task => error!("Health-check server exited"),
-        _ = service_task => error!("Service loop exited"),
+        r = http_task => error!(result = ?r, "Health-check server exited"),
+        r = service_task => error!(result = ?r, "Service loop exited"),
     }
     telemetry::flush();
     std::process::exit(1);

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -163,5 +163,6 @@ async fn main() {
         _ = http_task => error!("Health-check server exited"),
         _ = service_task => error!("Service loop exited"),
     }
+    telemetry::flush();
     std::process::exit(1);
 }

--- a/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/bin/zkproof_worker.rs
@@ -6,7 +6,7 @@ use fhevm_engine_common::{
 };
 use humantime::parse_duration;
 use std::{sync::Arc, time::Duration};
-use tokio::{join, task};
+use tokio::task;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Level};
 use zkproof_worker::verifier::ZkProofService;
@@ -151,13 +151,17 @@ async fn main() {
         std::process::exit(1);
     });
 
-    let service_task = async {
+    let service_task = async move {
         info!("Starting worker...");
         if let Err(err) = service.run().await {
             error!(error = %err, "Worker failed");
         }
-        Ok::<_, anyhow::Error>(())
     };
 
-    let (_http_result, _service_result) = join!(http_task, service_task);
+    // Either task returning means the service can't process work; crash so k8s restarts the service.
+    tokio::select! {
+        _ = http_task => error!("Health-check server exited"),
+        _ = service_task => error!("Service loop exited"),
+    }
+    std::process::exit(1);
 }

--- a/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/lib.rs
@@ -86,6 +86,17 @@ impl From<ExecutionError> for ServiceError {
     }
 }
 
+impl From<ServiceError> for ExecutionError {
+    fn from(err: ServiceError) -> Self {
+        match err {
+            ServiceError::Database(err) => ExecutionError::DbError(err),
+            ServiceError::InternalError(err) => {
+                ExecutionError::Other(Box::new(std::io::Error::other(err)))
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct Config {
     pub database_url: DatabaseURL,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use fhevm_engine_common::chain_id::ChainId;
-use fhevm_engine_common::pg_pool::{is_fatal_connection_error, PostgresPoolManager};
+use fhevm_engine_common::pg_pool::PostgresPoolManager;
 use fhevm_engine_common::tfhe_ops::current_ciphertext_version;
 use serial_test::serial;
 use test_harness::db_utils::ACL_CONTRACT_ADDR;
@@ -154,13 +154,24 @@ async fn test_db_disconnect_exits_service_loop() {
     .await
     .expect("pool should connect");
 
+    let pool = pool_mngr.pool();
     let service_task = tokio::spawn(crate::verifier::execute_verify_proofs_loop(
         pool_mngr,
         conf,
         Arc::new(RwLock::new(SystemTime::now())),
     ));
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Drive one proof through so the worker is past startup and running in its
+    // steady-state loop before we sever the connection.
+    let aux = utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
+    let zk_pok = utils::generate_sample_zk_pok(&pool, &aux.1).await;
+    let request_id = utils::insert_proof(&pool, 301, &zk_pok, &aux.0)
+        .await
+        .unwrap();
+    assert!(
+        utils::is_valid(&pool, request_id, 2000).await.unwrap(),
+        "worker should verify a proof before the disconnect"
+    );
 
     let admin_pool = sqlx::PgPool::connect(instance.db_url.as_str())
         .await
@@ -179,21 +190,15 @@ async fn test_db_disconnect_exits_service_loop() {
         "expected to terminate at least one worker backend"
     );
 
-    let err = tokio::time::timeout(Duration::from_secs(10), service_task)
+    let result = tokio::time::timeout(Duration::from_secs(10), service_task)
         .await
         .expect("service loop should exit after backend termination")
-        .expect("service task should join")
-        .expect_err("service loop should return a fatal error");
+        .expect("service task should join");
 
-    match err {
-        crate::ExecutionError::DbError(db_err) => {
-            assert!(
-                is_fatal_connection_error(&db_err),
-                "service loop should surface a fatal connection error, got {db_err}"
-            );
-        }
-        other => panic!("expected fatal DB error, got {other}"),
-    }
+    assert!(
+        result.is_err(),
+        "service loop should exit with an error on a DB disconnect, got {result:?}"
+    );
 }
 
 #[tokio::test]

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -141,7 +141,7 @@ async fn test_worker_recovers_after_backend_termination() {
         pg_pool_connections: 10,
         pg_polling_interval: 60,
         worker_thread_count: 1,
-        pg_timeout: Duration::from_secs(15),
+        pg_timeout: Duration::from_secs(60),
         pg_auto_explain_with_min_duration: None,
     };
 
@@ -157,6 +157,13 @@ async fn test_worker_recovers_after_backend_termination() {
     .expect("pool should connect");
 
     let pool = pool_mngr.pool();
+
+    // Build the proof before starting the worker. Generating it loads the large
+    // keyset and CRS; doing that while the worker is also loading them contends
+    // for the shared pool and can exhaust the acquire timeout on a slow runner.
+    let aux = utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
+    let zk_pok = utils::generate_sample_zk_pok(&pool, &aux.1).await;
+
     let _service_task = tokio::spawn(crate::verifier::execute_verify_proofs_loop(
         pool_mngr,
         conf,
@@ -164,8 +171,6 @@ async fn test_worker_recovers_after_backend_termination() {
     ));
 
     // Process one proof so the worker is fully up and running.
-    let aux = utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
-    let zk_pok = utils::generate_sample_zk_pok(&pool, &aux.1).await;
     let first = utils::insert_proof(&pool, 301, &zk_pok, &aux.0)
         .await
         .unwrap();

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -125,9 +125,11 @@ async fn test_rolled_back_claim_is_reprocessed_exactly_once() {
     assert_eq!(verified_count, 1, "request must be verified exactly once");
 }
 
+// A transient backend termination (DB still up) must not take the worker down:
+// sqlx reconnects, so it should keep processing.
 #[tokio::test]
 #[serial(db)]
-async fn test_db_disconnect_exits_service_loop() {
+async fn test_worker_recovers_after_backend_termination() {
     let instance = test_harness::instance::setup_test_db(ImportMode::WithKeysNoSns)
         .await
         .expect("valid db instance");
@@ -155,24 +157,24 @@ async fn test_db_disconnect_exits_service_loop() {
     .expect("pool should connect");
 
     let pool = pool_mngr.pool();
-    let service_task = tokio::spawn(crate::verifier::execute_verify_proofs_loop(
+    let _service_task = tokio::spawn(crate::verifier::execute_verify_proofs_loop(
         pool_mngr,
         conf,
         Arc::new(RwLock::new(SystemTime::now())),
     ));
 
-    // Drive one proof through so the worker is past startup and running in its
-    // steady-state loop before we sever the connection.
+    // Process one proof so the worker is fully up and running.
     let aux = utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
     let zk_pok = utils::generate_sample_zk_pok(&pool, &aux.1).await;
-    let request_id = utils::insert_proof(&pool, 301, &zk_pok, &aux.0)
+    let first = utils::insert_proof(&pool, 301, &zk_pok, &aux.0)
         .await
         .unwrap();
     assert!(
-        utils::is_valid(&pool, request_id, 2000).await.unwrap(),
+        utils::is_valid(&pool, first, 2000).await.unwrap(),
         "worker should verify a proof before the disconnect"
     );
 
+    // Sever every backend connection; the DB itself stays up.
     let admin_pool = sqlx::PgPool::connect(instance.db_url.as_str())
         .await
         .expect("admin pool should connect");
@@ -190,14 +192,13 @@ async fn test_db_disconnect_exits_service_loop() {
         "expected to terminate at least one worker backend"
     );
 
-    let result = tokio::time::timeout(Duration::from_secs(10), service_task)
+    // The worker must reconnect (listener + pool) and verify a new proof.
+    let second = utils::insert_proof(&pool, 302, &zk_pok, &aux.0)
         .await
-        .expect("service loop should exit after backend termination")
-        .expect("service task should join");
-
+        .unwrap();
     assert!(
-        result.is_err(),
-        "service loop should exit with an error on a DB disconnect, got {result:?}"
+        utils::is_valid(&pool, second, 2000).await.unwrap(),
+        "worker should reconnect and verify a proof after backend termination"
     );
 }
 

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -1,7 +1,15 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
 use fhevm_engine_common::chain_id::ChainId;
+use fhevm_engine_common::pg_pool::{is_fatal_connection_error, PostgresPoolManager};
 use fhevm_engine_common::tfhe_ops::current_ciphertext_version;
 use serial_test::serial;
 use test_harness::db_utils::ACL_CONTRACT_ADDR;
+use test_harness::instance::ImportMode;
+use tokio::sync::RwLock;
 
 use crate::MAX_INPUT_INDEX;
 
@@ -40,6 +48,152 @@ async fn test_verify_proof() {
     assert!(!utils::is_valid(&pool, request_id_invalid, max_retries)
         .await
         .unwrap());
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_rolled_back_claim_is_reprocessed_exactly_once() {
+    let (pool_mngr, _instance) = utils::setup().await.expect("valid setup");
+    let pool = pool_mngr.pool();
+
+    let aux = utils::aux_fixture(ACL_CONTRACT_ADDR.to_owned());
+    let zk_pok = utils::generate_sample_zk_pok(&pool, &aux.1).await;
+    let request_id: i64 = 201;
+
+    // Insert WITHOUT notifying so the idle worker doesn't race us to the row.
+    sqlx::query(
+        "INSERT INTO verify_proofs (zk_proof_id, input, chain_id, contract_address, user_address, verified)
+         VALUES ($1, $2, $3, $4, $5, NULL)",
+    )
+    .bind(request_id)
+    .bind(&zk_pok)
+    .bind(aux.0.chain_id.as_i64())
+    .bind(aux.0.contract_address.clone())
+    .bind(aux.0.user_address.clone())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // A worker that claims the row then crashes mid-flight: claim it, never commit.
+    {
+        let mut txn = pool.begin().await.unwrap();
+        let claimed = sqlx::query(
+            "SELECT zk_proof_id FROM verify_proofs
+             WHERE verified IS NULL AND zk_proof_id = $1
+             FOR UPDATE SKIP LOCKED",
+        )
+        .bind(request_id)
+        .fetch_optional(&mut *txn)
+        .await
+        .unwrap();
+        assert!(
+            claimed.is_some(),
+            "freshly inserted row should be claimable"
+        );
+        txn.rollback().await.unwrap(); // == crash before commit
+    }
+
+    // Rollback left no partial state: the row is still pending.
+    let verified: Option<bool> =
+        sqlx::query_scalar("SELECT verified FROM verify_proofs WHERE zk_proof_id = $1")
+            .bind(request_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        verified.is_none(),
+        "row must stay unverified after a mid-flight crash"
+    );
+
+    // Wake the worker; it must re-pick and complete the request.
+    sqlx::query("SELECT pg_notify('fhevm', '')")
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(
+        utils::is_valid(&pool, request_id, 1000).await.unwrap(),
+        "request must be re-processed after a mid-flight crash"
+    );
+
+    let verified_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM verify_proofs WHERE zk_proof_id = $1 AND verified = true",
+    )
+    .bind(request_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(verified_count, 1, "request must be verified exactly once");
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn test_db_disconnect_exits_service_loop() {
+    let instance = test_harness::instance::setup_test_db(ImportMode::WithKeysNoSns)
+        .await
+        .expect("valid db instance");
+
+    let conf = crate::Config {
+        database_url: instance.db_url.clone(),
+        listen_database_channel: "fhevm".to_string(),
+        notify_database_channel: "notify".to_string(),
+        pg_pool_connections: 10,
+        pg_polling_interval: 60,
+        worker_thread_count: 1,
+        pg_timeout: Duration::from_secs(15),
+        pg_auto_explain_with_min_duration: None,
+    };
+
+    let pool_mngr = PostgresPoolManager::connect_pool(
+        instance.parent_token.child_token(),
+        conf.database_url.as_str(),
+        conf.pg_timeout,
+        conf.pg_pool_connections,
+        Duration::from_secs(2),
+        conf.pg_auto_explain_with_min_duration,
+    )
+    .await
+    .expect("pool should connect");
+
+    let service_task = tokio::spawn(crate::verifier::execute_verify_proofs_loop(
+        pool_mngr,
+        conf,
+        Arc::new(RwLock::new(SystemTime::now())),
+    ));
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let admin_pool = sqlx::PgPool::connect(instance.db_url.as_str())
+        .await
+        .expect("admin pool should connect");
+    let terminated: Vec<bool> = sqlx::query_scalar(
+        "SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+         WHERE datname = current_database()
+           AND pid <> pg_backend_pid()",
+    )
+    .fetch_all(&admin_pool)
+    .await
+    .expect("backend termination should succeed");
+    assert!(
+        !terminated.is_empty() && terminated.into_iter().all(|res| res),
+        "expected to terminate at least one worker backend"
+    );
+
+    let err = tokio::time::timeout(Duration::from_secs(10), service_task)
+        .await
+        .expect("service loop should exit after backend termination")
+        .expect("service task should join")
+        .expect_err("service loop should return a fatal error");
+
+    match err {
+        crate::ExecutionError::DbError(db_err) => {
+            assert!(
+                is_fatal_connection_error(&db_err),
+                "service loop should surface a fatal connection error, got {db_err}"
+            );
+        }
+        other => panic!("expected fatal DB error, got {other}"),
+    }
 }
 
 #[tokio::test]

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -32,7 +32,7 @@ use tokio::time::interval;
 use tokio::{select, time::Duration};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 pub const MAX_CACHED_KEYS: usize = 100;
 const EVENT_CIPHERTEXT_COMPUTED: &str = "event_ciphertext_computed";
@@ -263,11 +263,9 @@ async fn execute_worker(
                 match res {
                     Some(notification) => info!( src = %notification.process_id(), "Received notification"),
                     None => {
-                        return Err(sqlx::Error::Io(std::io::Error::new(
-                            std::io::ErrorKind::BrokenPipe,
-                            "postgres LISTEN connection lost",
-                        ))
-                        .into());
+                        // sqlx already reconnected the LISTEN connection; keep going.
+                        warn!("postgres LISTEN connection reset; reconnected");
+                        continue;
                     },
                 };
             },

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -178,12 +178,22 @@ pub async fn execute_verify_proofs_loop(
             .await;
     }
 
-    // Wait for all tasks to complete
-    while let Some(result) = task_set.join_next().await {
-        if let Err(err) = result {
-            error!(error = %err, "A worker failed");
+    // A worker only returns on a fatal error; stop the rest and return so the
+    // process exits.
+    match task_set.join_next().await {
+        Some(Ok(Err(err))) => {
+            error!(error = %err, "A worker exited with a fatal DB error");
+            task_set.shutdown().await;
+            return Err(err.into());
         }
+        Some(Err(err)) => {
+            error!(error = %err, "A worker task panicked");
+            task_set.shutdown().await;
+            return Err(ExecutionError::from(err));
+        }
+        Some(Ok(Ok(()))) | None => {}
     }
+    task_set.shutdown().await;
 
     Ok(())
 }
@@ -253,8 +263,11 @@ async fn execute_worker(
                 match res {
                     Some(notification) => info!( src = %notification.process_id(), "Received notification"),
                     None => {
-                        error!("Connection lost");
-                        continue;
+                        return Err(sqlx::Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "postgres LISTEN connection lost",
+                        ))
+                        .into());
                     },
                 };
             },
@@ -307,9 +320,22 @@ async fn execute_verify_proof_routine(
     {
         let started_at = SystemTime::now();
         let request_id: i64 = row.zk_proof_id;
-        let input: Vec<u8> = row
-            .input
-            .ok_or(ExecutionError::NullInput(row.zk_proof_id))?;
+        let Some(input) = row.input else {
+            // A NULL input can never verify; mark it failed and commit so the
+            // malformed row isn't re-picked and crash-loops the worker.
+            error!(
+                message = "verify_proofs row has NULL input; marking failed",
+                request_id
+            );
+            sqlx::query(
+                "UPDATE verify_proofs SET verified = false, verified_at = NOW() WHERE zk_proof_id = $1",
+            )
+            .bind(request_id)
+            .execute(&mut *txn)
+            .await?;
+            txn.commit().await?;
+            return Ok(());
+        };
         let host_chain_id_raw: i64 = row.chain_id;
 
         // The filter above guarantees host_chain_id_raw is in HostChainsCache.

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -178,22 +178,22 @@ pub async fn execute_verify_proofs_loop(
             .await;
     }
 
-    // A worker only returns on a fatal error; stop the rest and return so the
-    // process exits.
-    match task_set.join_next().await {
-        Some(Ok(Err(err))) => {
-            error!(error = %err, "A worker exited with a fatal DB error");
-            task_set.shutdown().await;
-            return Err(err.into());
+    // Exit on the first worker to fail; clean exits just drain.
+    while let Some(result) = task_set.join_next().await {
+        match result {
+            Ok(Err(err)) => {
+                error!(error = %err, "A worker exited with a fatal DB error");
+                task_set.shutdown().await;
+                return Err(err.into());
+            }
+            Err(err) => {
+                error!(error = %err, "A worker task panicked");
+                task_set.shutdown().await;
+                return Err(ExecutionError::from(err));
+            }
+            Ok(Ok(())) => {}
         }
-        Some(Err(err)) => {
-            error!(error = %err, "A worker task panicked");
-            task_set.shutdown().await;
-            return Err(ExecutionError::from(err));
-        }
-        Some(Ok(Ok(()))) | None => {}
     }
-    task_set.shutdown().await;
 
     Ok(())
 }


### PR DESCRIPTION
### Summary

Make all three coprocessor workers (zkproof, tfhe, sns) now fail fast on a fatal DB connection error: log and exit(1) so k8s restarts the pod on a fresh pool, instead of hanging or retrying a dead one.
- pg_pool (zkproof + sns): add `is_fatal_connection_error`; `run_with_db_retry` exits only on a fatal connection error and retries everything else (deadlock, pool timeout, keys not yet seeded, other DB/internal errors), so a transient or item-specific failure can't take the whole worker down.
- zkproof: main selects the service and health-check tasks and exits non-zero when either returns.
- tfhe: has its own loop (not run_with_db_retry); classifies a lost connection as a typed CoprocessorError::FatalConnection at the source and exits on it
- sns: exits on a fatal connection too, and its S3 uploader now propagates one (instead of swallowing it).

Related: https://github.com/zama-ai/fhevm-internal/issues/1489