### PR TITLE
fix(test-suite): only run host_chains seed shim when the table exists

### DIFF
--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -168,6 +168,24 @@ describe("compat", () => {
     ).toBe(true);
   });
 
+  test("does not require legacy host chain seed shim for v0.11 coprocessor images", () => {
+    // v0.11 images predate the remove_tenants migration, so host_chains does
+    // not exist and the harness must not try to seed it.
+    expect(
+      requiresLegacyHostChainSeedShim({
+        versions: {
+          target: "latest-supported",
+          lockName: "v0.11.json",
+          env: {
+            COPROCESSOR_DB_MIGRATION_VERSION: "v0.11.0",
+            COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.11.0",
+          } as Record<string, string>,
+          sources: [],
+        },
+      }),
+    ).toBe(false);
+  });
+
   test("does not require legacy host chain seed shim for v0.13 coprocessor images", () => {
     expect(
       requiresLegacyHostChainSeedShim({

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -232,14 +232,25 @@ export const supportsCoprocessorDbStateRevert = (state: Pick<CompatState, "versi
     unparsed: "modern",
   });
 
-/** Detects when the test harness must seed host_chains for legacy coprocessor images. */
-export const requiresLegacyHostChainSeedShim = (state: Pick<CompatState, "versions">) =>
-  versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_DB_MIGRATION_VERSION ?? "", [0, 13, 0], {
-    unparsed: "modern",
-  }) ||
-  versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 0], {
-    unparsed: "modern",
-  });
+/**
+ * Detects when the test harness must seed host_chains for legacy coprocessor images.
+ *
+ * The host_chains table only exists from v0.12.0 onward (the remove_tenants
+ * migration splits it out of the old `tenants` table); v0.11.x images have no
+ * such table, so seeding it would fail. Within [0.12.0, 0.13.0) the table
+ * exists but the runtime does not reliably seed it before zkproof caches it, so
+ * the harness seeds it manually. From v0.13.0 the runtime self-seeds.
+ */
+export const requiresLegacyHostChainSeedShim = (state: Pick<CompatState, "versions">) => {
+  const dbMigrationVersion = state.versions.env.COPROCESSOR_DB_MIGRATION_VERSION ?? "";
+  const hostChainsTableExists = !versionBeforeReleaseFamily(dbMigrationVersion, [0, 12, 0], { unparsed: "modern" });
+  const runtimeNeedsManualSeed =
+    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 0], { unparsed: "modern" }) ||
+    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 0], {
+      unparsed: "modern",
+    });
+  return hostChainsTableExists && runtimeNeedsManualSeed;
+};
 
 /** Detects when the resolved host-listener bundle includes the listener-core consumer topology. */
 export const supportsHostListenerConsumer = (state: Pick<CompatState, "versions">) => {


### PR DESCRIPTION
## Problem

Running the **v0.11 mainnet profile** through `fhevm-cli` fails during the coprocessor step:

\`\`\`
[compat] registering host in coprocessor
ERROR:  relation "host_chains" does not exist
INSERT INTO host_chains (chain_id, name, acl_contract_addres...
\`\`\`

## Root cause

`host_chains` is created by the `20260128095635_remove_tenants.sql` migration, which splits the old `tenants` table into `keys` / `crs` / `host_chains` starting in **v0.12.0**. A **v0.11.x** coprocessor image only has the old `tenants` table — no `host_chains`.

The up-flow's legacy seed shim (`applyLegacyHostChainSeedShim`) manually runs `INSERT INTO host_chains ...`. It exists for **v0.12.x** images that have the table but don't reliably self-seed it before zkproof-worker caches it.

The gate that decides whether to run it regressed. It originally required `COPROCESSOR_DB_MIGRATION_VERSION >= 0.12.0` (table exists). A later refactor rewrote it to only check `< 0.13.0`, **dropping the lower bound**. So for the v0.11 profile (which pins the coprocessor to `v0.11.0`), the shim now fires and inserts into a table that the v0.11 image never created.

## Fix

Gate the shim on **both** conditions, restoring the intended `[0.12.0, 0.13.0)` window:
- `host_chains` table exists → `COPROCESSOR_DB_MIGRATION_VERSION >= v0.12.0`
- runtime too old to self-seed → DB migration or zkproof-worker `< v0.13.0`

## Tests

- Added a regression test asserting the shim is **off** for v0.11 images.
- Existing v0.12 (on) and v0.13 (off) tests still pass.
- `bun test src/compat.test.ts` → 29 pass; `tsc --noEmit` clean.