### PR TITLE
fix(test-suite): restore createEncryptedInput template for mocked ope…

### DIFF
--- a/library-solidity/codegen/src/testgen.ts
+++ b/library-solidity/codegen/src/testgen.ts
@@ -490,6 +490,15 @@ export function generateTypeScriptTestCode(
           })
           .filter((s) => s !== '')
           .join(', ');
+        const inputsAdd = t.inputs
+          .map((v, index) => {
+            if (o.arguments[index].type == ArgumentType.Euint) {
+              return `input.add${o.arguments[index].bits}(${v}n);`;
+            } else {
+              return '';
+            }
+          })
+          .join('\n');
         let expectedOutput = t.output.toString();
         if (typeof t.output === 'bigint' || typeof t.output === 'number') expectedOutput += 'n';
 
@@ -514,11 +523,9 @@ export function generateTypeScriptTestCode(
         } else {
           res.push(`
                 it('${testName} test ${testIndex} (${testArgs})', async function () {
-                    const encryptedAmount = await this.instances.alice.encryptTypedValues({
-                      values: [${typedValues}],
-                      contractAddress: this.contract${os.shardNumber}Address,
-                      userAddress: this.signers.alice.address,
-                    });
+                    const input = this.instances.alice.createEncryptedInput(this.contract${os.shardNumber}Address, this.signers.alice.address);
+                    ${inputsAdd}
+                    const encryptedAmount = await input.encrypt();
                     const tx = await this.contract${os.shardNumber}.${methodName}(${testArgsEncrypted}, encryptedAmount.inputProof);
                     await tx.wait();
                     const res = await decrypt${o.returnType.type === 1 ? o.returnType.bits : 'Bool'}(await this.contract${os.shardNumber}.res${o.returnType.type === 1 ? `Euint${o.returnType.bits}` : 'Ebool'}());


### PR DESCRIPTION
…rator tests

The cherry-pick of #2733 (129dad3a1) migrated both test templates in testgen.ts to the encryptTypedValues API, but on main only the publicDecrypt branch (used by test-suite e2e generation) was migrated. The mocked-instance branch, which generates
host-contracts/test/fhevmOperations/* and
library-solidity/test/fhevmOperations/*, was over-converted without regenerating those 26 files, so codegen-check fails on every PR into release/0.13.x that touches a codegen-filter path.

Restore the mocked-instance template to its state on main so codegen output matches the committed generated files again.