### PR TITLE
chore(kms-connector): improve tests compilation

### DIFF
--- a/.github/workflows/kms-connector-tests.yml
+++ b/.github/workflows/kms-connector-tests.yml
@@ -53,7 +53,7 @@ jobs:
       contents: 'read' # Required to checkout repository code
       packages: 'read' # Required to read GitHub packages/container registry
       pull-requests: 'read' # Required to read pull request information
-    runs-on: runs-on=${{ github.run_id }}/runner=64cpu-linux-x64
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     defaults:
       run:
         shell: bash

--- a/.github/workflows/sdk-rust-sdk-tests.yml
+++ b/.github/workflows/sdk-rust-sdk-tests.yml
@@ -43,6 +43,7 @@ jobs:
   test-rust-sdk:
     name: sdk-rust-sdk-tests/test-rust-sdk (bpr)
     needs: check-changes
+    if: ${{ needs.check-changes.outputs.changes-rust-sdk == 'true' }}
     timeout-minutes: 50
     permissions:
       actions: 'read' # Required to read workflow run information

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -22,7 +22,7 @@ fhevm_gateway_bindings = { path = "../gateway-contracts/rust_bindings", default-
 fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
 kms-grpc = { git = "https://github.com/zama-ai/kms.git", tag = "v0.13.20-0", default-features = true }
 bc2wrap = { git = "https://github.com/zama-ai/kms.git", tag = "v0.13.20-0", default-features = true }
-tfhe = "=1.6.1"
+tfhe = { version = "=1.6.1", default-features = false }
 user-decryption-signature = { path = "../shared/user-decryption-signature", default-features = false }
 
 #####################################################################
@@ -113,3 +113,10 @@ inherits = "release"
 opt-level = 1
 lto = false
 codegen-units = 16
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"
+


### PR DESCRIPTION
### What

Reduces memory consumption and build time when compiling the kms-connector tests.

`cargo test` builds ~20 separate test binaries, each statically linking the full dependency graph (tfhe, alloy, tonic, sqlx…).
With the default profile this generates full debug info on every binary, making link steps memory-hungry enough to freeze machines.

We can use a smaller machine in CI to run tests thanks to this.

### How

- `[profile.dev]` / `[profile.test]` `debug = "line-tables-only"`: keeps usable backtraces while cutting binary size and link-time memory
- `tfhe` `default-features = false`: minor cleanup; tfhe's feature set is driven by `kms-grpc` via feature unification anyway

### Notes

Spotted a small bug in `rust-sdk` CI after this [commit](https://github.com/zama-ai/fhevm/commit/88b11de0d67a096ef5e0659eb8106bb691acf763#diff-e77ddbc63a771942279b53f47597c04f14abc4c8b816af1cdbcb68d81d5b2f1f): tests were not skipped even if no changes to the sdk were made. So fixed it as well.