### PR TITLE
fix(coprocessor): retry transient unique-violation instead of killing the sns-worker

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, Instrument};
 
 const CODE_DEADLOCK_DETECTED: &str = "40P01";
+const CODE_UNIQUE_VIOLATION: &str = "23505";
 
 #[derive(Clone)]
 pub struct PostgresPoolManager {
@@ -217,6 +218,18 @@ impl PostgresPoolManager {
                         let code = db_err.code().unwrap_or("".into());
                         if code == CODE_DEADLOCK_DETECTED {
                             error!(error=%err, code=%code, "Transient DB error; retrying...");
+                        } else if code == CODE_UNIQUE_VIOLATION {
+                            // A unique violation here is a transient artifact of an
+                            // idempotent `INSERT ... ON CONFLICT` racing a concurrent
+                            // DELETE (e.g. a state/drift revert deleting
+                            // ciphertext_digest rows). The ON CONFLICT arbiter covers
+                            // only one of the table's unique indexes, so the conflict
+                            // can surface on another (the primary key) as a hard 23505.
+                            // Re-running the operation after the delete settles
+                            // succeeds, so back off and retry rather than tearing down
+                            // the whole worker.
+                            error!(error=%err, code=%code, "Transient unique-violation; backing off and retrying...");
+                            cancellable_sleep(&ct, backoff_delay).await;
                         } else {
                             error!(error=%db_err, code=%code, "Non-transient DB error; not retrying");
                             return Err(err);


### PR DESCRIPTION
## Why

A revert's `DELETE FROM ciphertext_digest` (a `coprocessor-db-state-revert` or a
real drift auto-revert) racing the sns-worker's
`INSERT … ON CONFLICT (handle) DO UPDATE` can raise a hard
`duplicate key value violates unique constraint "ciphertext_digest_pkey"`
(SQLSTATE `23505`): the `ON CONFLICT (handle)` arbiter covers only the
`(handle)` unique index, so a conflict surfacing on the **separate composite
primary key** index is not absorbed.

The retry classifier in `pg_pool.rs` treated every non-deadlock DB error as
fatal, so this transient `23505` returned `Err`, ended the single long-lived
SnS service loop, and the **whole sns-worker process exited** (`Ok`, no
restart). That coprocessor then produced no further digests for the rest of the
run and never submitted to consensus — which surfaces as flaky
`ciphertext-drift-auto-recovery` e2e failures (the test has zero liveness
margin), and can degrade a real coprocessor in production when a drift
auto-revert runs.

Full root-cause writeup, proofs, and timeline: zama-ai/fhevm-internal#1495.

## What

Treat `23505` like the existing deadlock (`40P01`) case: it is an idempotent
`INSERT … ON CONFLICT` racing a `DELETE`, so re-running the operation after the
delete settles succeeds. Back off and retry instead of tearing down the worker.

This is the quick, migration-free fix. The proper root-cause fix (make `handle`
the sole unique key by dropping the vestigial composite PK — catalog-only, no
backfill) is a follow-up migration.

## Proof (Postgres 16, exact constraint set)

8 concurrent upsert sessions + concurrent `DELETE` of the same handles:

| schema | DELETE racing? | result |
|---|---|---|
| `PK(tenant_id,handle)` + `UNIQUE(handle)` (current) | yes | 375 errors, all on `ciphertext_digest_pkey` |
| `PK(handle)` only | yes | 0 errors |
| current schema | no (upserts only) | 0 errors |

Also: with the pre-#2621 `ON CONFLICT DO NOTHING` (no target), the same race → 0
errors — confirming PR #2621's narrowed arbiter is what armed this.

## Test

`cargo fmt`, `cargo check`, and clippy pass (pre-commit hook). The behaviour is
validated by the Postgres repro above; the classifier itself has no existing
unit harness (a `sqlx::Error::Database` with a code is impractical to fabricate).

## Scope / risk

`pg_pool.rs` is shared by all coprocessor services, so this makes a `23505`
retryable for every service that uses the retry wrapper. A unique violation
under an idempotent `ON CONFLICT` write is transient, so retry-with-backoff is
strictly safer than the current "die on any non-deadlock DB error". A persistent
(non-transient) duplicate would back off and retry rather than crash — the same
trade-off already made for IO/TLS/pool-timeout errors.
