### PR TITLE
feat(host-contracts): export and mirror canonical ProtocolConfig state

### DIFF
--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -123,12 +123,16 @@ skipped. Operators are responsible for fan-out correctness.
 
 ### Initializing a non-canonical ProtocolConfig from the canonical chain
 
-The Ethereum `ProtocolConfig` is the source of truth for protocol state. New host chains seed
-their replica from it — not from the Gateway: the Gateway-based export
-(`task:exportKmsMigrationState` and the migration env plumbing) is superseded by the canonical
-export below as the state source for non-canonical chains.
+The Ethereum `ProtocolConfig` is the source of truth for protocol state, so **new** host chains
+seed their replica from it. (The Gateway-based export `task:exportKmsMigrationState` remains the
+mechanism for the one-time Gateway → Ethereum migration of existing deployments; it is just no
+longer the state source for seeding non-canonical chains.)
 
-Export the canonical KMS context to a reviewable JSON artifact:
+The flow is artifact-centric — the same three steps in every environment, only the signer of
+step 3 changes:
+
+**1. Export** the canonical KMS context to a reviewable JSON artifact (works from a clean
+checkout; needs only RPC access):
 
 ```bash
 npx hardhat task:exportCanonicalProtocolConfig \
@@ -139,18 +143,32 @@ npx hardhat task:exportCanonicalProtocolConfig \
 
 The artifact records the canonical chainId, the block number the read was pinned to, the
 contract address, the current KMS context id, the KMS node set, and all four thresholds
-(bigints serialized as strings). All reads happen at one block, so DAO signers reproduce the
-artifact byte-for-byte — even after a later `defineNewKmsContext` rotation — by re-running with
-`--block-number <N>` from the artifact and diffing the output.
+(bigints serialized as strings).
 
-Initialize the local replica from the canonical state (reads canonical via RPC at deploy time,
-then upgrades the local `ProtocolConfig` proxy via `initializeFromMigration` so the replica
-lands on canonical's `currentKmsContextId` instead of starting a fresh counter):
+**2. Review.** All reads happen at one block, so reviewers (e.g. DAO signers) reproduce the
+artifact byte-for-byte — even after a later `defineNewKmsContext` rotation — by re-running the
+export with `--block-number <N>` from the artifact and diffing the output.
+
+**3. Apply** the reviewed artifact to the local `ProtocolConfig` proxy. Both paths upgrade the
+empty proxy via `initializeFromMigration`, so the replica lands on canonical's
+`currentKmsContextId` instead of starting a fresh counter.
+
+| Environment       | Task                                                                       | Signer                                              |
+| ----------------- | -------------------------------------------------------------------------- | --------------------------------------------------- |
+| devnet / local    | `task:deployProtocolConfigFromCanonical --snapshot <artifact.json>`        | `DEPLOYER_PRIVATE_KEY`                              |
+| testnet / mainnet | `task:prepareDeployProtocolConfigFromCanonical --snapshot <artifact.json>` | DAO executes the printed `upgradeToAndCall` payload |
 
 ```bash
-npx hardhat task:deployProtocolConfigFromCanonical \
-  --canonical-rpc-url https://mainnet.example \
-  --canonical-protocol-config-address 0x...
+# devnet: direct upgrade with the deployer key
+npx hardhat task:deployProtocolConfigFromCanonical --snapshot canonical-protocol-config-snapshot.json
+
+# testnet/mainnet: deploy the implementation and print the DAO payload, without touching the proxy
+npx hardhat task:prepareDeployProtocolConfigFromCanonical --snapshot canonical-protocol-config-snapshot.json
 ```
+
+For quick devnet iteration, `task:deployProtocolConfigFromCanonical` also accepts
+`--canonical-rpc-url` + `--canonical-protocol-config-address` instead of `--snapshot` to read
+canonical live at deploy time — but then what is deployed is whatever canonical holds at that
+moment, not a reviewed artifact. The DAO path is artifact-only by design.
 
 Later canonical rotations are mirrored manually with `defineNewKmsContext`, as described above.

--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -174,4 +174,9 @@ For quick devnet iteration, `task:deployProtocolConfigFromCanonical` also accept
 canonical live at deploy time — but then what is deployed is whatever canonical holds at that
 moment, not a reviewed artifact. The DAO path is artifact-only by design.
 
+When deploying a full non-canonical host stack, `task:deployAllHostContracts
+--protocol-config-source canonical --canonical-rpc-url … --canonical-protocol-config-address …`
+runs the mirror in sequence with the other host contracts (this is what the fhevm-cli multi-chain
+stack uses, so e2e seeds non-canonical chains exactly like production).
+
 Later canonical rotations are mirrored manually with `defineNewKmsContext`, as described above.

--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -120,3 +120,37 @@ rotation to non-canonical chains call `defineNewKmsContext` directly on each non
 
 No on-chain guard prevents a non-canonical replica from drifting if a mirror transaction is
 skipped. Operators are responsible for fan-out correctness.
+
+### Initializing a non-canonical ProtocolConfig from the canonical chain
+
+The Ethereum `ProtocolConfig` is the source of truth for protocol state. New host chains seed
+their replica from it — not from the Gateway: the Gateway-based export
+(`task:exportKmsMigrationState` and the migration env plumbing) is superseded by the canonical
+export below as the state source for non-canonical chains.
+
+Export the canonical KMS context to a reviewable JSON artifact:
+
+```bash
+npx hardhat task:exportCanonicalProtocolConfig \
+  --canonical-rpc-url https://mainnet.example \
+  --canonical-protocol-config-address 0x... \
+  --out canonical-protocol-config-snapshot.json
+```
+
+The artifact records the canonical chainId, the block number the read was pinned to, the
+contract address, the current KMS context id, the KMS node set, and all four thresholds
+(bigints serialized as strings). All reads happen at one block, so DAO signers reproduce the
+artifact byte-for-byte — even after a later `defineNewKmsContext` rotation — by re-running with
+`--block-number <N>` from the artifact and diffing the output.
+
+Initialize the local replica from the canonical state (reads canonical via RPC at deploy time,
+then upgrades the local `ProtocolConfig` proxy via `initializeFromMigration` so the replica
+lands on canonical's `currentKmsContextId` instead of starting a fresh counter):
+
+```bash
+npx hardhat task:deployProtocolConfigFromCanonical \
+  --canonical-rpc-url https://mainnet.example \
+  --canonical-protocol-config-address 0x...
+```
+
+Later canonical rotations are mirrored manually with `defineNewKmsContext`, as described above.

--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -149,9 +149,12 @@ contract address, the current KMS context id, the KMS node set, and all four thr
 artifact byte-for-byte — even after a later `defineNewKmsContext` rotation — by re-running the
 export with `--block-number <N>` from the artifact and diffing the output.
 
-**3. Apply** the reviewed artifact to the local `ProtocolConfig` proxy. Both paths upgrade the
-empty proxy via `initializeFromMigration`, so the replica lands on canonical's
-`currentKmsContextId` instead of starting a fresh counter.
+**3. Apply** the reviewed artifact to the local `ProtocolConfig` proxy. Both environments run the
+same prepare step — deploy the implementation and build the
+`upgradeToAndCall(initializeFromMigration(…))` payload, landing the replica on canonical's
+`currentKmsContextId` instead of a fresh counter. They differ only in who executes that payload:
+the devnet task sends it immediately with the deployer key, so **what runs on devnet is
+byte-identical to what the DAO signs**.
 
 | Environment       | Task                                                                       | Signer                                              |
 | ----------------- | -------------------------------------------------------------------------- | --------------------------------------------------- |

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -4,7 +4,7 @@ import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 import type { ProtocolConfig } from '../types';
 import { assertContractMatchesVersionPrefix } from './utils/contractVersion';
 import { formatError } from './utils/formatError';
-import { type UpgradeProposal, buildUpgradeProposal, getFunctionFragment } from './utils/upgradeProposal';
+import { type UpgradeProposal, buildUpgradeProposal } from './utils/upgradeProposal';
 
 export type KmsNode = {
   txSenderAddress: string;
@@ -117,12 +117,10 @@ export async function buildCanonicalUpgradeProposal(
     `Mirroring ProtocolConfig from canonical chain ${snapshot.canonicalChainId} at block ${snapshot.blockNumber} (${snapshot.blockHash}): contextId=${snapshot.currentKmsContextId}, kmsNodes=${snapshot.kmsNodes.length}.`,
   );
 
-  const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
-  const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
   return buildUpgradeProposal(hre, {
     proxyAddress,
     contractName: 'ProtocolConfig',
-    innerFunctionSignature,
+    innerFunctionName: 'initializeFromMigration',
     decodedArgs: [snapshot.currentKmsContextId, snapshot.kmsNodes, snapshot.thresholds],
   });
 }

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -5,11 +5,6 @@ import type { ProtocolConfig } from '../types';
 import { formatError } from './utils/formatError';
 import { getRequiredEnvVar } from './utils/loadVariables';
 
-export type SecondaryDeployArgs = {
-  canonicalRpcUrl: string;
-  canonicalProtocolConfigAddress: string;
-};
-
 export type KmsNode = {
   txSenderAddress: string;
   signerAddress: string;
@@ -112,10 +107,22 @@ export async function mirrorProtocolConfigFromCanonical(
     secondaryProxyAddress: string;
   },
 ): Promise<CanonicalSnapshot> {
-  const { ethers, upgrades } = hre;
   const { canonicalProvider, canonicalProtocolConfigAddress, secondaryProxyAddress } = options;
 
   const snapshot = await readCanonicalSnapshot(hre, { canonicalProvider, canonicalProtocolConfigAddress });
+  await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
+
+  return snapshot;
+}
+
+// Upgrades the secondary ProtocolConfig proxy and initializes it from an already-read snapshot —
+// either freshly read (mirrorProtocolConfigFromCanonical) or parsed from a reviewed export artifact.
+export async function applyCanonicalSnapshot(
+  hre: HardhatRuntimeEnvironment,
+  options: { snapshot: CanonicalSnapshot; secondaryProxyAddress: string },
+): Promise<void> {
+  const { ethers, upgrades } = hre;
+  const { snapshot, secondaryProxyAddress } = options;
   const { currentContextId, kmsNodes, thresholds, canonicalChainId, canonicalBlockTag } = snapshot;
   console.log(
     `Mirroring ProtocolConfig from canonical chain ${canonicalChainId} at block ${canonicalBlockTag}: contextId=${currentContextId}, kmsNodes=${kmsNodes.length}.`,
@@ -133,6 +140,87 @@ export async function mirrorProtocolConfigFromCanonical(
       args: [currentContextId, kmsNodes, thresholds],
     },
   });
+}
 
-  return snapshot;
+// The JSON shape written by task:exportCanonicalProtocolConfig. Bigints are serialized as strings
+// so DAO signers can diff artifacts as plain text.
+export type CanonicalSnapshotArtifact = {
+  canonicalChainId: string;
+  blockNumber: number;
+  protocolConfigAddress: string;
+  currentKmsContextId: string;
+  kmsNodes: KmsNode[];
+  thresholds: { publicDecryption: string; userDecryption: string; kmsGen: string; mpc: string };
+};
+
+export function buildSnapshotArtifact(
+  snapshot: CanonicalSnapshot,
+  protocolConfigAddress: string,
+): CanonicalSnapshotArtifact {
+  return {
+    canonicalChainId: snapshot.canonicalChainId.toString(),
+    blockNumber: snapshot.canonicalBlockTag,
+    protocolConfigAddress,
+    currentKmsContextId: snapshot.currentContextId.toString(),
+    kmsNodes: snapshot.kmsNodes,
+    thresholds: {
+      publicDecryption: snapshot.thresholds.publicDecryption.toString(),
+      userDecryption: snapshot.thresholds.userDecryption.toString(),
+      kmsGen: snapshot.thresholds.kmsGen.toString(),
+      mpc: snapshot.thresholds.mpc.toString(),
+    },
+  };
+}
+
+export function parseSnapshotArtifact(raw: string): {
+  snapshot: CanonicalSnapshot;
+  protocolConfigAddress: string;
+} {
+  let artifact: CanonicalSnapshotArtifact;
+  try {
+    artifact = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Snapshot artifact is not valid JSON (${formatError(err)}).`);
+  }
+
+  const requireBigint = (field: string, value: unknown): bigint => {
+    if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+      throw new Error(`Snapshot artifact field "${field}" must be a decimal string, got ${JSON.stringify(value)}.`);
+    }
+    return BigInt(value);
+  };
+
+  if (typeof artifact.blockNumber !== 'number') {
+    throw new Error(
+      `Snapshot artifact field "blockNumber" must be a number, got ${JSON.stringify(artifact.blockNumber)}.`,
+    );
+  }
+  if (typeof artifact.protocolConfigAddress !== 'string' || artifact.protocolConfigAddress.length === 0) {
+    throw new Error('Snapshot artifact field "protocolConfigAddress" is missing.');
+  }
+  if (!Array.isArray(artifact.kmsNodes) || artifact.kmsNodes.length === 0) {
+    throw new Error('Snapshot artifact field "kmsNodes" must be a non-empty array.');
+  }
+  for (const [index, node] of artifact.kmsNodes.entries()) {
+    for (const field of ['txSenderAddress', 'signerAddress', 'ipAddress', 'storageUrl'] as const) {
+      if (typeof node?.[field] !== 'string') {
+        throw new Error(`Snapshot artifact field "kmsNodes[${index}].${field}" is missing.`);
+      }
+    }
+  }
+
+  const snapshot: CanonicalSnapshot = {
+    currentContextId: requireBigint('currentKmsContextId', artifact.currentKmsContextId),
+    kmsNodes: artifact.kmsNodes,
+    thresholds: {
+      publicDecryption: requireBigint('thresholds.publicDecryption', artifact.thresholds?.publicDecryption),
+      userDecryption: requireBigint('thresholds.userDecryption', artifact.thresholds?.userDecryption),
+      kmsGen: requireBigint('thresholds.kmsGen', artifact.thresholds?.kmsGen),
+      mpc: requireBigint('thresholds.mpc', artifact.thresholds?.mpc),
+    },
+    canonicalChainId: requireBigint('canonicalChainId', artifact.canonicalChainId),
+    canonicalBlockTag: artifact.blockNumber,
+  };
+
+  return { snapshot, protocolConfigAddress: artifact.protocolConfigAddress };
 }

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -1,0 +1,138 @@
+import type { Provider } from 'ethers';
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+import type { ProtocolConfig } from '../types';
+import { formatError } from './utils/formatError';
+import { getRequiredEnvVar } from './utils/loadVariables';
+
+export type SecondaryDeployArgs = {
+  canonicalRpcUrl: string;
+  canonicalProtocolConfigAddress: string;
+};
+
+export type KmsNode = {
+  txSenderAddress: string;
+  signerAddress: string;
+  ipAddress: string;
+  storageUrl: string;
+};
+
+export type KmsThresholds = {
+  publicDecryption: bigint;
+  userDecryption: bigint;
+  kmsGen: bigint;
+  mpc: bigint;
+};
+
+export type CanonicalSnapshot = {
+  currentContextId: bigint;
+  kmsNodes: KmsNode[];
+  thresholds: KmsThresholds;
+  canonicalChainId: bigint;
+  canonicalBlockTag: number;
+};
+
+// Reads the canonical ProtocolConfig's current KMS context, pinned to one block. Shared by the
+// secondary mirror deploy and the export task so both seed from the exact same read. Pass blockTag
+// to pin to a historical block (the export artifact's blockNumber) so a DAO signer can reproduce a
+// snapshot byte-for-byte even after a later context rotation; omit it to read the latest block.
+export async function readCanonicalSnapshot(
+  hre: HardhatRuntimeEnvironment,
+  options: { canonicalProvider: Provider; canonicalProtocolConfigAddress: string; blockTag?: number },
+): Promise<CanonicalSnapshot> {
+  const { ethers } = hre;
+  const { canonicalProvider, canonicalProtocolConfigAddress, blockTag } = options;
+
+  const canonicalProtocolConfigBase = await ethers.getContractAt('ProtocolConfig', canonicalProtocolConfigAddress);
+  const canonicalProtocolConfig = canonicalProtocolConfigBase.connect(canonicalProvider) as ProtocolConfig;
+
+  let canonicalVersion: string;
+  try {
+    canonicalVersion = await canonicalProtocolConfig.getVersion();
+  } catch (err) {
+    throw new Error(
+      `Canonical ProtocolConfig identity check failed: contract at ${canonicalProtocolConfigAddress} does not expose getVersion() (${formatError(err)}).`,
+    );
+  }
+  if (!/^ProtocolConfig v\d/.test(canonicalVersion)) {
+    throw new Error(
+      `Canonical ProtocolConfig identity check failed: contract at ${canonicalProtocolConfigAddress} reports version "${canonicalVersion}"; expected "ProtocolConfig v<n>...".`,
+    );
+  }
+
+  let canonicalChainId: bigint;
+  let canonicalBlockTag: number;
+  try {
+    canonicalChainId = (await canonicalProvider.getNetwork()).chainId;
+    canonicalBlockTag = blockTag ?? (await canonicalProvider.getBlockNumber());
+  } catch (err) {
+    throw new Error(`Canonical RPC handshake failed (${formatError(err)}).`);
+  }
+  const at = { blockTag: canonicalBlockTag };
+
+  const currentContextId: bigint = await canonicalProtocolConfig.getCurrentKmsContextId(at);
+  if (currentContextId === 0n) {
+    throw new Error(
+      `Canonical ProtocolConfig at ${canonicalProtocolConfigAddress} has no active KMS context (currentKmsContextId=0); cannot mirror.`,
+    );
+  }
+  const isCurrentContextValid: boolean = await canonicalProtocolConfig.isValidKmsContext(currentContextId, at);
+  if (!isCurrentContextValid) {
+    throw new Error(
+      `Canonical ProtocolConfig's current context ${currentContextId} is destroyed; cannot mirror a destroyed context.`,
+    );
+  }
+
+  const [rawNodes, publicDecryption, userDecryption, kmsGen, mpc] = await Promise.all([
+    canonicalProtocolConfig.getKmsNodesForContext(currentContextId, at),
+    canonicalProtocolConfig.getPublicDecryptionThresholdForContext(currentContextId, at),
+    canonicalProtocolConfig.getUserDecryptionThresholdForContext(currentContextId, at),
+    canonicalProtocolConfig.getKmsGenThresholdForContext(currentContextId, at),
+    canonicalProtocolConfig.getMpcThresholdForContext(currentContextId, at),
+  ]);
+  const kmsNodes: KmsNode[] = rawNodes.map((node) => ({
+    txSenderAddress: node.txSenderAddress,
+    signerAddress: node.signerAddress,
+    ipAddress: node.ipAddress,
+    storageUrl: node.storageUrl,
+  }));
+  const thresholds: KmsThresholds = { publicDecryption, userDecryption, kmsGen, mpc };
+
+  return { currentContextId, kmsNodes, thresholds, canonicalChainId, canonicalBlockTag };
+}
+
+// Upgrades the secondary ProtocolConfig proxy and initializes it from the canonical snapshot. Reuses
+// ProtocolConfig.initializeFromMigration (originally the Gateway -> Ethereum migration initializer) to
+// land on canonical's currentKmsContextId rather than start a fresh counter.
+export async function mirrorProtocolConfigFromCanonical(
+  hre: HardhatRuntimeEnvironment,
+  options: {
+    canonicalProvider: Provider;
+    canonicalProtocolConfigAddress: string;
+    secondaryProxyAddress: string;
+  },
+): Promise<CanonicalSnapshot> {
+  const { ethers, upgrades } = hre;
+  const { canonicalProvider, canonicalProtocolConfigAddress, secondaryProxyAddress } = options;
+
+  const snapshot = await readCanonicalSnapshot(hre, { canonicalProvider, canonicalProtocolConfigAddress });
+  const { currentContextId, kmsNodes, thresholds, canonicalChainId, canonicalBlockTag } = snapshot;
+  console.log(
+    `Mirroring ProtocolConfig from canonical chain ${canonicalChainId} at block ${canonicalBlockTag}: contextId=${currentContextId}, kmsNodes=${kmsNodes.length}.`,
+  );
+
+  const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
+  const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
+  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  const newImplem = await ethers.getContractFactory('ProtocolConfig', deployer);
+  const proxy = await upgrades.forceImport(secondaryProxyAddress, currentImplementation);
+
+  await upgrades.upgradeProxy(proxy, newImplem, {
+    call: {
+      fn: 'initializeFromMigration',
+      args: [currentContextId, kmsNodes, thresholds],
+    },
+  });
+
+  return snapshot;
+}

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -2,8 +2,8 @@ import type { Provider } from 'ethers';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import type { ProtocolConfig } from '../types';
+import { type PreparedDaoUpgrade, getFunctionFragment, prepareDaoUpgrade } from './utils/daoUpgrade';
 import { formatError } from './utils/formatError';
-import { getRequiredEnvVar } from './utils/loadVariables';
 
 export type KmsNode = {
   txSenderAddress: string;
@@ -99,32 +99,29 @@ export async function readCanonicalSnapshot(
   return { currentKmsContextId, kmsNodes, thresholds, canonicalChainId, blockNumber };
 }
 
-// Upgrades the secondary ProtocolConfig proxy and initializes it from a snapshot — freshly read via
-// readCanonicalSnapshot or parsed from a reviewed export artifact. Reuses
-// ProtocolConfig.initializeFromMigration (originally the Gateway -> Ethereum migration initializer)
-// to land on canonical's currentKmsContextId rather than start a fresh counter.
-export async function applyCanonicalSnapshot(
+// Builds the upgrade for a secondary ProtocolConfig proxy from a snapshot — freshly read via
+// readCanonicalSnapshot or parsed from a reviewed export artifact: deploys the implementation and
+// returns the upgradeToAndCall(initializeFromMigration(...)) payload. The DAO path prints it for
+// signers; the direct (devnet) path executes the very same payload with the deployer key
+// (executePreparedDaoUpgrade). Reusing initializeFromMigration (originally the Gateway -> Ethereum
+// migration initializer) lands the replica on canonical's currentKmsContextId rather than starting
+// a fresh counter.
+export async function prepareCanonicalSnapshotUpgrade(
   hre: HardhatRuntimeEnvironment,
-  options: { snapshot: CanonicalSnapshot; secondaryProxyAddress: string },
-): Promise<void> {
-  const { ethers, upgrades } = hre;
-  const { snapshot, secondaryProxyAddress } = options;
-  const { currentKmsContextId, kmsNodes, thresholds, canonicalChainId, blockNumber } = snapshot;
+  options: { snapshot: CanonicalSnapshot; proxyAddress: string },
+): Promise<PreparedDaoUpgrade> {
+  const { snapshot, proxyAddress } = options;
   console.log(
-    `Mirroring ProtocolConfig from canonical chain ${canonicalChainId} at block ${blockNumber}: contextId=${currentKmsContextId}, kmsNodes=${kmsNodes.length}.`,
+    `Mirroring ProtocolConfig from canonical chain ${snapshot.canonicalChainId} at block ${snapshot.blockNumber}: contextId=${snapshot.currentKmsContextId}, kmsNodes=${snapshot.kmsNodes.length}.`,
   );
 
-  const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
-  const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
-  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
-  const newImplem = await ethers.getContractFactory('ProtocolConfig', deployer);
-  const proxy = await upgrades.forceImport(secondaryProxyAddress, currentImplementation);
-
-  await upgrades.upgradeProxy(proxy, newImplem, {
-    call: {
-      fn: 'initializeFromMigration',
-      args: [currentKmsContextId, kmsNodes, thresholds],
-    },
+  const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
+  const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
+  return prepareDaoUpgrade(hre, {
+    proxyAddress,
+    contractName: 'ProtocolConfig',
+    innerFunctionSignature,
+    decodedArgs: [snapshot.currentKmsContextId, snapshot.kmsNodes, snapshot.thresholds],
   });
 }
 

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -27,10 +27,11 @@ export type CanonicalSnapshot = {
   blockNumber: number;
 };
 
-// Reads the canonical ProtocolConfig's current KMS context, pinned to one block. Shared by the
-// secondary mirror deploy and the export task so both seed from the exact same read. Pass blockNumber
-// to pin to a historical block (the export artifact's blockNumber) so a DAO signer can reproduce a
-// snapshot byte-for-byte even after a later context rotation; omit it to read the latest block.
+// Reads the canonical ProtocolConfig's current KMS context, pinned to one block. Shared by
+// task:exportCanonicalProtocolConfig and task:deployProtocolConfigFromCanonical's live-read mode so
+// both seed from the exact same read. Pass blockNumber to pin to a historical block (the export
+// artifact's blockNumber) so a DAO signer can reproduce a snapshot byte-for-byte even after a later
+// context rotation; omit it to read the latest block.
 export async function readCanonicalSnapshot(
   hre: HardhatRuntimeEnvironment,
   options: { canonicalProvider: Provider; canonicalProtocolConfigAddress: string; blockNumber?: number },

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -2,8 +2,8 @@ import type { Provider } from 'ethers';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import type { ProtocolConfig } from '../types';
-import { type PreparedDaoUpgrade, getFunctionFragment, prepareDaoUpgrade } from './utils/daoUpgrade';
 import { formatError } from './utils/formatError';
+import { type UpgradeProposal, buildUpgradeProposal, getFunctionFragment } from './utils/upgradeProposal';
 
 export type KmsNode = {
   txSenderAddress: string;
@@ -103,13 +103,13 @@ export async function readCanonicalSnapshot(
 // readCanonicalSnapshot or parsed from a reviewed export artifact: deploys the implementation and
 // returns the upgradeToAndCall(initializeFromMigration(...)) payload. The DAO path prints it for
 // signers; the direct (devnet) path executes the very same payload with the deployer key
-// (executePreparedDaoUpgrade). Reusing initializeFromMigration (originally the Gateway -> Ethereum
+// (executeUpgradeProposal). Reusing initializeFromMigration (originally the Gateway -> Ethereum
 // migration initializer) lands the replica on canonical's currentKmsContextId rather than starting
 // a fresh counter.
-export async function prepareCanonicalSnapshotUpgrade(
+export async function buildCanonicalUpgradeProposal(
   hre: HardhatRuntimeEnvironment,
   options: { snapshot: CanonicalSnapshot; proxyAddress: string },
-): Promise<PreparedDaoUpgrade> {
+): Promise<UpgradeProposal> {
   const { snapshot, proxyAddress } = options;
   console.log(
     `Mirroring ProtocolConfig from canonical chain ${snapshot.canonicalChainId} at block ${snapshot.blockNumber}: contextId=${snapshot.currentKmsContextId}, kmsNodes=${snapshot.kmsNodes.length}.`,
@@ -117,7 +117,7 @@ export async function prepareCanonicalSnapshotUpgrade(
 
   const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
   const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
-  return prepareDaoUpgrade(hre, {
+  return buildUpgradeProposal(hre, {
     proxyAddress,
     contractName: 'ProtocolConfig',
     innerFunctionSignature,

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -20,23 +20,35 @@ export type KmsThresholds = {
 };
 
 export type CanonicalSnapshot = {
-  currentContextId: bigint;
+  currentKmsContextId: bigint;
   kmsNodes: KmsNode[];
   thresholds: KmsThresholds;
   canonicalChainId: bigint;
-  canonicalBlockTag: number;
+  blockNumber: number;
 };
 
 // Reads the canonical ProtocolConfig's current KMS context, pinned to one block. Shared by the
-// secondary mirror deploy and the export task so both seed from the exact same read. Pass blockTag
+// secondary mirror deploy and the export task so both seed from the exact same read. Pass blockNumber
 // to pin to a historical block (the export artifact's blockNumber) so a DAO signer can reproduce a
 // snapshot byte-for-byte even after a later context rotation; omit it to read the latest block.
 export async function readCanonicalSnapshot(
   hre: HardhatRuntimeEnvironment,
-  options: { canonicalProvider: Provider; canonicalProtocolConfigAddress: string; blockTag?: number },
+  options: { canonicalProvider: Provider; canonicalProtocolConfigAddress: string; blockNumber?: number },
 ): Promise<CanonicalSnapshot> {
   const { ethers } = hre;
-  const { canonicalProvider, canonicalProtocolConfigAddress, blockTag } = options;
+  const { canonicalProvider, canonicalProtocolConfigAddress } = options;
+
+  // Handshake before the identity check so a dead or mistyped RPC URL is reported as an RPC
+  // problem, not as a contract identity failure.
+  let canonicalChainId: bigint;
+  let blockNumber: number;
+  try {
+    canonicalChainId = (await canonicalProvider.getNetwork()).chainId;
+    blockNumber = options.blockNumber ?? (await canonicalProvider.getBlockNumber());
+  } catch (err) {
+    throw new Error(`Canonical RPC handshake failed (${formatError(err)}).`);
+  }
+  const at = { blockTag: blockNumber };
 
   const canonicalProtocolConfigBase = await ethers.getContractAt('ProtocolConfig', canonicalProtocolConfigAddress);
   const canonicalProtocolConfig = canonicalProtocolConfigBase.connect(canonicalProvider) as ProtocolConfig;
@@ -55,35 +67,25 @@ export async function readCanonicalSnapshot(
     );
   }
 
-  let canonicalChainId: bigint;
-  let canonicalBlockTag: number;
-  try {
-    canonicalChainId = (await canonicalProvider.getNetwork()).chainId;
-    canonicalBlockTag = blockTag ?? (await canonicalProvider.getBlockNumber());
-  } catch (err) {
-    throw new Error(`Canonical RPC handshake failed (${formatError(err)}).`);
-  }
-  const at = { blockTag: canonicalBlockTag };
-
-  const currentContextId: bigint = await canonicalProtocolConfig.getCurrentKmsContextId(at);
-  if (currentContextId === 0n) {
+  const currentKmsContextId: bigint = await canonicalProtocolConfig.getCurrentKmsContextId(at);
+  if (currentKmsContextId === 0n) {
     throw new Error(
       `Canonical ProtocolConfig at ${canonicalProtocolConfigAddress} has no active KMS context (currentKmsContextId=0); cannot mirror.`,
     );
   }
-  const isCurrentContextValid: boolean = await canonicalProtocolConfig.isValidKmsContext(currentContextId, at);
+  const isCurrentContextValid: boolean = await canonicalProtocolConfig.isValidKmsContext(currentKmsContextId, at);
   if (!isCurrentContextValid) {
     throw new Error(
-      `Canonical ProtocolConfig's current context ${currentContextId} is destroyed; cannot mirror a destroyed context.`,
+      `Canonical ProtocolConfig's current context ${currentKmsContextId} is destroyed; cannot mirror a destroyed context.`,
     );
   }
 
   const [rawNodes, publicDecryption, userDecryption, kmsGen, mpc] = await Promise.all([
-    canonicalProtocolConfig.getKmsNodesForContext(currentContextId, at),
-    canonicalProtocolConfig.getPublicDecryptionThresholdForContext(currentContextId, at),
-    canonicalProtocolConfig.getUserDecryptionThresholdForContext(currentContextId, at),
-    canonicalProtocolConfig.getKmsGenThresholdForContext(currentContextId, at),
-    canonicalProtocolConfig.getMpcThresholdForContext(currentContextId, at),
+    canonicalProtocolConfig.getKmsNodesForContext(currentKmsContextId, at),
+    canonicalProtocolConfig.getPublicDecryptionThresholdForContext(currentKmsContextId, at),
+    canonicalProtocolConfig.getUserDecryptionThresholdForContext(currentKmsContextId, at),
+    canonicalProtocolConfig.getKmsGenThresholdForContext(currentKmsContextId, at),
+    canonicalProtocolConfig.getMpcThresholdForContext(currentKmsContextId, at),
   ]);
   const kmsNodes: KmsNode[] = rawNodes.map((node) => ({
     txSenderAddress: node.txSenderAddress,
@@ -93,39 +95,22 @@ export async function readCanonicalSnapshot(
   }));
   const thresholds: KmsThresholds = { publicDecryption, userDecryption, kmsGen, mpc };
 
-  return { currentContextId, kmsNodes, thresholds, canonicalChainId, canonicalBlockTag };
+  return { currentKmsContextId, kmsNodes, thresholds, canonicalChainId, blockNumber };
 }
 
-// Upgrades the secondary ProtocolConfig proxy and initializes it from the canonical snapshot. Reuses
-// ProtocolConfig.initializeFromMigration (originally the Gateway -> Ethereum migration initializer) to
-// land on canonical's currentKmsContextId rather than start a fresh counter.
-export async function mirrorProtocolConfigFromCanonical(
-  hre: HardhatRuntimeEnvironment,
-  options: {
-    canonicalProvider: Provider;
-    canonicalProtocolConfigAddress: string;
-    secondaryProxyAddress: string;
-  },
-): Promise<CanonicalSnapshot> {
-  const { canonicalProvider, canonicalProtocolConfigAddress, secondaryProxyAddress } = options;
-
-  const snapshot = await readCanonicalSnapshot(hre, { canonicalProvider, canonicalProtocolConfigAddress });
-  await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
-
-  return snapshot;
-}
-
-// Upgrades the secondary ProtocolConfig proxy and initializes it from an already-read snapshot —
-// either freshly read (mirrorProtocolConfigFromCanonical) or parsed from a reviewed export artifact.
+// Upgrades the secondary ProtocolConfig proxy and initializes it from a snapshot — freshly read via
+// readCanonicalSnapshot or parsed from a reviewed export artifact. Reuses
+// ProtocolConfig.initializeFromMigration (originally the Gateway -> Ethereum migration initializer)
+// to land on canonical's currentKmsContextId rather than start a fresh counter.
 export async function applyCanonicalSnapshot(
   hre: HardhatRuntimeEnvironment,
   options: { snapshot: CanonicalSnapshot; secondaryProxyAddress: string },
 ): Promise<void> {
   const { ethers, upgrades } = hre;
   const { snapshot, secondaryProxyAddress } = options;
-  const { currentContextId, kmsNodes, thresholds, canonicalChainId, canonicalBlockTag } = snapshot;
+  const { currentKmsContextId, kmsNodes, thresholds, canonicalChainId, blockNumber } = snapshot;
   console.log(
-    `Mirroring ProtocolConfig from canonical chain ${canonicalChainId} at block ${canonicalBlockTag}: contextId=${currentContextId}, kmsNodes=${kmsNodes.length}.`,
+    `Mirroring ProtocolConfig from canonical chain ${canonicalChainId} at block ${blockNumber}: contextId=${currentKmsContextId}, kmsNodes=${kmsNodes.length}.`,
   );
 
   const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
@@ -137,13 +122,14 @@ export async function applyCanonicalSnapshot(
   await upgrades.upgradeProxy(proxy, newImplem, {
     call: {
       fn: 'initializeFromMigration',
-      args: [currentContextId, kmsNodes, thresholds],
+      args: [currentKmsContextId, kmsNodes, thresholds],
     },
   });
 }
 
-// The JSON shape written by task:exportCanonicalProtocolConfig. Bigints are serialized as strings
-// so DAO signers can diff artifacts as plain text.
+// The JSON shape written by task:exportCanonicalProtocolConfig: the snapshot fields plus the
+// canonical contract address, with bigints serialized as strings so DAO signers can diff artifacts
+// as plain text.
 export type CanonicalSnapshotArtifact = {
   canonicalChainId: string;
   blockNumber: number;
@@ -159,9 +145,9 @@ export function buildSnapshotArtifact(
 ): CanonicalSnapshotArtifact {
   return {
     canonicalChainId: snapshot.canonicalChainId.toString(),
-    blockNumber: snapshot.canonicalBlockTag,
+    blockNumber: snapshot.blockNumber,
     protocolConfigAddress,
-    currentKmsContextId: snapshot.currentContextId.toString(),
+    currentKmsContextId: snapshot.currentKmsContextId.toString(),
     kmsNodes: snapshot.kmsNodes,
     thresholds: {
       publicDecryption: snapshot.thresholds.publicDecryption.toString(),
@@ -172,10 +158,7 @@ export function buildSnapshotArtifact(
   };
 }
 
-export function parseSnapshotArtifact(raw: string): {
-  snapshot: CanonicalSnapshot;
-  protocolConfigAddress: string;
-} {
+export function parseSnapshotArtifact(raw: string): CanonicalSnapshot {
   let artifact: CanonicalSnapshotArtifact;
   try {
     artifact = JSON.parse(raw);
@@ -195,9 +178,6 @@ export function parseSnapshotArtifact(raw: string): {
       `Snapshot artifact field "blockNumber" must be a number, got ${JSON.stringify(artifact.blockNumber)}.`,
     );
   }
-  if (typeof artifact.protocolConfigAddress !== 'string' || artifact.protocolConfigAddress.length === 0) {
-    throw new Error('Snapshot artifact field "protocolConfigAddress" is missing.');
-  }
   if (!Array.isArray(artifact.kmsNodes) || artifact.kmsNodes.length === 0) {
     throw new Error('Snapshot artifact field "kmsNodes" must be a non-empty array.');
   }
@@ -209,8 +189,8 @@ export function parseSnapshotArtifact(raw: string): {
     }
   }
 
-  const snapshot: CanonicalSnapshot = {
-    currentContextId: requireBigint('currentKmsContextId', artifact.currentKmsContextId),
+  return {
+    currentKmsContextId: requireBigint('currentKmsContextId', artifact.currentKmsContextId),
     kmsNodes: artifact.kmsNodes,
     thresholds: {
       publicDecryption: requireBigint('thresholds.publicDecryption', artifact.thresholds?.publicDecryption),
@@ -219,8 +199,6 @@ export function parseSnapshotArtifact(raw: string): {
       mpc: requireBigint('thresholds.mpc', artifact.thresholds?.mpc),
     },
     canonicalChainId: requireBigint('canonicalChainId', artifact.canonicalChainId),
-    canonicalBlockTag: artifact.blockNumber,
+    blockNumber: artifact.blockNumber,
   };
-
-  return { snapshot, protocolConfigAddress: artifact.protocolConfigAddress };
 }

--- a/host-contracts/tasks/protocolConfigMirror.ts
+++ b/host-contracts/tasks/protocolConfigMirror.ts
@@ -1,7 +1,8 @@
-import type { Provider } from 'ethers';
+import { type Provider, isAddress } from 'ethers';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import type { ProtocolConfig } from '../types';
+import { assertContractMatchesVersionPrefix } from './utils/contractVersion';
 import { formatError } from './utils/formatError';
 import { type UpgradeProposal, buildUpgradeProposal, getFunctionFragment } from './utils/upgradeProposal';
 
@@ -25,13 +26,14 @@ export type CanonicalSnapshot = {
   thresholds: KmsThresholds;
   canonicalChainId: bigint;
   blockNumber: number;
+  blockHash: string;
 };
 
 // Reads the canonical ProtocolConfig's current KMS context, pinned to one block. Shared by
 // task:exportCanonicalProtocolConfig and task:deployProtocolConfigFromCanonical's live-read mode so
 // both seed from the exact same read. Pass blockNumber to pin to a historical block (the export
 // artifact's blockNumber) so a DAO signer can reproduce a snapshot byte-for-byte even after a later
-// context rotation; omit it to read the latest block.
+// context rotation; omit it to read the latest finalized block.
 export async function readCanonicalSnapshot(
   hre: HardhatRuntimeEnvironment,
   options: { canonicalProvider: Provider; canonicalProtocolConfigAddress: string; blockNumber?: number },
@@ -40,33 +42,33 @@ export async function readCanonicalSnapshot(
   const { canonicalProvider, canonicalProtocolConfigAddress } = options;
 
   // Handshake before the identity check so a dead or mistyped RPC URL is reported as an RPC
-  // problem, not as a contract identity failure.
+  // problem, not as a contract identity failure. Pin to the finalized block when no explicit block
+  // is requested: a finalized block can't be reorged out, so the exported artifact stays
+  // reproducible. We resolve the full block (not just its number) to capture the hash too, which
+  // uniquely identifies the read's state across reorgs — a height alone is ambiguous.
   let canonicalChainId: bigint;
-  let blockNumber: number;
+  let blockTag: number | 'finalized';
+  let block: Awaited<ReturnType<Provider['getBlock']>>;
   try {
     canonicalChainId = (await canonicalProvider.getNetwork()).chainId;
-    blockNumber = options.blockNumber ?? (await canonicalProvider.getBlockNumber());
+    blockTag = options.blockNumber ?? 'finalized';
+    block = await canonicalProvider.getBlock(blockTag);
   } catch (err) {
     throw new Error(`Canonical RPC handshake failed (${formatError(err)}).`);
   }
+  if (block === null || block.hash === null) {
+    throw new Error(`Canonical RPC returned no finalized block for "${blockTag}".`);
+  }
+  const blockNumber = block.number;
+  const blockHash = block.hash;
   const at = { blockTag: blockNumber };
+
+  // Reuse the shared version-prefix check, pointed at the canonical provider rather than the local
+  // network so the identity check runs against the remote ProtocolConfig.
+  await assertContractMatchesVersionPrefix(hre, canonicalProtocolConfigAddress, 'ProtocolConfig', canonicalProvider);
 
   const canonicalProtocolConfigBase = await ethers.getContractAt('ProtocolConfig', canonicalProtocolConfigAddress);
   const canonicalProtocolConfig = canonicalProtocolConfigBase.connect(canonicalProvider) as ProtocolConfig;
-
-  let canonicalVersion: string;
-  try {
-    canonicalVersion = await canonicalProtocolConfig.getVersion();
-  } catch (err) {
-    throw new Error(
-      `Canonical ProtocolConfig identity check failed: contract at ${canonicalProtocolConfigAddress} does not expose getVersion() (${formatError(err)}).`,
-    );
-  }
-  if (!/^ProtocolConfig v\d/.test(canonicalVersion)) {
-    throw new Error(
-      `Canonical ProtocolConfig identity check failed: contract at ${canonicalProtocolConfigAddress} reports version "${canonicalVersion}"; expected "ProtocolConfig v<n>...".`,
-    );
-  }
 
   const currentKmsContextId: bigint = await canonicalProtocolConfig.getCurrentKmsContextId(at);
   if (currentKmsContextId === 0n) {
@@ -96,7 +98,7 @@ export async function readCanonicalSnapshot(
   }));
   const thresholds: KmsThresholds = { publicDecryption, userDecryption, kmsGen, mpc };
 
-  return { currentKmsContextId, kmsNodes, thresholds, canonicalChainId, blockNumber };
+  return { currentKmsContextId, kmsNodes, thresholds, canonicalChainId, blockNumber, blockHash };
 }
 
 // Builds the upgrade for a secondary ProtocolConfig proxy from a snapshot — freshly read via
@@ -112,7 +114,7 @@ export async function buildCanonicalUpgradeProposal(
 ): Promise<UpgradeProposal> {
   const { snapshot, proxyAddress } = options;
   console.log(
-    `Mirroring ProtocolConfig from canonical chain ${snapshot.canonicalChainId} at block ${snapshot.blockNumber}: contextId=${snapshot.currentKmsContextId}, kmsNodes=${snapshot.kmsNodes.length}.`,
+    `Mirroring ProtocolConfig from canonical chain ${snapshot.canonicalChainId} at block ${snapshot.blockNumber} (${snapshot.blockHash}): contextId=${snapshot.currentKmsContextId}, kmsNodes=${snapshot.kmsNodes.length}.`,
   );
 
   const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
@@ -131,6 +133,7 @@ export async function buildCanonicalUpgradeProposal(
 export type CanonicalSnapshotArtifact = {
   canonicalChainId: string;
   blockNumber: number;
+  blockHash: string;
   protocolConfigAddress: string;
   currentKmsContextId: string;
   kmsNodes: KmsNode[];
@@ -144,6 +147,7 @@ export function buildSnapshotArtifact(
   return {
     canonicalChainId: snapshot.canonicalChainId.toString(),
     blockNumber: snapshot.blockNumber,
+    blockHash: snapshot.blockHash,
     protocolConfigAddress,
     currentKmsContextId: snapshot.currentKmsContextId.toString(),
     kmsNodes: snapshot.kmsNodes,
@@ -176,11 +180,25 @@ export function parseSnapshotArtifact(raw: string): CanonicalSnapshot {
       `Snapshot artifact field "blockNumber" must be a number, got ${JSON.stringify(artifact.blockNumber)}.`,
     );
   }
+  if (typeof artifact.blockHash !== 'string' || !/^0x[0-9a-fA-F]{64}$/.test(artifact.blockHash)) {
+    throw new Error(
+      `Snapshot artifact field "blockHash" must be a 32-byte hex string, got ${JSON.stringify(artifact.blockHash)}.`,
+    );
+  }
   if (!Array.isArray(artifact.kmsNodes) || artifact.kmsNodes.length === 0) {
     throw new Error('Snapshot artifact field "kmsNodes" must be a non-empty array.');
   }
   for (const [index, node] of artifact.kmsNodes.entries()) {
-    for (const field of ['txSenderAddress', 'signerAddress', 'ipAddress', 'storageUrl'] as const) {
+    // Addresses get baked into the initializeFromMigration calldata, so reject a malformed one in
+    // a hand-reviewed artifact here rather than letting ABI encoding fail with an opaque error.
+    for (const field of ['txSenderAddress', 'signerAddress'] as const) {
+      if (!isAddress(node?.[field])) {
+        throw new Error(
+          `Snapshot artifact field "kmsNodes[${index}].${field}" must be a valid address, got ${JSON.stringify(node?.[field])}.`,
+        );
+      }
+    }
+    for (const field of ['ipAddress', 'storageUrl'] as const) {
       if (typeof node?.[field] !== 'string') {
         throw new Error(`Snapshot artifact field "kmsNodes[${index}].${field}" is missing.`);
       }
@@ -198,5 +216,6 @@ export function parseSnapshotArtifact(raw: string): CanonicalSnapshot {
     },
     canonicalChainId: requireBigint('canonicalChainId', artifact.canonicalChainId),
     blockNumber: artifact.blockNumber,
+    blockHash: artifact.blockHash,
   };
 }

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -6,6 +6,12 @@ import { task, types } from 'hardhat/config';
 import type { HardhatEthersHelpers, HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types';
 import path from 'path';
 
+import {
+  type SecondaryDeployArgs,
+  mirrorProtocolConfigFromCanonical,
+  readCanonicalSnapshot,
+} from './protocolConfigMirror';
+import { formatError } from './utils/formatError';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE } from './utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from './utils/loadVariables';
 
@@ -37,10 +43,6 @@ export function readExistingHostEnv(): Record<string, string> {
     return {};
   }
   return readHostEnv();
-}
-
-function formatError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 export async function waitForTaskReady(
@@ -535,6 +537,101 @@ task('task:deployProtocolConfig').setAction(async function (_taskArguments: Task
   await waitForTaskReady(hre, 'task:assertProtocolConfigReady');
   console.log('ProtocolConfig code set successfully at address:', proxyAddress);
 });
+
+// Initializes the local (non-canonical) ProtocolConfig replica from the canonical chain's current
+// KMS context, read via RPC and pinned to one block. Reuses initializeFromMigration (originally the
+// Gateway -> Ethereum migration initializer) to land on the canonical chain's `currentKmsContextId`
+// rather than start a fresh counter. Equivalent of `task:deployProtocolConfigSecondary` on main.
+task(
+  'task:deployProtocolConfigFromCanonical',
+  'Upgrades the existing ProtocolConfig proxy from a canonical-chain snapshot.',
+)
+  .addParam(
+    'canonicalRpcUrl',
+    'RPC URL of the canonical host chain to read the current ProtocolConfig state from.',
+    undefined,
+    types.string,
+  )
+  .addParam(
+    'canonicalProtocolConfigAddress',
+    'Address of the ProtocolConfig contract on the canonical host chain.',
+    undefined,
+    types.string,
+  )
+  .setAction(async function ({ canonicalRpcUrl, canonicalProtocolConfigAddress }: SecondaryDeployArgs, hre) {
+    const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+    const parsedEnv = readHostEnv();
+    const secondaryProxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
+    const { currentContextId, kmsNodes, canonicalChainId, canonicalBlockTag } = await mirrorProtocolConfigFromCanonical(
+      hre,
+      { canonicalProvider, canonicalProtocolConfigAddress, secondaryProxyAddress },
+    );
+    // On interval-mining networks, upgradeProxy can return before the tx is mined.
+    await waitForTaskReady(hre, 'task:assertProtocolConfigReady');
+    console.log(
+      `ProtocolConfig code set successfully at ${secondaryProxyAddress}, mirroring canonical chain ${canonicalChainId} context ${currentContextId} (block ${canonicalBlockTag}) with ${kmsNodes.length} KMS nodes.`,
+    );
+  });
+
+// Reads the canonical ProtocolConfig context at a pinned block and writes a JSON snapshot, without
+// deploying anything. DAO signers re-run this at the same block and diff the snapshot against
+// canonical before accepting secondary-host ownership.
+task(
+  'task:exportCanonicalProtocolConfig',
+  'Exports the canonical ProtocolConfig KMS context to a JSON snapshot for DAO review.',
+)
+  .addParam(
+    'canonicalRpcUrl',
+    'RPC URL of the canonical host chain to read ProtocolConfig from.',
+    undefined,
+    types.string,
+  )
+  .addParam(
+    'canonicalProtocolConfigAddress',
+    'Address of the ProtocolConfig contract on the canonical host chain.',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
+    'blockNumber',
+    "Canonical block height to pin the snapshot to. Defaults to latest; pass the artifact's blockNumber to reproduce a prior export for DAO review.",
+    undefined,
+    types.int,
+  )
+  .addOptionalParam('out', 'Path to write the snapshot JSON.', 'canonical-protocol-config-snapshot.json', types.string)
+  .setAction(async function (
+    {
+      canonicalRpcUrl,
+      canonicalProtocolConfigAddress,
+      blockNumber,
+      out,
+    }: { canonicalRpcUrl: string; canonicalProtocolConfigAddress: string; blockNumber?: number; out: string },
+    hre,
+  ) {
+    const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+    const snapshot = await readCanonicalSnapshot(hre, {
+      canonicalProvider,
+      canonicalProtocolConfigAddress,
+      blockTag: blockNumber,
+    });
+
+    const artifact = {
+      canonicalChainId: snapshot.canonicalChainId,
+      blockNumber: snapshot.canonicalBlockTag,
+      protocolConfigAddress: canonicalProtocolConfigAddress,
+      currentKmsContextId: snapshot.currentContextId,
+      kmsNodes: snapshot.kmsNodes,
+      thresholds: snapshot.thresholds,
+    };
+    fs.writeFileSync(
+      out,
+      JSON.stringify(artifact, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 2),
+    );
+    console.log(
+      `Canonical ProtocolConfig snapshot written to ${out}: chain ${snapshot.canonicalChainId}, block ${snapshot.canonicalBlockTag}, context ${snapshot.currentContextId}, ${snapshot.kmsNodes.length} KMS nodes.`,
+    );
+    return artifact;
+  });
 
 ////////////////////////////////////////////////////////////////////////////////
 // KMSGeneration (host-side)

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -7,8 +7,10 @@ import type { HardhatEthersHelpers, HardhatRuntimeEnvironment, TaskArguments } f
 import path from 'path';
 
 import {
-  type SecondaryDeployArgs,
+  applyCanonicalSnapshot,
+  buildSnapshotArtifact,
   mirrorProtocolConfigFromCanonical,
+  parseSnapshotArtifact,
   readCanonicalSnapshot,
 } from './protocolConfigMirror';
 import { formatError } from './utils/formatError';
@@ -546,33 +548,63 @@ task(
   'task:deployProtocolConfigFromCanonical',
   'Upgrades the existing ProtocolConfig proxy from a canonical-chain snapshot.',
 )
-  .addParam(
+  .addOptionalParam(
+    'snapshot',
+    'Path to a reviewed task:exportCanonicalProtocolConfig artifact to apply. When set, canonical RPC access is not needed and exactly the reviewed state is deployed.',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
     'canonicalRpcUrl',
-    'RPC URL of the canonical host chain to read the current ProtocolConfig state from.',
+    'RPC URL of the canonical host chain to read the current ProtocolConfig state from. Required without --snapshot.',
     undefined,
     types.string,
   )
-  .addParam(
+  .addOptionalParam(
     'canonicalProtocolConfigAddress',
-    'Address of the ProtocolConfig contract on the canonical host chain.',
+    'Address of the ProtocolConfig contract on the canonical host chain. Required without --snapshot.',
     undefined,
     types.string,
   )
-  .setAction(async function ({ canonicalRpcUrl, canonicalProtocolConfigAddress }: SecondaryDeployArgs, hre) {
+  .setAction(async function (
+    {
+      snapshot: snapshotPath,
+      canonicalRpcUrl,
+      canonicalProtocolConfigAddress,
+    }: { snapshot?: string; canonicalRpcUrl?: string; canonicalProtocolConfigAddress?: string },
+    hre,
+  ) {
+    if (!snapshotPath && !(canonicalRpcUrl && canonicalProtocolConfigAddress)) {
+      throw new Error(
+        'Pass either --snapshot <artifact.json> (reviewed export) or both --canonical-rpc-url and --canonical-protocol-config-address (live read).',
+      );
+    }
+
     // ProtocolConfig embeds aclAdd from addresses/FHEVMHostAddresses.sol at compile time; a stale
     // artifact would deploy bytecode authorized against the wrong ACL (same as FromMigration).
     await hre.run('compile:specific', { contract: 'contracts' });
-    const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
     const parsedEnv = readHostEnv();
     const secondaryProxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
-    const { currentContextId, kmsNodes, canonicalChainId, canonicalBlockTag } = await mirrorProtocolConfigFromCanonical(
-      hre,
-      { canonicalProvider, canonicalProtocolConfigAddress, secondaryProxyAddress },
-    );
+
+    let applied;
+    if (snapshotPath) {
+      const { snapshot } = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
+      console.log(`Applying reviewed canonical snapshot from ${snapshotPath}.`);
+      await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
+      applied = snapshot;
+    } else {
+      const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+      applied = await mirrorProtocolConfigFromCanonical(hre, {
+        canonicalProvider,
+        canonicalProtocolConfigAddress: canonicalProtocolConfigAddress!,
+        secondaryProxyAddress,
+      });
+    }
+
     // On interval-mining networks, upgradeProxy can return before the tx is mined.
     await waitForTaskReady(hre, 'task:assertProtocolConfigReady');
     console.log(
-      `ProtocolConfig code set successfully at ${secondaryProxyAddress}, mirroring canonical chain ${canonicalChainId} context ${currentContextId} (block ${canonicalBlockTag}) with ${kmsNodes.length} KMS nodes.`,
+      `ProtocolConfig code set successfully at ${secondaryProxyAddress}, mirroring canonical chain ${applied.canonicalChainId} context ${applied.currentContextId} (block ${applied.canonicalBlockTag}) with ${applied.kmsNodes.length} KMS nodes.`,
     );
   });
 
@@ -621,18 +653,8 @@ task(
       blockTag: blockNumber,
     });
 
-    const artifact = {
-      canonicalChainId: snapshot.canonicalChainId,
-      blockNumber: snapshot.canonicalBlockTag,
-      protocolConfigAddress: canonicalProtocolConfigAddress,
-      currentKmsContextId: snapshot.currentContextId,
-      kmsNodes: snapshot.kmsNodes,
-      thresholds: snapshot.thresholds,
-    };
-    fs.writeFileSync(
-      out,
-      JSON.stringify(artifact, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 2),
-    );
+    const artifact = buildSnapshotArtifact(snapshot, canonicalProtocolConfigAddress);
+    fs.writeFileSync(out, JSON.stringify(artifact, null, 2));
     console.log(
       `Canonical ProtocolConfig snapshot written to ${out}: chain ${snapshot.canonicalChainId}, block ${snapshot.canonicalBlockTag}, context ${snapshot.currentContextId}, ${snapshot.kmsNodes.length} KMS nodes.`,
     );

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -96,7 +96,7 @@ export async function assertContractMatchesVersionPrefix(
 // All Host Contracts
 ////////////////////////////////////////////////////////////////////////////////
 
-const PROTOCOL_CONFIG_SOURCES = ['fresh', 'migration'] as const;
+const PROTOCOL_CONFIG_SOURCES = ['fresh', 'migration', 'canonical'] as const;
 type ProtocolConfigSource = (typeof PROTOCOL_CONFIG_SOURCES)[number];
 
 task('task:deployAllHostContracts')
@@ -108,18 +108,52 @@ task('task:deployAllHostContracts')
   )
   .addOptionalParam(
     'protocolConfigSource',
-    "How to initialize ProtocolConfig: 'fresh' (default) calls initializeFromEmptyProxy with env-driven KMS nodes/thresholds; 'migration' calls initializeFromMigration consuming MIGRATION_CONTEXT_ID / MIGRATION_KMS_NODES / MIGRATION_KMS_THRESHOLDS.",
+    "How to initialize ProtocolConfig: 'fresh' (default) calls initializeFromEmptyProxy with env-driven KMS nodes/thresholds; 'migration' calls initializeFromMigration consuming MIGRATION_CONTEXT_ID / MIGRATION_KMS_NODES / MIGRATION_KMS_THRESHOLDS; 'canonical' mirrors the canonical chain's ProtocolConfig via task:deployProtocolConfigFromCanonical (non-canonical hosts only).",
     'fresh',
     types.string,
   )
+  .addOptionalParam(
+    'canonicalRpcUrl',
+    'RPC URL of the canonical host chain. Required with --protocol-config-source canonical.',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
+    'canonicalProtocolConfigAddress',
+    "Address of the canonical chain's ProtocolConfig. Required with --protocol-config-source canonical.",
+    undefined,
+    types.string,
+  )
   .setAction(async function (
-    { withKmsGeneration, protocolConfigSource }: { withKmsGeneration: boolean; protocolConfigSource: string },
+    {
+      withKmsGeneration,
+      protocolConfigSource,
+      canonicalRpcUrl,
+      canonicalProtocolConfigAddress,
+    }: {
+      withKmsGeneration: boolean;
+      protocolConfigSource: string;
+      canonicalRpcUrl?: string;
+      canonicalProtocolConfigAddress?: string;
+    },
     hre,
   ) {
     if (!PROTOCOL_CONFIG_SOURCES.includes(protocolConfigSource as ProtocolConfigSource)) {
       throw new Error(
         `Invalid --protocol-config-source "${protocolConfigSource}". Allowed values: ${PROTOCOL_CONFIG_SOURCES.join(', ')}.`,
       );
+    }
+    if (protocolConfigSource === 'canonical') {
+      if (withKmsGeneration) {
+        throw new Error(
+          '--protocol-config-source canonical seeds a non-canonical replica; it cannot be combined with --with-kms-generation true.',
+        );
+      }
+      if (!(canonicalRpcUrl && canonicalProtocolConfigAddress)) {
+        throw new Error(
+          '--protocol-config-source canonical requires --canonical-rpc-url and --canonical-protocol-config-address.',
+        );
+      }
     }
 
     if (process.env.SOLIDITY_COVERAGE !== 'true') {
@@ -139,6 +173,8 @@ task('task:deployAllHostContracts')
     await hre.run('task:deployFHEVMExecutor');
     if (protocolConfigSource === 'migration') {
       await hre.run('task:deployProtocolConfigFromMigration');
+    } else if (protocolConfigSource === 'canonical') {
+      await hre.run('task:deployProtocolConfigFromCanonical', { canonicalRpcUrl, canonicalProtocolConfigAddress });
     } else {
       await hre.run('task:deployProtocolConfig');
     }

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -7,11 +7,12 @@ import type { HardhatEthersHelpers, HardhatRuntimeEnvironment, TaskArguments } f
 import path from 'path';
 
 import {
-  applyCanonicalSnapshot,
   buildSnapshotArtifact,
   parseSnapshotArtifact,
+  prepareCanonicalSnapshotUpgrade,
   readCanonicalSnapshot,
 } from './protocolConfigMirror';
+import { executePreparedDaoUpgrade } from './utils/daoUpgrade';
 import { formatError } from './utils/formatError';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE } from './utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from './utils/loadVariables';
@@ -593,7 +594,12 @@ task(
         canonicalProtocolConfigAddress: canonicalProtocolConfigAddress as string,
       });
     }
-    await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
+
+    // Same prepare step as the DAO path (task:prepareDeployProtocolConfigFromCanonical), then
+    // execute the produced payload directly: devnet runs byte-identical calldata to what the DAO
+    // would sign.
+    const prepared = await prepareCanonicalSnapshotUpgrade(hre, { snapshot, proxyAddress: secondaryProxyAddress });
+    await executePreparedDaoUpgrade(hre, prepared);
 
     // On interval-mining networks, upgradeProxy can return before the tx is mined.
     await waitForTaskReady(hre, 'task:assertProtocolConfigReady');

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -559,6 +559,9 @@ task(
     types.string,
   )
   .setAction(async function ({ canonicalRpcUrl, canonicalProtocolConfigAddress }: SecondaryDeployArgs, hre) {
+    // ProtocolConfig embeds aclAdd from addresses/FHEVMHostAddresses.sol at compile time; a stale
+    // artifact would deploy bytecode authorized against the wrong ACL (same as FromMigration).
+    await hre.run('compile:specific', { contract: 'contracts' });
     const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
     const parsedEnv = readHostEnv();
     const secondaryProxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
@@ -608,6 +611,9 @@ task(
     }: { canonicalRpcUrl: string; canonicalProtocolConfigAddress: string; blockNumber?: number; out: string },
     hre,
   ) {
+    // readCanonicalSnapshot needs the ProtocolConfig artifact for its ABI; compile so the export
+    // also works from a clean checkout.
+    await hre.run('compile:specific', { contract: 'contracts' });
     const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
     const snapshot = await readCanonicalSnapshot(hre, {
       canonicalProvider,

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -9,7 +9,6 @@ import path from 'path';
 import {
   applyCanonicalSnapshot,
   buildSnapshotArtifact,
-  mirrorProtocolConfigFromCanonical,
   parseSnapshotArtifact,
   readCanonicalSnapshot,
 } from './protocolConfigMirror';
@@ -541,12 +540,10 @@ task('task:deployProtocolConfig').setAction(async function (_taskArguments: Task
 });
 
 // Initializes the local (non-canonical) ProtocolConfig replica from the canonical chain's current
-// KMS context, read via RPC and pinned to one block. Reuses initializeFromMigration (originally the
-// Gateway -> Ethereum migration initializer) to land on the canonical chain's `currentKmsContextId`
-// rather than start a fresh counter. Equivalent of `task:deployProtocolConfigSecondary` on main.
+// KMS context — from a reviewed export artifact (--snapshot) or a live block-pinned RPC read.
 task(
   'task:deployProtocolConfigFromCanonical',
-  'Upgrades the existing ProtocolConfig proxy from a canonical-chain snapshot.',
+  "Upgrades the existing ProtocolConfig proxy from the canonical chain's state (reviewed snapshot artifact, or live read).",
 )
   .addOptionalParam(
     'snapshot',
@@ -586,25 +583,22 @@ task(
     const parsedEnv = readHostEnv();
     const secondaryProxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
 
-    let applied;
+    let snapshot;
     if (snapshotPath) {
-      const { snapshot } = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
       console.log(`Applying reviewed canonical snapshot from ${snapshotPath}.`);
-      await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
-      applied = snapshot;
+      snapshot = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
     } else {
-      const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
-      applied = await mirrorProtocolConfigFromCanonical(hre, {
-        canonicalProvider,
-        canonicalProtocolConfigAddress: canonicalProtocolConfigAddress!,
-        secondaryProxyAddress,
+      snapshot = await readCanonicalSnapshot(hre, {
+        canonicalProvider: new hre.ethers.JsonRpcProvider(canonicalRpcUrl),
+        canonicalProtocolConfigAddress: canonicalProtocolConfigAddress as string,
       });
     }
+    await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
 
     // On interval-mining networks, upgradeProxy can return before the tx is mined.
     await waitForTaskReady(hre, 'task:assertProtocolConfigReady');
     console.log(
-      `ProtocolConfig code set successfully at ${secondaryProxyAddress}, mirroring canonical chain ${applied.canonicalChainId} context ${applied.currentContextId} (block ${applied.canonicalBlockTag}) with ${applied.kmsNodes.length} KMS nodes.`,
+      `ProtocolConfig code set successfully at ${secondaryProxyAddress}, mirroring canonical chain ${snapshot.canonicalChainId} context ${snapshot.currentKmsContextId} (block ${snapshot.blockNumber}) with ${snapshot.kmsNodes.length} KMS nodes.`,
     );
   });
 
@@ -650,13 +644,13 @@ task(
     const snapshot = await readCanonicalSnapshot(hre, {
       canonicalProvider,
       canonicalProtocolConfigAddress,
-      blockTag: blockNumber,
+      blockNumber,
     });
 
     const artifact = buildSnapshotArtifact(snapshot, canonicalProtocolConfigAddress);
     fs.writeFileSync(out, JSON.stringify(artifact, null, 2));
     console.log(
-      `Canonical ProtocolConfig snapshot written to ${out}: chain ${snapshot.canonicalChainId}, block ${snapshot.canonicalBlockTag}, context ${snapshot.currentContextId}, ${snapshot.kmsNodes.length} KMS nodes.`,
+      `Canonical ProtocolConfig snapshot written to ${out}: chain ${snapshot.canonicalChainId}, block ${snapshot.blockNumber}, context ${snapshot.currentKmsContextId}, ${snapshot.kmsNodes.length} KMS nodes.`,
     );
     return artifact;
   });

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -12,6 +12,7 @@ import {
   parseSnapshotArtifact,
   readCanonicalSnapshot,
 } from './protocolConfigMirror';
+import { assertContractMatchesVersionPrefix } from './utils/contractVersion';
 import { formatError } from './utils/formatError';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE } from './utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from './utils/loadVariables';
@@ -67,30 +68,9 @@ export async function waitForTaskReady(
   }
 }
 
-export async function assertContractMatchesVersionPrefix(
-  hre: HardhatRuntimeEnvironment,
-  address: string,
-  versionPrefix: string,
-): Promise<void> {
-  const contract = new hre.ethers.Contract(
-    address,
-    ['function getVersion() view returns (string)'],
-    hre.ethers.provider,
-  );
-
-  let version: string;
-  try {
-    version = await contract.getVersion();
-  } catch (err) {
-    throw new Error(
-      `Contract at ${address} does not expose getVersion(); it is not a ${versionPrefix} proxy. (${formatError(err)})`,
-    );
-  }
-
-  if (!version.startsWith(versionPrefix)) {
-    throw new Error(`Contract at ${address} reports version "${version}"; expected "${versionPrefix} v…".`);
-  }
-}
+// Re-exported for existing call sites (taskMigrate). Lives in utils/contractVersion to avoid a
+// cyclic import: protocolConfigMirror needs it too, and taskDeploy already imports from there.
+export { assertContractMatchesVersionPrefix };
 
 ////////////////////////////////////////////////////////////////////////////////
 // All Host Contracts
@@ -665,7 +645,7 @@ task(
   )
   .addOptionalParam(
     'blockNumber',
-    "Canonical block height to pin the snapshot to. Defaults to latest; pass the artifact's blockNumber to reproduce a prior export for DAO review.",
+    "Canonical block height to pin the snapshot to. Defaults to the latest finalized block; pass the artifact's blockNumber to reproduce a prior export for DAO review.",
     undefined,
     types.int,
   )

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -7,15 +7,15 @@ import type { HardhatEthersHelpers, HardhatRuntimeEnvironment, TaskArguments } f
 import path from 'path';
 
 import {
+  buildCanonicalUpgradeProposal,
   buildSnapshotArtifact,
   parseSnapshotArtifact,
-  prepareCanonicalSnapshotUpgrade,
   readCanonicalSnapshot,
 } from './protocolConfigMirror';
-import { executePreparedDaoUpgrade } from './utils/daoUpgrade';
 import { formatError } from './utils/formatError';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE } from './utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from './utils/loadVariables';
+import { executeUpgradeProposal } from './utils/upgradeProposal';
 
 const ADDRESSES_DIR = path.join(__dirname, '../addresses');
 const HOST_ENV_FILE = path.join(ADDRESSES_DIR, '.env.host');
@@ -598,8 +598,8 @@ task(
     // Same prepare step as the DAO path (task:prepareDeployProtocolConfigFromCanonical), then
     // execute the produced payload directly: devnet runs byte-identical calldata to what the DAO
     // would sign.
-    const prepared = await prepareCanonicalSnapshotUpgrade(hre, { snapshot, proxyAddress: secondaryProxyAddress });
-    await executePreparedDaoUpgrade(hre, prepared);
+    const prepared = await buildCanonicalUpgradeProposal(hre, { snapshot, proxyAddress: secondaryProxyAddress });
+    await executeUpgradeProposal(hre, prepared);
 
     // On interval-mining networks, upgradeProxy can return before the tx is mined.
     await waitForTaskReady(hre, 'task:assertProtocolConfigReady');

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -7,6 +7,7 @@ import type { HardhatEthersHelpers, HardhatRuntimeEnvironment, TaskArguments } f
 import path from 'path';
 
 import {
+  type CanonicalSnapshot,
   buildCanonicalUpgradeProposal,
   buildSnapshotArtifact,
   parseSnapshotArtifact,
@@ -600,7 +601,7 @@ task(
     const parsedEnv = readHostEnv();
     const secondaryProxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
 
-    let snapshot;
+    let snapshot: CanonicalSnapshot;
     if (snapshotPath) {
       console.log(`Applying reviewed canonical snapshot from ${snapshotPath}.`);
       snapshot = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));

--- a/host-contracts/tasks/taskMigrate.ts
+++ b/host-contracts/tasks/taskMigrate.ts
@@ -261,8 +261,8 @@ task(
     const proxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
     // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
     await hre.run('compile:specific', { contract: 'contracts' });
-    const { snapshot } = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
-    const decodedArgs = [snapshot.currentContextId, snapshot.kmsNodes, snapshot.thresholds];
+    const snapshot = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
+    const decodedArgs = [snapshot.currentKmsContextId, snapshot.kmsNodes, snapshot.thresholds];
     const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
     const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
     const preparedUpgrade = await prepareDaoUpgrade(hre, {

--- a/host-contracts/tasks/taskMigrate.ts
+++ b/host-contracts/tasks/taskMigrate.ts
@@ -22,7 +22,6 @@ import {
 } from './utils/protocolConfigMigrationEnv';
 import {
   buildUpgradeProposal,
-  getFunctionFragment,
   printUpgradeProposal,
   toJsonString,
   verifyProposalImplementation,
@@ -129,12 +128,10 @@ task(
     // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
     await hre.run('compile:specific', { contract: 'contracts' });
     const decodedArgs = buildProtocolConfigInitializeFromMigrationArgs();
-    const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
-    const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
     const preparedUpgrade = await buildUpgradeProposal(hre, {
       proxyAddress,
       contractName: 'ProtocolConfig',
-      innerFunctionSignature,
+      innerFunctionName: 'initializeFromMigration',
       decodedArgs,
     });
 
@@ -225,12 +222,10 @@ task(
     // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
     await hre.run('compile:specific', { contract: 'contracts' });
     const decodedArgs = buildKMSGenerationInitializeFromMigrationArgs();
-    const artifact = await hre.artifacts.readArtifact('KMSGeneration');
-    const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
     const preparedUpgrade = await buildUpgradeProposal(hre, {
       proxyAddress,
       contractName: 'KMSGeneration',
-      innerFunctionSignature,
+      innerFunctionName: 'initializeFromMigration',
       decodedArgs,
     });
 

--- a/host-contracts/tasks/taskMigrate.ts
+++ b/host-contracts/tasks/taskMigrate.ts
@@ -5,7 +5,7 @@ import { task, types } from 'hardhat/config';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 import path from 'path';
 
-import { parseSnapshotArtifact, prepareCanonicalSnapshotUpgrade } from './protocolConfigMirror';
+import { buildCanonicalUpgradeProposal, parseSnapshotArtifact } from './protocolConfigMirror';
 import {
   assertContractMatchesVersionPrefix,
   deployEmptyUUPS,
@@ -14,19 +14,19 @@ import {
   readHostEnv,
   waitForTaskReady,
 } from './taskDeploy';
-import {
-  getFunctionFragment,
-  prepareDaoUpgrade,
-  printPreparedDaoUpgrade,
-  toJsonString,
-  verifyPreparedImplementation,
-} from './utils/daoUpgrade';
 import { buildKMSGenerationInitializeFromMigrationArgs } from './utils/kmsGenerationMigrationEnv';
 import { getRequiredEnvVar, loadHostAddresses } from './utils/loadVariables';
 import {
   type ProtocolConfigMigrationKmsNode,
   buildProtocolConfigInitializeFromMigrationArgs,
 } from './utils/protocolConfigMigrationEnv';
+import {
+  buildUpgradeProposal,
+  getFunctionFragment,
+  printUpgradeProposal,
+  toJsonString,
+  verifyProposalImplementation,
+} from './utils/upgradeProposal';
 
 function assertEqual<T>(label: string, actual: T, expected: NoInfer<T>): void {
   if (actual !== expected) {
@@ -131,16 +131,16 @@ task(
     const decodedArgs = buildProtocolConfigInitializeFromMigrationArgs();
     const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
     const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
-    const preparedUpgrade = await prepareDaoUpgrade(hre, {
+    const preparedUpgrade = await buildUpgradeProposal(hre, {
       proxyAddress,
       contractName: 'ProtocolConfig',
       innerFunctionSignature,
       decodedArgs,
     });
 
-    printPreparedDaoUpgrade(preparedUpgrade);
+    printUpgradeProposal(preparedUpgrade);
     if (verifyContract) {
-      await verifyPreparedImplementation(hre, preparedUpgrade, 'contracts/ProtocolConfig.sol:ProtocolConfig');
+      await verifyProposalImplementation(hre, preparedUpgrade, 'contracts/ProtocolConfig.sol:ProtocolConfig');
     }
     return preparedUpgrade;
   });
@@ -171,11 +171,11 @@ task(
     // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
     await hre.run('compile:specific', { contract: 'contracts' });
     const snapshot = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
-    const preparedUpgrade = await prepareCanonicalSnapshotUpgrade(hre, { snapshot, proxyAddress });
+    const preparedUpgrade = await buildCanonicalUpgradeProposal(hre, { snapshot, proxyAddress });
 
-    printPreparedDaoUpgrade(preparedUpgrade);
+    printUpgradeProposal(preparedUpgrade);
     if (verifyContract) {
-      await verifyPreparedImplementation(hre, preparedUpgrade, 'contracts/ProtocolConfig.sol:ProtocolConfig');
+      await verifyProposalImplementation(hre, preparedUpgrade, 'contracts/ProtocolConfig.sol:ProtocolConfig');
     }
     return preparedUpgrade;
   });
@@ -227,16 +227,16 @@ task(
     const decodedArgs = buildKMSGenerationInitializeFromMigrationArgs();
     const artifact = await hre.artifacts.readArtifact('KMSGeneration');
     const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
-    const preparedUpgrade = await prepareDaoUpgrade(hre, {
+    const preparedUpgrade = await buildUpgradeProposal(hre, {
       proxyAddress,
       contractName: 'KMSGeneration',
       innerFunctionSignature,
       decodedArgs,
     });
 
-    printPreparedDaoUpgrade(preparedUpgrade);
+    printUpgradeProposal(preparedUpgrade);
     if (verifyContract) {
-      await verifyPreparedImplementation(hre, preparedUpgrade, 'contracts/KMSGeneration.sol:KMSGeneration');
+      await verifyProposalImplementation(hre, preparedUpgrade, 'contracts/KMSGeneration.sol:KMSGeneration');
     }
     return preparedUpgrade;
   });

--- a/host-contracts/tasks/taskMigrate.ts
+++ b/host-contracts/tasks/taskMigrate.ts
@@ -5,6 +5,7 @@ import { task, types } from 'hardhat/config';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 import path from 'path';
 
+import { parseSnapshotArtifact } from './protocolConfigMirror';
 import {
   assertContractMatchesVersionPrefix,
   deployEmptyUUPS,
@@ -219,6 +220,49 @@ task(
     // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
     await hre.run('compile:specific', { contract: 'contracts' });
     const decodedArgs = buildProtocolConfigInitializeFromMigrationArgs();
+    const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
+    const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
+    const preparedUpgrade = await prepareDaoUpgrade(hre, {
+      proxyAddress,
+      contractName: 'ProtocolConfig',
+      innerFunctionSignature,
+      decodedArgs,
+    });
+
+    printPreparedDaoUpgrade(preparedUpgrade);
+    if (verifyContract) {
+      await verifyPreparedImplementation(hre, preparedUpgrade, 'contracts/ProtocolConfig.sol:ProtocolConfig');
+    }
+    return preparedUpgrade;
+  });
+
+// DAO path for initializing a non-canonical ProtocolConfig replica from the canonical chain
+// (Ethereum). Consumes a reviewed task:exportCanonicalProtocolConfig artifact — not a live RPC
+// read — so the DAO executes exactly the state its signers reproduced and diffed. Devnet
+// equivalent: task:deployProtocolConfigFromCanonical.
+task(
+  'task:prepareDeployProtocolConfigFromCanonical',
+  'Deploys a ProtocolConfig implementation and prints DAO upgrade calldata from a reviewed canonical snapshot artifact',
+)
+  .addParam(
+    'snapshot',
+    'Path to the reviewed task:exportCanonicalProtocolConfig artifact to encode into the DAO payload.',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function ({ snapshot: snapshotPath, verifyContract }, hre) {
+    const parsedEnv = readHostEnv();
+    const proxyAddress = parsedEnv.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
+    // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
+    await hre.run('compile:specific', { contract: 'contracts' });
+    const { snapshot } = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
+    const decodedArgs = [snapshot.currentContextId, snapshot.kmsNodes, snapshot.thresholds];
     const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
     const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
     const preparedUpgrade = await prepareDaoUpgrade(hre, {

--- a/host-contracts/tasks/taskMigrate.ts
+++ b/host-contracts/tasks/taskMigrate.ts
@@ -1,11 +1,11 @@
 import { calculateERC7201StorageLocation } from '@openzeppelin/upgrades-core/dist/utils/erc7201';
-import { AbiCoder, FunctionFragment, Interface, type InterfaceAbi, getAddress, keccak256, toBeHex } from 'ethers';
+import { AbiCoder, getAddress, keccak256, toBeHex } from 'ethers';
 import fs from 'fs';
 import { task, types } from 'hardhat/config';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 import path from 'path';
 
-import { parseSnapshotArtifact } from './protocolConfigMirror';
+import { parseSnapshotArtifact, prepareCanonicalSnapshotUpgrade } from './protocolConfigMirror';
 import {
   assertContractMatchesVersionPrefix,
   deployEmptyUUPS,
@@ -14,110 +14,19 @@ import {
   readHostEnv,
   waitForTaskReady,
 } from './taskDeploy';
+import {
+  getFunctionFragment,
+  prepareDaoUpgrade,
+  printPreparedDaoUpgrade,
+  toJsonString,
+  verifyPreparedImplementation,
+} from './utils/daoUpgrade';
 import { buildKMSGenerationInitializeFromMigrationArgs } from './utils/kmsGenerationMigrationEnv';
 import { getRequiredEnvVar, loadHostAddresses } from './utils/loadVariables';
 import {
   type ProtocolConfigMigrationKmsNode,
   buildProtocolConfigInitializeFromMigrationArgs,
 } from './utils/protocolConfigMigrationEnv';
-
-////////////////////////////////////////////////////////////////////////////////
-// Proposal artifact helpers
-////////////////////////////////////////////////////////////////////////////////
-
-export function toJsonString(value: unknown): string {
-  return JSON.stringify(
-    value,
-    (_, nestedValue: unknown) => (typeof nestedValue === 'bigint' ? nestedValue.toString() : nestedValue),
-    2,
-  );
-}
-
-function getFunctionFragment(abi: InterfaceAbi, functionName: string): FunctionFragment {
-  const fragment = new Interface(abi).getFunction(functionName);
-  if (fragment === null) {
-    throw new Error(`Function ${functionName} not found in ABI.`);
-  }
-  return fragment;
-}
-
-export const UPGRADE_TO_AND_CALL_INTERFACE = new Interface([
-  'function upgradeToAndCall(address newImplementation, bytes data) payable',
-]);
-
-type PreparedDaoUpgrade = {
-  proxyAddress: string;
-  newImplementationAddress: string;
-  innerFunctionSignature: string;
-  decodedArgs: unknown[];
-  innerCalldata: string;
-  outerCalldata: string;
-};
-
-async function prepareDaoUpgrade(
-  hre: HardhatRuntimeEnvironment,
-  params: {
-    proxyAddress: string;
-    contractName: string;
-    innerFunctionSignature: string;
-    decodedArgs: unknown[];
-  },
-): Promise<PreparedDaoUpgrade> {
-  const { ethers, upgrades } = hre;
-  const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
-  const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
-  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
-  const newImplementation = await ethers.getContractFactory(params.contractName, deployer);
-  await upgrades.forceImport(params.proxyAddress, currentImplementation);
-  const newImplementationAddress = String(
-    await upgrades.prepareUpgrade(params.proxyAddress, newImplementation, {
-      kind: 'uups',
-    }),
-  );
-  const innerCalldata = newImplementation.interface.encodeFunctionData(
-    params.innerFunctionSignature,
-    params.decodedArgs,
-  );
-  const outerCalldata = UPGRADE_TO_AND_CALL_INTERFACE.encodeFunctionData('upgradeToAndCall', [
-    newImplementationAddress,
-    innerCalldata,
-  ]);
-
-  return {
-    proxyAddress: params.proxyAddress,
-    newImplementationAddress,
-    innerFunctionSignature: params.innerFunctionSignature,
-    decodedArgs: params.decodedArgs,
-    innerCalldata,
-    outerCalldata,
-  };
-}
-
-async function verifyPreparedImplementation(
-  hre: HardhatRuntimeEnvironment,
-  data: PreparedDaoUpgrade,
-  contract: string,
-): Promise<void> {
-  console.log('Waiting 2 minutes before contract verification... Please wait...');
-  await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
-  await hre.run('verify:verify', {
-    address: data.newImplementationAddress,
-    contract,
-    constructorArguments: [],
-  });
-}
-
-function printPreparedDaoUpgrade(data: PreparedDaoUpgrade): void {
-  console.log('proxyAddress:', data.proxyAddress);
-  console.log('newImplementationAddress:', data.newImplementationAddress);
-  console.log('innerFunctionSignature:', data.innerFunctionSignature);
-  console.log('decodedArgs:', toJsonString(data.decodedArgs));
-  console.log(`${data.innerFunctionSignature} calldata:`, data.innerCalldata);
-  console.log('upgradeToAndCall(address,bytes) calldata:', data.outerCalldata);
-  console.log(
-    `Cast command: cast calldata 'upgradeToAndCall(address,bytes)' ${data.newImplementationAddress} ${data.innerCalldata}`,
-  );
-}
 
 function assertEqual<T>(label: string, actual: T, expected: NoInfer<T>): void {
   if (actual !== expected) {
@@ -262,15 +171,7 @@ task(
     // The bootstrap task may have updated addresses/FHEVMHostAddresses.sol, so rebuild
     await hre.run('compile:specific', { contract: 'contracts' });
     const snapshot = parseSnapshotArtifact(fs.readFileSync(snapshotPath, 'utf-8'));
-    const decodedArgs = [snapshot.currentKmsContextId, snapshot.kmsNodes, snapshot.thresholds];
-    const artifact = await hre.artifacts.readArtifact('ProtocolConfig');
-    const innerFunctionSignature = getFunctionFragment(artifact.abi, 'initializeFromMigration').format('sighash');
-    const preparedUpgrade = await prepareDaoUpgrade(hre, {
-      proxyAddress,
-      contractName: 'ProtocolConfig',
-      innerFunctionSignature,
-      decodedArgs,
-    });
+    const preparedUpgrade = await prepareCanonicalSnapshotUpgrade(hre, { snapshot, proxyAddress });
 
     printPreparedDaoUpgrade(preparedUpgrade);
     if (verifyContract) {

--- a/host-contracts/tasks/utils/contractVersion.ts
+++ b/host-contracts/tasks/utils/contractVersion.ts
@@ -1,0 +1,29 @@
+import type { Provider } from 'ethers';
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+import { formatError } from './formatError';
+
+// Asserts the contract at `address` is the expected proxy by checking its getVersion() prefix.
+// Defaults to the local network provider; pass `provider` to check a contract on another chain
+// (e.g. the canonical ProtocolConfig read over a remote RPC).
+export async function assertContractMatchesVersionPrefix(
+  hre: HardhatRuntimeEnvironment,
+  address: string,
+  versionPrefix: string,
+  provider: Provider = hre.ethers.provider,
+): Promise<void> {
+  const contract = new hre.ethers.Contract(address, ['function getVersion() view returns (string)'], provider);
+
+  let version: string;
+  try {
+    version = await contract.getVersion();
+  } catch (err) {
+    throw new Error(
+      `Contract at ${address} does not expose getVersion(); it is not a ${versionPrefix} proxy. (${formatError(err)})`,
+    );
+  }
+
+  if (!version.startsWith(versionPrefix)) {
+    throw new Error(`Contract at ${address} reports version "${version}"; expected "${versionPrefix} v…".`);
+  }
+}

--- a/host-contracts/tasks/utils/daoUpgrade.ts
+++ b/host-contracts/tasks/utils/daoUpgrade.ts
@@ -1,0 +1,120 @@
+import { FunctionFragment, Interface, type InterfaceAbi } from 'ethers';
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+import { getRequiredEnvVar } from './loadVariables';
+
+// Generic prepare/execute machinery for UUPS upgrades governed by upgradeToAndCall payloads.
+//
+// The DAO path stops after `prepareDaoUpgrade` + `printPreparedDaoUpgrade`: the implementation is
+// deployed, the payload is printed, and the DAO executes it. The direct (devnet) path is the same
+// prepare step followed by `executePreparedDaoUpgrade`, which simply sends the prepared payload
+// with the deployer key — so what runs on devnet is byte-identical to what the DAO signs.
+
+export function toJsonString(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_, nestedValue: unknown) => (typeof nestedValue === 'bigint' ? nestedValue.toString() : nestedValue),
+    2,
+  );
+}
+
+export function getFunctionFragment(abi: InterfaceAbi, functionName: string): FunctionFragment {
+  const fragment = new Interface(abi).getFunction(functionName);
+  if (fragment === null) {
+    throw new Error(`Function ${functionName} not found in ABI.`);
+  }
+  return fragment;
+}
+
+export const UPGRADE_TO_AND_CALL_INTERFACE = new Interface([
+  'function upgradeToAndCall(address newImplementation, bytes data) payable',
+]);
+
+export type PreparedDaoUpgrade = {
+  proxyAddress: string;
+  newImplementationAddress: string;
+  innerFunctionSignature: string;
+  decodedArgs: unknown[];
+  innerCalldata: string;
+  outerCalldata: string;
+};
+
+export async function prepareDaoUpgrade(
+  hre: HardhatRuntimeEnvironment,
+  params: {
+    proxyAddress: string;
+    contractName: string;
+    innerFunctionSignature: string;
+    decodedArgs: unknown[];
+  },
+): Promise<PreparedDaoUpgrade> {
+  const { ethers, upgrades } = hre;
+  const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
+  const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
+  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  const newImplementation = await ethers.getContractFactory(params.contractName, deployer);
+  await upgrades.forceImport(params.proxyAddress, currentImplementation);
+  const newImplementationAddress = String(
+    await upgrades.prepareUpgrade(params.proxyAddress, newImplementation, {
+      kind: 'uups',
+    }),
+  );
+  const innerCalldata = newImplementation.interface.encodeFunctionData(
+    params.innerFunctionSignature,
+    params.decodedArgs,
+  );
+  const outerCalldata = UPGRADE_TO_AND_CALL_INTERFACE.encodeFunctionData('upgradeToAndCall', [
+    newImplementationAddress,
+    innerCalldata,
+  ]);
+
+  return {
+    proxyAddress: params.proxyAddress,
+    newImplementationAddress,
+    innerFunctionSignature: params.innerFunctionSignature,
+    decodedArgs: params.decodedArgs,
+    innerCalldata,
+    outerCalldata,
+  };
+}
+
+// The entire direct (non-DAO) execution path: send the exact payload the DAO would sign, using the
+// deployer key.
+export async function executePreparedDaoUpgrade(
+  hre: HardhatRuntimeEnvironment,
+  prepared: PreparedDaoUpgrade,
+): Promise<void> {
+  const { ethers } = hre;
+  const deployer = new ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(ethers.provider);
+  console.log(
+    `Executing prepared upgrade on ${prepared.proxyAddress} (implementation ${prepared.newImplementationAddress})...`,
+  );
+  const tx = await deployer.sendTransaction({ to: prepared.proxyAddress, data: prepared.outerCalldata });
+  await tx.wait();
+}
+
+export async function verifyPreparedImplementation(
+  hre: HardhatRuntimeEnvironment,
+  data: PreparedDaoUpgrade,
+  contract: string,
+): Promise<void> {
+  console.log('Waiting 2 minutes before contract verification... Please wait...');
+  await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+  await hre.run('verify:verify', {
+    address: data.newImplementationAddress,
+    contract,
+    constructorArguments: [],
+  });
+}
+
+export function printPreparedDaoUpgrade(data: PreparedDaoUpgrade): void {
+  console.log('proxyAddress:', data.proxyAddress);
+  console.log('newImplementationAddress:', data.newImplementationAddress);
+  console.log('innerFunctionSignature:', data.innerFunctionSignature);
+  console.log('decodedArgs:', toJsonString(data.decodedArgs));
+  console.log(`${data.innerFunctionSignature} calldata:`, data.innerCalldata);
+  console.log('upgradeToAndCall(address,bytes) calldata:', data.outerCalldata);
+  console.log(
+    `Cast command: cast calldata 'upgradeToAndCall(address,bytes)' ${data.newImplementationAddress} ${data.innerCalldata}`,
+  );
+}

--- a/host-contracts/tasks/utils/formatError.ts
+++ b/host-contracts/tasks/utils/formatError.ts
@@ -1,0 +1,3 @@
+export function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/host-contracts/tasks/utils/upgradeProposal.ts
+++ b/host-contracts/tasks/utils/upgradeProposal.ts
@@ -1,4 +1,4 @@
-import { FunctionFragment, Interface, type InterfaceAbi } from 'ethers';
+import { Interface } from 'ethers';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import { getRequiredEnvVar } from './loadVariables';
@@ -16,14 +16,6 @@ export function toJsonString(value: unknown): string {
     (_, nestedValue: unknown) => (typeof nestedValue === 'bigint' ? nestedValue.toString() : nestedValue),
     2,
   );
-}
-
-export function getFunctionFragment(abi: InterfaceAbi, functionName: string): FunctionFragment {
-  const fragment = new Interface(abi).getFunction(functionName);
-  if (fragment === null) {
-    throw new Error(`Function ${functionName} not found in ABI.`);
-  }
-  return fragment;
 }
 
 export const UPGRADE_TO_AND_CALL_INTERFACE = new Interface([
@@ -44,7 +36,7 @@ export async function buildUpgradeProposal(
   params: {
     proxyAddress: string;
     contractName: string;
-    innerFunctionSignature: string;
+    innerFunctionName: string;
     decodedArgs: unknown[];
   },
 ): Promise<UpgradeProposal> {
@@ -59,10 +51,10 @@ export async function buildUpgradeProposal(
       kind: 'uups',
     }),
   );
-  const innerCalldata = newImplementation.interface.encodeFunctionData(
-    params.innerFunctionSignature,
-    params.decodedArgs,
-  );
+  // The factory's interface already knows the new implementation's ABI, so encode by function name
+  // directly — no need to re-read the artifact or precompute a sighash at the call site.
+  const innerCalldata = newImplementation.interface.encodeFunctionData(params.innerFunctionName, params.decodedArgs);
+  const innerFunctionSignature = newImplementation.interface.getFunction(params.innerFunctionName)!.format('sighash');
   const outerCalldata = UPGRADE_TO_AND_CALL_INTERFACE.encodeFunctionData('upgradeToAndCall', [
     newImplementationAddress,
     innerCalldata,
@@ -71,7 +63,7 @@ export async function buildUpgradeProposal(
   return {
     proxyAddress: params.proxyAddress,
     newImplementationAddress,
-    innerFunctionSignature: params.innerFunctionSignature,
+    innerFunctionSignature,
     decodedArgs: params.decodedArgs,
     innerCalldata,
     outerCalldata,

--- a/host-contracts/tasks/utils/upgradeProposal.ts
+++ b/host-contracts/tasks/utils/upgradeProposal.ts
@@ -5,9 +5,9 @@ import { getRequiredEnvVar } from './loadVariables';
 
 // Generic prepare/execute machinery for UUPS upgrades governed by upgradeToAndCall payloads.
 //
-// The DAO path stops after `prepareDaoUpgrade` + `printPreparedDaoUpgrade`: the implementation is
+// The DAO path stops after `buildUpgradeProposal` + `printUpgradeProposal`: the implementation is
 // deployed, the payload is printed, and the DAO executes it. The direct (devnet) path is the same
-// prepare step followed by `executePreparedDaoUpgrade`, which simply sends the prepared payload
+// prepare step followed by `executeUpgradeProposal`, which simply sends the prepared payload
 // with the deployer key — so what runs on devnet is byte-identical to what the DAO signs.
 
 export function toJsonString(value: unknown): string {
@@ -30,7 +30,7 @@ export const UPGRADE_TO_AND_CALL_INTERFACE = new Interface([
   'function upgradeToAndCall(address newImplementation, bytes data) payable',
 ]);
 
-export type PreparedDaoUpgrade = {
+export type UpgradeProposal = {
   proxyAddress: string;
   newImplementationAddress: string;
   innerFunctionSignature: string;
@@ -39,7 +39,7 @@ export type PreparedDaoUpgrade = {
   outerCalldata: string;
 };
 
-export async function prepareDaoUpgrade(
+export async function buildUpgradeProposal(
   hre: HardhatRuntimeEnvironment,
   params: {
     proxyAddress: string;
@@ -47,7 +47,7 @@ export async function prepareDaoUpgrade(
     innerFunctionSignature: string;
     decodedArgs: unknown[];
   },
-): Promise<PreparedDaoUpgrade> {
+): Promise<UpgradeProposal> {
   const { ethers, upgrades } = hre;
   const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
   const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
@@ -80,10 +80,7 @@ export async function prepareDaoUpgrade(
 
 // The entire direct (non-DAO) execution path: send the exact payload the DAO would sign, using the
 // deployer key.
-export async function executePreparedDaoUpgrade(
-  hre: HardhatRuntimeEnvironment,
-  prepared: PreparedDaoUpgrade,
-): Promise<void> {
+export async function executeUpgradeProposal(hre: HardhatRuntimeEnvironment, prepared: UpgradeProposal): Promise<void> {
   const { ethers } = hre;
   const deployer = new ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(ethers.provider);
   console.log(
@@ -93,9 +90,9 @@ export async function executePreparedDaoUpgrade(
   await tx.wait();
 }
 
-export async function verifyPreparedImplementation(
+export async function verifyProposalImplementation(
   hre: HardhatRuntimeEnvironment,
-  data: PreparedDaoUpgrade,
+  data: UpgradeProposal,
   contract: string,
 ): Promise<void> {
   console.log('Waiting 2 minutes before contract verification... Please wait...');
@@ -107,7 +104,7 @@ export async function verifyPreparedImplementation(
   });
 }
 
-export function printPreparedDaoUpgrade(data: PreparedDaoUpgrade): void {
+export function printUpgradeProposal(data: UpgradeProposal): void {
   console.log('proxyAddress:', data.proxyAddress);
   console.log('newImplementationAddress:', data.newImplementationAddress);
   console.log('innerFunctionSignature:', data.innerFunctionSignature);

--- a/host-contracts/test/tasks/migration.ts
+++ b/host-contracts/test/tasks/migration.ts
@@ -7,7 +7,6 @@ import path from 'path';
 
 import { buildSnapshotArtifact, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
 import { buildKmsNodes, buildKmsThresholds } from '../../tasks/taskDeploy';
-import { UPGRADE_TO_AND_CALL_INTERFACE } from '../../tasks/utils/daoUpgrade';
 import { makeEnvHelpers } from '../../tasks/utils/envSnapshot';
 import {
   CRS_COUNTER_BASE,
@@ -30,6 +29,7 @@ import {
   restoreProtocolConfigMigrationEnv,
   snapshotProtocolConfigMigrationEnv,
 } from '../../tasks/utils/protocolConfigMigrationEnv';
+import { UPGRADE_TO_AND_CALL_INTERFACE } from '../../tasks/utils/upgradeProposal';
 import { deployEmptyProxy } from '../utils/deploymentHelpers';
 import {
   HOST_ENV_FILE,

--- a/host-contracts/test/tasks/migration.ts
+++ b/host-contracts/test/tasks/migration.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { buildSnapshotArtifact, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
 import { buildKmsNodes, buildKmsThresholds } from '../../tasks/taskDeploy';
-import { UPGRADE_TO_AND_CALL_INTERFACE } from '../../tasks/taskMigrate';
+import { UPGRADE_TO_AND_CALL_INTERFACE } from '../../tasks/utils/daoUpgrade';
 import { makeEnvHelpers } from '../../tasks/utils/envSnapshot';
 import {
   CRS_COUNTER_BASE,

--- a/host-contracts/test/tasks/migration.ts
+++ b/host-contracts/test/tasks/migration.ts
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
 import { Wallet } from 'ethers';
 import fs from 'fs';
-import { ethers, run, upgrades } from 'hardhat';
+import hre, { ethers, run, upgrades } from 'hardhat';
+import os from 'os';
+import path from 'path';
 
+import { buildSnapshotArtifact, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
 import { buildKmsNodes, buildKmsThresholds } from '../../tasks/taskDeploy';
 import { UPGRADE_TO_AND_CALL_INTERFACE } from '../../tasks/taskMigrate';
 import { makeEnvHelpers } from '../../tasks/utils/envSnapshot';
@@ -28,7 +31,13 @@ import {
   snapshotProtocolConfigMigrationEnv,
 } from '../../tasks/utils/protocolConfigMigrationEnv';
 import { deployEmptyProxy } from '../utils/deploymentHelpers';
-import { HOST_ENV_FILE, buildProtocolConfigNodes, buildProtocolConfigThresholds, readHostAddress } from './taskHelpers';
+import {
+  HOST_ENV_FILE,
+  buildProtocolConfigNodes,
+  buildProtocolConfigThresholds,
+  deployFreshProtocolConfigProxy,
+  readHostAddress,
+} from './taskHelpers';
 
 async function deployEmptyUUPSProxy(deployer: Wallet): Promise<string> {
   const factory = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
@@ -167,6 +176,75 @@ describe('Migration prepare tasks', function () {
   // ---------------------------------------------------------------------------
   // KMSGeneration
   // ---------------------------------------------------------------------------
+
+  describe('ProtocolConfig from canonical artifact', function () {
+    async function writeCanonicalArtifact(): Promise<{ file: string; canonicalAddress: string }> {
+      const canonicalAddress = await deployFreshProtocolConfigProxy(
+        deployer,
+        buildProtocolConfigNodes(),
+        buildProtocolConfigThresholds(),
+      );
+      const snapshot = await readCanonicalSnapshot(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: canonicalAddress,
+      });
+      const artifact = buildSnapshotArtifact(snapshot, canonicalAddress);
+      const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'canonical-snapshot-')), 'snapshot.json');
+      fs.writeFileSync(file, JSON.stringify(artifact, null, 2));
+      return { file, canonicalAddress };
+    }
+
+    it('prepares DAO calldata from a reviewed artifact without mutating the proxy', async function () {
+      const proxyAddress = await deployEmptyUUPSProxy(deployer);
+      patchHostEnv('PROTOCOL_CONFIG_CONTRACT_ADDRESS', proxyAddress);
+      const { file, canonicalAddress } = await writeCanonicalArtifact();
+      const canonical = await ethers.getContractAt('ProtocolConfig', canonicalAddress, deployer);
+      const canonicalContextId = await canonical.getCurrentKmsContextId();
+
+      const implementationSlotBefore = await readImplementationSlot(proxyAddress);
+      const preparedUpgrade = await run('task:prepareDeployProtocolConfigFromCanonical', {
+        snapshot: file,
+        verifyContract: false,
+      });
+      expect(await readImplementationSlot(proxyAddress)).to.equal(implementationSlotBefore);
+
+      const { newImplementationAddress, innerFunctionSignature, innerCalldata, outerCalldata } = preparedUpgrade;
+      expect(preparedUpgrade.proxyAddress).to.equal(proxyAddress);
+      const iface = new ethers.Interface([`function ${innerFunctionSignature}`]);
+      const decoded = iface.decodeFunctionData('initializeFromMigration', innerCalldata);
+      expect(decoded[0]).to.equal(canonicalContextId);
+      expect(decoded[1].map((node: string[]) => node[0])).to.deep.equal(
+        buildProtocolConfigNodes().map((node) => node.txSenderAddress),
+      );
+      expect(decoded[2][0]).to.equal(BigInt(buildProtocolConfigThresholds().publicDecryption));
+      expect(outerCalldata).to.equal(
+        UPGRADE_TO_AND_CALL_INTERFACE.encodeFunctionData('upgradeToAndCall', [newImplementationAddress, innerCalldata]),
+      );
+    });
+
+    it('applies a reviewed artifact with the devnet deploy task, without canonical RPC access', async function () {
+      const proxyAddress = await deployEmptyUUPSProxy(deployer);
+      patchHostEnv('PROTOCOL_CONFIG_CONTRACT_ADDRESS', proxyAddress);
+      const { file, canonicalAddress } = await writeCanonicalArtifact();
+      const canonical = await ethers.getContractAt('ProtocolConfig', canonicalAddress, deployer);
+      const canonicalContextId = await canonical.getCurrentKmsContextId();
+
+      await run('task:deployProtocolConfigFromCanonical', { snapshot: file });
+
+      const secondary = await ethers.getContractAt('ProtocolConfig', proxyAddress, deployer);
+      expect(await secondary.getCurrentKmsContextId()).to.equal(canonicalContextId);
+      expect((await secondary.getKmsNodesForContext(canonicalContextId)).length).to.equal(
+        buildProtocolConfigNodes().length,
+      );
+      expect(await secondary.getPublicDecryptionThresholdForContext(canonicalContextId)).to.equal(
+        BigInt(buildProtocolConfigThresholds().publicDecryption),
+      );
+    });
+
+    it('rejects when neither a snapshot nor canonical RPC parameters are given', async function () {
+      await expect(run('task:deployProtocolConfigFromCanonical')).to.be.rejectedWith(/either --snapshot/);
+    });
+  });
 
   describe('KMSGeneration migration', function () {
     // The KMSGeneration migration validates consensus tx senders against the

--- a/host-contracts/test/tasks/taskDeploy.ts
+++ b/host-contracts/test/tasks/taskDeploy.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import hre, { ethers, run } from 'hardhat';
 
-import { prepareCanonicalSnapshotUpgrade, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
-import { executePreparedDaoUpgrade } from '../../tasks/utils/daoUpgrade';
+import { buildCanonicalUpgradeProposal, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE, PREP_KEYGEN_COUNTER_BASE } from '../../tasks/utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from '../../tasks/utils/loadVariables';
+import { executeUpgradeProposal } from '../../tasks/utils/upgradeProposal';
 import type { KMSGeneration, ProtocolConfig } from '../../types';
 import {
   buildProtocolConfigNodes,
@@ -101,8 +101,8 @@ describe('canonical snapshot apply (canonical → secondary deploy flow)', funct
       canonicalProvider: ethers.provider,
       canonicalProtocolConfigAddress,
     });
-    const prepared = await prepareCanonicalSnapshotUpgrade(hre, { snapshot, proxyAddress: secondaryProxyAddress });
-    await executePreparedDaoUpgrade(hre, prepared);
+    const prepared = await buildCanonicalUpgradeProposal(hre, { snapshot, proxyAddress: secondaryProxyAddress });
+    await executeUpgradeProposal(hre, prepared);
     return snapshot;
   }
 

--- a/host-contracts/test/tasks/taskDeploy.ts
+++ b/host-contracts/test/tasks/taskDeploy.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import hre, { ethers, run } from 'hardhat';
 
-import { mirrorProtocolConfigFromCanonical, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
+import { applyCanonicalSnapshot, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE, PREP_KEYGEN_COUNTER_BASE } from '../../tasks/utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from '../../tasks/utils/loadVariables';
 import type { KMSGeneration, ProtocolConfig } from '../../types';
@@ -89,9 +89,19 @@ describe('task:assertNoPendingKeyManagementRequest', function () {
   });
 });
 
-describe('mirrorProtocolConfigFromCanonical (canonical → secondary deploy flow)', function () {
+describe('canonical snapshot apply (canonical → secondary deploy flow)', function () {
   const deployerPrivateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
   const deployer = new ethers.Wallet(deployerPrivateKey).connect(ethers.provider);
+
+  // The composition task:deployProtocolConfigFromCanonical performs in live-read mode.
+  async function readAndApply(canonicalProtocolConfigAddress: string, secondaryProxyAddress: string) {
+    const snapshot = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress,
+    });
+    await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
+    return snapshot;
+  }
 
   it('mirrors the canonical ProtocolConfig snapshot onto a fresh secondary proxy', async function () {
     const canonicalNodes = buildProtocolConfigNodes();
@@ -108,11 +118,7 @@ describe('mirrorProtocolConfigFromCanonical (canonical → secondary deploy flow
     expect(canonicalAddress).to.not.equal(secondaryProxyAddress);
 
     const blockBeforeMirror = await ethers.provider.getBlockNumber();
-    const snapshot = await mirrorProtocolConfigFromCanonical(hre, {
-      canonicalProvider: ethers.provider,
-      canonicalProtocolConfigAddress: canonicalAddress,
-      secondaryProxyAddress,
-    });
+    const snapshot = await readAndApply(canonicalAddress, secondaryProxyAddress);
     const blockAfterMirror = await ethers.provider.getBlockNumber();
 
     const secondary = (await ethers.getContractAt(
@@ -123,12 +129,12 @@ describe('mirrorProtocolConfigFromCanonical (canonical → secondary deploy flow
 
     const canonicalContextId = await canonical.getCurrentKmsContextId();
     const secondaryContextId = await secondary.getCurrentKmsContextId();
-    expect(snapshot.currentContextId).to.equal(canonicalContextId);
+    expect(snapshot.currentKmsContextId).to.equal(canonicalContextId);
     expect(secondaryContextId).to.equal(canonicalContextId);
 
     expect(snapshot.canonicalChainId).to.equal((await ethers.provider.getNetwork()).chainId);
-    expect(snapshot.canonicalBlockTag).to.be.gte(blockBeforeMirror);
-    expect(snapshot.canonicalBlockTag).to.be.lte(blockAfterMirror);
+    expect(snapshot.blockNumber).to.be.gte(blockBeforeMirror);
+    expect(snapshot.blockNumber).to.be.lte(blockAfterMirror);
 
     const canonicalNodesOnChain = await canonical.getKmsNodesForContext(canonicalContextId);
     const secondaryNodesOnChain = await secondary.getKmsNodesForContext(secondaryContextId);
@@ -157,45 +163,6 @@ describe('mirrorProtocolConfigFromCanonical (canonical → secondary deploy flow
     expect(await secondary.isValidKmsContext(secondaryContextId)).to.equal(true);
   });
 
-  it('rejects when the canonical address is not a ProtocolConfig', async function () {
-    const notProtocolConfig = await deployFreshKMSGenerationProxy(deployer);
-    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
-
-    await expect(
-      mirrorProtocolConfigFromCanonical(hre, {
-        canonicalProvider: ethers.provider,
-        canonicalProtocolConfigAddress: await notProtocolConfig.getAddress(),
-        secondaryProxyAddress,
-      }),
-    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*reports version "KMSGeneration/);
-  });
-
-  it('rejects when the canonical address is an uninitialized empty proxy', async function () {
-    const uninitializedEmpty = await deployFreshEmptyUUPSProxy(deployer);
-    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
-
-    await expect(
-      mirrorProtocolConfigFromCanonical(hre, {
-        canonicalProvider: ethers.provider,
-        canonicalProtocolConfigAddress: uninitializedEmpty,
-        secondaryProxyAddress,
-      }),
-    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*does not expose getVersion/);
-  });
-
-  it('rejects when the canonical ProtocolConfig has no active KMS context', async function () {
-    const noContextCanonical = await deployFreshUninitializedProtocolConfigProxy(deployer);
-    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
-
-    await expect(
-      mirrorProtocolConfigFromCanonical(hre, {
-        canonicalProvider: ethers.provider,
-        canonicalProtocolConfigAddress: noContextCanonical,
-        secondaryProxyAddress,
-      }),
-    ).to.be.rejectedWith(/has no active KMS context \(currentKmsContextId=0\); cannot mirror/);
-  });
-
   it('pins canonical reads to a historical block under a rotation', async function () {
     const canonicalAddress = await deployFreshProtocolConfigProxy(
       deployer,
@@ -209,13 +176,9 @@ describe('mirrorProtocolConfigFromCanonical (canonical → secondary deploy flow
     )) as unknown as ProtocolConfig;
     const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
 
-    const snapshot = await mirrorProtocolConfigFromCanonical(hre, {
-      canonicalProvider: ethers.provider,
-      canonicalProtocolConfigAddress: canonicalAddress,
-      secondaryProxyAddress,
-    });
-    const pinnedBlock = snapshot.canonicalBlockTag;
-    const pinnedContextId = snapshot.currentContextId;
+    const snapshot = await readAndApply(canonicalAddress, secondaryProxyAddress);
+    const pinnedBlock = snapshot.blockNumber;
+    const pinnedContextId = snapshot.currentKmsContextId;
 
     const rotatedNodes = buildProtocolConfigNodes().slice(0, 2);
     const rotatedThresholds = { publicDecryption: 1, userDecryption: 1, kmsGen: 1, mpc: 1 };
@@ -244,16 +207,38 @@ describe('canonical snapshot export (readCanonicalSnapshot)', function () {
       canonicalProtocolConfigAddress: canonicalAddress,
     });
     expect(snapshot.kmsNodes.length).to.equal(canonicalNodes.length);
-    expect(snapshot.currentContextId).to.not.equal(0n);
+    expect(snapshot.currentKmsContextId).to.not.equal(0n);
     expect(snapshot.canonicalChainId).to.equal((await ethers.provider.getNetwork()).chainId);
 
     // The DAO's review check: re-reading the artifact's pinned block reproduces the snapshot exactly.
     const reread = await readCanonicalSnapshot(hre, {
       canonicalProvider: ethers.provider,
       canonicalProtocolConfigAddress: canonicalAddress,
-      blockTag: snapshot.canonicalBlockTag,
+      blockNumber: snapshot.blockNumber,
     });
     expect(reread).to.deep.equal(snapshot);
+  });
+
+  it('rejects when the canonical address is not a ProtocolConfig', async function () {
+    const notProtocolConfig = await deployFreshKMSGenerationProxy(deployer);
+
+    await expect(
+      readCanonicalSnapshot(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: await notProtocolConfig.getAddress(),
+      }),
+    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*reports version "KMSGeneration/);
+  });
+
+  it('rejects when the canonical address is an uninitialized empty proxy', async function () {
+    const uninitializedEmpty = await deployFreshEmptyUUPSProxy(deployer);
+
+    await expect(
+      readCanonicalSnapshot(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: uninitializedEmpty,
+      }),
+    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*does not expose getVersion/);
   });
 
   it('rejects when the canonical ProtocolConfig has no active KMS context', async function () {
@@ -297,13 +282,13 @@ describe('canonical snapshot export (readCanonicalSnapshot)', function () {
       canonicalProvider: ethers.provider,
       canonicalProtocolConfigAddress: canonicalAddress,
     });
-    expect(atLatest.currentContextId).to.not.equal(exported.currentContextId);
+    expect(atLatest.currentKmsContextId).to.not.equal(exported.currentKmsContextId);
 
     // Re-reading at the artifact's blockNumber reproduces the original snapshot despite the rotation.
     const atPinned = await readCanonicalSnapshot(hre, {
       canonicalProvider: ethers.provider,
       canonicalProtocolConfigAddress: canonicalAddress,
-      blockTag: exported.canonicalBlockTag,
+      blockNumber: exported.blockNumber,
     });
     expect(atPinned).to.deep.equal(exported);
   });

--- a/host-contracts/test/tasks/taskDeploy.ts
+++ b/host-contracts/test/tasks/taskDeploy.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import hre, { ethers, run } from 'hardhat';
 
-import { buildCanonicalUpgradeProposal, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
+import {
+  buildCanonicalUpgradeProposal,
+  buildSnapshotArtifact,
+  parseSnapshotArtifact,
+  readCanonicalSnapshot,
+} from '../../tasks/protocolConfigMirror';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE, PREP_KEYGEN_COUNTER_BASE } from '../../tasks/utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from '../../tasks/utils/loadVariables';
 import { executeUpgradeProposal } from '../../tasks/utils/upgradeProposal';
@@ -242,7 +247,7 @@ describe('canonical snapshot export (readCanonicalSnapshot)', function () {
         canonicalProvider: ethers.provider,
         canonicalProtocolConfigAddress: await notProtocolConfig.getAddress(),
       }),
-    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*reports version "KMSGeneration/);
+    ).to.be.rejectedWith(/reports version "KMSGeneration.*expected "ProtocolConfig/);
   });
 
   it('rejects when the canonical address is an uninitialized empty proxy', async function () {
@@ -253,7 +258,7 @@ describe('canonical snapshot export (readCanonicalSnapshot)', function () {
         canonicalProvider: ethers.provider,
         canonicalProtocolConfigAddress: uninitializedEmpty,
       }),
-    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*does not expose getVersion/);
+    ).to.be.rejectedWith(/does not expose getVersion\(\); it is not a ProtocolConfig proxy/);
   });
 
   it('rejects when the canonical ProtocolConfig has no active KMS context', async function () {
@@ -306,5 +311,52 @@ describe('canonical snapshot export (readCanonicalSnapshot)', function () {
       blockNumber: exported.blockNumber,
     });
     expect(atPinned).to.deep.equal(exported);
+  });
+});
+
+describe('canonical snapshot artifact (buildSnapshotArtifact / parseSnapshotArtifact)', function () {
+  const deployer = new ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(ethers.provider);
+
+  async function exportArtifact(): Promise<string> {
+    const canonicalAddress = await deployFreshProtocolConfigProxy(
+      deployer,
+      buildProtocolConfigNodes(),
+      buildProtocolConfigThresholds(),
+    );
+    const snapshot = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+    });
+    return JSON.stringify(buildSnapshotArtifact(snapshot, canonicalAddress));
+  }
+
+  it('round-trips a snapshot through the JSON artifact, preserving the block hash', async function () {
+    const canonicalAddress = await deployFreshProtocolConfigProxy(
+      deployer,
+      buildProtocolConfigNodes(),
+      buildProtocolConfigThresholds(),
+    );
+    const snapshot = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+    });
+
+    const artifact = buildSnapshotArtifact(snapshot, canonicalAddress);
+    expect(artifact.blockHash).to.equal(snapshot.blockHash);
+    expect(parseSnapshotArtifact(JSON.stringify(artifact))).to.deep.equal(snapshot);
+  });
+
+  it('rejects an artifact whose blockHash is not a 32-byte hex string', async function () {
+    const artifact = JSON.parse(await exportArtifact());
+    artifact.blockHash = '0xdeadbeef';
+    expect(() => parseSnapshotArtifact(JSON.stringify(artifact))).to.throw(/"blockHash" must be a 32-byte hex string/);
+  });
+
+  it('rejects an artifact whose node signer address is malformed', async function () {
+    const artifact = JSON.parse(await exportArtifact());
+    artifact.kmsNodes[0].signerAddress = 'not-an-address';
+    expect(() => parseSnapshotArtifact(JSON.stringify(artifact))).to.throw(
+      /"kmsNodes\[0\]\.signerAddress" must be a valid address/,
+    );
   });
 });

--- a/host-contracts/test/tasks/taskDeploy.ts
+++ b/host-contracts/test/tasks/taskDeploy.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import hre, { ethers, run } from 'hardhat';
 
-import { applyCanonicalSnapshot, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
+import { prepareCanonicalSnapshotUpgrade, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
+import { executePreparedDaoUpgrade } from '../../tasks/utils/daoUpgrade';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE, PREP_KEYGEN_COUNTER_BASE } from '../../tasks/utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from '../../tasks/utils/loadVariables';
 import type { KMSGeneration, ProtocolConfig } from '../../types';
@@ -93,13 +94,15 @@ describe('canonical snapshot apply (canonical → secondary deploy flow)', funct
   const deployerPrivateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
   const deployer = new ethers.Wallet(deployerPrivateKey).connect(ethers.provider);
 
-  // The composition task:deployProtocolConfigFromCanonical performs in live-read mode.
+  // The composition task:deployProtocolConfigFromCanonical performs in live-read mode: the DAO
+  // prepare step, then direct execution of the produced payload.
   async function readAndApply(canonicalProtocolConfigAddress: string, secondaryProxyAddress: string) {
     const snapshot = await readCanonicalSnapshot(hre, {
       canonicalProvider: ethers.provider,
       canonicalProtocolConfigAddress,
     });
-    await applyCanonicalSnapshot(hre, { snapshot, secondaryProxyAddress });
+    const prepared = await prepareCanonicalSnapshotUpgrade(hre, { snapshot, proxyAddress: secondaryProxyAddress });
+    await executePreparedDaoUpgrade(hre, prepared);
     return snapshot;
   }
 

--- a/host-contracts/test/tasks/taskDeploy.ts
+++ b/host-contracts/test/tasks/taskDeploy.ts
@@ -24,7 +24,19 @@ describe('task:deployAllHostContracts', function () {
   it('rejects an invalid --protocol-config-source value before mutating state', async function () {
     await expect(
       run('task:deployAllHostContracts', { withKmsGeneration: false, protocolConfigSource: 'bogus' }),
-    ).to.be.rejectedWith(/Invalid --protocol-config-source "bogus"\. Allowed values: fresh, migration\./);
+    ).to.be.rejectedWith(/Invalid --protocol-config-source "bogus"\. Allowed values: fresh, migration, canonical\./);
+  });
+
+  it('rejects --protocol-config-source canonical on a canonical host', async function () {
+    await expect(
+      run('task:deployAllHostContracts', { withKmsGeneration: true, protocolConfigSource: 'canonical' }),
+    ).to.be.rejectedWith(/cannot be combined with --with-kms-generation true/);
+  });
+
+  it('rejects --protocol-config-source canonical without the canonical chain parameters', async function () {
+    await expect(
+      run('task:deployAllHostContracts', { withKmsGeneration: false, protocolConfigSource: 'canonical' }),
+    ).to.be.rejectedWith(/requires --canonical-rpc-url and --canonical-protocol-config-address/);
   });
 });
 

--- a/host-contracts/test/tasks/taskDeploy.ts
+++ b/host-contracts/test/tasks/taskDeploy.ts
@@ -1,10 +1,19 @@
 import { expect } from 'chai';
-import { ethers, run } from 'hardhat';
+import hre, { ethers, run } from 'hardhat';
 
+import { mirrorProtocolConfigFromCanonical, readCanonicalSnapshot } from '../../tasks/protocolConfigMirror';
 import { CRS_COUNTER_BASE, KEY_COUNTER_BASE, PREP_KEYGEN_COUNTER_BASE } from '../../tasks/utils/kmsGenerationConstants';
 import { getRequiredEnvVar } from '../../tasks/utils/loadVariables';
-import type { KMSGeneration } from '../../types';
-import { deployFreshKMSGenerationProxy, readHostAddress } from './taskHelpers';
+import type { KMSGeneration, ProtocolConfig } from '../../types';
+import {
+  buildProtocolConfigNodes,
+  buildProtocolConfigThresholds,
+  deployFreshEmptyUUPSProxy,
+  deployFreshKMSGenerationProxy,
+  deployFreshProtocolConfigProxy,
+  deployFreshUninitializedProtocolConfigProxy,
+  readHostAddress,
+} from './taskHelpers';
 
 describe('task:deployAllHostContracts', function () {
   it('requires the KMSGeneration deployment role to be explicit', async function () {
@@ -77,5 +86,225 @@ describe('task:assertNoPendingKeyManagementRequest', function () {
     await kmsGeneration.abortCrsgen(CRS_COUNTER_BASE + 1n);
 
     await run('task:assertNoPendingKeyManagementRequest', { address: kmsGenerationAddress });
+  });
+});
+
+describe('mirrorProtocolConfigFromCanonical (canonical → secondary deploy flow)', function () {
+  const deployerPrivateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
+  const deployer = new ethers.Wallet(deployerPrivateKey).connect(ethers.provider);
+
+  it('mirrors the canonical ProtocolConfig snapshot onto a fresh secondary proxy', async function () {
+    const canonicalNodes = buildProtocolConfigNodes();
+    const canonicalThresholds = buildProtocolConfigThresholds();
+    const canonicalAddress = await deployFreshProtocolConfigProxy(deployer, canonicalNodes, canonicalThresholds);
+    const canonical = (await ethers.getContractAt(
+      'ProtocolConfig',
+      canonicalAddress,
+      deployer,
+    )) as unknown as ProtocolConfig;
+
+    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+
+    expect(canonicalAddress).to.not.equal(secondaryProxyAddress);
+
+    const blockBeforeMirror = await ethers.provider.getBlockNumber();
+    const snapshot = await mirrorProtocolConfigFromCanonical(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+      secondaryProxyAddress,
+    });
+    const blockAfterMirror = await ethers.provider.getBlockNumber();
+
+    const secondary = (await ethers.getContractAt(
+      'ProtocolConfig',
+      secondaryProxyAddress,
+      deployer,
+    )) as unknown as ProtocolConfig;
+
+    const canonicalContextId = await canonical.getCurrentKmsContextId();
+    const secondaryContextId = await secondary.getCurrentKmsContextId();
+    expect(snapshot.currentContextId).to.equal(canonicalContextId);
+    expect(secondaryContextId).to.equal(canonicalContextId);
+
+    expect(snapshot.canonicalChainId).to.equal((await ethers.provider.getNetwork()).chainId);
+    expect(snapshot.canonicalBlockTag).to.be.gte(blockBeforeMirror);
+    expect(snapshot.canonicalBlockTag).to.be.lte(blockAfterMirror);
+
+    const canonicalNodesOnChain = await canonical.getKmsNodesForContext(canonicalContextId);
+    const secondaryNodesOnChain = await secondary.getKmsNodesForContext(secondaryContextId);
+    expect(secondaryNodesOnChain.length).to.equal(canonicalNodesOnChain.length);
+    expect(secondaryNodesOnChain.length).to.equal(canonicalNodes.length);
+    for (let i = 0; i < canonicalNodes.length; i += 1) {
+      expect(secondaryNodesOnChain[i].txSenderAddress).to.equal(canonicalNodesOnChain[i].txSenderAddress);
+      expect(secondaryNodesOnChain[i].signerAddress).to.equal(canonicalNodesOnChain[i].signerAddress);
+      expect(secondaryNodesOnChain[i].ipAddress).to.equal(canonicalNodesOnChain[i].ipAddress);
+      expect(secondaryNodesOnChain[i].storageUrl).to.equal(canonicalNodesOnChain[i].storageUrl);
+    }
+
+    expect(await secondary.getPublicDecryptionThresholdForContext(secondaryContextId)).to.equal(
+      await canonical.getPublicDecryptionThresholdForContext(canonicalContextId),
+    );
+    expect(await secondary.getUserDecryptionThresholdForContext(secondaryContextId)).to.equal(
+      await canonical.getUserDecryptionThresholdForContext(canonicalContextId),
+    );
+    expect(await secondary.getKmsGenThresholdForContext(secondaryContextId)).to.equal(
+      await canonical.getKmsGenThresholdForContext(canonicalContextId),
+    );
+    expect(await secondary.getMpcThresholdForContext(secondaryContextId)).to.equal(
+      await canonical.getMpcThresholdForContext(canonicalContextId),
+    );
+
+    expect(await secondary.isValidKmsContext(secondaryContextId)).to.equal(true);
+  });
+
+  it('rejects when the canonical address is not a ProtocolConfig', async function () {
+    const notProtocolConfig = await deployFreshKMSGenerationProxy(deployer);
+    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+
+    await expect(
+      mirrorProtocolConfigFromCanonical(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: await notProtocolConfig.getAddress(),
+        secondaryProxyAddress,
+      }),
+    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*reports version "KMSGeneration/);
+  });
+
+  it('rejects when the canonical address is an uninitialized empty proxy', async function () {
+    const uninitializedEmpty = await deployFreshEmptyUUPSProxy(deployer);
+    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+
+    await expect(
+      mirrorProtocolConfigFromCanonical(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: uninitializedEmpty,
+        secondaryProxyAddress,
+      }),
+    ).to.be.rejectedWith(/Canonical ProtocolConfig identity check failed.*does not expose getVersion/);
+  });
+
+  it('rejects when the canonical ProtocolConfig has no active KMS context', async function () {
+    const noContextCanonical = await deployFreshUninitializedProtocolConfigProxy(deployer);
+    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+
+    await expect(
+      mirrorProtocolConfigFromCanonical(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: noContextCanonical,
+        secondaryProxyAddress,
+      }),
+    ).to.be.rejectedWith(/has no active KMS context \(currentKmsContextId=0\); cannot mirror/);
+  });
+
+  it('pins canonical reads to a historical block under a rotation', async function () {
+    const canonicalAddress = await deployFreshProtocolConfigProxy(
+      deployer,
+      buildProtocolConfigNodes(),
+      buildProtocolConfigThresholds(),
+    );
+    const canonical = (await ethers.getContractAt(
+      'ProtocolConfig',
+      canonicalAddress,
+      deployer,
+    )) as unknown as ProtocolConfig;
+    const secondaryProxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+
+    const snapshot = await mirrorProtocolConfigFromCanonical(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+      secondaryProxyAddress,
+    });
+    const pinnedBlock = snapshot.canonicalBlockTag;
+    const pinnedContextId = snapshot.currentContextId;
+
+    const rotatedNodes = buildProtocolConfigNodes().slice(0, 2);
+    const rotatedThresholds = { publicDecryption: 1, userDecryption: 1, kmsGen: 1, mpc: 1 };
+    await canonical.defineNewKmsContext(rotatedNodes, rotatedThresholds);
+    const latestContextId = await canonical.getCurrentKmsContextId();
+    expect(latestContextId).to.not.equal(pinnedContextId);
+
+    const historicalContextId = await canonical.getCurrentKmsContextId({ blockTag: pinnedBlock });
+    expect(historicalContextId).to.equal(pinnedContextId);
+  });
+});
+
+describe('canonical snapshot export (readCanonicalSnapshot)', function () {
+  const deployer = new ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(ethers.provider);
+
+  it('reads the canonical context and reproduces it on re-read', async function () {
+    const canonicalNodes = buildProtocolConfigNodes();
+    const canonicalAddress = await deployFreshProtocolConfigProxy(
+      deployer,
+      canonicalNodes,
+      buildProtocolConfigThresholds(),
+    );
+
+    const snapshot = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+    });
+    expect(snapshot.kmsNodes.length).to.equal(canonicalNodes.length);
+    expect(snapshot.currentContextId).to.not.equal(0n);
+    expect(snapshot.canonicalChainId).to.equal((await ethers.provider.getNetwork()).chainId);
+
+    // The DAO's review check: re-reading the artifact's pinned block reproduces the snapshot exactly.
+    const reread = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+      blockTag: snapshot.canonicalBlockTag,
+    });
+    expect(reread).to.deep.equal(snapshot);
+  });
+
+  it('rejects when the canonical ProtocolConfig has no active KMS context', async function () {
+    const noContextCanonical = await deployFreshUninitializedProtocolConfigProxy(deployer);
+
+    await expect(
+      readCanonicalSnapshot(hre, {
+        canonicalProvider: ethers.provider,
+        canonicalProtocolConfigAddress: noContextCanonical,
+      }),
+    ).to.be.rejectedWith(/has no active KMS context \(currentKmsContextId=0\); cannot mirror/);
+  });
+
+  it('reproduces a pinned snapshot after a rotation, while a latest re-read drifts', async function () {
+    const canonicalAddress = await deployFreshProtocolConfigProxy(
+      deployer,
+      buildProtocolConfigNodes(),
+      buildProtocolConfigThresholds(),
+    );
+    const canonical = (await ethers.getContractAt(
+      'ProtocolConfig',
+      canonicalAddress,
+      deployer,
+    )) as unknown as ProtocolConfig;
+
+    const exported = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+    });
+
+    // Rotate the canonical committee so "latest" no longer matches the exported block.
+    await canonical.defineNewKmsContext(buildProtocolConfigNodes().slice(0, 2), {
+      publicDecryption: 1,
+      userDecryption: 1,
+      kmsGen: 1,
+      mpc: 1,
+    });
+
+    // Re-reading latest drifts: this is exactly what a signer would get with no block pin.
+    const atLatest = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+    });
+    expect(atLatest.currentContextId).to.not.equal(exported.currentContextId);
+
+    // Re-reading at the artifact's blockNumber reproduces the original snapshot despite the rotation.
+    const atPinned = await readCanonicalSnapshot(hre, {
+      canonicalProvider: ethers.provider,
+      canonicalProtocolConfigAddress: canonicalAddress,
+      blockTag: exported.canonicalBlockTag,
+    });
+    expect(atPinned).to.deep.equal(exported);
   });
 });

--- a/host-contracts/test/tasks/taskHelpers.ts
+++ b/host-contracts/test/tasks/taskHelpers.ts
@@ -74,3 +74,36 @@ export async function deployFreshKMSGenerationProxy(deployer: Wallet): Promise<K
 
   return (await ethers.getContractAt('KMSGeneration', proxyAddress, deployer)) as unknown as KMSGeneration;
 }
+
+export async function deployFreshEmptyUUPSProxy(deployer: Wallet): Promise<string> {
+  const emptyProxyFactory = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  return await deployEmptyProxy(emptyProxyFactory);
+}
+
+// Upgrades to the ProtocolConfig implementation WITHOUT calling an initializer: getVersion()
+// passes the identity check but no KMS context exists (currentKmsContextId=0).
+export async function deployFreshUninitializedProtocolConfigProxy(deployer: Wallet): Promise<string> {
+  const proxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  const newImplementation = await ethers.getContractFactory('ProtocolConfig', deployer);
+  const proxy = await upgrades.forceImport(proxyAddress, currentImplementation);
+  const upgraded = await upgrades.upgradeProxy(proxy, newImplementation);
+  await upgraded.waitForDeployment();
+  return proxyAddress;
+}
+
+export async function deployFreshProtocolConfigProxy(
+  deployer: Wallet,
+  kmsNodes: Array<{ txSenderAddress: string; signerAddress: string; ipAddress: string; storageUrl: string }>,
+  thresholds: { publicDecryption: number; userDecryption: number; kmsGen: number; mpc: number },
+): Promise<string> {
+  const proxyAddress = await deployFreshEmptyUUPSProxy(deployer);
+  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  const newImplementation = await ethers.getContractFactory('ProtocolConfig', deployer);
+  const proxy = await upgrades.forceImport(proxyAddress, currentImplementation);
+  const upgraded = await upgrades.upgradeProxy(proxy, newImplementation, {
+    call: { fn: 'initializeFromEmptyProxy', args: [kmsNodes, thresholds] },
+  });
+  await upgraded.waitForDeployment();
+  return proxyAddress;
+}

--- a/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
@@ -5,7 +5,7 @@ services:
     env_file:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/env/host-sc.env
     command:
-      - npx hardhat task:deployAllHostContracts $${HOST_SC_DEPLOY_KMS_GENERATION_ARGS}
+      - npx hardhat task:deployAllHostContracts $${HOST_SC_DEPLOY_KMS_GENERATION_ARGS} $${HOST_SC_DEPLOY_PROTOCOL_CONFIG_ARGS}
     volumes:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/addresses/${HOST_ADDRESS_DIR:-host}:/app/addresses # workdir in host's Dockerfile is /app
 

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -221,6 +221,14 @@ export const requiresModernHostAddressArtifacts = (state: CompatState) =>
 export const requiresGatewayKmsGenerationAddress = (state: CompatState) =>
   requiresLegacyGatewayKmsGenerationAddress(state) && !requiresModernHostAddressArtifacts(state);
 
+/**
+ * Detects when host images ship `task:deployProtocolConfigFromCanonical` (0.13.1+), so non-canonical
+ * chains can seed ProtocolConfig from the canonical chain like production instead of "fresh".
+ */
+export const supportsCanonicalProtocolConfigSeeding = (state: CompatState) =>
+  effectiveCompatOverrides(state).some((override) => override.group === "host-contracts") ||
+  !versionLt(state.versions.env.HOST_VERSION ?? "", [0, 13, 1], { unparsed: "modern" });
+
 type BundleIncompatibility = { severity: "error"; code: string; message: string };
 
 /** Detects whether the resolved bundle supports multi-chain listener/database topology. */

--- a/test-suite/fhevm/src/env.test.ts
+++ b/test-suite/fhevm/src/env.test.ts
@@ -216,6 +216,10 @@ describe("env", () => {
     expect(rendered.instanceEnvs["host-sc-chain-b"]?.HOST_SC_DEPLOY_KMS_GENERATION_ARGS).toBe(
       "--with-kms-generation false",
     );
+    // Rendered as an empty placeholder: the up flow patches the non-canonical chains' value with
+    // the canonical seeding args once the canonical ProtocolConfig address exists on disk.
+    expect(rendered.componentEnvs["host-sc"].HOST_SC_DEPLOY_PROTOCOL_CONFIG_ARGS).toBe("");
+    expect(rendered.instanceEnvs["host-sc-chain-b"]?.HOST_SC_DEPLOY_PROTOCOL_CONFIG_ARGS).toBe("");
     const legacy = {
       ...state,
       versions: { ...state.versions, env: { ...state.versions.env, HOST_VERSION: "v0.12.0" } },

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -8,6 +8,7 @@ import {
   requiresGatewayKmsGenerationAddress,
   requiresMultichainAclAddress,
   requiresModernHostAddressArtifacts,
+  supportsCanonicalProtocolConfigSeeding,
   supportsHostListenerConsumer,
   validateBundleCompatibility,
 } from "../compat/compat";
@@ -89,6 +90,7 @@ import {
   readEnvFile,
   remove,
   withHexPrefix,
+  writeEnvFile,
   writeJson,
 } from "../utils/fs";
 import { ensureDiscovery, createDiscovery, defaultEndpoints, discoverContracts, minioIp, validateDiscovery } from "./discovery";
@@ -477,6 +479,31 @@ const registerExtraChainInCoprocessor = async (state: State, chain: { key: strin
   }
 };
 
+/**
+ * Builds the `task:deployAllHostContracts` args that seed a non-canonical chain's ProtocolConfig
+ * from the canonical chain, mirroring production. Returns "" when the host image predates
+ * `task:deployProtocolConfigFromCanonical`, so older bundles keep the "fresh" seeding.
+ * Must run after the canonical host deploy: it reads the canonical ProtocolConfig address from the
+ * generated address file.
+ */
+const canonicalProtocolConfigSeedingArgs = async (state: State) => {
+  if (!supportsCanonicalProtocolConfigSeeding(state)) {
+    return "";
+  }
+  const canonicalChain = defaultHostChain(state)!;
+  const canonicalAddresses = await readEnvFile(hostChainAddressesPath(canonicalChain.key));
+  const canonicalProtocolConfigAddress = canonicalAddresses.PROTOCOL_CONFIG_CONTRACT_ADDRESS;
+  if (!canonicalProtocolConfigAddress) {
+    throw new PreflightError(
+      `Canonical host addresses at ${hostChainAddressesPath(canonicalChain.key)} lack PROTOCOL_CONFIG_CONTRACT_ADDRESS; cannot seed non-canonical chains from canonical.`,
+    );
+  }
+  return [
+    "--protocol-config-source canonical",
+    `--canonical-rpc-url http://${canonicalChain.node}:${canonicalChain.rpcPort}`,
+    `--canonical-protocol-config-address ${canonicalProtocolConfigAddress}`,
+  ].join(" ");
+};
 
 export const runStep = async (state: State, step: StepName) => {
   const stepIndex = stateStepIndex(step) + 1;
@@ -583,8 +610,19 @@ export const runStep = async (state: State, step: StepName) => {
         "HCU_LIMIT_CONTRACT_ADDRESS",
         ...(requiresModernHostAddressArtifacts(state) ? ["PROTOCOL_CONFIG_CONTRACT_ADDRESS", "KMS_GENERATION_CONTRACT_ADDRESS"] : []),
       ]);
+      // Production topology: non-canonical chains seed ProtocolConfig from the canonical chain
+      // (export → mirror), not "fresh" from env. The canonical address only exists after the
+      // canonical deploy above, so the placeholder env var is patched here, per chain, before
+      // its deploy container starts.
+      const canonicalSeedingArgs = await canonicalProtocolConfigSeedingArgs(state);
       for (const chain of extraHostChains(state)) {
         const scKey = chain.sc;
+        if (canonicalSeedingArgs) {
+          const scEnvPath = envPath(scKey);
+          const scEnv = await readEnvFile(scEnvPath);
+          scEnv.HOST_SC_DEPLOY_PROTOCOL_CONFIG_ARGS = canonicalSeedingArgs;
+          await writeEnvFile(scEnvPath, scEnv);
+        }
         await timed(`[multi-chain] ${scKey}-deploy`, async () => {
           await multiChainComposeTask(scKey, [`${scKey}-deploy`]);
           await waitForContainer(`${scKey}-deploy`, "complete");

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -287,6 +287,9 @@ export const renderEnvMaps = async (
   envs["host-sc"].RPC_URL = `http://${defaultChain.node}:${defaultChain.rpcPort}`;
   envs["host-sc"].HOST_ADDRESS_DIR = defaultChain.key;
   envs["host-sc"].HOST_SC_DEPLOY_KMS_GENERATION_ARGS = hostDeployKmsGenerationArgs(plan, true);
+  // Canonical host seeds ProtocolConfig fresh; non-canonical chains get this patched at deploy time
+  // by the up flow (see `canonicalProtocolConfigSeedingArgs`) once the canonical address exists.
+  envs["host-sc"].HOST_SC_DEPLOY_PROTOCOL_CONFIG_ARGS = "";
   envs["coprocessor"].RPC_HTTP_URL = `http://${defaultChain.node}:${defaultChain.rpcPort}`;
   envs["coprocessor"].RPC_WS_URL = `ws://${defaultChain.node}:${defaultChain.rpcPort}`;
   envs["kms-connector"].KMS_CONNECTOR_ETHEREUM_URL = `http://${defaultChain.node}:${defaultChain.rpcPort}`;

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -259,6 +259,7 @@ describe("render-compose", () => {
     const cmd = (template.services["host-sc-deploy"]?.command ?? []).join(" ");
     expect(cmd).toContain("task:deployAllHostContracts");
     expect(cmd).toContain("$${HOST_SC_DEPLOY_KMS_GENERATION_ARGS}");
+    expect(cmd).toContain("$${HOST_SC_DEPLOY_PROTOCOL_CONFIG_ARGS}");
   });
 
   test("merges instance env into list-form service environments without dropping KEY_ID", async () => {


### PR DESCRIPTION
## Summary

- Implements zama-ai/fhevm-internal#1501: backports the export/mirror pieces of #2657 onto the 0.13.x line, excluding the canonical/secondary deploy-task split — extended with an artifact-driven apply and a DAO path so the flow matches how infra actually operates per environment.
- The flow is **artifact-centric**: export → review → apply, with the JSON artifact as the single pivot so what is applied is exactly what reviewers diffed.

### Export
- `task:exportCanonicalProtocolConfig` writes a reviewable JSON artifact (canonical chainId, pinned blockNumber, contract address, current KMS context id, KMS nodes, all four thresholds; bigints as strings). Re-running with `--block-number` reproduces a prior artifact byte-for-byte even after a `defineNewKmsContext` rotation.
- `readCanonicalSnapshot` (ported from #2657) pins all reads to one block and guards identity (`getVersion`), no-active-context, and destroyed-context cases.

### Apply — one prepare step, two executors
- **devnet / local**: `task:deployProtocolConfigFromCanonical --snapshot <artifact.json>` — direct upgrade with `DEPLOYER_PRIVATE_KEY`, no canonical RPC needed. Without `--snapshot` it still supports the live-read mode (`--canonical-rpc-url` + `--canonical-protocol-config-address`) for quick iteration.
- **testnet / mainnet (DAO)**: `task:prepareDeployProtocolConfigFromCanonical --snapshot <artifact.json>` — deploys the implementation and prints the `upgradeToAndCall(initializeFromMigration(...))` payload without mutating the proxy, mirroring `task:prepareDeployProtocolConfigFromMigration`.
- Both run the **same prepare step** (`buildCanonicalUpgradeProposal`: deploy implementation + build the `upgradeToAndCall(initializeFromMigration(…))` payload); the devnet task then simply executes the produced payload with the deployer key (`executeUpgradeProposal`) — **devnet runs byte-identical calldata to what the DAO signs**, so every devnet deploy exercises the DAO payload end to end. The replica lands on canonical's `currentKmsContextId` (empty-proxy deployment idiom, not an upgrade of a live ProtocolConfig).
- Shared `buildSnapshotArtifact`/`parseSnapshotArtifact` keep export and both apply paths on one validated JSON shape.

### e2e: fhevm-cli seeds non-canonical chains like production

- `task:deployAllHostContracts` gains `--protocol-config-source canonical` (+ canonical RPC/address params), running the mirror in sequence with the other host contracts.
- The fhevm-cli multi-chain up flow patches each non-canonical chain's deploy args with the canonical chain's RPC + ProtocolConfig address (available on disk after the canonical deploy, which the flow already sequences first) — so the e2e stack reproduces production topology instead of seeding every chain "fresh", and every multi-chain e2e run executes the byte-identical payload the DAO would sign.
- Gated by a 0.13.1 compat floor (`supportsCanonicalProtocolConfigSeeding`): compat bundles with older host images keep the fresh seeding.

## Non-goals

- No canonical/secondary deploy-task split — explicitly out of scope per the issue.
- No deletion of the Gateway-migration tasks: `task:exportKmsMigrationState` + `FromMigration` tasks remain the mechanism for the one-time Gateway → Ethereum migration of existing 0.12 deployments; they are only superseded as the **seeding source** for new non-canonical chains (README clarified accordingly).
- No contract changes.

## Notes for reviewers

- Tests cover: the read→apply flow onto a fresh proxy, block pinning under rotation, no-active-context and identity-check failures on the shared read path, artifact round-trip through both apply paths (DAO calldata decode + devnet apply), and the deploy task's arg validation.
- The issue's destroyed-context failure mode is guarded in `readCanonicalSnapshot` but untestable on-chain: `destroyKmsContext` reverts for the current context (`CurrentKmsContextCannotBeDestroyed`), so the guard is defense-in-depth — same as on `main` (#2657).
- Both apply tasks and the export compile first (`compile:specific contracts`): `ProtocolConfig` embeds `aclAdd` at compile time, so a stale artifact could deploy bytecode authorized against the wrong ACL.
- `npm run lint:ts` fails on the base branch independently of this PR (missing `.eslintignore`).

## Validation

- `DOTENV_CONFIG_PATH=.env.example npx hardhat test test/tasks/*.ts --network hardhat` (37 passing across migration + taskDeploy + ownership/pausing suites)
- `npx prettier --check` on all changed files




