### PR TITLE
docs(sdk): note x-api-key is the only Zama-hosted relayer auth

### DIFF
--- a/sdk/js-sdk/src/core/types/auth.ts
+++ b/sdk/js-sdk/src/core/types/auth.ts
@@ -12,7 +12,10 @@ export type AuthBearerToken = {
 };
 
 /**
- * Custom header authentication
+ * Custom header authentication.
+ *
+ * This is the only form accepted by Zama's hosted relayer (it requires the API
+ * key in the `x-api-key` request header). Use it for Zama-hosted endpoints.
  */
 export type AuthApiKeyHeader = {
   type: 'ApiKeyHeader';
@@ -41,4 +44,12 @@ export type AuthApiKeyCookie = {
   value: string;
 };
 
+/**
+ * Supported authentication methods.
+ *
+ * All three forms are supported so the SDK works out of the box with both Zama-hosted
+ * and self-hosted relayers. A self-hosted relayer may accept any of them depending on
+ * its deployment. Zama's hosted relayer accepts only `ApiKeyHeader` (`x-api-key`
+ * request header) — `BearerToken` and `ApiKeyCookie` are rejected at the edge.
+ */
 export type Auth = AuthBearerToken | AuthApiKeyHeader | AuthApiKeyCookie;


### PR DESCRIPTION
## Summary

Comment-only change. Adds a JSDoc note on the public `Auth` types in `src/core/types/auth.ts` clarifying that:

- All three auth mechanisms (`BearerToken`, `ApiKeyHeader`, `ApiKeyCookie`) **remain supported**, so the SDK works out of the box with both Zama-hosted and self-hosted relayers.
- Zama's hosted relayer accepts **only** `ApiKeyHeader` (the `x-api-key` request header); `BearerToken` and `ApiKeyCookie` are rejected at the edge (Kong/Cloudflare).

No behavior change — the three mechanisms and all `setAuth` logic are untouched.

## Why

Per the auth discussion, the SDK intentionally keeps all three forms (self-hosted relayers may accept any of them depending on deployment). The gap was that the source didn't make the Zama-hosted constraint visible. This note documents it on the public type surface so it's clear to SDK users and to anyone generating docs from source.

## Notes

- This supersedes the earlier (closed) PR #2795, which removed Bearer/cookie — that approach was rejected in favor of keeping all three and documenting the constraint instead.
- The analogous mini-comment is also wanted in `relayer-sdk` and `zama-sdk` (tracked separately).