### PR TITLE
fix(common): scope upgrade version check to PR-changed contracts and enforce strict release run

### DIFF
--- a/.github/workflows/contracts-upgrade-version-check.yml
+++ b/.github/workflows/contracts-upgrade-version-check.yml
@@ -94,13 +94,15 @@ jobs:
           RELEASED_TAG: ${{ github.event.release.tag_name }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "release" ]; then
-            # Previous release in the published tag's version line, so a patch
-            # release compares against its own line (v0.13.1 -> v0.13.0 even
-            # when v0.14.0 exists).
+            # Highest stable release strictly below the published version, in
+            # its own version line: v0.13.1 -> v0.13.0 even when v0.14.0
+            # exists.  Prerelease suffixes are stripped first, so a prerelease
+            # compares like the version it precedes: v0.13.0-9 -> v0.12.5.
+            base="${RELEASED_TAG%%-*}"
             tag="$({ gh api "repos/${GH_REPOSITORY}/releases" --paginate \
               --jq '.[] | select((.draft or .prerelease) | not) | .tag_name'; \
-              echo "$RELEASED_TAG"; } | sort -u -V | grep -x -B1 -- "$RELEASED_TAG" | head -n1)"
-            if [ -z "$tag" ] || [ "$tag" = "$RELEASED_TAG" ]; then
+              echo "$base"; } | sort -u -V | grep -x -B1 -- "$base" | head -n1)"
+            if [ -z "$tag" ] || [ "$tag" = "$base" ]; then
               echo "::error::No previous release found to compare $RELEASED_TAG against"
               exit 1
             fi

--- a/.github/workflows/contracts-upgrade-version-check.yml
+++ b/.github/workflows/contracts-upgrade-version-check.yml
@@ -4,14 +4,18 @@ permissions: {}
 
 on:
   pull_request:
+  release:
+    types: [published]
 
 # Compare PR bytecode against the latest stable release, not main.
 # This avoids unnecessary reinitializer bumps when multiple PRs modify
 # the same contract between releases. Keep in sync with *-upgrade-tests.yml.
 #
-# Only contracts the PR changed are enforced; violations on other contracts
-# (e.g. drift left on main after a release moved the baseline) are warnings.
-# The release process includes a manual check for such drift before tagging.
+# PRs enforce errors only for contracts they changed; violations on other
+# contracts (e.g. drift left on main after a release moved the baseline) are
+# warnings.  Publishing a release strict-checks the released tag against the
+# previous release in its version line, catching that drift.  Forward-ported
+# fixes exist on both sides of that comparison, so they do not trigger it.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +24,8 @@ concurrency:
 jobs:
   check-changes:
     name: contracts-upgrade-version-check/check-changes
+    # paths-filter needs a PR diff; release runs check all packages instead.
+    if: github.event_name == 'pull_request'
     permissions:
       contents: "read" # Required to checkout repository code
       pull-requests: "read" # Required to read pull request for paths-filter
@@ -48,11 +54,15 @@ jobs:
   check:
     name: contracts-upgrade-version-check/${{ matrix.package }} (bpr)
     needs: check-changes
+    # check-changes is skipped on release events, which by default would skip
+    # this job too; run unless it failed or the workflow was cancelled.
+    if: ${{ !cancelled() && needs.check-changes.result != 'failure' }}
     permissions:
       contents: "read" # Required to checkout repository code
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     env:
-      PACKAGE_CHANGED: ${{ contains(fromJSON(needs.check-changes.outputs.packages), matrix.package) }}
+      # Release runs have no diff to filter on; they check both packages.
+      PACKAGE_CHANGED: ${{ github.event_name == 'release' || contains(fromJSON(needs.check-changes.outputs.packages || '[]'), matrix.package) }}
     strategy:
       fail-fast: false
       matrix:
@@ -81,8 +91,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPOSITORY: ${{ github.repository }}
+          RELEASED_TAG: ${{ github.event.release.tag_name }}
         run: |
-          tag="$(gh api "repos/${GH_REPOSITORY}/releases/latest" --jq .tag_name)"
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            # Previous release in the published tag's version line, so a patch
+            # release compares against its own line (v0.13.1 -> v0.13.0 even
+            # when v0.14.0 exists).
+            tag="$({ gh api "repos/${GH_REPOSITORY}/releases" --paginate \
+              --jq '.[] | select((.draft or .prerelease) | not) | .tag_name'; \
+              echo "$RELEASED_TAG"; } | sort -u -V | grep -x -B1 -- "$RELEASED_TAG" | head -n1)"
+            if [ -z "$tag" ] || [ "$tag" = "$RELEASED_TAG" ]; then
+              echo "::error::No previous release found to compare $RELEASED_TAG against"
+              exit 1
+            fi
+          else
+            tag="$(gh api "repos/${GH_REPOSITORY}/releases/latest" --jq .tag_name)"
+          fi
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
 
       - name: Checkout baseline (latest stable release)
@@ -139,7 +163,7 @@ jobs:
           cp "$PACKAGE/foundry.toml" "baseline/$PACKAGE/foundry.toml"
 
       - name: Determine contracts changed by this PR
-        if: env.PACKAGE_CHANGED == 'true'
+        if: env.PACKAGE_CHANGED == 'true' && github.event_name == 'pull_request'
         id: changed
         env:
           PACKAGE: ${{ matrix.package }}
@@ -156,4 +180,10 @@ jobs:
           PACKAGE: ${{ matrix.package }}
           UPGRADE_CHECK_BASE_REF: ${{ steps.baseline.outputs.tag }}
           CHANGED_CONTRACTS: ${{ steps.changed.outputs.contracts }}
-        run: bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE" --changed-contracts "$CHANGED_CONTRACTS"
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            # Enforce only contracts this PR changed; the rest warn.
+            bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE" --changed-contracts "$CHANGED_CONTRACTS"
+          else
+            bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE"
+          fi

--- a/.github/workflows/contracts-upgrade-version-check.yml
+++ b/.github/workflows/contracts-upgrade-version-check.yml
@@ -8,6 +8,10 @@ on:
 # Compare PR bytecode against the latest stable release, not main.
 # This avoids unnecessary reinitializer bumps when multiple PRs modify
 # the same contract between releases. Keep in sync with *-upgrade-tests.yml.
+#
+# Only contracts the PR changed are enforced; violations on other contracts
+# (e.g. drift left on main after a release moved the baseline) are warnings.
+# The release process includes a manual check for such drift before tagging.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -134,9 +138,22 @@ jobs:
           # Use PR's foundry.toml for both so compiler settings match (cbor_metadata, bytecode_hash)
           cp "$PACKAGE/foundry.toml" "baseline/$PACKAGE/foundry.toml"
 
+      - name: Determine contracts changed by this PR
+        if: env.PACKAGE_CHANGED == 'true'
+        id: changed
+        env:
+          PACKAGE: ${{ matrix.package }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          contracts="$(git diff --name-only "origin/$BASE_REF...HEAD" -- "$PACKAGE/contracts" \
+            | sed -n "s|^$PACKAGE/contracts/\([^/]*\)\.sol$|\1|p" | paste -sd, -)"
+          printf 'contracts=%s\n' "$contracts" >> "$GITHUB_OUTPUT"
+          echo "Changed contracts: ${contracts:-none}"
+
       - name: Run upgrade version check
         if: env.PACKAGE_CHANGED == 'true'
         env:
           PACKAGE: ${{ matrix.package }}
           UPGRADE_CHECK_BASE_REF: ${{ steps.baseline.outputs.tag }}
-        run: bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE"
+          CHANGED_CONTRACTS: ${{ steps.changed.outputs.contracts }}
+        run: bun ci/upgrade-check/check.ts "baseline/$PACKAGE" "$PACKAGE" --changed-contracts "$CHANGED_CONTRACTS"

--- a/ci/upgrade-check/check.ts
+++ b/ci/upgrade-check/check.ts
@@ -1,19 +1,41 @@
 #!/usr/bin/env bun
 // Checks that upgradeable contracts have proper version bumps when bytecode changes.
-// Usage: bun ci/upgrade-check/check.ts <baseline-pkg-dir> <pr-pkg-dir>
+// Usage: bun ci/upgrade-check/check.ts <baseline-pkg-dir> <pr-pkg-dir> [--changed-contracts <comma-separated names>]
+//
+// With --changed-contracts, only the listed contracts are enforced; violations
+// on other contracts are warnings.  An empty list downgrades everything.
 import { execFileSync } from "child_process";
 import { basename } from "path";
 
 import { collectUpgradeVersionResults } from "./lib";
 
-const [baselineDir, prDir] = process.argv.slice(2);
+const positional: string[] = [];
+let changedContracts: Set<string> | undefined;
+const argv = process.argv.slice(2);
+for (let idx = 0; idx < argv.length; idx++) {
+  if (argv[idx] === "--changed-contracts") {
+    const value = argv[++idx];
+    if (value === undefined) {
+      console.error("--changed-contracts requires a value (may be an empty string)");
+      process.exit(1);
+    }
+    changedContracts = new Set(value.split(",").filter(Boolean));
+  } else {
+    positional.push(argv[idx]);
+  }
+}
+
+const [baselineDir, prDir] = positional;
 if (!baselineDir || !prDir) {
-  console.error("Usage: bun ci/upgrade-check/check.ts <baseline-pkg-dir> <pr-pkg-dir>");
+  console.error(
+    "Usage: bun ci/upgrade-check/check.ts <baseline-pkg-dir> <pr-pkg-dir> [--changed-contracts <comma-separated names>]",
+  );
   process.exit(1);
 }
 
 const results = collectUpgradeVersionResults(baselineDir, prDir);
 let errors = 0;
+let warnings = 0;
 
 function printCommits(title: string, baseRef: string, targetRef: string, paths: string[]) {
   const repo = process.env.GITHUB_REPOSITORY;
@@ -69,11 +91,19 @@ for (const result of results) {
       console.log(`${result.name}: bytecode unchanged`);
     }
 
+    const enforced = changedContracts === undefined || changedContracts.has(result.name);
     for (const error of result.errors) {
-      console.error(`::error::${error}`);
-      errors++;
+      if (enforced) {
+        console.error(`::error::${error}`);
+        errors++;
+      } else {
+        console.log(
+          `::warning::${error} — ${result.name} was not changed by this PR, so this is not blocking. Fix it with a version-bump PR before the next release.`,
+        );
+        warnings++;
+      }
     }
-    if (result.errors.length > 0) {
+    if (result.errors.length > 0 && enforced) {
       printDiagnostics(result.name);
     }
   } finally {
@@ -86,4 +116,7 @@ if (errors > 0) {
   process.exit(1);
 }
 
+if (warnings > 0) {
+  console.log(`${warnings} violation(s) on contracts not changed by this PR were reported as warnings.`);
+}
 console.log("All contracts passed upgrade version checks");

--- a/ci/upgrade-check/check.ts
+++ b/ci/upgrade-check/check.ts
@@ -98,7 +98,7 @@ for (const result of results) {
         errors++;
       } else {
         console.log(
-          `::warning::${error} — ${result.name} was not changed by this PR, so this is not blocking. Fix it with a version-bump PR before the next release.`,
+          `::warning::${error} — ${result.name} was not changed by this PR, so this is not blocking. Fix it with a version-bump PR before the next release; this check runs strictly when the release is published.`,
         );
         warnings++;
       }


### PR DESCRIPTION
### Summary

- Fixes PRs being blocked by upgrade-check failures they didn't cause: pre-existing drift on main after a release moves the baseline, or forward ports of fixes already in the tag.
- `check.ts` gains a `--changed-contracts` flag: on PRs, only contracts whose source the PR touched fail the check; violations on other contracts are non-blocking warnings.
- New `release: published` trigger runs the full strict check on the released tag against the previous release in its version line (e.g. `v0.13.1` → `v0.13.0` even if `v0.14.0` exists), so a missed bump surfaces at release time. Forward-ported fixes exist on both sides of that comparison, so they don't trigger it.

| Event             | Check runs? | Enforcement                                                       |
| ----------------- | ----------- | ----------------------------------------------------------------- |
| Pull request      | Yes         | Errors only for contracts the PR changed; warnings for the rest    |
| Release published | Yes         | Strict — all contracts, against the previous release in the version line |
