### PR TITLE
test(sdk): fixes for localstack v12 and v13

### DIFF
--- a/sdk/js-sdk/test/fheTest/setup-ethers.ts
+++ b/sdk/js-sdk/test/fheTest/setup-ethers.ts
@@ -69,13 +69,17 @@ function _buildConfig(env: FheTestBaseEnv): FheTestEthersConfig {
 
   const bobWallet = ethers.HDNodeWallet.fromMnemonic(ethers.Mnemonic.fromPhrase(env.mnemonic), "m/44'/60'/0'/0/1");
 
-  // Use a ethers.NonceManager to avoid nonce issues in parallel mode
-  const signer = new ethers.NonceManager(wallet.connect(provider));
+  // Tests send transactions sequentially (each loop iteration awaits tx.wait()
+  // before the next). Using NonceManager adds a cached-delta layer on top of
+  // populateTransaction's own eth_getTransactionCount fetch, creating a window
+  // where both compute the same nonce on fast local chains (anvil auto-mine).
+  // Plain connected wallets query the chain nonce fresh per send and are safe
+  // for sequential flows.
+  const signer = wallet.connect(provider);
 
   const fheTestContract = new ethers.Contract(env.fheTestAddress, FHETestABI, signer);
 
-  // Use a ethers.NonceManager to avoid nonce issues in parallel mode
-  const bobSigner = new ethers.NonceManager(bobWallet.connect(provider));
+  const bobSigner = bobWallet.connect(provider);
 
   return {
     chainName: env.chainName,

--- a/sdk/js-sdk/test/fheTest/setupCommon.ts
+++ b/sdk/js-sdk/test/fheTest/setupCommon.ts
@@ -320,6 +320,12 @@ function initAliceFheTestHandlesIfNeeded(
   if (!aliceHasAllFheTestHandles(fheTestAddress, aliceAddress, rpcUrl)) {
     throw new Error(`FHETest initFheTest(false) completed but Alice handles are still missing for ${aliceAddress}.`);
   }
+
+  // The coprocessor registers Alice's handles on the gateway CiphertextCommits contract
+  // asynchronously. Tests that call the relayer for public/user decryption need
+  // this registration to complete before the relayer's readiness check passes.
+  // We block the setup thread briefly so the coprocessor can catch up.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 30_000);
 }
 
 /**

--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -186,7 +186,9 @@ describe("compat", () => {
     ).toBe(false);
   });
 
-  test("does not require legacy host chain seed shim for v0.13 coprocessor images", () => {
+  test("requires legacy host chain seed shim for v0.13.0 coprocessor images", () => {
+    // initialize_db.sh gained declarative seeding after v0.13.0 was cut;
+    // all v0.13.0-N Docker builds still need the harness shim.
     expect(
       requiresLegacyHostChainSeedShim({
         versions: {
@@ -195,6 +197,22 @@ describe("compat", () => {
           env: {
             COPROCESSOR_DB_MIGRATION_VERSION: "v0.13.0-6",
             COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.13.0-6",
+          } as Record<string, string>,
+          sources: [],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("does not require legacy host chain seed shim for v0.13.1+ coprocessor images", () => {
+    expect(
+      requiresLegacyHostChainSeedShim({
+        versions: {
+          target: "latest-supported",
+          lockName: "v0.13.1.json",
+          env: {
+            COPROCESSOR_DB_MIGRATION_VERSION: "v0.13.1",
+            COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.13.1",
           } as Record<string, string>,
           sources: [],
         },

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -251,16 +251,18 @@ export const supportsCoprocessorDbStateRevert = (state: Pick<CompatState, "versi
  *
  * The host_chains table only exists from v0.12.0 onward (the remove_tenants
  * migration splits it out of the old `tenants` table); v0.11.x images have no
- * such table, so seeding it would fail. Within [0.12.0, 0.13.0) the table
+ * such table, so seeding it would fail. Within [0.12.0, 0.13.1) the table
  * exists but the runtime does not reliably seed it before zkproof caches it, so
- * the harness seeds it manually. From v0.13.0 the runtime self-seeds.
+ * the harness seeds it manually. Declarative seeding was added to
+ * initialize_db.sh after v0.13.0 was cut, so all v0.13.0-N Docker builds still
+ * need the manual shim; v0.13.1+ images self-seed.
  */
 export const requiresLegacyHostChainSeedShim = (state: Pick<CompatState, "versions">) => {
   const dbMigrationVersion = state.versions.env.COPROCESSOR_DB_MIGRATION_VERSION ?? "";
   const hostChainsTableExists = !versionBeforeReleaseFamily(dbMigrationVersion, [0, 12, 0], { unparsed: "modern" });
   const runtimeNeedsManualSeed =
-    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 0], { unparsed: "modern" }) ||
-    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 0], {
+    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 1], { unparsed: "modern" }) ||
+    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 1], {
       unparsed: "modern",
     });
   return hostChainsTableExists && runtimeNeedsManualSeed;


### PR DESCRIPTION
## Changes

### Fix "nonce has already been used" error (`setup-ethers.ts`)

Removed `ethers.NonceManager` from both `signer` and `bobSigner`.

`NonceManager` maintains a cached nonce delta on top of each
`eth_getTransactionCount` call. On fast local chains (e.g. anvil with
auto-mining), a sequential test loop (`await tx.wait()` before each
send) can still hit a window where both `NonceManager` and
`populateTransaction` independently fetch the same nonce, causing
duplicate-nonce errors.

Since tests in this suite are sequential, plain connected wallets that
query the chain nonce fresh on every send are the correct choice.

### Fix fheTests for localstack v12 (`setupCommon.ts`)

Added a 30-second `Atomics.wait` block at the end of
`initAliceFheTestHandlesIfNeeded`.

The coprocessor registers Alice's handles on the gateway
`CiphertextCommits` contract asynchronously. Tests that invoke the
relayer for public or user decryption require that registration to be
complete before the relayer's readiness check passes. The blocking wait
gives the coprocessor time to catch up before the test run proceeds.
