### PR TITLE
feat(library-solidity): add FHE.toExternal methods for all encrypted types

### DIFF
--- a/docs/solidity-guides/inputs.md
+++ b/docs/solidity-guides/inputs.md
@@ -127,6 +127,22 @@ function transfer(
 2. **Type conversion**:\
    The function transforms `externalEbool`, `externalEaddress`, `externalEuintXX` into the appropriate encrypted type (`ebool`, `eaddress`, `euintXX`) for further operations within the contract.
 
+### Re-exporting a handle with `FHE.toExternal`
+
+`FHE.toExternal` is the inverse of `FHE.fromExternal`: it takes an on-chain encrypted value (`euintXX`, `ebool`, `eaddress`) that the contract already holds and re-wraps it into the matching external type (`externalEuintXX`, `externalEbool`, `externalEaddress`). The function is overloaded, so the target type is inferred from the argument — exactly like `fromExternal`.
+
+This is useful for **contract-to-contract composition**. Many functions — including standardized interfaces such as confidential tokens — type their entry points as `(externalEuintXX handle, bytes inputProof)` because the usual caller is an EOA submitting an encrypted input together with a zero-knowledge proof. A contract that already holds an `euintXX` cannot produce such a proof on-chain. `toExternal`, paired with the empty-proof path of `fromExternal`, bridges that gap:
+
+```solidity
+// Inside a contract that already holds `euint64 amount`:
+FHE.allow(amount, address(token)); // grant the callee access (ACL)
+token.transfer(to, FHE.toExternal(amount), ""); // re-wrap, pass an empty proof
+```
+
+On the receiving side, `FHE.fromExternal(encryptedAmount, "")` skips proof verification and simply checks that the handle is already allowed to the caller before returning it as a regular `euint64`. This is what enables smart-contract accounts to integrate with the FHEVM input ABI.
+
+> **Important:** `toExternal` only changes the static type — it performs no verification and grants no access. The empty-proof re-import reverts with `SenderNotAllowedToUseHandle` unless the handle has already been allowed (via `FHE.allow` / `FHE.allowThis`) to the relevant party. Always set up ACL permissions first.
+
 ## Best Practices
 
 - **Input packing**: Minimize the size and complexity of zero-knowledge proofs by packing all encrypted inputs into a single ciphertext.

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -600,6 +600,17 @@ function handleSolidityTFHEConvertPlaintextAndEinputToRespectiveType(fheType: Ad
         }
     }
 
+    /**
+     * @dev Convert an encrypted e${fheType.type.toLowerCase()} handle to its externalE${fheType.type.toLowerCase()} representation.
+     * @dev This only re-wraps the underlying handle into the externalE${fheType.type.toLowerCase()} type; it performs no
+     *      verification or access control. The resulting externalE${fheType.type.toLowerCase()} can be passed to another
+     *      contract and turned back into an e${fheType.type.toLowerCase()} via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(e${fheType.type.toLowerCase()} value) internal pure returns (externalE${fheType.type.toLowerCase()}) {
+        return externalE${fheType.type.toLowerCase()}.wrap(e${fheType.type.toLowerCase()}.unwrap(value));
+    }
+
     `;
 
   /// If boolean, add also the asEbool function that allows casting bool

--- a/library-solidity/examples/tests/FHEVMManualTestSuite.sol
+++ b/library-solidity/examples/tests/FHEVMManualTestSuite.sol
@@ -370,4 +370,35 @@ contract FHEVMManualTestSuite {
         FHE.allowThis(result);
         resEuint64 = result;
     }
+
+    /// @dev Verifies the toExternal -> fromExternal (empty proof) round-trip for euint64.
+    ///      The handle is allowed to the caller so it can be re-imported without a proof.
+    function test_toExternalEuint64(externalEuint64 a, bytes calldata inputProof) public {
+        euint64 aProc = FHE.fromExternal(a, inputProof);
+        FHE.allow(aProc, msg.sender);
+        externalEuint64 ext = FHE.toExternal(aProc);
+        euint64 recovered = FHE.fromExternal(ext, bytes(""));
+        FHE.allowThis(recovered);
+        resEuint64 = recovered;
+    }
+
+    /// @dev Verifies the toExternal -> fromExternal (empty proof) round-trip for ebool.
+    function test_toExternalEbool(externalEbool a, bytes calldata inputProof) public {
+        ebool aProc = FHE.fromExternal(a, inputProof);
+        FHE.allow(aProc, msg.sender);
+        externalEbool ext = FHE.toExternal(aProc);
+        ebool recovered = FHE.fromExternal(ext, bytes(""));
+        FHE.allowThis(recovered);
+        resEbool = recovered;
+    }
+
+    /// @dev Verifies the toExternal -> fromExternal (empty proof) round-trip for eaddress.
+    function test_toExternalEaddress(externalEaddress a, bytes calldata inputProof) public {
+        eaddress aProc = FHE.fromExternal(a, inputProof);
+        FHE.allow(aProc, msg.sender);
+        externalEaddress ext = FHE.toExternal(aProc);
+        eaddress recovered = FHE.fromExternal(ext, bytes(""));
+        FHE.allowThis(recovered);
+        resAdd = recovered;
+    }
 }

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -8505,6 +8505,17 @@ library FHE {
     }
 
     /**
+     * @dev Convert an encrypted ebool handle to its externalEbool representation.
+     * @dev This only re-wraps the underlying handle into the externalEbool type; it performs no
+     *      verification or access control. The resulting externalEbool can be passed to another
+     *      contract and turned back into an ebool via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(ebool value) internal pure returns (externalEbool) {
+        return externalEbool.wrap(ebool.unwrap(value));
+    }
+
+    /**
      * @dev Converts a plaintext boolean to an encrypted boolean.
      */
     function asEbool(bool value) internal returns (ebool) {
@@ -8528,6 +8539,17 @@ library FHE {
             if (!Impl.isAllowed(inputBytes32, msg.sender)) revert SenderNotAllowedToUseHandle(inputBytes32, msg.sender);
             return euint8.wrap(inputBytes32);
         }
+    }
+
+    /**
+     * @dev Convert an encrypted euint8 handle to its externalEuint8 representation.
+     * @dev This only re-wraps the underlying handle into the externalEuint8 type; it performs no
+     *      verification or access control. The resulting externalEuint8 can be passed to another
+     *      contract and turned back into an euint8 via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(euint8 value) internal pure returns (externalEuint8) {
+        return externalEuint8.wrap(euint8.unwrap(value));
     }
 
     /**
@@ -8557,6 +8579,17 @@ library FHE {
     }
 
     /**
+     * @dev Convert an encrypted euint16 handle to its externalEuint16 representation.
+     * @dev This only re-wraps the underlying handle into the externalEuint16 type; it performs no
+     *      verification or access control. The resulting externalEuint16 can be passed to another
+     *      contract and turned back into an euint16 via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(euint16 value) internal pure returns (externalEuint16) {
+        return externalEuint16.wrap(euint16.unwrap(value));
+    }
+
+    /**
      * @dev Convert a plaintext value to an encrypted euint16 value.
      */
     function asEuint16(uint16 value) internal returns (euint16) {
@@ -8580,6 +8613,17 @@ library FHE {
             if (!Impl.isAllowed(inputBytes32, msg.sender)) revert SenderNotAllowedToUseHandle(inputBytes32, msg.sender);
             return euint32.wrap(inputBytes32);
         }
+    }
+
+    /**
+     * @dev Convert an encrypted euint32 handle to its externalEuint32 representation.
+     * @dev This only re-wraps the underlying handle into the externalEuint32 type; it performs no
+     *      verification or access control. The resulting externalEuint32 can be passed to another
+     *      contract and turned back into an euint32 via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(euint32 value) internal pure returns (externalEuint32) {
+        return externalEuint32.wrap(euint32.unwrap(value));
     }
 
     /**
@@ -8609,6 +8653,17 @@ library FHE {
     }
 
     /**
+     * @dev Convert an encrypted euint64 handle to its externalEuint64 representation.
+     * @dev This only re-wraps the underlying handle into the externalEuint64 type; it performs no
+     *      verification or access control. The resulting externalEuint64 can be passed to another
+     *      contract and turned back into an euint64 via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(euint64 value) internal pure returns (externalEuint64) {
+        return externalEuint64.wrap(euint64.unwrap(value));
+    }
+
+    /**
      * @dev Convert a plaintext value to an encrypted euint64 value.
      */
     function asEuint64(uint64 value) internal returns (euint64) {
@@ -8632,6 +8687,17 @@ library FHE {
             if (!Impl.isAllowed(inputBytes32, msg.sender)) revert SenderNotAllowedToUseHandle(inputBytes32, msg.sender);
             return euint128.wrap(inputBytes32);
         }
+    }
+
+    /**
+     * @dev Convert an encrypted euint128 handle to its externalEuint128 representation.
+     * @dev This only re-wraps the underlying handle into the externalEuint128 type; it performs no
+     *      verification or access control. The resulting externalEuint128 can be passed to another
+     *      contract and turned back into an euint128 via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(euint128 value) internal pure returns (externalEuint128) {
+        return externalEuint128.wrap(euint128.unwrap(value));
     }
 
     /**
@@ -8661,6 +8727,17 @@ library FHE {
     }
 
     /**
+     * @dev Convert an encrypted eaddress handle to its externalEaddress representation.
+     * @dev This only re-wraps the underlying handle into the externalEaddress type; it performs no
+     *      verification or access control. The resulting externalEaddress can be passed to another
+     *      contract and turned back into an eaddress via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(eaddress value) internal pure returns (externalEaddress) {
+        return externalEaddress.wrap(eaddress.unwrap(value));
+    }
+
+    /**
      * @dev Convert a plaintext value to an encrypted eaddress value.
      */
     function asEaddress(address value) internal returns (eaddress) {
@@ -8684,6 +8761,17 @@ library FHE {
             if (!Impl.isAllowed(inputBytes32, msg.sender)) revert SenderNotAllowedToUseHandle(inputBytes32, msg.sender);
             return euint256.wrap(inputBytes32);
         }
+    }
+
+    /**
+     * @dev Convert an encrypted euint256 handle to its externalEuint256 representation.
+     * @dev This only re-wraps the underlying handle into the externalEuint256 type; it performs no
+     *      verification or access control. The resulting externalEuint256 can be passed to another
+     *      contract and turned back into an euint256 via fromExternal with an empty inputProof,
+     *      provided the handle has already been allowed to the caller.
+     */
+    function toExternal(euint256 value) internal pure returns (externalEuint256) {
+        return externalEuint256.wrap(euint256.unwrap(value));
     }
 
     /**

--- a/library-solidity/test/FHEToExternal.t.sol
+++ b/library-solidity/test/FHEToExternal.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import "../lib/FHE.sol";
+
+/// @dev Unit tests for FHE.toExternal: it must re-wrap an encrypted handle into its external
+///      representation while preserving the underlying bytes32 handle exactly. These tests are
+///      pure (no coprocessor needed) since toExternal performs no verification or ACL checks.
+contract FHEToExternalTest is Test {
+    bytes32 internal constant HANDLE =
+        bytes32(uint256(0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef));
+
+    function test_toExternalEbool_preservesHandle() public pure {
+        assertEq(externalEbool.unwrap(FHE.toExternal(ebool.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEuint8_preservesHandle() public pure {
+        assertEq(externalEuint8.unwrap(FHE.toExternal(euint8.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEuint16_preservesHandle() public pure {
+        assertEq(externalEuint16.unwrap(FHE.toExternal(euint16.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEuint32_preservesHandle() public pure {
+        assertEq(externalEuint32.unwrap(FHE.toExternal(euint32.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEuint64_preservesHandle() public pure {
+        assertEq(externalEuint64.unwrap(FHE.toExternal(euint64.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEuint128_preservesHandle() public pure {
+        assertEq(externalEuint128.unwrap(FHE.toExternal(euint128.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEuint256_preservesHandle() public pure {
+        assertEq(externalEuint256.unwrap(FHE.toExternal(euint256.wrap(HANDLE))), HANDLE);
+    }
+
+    function test_toExternalEaddress_preservesHandle() public pure {
+        assertEq(externalEaddress.unwrap(FHE.toExternal(eaddress.wrap(HANDLE))), HANDLE);
+    }
+
+    /// @dev Any handle value round-trips through toExternal unchanged (including zero).
+    function testFuzz_toExternalEuint64_preservesHandle(bytes32 handle) public pure {
+        assertEq(externalEuint64.unwrap(FHE.toExternal(euint64.wrap(handle))), handle);
+    }
+}

--- a/library-solidity/test/fhevmOperations/manual.ts
+++ b/library-solidity/test/fhevmOperations/manual.ts
@@ -935,4 +935,33 @@ describe('FHEVM manual operations', function () {
     await tx.wait();
     expect(await decrypt64(await this.contract.resEuint64())).to.equal(600_000_000n);
   });
+
+  it('toExternalEuint64 round-trips through fromExternal with empty proof', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.add64(123_456_789n);
+    const encryptedAmount = await input.encrypt();
+    const tx = await this.contract.test_toExternalEuint64(encryptedAmount.handles[0], encryptedAmount.inputProof);
+    await tx.wait();
+    expect(await decrypt64(await this.contract.resEuint64())).to.equal(123_456_789n);
+  });
+
+  it('toExternalEbool round-trips through fromExternal with empty proof', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.addBool(true);
+    const encryptedAmount = await input.encrypt();
+    const tx = await this.contract.test_toExternalEbool(encryptedAmount.handles[0], encryptedAmount.inputProof);
+    await tx.wait();
+    expect(await decryptBool(await this.contract.resEbool())).to.equal(true);
+  });
+
+  it('toExternalEaddress round-trips through fromExternal with empty proof', async function () {
+    const input = this.instances.alice.createEncryptedInput(this.contractAddress, this.signers.alice.address);
+    input.addAddress('0x8ba1f109551bd432803012645ac136ddd64dba72');
+    const encryptedAmount = await input.encrypt();
+    const tx = await this.contract.test_toExternalEaddress(encryptedAmount.handles[0], encryptedAmount.inputProof);
+    await tx.wait();
+    expect((await decryptAddress(await this.contract.resAdd())).toLowerCase()).to.equal(
+      '0x8ba1f109551bd432803012645ac136ddd64dba72',
+    );
+  });
 });

--- a/test-suite/e2e/contracts/operations/FHEVMManualTestSuite.sol
+++ b/test-suite/e2e/contracts/operations/FHEVMManualTestSuite.sol
@@ -545,4 +545,30 @@ contract FHEVMManualTestSuite is E2ECoprocessorConfig {
         resEbool = FHE.isIn(value, set);
         FHE.makePubliclyDecryptable(resEbool);
     }
+
+    // Verifies the toExternal -> fromExternal (empty proof) round-trip. The handle is allowed to the
+    // caller so it can be re-imported without a proof, then re-wrapped via toExternal and recovered.
+    function test_toExternalEuint64(externalEuint64 a, bytes calldata inputProof) external {
+        euint64 aProc = FHE.fromExternal(a, inputProof);
+        FHE.allow(aProc, msg.sender);
+        externalEuint64 ext = FHE.toExternal(aProc);
+        resEuint64 = FHE.fromExternal(ext, bytes(""));
+        FHE.makePubliclyDecryptable(resEuint64);
+    }
+
+    function test_toExternalEbool(externalEbool a, bytes calldata inputProof) external {
+        ebool aProc = FHE.fromExternal(a, inputProof);
+        FHE.allow(aProc, msg.sender);
+        externalEbool ext = FHE.toExternal(aProc);
+        resEbool = FHE.fromExternal(ext, bytes(""));
+        FHE.makePubliclyDecryptable(resEbool);
+    }
+
+    function test_toExternalEaddress(externalEaddress a, bytes calldata inputProof) external {
+        eaddress aProc = FHE.fromExternal(a, inputProof);
+        FHE.allow(aProc, msg.sender);
+        externalEaddress ext = FHE.toExternal(aProc);
+        resAdd = FHE.fromExternal(ext, bytes(""));
+        FHE.makePubliclyDecryptable(resAdd);
+    }
 }

--- a/test-suite/e2e/test/fhevmOperations/manual.ts
+++ b/test-suite/e2e/test/fhevmOperations/manual.ts
@@ -1721,4 +1721,43 @@ describe('FHEVM manual operations', function () {
     const res = await this.instance.publicDecrypt([handle]);
     assert.equal(res.clearValues[handle], 0n);
   });
+
+  it('toExternalEuint64 round-trips through fromExternal with empty proof', async function () {
+    const encryptedAmount = await this.instance.encryptTypedValues({
+      values: [{ type: 'uint64', value: 123456789n }],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+    const tx = await this.contract.test_toExternalEuint64(encryptedAmount.handles[0], encryptedAmount.inputProof);
+    await tx.wait();
+    const handle = await this.contract.resEuint64();
+    const res = await this.instance.publicDecrypt([handle]);
+    assert.equal(res.clearValues[handle], 123456789n);
+  });
+
+  it('toExternalEbool round-trips through fromExternal with empty proof', async function () {
+    const encryptedAmount = await this.instance.encryptTypedValues({
+      values: [{ type: 'bool', value: true }],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+    const tx = await this.contract.test_toExternalEbool(encryptedAmount.handles[0], encryptedAmount.inputProof);
+    await tx.wait();
+    const handle = await this.contract.resEbool();
+    const res = await this.instance.publicDecrypt([handle]);
+    assert.equal(res.clearValues[handle], true);
+  });
+
+  it('toExternalEaddress round-trips through fromExternal with empty proof', async function () {
+    const encryptedAmount = await this.instance.encryptTypedValues({
+      values: [{ type: 'address', value: ADDR_A }],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+    const tx = await this.contract.test_toExternalEaddress(encryptedAmount.handles[0], encryptedAmount.inputProof);
+    await tx.wait();
+    const handle = await this.contract.resAdd();
+    const res = await this.instance.publicDecrypt([handle]);
+    assert.equal(res.clearValues[handle], ADDR_A);
+  });
 });


### PR DESCRIPTION
## Summary

Adds `FHE.toExternal`, the inverse of `FHE.fromExternal`, requested by OpenZeppelin. It takes an on-chain encrypted value (`euintXX`/`ebool`/`eaddress`) the contract already holds and re-wraps it into the matching external type (`externalEuintXX`/`externalEbool`/`externalEaddress`).

The method is **overloaded** (target type inferred from the argument), mirroring the existing `fromExternal` API for symmetry:

```solidity
euint64 a = FHE.fromExternal(handle, proof);   // external -> internal
externalEuint64 ext = FHE.toExternal(a);        // internal -> external
```

### Why it's useful
Many functions — including standardized interfaces such as confidential tokens — type their entry points as `(externalEuintXX, bytes inputProof)` because the usual caller is an EOA submitting an encrypted input + ZK proof. A contract that already holds an `euintXX` can't produce such a proof on-chain. `toExternal`, paired with the empty-proof path of `fromExternal`, bridges that gap for contract-to-contract composition and smart-contract accounts. It only changes the static type — no verification, no ACL grant — so callers must set up ACL (`FHE.allow`) first.

## Changes
- **`codegen/src/templateFHEDotSol.ts`** — generator emits an overloaded `toExternal` per type, right after `fromExternal`.
- **`lib/FHE.sol`** — regenerated (8 methods: `ebool`, `euint8/16/32/64/128/256`, `eaddress`); purely additive.
- **`test/FHEToExternal.t.sol`** (new) — Foundry unit tests: bit-exact handle preservation for all 8 types + a 256-run fuzz.
- **`test/fhevmOperations/manual.ts`** + **`examples/tests/FHEVMManualTestSuite.sol`** — Hardhat round-trip tests (uint/bool/address).
- **`test-suite/e2e/...`** — mirrored round-trip tests for the real-stack integration suite (public-decrypt style).
- **`docs/solidity-guides/inputs.md`** — documents `toExternal`, the empty-proof pairing, and the ACL caveat.

## Testing
- **Foundry**: 9/9 pass (8 types + fuzz).
- **Mocked Hardhat**: 3/3 round-trips pass.
- **e2e (live stack, real KMS public decryption)**: 3/3 round-trips pass — `toExternalEuint64`/`Ebool`/`Eaddress` (3 ciphertexts, 3 proofs, 0 divergences).