### PR TITLE
test(test-suite): fail fast when a coprocessor is down before drift injection

### DIFF
--- a/test-suite/fhevm/src/cli.test.ts
+++ b/test-suite/fhevm/src/cli.test.ts
@@ -8,6 +8,7 @@ import {
   dbRevertDeleteExpectations,
   dbRevertTargetBlock,
   keyBootstrapLogArgs,
+  recentCoprocessorSenders,
   validateNamedProfileGrep,
   waitForKeyBootstrap,
 } from "./commands/test";
@@ -345,6 +346,28 @@ describe("cli", () => {
       expect(result.code).toBe(1);
       expect(result.stderr).not.toContain("not allowed on devnet");
     });
+  });
+
+  test("recentCoprocessorSenders extracts distinct submitters from the recent event window", () => {
+    // AddCiphertextMaterial data layout (4 words): keyId | ciphertextDigest | snsCiphertextDigest | sender.
+    const log = (addr: string) =>
+      ({ data: `0x${"11".repeat(32)}${"22".repeat(32)}${"33".repeat(32)}${"00".repeat(12)}${addr}` });
+    const a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const c = "cccccccccccccccccccccccccccccccccccccccc";
+
+    // Three coprocessors each submitting twice → three distinct senders.
+    expect(recentCoprocessorSenders([a, b, c, a, b, c].map(log), 24)).toEqual([`0x${a}`, `0x${b}`, `0x${c}`]);
+
+    // A crashed coprocessor (only a and b submit) → only two distinct senders.
+    expect(recentCoprocessorSenders([a, b, a, b].map(log), 24)).toEqual([`0x${a}`, `0x${b}`]);
+
+    // Sampling keeps only the most recent events: an old submitter that stopped
+    // drops out of the window once newer events push past the sample size.
+    expect(recentCoprocessorSenders([c, a, b, a, b].map(log), 4)).toEqual([`0x${a}`, `0x${b}`]);
+
+    // Malformed/short data is ignored rather than throwing.
+    expect(recentCoprocessorSenders([{ data: "0x1234" }, log(a)], 24)).toEqual([`0x${a}`]);
   });
 
   test("grep-backed named profiles accept targeted grep narrowing", () => {

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -347,6 +347,14 @@ const assertClusterFullyParticipating = async (
   }
   const payload = (await response.json()) as { result?: { data: string }[] };
   const senders = recentCoprocessorSenders(payload.result ?? [], CLUSTER_HEALTH_SAMPLE);
+  if (senders.length === 0) {
+    // No AddCiphertextMaterial activity to measure yet (e.g. running this profile
+    // standalone on a fresh stack with no prior submissions). With nothing to
+    // judge, skip the preflight rather than false-failing; a genuinely degraded
+    // cluster still surfaces via the injection/recovery timeout.
+    console.log("[drift-auto-recovery] no recent coprocessor submissions observed; skipping cluster-health preflight");
+    return;
+  }
   if (senders.length < expectedCount) {
     throw new PreflightError(
       `ciphertext-drift-auto-recovery needs all ${expectedCount} coprocessors submitting, but only ${senders.length} did across the last ${CLUSTER_HEALTH_SAMPLE} AddCiphertextMaterial events (${senders.join(", ") || "none"}). A coprocessor worker has likely crashed — the cluster is degraded, so consensus-based auto-revert cannot be exercised.`,

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -303,6 +303,60 @@ const assertOnChainDivergence = async (
   console.log(`[drift] on-chain divergence confirmed: ${logs.length} submissions with ${unique.size} distinct digest(s)`);
 };
 
+/** Number of most-recent AddCiphertextMaterial events sampled when checking
+ * that every coprocessor is still participating in consensus. */
+const CLUSTER_HEALTH_SAMPLE = 24;
+
+/** Extracts the distinct coprocessor tx-sender addresses (lowercased) from the
+ * most recent `sampleSize` AddCiphertextMaterial event logs. The sender is the
+ * 4th 32-byte word of the event data:
+ * keyId | ciphertextDigest | snsCiphertextDigest | coprocessorTxSender. */
+export const recentCoprocessorSenders = (logs: { data: string }[], sampleSize: number): string[] => {
+  const senders = new Set<string>();
+  for (const log of logs.slice(-sampleSize)) {
+    if (typeof log.data !== "string" || log.data.length < 2 + 4 * 64) {
+      continue;
+    }
+    senders.add(`0x${log.data.slice(2 + 3 * 64, 2 + 4 * 64).slice(-40)}`.toLowerCase());
+  }
+  return [...senders].sort();
+};
+
+/** Fails fast when fewer than the full coprocessor set is still submitting
+ * AddCiphertextMaterial. A crashed coprocessor worker (e.g. an sns-worker that
+ * exited on a fatal DB error) silently stops submitting; with one fewer honest
+ * node the drift test can no longer form the consensus its auto-revert depends
+ * on, which otherwise surfaces only as a confusing injection or revert timeout. */
+const assertClusterFullyParticipating = async (
+  gatewayRpcUrl: string,
+  contractAddress: string,
+  expectedCount: number,
+) => {
+  const response = await fetch(gatewayRpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_getLogs",
+      params: [{ fromBlock: "0x0", toBlock: "latest", address: contractAddress, topics: [ADD_CIPHERTEXT_MATERIAL_TOPIC] }],
+    }),
+  });
+  if (!response.ok) {
+    throw new PreflightError(`eth_getLogs failed: ${response.status} ${response.statusText}`);
+  }
+  const payload = (await response.json()) as { result?: { data: string }[] };
+  const senders = recentCoprocessorSenders(payload.result ?? [], CLUSTER_HEALTH_SAMPLE);
+  if (senders.length < expectedCount) {
+    throw new PreflightError(
+      `ciphertext-drift-auto-recovery needs all ${expectedCount} coprocessors submitting, but only ${senders.length} did across the last ${CLUSTER_HEALTH_SAMPLE} AddCiphertextMaterial events (${senders.join(", ") || "none"}). A coprocessor worker has likely crashed — the cluster is degraded, so consensus-based auto-revert cannot be exercised.`,
+    );
+  }
+  console.log(
+    `[drift-auto-recovery] cluster healthy: ${senders.length}/${expectedCount} coprocessors submitting recently`,
+  );
+};
+
 type DriftRevertDbOptions = {
   instanceIndex: number;
   postgresContainer: string;
@@ -920,6 +974,19 @@ export const test = async (testName: string | undefined, options: TestOptions) =
         // input drift is out of scope for auto-recovery.
         const grepPattern = process.env.GREP_PATTERN ?? "test add 42 to uint64 input and decrypt";
 
+        // Before injecting, confirm the whole coprocessor set is alive and
+        // submitting. Auto-revert needs the honest majority to form consensus;
+        // if a coprocessor worker has crashed (so it submits nothing) the test
+        // would otherwise hang until an injection or consensus timeout and
+        // report a misleading error instead of the real "degraded cluster".
+        const ciphertextCommitsAddress = state.discovery!.gateway.CIPHERTEXT_COMMITS_ADDRESS;
+        const gatewayRpcUrl = ciphertextCommitsAddress
+          ? hostReachableRpcUrl(state.discovery!.endpoints.gateway.http)
+          : undefined;
+        if (ciphertextCommitsAddress && gatewayRpcUrl) {
+          await assertClusterFullyParticipating(gatewayRpcUrl, ciphertextCommitsAddress, topologyForState(state).count);
+        }
+
         const injector = injectCiphertextDrift({
           instanceIndex: faultyInstanceIndex,
           timeoutSeconds: driftInjectTimeoutSeconds,
@@ -958,9 +1025,7 @@ export const test = async (testName: string | undefined, options: TestOptions) =
         // across the AddCiphertextMaterial submissions). Folded in from the
         // former `ciphertext-drift` profile so this single test covers both
         // detection and recovery.
-        const ciphertextCommitsAddress = state.discovery!.gateway.CIPHERTEXT_COMMITS_ADDRESS;
-        if (ciphertextCommitsAddress) {
-          const gatewayRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.gateway.http);
+        if (ciphertextCommitsAddress && gatewayRpcUrl) {
           await assertOnChainDivergence(gatewayRpcUrl, ciphertextCommitsAddress, injectedHandleHex);
         }
 


### PR DESCRIPTION
## Why

`ciphertext-drift-auto-recovery` has been flaky in CI (`fhevm-e2e-test`). Investigating two failing jobs showed both failures share one upstream cause: **one coprocessor instance came up degraded and submitted nothing for the entire run.**

In each failing run, that node's own gw-listener logged `Consensus was observed but local digests never became available for comparison` ~95–97× and it never appeared as a submitter. In one job the crash is captured directly: a coprocessor's `sns-worker` hit `duplicate key value violates unique constraint "ciphertext_digest_pkey"` (23505), classified it as a non-transient error, and **shut the worker down** — after which it produced no digests.

The drift test has **zero liveness margin**: with `two-of-three` it corrupts one coprocessor and needs both remaining honest nodes to reach consensus so the faulty node auto-reverts. If any coprocessor is down:
- if it's the injection target → the injection trigger never fires (`timed out waiting for drift injection trigger`);
- if it's an honest peer → no honest majority, no consensus, no revert (`timed out waiting for drift_revert_signal to reach status=reverting`).

Either way the test burns its full timeout (~180–425s) and reports a misleading error instead of the real one: a degraded cluster.

## What this does

Adds a **pre-injection guard**: before injecting drift, check that every coprocessor is still submitting `AddCiphertextMaterial` — distinct senders across the recent on-chain event window must be `>= topology.count`. If not, fail fast with the real cause and which senders were seen.

This is intentionally small and only changes the test harness. It does **not** fix the underlying coprocessor crash (the `sns-worker` exiting on a `ciphertext_digest_pkey` 23505 — the PK is still the legacy composite `(tenant_id, handle)` while the upsert keys on `(handle)`); that needs a separate coprocessor-side fix. The guard just makes the flake legible and fast instead of a confusing timeout.

## Test

- `bun test src/cli.test.ts` — 36 pass (incl. new `recentCoprocessorSenders` unit test)
- `tsc --noEmit` — clean