### PR TITLE
fix(coprocessor): collapse overlapping unique keys [0.13.x backport]

### DIFF
--- a/coprocessor/fhevm-engine/db-migration/migrations/20260603120000_collapse_overlapping_unique_keys.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260603120000_collapse_overlapping_unique_keys.sql
@@ -1,0 +1,54 @@
+-- Collapse the overlapping unique keys on `ciphertext_digest`, `computations`,
+-- and `ciphertexts` down to a single unique key per table.
+--
+-- Since `remove_tenants`, `tenant_id` is a constant default, yet these three
+-- tables each still carry TWO overlapping unique indexes: a vestigial
+-- tenant-prefixed PRIMARY KEY plus a tenant-free UNIQUE index that the workers
+-- actually target:
+--
+--   table              vestigial PK (tenant-prefixed)               tenant-free UNIQUE index
+--   ciphertext_digest  (tenant_id, handle)                          idx_ciphertext_digest_no_tenant (handle)
+--   computations       (tenant_id, output_handle, transaction_id)   idx_computations_no_tenant (output_handle, transaction_id)
+--   ciphertexts        (tenant_id, handle, ciphertext_version)      idx_ciphertexts_no_tenant (handle, ciphertext_version)
+--
+-- Each writer upserts with `INSERT ... ON CONFLICT (<tenant-free cols>)`, whose
+-- arbiter covers only the tenant-free index:
+--   * sns-worker      ON CONFLICT (handle) DO UPDATE              -> ciphertext_digest
+--   * host-listener   ON CONFLICT (output_handle, transaction_id) -> computations
+--   * tfhe-worker     ON CONFLICT (handle, ciphertext_version)    -> ciphertexts
+--
+-- When a state/drift revert runs `DELETE FROM <table>` concurrently with such an
+-- upsert, the duplicate can surface on the *other* unique index (the composite
+-- primary key), which the arbiter does not cover, raising a hard
+-- `duplicate key value violates unique constraint "..._pkey"` (SQLSTATE 23505)
+-- instead of being absorbed by the ON CONFLICT clause. That crashed the
+-- sns-worker (see zama-ai/fhevm-internal#1495); host-listener and tfhe-worker
+-- share the same upsert+revert shape, so the same race is reachable on
+-- `computations` and `ciphertexts` too.
+--
+-- Collapsing each table to a single unique key (its tenant-free index) removes
+-- the blind spot: the ON CONFLICT arbiter then covers the table's only unique
+-- index, so any conflict is always absorbed by the upsert. Dropping `tenant_id`
+-- from the key is safe because handles already embed `chain_id`, so the
+-- tenant-free columns are globally unique on their own.
+--
+-- This is catalog-only: each tenant-free unique index already exists and its
+-- columns are already NOT NULL (they came from the old composite primary keys),
+-- so `ADD PRIMARY KEY USING INDEX` promotes the existing index in place with no
+-- table rewrite, scan, or backfill (verified on PostgreSQL 15.7: relfilenode
+-- unchanged, sub-millisecond on 500k rows). Each statement still briefly takes an
+-- ACCESS EXCLUSIVE lock, so apply with a bounded `lock_timeout` + retry rather
+-- than letting it queue behind long-running transactions. `tenant_id` is kept as
+-- a plain column on every table.
+
+ALTER TABLE ciphertext_digest DROP CONSTRAINT IF EXISTS ciphertext_digest_pkey;
+ALTER TABLE ciphertext_digest
+    ADD CONSTRAINT ciphertext_digest_pkey PRIMARY KEY USING INDEX idx_ciphertext_digest_no_tenant;
+
+ALTER TABLE computations DROP CONSTRAINT IF EXISTS computations_pkey;
+ALTER TABLE computations
+    ADD CONSTRAINT computations_pkey PRIMARY KEY USING INDEX idx_computations_no_tenant;
+
+ALTER TABLE ciphertexts DROP CONSTRAINT IF EXISTS ciphertexts_pkey;
+ALTER TABLE ciphertexts
+    ADD CONSTRAINT ciphertexts_pkey PRIMARY KEY USING INDEX idx_ciphertexts_no_tenant;


### PR DESCRIPTION
## What

Backport of #2731 to `release/0.13.x`: collapse the overlapping unique keys on
`ciphertext_digest`, `computations`, and `ciphertexts` to a single unique key
each (drop the vestigial tenant-prefixed composite PK; promote the existing
tenant-free unique index to the primary key via `ADD PRIMARY KEY USING INDEX`).

Single migration file, no code changes.

## Why — this is live on `release/0.13.x`

The 0.13.x e2e operators tests are failing on this exact bug. From
[run 26967720865](https://github.com/zama-ai/fhevm/actions/runs/26967720865) (sns-worker):

```
Non-transient DB error; not retrying
error: duplicate key value violates unique constraint "ciphertext_digest_pkey"  code: 23505
Worker stopped
```

Root cause (see zama-ai/fhevm-internal#1495): each table carries two overlapping
unique indexes, and the workers upsert with `ON CONFLICT` on only the tenant-free
columns. Because the composite PK index was created first, Postgres checks it
*before* the `ON CONFLICT (handle)` arbiter, so a conflict surfaces on the PK —
which the arbiter doesn't cover — raising a hard 23505 instead of being absorbed.
That kills the sns-worker.

On 0.13.x this is triggered by **concurrent duplicate-handle inserts** from the
`--parallel` operators tests (deterministic FHE results → same handle produced
more than once → two concurrent sns-worker transactions insert it at once). No
drift revert is needed — reproduced locally as **2 → 0** duplicate-key errors
when collapsing to a single unique key.

## Safety

Catalog-only: the tenant-free unique index already exists and its columns are
already `NOT NULL`, so the promotion is no table rewrite, no scan. Verified on a
testnet-scale debug DB (incl. the 1.1 TB `ciphertexts`): `relfilenode` unchanged,
the operation itself is sub-second on warm storage. No foreign keys reference any
of the three PKs.

Note: backport of #2731, which is still open on `main`.
