### PR TITLE
fix(test-suite): add gas limit buffer and fix network import

### DIFF
--- a/test-suite/e2e/test/network.ts
+++ b/test-suite/e2e/test/network.ts
@@ -1,7 +1,7 @@
-import { network } from 'hardhat';
+import hre from 'hardhat';
 
 const LIVE_NETWORKS = new Set(['devnet', 'devnetNative', 'zwsDev', 'sepolia', 'mainnet', 'polygonAmoy']);
 
-export const activeNetworkName = () => network.name;
+export const activeNetworkName = () => hre.network.name;
 
 export const isLiveNetwork = () => LIVE_NETWORKS.has(activeNetworkName());

--- a/test-suite/e2e/test/signers.ts
+++ b/test-suite/e2e/test/signers.ts
@@ -4,7 +4,7 @@ import type { Signer } from 'ethers';
 import { config, ethers } from 'hardhat';
 import { promisify } from 'util';
 
-import { waitForBalance } from './utils';
+import { waitForBalance, withGasBuffer } from './utils';
 
 const exec = promisify(oldExec);
 
@@ -39,20 +39,20 @@ export const initSigners = async (quantity: number): Promise<void> => {
   if (!signers) {
     if (process.env.HARDHAT_PARALLEL && config.defaultNetwork === 'local') {
       signers = {
-        alice: ethers.Wallet.createRandom().connect(ethers.provider),
-        bob: ethers.Wallet.createRandom().connect(ethers.provider),
-        carol: ethers.Wallet.createRandom().connect(ethers.provider),
-        dave: ethers.Wallet.createRandom().connect(ethers.provider),
-        eve: ethers.Wallet.createRandom().connect(ethers.provider),
+        alice: withGasBuffer(ethers.Wallet.createRandom().connect(ethers.provider)),
+        bob: withGasBuffer(ethers.Wallet.createRandom().connect(ethers.provider)),
+        carol: withGasBuffer(ethers.Wallet.createRandom().connect(ethers.provider)),
+        dave: withGasBuffer(ethers.Wallet.createRandom().connect(ethers.provider)),
+        eve: withGasBuffer(ethers.Wallet.createRandom().connect(ethers.provider)),
       };
     } else if (!process.env.HARDHAT_PARALLEL) {
       const eSigners = await ethers.getSigners();
       signers = {
-        alice: eSigners[0],
-        bob: eSigners[1],
-        carol: eSigners[2],
-        dave: eSigners[3],
-        eve: eSigners[4],
+        alice: withGasBuffer(eSigners[0]),
+        bob: withGasBuffer(eSigners[1]),
+        carol: withGasBuffer(eSigners[2]),
+        dave: withGasBuffer(eSigners[3]),
+        eve: withGasBuffer(eSigners[4]),
       };
     } else {
       throw new Error("Can't run parallel mode if network is not 'local'");
@@ -75,7 +75,7 @@ export const getSigners = async (): Promise<Signers> => {
 
 export const getSigner = async (signerNumber: number): Promise<HardhatEthersSigner> => {
   const eSigners = await ethers.getSigners();
-  return eSigners[signerNumber];
+  return withGasBuffer(eSigners[signerNumber]);
 };
 
 export const requestFaucet = faucet;

--- a/test-suite/e2e/test/utils.ts
+++ b/test-suite/e2e/test/utils.ts
@@ -3,7 +3,7 @@ import { ALL_FHE_TYPE_INFOS } from '@fhevm/solidity/lib-js/fheTypeInfos';
 import { ALL_OPERATORS_PRICES } from '@fhevm/solidity/lib-js/operatorsPrices';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
 import { toBufferBE } from 'bigint-buffer';
-import { ContractMethodArgs, Log, TransactionReceipt, Typed } from 'ethers';
+import { ContractMethodArgs, Log, Signer, TransactionReceipt, TransactionRequest, Typed } from 'ethers';
 import { ethers, network } from 'hardhat';
 import hre from 'hardhat';
 
@@ -77,6 +77,36 @@ export const createTransaction = async <A extends [...{ [I in keyof A]-?: A[I] |
   ];
   return method(...updatedParams);
 };
+
+// Headroom (%) over `eth_estimateGas`, capped at GAS_LIMIT_CAP.
+const GAS_LIMIT_BUFFER_PERCENT = 50n;
+const GAS_LIMIT_CAP = 10_000_000n;
+const GAS_BUFFERED = Symbol.for('fhevm-e2e/gas-buffered');
+
+/**
+ * Buffers gasLimit on every tx a signer sends without an explicit one. The generated operator
+ * tests call contract methods directly, so ethers v6 uses the bare estimate with no margin;
+ * under `--parallel` that occasionally under-estimates (e.g. the per-block HCU meter SSTORE) and
+ * the op reverts with `EvmError: OutOfGas`. Idempotent (guarded by GAS_BUFFERED).
+ */
+export function withGasBuffer<T extends Signer>(signer: T): T {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const patched = signer as any;
+  if (patched[GAS_BUFFERED]) {
+    return signer;
+  }
+  const originalSendTransaction = signer.sendTransaction.bind(signer);
+  patched.sendTransaction = async (tx: TransactionRequest) => {
+    if (tx.gasLimit == null) {
+      const estimated = await signer.estimateGas(tx);
+      const buffered = (estimated * (100n + GAS_LIMIT_BUFFER_PERCENT)) / 100n;
+      tx = { ...tx, gasLimit: buffered < GAS_LIMIT_CAP ? buffered : GAS_LIMIT_CAP };
+    }
+    return originalSendTransaction(tx);
+  };
+  patched[GAS_BUFFERED] = true;
+  return signer;
+}
 
 export const mineNBlocks = async (n: number) => {
   for (let index = 0; index < n; index++) {


### PR DESCRIPTION
## Summary

- operator tests call ops directly, so ethers uses `gasLimit = eth_estimateGas` with no margin; under `--parallel` it occasionally under-estimates (block-state-dependent HCU meter SSTORE) 
- a new `withGasBuffer()` applies `estimate * 1.5` at the signer level
- corrects the network import from hardhat
