### PR TITLE
test(test-suite): v0.13.0 testnet migration rollout (runbook validation + multi-chain deploy)

### DIFF
--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -218,6 +218,24 @@ export default async function run(ctx: RolloutRunContext) {
   logPhase("01.apply host proposal effect: ProtocolConfig + KMSGeneration migration, then KMSVerifier/HCULimit/FHEVMExecutor/ACL");
   await ctx.runHostContractTask("npx hardhat task:deployProtocolConfigFromMigration", { env: migrationEnv });
   await ctx.runHostContractTask("npx hardhat task:deployKMSGenerationFromMigration", { env: migrationEnv });
+
+  // Polygon (runbook Phase 7): fresh-deploy the new host chain. Must happen
+  // BEFORE refreshDiscovery, which (with HOST_VERSION>=0.13) requires a
+  // PROTOCOL_CONFIG_CONTRACT_ADDRESS on EVERY host chain. Polygon gets
+  // ProtocolConfig-from-migration but no standalone KMSGeneration
+  // (--with-kms-generation false), matching the gitops Eth/Polygon asymmetry.
+  // Ownership transfer (Phase 7.14/8) is intentionally skipped: the rollout owns
+  // the deployer key (no DAO/multisig), and transferring would lock later steps.
+  logPhase("01.polygon: fresh v0.13.0 host-contract deploy on the 2nd chain (chain-b)");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployEmptyUUPSProxies --with-kms-generation false");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployPauserSet");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployACL");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployFHEVMExecutor");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployProtocolConfigFromMigration", { env: migrationEnv });
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployKMSVerifier");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployInputVerifier");
+  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployHCULimit");
+
   await ctx.refreshDiscovery();
   await upgradeContract(host(ctx), "task:upgradeKMSVerifier", "KMSVerifier");
   await assertKmsMigration(ctx, migrationCtx);

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -234,11 +234,17 @@ export default async function run(ctx: RolloutRunContext) {
   // artifact (the primary host migration tasks self-compile; this fresh-deploy path
   // does not).
   logPhase("01.polygon: fresh v0.13.0 host-contract deploy on the 2nd chain (chain-b)");
+  // Order mirrors gitops Phase 7 and is load-bearing: the upgradeable contracts
+  // (e.g. KMSGeneration) reference `protocolConfigAdd` from FHEVMHostAddresses.sol,
+  // so a full compile fails until the empty proxies are deployed and that address
+  // file is populated. Compile only immutable contracts first (PauserSet etc.),
+  // deploy the empty proxies, then full-compile, then deploy the rest.
   const polygonDeploy = [
-    "npx hardhat compile",
+    "npx hardhat compile:specific --contract contracts/immutable",
     "npx hardhat task:deployEmptyUUPSProxies --with-kms-generation false",
     "export $(cat addresses/.env.host | xargs)",
     "npx hardhat task:deployPauserSet",
+    "npx hardhat compile:specific --contract contracts",
     "npx hardhat task:deployACL",
     "npx hardhat task:deployFHEVMExecutor",
     "npx hardhat task:deployProtocolConfigFromMigration",

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -226,15 +226,27 @@ export default async function run(ctx: RolloutRunContext) {
   // (--with-kms-generation false), matching the gitops Eth/Polygon asymmetry.
   // Ownership transfer (Phase 7.14/8) is intentionally skipped: the rollout owns
   // the deployer key (no DAO/multisig), and transferring would lock later steps.
+  // Run the Polygon fresh-deploy as ONE command in a single chain-b container
+  // (mirroring the gitops polygon-sc-deploy job): each runHostContractTaskOnChain
+  // is an ephemeral container, so compile + the deploy tasks must share one
+  // invocation and the deployed addresses must be re-exported between tasks.
+  // `npx hardhat compile` first because deployEmptyUUPSProxies needs the PauserSet
+  // artifact (the primary host migration tasks self-compile; this fresh-deploy path
+  // does not).
   logPhase("01.polygon: fresh v0.13.0 host-contract deploy on the 2nd chain (chain-b)");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployEmptyUUPSProxies --with-kms-generation false");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployPauserSet");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployACL");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployFHEVMExecutor");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployProtocolConfigFromMigration", { env: migrationEnv });
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployKMSVerifier");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployInputVerifier");
-  await ctx.runHostContractTaskOnChain("chain-b", "npx hardhat task:deployHCULimit");
+  const polygonDeploy = [
+    "npx hardhat compile",
+    "npx hardhat task:deployEmptyUUPSProxies --with-kms-generation false",
+    "export $(cat addresses/.env.host | xargs)",
+    "npx hardhat task:deployPauserSet",
+    "npx hardhat task:deployACL",
+    "npx hardhat task:deployFHEVMExecutor",
+    "npx hardhat task:deployProtocolConfigFromMigration",
+    "npx hardhat task:deployKMSVerifier",
+    "npx hardhat task:deployInputVerifier",
+    "npx hardhat task:deployHCULimit",
+  ].join(" && ");
+  await ctx.runHostContractTaskOnChain("chain-b", polygonDeploy, { env: migrationEnv });
 
   await ctx.refreshDiscovery();
   await upgradeContract(host(ctx), "task:upgradeKMSVerifier", "KMSVerifier");

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -278,17 +278,11 @@ export default async function run(ctx: RolloutRunContext) {
 
   // ---- Polygon: addHostChain proposal effect (Phase 9 of the runbook) ----
   // LIMITATION: the rollout boots the 2nd host chain via the multi-chain scenario,
-  // so we exercise the addHostChain proposal-effect task against the gateway, but
-  // the runbook's fresh Polygon host-contract deploy (Phase 7) + ownership transfer
-  // need rollout multi-chain contract-deploy support that isn't wired yet -- that
-  // gap is itself a finding. We run addHostChainsToGatewayConfig to test the
-  // registration path; flagged in the gap report.
-  // FINDING / modeling limit: the rollout's multi-chain scenario boots chain-b as
-  // an already-registered host chain, so addHostChain reverts with
-  // HostChainAlreadyRegistered (selector 0x96a56828). The runbook's "add a new
-  // host chain" proposal-effect therefore can't be freshly exercised here (the
-  // desired end-state -- chain-b registered -- already holds). Tolerate that one
-  // revert; any other failure still fails the rollout.
+  // so the runbook's fresh Polygon host-contract deploy is exercised above, but
+  // the gateway proposal-effect cannot add a truly new chain here. The desired
+  // end-state already holds, and addHostChain reverts with
+  // HostChainAlreadyRegistered (selector 0x96a56828). Tolerate that one modeling
+  // limit; any other failure still fails the rollout.
   logPhase("05 polygon: addHostChainsToGatewayConfig (registration proposal effect)");
   const addHostChain = [
     "if out=$(npx hardhat task:addHostChainsToGatewayConfig 2>&1); then printf '%s\\n' \"$out\";",

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -1,0 +1,246 @@
+import path from "node:path";
+
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { phaseVersions, scenario, versionSources } from "./versions";
+
+export type RolloutEnv = Record<string, string>;
+
+const logPhase = (label: string) => {
+  console.log(`\n[rollout] ${label}`);
+};
+
+// Apply a contract upgrade with the owner key (the DAO-execution stand-in: the
+// rollout can't run governance, so the proxy owner upgrades directly).
+const upgradeContract = async (runTask: (command: string) => Promise<void>, task: string, name: string) => {
+  const current = `previous-contracts/${name}.sol:${name}`;
+  const next = `contracts/${name}.sol:${name}`;
+  console.log(`[apply] ${name}: ${current} -> ${next}`);
+  await runTask(
+    [
+      "npx hardhat",
+      task,
+      `--current-implementation ${current}`,
+      `--new-implementation ${next}`,
+      "--verify-contract false",
+      "--use-internal-proxy-address true",
+    ].join(" "),
+  );
+};
+
+// Run the runbook's prepare step: deploy the new implementation and emit the DAO
+// upgrade calldata WITHOUT mutating the proxy. These prepareUpgrade*/prepareDeploy*
+// tasks have never run in a container (per Amina/Yohan); exercising them here is
+// the highest-value part of this rollout. Output lands in the receipt/logs as the
+// command audit trail Yohan asked for.
+const prepareUpgrade = async (runTask: (command: string) => Promise<void>, task: string, name: string) => {
+  const current = `previous-contracts/${name}.sol:${name}`;
+  const next = `contracts/${name}.sol:${name}`;
+  console.log(`[prepare] ${name}: ${task}`);
+  await runTask(
+    [
+      "npx hardhat",
+      task,
+      `--current-implementation ${current}`,
+      `--new-implementation ${next}`,
+      "--verify-contract false",
+      "--use-internal-proxy-address true",
+    ].join(" "),
+  );
+};
+
+const writePhaseVersionLock = (ctx: RolloutRunContext, name: string, versions: RolloutEnv) =>
+  ctx.writeVersionLock(name, { versions, sources: versionSources });
+
+const contractVersionKeys = ["GATEWAY_VERSION", "HOST_VERSION"];
+
+const prepareContractMigrationSources = async (ctx: RolloutRunContext, targetLockFile: string) => {
+  console.log("[contracts] preserve v0.12 sources as previous-contracts, activate v0.13 sources");
+  await ctx.snapshotContracts("host");
+  await ctx.snapshotContracts("gateway");
+  await ctx.applyVersionLock("v0.13 contract migration sources", {
+    lockFile: targetLockFile,
+    allowedVersionKeys: contractVersionKeys,
+  });
+};
+
+const parseGatewayMigrationEnv = (value: unknown): RolloutEnv => {
+  if (!value || typeof value !== "object") {
+    throw new Error("migration-state.json is missing its export object");
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => {
+      if (item === undefined || item === null) {
+        throw new Error(`migration-state.json export.${key} is empty`);
+      }
+      return [key, String(item)];
+    }),
+  );
+};
+
+// One-node fixture: legacy GatewayConfig exports cryptographic threshold mpc=0,
+// which v0.13 ProtocolConfig rejects. Normalize only that synthetic case.
+export const needsLocalOneNodeMpcNormalization = (env: RolloutEnv): boolean => {
+  const kmsNodes = JSON.parse(env.MIGRATION_KMS_NODES ?? "[]") as unknown[];
+  const thresholds = JSON.parse(env.MIGRATION_KMS_THRESHOLDS ?? "{}") as Record<string, unknown>;
+  return kmsNodes.length === 1 && String(thresholds.mpc) === "0";
+};
+
+export const normalizeLocalOneNodeMpcThreshold = (env: RolloutEnv): RolloutEnv => {
+  if (!needsLocalOneNodeMpcNormalization(env)) {
+    return env;
+  }
+  const thresholds = JSON.parse(env.MIGRATION_KMS_THRESHOLDS ?? "{}") as Record<string, unknown>;
+  console.log("[contracts] local one-node migration: normalize ProtocolConfig mpc threshold 0 -> 1");
+  return { ...env, MIGRATION_KMS_THRESHOLDS: JSON.stringify({ ...thresholds, mpc: "1" }) };
+};
+
+type GatewayMigrationContext = {
+  kmsGenerationProxy: string;
+  gatewayConfigProxy: string;
+  migrationEnv: RolloutEnv;
+  mpcThresholdNormalized: boolean;
+};
+
+// Phase 1 of the runbook: export the gateway KMS migration state. Writes the
+// MIGRATION_* values consumed by the host ProtocolConfig/KMSGeneration tasks.
+const exportGatewayKmsMigrationEnv = async (ctx: RolloutRunContext): Promise<GatewayMigrationContext> => {
+  const state = await ctx.readState();
+  const gateway = state.discovery?.gateway;
+  if (!gateway?.KMS_GENERATION_ADDRESS || !gateway.GATEWAY_CONFIG_ADDRESS) {
+    throw new Error("gateway KMSGeneration and GatewayConfig addresses must be discovered before contract migration");
+  }
+  const output = "kms-migration-state.json";
+  await ctx.runGatewayContractTask(
+    [
+      "npx hardhat compile &&",
+      "npx hardhat task:exportKmsMigrationState",
+      `--kms-generation-proxy ${gateway.KMS_GENERATION_ADDRESS}`,
+      `--gateway-config-proxy ${gateway.GATEWAY_CONFIG_ADDRESS}`,
+      `--output /app/addresses/${output}`,
+    ].join(" "),
+  );
+  const stateFile = path.join(ctx.stateDir(), "runtime", "addresses", "gateway", output);
+  const migrationState = JSON.parse(await Bun.file(stateFile).text()) as { export?: unknown };
+  const rawEnv = parseGatewayMigrationEnv(migrationState.export);
+  return {
+    kmsGenerationProxy: gateway.KMS_GENERATION_ADDRESS,
+    gatewayConfigProxy: gateway.GATEWAY_CONFIG_ADDRESS,
+    migrationEnv: normalizeLocalOneNodeMpcThreshold(rawEnv),
+    mpcThresholdNormalized: needsLocalOneNodeMpcNormalization(rawEnv),
+  };
+};
+
+const GATEWAY_RPC_URL = "http://gateway-node:8546";
+
+const assertKmsMigration = async (
+  ctx: RolloutRunContext,
+  { gatewayConfigProxy, kmsGenerationProxy, mpcThresholdNormalized }: GatewayMigrationContext,
+) => {
+  const assertCommand = [
+    "npx hardhat compile &&",
+    "npx hardhat task:assertKmsMigrationSucceeded",
+    `--gateway-config-proxy ${gatewayConfigProxy}`,
+    `--gateway-kms-generation-proxy ${kmsGenerationProxy}`,
+    "--use-internal-proxy-address true",
+  ].join(" ");
+  if (!mpcThresholdNormalized) {
+    await ctx.runHostContractTask(assertCommand, { env: { GATEWAY_RPC_URL } });
+    return;
+  }
+  const wrapped = [
+    `if out=$(${assertCommand} 2>&1); then printf '%s\\n' "$out";`,
+    `else status=$?; printf '%s\\n' "$out";`,
+    `printf '%s\\n' "$out" | grep -q 'ProtocolConfig MPC threshold mismatch: expected 0, got 1' || exit $status;`,
+    `echo '[runbook] tolerated synthetic-fixture mpc threshold mismatch';`,
+    "fi",
+  ].join(" ");
+  await ctx.runHostContractTask(wrapped, { env: { GATEWAY_RPC_URL } });
+};
+
+const gw = (ctx: RolloutRunContext) => (command: string) => ctx.runGatewayContractTask(command);
+const host = (ctx: RolloutRunContext) => (command: string) => ctx.runHostContractTask(command);
+
+export default async function run(ctx: RolloutRunContext) {
+  const baselineLock = await writePhaseVersionLock(ctx, "00-baseline", phaseVersions.baseline);
+  const contractsLock = await writePhaseVersionLock(ctx, "01-contracts", phaseVersions.contracts);
+  const kmsLock = await writePhaseVersionLock(ctx, "02-kms", phaseVersions.kms);
+  const coprocessorLock = await writePhaseVersionLock(ctx, "03-coprocessor", phaseVersions.coprocessor);
+  const relayerLock = await writePhaseVersionLock(ctx, "04-relayer", phaseVersions.relayer);
+
+  logPhase("00 baseline: boot exact testnet v0.12 state (KMS core already v0.13.10)");
+  await ctx.up({ lockFile: baselineLock, scenario, overrides: [{ group: "test-suite" }] });
+  await ctx.test("rollout-standard", { parallel: false });
+
+  // ---- Contract migration, following gitops#1063 + the 0.13.0 runbook ----
+  logPhase("01 contracts: testnet v0.12 -> v0.13.0 migration (prepare, then apply the proposal effect)");
+  await prepareContractMigrationSources(ctx, contractsLock);
+
+  // Phase 0: preflight assertion.
+  await ctx.runHostContractTask("npx hardhat task:assertNoPendingKeyManagementRequest");
+
+  // Phase 1: export gateway migration state (before gateway KMSGeneration goes view-only).
+  const migrationCtx = await exportGatewayKmsMigrationEnv(ctx);
+  const { migrationEnv } = migrationCtx;
+
+  // Phase 2+3: PREPARE (the never-tested-in-container steps). Deploy impls + emit
+  // DAO calldata without mutating proxies. Gateway then host.
+  logPhase("01.prepare gateway: prepareUpgrade* (GatewayConfig, KMSGeneration, Decryption, CiphertextCommits, InputVerification)");
+  await prepareUpgrade(gw(ctx), "task:prepareUpgradeGatewayConfig", "GatewayConfig");
+  await prepareUpgrade(gw(ctx), "task:prepareUpgradeKMSGeneration", "KMSGeneration");
+  await prepareUpgrade(gw(ctx), "task:prepareUpgradeDecryption", "Decryption");
+  await prepareUpgrade(gw(ctx), "task:prepareUpgradeCiphertextCommits", "CiphertextCommits");
+  await prepareUpgrade(gw(ctx), "task:prepareUpgradeInputVerification", "InputVerification");
+
+  logPhase("01.prepare host: empty proxies, prepareDeploy*FromMigration, prepareUpgrade* (KMSVerifier, HCULimit, FHEVMExecutor, ACL)");
+  await ctx.runHostContractTask("npx hardhat task:deployEmptyProxiesProtocolConfigKMSGeneration");
+  // prepareDeploy* build initializeFromMigration calldata FROM ENV (gap #2:
+  // a stale env yields a proposal with wrong signers/thresholds vs the export).
+  await ctx.runHostContractTask("npx hardhat task:prepareDeployProtocolConfigFromMigration --verify-contract false", { env: migrationEnv });
+  await ctx.runHostContractTask("npx hardhat task:prepareDeployKMSGenerationFromMigration --verify-contract false", { env: migrationEnv });
+  await prepareUpgrade(host(ctx), "task:prepareUpgradeKMSVerifier", "KMSVerifier");
+  await prepareUpgrade(host(ctx), "task:prepareUpgradeHCULimit", "HCULimit");
+  await prepareUpgrade(host(ctx), "task:prepareUpgradeFHEVMExecutor", "FHEVMExecutor");
+  await prepareUpgrade(host(ctx), "task:prepareUpgradeACL", "ACL");
+
+  // Phase 5: APPLY the proposal effect (owner-key stand-in for DAO execution),
+  // gateway-before-host (MASSIVE WARNING in the runbook: gateway proposal first).
+  logPhase("01.apply gateway proposal effect: GatewayConfig + KMSGeneration (view-only)");
+  await upgradeContract(gw(ctx), "task:upgradeGatewayConfig", "GatewayConfig");
+  await upgradeContract(gw(ctx), "task:upgradeKMSGeneration", "KMSGeneration");
+
+  logPhase("01.apply host proposal effect: ProtocolConfig + KMSGeneration migration, then KMSVerifier/HCULimit/FHEVMExecutor/ACL");
+  await ctx.runHostContractTask("npx hardhat task:deployProtocolConfigFromMigration", { env: migrationEnv });
+  await ctx.runHostContractTask("npx hardhat task:deployKMSGenerationFromMigration", { env: migrationEnv });
+  await ctx.refreshDiscovery();
+  await upgradeContract(host(ctx), "task:upgradeKMSVerifier", "KMSVerifier");
+  await assertKmsMigration(ctx, migrationCtx);
+  await upgradeContract(host(ctx), "task:upgradeHCULimit", "HCULimit");
+  await upgradeContract(host(ctx), "task:upgradeFHEVMExecutor", "FHEVMExecutor");
+  await upgradeContract(host(ctx), "task:upgradeACL", "ACL");
+  await ctx.refreshDiscovery();
+  await ctx.test("rollout-standard", { parallel: false });
+
+  // ---- Runtime components (gitops has no PR for these yet -- inferred v0.13.0) ----
+  logPhase("02 kms: core v0.13.10 -> v0.13.20 and connector v0.12.0 -> v0.13.0");
+  await ctx.upgradeRuntimeGroup("kms", { lockFile: kmsLock });
+  await ctx.test("rollout-standard", { parallel: false });
+
+  logPhase("03 coprocessor: v0.12.x -> v0.13.0 (host-listener-consumer activates)");
+  await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
+  await ctx.test("rollout-standard", { parallel: false });
+
+  logPhase("04 relayer: v0.11.1 -> v0.13.0");
+  await ctx.upgradeRuntimeGroup("relayer", { lockFile: relayerLock });
+  await ctx.test("rollout-standard", { parallel: false });
+
+  // ---- Polygon: addHostChain proposal effect (Phase 9 of the runbook) ----
+  // LIMITATION: the rollout boots the 2nd host chain via the multi-chain scenario,
+  // so we exercise the addHostChain proposal-effect task against the gateway, but
+  // the runbook's fresh Polygon host-contract deploy (Phase 7) + ownership transfer
+  // need rollout multi-chain contract-deploy support that isn't wired yet -- that
+  // gap is itself a finding. We run addHostChainsToGatewayConfig to test the
+  // registration path; flagged in the gap report.
+  logPhase("05 polygon: addHostChainsToGatewayConfig (registration proposal effect)");
+  await ctx.runGatewayContractTask("npx hardhat task:addHostChainsToGatewayConfig");
+  await ctx.test("rollout-standard", { parallel: false });
+}

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -175,8 +175,15 @@ export default async function run(ctx: RolloutRunContext) {
   logPhase("01 contracts: testnet v0.12 -> v0.13.0 migration (prepare, then apply the proposal effect)");
   await prepareContractMigrationSources(ctx, contractsLock);
 
-  // Phase 0: preflight assertion.
-  await ctx.runHostContractTask("npx hardhat task:assertNoPendingKeyManagementRequest");
+  // RUNBOOK GAP (finding #1, confirmed by run 27684221770): the Notion runbook's
+  // "Step 0 -- assert no pending key-management request on the HOST KMSGeneration,
+  // before anything else" is not runnable at the v0.12 starting state. At v0.12
+  // KMSGeneration lives on the GATEWAY; the host KMSGeneration proxy only exists
+  // after deployEmptyProxies + deployKMSGenerationFromMigration, so
+  // `task:assertNoPendingKeyManagementRequest` (a host task) cannot resolve an
+  // address as step 0 and aborts. The intent (no pending keygen before migrating)
+  // must target the gateway KMSGeneration, or move post-migration. Skipped here;
+  // the post-migration state is validated by task:assertKmsMigrationSucceeded.
 
   // Phase 1: export gateway migration state (before gateway KMSGeneration goes view-only).
   const migrationCtx = await exportGatewayKmsMigrationEnv(ctx);

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/run.ts
@@ -283,7 +283,20 @@ export default async function run(ctx: RolloutRunContext) {
   // need rollout multi-chain contract-deploy support that isn't wired yet -- that
   // gap is itself a finding. We run addHostChainsToGatewayConfig to test the
   // registration path; flagged in the gap report.
+  // FINDING / modeling limit: the rollout's multi-chain scenario boots chain-b as
+  // an already-registered host chain, so addHostChain reverts with
+  // HostChainAlreadyRegistered (selector 0x96a56828). The runbook's "add a new
+  // host chain" proposal-effect therefore can't be freshly exercised here (the
+  // desired end-state -- chain-b registered -- already holds). Tolerate that one
+  // revert; any other failure still fails the rollout.
   logPhase("05 polygon: addHostChainsToGatewayConfig (registration proposal effect)");
-  await ctx.runGatewayContractTask("npx hardhat task:addHostChainsToGatewayConfig");
+  const addHostChain = [
+    "if out=$(npx hardhat task:addHostChainsToGatewayConfig 2>&1); then printf '%s\\n' \"$out\";",
+    "else status=$?; printf '%s\\n' \"$out\";",
+    "printf '%s\\n' \"$out\" | grep -qiE 'HostChainAlreadyRegistered|0x96a56828' || exit $status;",
+    "echo '[runbook] tolerated HostChainAlreadyRegistered: chain-b pre-registered by the rollout scenario';",
+    "fi",
+  ].join(" ");
+  await ctx.runGatewayContractTask(addHostChain);
   await ctx.test("rollout-standard", { parallel: false });
 }

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/versions.ts
@@ -1,0 +1,121 @@
+type Env = Record<string, string>;
+
+// Reproduces the TESTNET v0.12 -> v0.13.0 upgrade (the imminent cutover),
+// following Yohan's "0.13.0 migration runbooks" + gitops PR zama-zws/gitops#1063
+// step-for-step, to surface gaps in the runbook (NOT to force green).
+//
+// Single coprocessor, threshold 1, two host chains (host + a Polygon stand-in):
+// matches testnet onboarding Phase 1 (Zama-only consensus) during the upgrade
+// window, and lets us exercise the Polygon deploy + addHostChain proposal path.
+// The split prepare/apply flow lives in run.ts.
+export const scenario = "multi-chain";
+
+// EXACT current-testnet tags (the "from"), read from gitops on 2026-06-17. The
+// baseline is heterogeneous: KMS core is already promoted to v0.13.10 while the
+// rest is v0.12.x, and even the coprocessor workers are mixed. Do not collapse
+// these to a single tag -- fidelity to the real testnet state matters here.
+//   contracts (gw+host) ...... v0.12.1   (gitops#1063 old image)
+//   kms-core ................. v0.13.10  (already on testnet)
+//   kms-connector (all) ...... v0.12.0
+//   coproc tfhe/zkproof ...... v0.12.3
+//   coproc sns/listeners/txs . v0.12.0
+//   coproc db-migration ...... v0.12.2
+//   relayer / relayer-migrate  v0.11.1 / v0.11.0
+const target = "v0.13.0";
+const relayerSdkVersion = "0.4.2";
+
+export const from = {
+  RELAYER_VERSION: "v0.11.1",
+  RELAYER_MIGRATE_VERSION: "v0.11.0",
+  GATEWAY_VERSION: "v0.12.1",
+  HOST_VERSION: "v0.12.1",
+  CORE_VERSION: "v0.13.10",
+  CONNECTOR_DB_MIGRATION_VERSION: "v0.12.0",
+  CONNECTOR_GW_LISTENER_VERSION: "v0.12.0",
+  CONNECTOR_KMS_WORKER_VERSION: "v0.12.0",
+  CONNECTOR_TX_SENDER_VERSION: "v0.12.0",
+  COPROCESSOR_DB_MIGRATION_VERSION: "v0.12.2",
+  COPROCESSOR_HOST_LISTENER_VERSION: "v0.12.0",
+  COPROCESSOR_GW_LISTENER_VERSION: "v0.12.0",
+  COPROCESSOR_TX_SENDER_VERSION: "v0.12.0",
+  COPROCESSOR_TFHE_WORKER_VERSION: "v0.12.3",
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.12.3",
+  COPROCESSOR_SNS_WORKER_VERSION: "v0.12.0",
+  // listener-core (v2) is a v0.13 component with no v0.12 image; it only
+  // activates once COPROCESSOR_HOST_LISTENER_VERSION reaches v0.13 (gated by
+  // supportsHostListenerConsumer), so the value is inert at the v0.12 baseline.
+  LISTENER_CORE_VERSION: target,
+  TEST_SUITE_VERSION: target,
+  RELAYER_SDK_VERSION: relayerSdkVersion,
+} satisfies Env;
+
+// Target ("to"). Contracts v0.13.0 are CONFIRMED by gitops#1063. KMS core ->
+// v0.13.20 follows the v0.13.0 release pairing (Amina, 2026-06-11). The runtime
+// targets (connector/coprocessor/relayer -> v0.13.0) are INFERRED: gitops has no
+// open PR yet that bumps the runtime services, which is itself a runbook gap.
+export const to = {
+  ...from,
+  RELAYER_VERSION: target,
+  RELAYER_MIGRATE_VERSION: target,
+  GATEWAY_VERSION: target,
+  HOST_VERSION: target,
+  CORE_VERSION: "v0.13.20",
+  CONNECTOR_DB_MIGRATION_VERSION: target,
+  CONNECTOR_GW_LISTENER_VERSION: target,
+  CONNECTOR_KMS_WORKER_VERSION: target,
+  CONNECTOR_TX_SENDER_VERSION: target,
+  COPROCESSOR_DB_MIGRATION_VERSION: target,
+  COPROCESSOR_HOST_LISTENER_VERSION: target,
+  COPROCESSOR_GW_LISTENER_VERSION: target,
+  COPROCESSOR_TX_SENDER_VERSION: target,
+  COPROCESSOR_TFHE_WORKER_VERSION: target,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: target,
+  COPROCESSOR_SNS_WORKER_VERSION: target,
+  LISTENER_CORE_VERSION: target,
+} satisfies Env;
+
+type EnvKey = keyof typeof from;
+
+const relayerKeys = ["RELAYER_VERSION", "RELAYER_MIGRATE_VERSION"] as const satisfies readonly EnvKey[];
+const contractKeys = ["GATEWAY_VERSION", "HOST_VERSION"] as const satisfies readonly EnvKey[];
+const kmsKeys = [
+  "CORE_VERSION",
+  "CONNECTOR_DB_MIGRATION_VERSION",
+  "CONNECTOR_GW_LISTENER_VERSION",
+  "CONNECTOR_KMS_WORKER_VERSION",
+  "CONNECTOR_TX_SENDER_VERSION",
+] as const satisfies readonly EnvKey[];
+const coprocessorKeys = [
+  "COPROCESSOR_DB_MIGRATION_VERSION",
+  "COPROCESSOR_HOST_LISTENER_VERSION",
+  "COPROCESSOR_GW_LISTENER_VERSION",
+  "COPROCESSOR_TX_SENDER_VERSION",
+  "COPROCESSOR_TFHE_WORKER_VERSION",
+  "COPROCESSOR_ZKPROOF_WORKER_VERSION",
+  "COPROCESSOR_SNS_WORKER_VERSION",
+  "LISTENER_CORE_VERSION",
+] as const satisfies readonly EnvKey[];
+
+const withTargetVersions = (...keys: EnvKey[]): Env => ({
+  ...from,
+  ...Object.fromEntries(keys.map((key) => [key, to[key]])),
+});
+
+// Runbook order (devnet precedent, per Amina/Yohan): contracts (prepare + apply
+// the proposal effect) -> kms -> coprocessor -> relayer; the Polygon fresh
+// deploy + addHostChain proposal effect runs against the second host chain.
+export const phaseVersions = {
+  baseline: from,
+  contracts: withTargetVersions(...contractKeys),
+  kms: withTargetVersions(...contractKeys, ...kmsKeys),
+  coprocessor: withTargetVersions(...contractKeys, ...kmsKeys, ...coprocessorKeys),
+  relayer: to,
+};
+
+export const versionSources = [
+  "rollout=v0.13.0-testnet",
+  "from=v0.12.1-testnet-baseline",
+  `target=${target}`,
+  "kms-core=v0.13.10->v0.13.20",
+  "follows=gitops#1063 + 0.13.0 migration runbooks",
+];

--- a/test-suite/fhevm/src/commands/rollout-run.ts
+++ b/test-suite/fhevm/src/commands/rollout-run.ts
@@ -14,7 +14,7 @@ import {
   up,
   upgradeRuntimeGroup as upgradeStackRuntimeGroup,
 } from "../flow/up-flow";
-import { STATE_DIR } from "../layout";
+import { STATE_DIR, hostChainRuntimes } from "../layout";
 import { loadState } from "../state/state";
 import type { LocalOverride, State, UpOptions, VersionBundle, VersionTarget } from "../types";
 import { ensureDir, writeJson } from "../utils/fs";
@@ -56,6 +56,9 @@ export type RolloutRunContext = {
   refreshDiscovery(): Promise<void>;
   runGatewayContractTask(command: string, options?: RolloutContractTaskOptions): Promise<void>;
   runHostContractTask(command: string, options?: RolloutContractTaskOptions): Promise<void>;
+  // Runs a host contract task against a specific host chain's deploy container
+  // (e.g. a Polygon stand-in second chain). Enables multi-chain contract deploys.
+  runHostContractTaskOnChain(chainKey: string, command: string, options?: RolloutContractTaskOptions): Promise<void>;
   snapshotContracts(surface: "host" | "gateway"): Promise<void>;
   stateDir(): string;
   test(profile?: string, options?: RolloutTestOptions): Promise<void>;
@@ -115,6 +118,19 @@ export const createRolloutContext = (receipt: RolloutReceipt = createRolloutRece
     await runContractTask("host-sc", "host-sc-deploy", command, options);
     await receipt.record("host-contract-task", command, {
       details: { envKeys: Object.keys(options.env ?? {}).sort() },
+    });
+  },
+  async runHostContractTaskOnChain(chainKey, command, options = {}) {
+    const state = await loadState();
+    const runtime = hostChainRuntimes(state?.scenario.hostChains ?? []).find((chain) => chain.key === chainKey);
+    if (!runtime) {
+      throw new PreflightError(`unknown host chain "${chainKey}"; check the scenario hostChains`);
+    }
+    // The non-default chain's deploy container is `${runtime.sc}-deploy` with its
+    // env at envPath(runtime.sc) (RPC/CHAIN_ID/HOST_ADDRESS_DIR for that chain).
+    await runContractTask("host-sc", `${runtime.sc}-deploy`, command, { ...options, envComponent: runtime.sc });
+    await receipt.record("host-contract-task", `[chain ${chainKey}] ${command}`, {
+      details: { chain: chainKey, envKeys: Object.keys(options.env ?? {}).sort() },
     });
   },
   async snapshotContracts(surface) {

--- a/test-suite/fhevm/src/commands/rollout-run.ts
+++ b/test-suite/fhevm/src/commands/rollout-run.ts
@@ -14,7 +14,7 @@ import {
   up,
   upgradeRuntimeGroup as upgradeStackRuntimeGroup,
 } from "../flow/up-flow";
-import { STATE_DIR, hostChainRuntimes } from "../layout";
+import { STATE_DIR, composePath, hostChainRuntimes } from "../layout";
 import { loadState } from "../state/state";
 import type { LocalOverride, State, UpOptions, VersionBundle, VersionTarget } from "../types";
 import { ensureDir, writeJson } from "../utils/fs";
@@ -128,7 +128,11 @@ export const createRolloutContext = (receipt: RolloutReceipt = createRolloutRece
     }
     // The non-default chain's deploy container is `${runtime.sc}-deploy` with its
     // env at envPath(runtime.sc) (RPC/CHAIN_ID/HOST_ADDRESS_DIR for that chain).
-    await runContractTask("host-sc", `${runtime.sc}-deploy`, command, { ...options, envComponent: runtime.sc });
+    await runContractTask("host-sc", `${runtime.sc}-deploy`, command, {
+      ...options,
+      envComponent: runtime.sc,
+      composeFile: composePath(runtime.sc),
+    });
     await receipt.record("host-contract-task", `[chain ${chainKey}] ${command}`, {
       details: { chain: chainKey, envKeys: Object.keys(options.env ?? {}).sort() },
     });

--- a/test-suite/fhevm/src/flow/contracts.ts
+++ b/test-suite/fhevm/src/flow/contracts.ts
@@ -63,9 +63,11 @@ export const snapshotContractSources = async (surface: ContractSurface) => {
 /** Runs a host or gateway contract task inside its deploy container. */
 export const runContractTask = async (
   component: "host-sc" | "gateway-sc",
-  service: "host-sc-deploy" | "gateway-sc-deploy",
+  service: string,
   command: string,
-  options: { env?: Record<string, string> } = {},
+  // envComponent overrides which generated env file is loaded (used to target a
+  // non-default host chain's deploy container, whose env lives at envPath(<sc>)).
+  options: { env?: Record<string, string>; envComponent?: string } = {},
 ) => {
   const state = await loadState();
   if (!state) {
@@ -88,7 +90,7 @@ export const runContractTask = async (
     "-lc",
     withPreviousContractsSnapshot(command),
   ];
-  const env = { ...resolvedComposeEnv(runningState), ...(await readEnvFileIfExists(envPath(component))), ...options.env };
+  const env = { ...resolvedComposeEnv(runningState), ...(await readEnvFileIfExists(envPath(options.envComponent ?? component))), ...options.env };
   await runStreaming(argv, { env });
 };
 

--- a/test-suite/fhevm/src/flow/contracts.ts
+++ b/test-suite/fhevm/src/flow/contracts.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { PreflightError } from "../errors";
 import { resolvedComposeEnv } from "../generate/compose";
-import { RUNTIME_DIR, dockerArgs, envPath } from "../layout";
+import { PROJECT, RUNTIME_DIR, dockerArgs, envPath } from "../layout";
 import { loadState } from "../state/state";
 import { ensureDir, exists, readEnvFileIfExists, remove } from "../utils/fs";
 import { run, runStreaming } from "../utils/process";
@@ -67,7 +67,10 @@ export const runContractTask = async (
   command: string,
   // envComponent overrides which generated env file is loaded (used to target a
   // non-default host chain's deploy container, whose env lives at envPath(<sc>)).
-  options: { env?: Record<string, string>; envComponent?: string } = {},
+  // composeFile targets a non-default chain's generated compose override
+  // (which defines that chain's `<sc>-deploy` service), since the default
+  // host-sc compose files don't include it.
+  options: { env?: Record<string, string>; envComponent?: string; composeFile?: string } = {},
 ) => {
   const state = await loadState();
   if (!state) {
@@ -77,8 +80,11 @@ export const runContractTask = async (
   assertContractTaskStackRunning(true, (await projectContainers()).length);
   await ensureRuntimeArtifacts(runningState, "contract task");
   await maybeBuild(component, runningState);
+  const composePrefix = options.composeFile
+    ? ["docker", "compose", "-p", PROJECT, "-f", options.composeFile]
+    : dockerArgs(component);
   const argv = [
-    ...dockerArgs(component),
+    ...composePrefix,
     "run",
     "--rm",
     "--no-deps",

--- a/test-suite/fhevm/src/rollout-run.test.ts
+++ b/test-suite/fhevm/src/rollout-run.test.ts
@@ -35,6 +35,9 @@ const fakeContext = () => {
     async runHostContractTask(command) {
       calls.push(`host:${command}`);
     },
+    async runHostContractTaskOnChain(chainKey, command) {
+      calls.push(`host[${chainKey}]:${command}`);
+    },
     async snapshotContracts(surface) {
       calls.push(`snapshot:${surface}`);
     },

--- a/test-suite/fhevm/src/rollout-v013-testnet.test.ts
+++ b/test-suite/fhevm/src/rollout-v013-testnet.test.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+
+import { expect, test } from "bun:test";
+
+import { loadRolloutRunbook } from "./commands/rollout-run";
+import { loadCoprocessorScenario } from "./scenario/resolve";
+import { needsLocalOneNodeMpcNormalization } from "../rollouts/v0.13.0-testnet/run";
+import { phaseVersions, scenario } from "../rollouts/v0.13.0-testnet/versions";
+
+const CLI_DIR = path.resolve(import.meta.dir, "..");
+
+test("models testnet on a single-coprocessor, two-host-chain topology (Polygon stand-in)", async () => {
+  expect(scenario).toBe("multi-chain");
+  const resolved = await loadCoprocessorScenario(scenario);
+  expect(resolved.topology.count).toBe(1);
+  expect(resolved.topology.threshold).toBe(1);
+  expect(resolved.hostChains?.length).toBe(2);
+});
+
+test("pins the EXACT current testnet baseline (heterogeneous from-tags)", () => {
+  expect(phaseVersions.baseline.GATEWAY_VERSION).toBe("v0.12.1");
+  expect(phaseVersions.baseline.HOST_VERSION).toBe("v0.12.1");
+  expect(phaseVersions.baseline.CORE_VERSION).toBe("v0.13.10"); // KMS already promoted on testnet
+  expect(phaseVersions.baseline.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.12.0");
+  expect(phaseVersions.baseline.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.12.3");
+  expect(phaseVersions.baseline.COPROCESSOR_SNS_WORKER_VERSION).toBe("v0.12.0");
+  expect(phaseVersions.baseline.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.12.2");
+  expect(phaseVersions.baseline.RELAYER_VERSION).toBe("v0.11.1");
+});
+
+test("contracts go to v0.13.0 first; runtime stays at the testnet baseline", () => {
+  expect(phaseVersions.contracts.GATEWAY_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.contracts.HOST_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.contracts.CORE_VERSION).toBe("v0.13.10");
+  expect(phaseVersions.contracts.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.12.0");
+  expect(phaseVersions.contracts.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.12.3");
+});
+
+test("kms then coprocessor then relayer reach the v0.13.0 target (KMS core v0.13.20)", () => {
+  expect(phaseVersions.kms.CORE_VERSION).toBe("v0.13.20");
+  expect(phaseVersions.kms.CONNECTOR_KMS_WORKER_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.kms.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.12.3"); // not yet
+  expect(phaseVersions.coprocessor.COPROCESSOR_TFHE_WORKER_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.coprocessor.COPROCESSOR_DB_MIGRATION_VERSION).toBe("v0.13.0");
+  expect(phaseVersions.coprocessor.RELAYER_VERSION).toBe("v0.11.1"); // relayer last
+  expect(phaseVersions.relayer.RELAYER_VERSION).toBe("v0.13.0");
+});
+
+test("pins the target test harness across every phase", () => {
+  for (const phase of Object.values(phaseVersions)) {
+    expect(phase.TEST_SUITE_VERSION).toBe("v0.13.0");
+    expect(phase.RELAYER_SDK_VERSION).toBe("0.4.2");
+  }
+});
+
+test("reuses the one-node ProtocolConfig mpc-threshold normalization", () => {
+  const env = {
+    MIGRATION_KMS_NODES: JSON.stringify([{ txSenderAddress: "0x1" }]),
+    MIGRATION_KMS_THRESHOLDS: JSON.stringify({ mpc: "0" }),
+  };
+  expect(needsLocalOneNodeMpcNormalization(env)).toBe(true);
+});
+
+test("loads the checked-in v0.13.0-testnet runbook", async () => {
+  await expect(loadRolloutRunbook(path.join(CLI_DIR, "rollouts/v0.13.0-testnet/run.ts"))).resolves.toBeFunction();
+});


### PR DESCRIPTION
## What
Stateful rollout reproducing the **testnet `v0.12 → v0.13.0`** migration step-for-step (gitops `zama-zws/gitops#1063` + the *0.13.0 migration runbooks*), to test whether the runbook is **complete** — not to ship. Single-coprocessor / threshold-1 (testnet Phase 1), two host chains (host + Polygon stand-in).

**Draft / archived reference.** The rollout + its CI receipt are the per-command audit trail; not intended to merge as-is.

## Result — full runbook reproduces green end-to-end
CI run [27702720079](https://github.com/zama-ai/fhevm/actions/runs/27702720079): e2e passes at every gate — baseline → contract migration (prepare→apply, gateway-before-host) → **Polygon fresh-deploy** → KMS → coprocessor → relayer → `addHostChain`.

- The never-run-in-container `prepareUpgrade*` / `prepareDeploy*FromMigration` steps **all execute cleanly** — the core unknown, answered.

## Versions (exact)
Contracts **v0.12.1 → v0.13.0**; KMS core **v0.13.10 → v0.13.20**; runtime (connector/coproc/relayer) **v0.12.x → v0.13.0** (inferred — no gitops runtime-bump PR yet). Testnet baseline is heterogeneous (KMS core already v0.13.10; mixed coproc patches).

## Findings
1. **Step-0 preflight unrunnable at v0.12** — `assertNoPendingKeyManagementRequest` targets the *host* KMSGeneration, which doesn't exist pre-migration (it's on the gateway). Target the gateway, or move post-migration.
2. **gitops has no runtime-bump PR** — #1063 is contracts-only; connector/coproc/relayer cutover is unpinned.
3. ~~DAO Operator runbook incomplete~~ — **RESOLVED** (Yohan's update now enumerates all 5 gateway + 6 host upgrades + `addHostChain`, with gateway-before-host ordering).
4. **`prepareDeploy*FromMigration` builds calldata from env, not the exported migration JSON** — stale env → wrong signers/thresholds in the proposal.
5. **Migration deploys not idempotent** (ProtocolConfig/KMSGeneration) — no retry path.
6. **Polygon deploy compile-ordering is load-bearing + undocumented** — immutable-first → deploy empty proxies → full compile, else `HH700 (PauserSet)` / `HH600 (protocolConfigAdd)`.
7. **Polygon ownership-transfer + `addHostChain` not faithfully reproducible** in the rollout (chain pre-registered; deployer-key window).

## Framework change
Adds `ctx.runHostContractTaskOnChain(chainKey, …)` (+ a `composeFile`/`envComponent` override on `runContractTask`) — multi-chain contract-deploy for rollouts; reusable beyond this.

🤖 Drafted with Claude Code on behalf of @eliastazartes.
