### PR TITLE
feat(sdk): drop Bearer and cookie auth, x-api-key header only

### DIFF
--- a/sdk/js-sdk/src/core/base/auth.ts
+++ b/sdk/js-sdk/src/core/base/auth.ts
@@ -5,36 +5,12 @@ import { isNonEmptyString } from './string.js';
 /**
  * Set the authentication method for the request. The default is no authentication.
  * It supports:
- * - Bearer Token
- * - Custom header
- * - Custom cookie
+ * - Custom header (default header name `x-api-key`)
  */
 export function setAuth(init: RequestInit, auth?: Auth): RequestInit {
   if (auth) {
-    switch (auth.type) {
-      case 'BearerToken': {
-        (init.headers as Record<string, string>).authorization = `Bearer ${validateHeaderValue(auth.token)}`;
-        break;
-      }
-
-      case 'ApiKeyHeader': {
-        const h = isNonEmptyString(auth.header) ? normalizeHeaderName(auth.header) : 'x-api-key';
-        (init.headers as Record<string, string>)[h] = validateHeaderValue(auth.value);
-        break;
-      }
-
-      case 'ApiKeyCookie': {
-        const h = isNonEmptyString(auth.cookie) ? normalizeHeaderName(auth.cookie) : 'x-api-key';
-        const v = validateHeaderValue(auth.value);
-        if (typeof window !== 'undefined') {
-          document.cookie = `${h}=${v}; path=/; SameSite=Lax; Secure; HttpOnly;`;
-          init.credentials = 'include';
-        } else {
-          (init.headers as Record<string, string>).cookie = `${h}=${v};`;
-        }
-        break;
-      }
-    }
+    const h = isNonEmptyString(auth.header) ? normalizeHeaderName(auth.header) : 'x-api-key';
+    (init.headers as Record<string, string>)[h] = validateHeaderValue(auth.value);
   }
   return init;
 }

--- a/sdk/js-sdk/src/core/types/auth.ts
+++ b/sdk/js-sdk/src/core/types/auth.ts
@@ -1,15 +1,4 @@
-export type AuthType = 'BearerToken' | 'ApiKeyHeader' | 'ApiKeyCookie';
-
-/**
- * Bearer Token Authentication
- */
-export type AuthBearerToken = {
-  type: 'BearerToken';
-  /**
-   * The Bearer token.
-   */
-  token: string;
-};
+export type AuthType = 'ApiKeyHeader';
 
 /**
  * Custom header authentication
@@ -26,19 +15,4 @@ export type AuthApiKeyHeader = {
   value: string;
 };
 
-/**
- * Custom cookie authentication
- */
-export type AuthApiKeyCookie = {
-  type: 'ApiKeyCookie';
-  /**
-   * The cookie name. The default value is `x-api-key`.
-   */
-  cookie?: string;
-  /**
-   * The API key.
-   */
-  value: string;
-};
-
-export type Auth = AuthBearerToken | AuthApiKeyHeader | AuthApiKeyCookie;
+export type Auth = AuthApiKeyHeader;

--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fhevm/sdk",
   "description": "TypeScript Interface for FHEVM",
-  "version": "1.1.0-alpha.4",
+  "version": "1.1.0-alpha.5",
   "type": "module",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary

Removes `Authorization: Bearer` and the `x-api-key` **cookie** form as auth methods, making the **`x-api-key` request header** the only supported auth in `@fhevm/sdk`. Bumps the package to `1.1.0-alpha.5`.

## Why

The Zama-hosted relayer is behind a Cloudflare rule that **rejects any request without an `x-api-key` header**. `Authorization: Bearer` and `Cookie: x-api-key=…` never reach the origin — Cloudflare returns a canned 403 at the edge (no `cf-cache-status`, no `request_id`), identical to sending no auth at all. Only the `x-api-key` header reaches the origin. So Bearer/cookie were dead weight: they looked valid in the SDK but silently 403'd.

| Auth sent | Status | Reaches relayer? |
|---|---|---|
| `x-api-key:` header | 401 (origin) | yes (only key value wrong) |
| `Authorization: Bearer` | 403 (CF edge) | no |
| `Cookie: x-api-key=…` | 403 (CF edge) | no |
| no auth | 403 (CF edge) | no |

## Changes

- **`src/core/types/auth.ts`** — deleted `AuthBearerToken` and `AuthApiKeyCookie`; reduced `Auth` to `AuthApiKeyHeader`; narrowed `AuthType` to `'ApiKeyHeader'`.
- **`src/core/base/auth.ts`** — removed the `BearerToken` and `ApiKeyCookie` branches (including the `document.cookie` path); dropped the now single-case `switch`.
- **`src/package.json`** — `1.1.0-alpha.4` → `1.1.0-alpha.5`.

No dedicated auth test file or Bearer/cookie mock routes exist in this repo. The `Bearer` strings in `fetch.test.ts` are generic header-normalization test data, not auth-feature tests, and are left intact.

## ⚠️ Breaking change

`Auth` no longer accepts `BearerToken` or `ApiKeyCookie`. Migration is one line:

\`\`\`ts
auth: { type: 'ApiKeyHeader', value: ZAMA_FHEVM_API_KEY }
\`\`\`

## Coordination hold

Per the auth discussion, the plan is to **relax the Cloudflare rule to accept either header temporarily and set a cutover date** before SDKs drop Bearer. Hold this merge until the cutover is agreed so a published SDK doesn't drop Bearer ahead of schedule.

## Verification

- `tsc -b tsconfig.json --noEmit` (src) — clean
- `tsc --project test/tsconfig.json --noEmit` (tests) — clean
- ESLint on both changed files — clean
- Vitest auth/fetch suites — 74 passed