### PR TITLE
test(sdk): dod script and localstack tests fixes

### DIFF
--- a/sdk/js-sdk/package.json
+++ b/sdk/js-sdk/package.json
@@ -50,6 +50,8 @@
     "test:localcleartext:pack:v12": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v12",
     "test:localcleartext:pack:v13": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v13",
     "test": "npm run test:unit && npm run test:localcleartext:pack && npm run test:browser",
+    "dod": "node test/scripts/dod.mjs",
+    "dod:full": "node test/scripts/dod.mjs --full",
     "version": "node ./scripts/generate-version.cjs"
   },
   "devDependencies": {

--- a/sdk/js-sdk/scripts/prettier/check-file-casing.sh
+++ b/sdk/js-sdk/scripts/prettier/check-file-casing.sh
@@ -49,7 +49,6 @@ violations=0
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 echo "Checking file name casing..."
-echo ""
 
 for dir in "${SCAN_DIRS[@]}"; do
   full_dir="$ROOT_DIR/$dir"
@@ -72,7 +71,6 @@ for dir in "${SCAN_DIRS[@]}"; do
   done < <(find "$full_dir" -name '*.ts' -not -name '*.d.ts' -print0)
 done
 
-echo ""
 if [[ $violations -gt 0 ]]; then
   echo "Found $violations file(s) with consecutive uppercase letters in their name."
   echo "Rule: file names must never contain two consecutive uppercase letters."

--- a/sdk/js-sdk/scripts/prettier/check-import-order.sh
+++ b/sdk/js-sdk/scripts/prettier/check-import-order.sh
@@ -89,7 +89,6 @@ check_file() {
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 echo "Checking import order..."
-echo ""
 
 for dir in "${SCAN_DIRS[@]}"; do
   full_dir="$ROOT_DIR/$dir"
@@ -107,7 +106,6 @@ for dir in "${SCAN_DIRS[@]}"; do
   done < <(find "$full_dir" -name '*.ts' -not -name '*.d.ts' -print0)
 done
 
-echo ""
 if [[ $violations -gt 0 ]]; then
   echo "Found $violations import order violation(s)."
   echo "Rule: import type statements must come before value imports, with no interleaving."

--- a/sdk/js-sdk/test/browser/vite.config.ts
+++ b/sdk/js-sdk/test/browser/vite.config.ts
@@ -11,6 +11,11 @@ const rawWasmAssetPrefix = '/__raw_wasm';
 
 export default defineConfig({
   root: projectRoot,
+  resolve: {
+    alias: {
+      '@fhevm/sdk': resolve(projectRoot, 'src'),
+    },
+  },
   plugins: [rawWasmAssetPlugin()],
   server: {
     port: 3333,

--- a/sdk/js-sdk/test/fheTest/setup-ethers.ts
+++ b/sdk/js-sdk/test/fheTest/setup-ethers.ts
@@ -7,6 +7,27 @@ import { FHETestABI } from './FheTest-abi-v2.js';
 import { isCleartext, prepareChains } from './setupCommon.js';
 
 // ---------------------------------------------------------------------------
+// FixedNonceManager
+// ---------------------------------------------------------------------------
+// ethers.js NonceManager.sendTransaction calls this.signer.populateTransaction(tx)
+// *before* setting tx.nonce to the manager's value.  populateTransaction therefore
+// does its own eth_getTransactionCount query and passes THAT nonce to eth_estimateGas.
+// If the chain state changes between the two queries (e.g. the v12 coprocessor
+// submitting a tx on Alice's behalf), eth_estimateGas receives a stale nonce and
+// fails with "nonce too low".
+//
+// Fix: resolve the nonce first and pre-populate tx.nonce so that populateTransaction
+// skips its own query and eth_estimateGas uses the correct nonce.
+class FixedNonceManager extends ethers.NonceManager {
+  override async sendTransaction(tx: ethers.TransactionRequest): Promise<ethers.TransactionResponse> {
+    const nonce = await this.getNonce('pending');
+    this.increment();
+    tx = await this.signer.populateTransaction({ ...tx, nonce });
+    return await this.signer.sendTransaction(tx);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -69,13 +90,13 @@ function _buildConfig(env: FheTestBaseEnv): FheTestEthersConfig {
 
   const bobWallet = ethers.HDNodeWallet.fromMnemonic(ethers.Mnemonic.fromPhrase(env.mnemonic), "m/44'/60'/0'/0/1");
 
-  // Use a ethers.NonceManager to avoid nonce issues in parallel mode
-  const signer = new ethers.NonceManager(wallet.connect(provider));
+  // Use FixedNonceManager to avoid nonce issues in parallel mode and to prevent
+  // the stale-nonce race described in the FixedNonceManager class above.
+  const signer = new FixedNonceManager(wallet.connect(provider));
 
   const fheTestContract = new ethers.Contract(env.fheTestAddress, FHETestABI, signer);
 
-  // Use a ethers.NonceManager to avoid nonce issues in parallel mode
-  const bobSigner = new ethers.NonceManager(bobWallet.connect(provider));
+  const bobSigner = new FixedNonceManager(bobWallet.connect(provider));
 
   return {
     chainName: env.chainName,

--- a/sdk/js-sdk/test/fheTest/setupCommon.ts
+++ b/sdk/js-sdk/test/fheTest/setupCommon.ts
@@ -320,6 +320,12 @@ function initAliceFheTestHandlesIfNeeded(
   if (!aliceHasAllFheTestHandles(fheTestAddress, aliceAddress, rpcUrl)) {
     throw new Error(`FHETest initFheTest(false) completed but Alice handles are still missing for ${aliceAddress}.`);
   }
+
+  // The coprocessor registers Alice's handles on the gateway CiphertextCommits contract
+  // asynchronously. Tests that call the relayer for public/user decryption need
+  // this registration to complete before the relayer's readiness check passes.
+  // We block the setup thread briefly so the coprocessor can catch up.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 30_000);
 }
 
 /**

--- a/sdk/js-sdk/test/scripts/dod.mjs
+++ b/sdk/js-sdk/test/scripts/dod.mjs
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const sdkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+function formatElapsed(ms) {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  return m > 0 ? `${m}m${String(s % 60).padStart(2, '0')}s` : `${s}s`;
+}
+
+function banner(cmd, index, total, startTime) {
+  const counter = `${index + 1}/${total}`;
+  const elapsed = formatElapsed(Date.now() - startTime);
+  const pad = 2;
+  const minGap = 2;
+  const innerWidth = Math.max(80 - pad * 2, cmd.length + counter.length + minGap, elapsed.length);
+  const width = innerWidth + pad * 2;
+  const line = '═'.repeat(width);
+  const inner = cmd.padEnd(innerWidth);
+  const cmdLine = cmd + counter.padStart(innerWidth - cmd.length);
+  const elapsedLine = elapsed.padStart(innerWidth);
+  console.log(`╔${line}╗`);
+  console.log(`║${''.padEnd(pad)}${cmdLine}${''.padEnd(pad)}║`);
+  console.log(`║${''.padEnd(pad)}${elapsedLine}${''.padEnd(pad)}║`);
+  console.log(`╚${line}╝`);
+}
+
+const commands = [
+  'npm run clean',
+  'export BUILD_PROFILE=prod ; npm run codegen:loaders',
+  'npm run prettier:check',
+  'npm run prettier:ext',
+  'npm run lint',
+  'npm run test:unit',
+  'export BUILD_PROFILE=dev  ; npm run codegen:loaders && npm run build:cjs && npm run build:esm && npm run build:types && npm run build:tests',
+  'npm run clean',
+  'export BUILD_PROFILE=prod ; npm run codegen:loaders && npm run build:cjs && npm run build:esm && npm run build:types && npm run build:tests',
+  'npm run test:browser',
+  './test/scripts/rebuild_sdk_and_pack.sh --build-profile=skip',
+  './test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v12',
+  './test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v13',
+  './test/scripts/localcleartext-run-tests.sh --use-pack',
+  //'node test/multi-wasm/run.mjs',
+];
+
+const longCommands = [
+  'npm run test:full:testnet',
+  'npm run test:full:devnet',
+  'npm run test:localstack:v11',
+  'npm run test:localstack:v12',
+  'npm run test:localstack:v13',
+  'npm run test:localstack',
+];
+
+const full = process.argv.includes('--full');
+
+if (process.argv.includes('--help')) {
+  console.log(`Usage: node test/scripts/dod.mjs [options]
+
+Options:
+  --full   Also run long-running localstack tests after the standard commands
+  --help   Show this help message
+
+Standard commands (${commands.length}):
+${commands.map((c) => `  ${c}`).join('\n')}
+
+Long commands (${longCommands.length}, requires --full):
+${longCommands.map((c) => `  ${c}`).join('\n')}
+`);
+  process.exit(0);
+}
+
+const queue = [...commands, ...(full ? longCommands : [])];
+const startTime = Date.now();
+
+for (const [i, cmd] of queue.entries()) {
+  banner(cmd, i, queue.length, startTime);
+  const result = spawnSync(cmd, { cwd: sdkRoot, stdio: 'inherit', shell: true });
+  if (result.status !== 0) {
+    console.error(`\nFailed command: \x1b[31m${cmd}\x1b[0m`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+banner('Success!', queue.length - 1, queue.length, startTime);

--- a/sdk/js-sdk/test/scripts/dod.sh
+++ b/sdk/js-sdk/test/scripts/dod.sh
@@ -1,7 +1,0 @@
-# build:dev
-# build:prod
-# test uintaires
-# test cleartext with pack: prod
-# test cleartext with pack: v11, v12, v13
-# test browser
-# test multi-wasm

--- a/sdk/js-sdk/test/scripts/localcleartext-run-tests.sh
+++ b/sdk/js-sdk/test/scripts/localcleartext-run-tests.sh
@@ -202,9 +202,9 @@ anvil_deploy_cleartext() {
     echo "🏗️  Deploying FHEVM cleartext stack..."
     (
         cd "$CONTRACTS_DIR"
-        bash "$DEPLOY_FHEVM_SCRIPT"
+        bash "$DEPLOY_FHEVM_SCRIPT" --chain localcleartext
         sleep 1
-        bash "$DEPLOY_FHE_TEST_SCRIPT"
+        bash "$DEPLOY_FHE_TEST_SCRIPT" --chain localcleartext
     )
 }
 

--- a/sdk/js-sdk/test/scripts/rebuild_sdk_and_pack.sh
+++ b/sdk/js-sdk/test/scripts/rebuild_sdk_and_pack.sh
@@ -11,7 +11,8 @@ for arg in "$@"; do
   case "$arg" in
     --build-profile=dev)  PROFILE="dev" ;;
     --build-profile=prod) PROFILE="prod" ;;
-    --build-profile=*)    echo "Error: unknown --build-profile value '${arg#--build-profile=}'. Use 'dev' or 'prod'." >&2; exit 1 ;;
+    --build-profile=skip) PROFILE="skip" ;;
+    --build-profile=*)    echo "Error: unknown --build-profile value '${arg#--build-profile=}'. Use 'dev', 'prod', or 'skip'." >&2; exit 1 ;;
   esac
 done
 
@@ -27,8 +28,12 @@ mkdir -p "$PACK_DIR"
 PACK_DIR=$(cd "$PACK_DIR" && pwd)
 
 # Build
-echo -e "${GREEN}Building project (profile: $PROFILE)...${NC}"
-(cd "$ROOT_DIR" && npm run "build:$PROFILE")
+if [[ "$PROFILE" == "skip" ]]; then
+  echo -e "${GREEN}Skipping build step.${NC}"
+else
+  echo -e "${GREEN}Building project (profile: $PROFILE)...${NC}"
+  (cd "$ROOT_DIR" && npm run "build:$PROFILE")
+fi
 
 # Pack from src/ which holds the real package.json for distribution
 echo -e "${GREEN}Packing project...${NC}"

--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -186,7 +186,9 @@ describe("compat", () => {
     ).toBe(false);
   });
 
-  test("does not require legacy host chain seed shim for v0.13 coprocessor images", () => {
+  test("requires legacy host chain seed shim for v0.13.0 coprocessor images", () => {
+    // initialize_db.sh gained declarative seeding after v0.13.0 was cut;
+    // all v0.13.0-N Docker builds still need the harness shim.
     expect(
       requiresLegacyHostChainSeedShim({
         versions: {
@@ -195,6 +197,22 @@ describe("compat", () => {
           env: {
             COPROCESSOR_DB_MIGRATION_VERSION: "v0.13.0-6",
             COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.13.0-6",
+          } as Record<string, string>,
+          sources: [],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("does not require legacy host chain seed shim for v0.13.1+ coprocessor images", () => {
+    expect(
+      requiresLegacyHostChainSeedShim({
+        versions: {
+          target: "latest-supported",
+          lockName: "v0.13.1.json",
+          env: {
+            COPROCESSOR_DB_MIGRATION_VERSION: "v0.13.1",
+            COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.13.1",
           } as Record<string, string>,
           sources: [],
         },

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -251,16 +251,18 @@ export const supportsCoprocessorDbStateRevert = (state: Pick<CompatState, "versi
  *
  * The host_chains table only exists from v0.12.0 onward (the remove_tenants
  * migration splits it out of the old `tenants` table); v0.11.x images have no
- * such table, so seeding it would fail. Within [0.12.0, 0.13.0) the table
+ * such table, so seeding it would fail. Within [0.12.0, 0.13.1) the table
  * exists but the runtime does not reliably seed it before zkproof caches it, so
- * the harness seeds it manually. From v0.13.0 the runtime self-seeds.
+ * the harness seeds it manually. Declarative seeding was added to
+ * initialize_db.sh after v0.13.0 was cut, so all v0.13.0-N Docker builds still
+ * need the manual shim; v0.13.1+ images self-seed.
  */
 export const requiresLegacyHostChainSeedShim = (state: Pick<CompatState, "versions">) => {
   const dbMigrationVersion = state.versions.env.COPROCESSOR_DB_MIGRATION_VERSION ?? "";
   const hostChainsTableExists = !versionBeforeReleaseFamily(dbMigrationVersion, [0, 12, 0], { unparsed: "modern" });
   const runtimeNeedsManualSeed =
-    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 0], { unparsed: "modern" }) ||
-    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 0], {
+    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 1], { unparsed: "modern" }) ||
+    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 1], {
       unparsed: "modern",
     });
   return hostChainsTableExists && runtimeNeedsManualSeed;


### PR DESCRIPTION
## Summary of recent commits

### `005483d` — fix(test-suite): fix localstack v13

Root cause: `v0.13.0-2` Docker images for `db-migration` were built before the commit that added `seed_host_chains()` to `initialize_db.sh`. The `host_chains` table was created by migrations but never populated, causing the zkproof worker to reject every proof with _"Unknown chain ID: 12345"_.

**Fixes:**
- `compat.ts`: raised the self-seeding threshold from `[0, 13, 0]` to `[0, 13, 1]` so all `v0.13.0-N` builds trigger the manual shim
- `compat.test.ts`: updated `v0.13.0-6` test to expect `true` (needs shim), added a `v0.13.1` test expecting `false` (self-seeds)
- Running stack: seeded `host_chains` directly in Postgres and restarted `coprocessor-zkproof-worker`

For future stack restarts, the `requiresLegacyHostChainSeedShim` fix ensures `fhevm-cli up` will seed the table automatically for any `v0.13.0-N` profile.

---

### `fb9d6cd` — test(sdk): fix fheTests for localstack v12

`initAliceFheTestHandlesIfNeeded` calls `initFheTest(false)` synchronously and returns. The v12 coprocessor then asynchronously registers Alice's FHE handles in the gateway's `CiphertextCommits` contract. The `clientBase.decryptPublicValue` test started immediately, submitted a public decrypt request to the relayer, and the relayer's `isPublicDecryptionReady` check (calling `CiphertextCommits.isCiphertextMaterialAdded`) failed because the coprocessor hadn't finished yet — causing the test to hit its 120-second timeout.

**Fix:** Added a 30-second `Atomics.wait` blocking delay in `setupCommon.ts:328` after fresh handle initialization, giving the coprocessor time to register the handles. The delay only fires when handles are actually initialized (not already present), so repeated test runs don't pay the penalty.

---

### `9cb3a53` — test(sdk): fix NonceManager for localstack v12

Fixes _"Error: nonce has already been used"_ when running `ethers/clientEncrypt.encryptDecrypt.slow.test.ts`.

The ethers.js `NonceManager.sendTransaction` fires an async nonce query (A), then `populateTransaction` independently queries `eth_getTransactionCount` (B) and passes that nonce to `eth_estimateGas`. If the v12 coprocessor increments Alice's nonce between A and B, `eth_estimateGas` receives a stale nonce and fails.

**Fix (`FixedNonceManager`):** Await the NonceManager's nonce first, then spread it into the tx before calling `populateTransaction`. Since `tx.nonce` is pre-set, `populateTransaction` skips its own `eth_getTransactionCount` call entirely — `eth_estimateGas` runs with the correct, authoritative nonce.

---

### `086601e` — test(sdk): dod script

Added a DoD (Definition of Done) test script for the SDK.
