### PR TITLE
ci(gateway-contracts): drop KMSGeneration from the upgrade manifest

### DIFF
--- a/gateway-contracts/upgrade-manifest.json
+++ b/gateway-contracts/upgrade-manifest.json
@@ -1,1 +1,1 @@
-["GatewayConfig", "Decryption", "CiphertextCommits", "InputVerification", "KMSGeneration"]
+["GatewayConfig", "Decryption", "CiphertextCommits", "InputVerification"]


### PR DESCRIPTION
## Summary

Since **v0.13.0** was published as the latest stable release (June 11), `gateway-contracts-upgrade-tests/sc-upgrade` fails for **every PR touching `gateway-contracts/`**, on `main` and release/feature branches alike:

> `KMSGeneration existed in previous release but KMSGenerationAddress is not set — check address mapping`

## Root cause

- The job deploys the previous release (resolved via `releases/latest`) and verifies every contract in `upgrade-manifest.json`, inferring *“was deployed in the previous release”* from **source-file existence** in the baseline checkout.
- Up to v0.12.x, gateway `KMSGeneration` was deployed by the gateway compose flow, so the assumption held.
- With the 0.13 gateway→host migration, KMS generation moved to the host chain. v0.13.0 (and `main`) keep `gateway-contracts/contracts/KMSGeneration.sol` **only as migration-support source** for `task:exportKmsMigrationState` (reading existing 0.12 deployments) — the deploy flow no longer deploys it, so no `KMS_GENERATION_ADDRESS` is ever written.
- First baseline where “file exists” ≠ “was deployed” → the check trips.

## Fix

Remove `KMSGeneration` from `gateway-contracts/upgrade-manifest.json` — it is no longer part of the gateway upgrade surface. The manifest also feeds `contracts-upgrade-version-check` and `ci/abi-compat`; dropping an undeployed, effectively frozen contract from those is intended (the only ABI consumer is the migration export task reading 0.12 proxies).

If gateway KMSGeneration is ever revived ("not used yet" per `pauseContracts.ts`), re-add it to the manifest together with its deploy task.

Same fix applied to the 0.13.1 line in #2665.