### PR TITLE
ci(host-contracts): bring ProtocolConfig under the upgrade guard

### DIFF
--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -181,6 +181,7 @@ jobs:
               KMSVerifier) proxy_address="$KMS_VERIFIER_CONTRACT_ADDRESS" ;;
               InputVerifier) proxy_address="$INPUT_VERIFIER_CONTRACT_ADDRESS" ;;
               HCULimit) proxy_address="$HCU_LIMIT_CONTRACT_ADDRESS" ;;
+              ProtocolConfig) proxy_address="$PROTOCOL_CONFIG_CONTRACT_ADDRESS" ;;
               *)
                 echo "::error::Unsupported host upgrade manifest entry: $name"
                 exit 1
@@ -284,6 +285,8 @@ jobs:
           InputVerifier_ADDR=$INPUT_VERIFIER_CONTRACT_ADDRESS
           # shellcheck disable=SC2034
           HCULimit_ADDR=$HCU_LIMIT_CONTRACT_ADDRESS
+          # shellcheck disable=SC2034
+          ProtocolConfig_ADDR=$PROTOCOL_CONFIG_CONTRACT_ADDRESS
 
           for name in $(jq -r '.[]' upgrade-manifest.json); do
             addr_var="${name}_ADDR"

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -399,6 +399,56 @@ task('task:prepareUpgradeKMSVerifier')
     await prepareUpgradeContract('KMSVerifier', 'KMS_VERIFIER_CONTRACT_ADDRESS', taskArgs, hre);
   });
 
+task('task:upgradeProtocolConfig')
+  .addParam(
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/ProtocolConfig.sol:ProtocolConfig',
+  )
+  .addParam(
+    'newImplementation',
+    'The new implementation solidity contract path and name, eg: examples/ProtocolConfigUpgradedExample.sol:ProtocolConfigUpgradedExample',
+  )
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await upgradeContract('ProtocolConfig', 'PROTOCOL_CONFIG_CONTRACT_ADDRESS', taskArgs, hre);
+  });
+
+task('task:prepareUpgradeProtocolConfig')
+  .addParam(
+    'currentImplementation',
+    'The currently deployed implementation solidity contract path and name, eg: contracts/ProtocolConfig.sol:ProtocolConfig',
+  )
+  .addParam(
+    'newImplementation',
+    'The new implementation solidity contract path and name, eg: contracts/ProtocolConfig.sol:ProtocolConfig',
+  )
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    await prepareUpgradeContract('ProtocolConfig', 'PROTOCOL_CONFIG_CONTRACT_ADDRESS', taskArgs, hre);
+  });
+
 task('task:upgradeInputVerifier')
   .addParam(
     'currentImplementation',

--- a/host-contracts/upgrade-manifest.json
+++ b/host-contracts/upgrade-manifest.json
@@ -1,1 +1,1 @@
-["ACL", "FHEVMExecutor", "KMSVerifier", "InputVerifier", "HCULimit"]
+["ACL", "FHEVMExecutor", "KMSVerifier", "InputVerifier", "HCULimit", "ProtocolConfig"]


### PR DESCRIPTION
## Summary

Follow-up to the question raised in #2772 (and the v0.13.0 baseline incidents from June 12): `ProtocolConfig` and host `KMSGeneration` are outside `host-contracts/upgrade-manifest.json`, so neither `contracts-upgrade-version-check` nor `host-contracts-upgrade-tests` guards them against bytecode changes without version bumps — the exact class of unguarded drift that broke gateway CI when v0.13.0 became the baseline. Audit fixes are about to land on these contracts; this closes the gap for ProtocolConfig.

## Changes

- `host-contracts/upgrade-manifest.json`: add `ProtocolConfig`.
- `host-contracts/tasks/upgradeContracts.ts`: add `task:upgradeProtocolConfig` / `task:prepareUpgradeProtocolConfig`, mirroring the existing five pairs.
- `.github/workflows/host-contracts-upgrade-tests.yml`: add the ProtocolConfig entries to the proxy-address case statement and the verify mapping.

## Why this is safe to enable now

- ProtocolConfig's drift vs the v0.13.0 baseline is **comments-only** (a natspec note and the `currnet` typo that N-04/#2771 fixes); with `cbor_metadata = false` / `bytecode_hash = 'none'` the compiled bytecode is identical, so the version check passes by construction.
- The upgrade-test step stays dormant until someone first bumps `REINITIALIZER_VERSION` (currently 2 on both sides); the `reinitializeV{N-1}` naming convention is only enforced at that point, so ProtocolConfig adopts `reinitializeV2()` with its first in-place upgrade.
- The CI baseline deploy (`--with-kms-generation true`) writes `PROTOCOL_CONFIG_CONTRACT_ADDRESS`, so the verify mapping resolves.

## KMSGeneration deliberately left out (blocker)

Host `KMSGeneration` on `main` still reads the context-less `getKmsGenThreshold()` in its migration-consensus check, while v0.13.0 ships the context-aware `getKmsGenThresholdForContext(contextId)` (**L-03**, `551e4eecf` on `release/0.13.x`). That is a real bytecode difference with no version bump on `main`, so adding KMSGeneration to the manifest today would fail the version check on every host PR.

Note: **L-03 appears to be missing from the audit forward-port stack** (#2766–#2771 cover N-01, M-01, N-03, N-04, L-05). Once the L-03 forward-port lands on `main`, KMSGeneration can join the manifest the same way (its upgrade-task pair + one mapping line).

## Validation

- `DOTENV_CONFIG_PATH=.env.example npm run compile` (tasks parse, contracts compile)
- `npx prettier --check` on changed files
- ProtocolConfig import graph (`IProtocolConfig`, `shared/Structs`, `shared/Constants`, `shared/UUPSUpgradeableEmptyProxy`, `shared/ACLOwnable`) verified unchanged vs v0.13.0