### PR TITLE
fix(test-suite): rank numeric build suffix (0.13.0-N) at the release for compat floors

### DIFF
--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -320,6 +320,22 @@ describe("compat", () => {
     expect(requiresGatewayKmsGenerationAddress(state)).toBe(false);
   });
 
+  test("treats numeric build suffix (v0.13.0-8) as the 0.13.0 release, not a prerelease below it", () => {
+    const state = {
+      versions: {
+        target: "latest-supported" as const,
+        lockName: "latest-supported.json",
+        env: { GATEWAY_VERSION: "v0.13.0-8", HOST_VERSION: "v0.13.0-8" } as Record<string, string>,
+        sources: [],
+      },
+      overrides: [],
+      scenario: testDefaultScenario(),
+    };
+    expect(requiresModernHostAddressArtifacts(state)).toBe(true);
+    expect(requiresLegacyGatewayKmsGenerationAddress(state)).toBe(false);
+    expect(requiresGatewayKmsGenerationAddress(state)).toBe(false);
+  });
+
   test("routes semver relayer images to the legacy console registry", () => {
     const policy = compatPolicyForState({
       versions: {

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -117,14 +117,17 @@ const SHIM_PROFILES = {
 
 /** Parses a semver-like version string into comparable numeric parts. */
 const parseCompatVersion = (version: string) => {
-  const match = version.match(/^v?(\d+)\.(\d+)\.(\d+)(?:([-+]).*)?$/);
+  const match = version.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([^+]*))?(?:\+.*)?$/);
   if (!match) {
     return undefined;
   }
-  const [, major, minor, patch, suffixType] = match;
+  const [, major, minor, patch, prereleaseId] = match;
+  // Zama release tags carry a numeric build suffix (e.g. `0.13.0-8` is the 8th build *of* 0.13.0);
+  // it must rank equal to `0.13.0` for feature-floor checks, not below it. Only a non-numeric
+  // identifier (`-rc.1`, `-alpha`, …) is a true pre-release that precedes the release.
   return {
     parts: [Number(major), Number(minor), Number(patch)] as const,
-    prerelease: suffixType === "-",
+    prerelease: prereleaseId !== undefined && !/^\d+$/.test(prereleaseId),
   };
 };
 


### PR DESCRIPTION
## Problem

Running the e2e test-suite against **pinned `v0.13.0-N` images** (no local source build) aborts at `gateway-sc-deploy`:

```
gateway-sc-deploy completed but .../runtime/addresses/gateway/.env.gateway is missing KMS_GENERATION_ADDRESS
```

This blocks reproducing/validating a release with matched, pinned versions (e.g. the `v0.13.0-8` multichain run).

## Root cause

`parseCompatVersion` flagged **any** `-suffix` tag as a SemVer pre-release. So for the compat floors:

- `versionLt("v0.13.0-8", [0,13,0])` → base parts equal, tie-break `return prerelease` → **true**, i.e. `0.13.0-8` compared as **`< 0.13.0`**.
- → `requiresLegacyGatewayKmsGenerationAddress` = true and `requiresModernHostAddressArtifacts` = false
- → `requiresGatewayKmsGenerationAddress` = true → bring-up requires a KMSGeneration address from the **gateway** deploy.

But KMSGeneration moved to the **canonical host** in v0.13 and is no longer deployed on the gateway, so the generated `.env.gateway` never contains it → abort.

It only reproduced with **pinned images** because building `host-contracts` from source adds a workspace override that forces `requiresModernHostAddressArtifacts` true, masking the bug (that's why source-built CI was green).

This is a whole *class* of bugs: the same tie-break mis-ranks `0.12.0-N`, `0.11.0-N`, `0.10.0-N` against their `[X,Y,0]` floors.

## Fix

Zama release tags use a **numeric** build suffix (`0.13.0-8` = the 8th build *of* 0.13.0), which must rank **equal** to `0.13.0` for feature-floor checks — not below it. Only a **non-numeric** identifier (`-rc.1`, `-alpha`, …) is a true pre-release that precedes the release.

`parseCompatVersion` now marks `prerelease` only for non-numeric suffixes. Build metadata (`+…`) is still ignored, SHAs still parse as unparsed, and `v0.10.0-rc.1 < v0.10.0` still holds (existing relayer-v1/v2 compat test stays green).

## Tests

- New regression test: a pinned `v0.13.0-8` bundle (no override) → `requiresModernHostAddressArtifacts = true`, `requiresGatewayKmsGenerationAddress = false`.
- Full suite: **140 pass / 0 fail**, `tsc --noEmit` clean.

## Scope / risk

One-function change to the comparator primitive; verified behavior-preserving for every existing call site (pre-release-aware checks like the relayer rule are unaffected because `-rc` stays a pre-release).
