### PR TITLE
chore(kms-connector): enable garbage collection

### DIFF
--- a/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
@@ -1,6 +1,9 @@
 use tx_sender::{
     core::{Config, TransactionSender},
-    monitoring::{health::HealthStatus, metrics::spawn_gauge_update_routine},
+    monitoring::{
+        garbage_collection::spawn_garbage_collection_routine, health::HealthStatus,
+        metrics::spawn_gauge_update_routine,
+    },
 };
 
 use connector_utils::{
@@ -44,11 +47,21 @@ async fn run() -> anyhow::Result<()> {
             install_signal_handlers(cancel_token.clone())?;
             let monitoring_endpoint = config.monitoring_endpoint;
             let gauge_update_interval = config.gauge_update_interval;
+            let gc_run_interval = config.gc_run_interval;
+            let gc_decryption_expiry = config.gc_decryption_expiry;
+            let gc_decryption_under_process_limit = config.gc_decryption_under_process_limit;
 
             info!("Starting TransactionSender");
             let (tx_sender, state) = TransactionSender::from_config(config).await?;
             spawn_gauge_update_routine(
                 gauge_update_interval,
+                state.db_pool.clone(),
+                cancel_token.clone(),
+            );
+            spawn_garbage_collection_routine(
+                gc_run_interval,
+                gc_decryption_expiry,
+                gc_decryption_under_process_limit,
                 state.db_pool.clone(),
                 cancel_token.clone(),
             );

--- a/kms-connector/crates/tx-sender/src/monitoring/garbage_collection.rs
+++ b/kms-connector/crates/tx-sender/src/monitoring/garbage_collection.rs
@@ -40,7 +40,7 @@ async fn run_garbage_collection_routine(
     }
 }
 
-pub async fn delete_completed_and_failed_public_decryption_requests(
+async fn delete_completed_and_failed_public_decryption_requests(
     db_pool: &Pool<Postgres>,
     expiry: PgInterval,
 ) {
@@ -63,7 +63,7 @@ pub async fn delete_completed_and_failed_public_decryption_requests(
     }
 }
 
-pub async fn delete_completed_and_failed_user_decryption_requests(
+async fn delete_completed_and_failed_user_decryption_requests(
     db_pool: &Pool<Postgres>,
     expiry: PgInterval,
 ) {
@@ -86,7 +86,7 @@ pub async fn delete_completed_and_failed_user_decryption_requests(
     }
 }
 
-pub async fn delete_completed_and_failed_public_decryption_responses(
+async fn delete_completed_and_failed_public_decryption_responses(
     db_pool: &Pool<Postgres>,
     expiry: PgInterval,
 ) {
@@ -109,7 +109,7 @@ pub async fn delete_completed_and_failed_public_decryption_responses(
     }
 }
 
-pub async fn delete_completed_and_failed_user_decryption_responses(
+async fn delete_completed_and_failed_user_decryption_responses(
     db_pool: &Pool<Postgres>,
     expiry: PgInterval,
 ) {
@@ -132,7 +132,7 @@ pub async fn delete_completed_and_failed_user_decryption_responses(
     }
 }
 
-pub async fn unlock_public_decryption_requests(
+async fn unlock_public_decryption_requests(
     db_pool: &Pool<Postgres>,
     under_process_limit: PgInterval,
 ) {
@@ -154,7 +154,7 @@ pub async fn unlock_public_decryption_requests(
     }
 }
 
-pub async fn unlock_user_decryption_requests(
+async fn unlock_user_decryption_requests(
     db_pool: &Pool<Postgres>,
     under_process_limit: PgInterval,
 ) {
@@ -176,7 +176,7 @@ pub async fn unlock_user_decryption_requests(
     }
 }
 
-pub async fn unlock_public_decryption_responses(
+async fn unlock_public_decryption_responses(
     db_pool: &Pool<Postgres>,
     under_process_limit: PgInterval,
 ) {
@@ -198,7 +198,7 @@ pub async fn unlock_public_decryption_responses(
     }
 }
 
-pub async fn unlock_user_decryption_responses(
+async fn unlock_user_decryption_responses(
     db_pool: &Pool<Postgres>,
     under_process_limit: PgInterval,
 ) {

--- a/kms-connector/crates/tx-sender/src/monitoring/garbage_collection.rs
+++ b/kms-connector/crates/tx-sender/src/monitoring/garbage_collection.rs
@@ -4,6 +4,18 @@ use tokio::{select, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
+/// Spawns the background routine responsible for cleaning up the database.
+///
+/// # Arguments
+///
+/// * `period` - Duration to wait between two runs of the routine.
+/// * `decryption_expiry` - Age after which `completed`/`failed` decryption
+///   requests and responses are deleted (computed from their `updated_at`).
+/// * `under_process_limit` - Age after which decryption requests and responses
+///   stuck in the `under_process` status are unlocked back to `pending`
+///   (computed from their `updated_at`).
+/// * `db_pool` - Connection pool to the database to clean up.
+/// * `cancel_token` - Token used to stop the routine gracefully.
 pub fn spawn_garbage_collection_routine(
     period: Duration,
     decryption_expiry: PgInterval,

--- a/kms-connector/crates/tx-sender/tests/gc.rs
+++ b/kms-connector/crates/tx-sender/tests/gc.rs
@@ -15,49 +15,24 @@ use connector_utils::{
 use rstest::rstest;
 use sqlx::{Pool, Postgres, Row, postgres::types::PgInterval};
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
-use tx_sender::monitoring::garbage_collection::{
-    delete_completed_and_failed_public_decryption_requests,
-    delete_completed_and_failed_public_decryption_responses,
-    delete_completed_and_failed_user_decryption_requests,
-    delete_completed_and_failed_user_decryption_responses, unlock_public_decryption_requests,
-    unlock_public_decryption_responses, unlock_user_decryption_requests,
-    unlock_user_decryption_responses,
-};
+use tx_sender::monitoring::garbage_collection::spawn_garbage_collection_routine;
+
+/// Interval short enough that an inserted element is "expired" after a brief sleep.
+const SHORT_INTERVAL: Duration = Duration::from_secs(1);
+/// Interval long enough that a freshly inserted element is never collected during a test.
+const LONG_INTERVAL: Duration = Duration::from_secs(120);
 
 #[rstest]
+#[case::public_decryption_request("PublicDecryptionRequest")]
+#[case::user_decryption_request("UserDecryptionRequest")]
+#[case::public_decryption_response("PublicDecryptionResponse")]
+#[case::user_decryption_response("UserDecryptionResponse")]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-async fn deletes_old_public_decryption_requests() -> anyhow::Result<()> {
-    test_delete_old_elements_from_db("PublicDecryptionRequest").await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn deletes_old_user_decryption_requests() -> anyhow::Result<()> {
-    test_delete_old_elements_from_db("UserDecryptionRequest").await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn deletes_old_public_decryption_responses() -> anyhow::Result<()> {
-    test_delete_old_elements_from_db("PublicDecryptionResponse").await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn deletes_old_user_decryption_responses() -> anyhow::Result<()> {
-    test_delete_old_elements_from_db("UserDecryptionResponse").await
-}
-
-async fn test_delete_old_elements_from_db(elem: &str) -> anyhow::Result<()> {
+async fn deletes_old_completed_and_failed_decryption(#[case] elem: &str) -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
-
-    // Use small expiry
-    let expiry = PgInterval::try_from(Duration::from_secs(1)).unwrap();
 
     let mut inserted_ids = vec![];
     let statuses = [
@@ -72,7 +47,7 @@ async fn test_delete_old_elements_from_db(elem: &str) -> anyhow::Result<()> {
 
     // Sleep to let elements "expires" in DB
     tokio::time::sleep(Duration::from_secs(2)).await;
-    trigger_gc_delete_elem(test_instance.db(), elem, expiry).await;
+    run_garbage_collection(test_instance.db(), SHORT_INTERVAL, LONG_INTERVAL).await;
 
     // Verify old completed/failed elem are removed from DB, and others are still in DB
     let remaining_ids = fetch_elem_ids_in_db(test_instance.db(), elem).await?;
@@ -81,42 +56,15 @@ async fn test_delete_old_elements_from_db(elem: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////
-
 #[rstest]
+#[case::public_decryption_request("PublicDecryptionRequest")]
+#[case::user_decryption_request("UserDecryptionRequest")]
+#[case::public_decryption_response("PublicDecryptionResponse")]
+#[case::user_decryption_response("UserDecryptionResponse")]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-async fn do_not_delete_recent_public_decryption_requests() -> anyhow::Result<()> {
-    test_do_not_delete_recent_elements_from_db("PublicDecryptionRequest").await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn do_not_delete_recent_user_decryption_requests() -> anyhow::Result<()> {
-    test_do_not_delete_recent_elements_from_db("UserDecryptionRequest").await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn do_not_delete_recent_public_decryption_responses() -> anyhow::Result<()> {
-    test_do_not_delete_recent_elements_from_db("PublicDecryptionResponse").await
-}
-
-#[rstest]
-#[timeout(Duration::from_secs(60))]
-#[tokio::test]
-async fn do_not_delete_recent_user_decryption_responses() -> anyhow::Result<()> {
-    test_do_not_delete_recent_elements_from_db("UserDecryptionResponse").await
-}
-
-async fn test_do_not_delete_recent_elements_from_db(elem: &str) -> anyhow::Result<()> {
+async fn does_not_delete_recent_decryption(#[case] elem: &str) -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
-
-    // Use "long" expiry
-    let expiry = PgInterval::try_from(Duration::from_secs(120)).unwrap();
 
     let mut inserted_ids = vec![];
     let statuses = [
@@ -128,7 +76,9 @@ async fn test_do_not_delete_recent_elements_from_db(elem: &str) -> anyhow::Resul
     for status in statuses {
         inserted_ids.push(insert_elem_in_db_and_get_id(test_instance.db(), elem, status).await?);
     }
-    trigger_gc_delete_elem(test_instance.db(), elem, expiry).await;
+
+    // Long intervals: nothing is old enough to be collected.
+    run_garbage_collection(test_instance.db(), LONG_INTERVAL, LONG_INTERVAL).await;
 
     // Verify all elems are still in DB
     let remaining_ids = fetch_elem_ids_in_db(test_instance.db(), elem).await?;
@@ -137,77 +87,80 @@ async fn test_do_not_delete_recent_elements_from_db(elem: &str) -> anyhow::Resul
     Ok(())
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////
-
 #[rstest]
+#[case::public_decryption_request("PublicDecryptionRequest")]
+#[case::user_decryption_request("UserDecryptionRequest")]
+#[case::public_decryption_response("PublicDecryptionResponse")]
+#[case::user_decryption_response("UserDecryptionResponse")]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-async fn unlock_old_elems_under_process() -> anyhow::Result<()> {
+async fn unlocks_old_under_process_decryption(#[case] elem: &str) -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    // Use a small `under_process_limit`
-    let under_process_limit = PgInterval::try_from(Duration::from_secs(1)).unwrap();
+    let id = insert_elem_in_db_and_get_id(test_instance.db(), elem, OperationStatus::UnderProcess)
+        .await?;
 
-    let mut inserted_ids = vec![];
-    let elem_type = [
-        "PublicDecryptionRequest",
-        "UserDecryptionRequest",
-        "PublicDecryptionResponse",
-        "UserDecryptionResponse",
-    ];
-    for elem in elem_type {
-        inserted_ids.push(
-            insert_elem_in_db_and_get_id(test_instance.db(), elem, OperationStatus::UnderProcess)
-                .await?,
-        );
-    }
-
-    // Sleep to reach the `under_process_limit`
+    // Sleep to reach the (short) `under_process_limit`.
     tokio::time::sleep(Duration::from_secs(2)).await;
-    for (i, elem) in elem_type.into_iter().enumerate() {
-        trigger_gc_unlock_elem(test_instance.db(), elem, under_process_limit).await;
-        let status = get_elem_status(test_instance.db(), elem, inserted_ids[i]).await?;
-        assert_eq!(status, OperationStatus::Pending);
-    }
+    // Use a long expiry so the GC does not delete the element before unlocking it.
+    run_garbage_collection(test_instance.db(), LONG_INTERVAL, SHORT_INTERVAL).await;
+
+    let status = get_elem_status(test_instance.db(), elem, id).await?;
+    assert_eq!(status, OperationStatus::Pending);
 
     Ok(())
 }
 
 #[rstest]
+#[case::public_decryption_request("PublicDecryptionRequest")]
+#[case::user_decryption_request("UserDecryptionRequest")]
+#[case::public_decryption_response("PublicDecryptionResponse")]
+#[case::user_decryption_response("UserDecryptionResponse")]
 #[timeout(Duration::from_secs(60))]
 #[tokio::test]
-async fn do_not_unlock_recent_elems_under_process() -> anyhow::Result<()> {
+async fn does_not_unlock_recent_under_process_decryption(#[case] elem: &str) -> anyhow::Result<()> {
     let test_instance = TestInstanceBuilder::db_setup().await?;
 
-    // Use a long `under_process_limit`
-    let under_process_limit = PgInterval::try_from(Duration::from_secs(120)).unwrap();
+    let id = insert_elem_in_db_and_get_id(test_instance.db(), elem, OperationStatus::UnderProcess)
+        .await?;
 
-    let mut inserted_ids = vec![];
-    let elem_type = [
-        "PublicDecryptionRequest",
-        "UserDecryptionRequest",
-        "PublicDecryptionResponse",
-        "UserDecryptionResponse",
-    ];
-    for elem in elem_type {
-        inserted_ids.push(
-            insert_elem_in_db_and_get_id(test_instance.db(), elem, OperationStatus::UnderProcess)
-                .await?,
-        );
-    }
+    // Long `under_process_limit`: the element is too recent to be unlocked.
+    run_garbage_collection(test_instance.db(), LONG_INTERVAL, LONG_INTERVAL).await;
 
-    for (i, elem) in elem_type.into_iter().enumerate() {
-        trigger_gc_unlock_elem(test_instance.db(), elem, under_process_limit).await;
-        let status = get_elem_status(test_instance.db(), elem, inserted_ids[i]).await?;
-        assert_eq!(status, OperationStatus::UnderProcess);
-    }
+    let status = get_elem_status(test_instance.db(), elem, id).await?;
+    assert_eq!(status, OperationStatus::UnderProcess);
 
     Ok(())
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Runs the garbage collection routine against `db` for a short while, then stops it.
+///
+/// The routine performs both deletion and unlocking on every iteration, so callers pick a long
+/// interval for the dimension they don't want to trigger.
+async fn run_garbage_collection(
+    db: &Pool<Postgres>,
+    decryption_expiry: Duration,
+    under_process_limit: Duration,
+) {
+    info!("Triggering the garbage collection routine...");
+    let cancel_token = CancellationToken::new();
+    let handle = spawn_garbage_collection_routine(
+        Duration::from_millis(200),
+        PgInterval::try_from(decryption_expiry).unwrap(),
+        PgInterval::try_from(under_process_limit).unwrap(),
+        db.clone(),
+        cancel_token.clone(),
+    );
+
+    // Let the routine run a few (idempotent) iterations, then stop it.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    cancel_token.cancel();
+    handle.await.expect("garbage collection routine panicked");
+    info!("Done!");
+}
 
 async fn insert_elem_in_db_and_get_id(
     db: &Pool<Postgres>,
@@ -241,46 +194,6 @@ async fn insert_elem_in_db_and_get_id(
         _ => panic!("Unexpected element type"),
     };
     Ok(id)
-}
-
-async fn trigger_gc_delete_elem(db: &Pool<Postgres>, elem: &str, expiry: PgInterval) {
-    info!("Trigger deletion of {elem} by the GC...");
-    match elem {
-        "PublicDecryptionRequest" => {
-            delete_completed_and_failed_public_decryption_requests(db, expiry).await;
-        }
-        "UserDecryptionRequest" => {
-            delete_completed_and_failed_user_decryption_requests(db, expiry).await;
-        }
-        "PublicDecryptionResponse" => {
-            delete_completed_and_failed_public_decryption_responses(db, expiry).await;
-        }
-        "UserDecryptionResponse" => {
-            delete_completed_and_failed_user_decryption_responses(db, expiry).await;
-        }
-        _ => panic!("Unexpected element type"),
-    }
-    info!("Done!");
-}
-
-async fn trigger_gc_unlock_elem(db: &Pool<Postgres>, elem: &str, under_process_limit: PgInterval) {
-    info!("Trigger unlocking of {elem} by the GC...");
-    match elem {
-        "PublicDecryptionRequest" => {
-            unlock_public_decryption_requests(db, under_process_limit).await;
-        }
-        "UserDecryptionRequest" => {
-            unlock_user_decryption_requests(db, under_process_limit).await;
-        }
-        "PublicDecryptionResponse" => {
-            unlock_public_decryption_responses(db, under_process_limit).await;
-        }
-        "UserDecryptionResponse" => {
-            unlock_user_decryption_responses(db, under_process_limit).await;
-        }
-        _ => panic!("Unexpected element type"),
-    }
-    info!("Done!");
 }
 
 async fn fetch_elem_ids_in_db(db: &Pool<Postgres>, elem: &str) -> anyhow::Result<Vec<U256>> {


### PR DESCRIPTION
Enables the garbage collection to remove already processed decryption from kms-connector's DB.

Also refactor the `gc` tests to make them parametrized.