### PR TITLE
fix(coprocessor): revert input rerand before expand (#2383)

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
@@ -722,6 +722,48 @@ impl SupportedFheCiphertexts {
         }
     }
 
+    pub fn add_re_randomization_metadata(&mut self, hash_data: &[u8]) {
+        match self {
+            SupportedFheCiphertexts::FheBool(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint4(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint8(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint16(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint32(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint64(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint128(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint160(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheUint256(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheBytes64(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheBytes128(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::FheBytes256(ct) => {
+                ct.re_randomization_metadata_mut().set_data(hash_data);
+            }
+            SupportedFheCiphertexts::Scalar(_) => (),
+        }
+    }
+
     pub fn add_to_rerandomisation_context(&self, context: &mut ReRandomizationContext) {
         match self {
             SupportedFheCiphertexts::FheBool(c) => context.add_ciphertext(c),

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -130,7 +130,7 @@ async fn test_max_input_index() {
 
 #[tokio::test]
 #[serial(db)]
-async fn test_verify_proof_rerandomises_compact_list_before_expansion() {
+async fn test_verify_proof_rerandomises_ciphertexts_before_storage() {
     let (pool_mngr, _instance) = utils::setup().await.expect("valid setup");
     let pool = pool_mngr.pool();
 
@@ -193,17 +193,6 @@ async fn test_verify_proof_rerandomises_compact_list_before_expansion() {
             .zip(&baseline)
             .all(|(stored_ct, baseline_ct)| stored_ct.ciphertext != *baseline_ct),
         "stored ciphertexts should differ from the pre-rerandomization compression"
-    );
-
-    let expected = utils::compress_inputs_with_compact_list_rerandomization(&pool, &zk_pok, &aux.0)
-        .await
-        .unwrap();
-    assert_eq!(
-        stored
-            .iter()
-            .map(|ct| ct.ciphertext.clone())
-            .collect::<Vec<_>>(),
-        expected
     );
 
     let decrypted = utils::decrypt_ciphertexts(&pool, &handles).await.unwrap();

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
@@ -5,8 +5,6 @@ use fhevm_engine_common::pg_pool::PostgresPoolManager;
 use fhevm_engine_common::tfhe_ops::{current_ciphertext_version, extract_ct_list};
 use fhevm_engine_common::types::SupportedFheCiphertexts;
 use fhevm_engine_common::utils::{safe_deserialize_conformant, safe_serialize};
-use sha3::Digest;
-use sha3::Keccak256;
 use sqlx::Row;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -225,63 +223,6 @@ pub(crate) async fn compress_inputs_without_rerandomization(
         let expanded = verified_list.expand_without_verification()?;
         let cts = extract_ct_list(&expanded)?;
         cts.into_iter()
-            .map(|ct| ct.compress().map_err(anyhow::Error::from))
-            .collect()
-    })
-    .await?
-}
-
-pub(crate) async fn compress_inputs_with_compact_list_rerandomization(
-    pool: &sqlx::PgPool,
-    raw_ct: &[u8],
-    aux_data: &ZkData,
-) -> anyhow::Result<Vec<Vec<u8>>> {
-    let db_key_cache = DbKeyCache::new(MAX_CACHED_KEYS).expect("create db key cache");
-    let latest_key = db_key_cache.fetch_latest_from_pool(pool).await?;
-    let latest_crs = CrsCache::load(pool)
-        .await?
-        .get_latest()
-        .cloned()
-        .expect("latest CRS");
-    let aux_data_bytes = aux_data.assemble()?;
-
-    let verified_list: tfhe::ProvenCompactCiphertextList = safe_deserialize_conformant(
-        raw_ct,
-        &IntegerProvenCompactCiphertextListConformanceParams::from_public_key_encryption_parameters_and_crs_parameters(
-            latest_key.pks.parameters(),
-            &latest_crs.crs,
-        ),
-    )?;
-
-    if verified_list.is_empty() {
-        return Ok(vec![]);
-    }
-
-    assert!(verified_list
-        .verify(&latest_crs.crs, &latest_key.pks, &aux_data_bytes)
-        .is_valid());
-
-    let mut hasher = Keccak256::new();
-    hasher.update(crate::verifier::RAW_CT_HASH_DOMAIN_SEPARATOR);
-    hasher.update(raw_ct);
-    let blob_hash = hasher.finalize().to_vec();
-
-    tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<Vec<u8>>> {
-        tfhe::set_server_key(latest_key.sks.clone());
-
-        let mut re_rand_context = tfhe::ReRandomizationContext::new(
-            crate::verifier::RERANDOMISATION_DOMAIN_SEPARATOR,
-            [blob_hash.as_slice()],
-            crate::verifier::COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR,
-        );
-        re_rand_context.add_ciphertext(&verified_list);
-
-        let mut seed_gen = re_rand_context.finalize();
-        let expanded = verified_list
-            .re_randomize_and_expand_without_verification(&latest_key.pks, seed_gen.next_seed()?)?;
-
-        let mut cts = extract_ct_list(&expanded)?;
-        cts.iter_mut()
             .map(|ct| ct.compress().map_err(anyhow::Error::from))
             .collect()
     })

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -16,7 +16,6 @@ use sqlx::{postgres::PgListener, PgPool};
 use sqlx::{Postgres, Transaction};
 use std::str::FromStr;
 use tfhe::integer::ciphertext::IntegerProvenCompactCiphertextListConformanceParams;
-use tfhe::prelude::CiphertextList;
 use tfhe::ReRandomizationContext;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
@@ -38,10 +37,10 @@ use tracing::{debug, error, info};
 pub const MAX_CACHED_KEYS: usize = 100;
 const EVENT_CIPHERTEXT_COMPUTED: &str = "event_ciphertext_computed";
 
-pub(crate) const RAW_CT_HASH_DOMAIN_SEPARATOR: [u8; 8] = *b"ZK-w_rct";
-pub(crate) const HANDLE_HASH_DOMAIN_SEPARATOR: [u8; 8] = *b"ZK-w_hdl";
-pub(crate) const RERANDOMISATION_DOMAIN_SEPARATOR: [u8; 8] = *b"ZKw_Rrnd";
-pub(crate) const COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR: [u8; 8] = *b"TFHE_Enc";
+const RAW_CT_HASH_DOMAIN_SEPARATOR: [u8; 8] = *b"ZK-w_rct";
+const HANDLE_HASH_DOMAIN_SEPARATOR: [u8; 8] = *b"ZK-w_hdl";
+const RERANDOMISATION_DOMAIN_SEPARATOR: [u8; 8] = *b"ZKw_Rrnd";
+const COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR: [u8; 8] = *b"TFHE_Enc";
 
 pub(crate) struct Ciphertext {
     handle: Vec<u8>,
@@ -456,22 +455,25 @@ pub(crate) fn verify_proof(
     let verified_list = verify_proof_only(request_id, raw_ct, key, crs, aux_data)
         .inspect_err(telemetry::set_current_span_error)?;
 
-    // Step 2: Compute blob hash used to seed the compact-list re-randomization
+    // Step 2: Expand the verified ciphertext list
+    let mut cts = expand_verified_list(request_id, &verified_list)
+        .inspect_err(telemetry::set_current_span_error)?;
+
+    // Step 3: Compute blob hash and set re-randomization metadata on all ciphertexts
     let mut h = Keccak256::new();
     h.update(RAW_CT_HASH_DOMAIN_SEPARATOR);
     h.update(raw_ct);
     let blob_hash = h.finalize().to_vec();
 
-    // Step 3: Re-randomize the verified compact list, then expand
-    let mut cts = rerand_and_expand_verified_list(request_id, &verified_list, &blob_hash, &key.pks)
-        .inspect_err(telemetry::set_current_span_error)?;
-
-    // Step 4: Compute handle hashes
     let handles: Vec<Vec<u8>> = cts
         .iter_mut()
         .enumerate()
-        .map(|(idx, _ct)| compute_handle_hash(&blob_hash, idx, aux_data))
+        .map(|(idx, ct)| set_ciphertext_metadata(&blob_hash, idx, ct, aux_data))
         .collect::<Result<Vec<_>, ExecutionError>>()
+        .inspect_err(telemetry::set_current_span_error)?;
+
+    // Step 4: Re-randomize all ciphertexts before compression
+    re_randomise_ciphertexts(&mut cts, &blob_hash, &key.pks)
         .inspect_err(telemetry::set_current_span_error)?;
 
     // Step 5: Compress and build final ciphertext records
@@ -540,42 +542,18 @@ fn verify_proof_only(
 }
 
 #[tracing::instrument(name = "expand_ciphertext_list", skip_all, fields(count = tracing::field::Empty))]
-fn rerand_and_expand_verified_list(
+fn expand_verified_list(
     request_id: i64,
     the_list: &tfhe::ProvenCompactCiphertextList,
-    blob_hash: &[u8],
-    cpk: &tfhe::CompactPublicKey,
 ) -> Result<Vec<SupportedFheCiphertexts>, ExecutionError> {
     if the_list.is_empty() {
         return Ok(vec![]);
     }
 
-    let mut re_rand_context = ReRandomizationContext::new(
-        RERANDOMISATION_DOMAIN_SEPARATOR,
-        [blob_hash],
-        COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR,
-    );
-    re_rand_context.add_ciphertext(the_list);
-    let mut seed_gen = re_rand_context.finalize();
-    let seed = seed_gen
-        .next_seed()
-        .map_err(FhevmError::ReRandomisationError)?;
-
-    let rerand_expand_span = tracing::info_span!(
-        "rerandomize_and_expand_ciphertext_list",
-        request_id,
-        input_count = the_list.len(),
-        expanded_count = tracing::field::Empty,
-    );
-    let expanded: tfhe::CompactCiphertextListExpander = rerand_expand_span.in_scope(|| {
-        let expanded = the_list
-            .re_randomize_and_expand_without_verification(cpk, seed)
-            .map_err(|err| ExecutionError::InvalidProof(request_id, err.to_string()))
-            .inspect_err(telemetry::set_current_span_error)?;
-
-        tracing::Span::current().record("expanded_count", expanded.len());
-        Ok::<_, ExecutionError>(expanded)
-    })?;
+    let expanded: tfhe::CompactCiphertextListExpander = the_list
+        .expand_without_verification()
+        .map_err(|err| ExecutionError::InvalidProof(request_id, err.to_string()))
+        .inspect_err(telemetry::set_current_span_error)?;
 
     let cts = extract_ct_list(&expanded)
         .map_err(ExecutionError::from)
@@ -584,11 +562,12 @@ fn rerand_and_expand_verified_list(
     Ok(cts)
 }
 
-/// Computes the handle hash
+/// Computes the handle hash and sets re-randomization metadata on a ciphertext.
 /// Returns the full 256-bit handle hash (before index/chain/type/version are patched in).
-fn compute_handle_hash(
+fn set_ciphertext_metadata(
     blob_hash: &[u8],
     ct_idx: usize,
+    the_ct: &mut SupportedFheCiphertexts,
     aux_data: &auxiliary::ZkData,
 ) -> Result<Vec<u8>, ExecutionError> {
     if ct_idx > MAX_INPUT_INDEX as usize {
@@ -610,7 +589,36 @@ fn compute_handle_hash(
     let handle = handle_hash.finalize().to_vec();
     assert_eq!(handle.len(), 32);
 
+    // Add the full 256bit hash as re-randomization metadata, NOT the
+    // truncated hash of the handle
+    the_ct.add_re_randomization_metadata(&handle);
+
     Ok(handle)
+}
+
+/// Re-randomizes all ciphertexts using the compact public key.
+#[tracing::instrument(name = "rerandomise_cts", skip_all)]
+fn re_randomise_ciphertexts(
+    cts: &mut [SupportedFheCiphertexts],
+    blob_hash: &[u8],
+    cpk: &tfhe::CompactPublicKey,
+) -> Result<(), ExecutionError> {
+    let mut re_rand_context = ReRandomizationContext::new(
+        RERANDOMISATION_DOMAIN_SEPARATOR,
+        [blob_hash],
+        COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR,
+    );
+    for ct in cts.iter() {
+        ct.add_to_re_randomization_context(&mut re_rand_context);
+    }
+    let mut seed_gen = re_rand_context.finalize();
+    for ct in cts.iter_mut() {
+        let seed = seed_gen
+            .next_seed()
+            .map_err(FhevmError::ReRandomisationError)?;
+        ct.re_randomise(cpk, seed)?;
+    }
+    Ok(())
 }
 
 /// Compresses the ciphertext and builds the final Ciphertext record with patched handle.


### PR DESCRIPTION
This reverts commit 847c02777d92a49718d3341bfcd38fd4c860fc7a.

The original change is consensus-breaking: re-randomising inputs before expand instead of before compression means ciphertexts are no longer bitwise-equal across coprocessors for the same input with the planned upgrade process. The upcoming release cannot ship consensus-breaking changes without production downtime, so we revert now and re-introduce this once blue-green upgrade is available.