### PR TITLE
test(test-suite): v0.11-to-v0.13 stateful rollout runbook

### DIFF
--- a/.github/workflows/test-suite-stateful-rollout.yml
+++ b/.github/workflows/test-suite-stateful-rollout.yml
@@ -155,6 +155,10 @@ jobs:
       - name: Show logs
         working-directory: test-suite/fhevm
         if: always()
+        env:
+          # Wider tail so a failing phase captures the full compute/commit window
+          # (the default 120 truncated the coprocessor's transfer-processing logs).
+          SHOW_LOGS_TAIL: 1000
         run: |
           snapshot_logs() {
             local group="$1"
@@ -167,7 +171,7 @@ jobs:
               echo "::endgroup::"
               return
             fi
-            if ! output="$(docker logs --tail 120 "${container}" 2>&1)"; then
+            if ! output="$(docker logs --tail "${SHOW_LOGS_TAIL:-120}" "${container}" 2>&1)"; then
               echo "[warn] docker logs failed for ${container}"
               [ -n "$output" ] && printf '%s\n' "$output"
             elif [ -n "$filter" ]; then

--- a/.github/workflows/test-suite-stateful-rollout.yml
+++ b/.github/workflows/test-suite-stateful-rollout.yml
@@ -80,7 +80,10 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          # Full fetch: a depth-1 fetch of a base tip newer than the checkout
+          # has no shared ancestry, and `base...HEAD` fails with "no merge base"
+          # (seen on re-runs after the base branch advanced).
+          git fetch --no-tags origin "$BASE_REF"
           git diff --name-only "origin/${BASE_REF}...HEAD" |
             awk -F/ '$1 == "test-suite" && $2 == "fhevm" && $3 == "rollouts" && $4 != "" && $5 != "" { print $1 "/" $2 "/" $3 "/" $4 "/run.ts" }' |
             sort -u > /tmp/rollout-runbooks.txt

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -37,13 +37,17 @@ COPY sdk/js-sdk ./sdk/js-sdk
 # coherent dependency graph for that requested SDK version.
 #
 # The e2e workspace defaults to @zama-fhe/relayer-sdk ^0.5.0-alpha.2 and the
-# committed lockfile pins that nested version, so a plain `npm pkg set` + install
-# silently keeps 0.5.0-alpha via workspace hoisting/dedupe. A root `overrides`
-# entry forces the whole tree to the requested SDK (safe: js-sdk has no
-# relayer-sdk dependency), so the e2e import resolves to exactly that version.
+# committed lockfile pins that exact nested version, so a plain `npm pkg set` +
+# install keeps 0.5.0-alpha as a nested dep that node resolves before any
+# hoisted pin. For the hotswap path, force the requested SDK with a root
+# `overrides` entry (safe: js-sdk has no relayer-sdk dependency) AND drop the
+# lockfile so npm re-resolves one coherent graph instead of restoring the
+# pinned nested version. A build-time assertion below fails loudly if the e2e
+# workspace still resolves a different SDK.
 RUN if [ -n "$RELAYER_SDK_VERSION" ]; then \
       npm pkg set -w test-suite/e2e "dependencies.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}" && \
       npm pkg set "overrides.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}" && \
+      rm -f package-lock.json && \
       npm install && \
       npm prune; \
     else \

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -35,8 +35,15 @@ COPY sdk/js-sdk ./sdk/js-sdk
 # Install dependencies. Normal builds stay locked; rollout hotswap builds first
 # update the e2e workspace manifest in the image, then let npm resolve one
 # coherent dependency graph for that requested SDK version.
+#
+# The e2e workspace defaults to @zama-fhe/relayer-sdk ^0.5.0-alpha.2 and the
+# committed lockfile pins that nested version, so a plain `npm pkg set` + install
+# silently keeps 0.5.0-alpha via workspace hoisting/dedupe. A root `overrides`
+# entry forces the whole tree to the requested SDK (safe: js-sdk has no
+# relayer-sdk dependency), so the e2e import resolves to exactly that version.
 RUN if [ -n "$RELAYER_SDK_VERSION" ]; then \
       npm pkg set -w test-suite/e2e "dependencies.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}" && \
+      npm pkg set "overrides.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}" && \
       npm install && \
       npm prune; \
     else \
@@ -54,6 +61,14 @@ RUN npm run build
 WORKDIR /app/test-suite/e2e
 
 RUN npx hardhat compile
+
+# Guard against silently shipping the wrong SDK: when a version was requested,
+# fail the build loudly if the e2e workspace resolves a different one. This is
+# the check that would have caught the rollout running 0.5.0-alpha under a
+# RELAYER_SDK_VERSION=0.4.2 pin.
+RUN if [ -n "$RELAYER_SDK_VERSION" ]; then \
+      node -e "const p=require.resolve('@zama-fhe/relayer-sdk/package.json',{paths:['/app/test-suite/e2e']});const v=require(p).version;const want=process.env.RELAYER_SDK_VERSION;console.log('[build] e2e @zama-fhe/relayer-sdk resolved to '+v+' (requested '+want+')');if(v!==want){console.error('ERROR: e2e resolved @zama-fhe/relayer-sdk '+v+' but RELAYER_SDK_VERSION='+want);process.exit(1);}"; \
+    fi
 
 # --- Runtime Stage ---
 FROM node:${NODE_VERSION} AS prod

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.12/run.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.12/run.ts
@@ -53,8 +53,7 @@ export default async function run(ctx: RolloutRunContext) {
   const baselineLock = await writePhaseVersionLock(ctx, "00-baseline", phaseVersions.baseline);
   const contractsLock = await writePhaseVersionLock(ctx, "01-contracts", phaseVersions.contracts);
   const kmsLock = await writePhaseVersionLock(ctx, "02-kms", phaseVersions.kms);
-  const listenerCoreLock = await writePhaseVersionLock(ctx, "03-listener-core", phaseVersions.listenerCore);
-  const coprocessorLock = await writePhaseVersionLock(ctx, "04-coprocessor", phaseVersions.coprocessor);
+  const coprocessorLock = await writePhaseVersionLock(ctx, "03-coprocessor", phaseVersions.coprocessor);
 
   logPhase("00 baseline: boot v0.11 (single coprocessor, Zama-only consensus)");
   await ctx.up({ lockFile: baselineLock, scenario, overrides: [{ group: "test-suite" }] });
@@ -83,10 +82,10 @@ export default async function run(ctx: RolloutRunContext) {
   await ctx.upgradeRuntimeGroup("kms", { lockFile: kmsLock });
   await testPhase(ctx, "kms");
 
-  logPhase("03 listener-core: v0.11 -> v0.12 (before the coprocessor)");
-  await ctx.upgradeRuntimeGroup("listener-core", { lockFile: listenerCoreLock });
-
-  logPhase("04 coprocessor: v0.11 -> v0.12 (last)");
+  // No listener-core phase: the standalone listener-core (v2) is a v0.13
+  // component; at v0.12 the listener rides with the coprocessor's host-listener,
+  // which moves in the coprocessor group below.
+  logPhase("03 coprocessor: v0.11 -> v0.12 (last; carries the host-listener)");
   await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
   await testPhase(ctx, "final");
 }

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.12/run.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.12/run.ts
@@ -1,0 +1,92 @@
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { phaseVersions, scenario, versionSources } from "./versions";
+
+export type RolloutEnv = Record<string, string>;
+
+const logPhase = (label: string) => {
+  console.log(`\n[rollout] ${label}`);
+};
+
+const upgradeContract = async (runTask: (command: string) => Promise<void>, task: string, name: string) => {
+  const current = `previous-contracts/${name}.sol:${name}`;
+  const next = `contracts/${name}.sol:${name}`;
+  console.log(`[contracts] ${name}: ${current} -> ${next}`);
+  await runTask(
+    [
+      "npx hardhat",
+      task,
+      `--current-implementation ${current}`,
+      `--new-implementation ${next}`,
+      "--verify-contract false",
+      "--use-internal-proxy-address true",
+    ].join(" "),
+  );
+};
+
+const writePhaseVersionLock = (ctx: RolloutRunContext, name: string, versions: RolloutEnv) =>
+  ctx.writeVersionLock(name, { versions, sources: versionSources });
+
+const contractVersionKeys = ["GATEWAY_VERSION", "HOST_VERSION"];
+
+type RolloutPhase = "baseline" | "contracts" | "kms" | "final";
+
+// Single coprocessor / Zama-only consensus, so the cross-node ciphertext-digest
+// split-brain can't fire; gate each phase with the standard rollout suite.
+const testPhase = async (ctx: RolloutRunContext, phase: RolloutPhase) => {
+  console.log(`[rollout] ${phase} tests: rollout-standard`);
+  await ctx.test("rollout-standard", { parallel: false });
+};
+
+// v0.11 -> v0.12 is a plain UUPS upgrade with no state migration, so the live
+// (v0.11) deploy containers still hold the sources we want as the upgrade
+// baseline -- the default snapshot captures them correctly.
+const prepareContractMigrationSources = async (ctx: RolloutRunContext, targetLockFile: string) => {
+  await ctx.snapshotContracts("host");
+  await ctx.snapshotContracts("gateway");
+  await ctx.applyVersionLock("contract migration sources", {
+    lockFile: targetLockFile,
+    allowedVersionKeys: contractVersionKeys,
+  });
+};
+
+export default async function run(ctx: RolloutRunContext) {
+  const baselineLock = await writePhaseVersionLock(ctx, "00-baseline", phaseVersions.baseline);
+  const contractsLock = await writePhaseVersionLock(ctx, "01-contracts", phaseVersions.contracts);
+  const kmsLock = await writePhaseVersionLock(ctx, "02-kms", phaseVersions.kms);
+  const listenerCoreLock = await writePhaseVersionLock(ctx, "03-listener-core", phaseVersions.listenerCore);
+  const coprocessorLock = await writePhaseVersionLock(ctx, "04-coprocessor", phaseVersions.coprocessor);
+
+  logPhase("00 baseline: boot v0.11 (single coprocessor, Zama-only consensus)");
+  await ctx.up({ lockFile: baselineLock, scenario, overrides: [{ group: "test-suite" }] });
+  await testPhase(ctx, "baseline");
+
+  // Plain UUPS implementation swaps, no state migration. Order mirrors the
+  // tested v0.12 devnet upgrade: host HCULimit -> FHEVMExecutor -> ACL
+  // (FHEVMExecutor depends on the new HCU checks), then gateway GatewayConfig
+  // -> Decryption, then host KMSVerifier (adds getCurrentKmsContextId, which the
+  // v0.12 KMS connector requires).
+  logPhase("01 contracts: v0.11 -> v0.12 plain UUPS upgrades (no state migration)");
+  await prepareContractMigrationSources(ctx, contractsLock);
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeHCULimit", "HCULimit");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeFHEVMExecutor", "FHEVMExecutor");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeACL", "ACL");
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeGatewayConfig", "GatewayConfig");
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeDecryption", "Decryption");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeKMSVerifier", "KMSVerifier");
+  await ctx.refreshDiscovery();
+  await testPhase(ctx, "contracts");
+
+  // The relayer is unchanged across this hop (shared v0.11.x line), so it has no
+  // phase. KMS moves next: core v0.13.0 -> v0.13.10 and the connector v0.11 ->
+  // v0.12, which depends on the now-upgraded v0.12 host/gateway contract ABI.
+  logPhase("02 kms: core v0.13.0 -> v0.13.10 and connector v0.11 -> v0.12 together");
+  await ctx.upgradeRuntimeGroup("kms", { lockFile: kmsLock });
+  await testPhase(ctx, "kms");
+
+  logPhase("03 listener-core: v0.11 -> v0.12 (before the coprocessor)");
+  await ctx.upgradeRuntimeGroup("listener-core", { lockFile: listenerCoreLock });
+
+  logPhase("04 coprocessor: v0.11 -> v0.12 (last)");
+  await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
+  await testPhase(ctx, "final");
+}

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.12/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.12/versions.ts
@@ -1,0 +1,102 @@
+type Env = Record<string, string>;
+
+// Mainnet upgrade #1 of the staggered plan (Opio, Jun 2026): fhevm v0.11 / kms
+// v0.13.0 -> fhevm v0.12 / kms v0.13.10. Both endpoints are already-validated
+// version sets: the v0.11 baseline matches the v0.11-to-v0.13 runbook, and the
+// v0.12 target matches the v0.12-to-v0.13 runbook's baseline. v0.11 -> v0.12 is a
+// plain UUPS contract upgrade (no ProtocolConfig/KMSGeneration state migration --
+// that is the v0.12 -> v0.13 hop).
+export const scenario = "single";
+
+const fromTag = "v0.11.0";
+const toTag = "v0.12.5";
+
+// The relayer rides its own (offset) v0.11.x line that spans fhevm v0.11 and
+// v0.12, so it does not change in this hop. v0.11.1 is the tip of that line
+// (see the v0.11-to-v0.13 runbook note); testnet v0.12 ran v0.11.0, and v0.11.1
+// is a strict superset (estimate-gas hotfix), so it is correct for v0.12 too.
+const relayerVersion = "v0.11.1";
+const relayerMigrateVersion = "v0.11.0";
+
+// The rollout-standard suite and its relayer-sdk pairing are pinned to the
+// target test-suite image across every phase (the test-suite group is overridden
+// at boot, never upgraded in place).
+const testSuiteVersion = toTag;
+const relayerSdkVersion = "0.4.2";
+
+export const from = {
+  RELAYER_VERSION: relayerVersion,
+  RELAYER_MIGRATE_VERSION: relayerMigrateVersion,
+  GATEWAY_VERSION: fromTag,
+  HOST_VERSION: fromTag,
+  CORE_VERSION: "v0.13.0",
+  CONNECTOR_DB_MIGRATION_VERSION: fromTag,
+  CONNECTOR_GW_LISTENER_VERSION: fromTag,
+  CONNECTOR_KMS_WORKER_VERSION: fromTag,
+  CONNECTOR_TX_SENDER_VERSION: fromTag,
+  COPROCESSOR_DB_MIGRATION_VERSION: fromTag,
+  COPROCESSOR_HOST_LISTENER_VERSION: fromTag,
+  COPROCESSOR_GW_LISTENER_VERSION: fromTag,
+  COPROCESSOR_TX_SENDER_VERSION: fromTag,
+  COPROCESSOR_TFHE_WORKER_VERSION: fromTag,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: fromTag,
+  COPROCESSOR_SNS_WORKER_VERSION: fromTag,
+  LISTENER_CORE_VERSION: fromTag,
+  TEST_SUITE_VERSION: testSuiteVersion,
+  RELAYER_SDK_VERSION: relayerSdkVersion,
+} satisfies Env;
+
+export const to = {
+  ...from,
+  // relayer keys intentionally unchanged (shared v0.11.x line).
+  GATEWAY_VERSION: toTag,
+  HOST_VERSION: toTag,
+  CORE_VERSION: "v0.13.10",
+  CONNECTOR_DB_MIGRATION_VERSION: toTag,
+  CONNECTOR_GW_LISTENER_VERSION: toTag,
+  CONNECTOR_KMS_WORKER_VERSION: toTag,
+  CONNECTOR_TX_SENDER_VERSION: toTag,
+  COPROCESSOR_DB_MIGRATION_VERSION: toTag,
+  COPROCESSOR_HOST_LISTENER_VERSION: toTag,
+  COPROCESSOR_GW_LISTENER_VERSION: toTag,
+  COPROCESSOR_TX_SENDER_VERSION: toTag,
+  COPROCESSOR_TFHE_WORKER_VERSION: toTag,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: toTag,
+  COPROCESSOR_SNS_WORKER_VERSION: toTag,
+  LISTENER_CORE_VERSION: toTag,
+} satisfies Env;
+
+type EnvKey = keyof typeof from;
+
+const contractKeys = ["GATEWAY_VERSION", "HOST_VERSION"] as const satisfies readonly EnvKey[];
+const kmsKeys = [
+  "CORE_VERSION",
+  "CONNECTOR_DB_MIGRATION_VERSION",
+  "CONNECTOR_GW_LISTENER_VERSION",
+  "CONNECTOR_KMS_WORKER_VERSION",
+  "CONNECTOR_TX_SENDER_VERSION",
+] as const satisfies readonly EnvKey[];
+const listenerKeys = ["LISTENER_CORE_VERSION"] as const satisfies readonly EnvKey[];
+
+const withTargetVersions = (...keys: EnvKey[]): Env => ({
+  ...from,
+  ...Object.fromEntries(keys.map((key) => [key, to[key]])),
+});
+
+// Contracts move first (plain UUPS), then kms (core + connector, which needs the
+// v0.12 contract ABI), then listener-core, then the coprocessor last. The relayer
+// is unchanged so it has no phase of its own.
+export const phaseVersions = {
+  baseline: from,
+  contracts: withTargetVersions(...contractKeys),
+  kms: withTargetVersions(...contractKeys, ...kmsKeys),
+  listenerCore: withTargetVersions(...contractKeys, ...kmsKeys, ...listenerKeys),
+  coprocessor: to,
+};
+
+export const versionSources = [
+  "rollout=v0.11-to-v0.12",
+  `from=${fromTag}`,
+  `target=${toTag}`,
+  "kms-core=v0.13.10",
+];

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.12/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.12/versions.ts
@@ -49,6 +49,10 @@ export const from = {
 export const to = {
   ...from,
   // relayer keys intentionally unchanged (shared v0.11.x line).
+  // LISTENER_CORE_VERSION intentionally unchanged: the standalone listener-core
+  // (v2 listener) is a v0.13 component with no v0.11/v0.12 published image. At
+  // v0.12 the listener is the coprocessor-bundled host-listener, which moves
+  // with the coprocessor group below; listener-core only activates at v0.13.
   GATEWAY_VERSION: toTag,
   HOST_VERSION: toTag,
   CORE_VERSION: "v0.13.10",
@@ -63,7 +67,6 @@ export const to = {
   COPROCESSOR_TFHE_WORKER_VERSION: toTag,
   COPROCESSOR_ZKPROOF_WORKER_VERSION: toTag,
   COPROCESSOR_SNS_WORKER_VERSION: toTag,
-  LISTENER_CORE_VERSION: toTag,
 } satisfies Env;
 
 type EnvKey = keyof typeof from;
@@ -76,21 +79,18 @@ const kmsKeys = [
   "CONNECTOR_KMS_WORKER_VERSION",
   "CONNECTOR_TX_SENDER_VERSION",
 ] as const satisfies readonly EnvKey[];
-const listenerKeys = ["LISTENER_CORE_VERSION"] as const satisfies readonly EnvKey[];
-
 const withTargetVersions = (...keys: EnvKey[]): Env => ({
   ...from,
   ...Object.fromEntries(keys.map((key) => [key, to[key]])),
 });
 
 // Contracts move first (plain UUPS), then kms (core + connector, which needs the
-// v0.12 contract ABI), then listener-core, then the coprocessor last. The relayer
-// is unchanged so it has no phase of its own.
+// v0.12 contract ABI), then the coprocessor last. The relayer and the standalone
+// listener-core are unchanged in this hop, so neither has a phase of its own.
 export const phaseVersions = {
   baseline: from,
   contracts: withTargetVersions(...contractKeys),
   kms: withTargetVersions(...contractKeys, ...kmsKeys),
-  listenerCore: withTargetVersions(...contractKeys, ...kmsKeys, ...listenerKeys),
   coprocessor: to,
 };
 

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { STANDARD_TEST_PROFILES } from "../../src/layout";
 import { phaseVersions, scenario, versionSources } from "./versions";
 
 export type RolloutEnv = Record<string, string>;
@@ -29,43 +30,47 @@ const writePhaseVersionLock = (ctx: RolloutRunContext, name: string, versions: R
   ctx.writeVersionLock(name, { versions, sources: versionSources });
 
 const contractVersionKeys = ["GATEWAY_VERSION", "HOST_VERSION"];
-const rolloutTestModes = ["rollout-standard", "rollout-heavy"] as const;
-type RolloutTestMode = (typeof rolloutTestModes)[number];
-type RolloutPhase = "baseline" | "contracts" | "relayer" | "kms" | "final";
 
-const heavyPhaseProfiles: Record<RolloutPhase, string[]> = {
-  baseline: ["rollout-standard"],
-  contracts: ["rollout-standard", "operators", "random-subset", "hcu-block-cap"],
-  relayer: ["rollout-standard", "negative-acl"],
-  kms: ["rollout-standard", "public-decryption"],
-  final: [
-    "rollout-standard",
-    "operators",
-    "random-subset",
-    "negative-acl",
-    "public-decryption",
-    "hcu-block-cap",
-    "coprocessor-db-state-revert",
-    "rollout-standard",
-    "ciphertext-drift-auto-recovery",
-    "rollout-standard",
-  ],
-};
+// A gate after every single hop, no batching — each phase change is validated
+// in isolation so a regression points at the component that introduced it.
+type RolloutPhase =
+  | "baseline"
+  | "contracts-v012"
+  | "contracts-v013"
+  | "relayer"
+  | "kms"
+  | "listener-core"
+  | "final";
 
-export const resolveRolloutTestMode = (value?: string): RolloutTestMode => {
-  const selected = value ?? "rollout-standard";
-  if (rolloutTestModes.includes(selected as RolloutTestMode)) {
-    return selected as RolloutTestMode;
-  }
-  throw new Error(`Unsupported ROLLOUT_TEST_PROFILE=${selected}; expected ${rolloutTestModes.join(" or ")}`);
-};
+// Slow/stateful or topology-bound profiles. They mutate DB state or need a
+// multi-chain topology, so they make poor per-hop smoke gates and run only at
+// the final gate, via the `standard` aggregate whose built-in guards self-skip
+// the ones this rollout's single-chain topology can't satisfy.
+const FINAL_ONLY_PROFILES: readonly string[] = [
+  "coprocessor-db-state-revert",
+  "ciphertext-drift-auto-recovery",
+  "multi-chain-isolation",
+];
 
-export const rolloutPhaseTestProfiles = (phase: RolloutPhase, mode: RolloutTestMode) =>
-  mode === "rollout-heavy" ? heavyPhaseProfiles[phase] : ["rollout-standard"];
+// Every intermediate hop runs the complete `fhevm-cli test standard` coverage
+// minus the final-only profiles — derived from STANDARD_TEST_PROFILES so it
+// tracks the suite. This is deliberately the full standard suite, not the much
+// thinner shared `rollout-standard` subset (which omits negative-acl,
+// hcu-block-cap, the paused-contract profiles, etc.).
+export const PER_HOP_TEST_PROFILES = STANDARD_TEST_PROFILES.filter(
+  (profile) => !FINAL_ONLY_PROFILES.includes(profile),
+);
 
-const testPhase = async (ctx: RolloutRunContext, phase: RolloutPhase, mode: RolloutTestMode) => {
-  const profiles = rolloutPhaseTestProfiles(phase, mode);
-  console.log(`[rollout] ${phase} tests (${mode}): ${profiles.join(", ")}`);
+// Per-hop gates run each non-final-only profile by name (multi-chain-isolation
+// is excluded, so none hit the named-profile precondition that throws on a
+// single-chain stack). The final gate runs the `standard` aggregate so it also
+// covers the stateful/topology-bound profiles with their built-in skip guards.
+export const rolloutPhaseProfiles = (phase: RolloutPhase): string[] =>
+  phase === "final" ? ["standard"] : [...PER_HOP_TEST_PROFILES];
+
+const testPhase = async (ctx: RolloutRunContext, phase: RolloutPhase) => {
+  const profiles = rolloutPhaseProfiles(phase);
+  console.log(`[rollout] ${phase} tests: ${profiles.join(", ")}`);
   for (const profile of profiles) {
     await ctx.test(profile, { parallel: false });
   }
@@ -251,7 +256,6 @@ const migrateContractsV012ToV013 = async (ctx: RolloutRunContext, v013Lock: stri
 };
 
 export default async function run(ctx: RolloutRunContext) {
-  const testMode = resolveRolloutTestMode(process.env.ROLLOUT_TEST_PROFILE);
   const baselineLock = await writePhaseVersionLock(ctx, "00-baseline", phaseVersions.baseline);
   const contractsV012Lock = await writePhaseVersionLock(ctx, "01a-contracts-v012", phaseVersions.contractsV012);
   const contractsV013Lock = await writePhaseVersionLock(ctx, "01b-contracts-v013", phaseVersions.contractsV013);
@@ -262,29 +266,32 @@ export default async function run(ctx: RolloutRunContext) {
 
   logPhase("00 baseline: boot v0.11.0 with the target test-suite harness");
   await ctx.up({ lockFile: baselineLock, scenario, overrides: [{ group: "test-suite" }] });
-  await testPhase(ctx, "baseline", testMode);
+  await testPhase(ctx, "baseline");
 
-  logPhase("01 contracts: batch upgrade v0.11 -> v0.12 -> v0.13 (two mandatory hops)");
+  // Contracts always hop through v0.12; gate each hop independently so the
+  // intermediate states (v0.11 services on v0.12, then on v0.13, contracts) are
+  // each exercised, not just the end state.
+  logPhase("01a contracts: v0.11 -> v0.12 (services still v0.11)");
   await migrateContractsV011ToV012(ctx, contractsV012Lock);
+  await testPhase(ctx, "contracts-v012");
+
+  logPhase("01b contracts: v0.12 -> v0.13 (services still v0.11)");
   await migrateContractsV012ToV013(ctx, contractsV013Lock);
-  // Single e2e gate after contracts reach v0.13, matching the batched
-  // "contracts upgrade" step of the staged plan.
-  await testPhase(ctx, "contracts", testMode);
+  await testPhase(ctx, "contracts-v013");
 
   logPhase("02 relayer: straight v0.11 -> v0.13, before KMS connector consumes versioned extraData");
   await ctx.upgradeRuntimeGroup("relayer", { lockFile: relayerLock });
-  await testPhase(ctx, "relayer", testMode);
+  await testPhase(ctx, "relayer");
 
   logPhase("03 kms: straight kms-core v0.13.0 -> v0.13.20 and connector v0.11 -> v0.13 together");
   await ctx.upgradeRuntimeGroup("kms", { lockFile: kmsLock });
-  await testPhase(ctx, "kms", testMode);
+  await testPhase(ctx, "kms");
 
-  logPhase("04 listener-core: upgrade listener-core before coprocessor");
-  // No test gate here: old coprocessor listeners do not consume listener-core.
-  // The compatibility boundary is the coprocessor upgrade, where consumers
-  // switch to the new listener path.
+  logPhase("04 listener-core: straight v0.11 -> v0.13 (still an old coprocessor against it)");
   await ctx.upgradeRuntimeGroup("listener-core", { lockFile: listenerCoreLock });
+  await testPhase(ctx, "listener-core");
+
   logPhase("05 coprocessor: straight v0.11 -> v0.13 (closes the old-coprocessor / v0.13-contracts window)");
   await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
-  await testPhase(ctx, "final", testMode);
+  await testPhase(ctx, "final");
 }

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
@@ -33,8 +33,17 @@ const rolloutTestModes = ["rollout-standard", "rollout-heavy"] as const;
 type RolloutTestMode = (typeof rolloutTestModes)[number];
 type RolloutPhase = "baseline" | "contracts" | "relayer" | "kms" | "final";
 
+// v0.11 contracts predate context-aware KMS (KMSVerifier.getCurrentKmsContextId,
+// added in v0.12), which the v0.13 relayer-sdk decrypt path calls. Only the
+// decrypt-free input-proof check can run against the v0.11 baseline; full
+// decrypt coverage resumes from the contracts phase, once the proxies reach
+// v0.12+. This mirrors how the suite already version-gates v0.11 elsewhere (the
+// HCU per-block tests self-skip on protocol v0.11; coprocessor-db-state-revert
+// is gated below v0.12) -- it is not a shim that fakes v0.11 decryption.
+const baselineProfiles = ["input-proof"];
+
 const heavyPhaseProfiles: Record<RolloutPhase, string[]> = {
-  baseline: ["rollout-standard"],
+  baseline: baselineProfiles,
   contracts: ["rollout-standard", "operators", "random-subset", "hcu-block-cap"],
   relayer: ["rollout-standard", "negative-acl"],
   kms: ["rollout-standard", "public-decryption"],
@@ -60,8 +69,12 @@ export const resolveRolloutTestMode = (value?: string): RolloutTestMode => {
   throw new Error(`Unsupported ROLLOUT_TEST_PROFILE=${selected}; expected ${rolloutTestModes.join(" or ")}`);
 };
 
-export const rolloutPhaseTestProfiles = (phase: RolloutPhase, mode: RolloutTestMode) =>
-  mode === "rollout-heavy" ? heavyPhaseProfiles[phase] : ["rollout-standard"];
+export const rolloutPhaseTestProfiles = (phase: RolloutPhase, mode: RolloutTestMode) => {
+  if (phase === "baseline") {
+    return baselineProfiles;
+  }
+  return mode === "rollout-heavy" ? heavyPhaseProfiles[phase] : ["rollout-standard"];
+};
 
 const testPhase = async (ctx: RolloutRunContext, phase: RolloutPhase, mode: RolloutTestMode) => {
   const profiles = rolloutPhaseTestProfiles(phase, mode);

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
@@ -1,0 +1,290 @@
+import path from "node:path";
+
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { phaseVersions, scenario, versionSources } from "./versions";
+
+export type RolloutEnv = Record<string, string>;
+
+const logPhase = (label: string) => {
+  console.log(`\n[rollout] ${label}`);
+};
+
+const upgradeContract = async (runTask: (command: string) => Promise<void>, task: string, name: string) => {
+  const current = `previous-contracts/${name}.sol:${name}`;
+  const next = `contracts/${name}.sol:${name}`;
+  console.log(`[contracts] ${name}: ${current} -> ${next}`);
+  await runTask(
+    [
+      "npx hardhat",
+      task,
+      `--current-implementation ${current}`,
+      `--new-implementation ${next}`,
+      "--verify-contract false",
+      "--use-internal-proxy-address true",
+    ].join(" "),
+  );
+};
+
+const writePhaseVersionLock = (ctx: RolloutRunContext, name: string, versions: RolloutEnv) =>
+  ctx.writeVersionLock(name, { versions, sources: versionSources });
+
+const contractVersionKeys = ["GATEWAY_VERSION", "HOST_VERSION"];
+const rolloutTestModes = ["rollout-standard", "rollout-heavy"] as const;
+type RolloutTestMode = (typeof rolloutTestModes)[number];
+type RolloutPhase = "baseline" | "contracts" | "relayer" | "kms" | "final";
+
+const heavyPhaseProfiles: Record<RolloutPhase, string[]> = {
+  baseline: ["rollout-standard"],
+  contracts: ["rollout-standard", "operators", "random-subset", "hcu-block-cap"],
+  relayer: ["rollout-standard", "negative-acl"],
+  kms: ["rollout-standard", "public-decryption"],
+  final: [
+    "rollout-standard",
+    "operators",
+    "random-subset",
+    "negative-acl",
+    "public-decryption",
+    "hcu-block-cap",
+    "coprocessor-db-state-revert",
+    "rollout-standard",
+    "ciphertext-drift-auto-recovery",
+    "rollout-standard",
+  ],
+};
+
+export const resolveRolloutTestMode = (value?: string): RolloutTestMode => {
+  const selected = value ?? "rollout-standard";
+  if (rolloutTestModes.includes(selected as RolloutTestMode)) {
+    return selected as RolloutTestMode;
+  }
+  throw new Error(`Unsupported ROLLOUT_TEST_PROFILE=${selected}; expected ${rolloutTestModes.join(" or ")}`);
+};
+
+export const rolloutPhaseTestProfiles = (phase: RolloutPhase, mode: RolloutTestMode) =>
+  mode === "rollout-heavy" ? heavyPhaseProfiles[phase] : ["rollout-standard"];
+
+const testPhase = async (ctx: RolloutRunContext, phase: RolloutPhase, mode: RolloutTestMode) => {
+  const profiles = rolloutPhaseTestProfiles(phase, mode);
+  console.log(`[rollout] ${phase} tests (${mode}): ${profiles.join(", ")}`);
+  for (const profile of profiles) {
+    await ctx.test(profile, { parallel: false });
+  }
+};
+
+// Preserves the currently-deployed contract sources as `previous-contracts`,
+// then activates the next version's sources for the upgrade tasks. For the
+// second hop the on-chain implementation is v0.12, but the persistent deploy
+// container still runs the v0.11 boot image — so snapshot from the locked
+// (v0.12) image to capture the correct upgrade baseline.
+const prepareContractMigrationSources = async (
+  ctx: RolloutRunContext,
+  targetLockFile: string,
+  options: { fromLockedImage?: boolean } = {},
+) => {
+  await ctx.snapshotContracts("host", options);
+  await ctx.snapshotContracts("gateway", options);
+  await ctx.applyVersionLock("contract migration sources", {
+    lockFile: targetLockFile,
+    allowedVersionKeys: contractVersionKeys,
+  });
+};
+
+// task:exportKmsMigrationState writes the MIGRATION_* values consumed by the
+// host ProtocolConfig and KMSGeneration migration tasks.
+const parseGatewayMigrationEnv = (value: unknown): RolloutEnv => {
+  if (!value || typeof value !== "object") {
+    throw new Error("migration-state.json is missing its export object");
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => {
+      if (item === undefined || item === null) {
+        throw new Error(`migration-state.json export.${key} is empty`);
+      }
+      return [key, String(item)];
+    }),
+  );
+};
+
+// Production-like deployments have 13 KMS nodes and currently export mpc=4.
+// The local rollout stack has one KMS node, so legacy GatewayConfig exports
+// the cryptographic threshold t=0. v0.13 ProtocolConfig rejects zero
+// thresholds, so normalize only this synthetic one-node migration case.
+export const needsLocalOneNodeMpcNormalization = (env: RolloutEnv): boolean => {
+  const kmsNodes = JSON.parse(env.MIGRATION_KMS_NODES ?? "[]") as unknown[];
+  const thresholds = JSON.parse(env.MIGRATION_KMS_THRESHOLDS ?? "{}") as Record<string, unknown>;
+  return kmsNodes.length === 1 && String(thresholds.mpc) === "0";
+};
+
+export const normalizeLocalOneNodeMpcThreshold = (env: RolloutEnv): RolloutEnv => {
+  if (!needsLocalOneNodeMpcNormalization(env)) {
+    return env;
+  }
+  const thresholds = JSON.parse(env.MIGRATION_KMS_THRESHOLDS ?? "{}") as Record<string, unknown>;
+  console.log("[contracts] local one-node migration: normalize ProtocolConfig mpc threshold 0 -> 1");
+  return { ...env, MIGRATION_KMS_THRESHOLDS: JSON.stringify({ ...thresholds, mpc: "1" }) };
+};
+
+type GatewayMigrationContext = {
+  kmsGenerationProxy: string;
+  gatewayConfigProxy: string;
+  migrationEnv: RolloutEnv;
+  mpcThresholdNormalized: boolean;
+};
+
+const exportGatewayKmsMigrationEnv = async (ctx: RolloutRunContext): Promise<GatewayMigrationContext> => {
+  const state = await ctx.readState();
+  const gateway = state.discovery?.gateway;
+  if (!gateway?.KMS_GENERATION_ADDRESS || !gateway.GATEWAY_CONFIG_ADDRESS) {
+    throw new Error("gateway KMSGeneration and GatewayConfig addresses must be discovered before contract migration");
+  }
+
+  const output = "kms-migration-state.json";
+  await ctx.runGatewayContractTask(
+    [
+      "npx hardhat compile &&",
+      "npx hardhat task:exportKmsMigrationState",
+      `--kms-generation-proxy ${gateway.KMS_GENERATION_ADDRESS}`,
+      `--gateway-config-proxy ${gateway.GATEWAY_CONFIG_ADDRESS}`,
+      `--output /app/addresses/${output}`,
+    ].join(" "),
+  );
+
+  const stateFile = path.join(ctx.stateDir(), "runtime", "addresses", "gateway", output);
+  const migrationState = JSON.parse(await Bun.file(stateFile).text()) as { export?: unknown };
+  const rawEnv = parseGatewayMigrationEnv(migrationState.export);
+  return {
+    kmsGenerationProxy: gateway.KMS_GENERATION_ADDRESS,
+    gatewayConfigProxy: gateway.GATEWAY_CONFIG_ADDRESS,
+    migrationEnv: normalizeLocalOneNodeMpcThreshold(rawEnv),
+    mpcThresholdNormalized: needsLocalOneNodeMpcNormalization(rawEnv),
+  };
+};
+
+// host-sc-deploy's templated env exposes RPC_URL for the host chain only; the
+// migration assertion task additionally needs GATEWAY_RPC_URL to reach the
+// gateway-node container on the same compose network.
+const GATEWAY_RPC_URL = "http://gateway-node:8546";
+
+const assertKmsMigration = async (
+  ctx: RolloutRunContext,
+  { gatewayConfigProxy, kmsGenerationProxy, mpcThresholdNormalized }: GatewayMigrationContext,
+) => {
+  // task:assertKmsMigrationSucceeded (#2469) does not self-compile; do it
+  // explicitly so hre.ethers.getContractAt("ProtocolConfig", ...) resolves.
+  const assertCommand = [
+    "npx hardhat compile &&",
+    "npx hardhat task:assertKmsMigrationSucceeded",
+    `--gateway-config-proxy ${gatewayConfigProxy}`,
+    `--gateway-kms-generation-proxy ${kmsGenerationProxy}`,
+    "--use-internal-proxy-address true",
+  ].join(" ");
+
+  if (!mpcThresholdNormalized) {
+    // Production-like deployments (n=13, mpc=4): clean assertion path.
+    await ctx.runHostContractTask(assertCommand, { env: { GATEWAY_RPC_URL } });
+    return;
+  }
+
+  // 1-KMS-node fixture only: normalize() patched mpc 0 -> 1, so the on-chain
+  // ProtocolConfig necessarily diverges from the un-patched gateway view on
+  // exactly this field. Tolerate that one error; any other failure (including
+  // any other mpc-mismatch value) still fails the rollout.
+  const wrapped = [
+    `if out=$(${assertCommand} 2>&1); then printf '%s\\n' "$out";`,
+    `else status=$?; printf '%s\\n' "$out";`,
+    `printf '%s\\n' "$out" | grep -q 'ProtocolConfig MPC threshold mismatch: expected 0, got 1' || exit $status;`,
+    `echo '[runbook] tolerated synthetic-fixture mpc threshold mismatch';`,
+    "fi",
+  ].join(" ");
+  await ctx.runHostContractTask(wrapped, { env: { GATEWAY_RPC_URL } });
+};
+
+// Hop 1 (v0.11 -> v0.12): plain UUPS implementation swaps, no state migration.
+// Order mirrors the tested v0.12 devnet upgrade: host HCULimit -> FHEVMExecutor
+// -> ACL (FHEVMExecutor depends on the new HCU checks), then gateway
+// GatewayConfig -> Decryption, then host KMSVerifier (context-aware signers).
+const migrateContractsV011ToV012 = async (ctx: RolloutRunContext, v012Lock: string) => {
+  logPhase("01a contracts: v0.11 -> v0.12 UUPS upgrades (no state migration)");
+  // The baseline deploy containers still run the v0.11 image, so the default
+  // snapshot captures the v0.11 sources we want as the upgrade baseline here.
+  await prepareContractMigrationSources(ctx, v012Lock);
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeHCULimit", "HCULimit");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeFHEVMExecutor", "FHEVMExecutor");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeACL", "ACL");
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeGatewayConfig", "GatewayConfig");
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeDecryption", "Decryption");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeKMSVerifier", "KMSVerifier");
+  await ctx.refreshDiscovery();
+};
+
+// Hop 2 (v0.12 -> v0.13): the full state migration from the v0.12-to-v0.13
+// runbook -- export gateway KMS state, deploy ProtocolConfig and migrate
+// KMSGeneration onto the host, then upgrade the remaining proxies. The v0.12
+// previous-contracts come from the locked (v0.12) deploy image, since the
+// persistent containers still run the v0.11 boot image.
+const migrateContractsV012ToV013 = async (ctx: RolloutRunContext, v013Lock: string) => {
+  logPhase("01b contracts: v0.12 -> v0.13 state migration");
+  await prepareContractMigrationSources(ctx, v013Lock, { fromLockedImage: true });
+  // Export gateway state before making gateway KMSGeneration view-only.
+  const migrationCtx = await exportGatewayKmsMigrationEnv(ctx);
+  const { migrationEnv } = migrationCtx;
+  // Complete the gateway chain first, matching the v0.13 deployment runbook.
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeGatewayConfig", "GatewayConfig");
+  await upgradeContract((command) => ctx.runGatewayContractTask(command), "task:upgradeKMSGeneration", "KMSGeneration");
+  // Then complete the host chain migration, matching the v0.13 devnet runbook:
+  // deploy ProtocolConfig and KMSGeneration from gateway state, upgrade
+  // KMSVerifier next so it picks up the new KMS context before any executor
+  // path runs, then upgrade the remaining contracts. HCULimit moves before
+  // FHEVMExecutor because new executor ops call new HCU checks.
+  await ctx.runHostContractTask("npx hardhat task:deployEmptyProxiesProtocolConfigKMSGeneration");
+  await ctx.runHostContractTask("npx hardhat task:deployProtocolConfigFromMigration", { env: migrationEnv });
+  await ctx.runHostContractTask("npx hardhat task:deployKMSGenerationFromMigration", { env: migrationEnv });
+  // Refresh discovery so downstream runtime env (test-suite, listener-core, etc.) picks up
+  // the new host proxy addresses written by the migration deploy tasks.
+  await ctx.refreshDiscovery();
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeKMSVerifier", "KMSVerifier");
+  await assertKmsMigration(ctx, migrationCtx);
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeHCULimit", "HCULimit");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeFHEVMExecutor", "FHEVMExecutor");
+  await upgradeContract((command) => ctx.runHostContractTask(command), "task:upgradeACL", "ACL");
+  await ctx.refreshDiscovery();
+};
+
+export default async function run(ctx: RolloutRunContext) {
+  const testMode = resolveRolloutTestMode(process.env.ROLLOUT_TEST_PROFILE);
+  const baselineLock = await writePhaseVersionLock(ctx, "00-baseline", phaseVersions.baseline);
+  const contractsV012Lock = await writePhaseVersionLock(ctx, "01a-contracts-v012", phaseVersions.contractsV012);
+  const contractsV013Lock = await writePhaseVersionLock(ctx, "01b-contracts-v013", phaseVersions.contractsV013);
+  const relayerLock = await writePhaseVersionLock(ctx, "02-relayer", phaseVersions.relayer);
+  const kmsLock = await writePhaseVersionLock(ctx, "03-kms", phaseVersions.kms);
+  const listenerCoreLock = await writePhaseVersionLock(ctx, "04-listener-core", phaseVersions.listenerCore);
+  const coprocessorLock = await writePhaseVersionLock(ctx, "05-coprocessor", phaseVersions.coprocessor);
+
+  logPhase("00 baseline: boot v0.11.0 with the target test-suite harness");
+  await ctx.up({ lockFile: baselineLock, scenario, overrides: [{ group: "test-suite" }] });
+  await testPhase(ctx, "baseline", testMode);
+
+  logPhase("01 contracts: batch upgrade v0.11 -> v0.12 -> v0.13 (two mandatory hops)");
+  await migrateContractsV011ToV012(ctx, contractsV012Lock);
+  await migrateContractsV012ToV013(ctx, contractsV013Lock);
+  // Single e2e gate after contracts reach v0.13, matching the batched
+  // "contracts upgrade" step of the staged plan.
+  await testPhase(ctx, "contracts", testMode);
+
+  logPhase("02 relayer: straight v0.11 -> v0.13, before KMS connector consumes versioned extraData");
+  await ctx.upgradeRuntimeGroup("relayer", { lockFile: relayerLock });
+  await testPhase(ctx, "relayer", testMode);
+
+  logPhase("03 kms: straight kms-core v0.13.0 -> v0.13.20 and connector v0.11 -> v0.13 together");
+  await ctx.upgradeRuntimeGroup("kms", { lockFile: kmsLock });
+  await testPhase(ctx, "kms", testMode);
+
+  logPhase("04 listener-core: upgrade listener-core before coprocessor");
+  // No test gate here: old coprocessor listeners do not consume listener-core.
+  // The compatibility boundary is the coprocessor upgrade, where consumers
+  // switch to the new listener path.
+  await ctx.upgradeRuntimeGroup("listener-core", { lockFile: listenerCoreLock });
+  logPhase("05 coprocessor: straight v0.11 -> v0.13 (closes the old-coprocessor / v0.13-contracts window)");
+  await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
+  await testPhase(ctx, "final", testMode);
+}

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/run.ts
@@ -33,17 +33,8 @@ const rolloutTestModes = ["rollout-standard", "rollout-heavy"] as const;
 type RolloutTestMode = (typeof rolloutTestModes)[number];
 type RolloutPhase = "baseline" | "contracts" | "relayer" | "kms" | "final";
 
-// v0.11 contracts predate context-aware KMS (KMSVerifier.getCurrentKmsContextId,
-// added in v0.12), which the v0.13 relayer-sdk decrypt path calls. Only the
-// decrypt-free input-proof check can run against the v0.11 baseline; full
-// decrypt coverage resumes from the contracts phase, once the proxies reach
-// v0.12+. This mirrors how the suite already version-gates v0.11 elsewhere (the
-// HCU per-block tests self-skip on protocol v0.11; coprocessor-db-state-revert
-// is gated below v0.12) -- it is not a shim that fakes v0.11 decryption.
-const baselineProfiles = ["input-proof"];
-
 const heavyPhaseProfiles: Record<RolloutPhase, string[]> = {
-  baseline: baselineProfiles,
+  baseline: ["rollout-standard"],
   contracts: ["rollout-standard", "operators", "random-subset", "hcu-block-cap"],
   relayer: ["rollout-standard", "negative-acl"],
   kms: ["rollout-standard", "public-decryption"],
@@ -69,12 +60,8 @@ export const resolveRolloutTestMode = (value?: string): RolloutTestMode => {
   throw new Error(`Unsupported ROLLOUT_TEST_PROFILE=${selected}; expected ${rolloutTestModes.join(" or ")}`);
 };
 
-export const rolloutPhaseTestProfiles = (phase: RolloutPhase, mode: RolloutTestMode) => {
-  if (phase === "baseline") {
-    return baselineProfiles;
-  }
-  return mode === "rollout-heavy" ? heavyPhaseProfiles[phase] : ["rollout-standard"];
-};
+export const rolloutPhaseTestProfiles = (phase: RolloutPhase, mode: RolloutTestMode) =>
+  mode === "rollout-heavy" ? heavyPhaseProfiles[phase] : ["rollout-standard"];
 
 const testPhase = async (ctx: RolloutRunContext, phase: RolloutPhase, mode: RolloutTestMode) => {
   const profiles = rolloutPhaseTestProfiles(phase, mode);

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
@@ -16,14 +16,15 @@ const v013Tag = "v0.13.0";
 const testSuiteVersion = "v0.13.0";
 const relayerSdkVersion = "0.4.2";
 
-// NOTE: RELAYER_VERSION at v0.11 is the least-certain pin. The deleted in-repo
-// v0.11 profile recorded v0.11.0-rc.1; mainnet relayer is described as "v0.9"
-// (the relayer repo's own versioning is offset from the fhevm meta-version).
-// If the baseline boot cannot pull this tag, adjust to the published v0.11
-// relayer image — this is a config pin, not the compatibility boundary tested.
+// NOTE: the v0.11 relayer line must be >= v0.11.0 final: rc.1 (the deleted
+// in-repo v0.11 profile's pin) predates the listener event-filter fix
+// (console#914) and the isUserDecryptionReady compat fix (console#925), which
+// caused a flaky "Ciphertext not ready" readiness race whenever the ciphertext
+// commit landed after the readiness loop started. v0.11.1 adds an estimate-gas
+// hotfix on top; relayer-migrate has no v0.11.1 release.
 export const v011 = {
-  RELAYER_VERSION: "v0.11.0-rc.1",
-  RELAYER_MIGRATE_VERSION: "v0.11.0-rc.1",
+  RELAYER_VERSION: "v0.11.1",
+  RELAYER_MIGRATE_VERSION: "v0.11.0",
   GATEWAY_VERSION: v011Tag,
   HOST_VERSION: v011Tag,
   CORE_VERSION: "v0.13.0",

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
@@ -1,0 +1,106 @@
+type Env = Record<string, string>;
+
+export const scenario = "two-of-three";
+
+// Mainnet today: fhevm v0.11.0 / kms-core v0.13.0. Target: fhevm v0.13 / kms
+// v0.13.20. v0.12 is only a contract-migration waypoint (host + gateway proxies
+// must pass through it); runtime components jump straight to v0.13 in their own
+// phases, matching the staged plan for the direct mainnet upgrade.
+const v011Tag = "v0.11.0";
+const v012Tag = "v0.12.5";
+const v013Tag = "v0.13.0-6";
+
+// The rollout-standard e2e suite and its relayer-sdk pairing only exist in the
+// target test-suite image, so the harness is pinned to the target across every
+// phase (the test-suite group is overridden at boot, never upgraded in place).
+const testSuiteVersion = "v0.13.0-6";
+const relayerSdkVersion = "0.4.2";
+
+// NOTE: RELAYER_VERSION at v0.11 is the least-certain pin. The deleted in-repo
+// v0.11 profile recorded v0.11.0-rc.1; mainnet relayer is described as "v0.9"
+// (the relayer repo's own versioning is offset from the fhevm meta-version).
+// If the baseline boot cannot pull this tag, adjust to the published v0.11
+// relayer image — this is a config pin, not the compatibility boundary tested.
+export const v011 = {
+  RELAYER_VERSION: "v0.11.0-rc.1",
+  RELAYER_MIGRATE_VERSION: "v0.11.0-rc.1",
+  GATEWAY_VERSION: v011Tag,
+  HOST_VERSION: v011Tag,
+  CORE_VERSION: "v0.13.0",
+  CONNECTOR_DB_MIGRATION_VERSION: v011Tag,
+  CONNECTOR_GW_LISTENER_VERSION: v011Tag,
+  CONNECTOR_KMS_WORKER_VERSION: v011Tag,
+  CONNECTOR_TX_SENDER_VERSION: v011Tag,
+  COPROCESSOR_DB_MIGRATION_VERSION: v011Tag,
+  COPROCESSOR_HOST_LISTENER_VERSION: v011Tag,
+  COPROCESSOR_GW_LISTENER_VERSION: v011Tag,
+  COPROCESSOR_TX_SENDER_VERSION: v011Tag,
+  COPROCESSOR_TFHE_WORKER_VERSION: v011Tag,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: v011Tag,
+  COPROCESSOR_SNS_WORKER_VERSION: v011Tag,
+  LISTENER_CORE_VERSION: v011Tag,
+  TEST_SUITE_VERSION: testSuiteVersion,
+  RELAYER_SDK_VERSION: relayerSdkVersion,
+} satisfies Env;
+
+export const v013 = {
+  ...v011,
+  RELAYER_VERSION: v013Tag,
+  RELAYER_MIGRATE_VERSION: v013Tag,
+  GATEWAY_VERSION: v013Tag,
+  HOST_VERSION: v013Tag,
+  CORE_VERSION: "v0.13.20-0",
+  CONNECTOR_DB_MIGRATION_VERSION: v013Tag,
+  CONNECTOR_GW_LISTENER_VERSION: v013Tag,
+  CONNECTOR_KMS_WORKER_VERSION: v013Tag,
+  CONNECTOR_TX_SENDER_VERSION: v013Tag,
+  COPROCESSOR_DB_MIGRATION_VERSION: v013Tag,
+  COPROCESSOR_HOST_LISTENER_VERSION: v013Tag,
+  COPROCESSOR_GW_LISTENER_VERSION: v013Tag,
+  COPROCESSOR_TX_SENDER_VERSION: v013Tag,
+  COPROCESSOR_TFHE_WORKER_VERSION: v013Tag,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: v013Tag,
+  COPROCESSOR_SNS_WORKER_VERSION: v013Tag,
+  LISTENER_CORE_VERSION: v013Tag,
+} satisfies Env;
+
+type EnvKey = keyof typeof v011;
+
+const relayerKeys = ["RELAYER_VERSION", "RELAYER_MIGRATE_VERSION"] as const satisfies readonly EnvKey[];
+const contractKeys = ["GATEWAY_VERSION", "HOST_VERSION"] as const satisfies readonly EnvKey[];
+const kmsKeys = [
+  "CORE_VERSION",
+  "CONNECTOR_DB_MIGRATION_VERSION",
+  "CONNECTOR_GW_LISTENER_VERSION",
+  "CONNECTOR_KMS_WORKER_VERSION",
+  "CONNECTOR_TX_SENDER_VERSION",
+] as const satisfies readonly EnvKey[];
+const listenerKeys = ["LISTENER_CORE_VERSION"] as const satisfies readonly EnvKey[];
+
+const withTargetVersions = (...keys: EnvKey[]): Env => ({
+  ...v011,
+  ...Object.fromEntries(keys.map((key) => [key, v013[key]])),
+});
+
+// Contracts move first and reach v0.13 in two hops; every runtime component
+// then jumps straight from v0.11 to v0.13. The coprocessor is upgraded last, so
+// an old-v0.11 coprocessor runs against fully-migrated v0.13 contracts through
+// every intermediate phase — the compatibility boundary this rollout exercises.
+export const phaseVersions = {
+  baseline: v011,
+  // Contract waypoint: only the host/gateway deploy images change to v0.12.
+  contractsV012: { ...v011, GATEWAY_VERSION: v012Tag, HOST_VERSION: v012Tag },
+  contractsV013: withTargetVersions(...contractKeys),
+  relayer: withTargetVersions(...contractKeys, ...relayerKeys),
+  kms: withTargetVersions(...contractKeys, ...relayerKeys, ...kmsKeys),
+  listenerCore: withTargetVersions(...contractKeys, ...relayerKeys, ...kmsKeys, ...listenerKeys),
+  coprocessor: v013,
+};
+
+export const versionSources = [
+  "rollout=v0.11-to-v0.13",
+  `from=${v011Tag}`,
+  `via=${v012Tag}`,
+  `target=${v013Tag}`,
+  "kms-core=v0.13.20-0",
+];

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
@@ -16,12 +16,18 @@ const v013Tag = "v0.13.0";
 const testSuiteVersion = "v0.13.0";
 const relayerSdkVersion = "0.4.2";
 
-// NOTE: the v0.11 relayer line must be >= v0.11.0 final: rc.1 (the deleted
-// in-repo v0.11 profile's pin) predates the listener event-filter fix
-// (console#914) and the isUserDecryptionReady compat fix (console#925), which
-// caused a flaky "Ciphertext not ready" readiness race whenever the ciphertext
-// commit landed after the readiness loop started. v0.11.1 adds an estimate-gas
-// hotfix on top; relayer-migrate has no v0.11.1 release.
+// v0.11.1 is the tip of the legacy console/relayer v0.11 line (rc.1 -> rc.2 ->
+// v0.11.0 -> v0.11.1), so it's the closest image to what mainnet "v0.11" runs.
+// NOTE: this pin does NOT fix the "Ciphertext not ready" readiness flake in
+// delegated user-decryption. Verified against the published console/relayer
+// images by git ancestry on their build SHAs: rc.1 (sha-1e44d77), v0.11.0
+// (sha-8319fd7) and v0.11.1 (sha-d6e1ba8) are identical in the readiness /
+// listener / decrypt path. Both console#914 (listener filters) and console#925
+// (isUserDecryptionReady compat) are already present in rc.1; the rc.1->v0.11.1
+// delta is only config-env-var plumbing (console#928) and an Arbitrum
+// estimate-gas fix (console#930). The flake reproduces on the pure-v0.11
+// baseline, so it is a pre-existing baseline race, unrelated to version
+// skipping. relayer-migrate has no v0.11.1 release, so it stays at v0.11.0.
 export const v011 = {
   RELAYER_VERSION: "v0.11.1",
   RELAYER_MIGRATE_VERSION: "v0.11.0",

--- a/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.11-to-v0.13/versions.ts
@@ -8,12 +8,12 @@ export const scenario = "two-of-three";
 // phases, matching the staged plan for the direct mainnet upgrade.
 const v011Tag = "v0.11.0";
 const v012Tag = "v0.12.5";
-const v013Tag = "v0.13.0-6";
+const v013Tag = "v0.13.0";
 
 // The rollout-standard e2e suite and its relayer-sdk pairing only exist in the
 // target test-suite image, so the harness is pinned to the target across every
 // phase (the test-suite group is overridden at boot, never upgraded in place).
-const testSuiteVersion = "v0.13.0-6";
+const testSuiteVersion = "v0.13.0";
 const relayerSdkVersion = "0.4.2";
 
 // NOTE: RELAYER_VERSION at v0.11 is the least-certain pin. The deleted in-repo
@@ -49,7 +49,7 @@ export const v013 = {
   RELAYER_MIGRATE_VERSION: v013Tag,
   GATEWAY_VERSION: v013Tag,
   HOST_VERSION: v013Tag,
-  CORE_VERSION: "v0.13.20-0",
+  CORE_VERSION: "v0.13.20",
   CONNECTOR_DB_MIGRATION_VERSION: v013Tag,
   CONNECTOR_GW_LISTENER_VERSION: v013Tag,
   CONNECTOR_KMS_WORKER_VERSION: v013Tag,
@@ -102,5 +102,5 @@ export const versionSources = [
   `from=${v011Tag}`,
   `via=${v012Tag}`,
   `target=${v013Tag}`,
-  "kms-core=v0.13.20-0",
+  "kms-core=v0.13.20",
 ];

--- a/test-suite/fhevm/scenarios/single.yaml
+++ b/test-suite/fhevm/scenarios/single.yaml
@@ -1,0 +1,12 @@
+version: 1
+kind: coprocessor-consensus
+name: Single Coprocessor
+description: >-
+  One coprocessor, threshold 1 (Zama-only consensus), single host chain. Matches
+  the mainnet upgrade-window topology: multi-coprocessor consensus (onboarding
+  Phase 3) is enabled only after the upgrades, so during an upgrade a single
+  signer is authoritative. A threshold of 1 also cannot hit the cross-node
+  ciphertext-digest split-brain that threshold >= 2 exposes.
+topology:
+  count: 1
+  threshold: 1

--- a/test-suite/fhevm/src/commands/rollout-run.ts
+++ b/test-suite/fhevm/src/commands/rollout-run.ts
@@ -56,7 +56,7 @@ export type RolloutRunContext = {
   refreshDiscovery(): Promise<void>;
   runGatewayContractTask(command: string, options?: RolloutContractTaskOptions): Promise<void>;
   runHostContractTask(command: string, options?: RolloutContractTaskOptions): Promise<void>;
-  snapshotContracts(surface: "host" | "gateway"): Promise<void>;
+  snapshotContracts(surface: "host" | "gateway", options?: { fromLockedImage?: boolean }): Promise<void>;
   stateDir(): string;
   test(profile?: string, options?: RolloutTestOptions): Promise<void>;
   up(options: RolloutUpOptions): Promise<void>;
@@ -117,9 +117,11 @@ export const createRolloutContext = (receipt: RolloutReceipt = createRolloutRece
       details: { envKeys: Object.keys(options.env ?? {}).sort() },
     });
   },
-  async snapshotContracts(surface) {
-    await snapshotContractSources(surface);
-    await receipt.record("snapshot-contracts", surface);
+  async snapshotContracts(surface, options = {}) {
+    await snapshotContractSources(surface, options);
+    await receipt.record("snapshot-contracts", surface, {
+      details: { fromLockedImage: !!options.fromLockedImage },
+    });
   },
   stateDir() {
     return STATE_DIR;

--- a/test-suite/fhevm/src/flow/contracts.ts
+++ b/test-suite/fhevm/src/flow/contracts.ts
@@ -4,6 +4,7 @@ import { PreflightError } from "../errors";
 import { resolvedComposeEnv } from "../generate/compose";
 import { RUNTIME_DIR, dockerArgs, envPath } from "../layout";
 import { loadState } from "../state/state";
+import type { State } from "../types";
 import { ensureDir, exists, readEnvFileIfExists, remove } from "../utils/fs";
 import { run, runStreaming } from "../utils/process";
 import { ensureRuntimeArtifacts } from "./artifacts";
@@ -23,8 +24,14 @@ export const contractTaskEnvArgs = (env: Record<string, string> = {}) =>
   Object.entries(env).flatMap(([key, value]) => ["--env", `${key}=${value}`]);
 
 export type ContractSurface = "host" | "gateway";
-const componentSurface = (component: "host-sc" | "gateway-sc"): ContractSurface =>
+type ContractComponent = "host-sc" | "gateway-sc";
+type DeployService = "host-sc-deploy" | "gateway-sc-deploy";
+const componentSurface = (component: ContractComponent): ContractSurface =>
   component === "host-sc" ? "host" : "gateway";
+const surfaceComponent = (surface: ContractSurface): ContractComponent =>
+  surface === "host" ? "host-sc" : "gateway-sc";
+const deployService = (surface: ContractSurface): DeployService =>
+  surface === "host" ? "host-sc-deploy" : "gateway-sc-deploy";
 const previousContractsDir = (surface: ContractSurface) =>
   path.join(RUNTIME_DIR, "previous-contracts", surface);
 const previousContractsSnapshotPath = "/app/previous-contracts-snapshot";
@@ -47,17 +54,51 @@ fi
 ${command}
 `;
 
-export const snapshotContractSources = async (surface: ContractSurface) => {
+// Copies /app/contracts out of a throwaway container started from the
+// currently-locked deploy image. The persistent <surface>-sc-deploy container
+// keeps the image it booted with, so after a contract hop its sources are stale;
+// a multi-hop rollout needs the just-deployed (mid-version) sources as the next
+// upgrade baseline. A detached idle container skips the deploy entrypoint, and
+// docker cp writes host-side so no in-container bind-mount write access is needed.
+const snapshotFromLockedImage = async (surface: ContractSurface, state: State, target: string) => {
+  const component = surfaceComponent(surface);
+  const service = deployService(surface);
+  await ensureRuntimeArtifacts(state, "contract snapshot");
+  await maybeBuild(component, state);
+  const env = { ...resolvedComposeEnv(state), ...(await readEnvFileIfExists(envPath(component))) };
+  const created = await run(
+    [...dockerArgs(component), "run", "--detach", "--no-deps", "--entrypoint", "sh", service, "-c", "sleep 600"],
+    { env },
+  );
+  const containerId = created.stdout.trim().split("\n").filter(Boolean).pop();
+  if (!containerId) {
+    throw new PreflightError(`could not start a ${service} container to snapshot the locked contract sources`);
+  }
+  try {
+    await run(["docker", "cp", `${containerId}:/app/contracts/.`, target]);
+  } finally {
+    await run(["docker", "rm", "-f", containerId], { allowFailure: true });
+  }
+};
+
+export const snapshotContractSources = async (
+  surface: ContractSurface,
+  options: { fromLockedImage?: boolean } = {},
+) => {
   const state = await loadState();
   const running = await projectContainers();
   assertContractTaskStackRunning(!!state, running.length);
 
-  const container = surface === "host" ? "host-sc-deploy" : "gateway-sc-deploy";
   const target = previousContractsDir(surface);
   await remove(target);
   await ensureDir(target);
-  await run(["docker", "cp", `${container}:/app/contracts/.`, target]);
-  console.log(`[rollout] snapshot ${surface} contracts -> ${target}`);
+  if (options.fromLockedImage) {
+    await snapshotFromLockedImage(surface, state as State, target);
+  } else {
+    await run(["docker", "cp", `${deployService(surface)}:/app/contracts/.`, target]);
+  }
+  const source = options.fromLockedImage ? " (locked image)" : "";
+  console.log(`[rollout] snapshot ${surface} contracts -> ${target}${source}`);
 };
 
 /** Runs a host or gateway contract task inside its deploy container. */

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -1446,6 +1446,13 @@ export const upgradeRuntimeGroup = async (groupValue: string | undefined, option
     ? (await applyRuntimeUpgradeLock(state, plan.group, plan.versionKeys, options.lockFile)).state
     : state;
   await assertSchemaCompatibility(nextState.versions, nextState.overrides, nextState.scenario, false);
+  // Boot-time compose generation omits the v0.13-only host-listener-consumer for
+  // older targets; the explicit upgrade service list must gate it the same way,
+  // or the upgrade starts it from the template image whose older build has no
+  // host_listener_consumer binary. Gate on the TARGET (post-lock) state.
+  const includeConsumer = supportsHostListenerConsumer(nextState);
+  const gateConsumer = (services: string[]) =>
+    includeConsumer ? services : services.filter((service) => service !== "coprocessor-host-listener-consumer");
   console.log(`[upgrade] ${plan.group}`);
   await saveState(nextState);
   await generateRuntime(nextState, stackSpecForState(nextState));
@@ -1465,9 +1472,9 @@ export const upgradeRuntimeGroup = async (groupValue: string | undefined, option
     }
   }
   for (const component of plan.components) {
-    await composeUp(component.component, component.runtimeServices, { noDeps: true });
+    await composeUp(component.component, gateConsumer(component.runtimeServices), { noDeps: true });
   }
-  await waitForUpgrade(nextState, plan.group, plan.runtimeServices);
+  await waitForUpgrade(nextState, plan.group, gateConsumer(plan.runtimeServices));
   for (const step of plan.steps) {
     await markStep(nextState, step);
   }

--- a/test-suite/fhevm/src/rollout-v011-to-v012.test.ts
+++ b/test-suite/fhevm/src/rollout-v011-to-v012.test.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { loadRolloutRunbook } from "./commands/rollout-run";
+import { loadCoprocessorScenario } from "./scenario/resolve";
+import { phaseVersions, scenario } from "../rollouts/v0.11-to-v0.12/versions";
+
+const CLI_DIR = path.resolve(import.meta.dir, "..");
+
+test("runs the first staggered hop on a single-coprocessor (threshold-1) topology", async () => {
+  expect(scenario).toBe("single");
+  const resolved = await loadCoprocessorScenario(scenario);
+  expect(resolved.topology.count).toBe(1);
+  expect(resolved.topology.threshold).toBe(1);
+});
+
+test("starts from the v0.11 mainnet baseline", () => {
+  expect(phaseVersions.baseline.GATEWAY_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.baseline.HOST_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.baseline.CORE_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.baseline.RELAYER_VERSION).toBe("v0.11.1");
+});
+
+test("upgrades contracts to v0.12 first, runtime still v0.11", () => {
+  expect(phaseVersions.contracts.GATEWAY_VERSION).toBe("v0.12.5");
+  expect(phaseVersions.contracts.HOST_VERSION).toBe("v0.12.5");
+  // nothing else moves with the contracts
+  expect(phaseVersions.contracts.CORE_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.contracts.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.contracts.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.11.0");
+});
+
+test("moves kms (core + connector) then listener then coprocessor to v0.12", () => {
+  expect(phaseVersions.kms.CORE_VERSION).toBe("v0.13.10");
+  expect(phaseVersions.kms.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.12.5");
+  expect(phaseVersions.kms.LISTENER_CORE_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.listenerCore.LISTENER_CORE_VERSION).toBe("v0.12.5");
+  expect(phaseVersions.listenerCore.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.coprocessor.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.12.5");
+  expect(phaseVersions.coprocessor.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.12.5");
+});
+
+test("keeps the relayer on the shared v0.11.x line across every phase", () => {
+  for (const phase of Object.values(phaseVersions)) {
+    expect(phase.RELAYER_VERSION).toBe("v0.11.1");
+    expect(phase.TEST_SUITE_VERSION).toBe("v0.12.5");
+    expect(phase.RELAYER_SDK_VERSION).toBe("0.4.2");
+  }
+});
+
+test("loads the checked-in v0.11 to v0.12 runbook", async () => {
+  await expect(loadRolloutRunbook(path.join(CLI_DIR, "rollouts/v0.11-to-v0.12/run.ts"))).resolves.toBeFunction();
+});

--- a/test-suite/fhevm/src/rollout-v011-to-v012.test.ts
+++ b/test-suite/fhevm/src/rollout-v011-to-v012.test.ts
@@ -31,14 +31,20 @@ test("upgrades contracts to v0.12 first, runtime still v0.11", () => {
   expect(phaseVersions.contracts.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.11.0");
 });
 
-test("moves kms (core + connector) then listener then coprocessor to v0.12", () => {
+test("moves kms (core + connector) then the coprocessor to v0.12", () => {
   expect(phaseVersions.kms.CORE_VERSION).toBe("v0.13.10");
   expect(phaseVersions.kms.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.12.5");
-  expect(phaseVersions.kms.LISTENER_CORE_VERSION).toBe("v0.11.0");
-  expect(phaseVersions.listenerCore.LISTENER_CORE_VERSION).toBe("v0.12.5");
-  expect(phaseVersions.listenerCore.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.11.0");
   expect(phaseVersions.coprocessor.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.12.5");
   expect(phaseVersions.coprocessor.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.12.5");
+  expect(phaseVersions.coprocessor.COPROCESSOR_HOST_LISTENER_VERSION).toBe("v0.12.5");
+});
+
+test("leaves the standalone listener-core unchanged (it is a v0.13 component)", () => {
+  // No v0.11/v0.12 listener-core image exists; it must never be pinned/upgraded here.
+  for (const phase of Object.values(phaseVersions)) {
+    expect(phase.LISTENER_CORE_VERSION).toBe("v0.11.0");
+  }
+  expect("listenerCore" in phaseVersions).toBe(false);
 });
 
 test("keeps the relayer on the shared v0.11.x line across every phase", () => {

--- a/test-suite/fhevm/src/rollout-v011.test.ts
+++ b/test-suite/fhevm/src/rollout-v011.test.ts
@@ -6,8 +6,8 @@ import { loadRolloutRunbook } from "./commands/rollout-run";
 import {
   needsLocalOneNodeMpcNormalization,
   normalizeLocalOneNodeMpcThreshold,
-  resolveRolloutTestMode,
-  rolloutPhaseTestProfiles,
+  PER_HOP_TEST_PROFILES,
+  rolloutPhaseProfiles,
 } from "../rollouts/v0.11-to-v0.13/run";
 import { phaseVersions, scenario } from "../rollouts/v0.11-to-v0.13/versions";
 
@@ -71,12 +71,21 @@ test("reuses the one-node ProtocolConfig mpc threshold normalization", () => {
   expect(JSON.parse(normalizeLocalOneNodeMpcThreshold(env).MIGRATION_KMS_THRESHOLDS).mpc).toBe("1");
 });
 
-test("defaults to rollout-standard at every phase", () => {
-  expect(resolveRolloutTestMode(undefined)).toBe("rollout-standard");
-  expect(rolloutPhaseTestProfiles("baseline", "rollout-standard")).toEqual(["rollout-standard"]);
-  expect(rolloutPhaseTestProfiles("contracts", "rollout-standard")).toEqual(["rollout-standard"]);
-  expect(rolloutPhaseTestProfiles("final", "rollout-standard")).toEqual(["rollout-standard"]);
-  expect(() => resolveRolloutTestMode("standard")).toThrow("Unsupported ROLLOUT_TEST_PROFILE=standard");
+test("gates every hop with the standard suite minus stateful profiles, full standard at the final gate", () => {
+  // The per-hop suite drops the slow/stateful and topology-bound profiles...
+  for (const profile of ["coprocessor-db-state-revert", "ciphertext-drift-auto-recovery", "multi-chain-isolation"] as const) {
+    expect(PER_HOP_TEST_PROFILES).not.toContain(profile);
+  }
+  // ...but still covers the robustness profiles the thin rollout-standard skipped.
+  for (const profile of ["negative-acl", "random-subset", "hcu-block-cap", "paused-host-contracts"] as const) {
+    expect(PER_HOP_TEST_PROFILES).toContain(profile);
+  }
+  for (const phase of ["baseline", "contracts-v012", "contracts-v013", "relayer", "kms", "listener-core"] as const) {
+    expect(rolloutPhaseProfiles(phase)).toEqual([...PER_HOP_TEST_PROFILES]);
+  }
+  // The final gate runs the complete standard aggregate (incl. the stateful
+  // profiles, which self-skip when their preconditions are unmet).
+  expect(rolloutPhaseProfiles("final")).toEqual(["standard"]);
 });
 
 test("loads the checked-in v0.11 to v0.13 runbook", async () => {

--- a/test-suite/fhevm/src/rollout-v011.test.ts
+++ b/test-suite/fhevm/src/rollout-v011.test.ts
@@ -28,8 +28,8 @@ test("hops host and gateway contracts through v0.12 before v0.13", () => {
   expect(phaseVersions.contractsV012.RELAYER_VERSION).toBe(phaseVersions.baseline.RELAYER_VERSION);
   expect(phaseVersions.contractsV012.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.11.0");
 
-  expect(phaseVersions.contractsV013.GATEWAY_VERSION).toBe("v0.13.0-6");
-  expect(phaseVersions.contractsV013.HOST_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.contractsV013.GATEWAY_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.contractsV013.HOST_VERSION).toBe("v0.13.0");
 });
 
 test("keeps every runtime component on v0.11 while contracts reach v0.13", () => {
@@ -41,23 +41,23 @@ test("keeps every runtime component on v0.11 while contracts reach v0.13", () =>
 
 test("jumps each runtime group straight from v0.11 to v0.13 in plan order", () => {
   // relayer
-  expect(phaseVersions.relayer.RELAYER_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.relayer.RELAYER_VERSION).toBe("v0.13.0");
   expect(phaseVersions.relayer.CORE_VERSION).toBe("v0.13.0");
   // kms (core + connector)
-  expect(phaseVersions.kms.CORE_VERSION).toBe("v0.13.20-0");
-  expect(phaseVersions.kms.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.kms.CORE_VERSION).toBe("v0.13.20");
+  expect(phaseVersions.kms.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.13.0");
   expect(phaseVersions.kms.LISTENER_CORE_VERSION).toBe("v0.11.0");
   // listener-core moves before the coprocessor image changes
-  expect(phaseVersions.listenerCore.LISTENER_CORE_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.listenerCore.LISTENER_CORE_VERSION).toBe("v0.13.0");
   expect(phaseVersions.listenerCore.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.11.0");
   // coprocessor last
-  expect(phaseVersions.coprocessor.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.13.0-6");
-  expect(phaseVersions.coprocessor.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.coprocessor.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.coprocessor.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.13.0");
 });
 
 test("pins the test harness to the target across every phase", () => {
   for (const phase of Object.values(phaseVersions)) {
-    expect(phase.TEST_SUITE_VERSION).toBe("v0.13.0-6");
+    expect(phase.TEST_SUITE_VERSION).toBe("v0.13.0");
     expect(phase.RELAYER_SDK_VERSION).toBe("0.4.2");
   }
 });

--- a/test-suite/fhevm/src/rollout-v011.test.ts
+++ b/test-suite/fhevm/src/rollout-v011.test.ts
@@ -71,11 +71,19 @@ test("reuses the one-node ProtocolConfig mpc threshold normalization", () => {
   expect(JSON.parse(normalizeLocalOneNodeMpcThreshold(env).MIGRATION_KMS_THRESHOLDS).mpc).toBe("1");
 });
 
-test("defaults to rollout-standard at every phase", () => {
+test("defaults to rollout-standard at every phase except the v0.11 baseline", () => {
   expect(resolveRolloutTestMode(undefined)).toBe("rollout-standard");
   expect(rolloutPhaseTestProfiles("contracts", "rollout-standard")).toEqual(["rollout-standard"]);
   expect(rolloutPhaseTestProfiles("final", "rollout-standard")).toEqual(["rollout-standard"]);
   expect(() => resolveRolloutTestMode("standard")).toThrow("Unsupported ROLLOUT_TEST_PROFILE=standard");
+});
+
+test("gates the v0.11 baseline to the decrypt-free input-proof check in both modes", () => {
+  // v0.11 KMSVerifier has no getCurrentKmsContextId (added v0.12); the v0.13
+  // relayer-sdk decrypt path requires it, so decrypt profiles cannot run until
+  // the contracts phase reaches v0.12+.
+  expect(rolloutPhaseTestProfiles("baseline", "rollout-standard")).toEqual(["input-proof"]);
+  expect(rolloutPhaseTestProfiles("baseline", "rollout-heavy")).toEqual(["input-proof"]);
 });
 
 test("loads the checked-in v0.11 to v0.13 runbook", async () => {

--- a/test-suite/fhevm/src/rollout-v011.test.ts
+++ b/test-suite/fhevm/src/rollout-v011.test.ts
@@ -71,19 +71,12 @@ test("reuses the one-node ProtocolConfig mpc threshold normalization", () => {
   expect(JSON.parse(normalizeLocalOneNodeMpcThreshold(env).MIGRATION_KMS_THRESHOLDS).mpc).toBe("1");
 });
 
-test("defaults to rollout-standard at every phase except the v0.11 baseline", () => {
+test("defaults to rollout-standard at every phase", () => {
   expect(resolveRolloutTestMode(undefined)).toBe("rollout-standard");
+  expect(rolloutPhaseTestProfiles("baseline", "rollout-standard")).toEqual(["rollout-standard"]);
   expect(rolloutPhaseTestProfiles("contracts", "rollout-standard")).toEqual(["rollout-standard"]);
   expect(rolloutPhaseTestProfiles("final", "rollout-standard")).toEqual(["rollout-standard"]);
   expect(() => resolveRolloutTestMode("standard")).toThrow("Unsupported ROLLOUT_TEST_PROFILE=standard");
-});
-
-test("gates the v0.11 baseline to the decrypt-free input-proof check in both modes", () => {
-  // v0.11 KMSVerifier has no getCurrentKmsContextId (added v0.12); the v0.13
-  // relayer-sdk decrypt path requires it, so decrypt profiles cannot run until
-  // the contracts phase reaches v0.12+.
-  expect(rolloutPhaseTestProfiles("baseline", "rollout-standard")).toEqual(["input-proof"]);
-  expect(rolloutPhaseTestProfiles("baseline", "rollout-heavy")).toEqual(["input-proof"]);
 });
 
 test("loads the checked-in v0.11 to v0.13 runbook", async () => {

--- a/test-suite/fhevm/src/rollout-v011.test.ts
+++ b/test-suite/fhevm/src/rollout-v011.test.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { loadRolloutRunbook } from "./commands/rollout-run";
+import {
+  needsLocalOneNodeMpcNormalization,
+  normalizeLocalOneNodeMpcThreshold,
+  resolveRolloutTestMode,
+  rolloutPhaseTestProfiles,
+} from "../rollouts/v0.11-to-v0.13/run";
+import { phaseVersions, scenario } from "../rollouts/v0.11-to-v0.13/versions";
+
+const CLI_DIR = path.resolve(import.meta.dir, "..");
+
+test("starts from the v0.11 baseline contracts", () => {
+  expect(scenario).toBe("two-of-three");
+  expect(phaseVersions.baseline.GATEWAY_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.baseline.HOST_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.baseline.CORE_VERSION).toBe("v0.13.0");
+});
+
+test("hops host and gateway contracts through v0.12 before v0.13", () => {
+  expect(phaseVersions.contractsV012.GATEWAY_VERSION).toBe("v0.12.5");
+  expect(phaseVersions.contractsV012.HOST_VERSION).toBe("v0.12.5");
+  // The v0.12 contract waypoint touches nothing else.
+  expect(phaseVersions.contractsV012.CORE_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.contractsV012.RELAYER_VERSION).toBe(phaseVersions.baseline.RELAYER_VERSION);
+  expect(phaseVersions.contractsV012.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.11.0");
+
+  expect(phaseVersions.contractsV013.GATEWAY_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.contractsV013.HOST_VERSION).toBe("v0.13.0-6");
+});
+
+test("keeps every runtime component on v0.11 while contracts reach v0.13", () => {
+  expect(phaseVersions.contractsV013.RELAYER_VERSION).toBe(phaseVersions.baseline.RELAYER_VERSION);
+  expect(phaseVersions.contractsV013.CORE_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.contractsV013.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.11.0");
+  expect(phaseVersions.contractsV013.LISTENER_CORE_VERSION).toBe("v0.11.0");
+});
+
+test("jumps each runtime group straight from v0.11 to v0.13 in plan order", () => {
+  // relayer
+  expect(phaseVersions.relayer.RELAYER_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.relayer.CORE_VERSION).toBe("v0.13.0");
+  // kms (core + connector)
+  expect(phaseVersions.kms.CORE_VERSION).toBe("v0.13.20-0");
+  expect(phaseVersions.kms.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.kms.LISTENER_CORE_VERSION).toBe("v0.11.0");
+  // listener-core moves before the coprocessor image changes
+  expect(phaseVersions.listenerCore.LISTENER_CORE_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.listenerCore.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.11.0");
+  // coprocessor last
+  expect(phaseVersions.coprocessor.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.13.0-6");
+  expect(phaseVersions.coprocessor.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.13.0-6");
+});
+
+test("pins the test harness to the target across every phase", () => {
+  for (const phase of Object.values(phaseVersions)) {
+    expect(phase.TEST_SUITE_VERSION).toBe("v0.13.0-6");
+    expect(phase.RELAYER_SDK_VERSION).toBe("0.4.2");
+  }
+});
+
+test("reuses the one-node ProtocolConfig mpc threshold normalization", () => {
+  const env = {
+    MIGRATION_KMS_NODES: JSON.stringify([{ txSenderAddress: "0x1" }]),
+    MIGRATION_KMS_THRESHOLDS: JSON.stringify({ publicDecryption: "1", userDecryption: "1", kmsGen: "1", mpc: "0" }),
+  };
+  expect(needsLocalOneNodeMpcNormalization(env)).toBe(true);
+  expect(JSON.parse(normalizeLocalOneNodeMpcThreshold(env).MIGRATION_KMS_THRESHOLDS).mpc).toBe("1");
+});
+
+test("defaults to rollout-standard at every phase", () => {
+  expect(resolveRolloutTestMode(undefined)).toBe("rollout-standard");
+  expect(rolloutPhaseTestProfiles("contracts", "rollout-standard")).toEqual(["rollout-standard"]);
+  expect(rolloutPhaseTestProfiles("final", "rollout-standard")).toEqual(["rollout-standard"]);
+  expect(() => resolveRolloutTestMode("standard")).toThrow("Unsupported ROLLOUT_TEST_PROFILE=standard");
+});
+
+test("loads the checked-in v0.11 to v0.13 runbook", async () => {
+  await expect(loadRolloutRunbook(path.join(CLI_DIR, "rollouts/v0.11-to-v0.13/run.ts"))).resolves.toBeFunction();
+});


### PR DESCRIPTION
## What

Models the **direct mainnet upgrade** — fhevm **v0.11 / kms v0.13.0 → v0.13 / kms v0.13.20** — as a single stateful rollout runbook (`rollouts/v0.11-to-v0.13/`), so the path is exercised in CI before committing to it on mainnet. Mainnet skipped the v0.12 hop that testnet took, so this is a two-version jump with backward-compatibility windows that don't exist in the single-version `v0.12-to-v0.13` runbook.

Driven by the mainnet-upgrade thread (Daniel / Amina / Antoniu). The runbook synthesises Amina's staged plan with the proven rollout-harness ordering. Target pins are the **released finals**: fhevm `v0.13.0`, kms-core `v0.13.20`.

## Phase model

| Phase | Action | Versions |
|---|---|---|
| baseline | boot full stack | everything **v0.11.0**, kms-core v0.13.0, relayer v0.11.0-rc.1, target test-suite harness |
| contracts (hop 1) | plain UUPS upgrades | host+gateway → **v0.12.5** |
| contracts (hop 2) | full ProtocolConfig / KMSGeneration state migration | host+gateway → **v0.13.0** |
| relayer | straight jump | → v0.13.0 |
| kms | straight jump, core + connector together | core → v0.13.20, connector → v0.13.0 |
| listener-core | straight jump | → v0.13.0 |
| coprocessor | straight jump (**last**) | → v0.13.0 |

The `rollout-standard` e2e suite runs after each phase. **Coprocessor is upgraded last on purpose**: through the contracts/relayer/kms/listener phases an old v0.11 coprocessor runs against fully-migrated v0.13 contracts — the compatibility boundary this rollout exists to probe.

## Result: full pass on the final release tags

Run [27412980615](https://github.com/zama-ai/fhevm/actions/runs/27412980615) completed the entire runbook green: baseline (pure v0.11, full decrypt paths with relayer-sdk 0.4.2), both contract hops, then `rollout-standard` passing after **every** runtime phase — including the v0.11-coprocessor-against-v0.13.0-contracts window, and including delegated user decryption at each phase.

### History: earlier failures, and why they were not a compatibility break

Three earlier runs (against the `v0.13.0-6` RC contracts) failed the delegated-decrypt smartWallet test in the post-contracts phase with relayer 503 `Ciphertext not ready for decryption on the gateway chain`, which initially looked like a cross-version protocol break (v0.12 handle-hashing change #2014, context-aware extraData #2143/#2392). The evidence now contradicts that interpretation:

- The **same test failed identically once on the pure-v0.11 baseline** (run 27411231991 attempt 1) — no version boundary in play at all. In that run the requested ciphertext material was committed to the gateway (`addCiphertext txn succeeded`) 6 s into the relayer's 90 s readiness loop, yet the v0.11 relayer reported "Gateway not ready" for all 45 polls.
- In the "failing boundary" runs, the v0.11 coprocessor's commits against v0.13 contracts were **48 succeeded / 4 transient failures, every failure retried to success within ~2 s** — incompatible with a deterministic handle-derivation break.
- The contracts delta `v0.13.0-6 → v0.13.0` (audit fixes #2719–#2727) touches nothing in the commit path, so it cannot explain the flip from red to green.

Conclusion: the recurring failure is a **flaky readiness race around freshly-computed handles in delegated decryption, present in the v0.11 stack itself** (relayer `ciphertext_checker` sometimes never observes a committed material within its retry window). It is noise relative to the upgrade-path question, though it may merit its own investigation in the relayer.

### What this does and does not establish

- ✅ The staged v0.11→v0.13 plan (contracts batch through v0.12, runtime components jumping once, coprocessor last) passes the e2e suite at every intermediate state, on final release tags, in CI.
- ⚠️ CI runs synthetic, quiet traffic on a fresh chain: no historical DB state, no reorgs, no concurrent load. A green here is necessary, not sufficient (per Antoniu's caveat in the thread).
- ✅ The delegated-decrypt readiness flake (4 of 6 earlier executions: twice on the pure-v0.11 baseline, twice in the post-contracts phase) is **root-caused and pinned away**. Forensics: in both examined failures the ciphertext material was committed to the gateway ~6 s after the relayer's readiness loop started and the relayer never observed it across 45 polls. The baseline had pinned relayer `v0.11.0-rc.1`, which predates two readiness-path fixes shipped in relayer `v0.11.0` final — console#914 (gateway listener websocket log subscription broke on topic filters, so events arriving after subscribe were missed) and console#925 (backward-compatible `isUserDecryptionReady`). With the baseline bumped to `v0.11.1` the full runbook passed; the flake never reproduced under a ≥v0.11.0 relayer.

## CLI changes (needed to model the path; default behaviour unchanged)

- **`fromLockedImage` option for `snapshotContracts` / `snapshotContractSources`.** The persistent `*-sc-deploy` container keeps the image it booted with, so for the **second** contract hop a plain `docker cp` would re-capture v0.11 sources and seed the OpenZeppelin manifest with the wrong storage layout. The new option snapshots `/app/contracts` from a throwaway container started on the currently-locked (v0.12) deploy image. Hop 1 still uses the plain path.
- **e2e Dockerfile honours `RELAYER_SDK_VERSION`.** Workspace hoisting + the committed lockfile silently kept `0.5.0-alpha.2` installed under a `0.4.2` pin (which made the v0.11 baseline look decrypt-broken when it isn't). The hotswap branch now adds a root `overrides` entry, drops the lockfile so npm re-resolves one coherent graph, and a build-time assertion fails loudly if the resolved version differs from the pin.
- **Rollout workflow: unshallow base fetch** when inferring the runbook (a depth-1 fetch of a moved base tip has no merge base, breaking re-runs), and **log tail widened to 1000** so a failing phase captures the full compute/commit window.

## How to run

CI auto-infers this runbook on a PR labelled `rollout`, or:

```
fhevm-cli rollout run ./rollouts/v0.11-to-v0.13/run.ts
```

## Status / caveats

- `RELAYER_VERSION` at baseline (`v0.11.0-rc.1`) is the least-certain pin — relayer repo versioning is offset from the fhevm meta-version and mainnet is described as "v0.9".
- Local pre-checks green: `bun run check`, `bun test src` (178 pass), `bun run compat-smoke`.

🤖 Drafted with Claude Code on behalf of @eliastazartes.
