### PR TITLE
feat: solana verified-input fhe_eval operand + input-flow e2e leg

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -3492,6 +3492,11 @@
       "code": 6079,
       "name": "InputBindUserNotSubject",
       "msg": "attested user address is not an output ACL subject"
+    },
+    {
+      "code": 6080,
+      "name": "InputBindTransientSessionUnsupported",
+      "msg": "verified-input-derived value cannot be written to a transient session"
     }
   ],
   "types": [

--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -3917,6 +3917,103 @@
       }
     },
     {
+      "name": "CoprocessorInputAttestation",
+      "docs": [
+        "A coprocessor input attestation carried inline by a [`FheEvalOperand::VerifiedInput`], re-verified",
+        "in-frame (no account, no PDA) — the instruction-local analog of EVM `allowTransient(input, contract)`."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "input_handle",
+            "docs": [
+              "The verified input handle used as the operand."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "ct_handles",
+            "docs": [
+              "All ciphertext handles covered by the proof."
+            ],
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "handle_index",
+            "docs": [
+              "Index of `input_handle` within `ct_handles`."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "user_address",
+            "docs": [
+              "Attested user identity (bytes32)."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "contract_address",
+            "docs": [
+              "Attested contract identity — the input's ACL domain key (bytes32)."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "contract_chain_id",
+            "docs": [
+              "Gateway-side contract chain id the attestation binds."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "extra_data",
+            "docs": [
+              "Opaque extra data covered by the attestation."
+            ],
+            "type": "bytes"
+          },
+          {
+            "name": "signatures",
+            "docs": [
+              "Coprocessor EIP-712 signatures (65-byte secp256k1)."
+            ],
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  65
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "DenySubjectUpdatedEvent",
       "docs": [
         "Emitted when a subject deny-list record is updated."
@@ -4197,6 +4294,22 @@
                   "u8",
                   32
                 ]
+              }
+            ]
+          },
+          {
+            "name": "VerifiedInput",
+            "fields": [
+              {
+                "name": "attestation",
+                "docs": [
+                  "The inline attestation re-verified to authorize this operand."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "CoprocessorInputAttestation"
+                  }
+                }
               }
             ]
           }

--- a/solana/crates/zama-fhe/src/lib.rs
+++ b/solana/crates/zama-fhe/src/lib.rs
@@ -1625,6 +1625,9 @@ fn validate_lowered_encrypted_operand(
         FheEvalOperand::TransientSession { session_index, .. } => {
             mark_lowered_account(used_accounts, *session_index)?;
         }
+        FheEvalOperand::VerifiedInput { .. } => {
+            // No remaining account: the attestation is carried inline and verified in-frame.
+        }
         FheEvalOperand::Scalar(_) => return Err(EvalBuildError::ScalarEncryptedOperand),
     }
     Ok(())

--- a/solana/programs/zama-host/src/errors.rs
+++ b/solana/programs/zama-host/src/errors.rs
@@ -249,4 +249,9 @@ pub enum ZamaHostError {
     /// The coprocessor-attested user is not among the output ACL subjects.
     #[msg("attested user address is not an output ACL subject")]
     InputBindUserNotSubject,
+    /// A value derived from a verified external input may not be parked in a transient session:
+    /// the session capability does not carry the attested binding, so consuming it later would
+    /// drop the replay guard. Such values must flow to a durable output that binds the attestation.
+    #[msg("verified-input-derived value cannot be written to a transient session")]
+    InputBindTransientSessionUnsupported,
 }

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -3,6 +3,7 @@
 use anchor_lang::prelude::*;
 
 use super::common::*;
+use super::verify_coprocessor_input::{verify_input_attestation, InputVerifierParams};
 use crate::{
     errors::ZamaHostError,
     events::{
@@ -126,6 +127,7 @@ fn execute_eval_frame<'info>(
         handle_context.chain_id,
         current_slot,
         instructions_sysvar,
+        InputVerifierParams::from_config(&ctx.accounts.host_config),
     );
     walk_eval_frame(&mut execution, ctx, args, handle_context)?;
     execution.finish(ctx)
@@ -145,6 +147,7 @@ struct EvalExecutionState<'a, 'info> {
     chain_id: u64,
     current_slot: u64,
     instructions_sysvar: Option<&'a AccountInfo<'info>>,
+    verifier_params: InputVerifierParams,
 }
 
 impl<'a, 'info> EvalExecutionState<'a, 'info> {
@@ -158,6 +161,7 @@ impl<'a, 'info> EvalExecutionState<'a, 'info> {
         chain_id: u64,
         current_slot: u64,
         instructions_sysvar: Option<&'a AccountInfo<'info>>,
+        verifier_params: InputVerifierParams,
     ) -> Self {
         Self {
             remaining_accounts,
@@ -170,6 +174,7 @@ impl<'a, 'info> EvalExecutionState<'a, 'info> {
             chain_id,
             current_slot,
             instructions_sysvar,
+            verifier_params,
         }
     }
 
@@ -256,6 +261,28 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
             self.instructions_sysvar,
         )?;
         Ok(ResolvedOperand::transient_session(handle, capability.grant))
+    }
+
+    #[inline(never)]
+    fn resolve_verified_input_operand(
+        &mut self,
+        attestation: &CoprocessorInputAttestation,
+    ) -> Result<ResolvedOperand> {
+        // Authoritative in-frame verification: re-run the coprocessor attestation. No account, no
+        // PDA — the "allow" exists only for this instruction's execution. public_decrypt is NOT
+        // implied by a verified input; the durable output gets an explicit allow_for_decryption.
+        verify_input_attestation(
+            &self.verifier_params,
+            attestation.input_handle,
+            &attestation.ct_handles,
+            attestation.handle_index,
+            &attestation.user_address,
+            &attestation.contract_address,
+            attestation.contract_chain_id,
+            &attestation.extra_data,
+            &attestation.signatures,
+        )?;
+        Ok(ResolvedOperand::encrypted(attestation.input_handle, false))
     }
 
     fn record_op_event(&mut self, event: EvalEvent) {

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -284,7 +284,10 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
         )?;
         Ok(ResolvedOperand::verified_input(
             attestation.input_handle,
-            Pubkey::new_from_array(attestation.contract_address),
+            VerifiedInputBinding {
+                user_address: Pubkey::new_from_array(attestation.user_address),
+                contract_address: Pubkey::new_from_array(attestation.contract_address),
+            },
         ))
     }
 
@@ -301,7 +304,7 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
         output_policies: Vec<SessionPolicy>,
         output_public_decrypt_allowed: bool,
         enforce_public_decrypt_role_propagation: bool,
-        verified_input_domain: Option<Pubkey>,
+        verified_input: Option<VerifiedInputBinding>,
     ) -> Result<()> {
         accept_eval_output(
             ctx,
@@ -313,7 +316,7 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
             output_policies,
             output_public_decrypt_allowed,
             enforce_public_decrypt_role_propagation,
-            verified_input_domain,
+            verified_input,
             self.current_slot,
         )
     }
@@ -346,7 +349,7 @@ fn accept_eval_output<'info>(
     output_policies: Vec<SessionPolicy>,
     output_public_decrypt_allowed: bool,
     enforce_public_decrypt_role_propagation: bool,
-    verified_input_domain: Option<Pubkey>,
+    verified_input: Option<VerifiedInputBinding>,
     current_slot: u64,
 ) -> Result<()> {
     require!(
@@ -385,12 +388,13 @@ fn accept_eval_output<'info>(
             output_subjects,
             output_public_decrypt,
         } => {
-            if let Some(domain) = verified_input_domain {
-                require_keys_eq!(
+            if let Some(binding) = verified_input {
+                assert_verified_input_output_binding(
+                    &binding,
                     *output_acl_domain_key,
-                    domain,
-                    ZamaHostError::AclDomainKeyMismatch
-                );
+                    *output_app_account,
+                    output_subjects,
+                )?;
             }
             assert_session_policies_allow_output(
                 &output_policies,
@@ -435,8 +439,39 @@ fn accept_eval_output<'info>(
         handle: result,
         public_decrypt_allowed: output_public_decrypt_allowed,
         session_policies: output_policies,
-        verified_input_domain,
+        verified_input,
     });
+    Ok(())
+}
+
+/// A durable output derived from a verified external input must bind the attested identities: the
+/// output domain and app account must both be the attested `contract_address` (so the attested
+/// domain owns the output — and since the output app account must itself sign, the attested domain
+/// must sign, the EVM `contractAddress == msg.sender` invariant), and the attested `user_address`
+/// must be one of the output subjects. This stops a copied (public) attestation from being turned
+/// into a decryptable derived value by any signer other than the attested domain.
+fn assert_verified_input_output_binding(
+    binding: &VerifiedInputBinding,
+    output_acl_domain_key: Pubkey,
+    output_app_account: Pubkey,
+    output_subjects: &[AclSubjectEntry],
+) -> Result<()> {
+    require_keys_eq!(
+        output_acl_domain_key,
+        binding.contract_address,
+        ZamaHostError::AclDomainKeyMismatch
+    );
+    require_keys_eq!(
+        output_app_account,
+        binding.contract_address,
+        ZamaHostError::InputBindContractMismatch
+    );
+    require!(
+        output_subjects
+            .iter()
+            .any(|subject| subject.pubkey == binding.user_address),
+        ZamaHostError::InputBindUserNotSubject
+    );
     Ok(())
 }
 
@@ -467,7 +502,19 @@ pub(super) struct ProducedValue {
     handle: [u8; 32],
     public_decrypt_allowed: bool,
     session_policies: Vec<SessionPolicy>,
-    verified_input_domain: Option<Pubkey>,
+    verified_input: Option<VerifiedInputBinding>,
+}
+
+/// The coprocessor-attested identities a verified external input carries forward. A durable output
+/// derived from it must bind these: `output_acl_domain_key` and `output_app_account` must equal the
+/// attested `contract_address` (so the attested domain — which `app_account` must sign for — owns
+/// the output, the EVM `contractAddress == msg.sender` invariant), and the attested `user_address`
+/// must be one of the output subjects. This makes a copied (public) attestation unusable by any
+/// signer other than the attested domain.
+#[derive(Clone, Copy)]
+pub(super) struct VerifiedInputBinding {
+    pub(super) user_address: Pubkey,
+    pub(super) contract_address: Pubkey,
 }
 
 #[derive(Clone)]
@@ -476,9 +523,9 @@ pub(super) struct ResolvedOperand {
     pub(super) scalar: bool,
     pub(super) public_decrypt_allowed: bool,
     pub(super) session_policies: Vec<SessionPolicy>,
-    /// Set when this value traces back to a verified external input: the acl_domain_key the
-    /// coprocessor attested it for. Any durable output derived from it must bind that exact domain.
-    pub(super) verified_input_domain: Option<Pubkey>,
+    /// Set when this value traces back to a verified external input: the attested identities its
+    /// derived durable outputs must bind to (see [`VerifiedInputBinding`]).
+    pub(super) verified_input: Option<VerifiedInputBinding>,
 }
 
 impl ResolvedOperand {
@@ -488,7 +535,7 @@ impl ResolvedOperand {
             scalar: false,
             public_decrypt_allowed,
             session_policies: Vec::new(),
-            verified_input_domain: None,
+            verified_input: None,
         }
     }
 
@@ -498,22 +545,22 @@ impl ResolvedOperand {
             scalar: true,
             public_decrypt_allowed: true,
             session_policies: Vec::new(),
-            verified_input_domain: None,
+            verified_input: None,
         }
     }
 
-    /// Builds an operand from an in-frame verified external input, pinning its derived outputs to
-    /// the attested acl_domain_key. The input is authorized by its provider for that domain, so it
-    /// propagates public-decrypt like a public scalar (EVM `fromExternal` parity: the app that
-    /// received the input controls whether results are made publicly decryptable, via an explicit
-    /// allow_for_decryption — it is not blocked by the input itself).
-    fn verified_input(handle: [u8; 32], domain: Pubkey) -> Self {
+    /// Builds an operand from an in-frame verified external input, carrying the attested identities
+    /// its derived durable outputs must bind to. The input is authorized by its provider for that
+    /// domain, so it propagates public-decrypt like a public scalar (EVM `fromExternal` parity: the
+    /// app that received the input controls whether results are made publicly decryptable, via an
+    /// explicit allow_for_decryption — it is not blocked by the input itself).
+    fn verified_input(handle: [u8; 32], binding: VerifiedInputBinding) -> Self {
         Self {
             handle,
             scalar: false,
             public_decrypt_allowed: true,
             session_policies: Vec::new(),
-            verified_input_domain: Some(domain),
+            verified_input: Some(binding),
         }
     }
 
@@ -523,7 +570,7 @@ impl ResolvedOperand {
             scalar: false,
             public_decrypt_allowed: value.public_decrypt_allowed,
             session_policies: value.session_policies.clone(),
-            verified_input_domain: value.verified_input_domain,
+            verified_input: value.verified_input,
         }
     }
 
@@ -534,7 +581,7 @@ impl ResolvedOperand {
             handle,
             scalar: false,
             public_decrypt_allowed: grant.public_decrypt_allowed,
-            verified_input_domain: None,
+            verified_input: None,
             session_policies: vec![SessionPolicy {
                 subject: grant.subject,
                 receiver_program: grant.receiver_program,
@@ -594,22 +641,33 @@ fn inputs3_allow_public_decrypt(
     first.public_decrypt_allowed && second.public_decrypt_allowed && third.public_decrypt_allowed
 }
 
-/// The attested acl_domain_key a verified external input pins its derived outputs to. Folds the
-/// operands' taints: at most one attested domain may flow into a single op (mixing two would be
-/// ambiguous), and a durable output derived from it must bind that exact acl_domain_key.
-fn combine_verified_input_domain(operands: &[&ResolvedOperand]) -> Result<Option<Pubkey>> {
-    let mut domain: Option<Pubkey> = None;
+/// The verified-input binding a derived output must satisfy. Folds the operands' taints: at most one
+/// attested input may flow into a single op (mixing two distinct attestations would be ambiguous),
+/// and a durable output derived from it must bind the attested domain/user (see [`accept_eval_output`]).
+fn combine_verified_input_binding(
+    operands: &[&ResolvedOperand],
+) -> Result<Option<VerifiedInputBinding>> {
+    let mut binding: Option<VerifiedInputBinding> = None;
     for operand in operands {
-        if let Some(input_domain) = operand.verified_input_domain {
-            match domain {
-                None => domain = Some(input_domain),
+        if let Some(input) = operand.verified_input {
+            match binding {
+                None => binding = Some(input),
                 Some(existing) => {
-                    require_keys_eq!(existing, input_domain, ZamaHostError::AclDomainKeyMismatch)
+                    require_keys_eq!(
+                        existing.contract_address,
+                        input.contract_address,
+                        ZamaHostError::AclDomainKeyMismatch
+                    );
+                    require_keys_eq!(
+                        existing.user_address,
+                        input.user_address,
+                        ZamaHostError::InputBindUserNotSubject
+                    );
                 }
             }
         }
     }
-    Ok(domain)
+    Ok(binding)
 }
 
 fn assert_session_policies_allow_output(

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -363,6 +363,10 @@ fn accept_eval_output<'info>(
             session_index,
             capability,
         } => {
+            require!(
+                verified_input.is_none(),
+                ZamaHostError::InputBindTransientSessionUnsupported
+            );
             assert_session_policies_allow_transient_grant(&output_policies, *capability)?;
             let session_info = remaining_account(
                 ctx.remaining_accounts,

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -282,7 +282,10 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
             &attestation.extra_data,
             &attestation.signatures,
         )?;
-        Ok(ResolvedOperand::encrypted(attestation.input_handle, false))
+        Ok(ResolvedOperand::verified_input(
+            attestation.input_handle,
+            Pubkey::new_from_array(attestation.contract_address),
+        ))
     }
 
     fn record_op_event(&mut self, event: EvalEvent) {
@@ -298,6 +301,7 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
         output_policies: Vec<SessionPolicy>,
         output_public_decrypt_allowed: bool,
         enforce_public_decrypt_role_propagation: bool,
+        verified_input_domain: Option<Pubkey>,
     ) -> Result<()> {
         accept_eval_output(
             ctx,
@@ -309,6 +313,7 @@ impl EvalStepVisitor for EvalExecutionState<'_, '_> {
             output_policies,
             output_public_decrypt_allowed,
             enforce_public_decrypt_role_propagation,
+            verified_input_domain,
             self.current_slot,
         )
     }
@@ -341,6 +346,7 @@ fn accept_eval_output<'info>(
     output_policies: Vec<SessionPolicy>,
     output_public_decrypt_allowed: bool,
     enforce_public_decrypt_role_propagation: bool,
+    verified_input_domain: Option<Pubkey>,
     current_slot: u64,
 ) -> Result<()> {
     require!(
@@ -379,6 +385,13 @@ fn accept_eval_output<'info>(
             output_subjects,
             output_public_decrypt,
         } => {
+            if let Some(domain) = verified_input_domain {
+                require_keys_eq!(
+                    *output_acl_domain_key,
+                    domain,
+                    ZamaHostError::AclDomainKeyMismatch
+                );
+            }
             assert_session_policies_allow_output(
                 &output_policies,
                 *output_acl_domain_key,
@@ -422,6 +435,7 @@ fn accept_eval_output<'info>(
         handle: result,
         public_decrypt_allowed: output_public_decrypt_allowed,
         session_policies: output_policies,
+        verified_input_domain,
     });
     Ok(())
 }
@@ -453,6 +467,7 @@ pub(super) struct ProducedValue {
     handle: [u8; 32],
     public_decrypt_allowed: bool,
     session_policies: Vec<SessionPolicy>,
+    verified_input_domain: Option<Pubkey>,
 }
 
 #[derive(Clone)]
@@ -461,6 +476,9 @@ pub(super) struct ResolvedOperand {
     pub(super) scalar: bool,
     pub(super) public_decrypt_allowed: bool,
     pub(super) session_policies: Vec<SessionPolicy>,
+    /// Set when this value traces back to a verified external input: the acl_domain_key the
+    /// coprocessor attested it for. Any durable output derived from it must bind that exact domain.
+    pub(super) verified_input_domain: Option<Pubkey>,
 }
 
 impl ResolvedOperand {
@@ -470,6 +488,7 @@ impl ResolvedOperand {
             scalar: false,
             public_decrypt_allowed,
             session_policies: Vec::new(),
+            verified_input_domain: None,
         }
     }
 
@@ -479,6 +498,20 @@ impl ResolvedOperand {
             scalar: true,
             public_decrypt_allowed: true,
             session_policies: Vec::new(),
+            verified_input_domain: None,
+        }
+    }
+
+    /// Builds an operand from an in-frame verified external input, pinning its derived outputs to
+    /// the attested acl_domain_key. public_decrypt is not implied (the durable output asks
+    /// explicitly).
+    fn verified_input(handle: [u8; 32], domain: Pubkey) -> Self {
+        Self {
+            handle,
+            scalar: false,
+            public_decrypt_allowed: false,
+            session_policies: Vec::new(),
+            verified_input_domain: Some(domain),
         }
     }
 
@@ -488,6 +521,7 @@ impl ResolvedOperand {
             scalar: false,
             public_decrypt_allowed: value.public_decrypt_allowed,
             session_policies: value.session_policies.clone(),
+            verified_input_domain: value.verified_input_domain,
         }
     }
 
@@ -498,6 +532,7 @@ impl ResolvedOperand {
             handle,
             scalar: false,
             public_decrypt_allowed: grant.public_decrypt_allowed,
+            verified_input_domain: None,
             session_policies: vec![SessionPolicy {
                 subject: grant.subject,
                 receiver_program: grant.receiver_program,
@@ -555,6 +590,24 @@ fn inputs3_allow_public_decrypt(
     third: &ResolvedOperand,
 ) -> bool {
     first.public_decrypt_allowed && second.public_decrypt_allowed && third.public_decrypt_allowed
+}
+
+/// The attested acl_domain_key a verified external input pins its derived outputs to. Folds the
+/// operands' taints: at most one attested domain may flow into a single op (mixing two would be
+/// ambiguous), and a durable output derived from it must bind that exact acl_domain_key.
+fn combine_verified_input_domain(operands: &[&ResolvedOperand]) -> Result<Option<Pubkey>> {
+    let mut domain: Option<Pubkey> = None;
+    for operand in operands {
+        if let Some(input_domain) = operand.verified_input_domain {
+            match domain {
+                None => domain = Some(input_domain),
+                Some(existing) => {
+                    require_keys_eq!(existing, input_domain, ZamaHostError::AclDomainKeyMismatch)
+                }
+            }
+        }
+    }
+    Ok(domain)
 }
 
 fn assert_session_policies_allow_output(

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -503,13 +503,15 @@ impl ResolvedOperand {
     }
 
     /// Builds an operand from an in-frame verified external input, pinning its derived outputs to
-    /// the attested acl_domain_key. public_decrypt is not implied (the durable output asks
-    /// explicitly).
+    /// the attested acl_domain_key. The input is authorized by its provider for that domain, so it
+    /// propagates public-decrypt like a public scalar (EVM `fromExternal` parity: the app that
+    /// received the input controls whether results are made publicly decryptable, via an explicit
+    /// allow_for_decryption — it is not blocked by the input itself).
     fn verified_input(handle: [u8; 32], domain: Pubkey) -> Self {
         Self {
             handle,
             scalar: false,
-            public_decrypt_allowed: false,
+            public_decrypt_allowed: true,
             session_policies: Vec::new(),
             verified_input_domain: Some(domain),
         }

--- a/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
@@ -257,7 +257,11 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
     ) -> Result<ResolvedOperand> {
         // Structural only — the handle is known from the operand; execution re-verifies the
         // attestation authoritatively (matches how transient-session consume is execution-gated).
-        Ok(ResolvedOperand::encrypted(attestation.input_handle, false))
+        // The attested domain is still tracked so admission rejects a wrong output acl_domain_key.
+        Ok(ResolvedOperand::verified_input(
+            attestation.input_handle,
+            Pubkey::new_from_array(attestation.contract_address),
+        ))
     }
 
     fn record_op_event(&mut self, _event: EvalEvent) {}
@@ -270,6 +274,7 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
         output_policies: Vec<SessionPolicy>,
         output_public_decrypt_allowed: bool,
         enforce_public_decrypt_role_propagation: bool,
+        verified_input_domain: Option<Pubkey>,
     ) -> Result<()> {
         require!(
             !self.produced.iter().any(|value| value.handle == result),
@@ -302,6 +307,13 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
                 output_subjects,
                 output_public_decrypt,
             } => {
+                if let Some(domain) = verified_input_domain {
+                    require_keys_eq!(
+                        *output_acl_domain_key,
+                        domain,
+                        ZamaHostError::AclDomainKeyMismatch
+                    );
+                }
                 assert_session_policies_allow_output(
                     &output_policies,
                     *output_acl_domain_key,
@@ -343,6 +355,7 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
             handle: result,
             public_decrypt_allowed: output_public_decrypt_allowed,
             session_policies: output_policies,
+            verified_input_domain,
         });
         Ok(())
     }

--- a/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
@@ -251,6 +251,15 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
         self.resolve_transient_session(handle, session_index, capability_index)
     }
 
+    fn resolve_verified_input_operand(
+        &mut self,
+        attestation: &CoprocessorInputAttestation,
+    ) -> Result<ResolvedOperand> {
+        // Structural only — the handle is known from the operand; execution re-verifies the
+        // attestation authoritatively (matches how transient-session consume is execution-gated).
+        Ok(ResolvedOperand::encrypted(attestation.input_handle, false))
+    }
+
     fn record_op_event(&mut self, _event: EvalEvent) {}
 
     fn accept_output<'info>(

--- a/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
@@ -257,10 +257,14 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
     ) -> Result<ResolvedOperand> {
         // Structural only — the handle is known from the operand; execution re-verifies the
         // attestation authoritatively (matches how transient-session consume is execution-gated).
-        // The attested domain is still tracked so admission rejects a wrong output acl_domain_key.
+        // The attested identities are still tracked so admission rejects an output that does not
+        // bind them.
         Ok(ResolvedOperand::verified_input(
             attestation.input_handle,
-            Pubkey::new_from_array(attestation.contract_address),
+            VerifiedInputBinding {
+                user_address: Pubkey::new_from_array(attestation.user_address),
+                contract_address: Pubkey::new_from_array(attestation.contract_address),
+            },
         ))
     }
 
@@ -274,7 +278,7 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
         output_policies: Vec<SessionPolicy>,
         output_public_decrypt_allowed: bool,
         enforce_public_decrypt_role_propagation: bool,
-        verified_input_domain: Option<Pubkey>,
+        verified_input: Option<VerifiedInputBinding>,
     ) -> Result<()> {
         require!(
             !self.produced.iter().any(|value| value.handle == result),
@@ -307,12 +311,13 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
                 output_subjects,
                 output_public_decrypt,
             } => {
-                if let Some(domain) = verified_input_domain {
-                    require_keys_eq!(
+                if let Some(binding) = verified_input {
+                    assert_verified_input_output_binding(
+                        &binding,
                         *output_acl_domain_key,
-                        domain,
-                        ZamaHostError::AclDomainKeyMismatch
-                    );
+                        *output_app_account,
+                        output_subjects,
+                    )?;
                 }
                 assert_session_policies_allow_output(
                     &output_policies,
@@ -355,7 +360,7 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
             handle: result,
             public_decrypt_allowed: output_public_decrypt_allowed,
             session_policies: output_policies,
-            verified_input_domain,
+            verified_input,
         });
         Ok(())
     }

--- a/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
@@ -291,6 +291,10 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
                 session_index,
                 capability,
             } => {
+                require!(
+                    verified_input.is_none(),
+                    ZamaHostError::InputBindTransientSessionUnsupported
+                );
                 assert_session_policies_allow_transient_grant(&output_policies, *capability)?;
                 self.admit_transient_session_append(
                     ctx.remaining_accounts,

--- a/solana/programs/zama-host/src/instructions/fhe_eval/preflight.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/preflight.rs
@@ -163,6 +163,9 @@ fn preflight_encrypted_operand(
             preflight.require_instructions_sysvar();
             preflight.mark_account(*session_index)?;
         }
+        FheEvalOperand::VerifiedInput { .. } => {
+            // No remaining account: the attestation is carried inline and verified in-frame.
+        }
         FheEvalOperand::Scalar(_) => return Err(error!(ZamaHostError::InvalidFheEvalAccount)),
     }
     Ok(())

--- a/solana/programs/zama-host/src/instructions/fhe_eval/walk.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/walk.rs
@@ -62,7 +62,7 @@ pub(super) trait EvalStepVisitor {
         output_policies: Vec<SessionPolicy>,
         output_public_decrypt_allowed: bool,
         enforce_public_decrypt_role_propagation: bool,
-        verified_input_domain: Option<Pubkey>,
+        verified_input: Option<VerifiedInputBinding>,
     ) -> Result<()>;
 
     /// Resolves an operand that must be encrypted (rejects scalars).
@@ -128,7 +128,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
             } => {
                 let lhs = visitor.resolve_lhs_operand(lhs)?;
                 let rhs = visitor.resolve_rhs_operand(rhs)?;
-                let verified_input_domain = combine_verified_input_domain(&[&lhs, &rhs])?;
+                let verified_input = combine_verified_input_binding(&[&lhs, &rhs])?;
                 assert_binary_operand_types(
                     *op,
                     lhs.handle,
@@ -162,7 +162,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                     input_session_policies(&lhs, &rhs),
                     inputs_allow_public_decrypt(&lhs, &rhs),
                     true,
-                    verified_input_domain,
+                    verified_input,
                 )?;
             }
             FheEvalStep::Ternary {
@@ -176,8 +176,8 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                 let control = visitor.resolve_encrypted_operand(control)?;
                 let if_true = visitor.resolve_encrypted_operand(if_true)?;
                 let if_false = visitor.resolve_encrypted_operand(if_false)?;
-                let verified_input_domain =
-                    combine_verified_input_domain(&[&control, &if_true, &if_false])?;
+                let verified_input =
+                    combine_verified_input_binding(&[&control, &if_true, &if_false])?;
                 assert_ternary_operand_types(
                     control.handle,
                     if_true.handle,
@@ -210,7 +210,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                     input_session_policies3(&control, &if_true, &if_false),
                     inputs3_allow_public_decrypt(&control, &if_true, &if_false),
                     true,
-                    verified_input_domain,
+                    verified_input,
                 )?;
             }
             FheEvalStep::TrivialEncrypt {

--- a/solana/programs/zama-host/src/instructions/fhe_eval/walk.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/walk.rs
@@ -62,6 +62,7 @@ pub(super) trait EvalStepVisitor {
         output_policies: Vec<SessionPolicy>,
         output_public_decrypt_allowed: bool,
         enforce_public_decrypt_role_propagation: bool,
+        verified_input_domain: Option<Pubkey>,
     ) -> Result<()>;
 
     /// Resolves an operand that must be encrypted (rejects scalars).
@@ -127,6 +128,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
             } => {
                 let lhs = visitor.resolve_lhs_operand(lhs)?;
                 let rhs = visitor.resolve_rhs_operand(rhs)?;
+                let verified_input_domain = combine_verified_input_domain(&[&lhs, &rhs])?;
                 assert_binary_operand_types(
                     *op,
                     lhs.handle,
@@ -160,6 +162,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                     input_session_policies(&lhs, &rhs),
                     inputs_allow_public_decrypt(&lhs, &rhs),
                     true,
+                    verified_input_domain,
                 )?;
             }
             FheEvalStep::Ternary {
@@ -173,6 +176,8 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                 let control = visitor.resolve_encrypted_operand(control)?;
                 let if_true = visitor.resolve_encrypted_operand(if_true)?;
                 let if_false = visitor.resolve_encrypted_operand(if_false)?;
+                let verified_input_domain =
+                    combine_verified_input_domain(&[&control, &if_true, &if_false])?;
                 assert_ternary_operand_types(
                     control.handle,
                     if_true.handle,
@@ -205,6 +210,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                     input_session_policies3(&control, &if_true, &if_false),
                     inputs3_allow_public_decrypt(&control, &if_true, &if_false),
                     true,
+                    verified_input_domain,
                 )?;
             }
             FheEvalStep::TrivialEncrypt {
@@ -227,7 +233,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                     fhe_type: *fhe_type,
                     result,
                 }));
-                visitor.accept_output(ctx, result, output, Vec::new(), false, false)?;
+                visitor.accept_output(ctx, result, output, Vec::new(), false, false, None)?;
             }
             FheEvalStep::Rand { fhe_type, output } => {
                 assert_supported_rand_type(*fhe_type)?;
@@ -240,7 +246,7 @@ pub(super) fn walk_eval_frame<'info, V: EvalStepVisitor>(
                     fhe_type: *fhe_type,
                     result,
                 }));
-                visitor.accept_output(ctx, result, output, Vec::new(), false, false)?;
+                visitor.accept_output(ctx, result, output, Vec::new(), false, false, None)?;
             }
         }
     }

--- a/solana/programs/zama-host/src/instructions/fhe_eval/walk.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/walk.rs
@@ -40,6 +40,14 @@ pub(super) trait EvalStepVisitor {
         capability_index: u16,
     ) -> Result<ResolvedOperand>;
 
+    /// Resolves an external input verified in-frame via the coprocessor attestation. Admission
+    /// resolves it structurally (the handle is known from the operand data); execution re-runs the
+    /// secp256k1 attestation authoritatively. Instruction-local — no account, no PDA.
+    fn resolve_verified_input_operand(
+        &mut self,
+        attestation: &CoprocessorInputAttestation,
+    ) -> Result<ResolvedOperand>;
+
     /// Records the per-op event for the produced handle. Admission ignores it;
     /// execution buffers it for transport.
     fn record_op_event(&mut self, event: EvalEvent);
@@ -74,6 +82,9 @@ pub(super) trait EvalStepVisitor {
                 session_index,
                 capability_index,
             } => self.resolve_transient_session_operand(*handle, *session_index, *capability_index),
+            FheEvalOperand::VerifiedInput { attestation } => {
+                self.resolve_verified_input_operand(attestation)
+            }
             FheEvalOperand::Scalar(_) => Err(error!(ZamaHostError::InvalidFheEvalAccount)),
         }
     }

--- a/solana/programs/zama-host/src/instructions/verify_coprocessor_input.rs
+++ b/solana/programs/zama-host/src/instructions/verify_coprocessor_input.rs
@@ -31,6 +31,85 @@ pub struct VerifyCoprocessorInput<'info> {
     pub host_config: Account<'info, HostConfig>,
 }
 
+/// The host_config fields needed to verify an input attestation, copied out so callers that don't
+/// hold a `&HostConfig` (the `fhe_eval` operand resolver) can carry them by value.
+#[derive(Clone, Copy)]
+pub(crate) struct InputVerifierParams {
+    pub chain_id: u64,
+    pub gateway_chain_id: u64,
+    pub input_verification_contract: [u8; 20],
+    pub coprocessor_signer: [u8; 20],
+}
+
+impl InputVerifierParams {
+    pub fn from_config(config: &HostConfig) -> Self {
+        Self {
+            chain_id: config.chain_id,
+            gateway_chain_id: config.gateway_chain_id,
+            input_verification_contract: config.input_verification_contract,
+            coprocessor_signer: config.coprocessor_signer,
+        }
+    }
+}
+
+/// Verifies the coprocessor's EIP-712 `CiphertextVerification` attestation for an encrypted input:
+/// config sanity, per-handle metadata, selected-handle match, and `secp256k1_recover` of the
+/// signer against the configured coprocessor signer. Shared by the standalone instruction and the
+/// `fhe_eval` `VerifiedInput` operand. The attested `contract_address` IS the input's ACL domain
+/// key (the natural domain for an input-derived handle, EVM parity with the verifyInput contract).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn verify_input_attestation(
+    params: &InputVerifierParams,
+    input_handle: [u8; 32],
+    ct_handles: &[[u8; 32]],
+    handle_index: u8,
+    user_address: &[u8; 32],
+    contract_address: &[u8; 32],
+    contract_chain_id: u64,
+    extra_data: &[u8],
+    signatures: &[[u8; 65]],
+) -> Result<()> {
+    require!(
+        params.coprocessor_signer != [0u8; 20] && params.input_verification_contract != [0u8; 20],
+        ZamaHostError::GatewayVerifierConfigUnset
+    );
+    require!(
+        !ct_handles.is_empty() && ct_handles.len() <= MAX_INPUT_PROOF_HANDLES,
+        ZamaHostError::InvalidInputProof
+    );
+    require!(
+        extra_data.len() <= MAX_INPUT_PROOF_EXTRA_DATA,
+        ZamaHostError::InvalidInputProof
+    );
+    for (index, handle) in ct_handles.iter().enumerate() {
+        assert_input_handle_metadata(*handle, params.chain_id, index as u8)?;
+    }
+    let selected = ct_handles
+        .get(handle_index as usize)
+        .ok_or(ZamaHostError::InvalidInputHandleIndex)?;
+    require!(*selected == input_handle, ZamaHostError::InvalidInputHandle);
+
+    let verifier = Eip712VerifierConfig {
+        gateway_chain_id: params.gateway_chain_id,
+        verifying_contract: params.input_verification_contract,
+        signers: std::slice::from_ref(&params.coprocessor_signer),
+        threshold: 1,
+    };
+    require!(
+        verify_coprocessor_attestation(
+            &verifier,
+            ct_handles,
+            user_address,
+            contract_address,
+            contract_chain_id,
+            extra_data,
+            signatures,
+        ),
+        ZamaHostError::InvalidInputAttestation
+    );
+    Ok(())
+}
+
 /// Verifies an encrypted input by recovering the coprocessor's EIP-712
 /// `CiphertextVerification` attestation on-chain and emitting the verified-input receipt.
 #[allow(clippy::too_many_arguments)]
@@ -48,46 +127,17 @@ pub fn verify_coprocessor_input(
     assert_no_remaining_accounts(ctx.remaining_accounts)?;
     assert_not_paused(&ctx.accounts.host_config)?;
 
-    let config = &ctx.accounts.host_config;
-    require!(
-        config.coprocessor_signer != [0u8; 20] && config.input_verification_contract != [0u8; 20],
-        ZamaHostError::GatewayVerifierConfigUnset
-    );
-
-    require!(
-        !ct_handles.is_empty() && ct_handles.len() <= MAX_INPUT_PROOF_HANDLES,
-        ZamaHostError::InvalidInputProof
-    );
-    require!(
-        extra_data.len() <= MAX_INPUT_PROOF_EXTRA_DATA,
-        ZamaHostError::InvalidInputProof
-    );
-    for (index, handle) in ct_handles.iter().enumerate() {
-        assert_input_handle_metadata(*handle, config.chain_id, index as u8)?;
-    }
-    let selected = ct_handles
-        .get(handle_index as usize)
-        .ok_or(ZamaHostError::InvalidInputHandleIndex)?;
-    require!(*selected == input_handle, ZamaHostError::InvalidInputHandle);
-
-    let verifier = Eip712VerifierConfig {
-        gateway_chain_id: config.gateway_chain_id,
-        verifying_contract: config.input_verification_contract,
-        signers: std::slice::from_ref(&config.coprocessor_signer),
-        threshold: 1,
-    };
-    require!(
-        verify_coprocessor_attestation(
-            &verifier,
-            &ct_handles,
-            &user_address,
-            &contract_address,
-            contract_chain_id,
-            &extra_data,
-            &signatures,
-        ),
-        ZamaHostError::InvalidInputAttestation
-    );
+    verify_input_attestation(
+        &InputVerifierParams::from_config(&ctx.accounts.host_config),
+        input_handle,
+        &ct_handles,
+        handle_index,
+        &user_address,
+        &contract_address,
+        contract_chain_id,
+        &extra_data,
+        &signatures,
+    )?;
 
     // Verification only: the signed attestation proves "the coprocessor blessed handle H for
     // (user, contract)", which we surface as the receipt below. No ACL is created here — durable

--- a/solana/programs/zama-host/src/state/mod.rs
+++ b/solana/programs/zama-host/src/state/mod.rs
@@ -222,6 +222,28 @@ pub enum FheEvalStep {
     },
 }
 
+/// A coprocessor input attestation carried inline by a [`FheEvalOperand::VerifiedInput`], re-verified
+/// in-frame (no account, no PDA) — the instruction-local analog of EVM `allowTransient(input, contract)`.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, Eq)]
+pub struct CoprocessorInputAttestation {
+    /// The verified input handle used as the operand.
+    pub input_handle: [u8; 32],
+    /// All ciphertext handles covered by the proof.
+    pub ct_handles: Vec<[u8; 32]>,
+    /// Index of `input_handle` within `ct_handles`.
+    pub handle_index: u8,
+    /// Attested user identity (bytes32).
+    pub user_address: [u8; 32],
+    /// Attested contract identity — the input's ACL domain key (bytes32).
+    pub contract_address: [u8; 32],
+    /// Gateway-side contract chain id the attestation binds.
+    pub contract_chain_id: u64,
+    /// Opaque extra data covered by the attestation.
+    pub extra_data: Vec<u8>,
+    /// Coprocessor EIP-712 signatures (65-byte secp256k1).
+    pub signatures: Vec<[u8; 65]>,
+}
+
 /// Operand source for a composed FHE eval operation.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, Eq)]
 pub enum FheEvalOperand {
@@ -250,6 +272,13 @@ pub enum FheEvalOperand {
     },
     /// Plaintext scalar bytes. Scalar operands are only valid on the RHS.
     Scalar([u8; 32]),
+    /// External encrypted input verified in-frame by re-running the coprocessor attestation.
+    /// The "allow" is instruction-local (no ACL record, no session, no PDA): the input is usable
+    /// only where it is consumed in the same `fhe_eval`. Valid as an encrypted operand, not a scalar.
+    VerifiedInput {
+        /// The inline attestation re-verified to authorize this operand.
+        attestation: CoprocessorInputAttestation,
+    },
 }
 
 /// Output policy for a composed FHE eval operation.

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -6937,6 +6937,7 @@ fn verified_input_add_eval_ix(
     nonce_key: [u8; 32],
     encrypted_value_label: [u8; 32],
     output_acl_record: Pubkey,
+    output_subjects: Vec<AclSubjectEntry>,
 ) -> Instruction {
     let mut eval_ix = anchor_ix(
         program_id,
@@ -6966,7 +6967,7 @@ fn verified_input_add_eval_ix(
                         output_acl_domain_key: acl_domain,
                         output_app_account: authority,
                         output_encrypted_value_label: encrypted_value_label,
-                        output_subjects: vec![AclSubjectEntry::use_only(authority)],
+                        output_subjects,
                         output_public_decrypt: false,
                     },
                 }],
@@ -7036,6 +7037,7 @@ fn mollusk_fhe_eval_verified_input_scalar_add_binds_durable_output() {
         nonce_key,
         encrypted_value_label,
         output_acl_record,
+        vec![AclSubjectEntry::use_only(authority)],
     );
 
     assert_transaction_success(&context, &[eval_ix]);
@@ -7147,6 +7149,7 @@ fn mollusk_fhe_eval_verified_input_rejects_forged_attestation() {
         nonce_key,
         value_label,
         output_acl_record,
+        vec![AclSubjectEntry::use_only(authority)],
     );
 
     let result = context.process_instruction(&eval_ix);
@@ -7204,6 +7207,7 @@ fn mollusk_fhe_eval_verified_input_does_not_leak_to_a_later_instruction() {
         nonce_key,
         value_label,
         output_acl_record,
+        vec![AclSubjectEntry::use_only(authority)],
     );
     assert_transaction_success(&context, &[consume_ix]);
 
@@ -7269,8 +7273,89 @@ fn mollusk_fhe_eval_verified_input_rejects_wrong_output_acl_domain_key() {
         nonce_key,
         value_label,
         output_acl_record,
+        vec![AclSubjectEntry::use_only(authority)],
     );
 
     let result = context.process_instruction(&eval_ix);
     assert_instruction_custom_error(&result, host::errors::ZamaHostError::AclDomainKeyMismatch);
+}
+
+/// (e) A verified input is authorized by its provider for the attested domain, so it propagates
+/// public-decrypt like a public scalar: a durable output derived from it may grant the
+/// PUBLIC_DECRYPT-capable `user` role (so the app can later allow_for_decryption) even though the
+/// app account authority is a plain signer. Before binding the input's domain this same shape was
+/// rejected as an un-propagated public-decrypt escalation.
+#[test]
+fn mollusk_fhe_eval_verified_input_propagates_public_decrypt_to_durable_output() {
+    let program_id = host::id();
+    let authority = Pubkey::new_unique();
+    let key = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(authority, evm_address_of(&key));
+
+    let acl_domain = Pubkey::new_unique();
+    let value_label = label("verified-input-pubdec");
+    let nonce_key = host::acl_nonce_key(acl_domain, authority, value_label);
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    let attestation = verified_input_attestation(
+        &key,
+        input_handle,
+        authority.to_bytes(),
+        acl_domain.to_bytes(),
+    );
+
+    let output_acl_record = host::acl_record_address(nonce_key, 0).0;
+    let context = transient_context(
+        authority,
+        vec![
+            (host_config, host_config_account),
+            (output_acl_record, system_account(0)),
+        ],
+    );
+
+    let scalar = amount_plaintext(2);
+    let context_id = label("verified-input-frame");
+    let output_handle = current_bound_eval_handle(
+        &context.mollusk,
+        FheBinaryOpCode::Add,
+        input_handle,
+        scalar,
+        true,
+        5,
+        context_id,
+        0,
+        nonce_key,
+        0,
+    );
+
+    let eval_ix = verified_input_add_eval_ix(
+        program_id,
+        authority,
+        host_config,
+        attestation,
+        scalar,
+        context_id,
+        acl_domain,
+        nonce_key,
+        value_label,
+        output_acl_record,
+        vec![AclSubjectEntry::user(authority)],
+    );
+
+    assert_transaction_success(&context, &[eval_ix]);
+
+    let output_record =
+        read_acl_record(&context, output_acl_record).expect("expected durable output ACL");
+    assert_bound_acl_record(
+        &output_record,
+        output_handle,
+        nonce_key,
+        0,
+        acl_domain,
+        authority,
+        value_label,
+        authority,
+        host::ACL_ROLE_ALL,
+        context.mollusk.sysvars.clock.slot,
+    );
 }

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -6990,17 +6990,15 @@ fn mollusk_fhe_eval_verified_input_scalar_add_binds_durable_output() {
     let (host_config, host_config_account) =
         host_config_account_with_verifier(authority, evm_address_of(&key));
 
-    // The attested contract IS the app-level ACL domain key (#3).
-    let acl_domain = Pubkey::new_unique();
+    // `authority` is the app's signing authority — the attested contract (a mint/token PDA signing
+    // via CPI in a real app). The attested input owner is a DIFFERENT end user, recorded as a
+    // subject. The output binds to the app authority: acl_domain == app_account == attested contract.
+    let user = Pubkey::new_unique();
     let encrypted_value_label = label("verified-input-add");
-    let nonce_key = host::acl_nonce_key(acl_domain, authority, encrypted_value_label);
+    let nonce_key = host::acl_nonce_key(authority, authority, encrypted_value_label);
     let input_handle = input_handle_for_chain(0x01, 0, 5);
-    let attestation = verified_input_attestation(
-        &key,
-        input_handle,
-        authority.to_bytes(),
-        acl_domain.to_bytes(),
-    );
+    let attestation =
+        verified_input_attestation(&key, input_handle, user.to_bytes(), authority.to_bytes());
 
     let output_acl_record = host::acl_record_address(nonce_key, 0).0;
     let context = transient_context(
@@ -7033,11 +7031,11 @@ fn mollusk_fhe_eval_verified_input_scalar_add_binds_durable_output() {
         attestation,
         scalar,
         context_id,
-        acl_domain,
+        authority,
         nonce_key,
         encrypted_value_label,
         output_acl_record,
-        vec![AclSubjectEntry::use_only(authority)],
+        vec![AclSubjectEntry::use_only(user)],
     );
 
     assert_transaction_success(&context, &[eval_ix]);
@@ -7049,10 +7047,10 @@ fn mollusk_fhe_eval_verified_input_scalar_add_binds_durable_output() {
         output_handle,
         nonce_key,
         0,
-        acl_domain,
+        authority,
         authority,
         encrypted_value_label,
-        authority,
+        user,
         host::ACL_ROLE_USE,
         context.mollusk.sysvars.clock.slot,
     );
@@ -7117,16 +7115,17 @@ fn mollusk_fhe_eval_verified_input_rejects_forged_attestation() {
     let (host_config, host_config_account) =
         host_config_account_with_verifier(authority, evm_address_of(&trusted));
 
-    let acl_domain = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
     let value_label = label("verified-input-forged");
-    let nonce_key = host::acl_nonce_key(acl_domain, authority, value_label);
+    let nonce_key = host::acl_nonce_key(authority, authority, value_label);
     let input_handle = input_handle_for_chain(0x01, 0, 5);
-    // Signed by the attacker, not the trusted coprocessor signer.
+    // A well-formed (user, app) binding, but signed by the attacker — not the trusted coprocessor
+    // signer. The output binding passes; the in-frame secp256k1 verify is what rejects it.
     let attestation = verified_input_attestation(
         &attacker,
         input_handle,
+        user.to_bytes(),
         authority.to_bytes(),
-        acl_domain.to_bytes(),
     );
 
     let output_acl_record = host::acl_record_address(nonce_key, 0).0;
@@ -7145,11 +7144,11 @@ fn mollusk_fhe_eval_verified_input_rejects_forged_attestation() {
         attestation,
         amount_plaintext(2),
         label("verified-input-frame"),
-        acl_domain,
+        authority,
         nonce_key,
         value_label,
         output_acl_record,
-        vec![AclSubjectEntry::use_only(authority)],
+        vec![AclSubjectEntry::use_only(user)],
     );
 
     let result = context.process_instruction(&eval_ix);
@@ -7171,16 +7170,12 @@ fn mollusk_fhe_eval_verified_input_does_not_leak_to_a_later_instruction() {
     let (host_config, host_config_account) =
         host_config_account_with_verifier(authority, evm_address_of(&key));
 
-    let acl_domain = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
     let value_label = label("verified-input-noleak");
-    let nonce_key = host::acl_nonce_key(acl_domain, authority, value_label);
+    let nonce_key = host::acl_nonce_key(authority, authority, value_label);
     let input_handle = input_handle_for_chain(0x01, 0, 5);
-    let attestation = verified_input_attestation(
-        &key,
-        input_handle,
-        authority.to_bytes(),
-        acl_domain.to_bytes(),
-    );
+    let attestation =
+        verified_input_attestation(&key, input_handle, user.to_bytes(), authority.to_bytes());
 
     let output_acl_record = host::acl_record_address(nonce_key, 0).0;
     // An empty account standing in for the ACL record the input would need but was never granted.
@@ -7203,11 +7198,11 @@ fn mollusk_fhe_eval_verified_input_does_not_leak_to_a_later_instruction() {
         attestation,
         amount_plaintext(2),
         context_id,
-        acl_domain,
+        authority,
         nonce_key,
         value_label,
         output_acl_record,
-        vec![AclSubjectEntry::use_only(authority)],
+        vec![AclSubjectEntry::use_only(user)],
     );
     assert_transaction_success(&context, &[consume_ix]);
 
@@ -7239,19 +7234,16 @@ fn mollusk_fhe_eval_verified_input_rejects_wrong_output_acl_domain_key() {
     let (host_config, host_config_account) =
         host_config_account_with_verifier(authority, evm_address_of(&key));
 
-    let attested_domain = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
     let wrong_domain = Pubkey::new_unique();
     let value_label = label("verified-input-domain");
-    // Output ACL metadata is internally consistent with the WRONG domain, isolating the failure to
-    // the verified-input domain binding rather than a nonce-key / metadata mismatch.
+    // The attested contract is the app authority (`authority`); the output is bound under a WRONG
+    // domain. Output metadata is internally consistent with the wrong domain, isolating the failure
+    // to the verified-input domain binding rather than a nonce-key / metadata mismatch.
     let nonce_key = host::acl_nonce_key(wrong_domain, authority, value_label);
     let input_handle = input_handle_for_chain(0x01, 0, 5);
-    let attestation = verified_input_attestation(
-        &key,
-        input_handle,
-        authority.to_bytes(),
-        attested_domain.to_bytes(),
-    );
+    let attestation =
+        verified_input_attestation(&key, input_handle, user.to_bytes(), authority.to_bytes());
 
     let output_acl_record = host::acl_record_address(nonce_key, 0).0;
     let context = transient_context(
@@ -7273,7 +7265,7 @@ fn mollusk_fhe_eval_verified_input_rejects_wrong_output_acl_domain_key() {
         nonce_key,
         value_label,
         output_acl_record,
-        vec![AclSubjectEntry::use_only(authority)],
+        vec![AclSubjectEntry::use_only(user)],
     );
 
     let result = context.process_instruction(&eval_ix);
@@ -7293,16 +7285,12 @@ fn mollusk_fhe_eval_verified_input_propagates_public_decrypt_to_durable_output()
     let (host_config, host_config_account) =
         host_config_account_with_verifier(authority, evm_address_of(&key));
 
-    let acl_domain = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
     let value_label = label("verified-input-pubdec");
-    let nonce_key = host::acl_nonce_key(acl_domain, authority, value_label);
+    let nonce_key = host::acl_nonce_key(authority, authority, value_label);
     let input_handle = input_handle_for_chain(0x01, 0, 5);
-    let attestation = verified_input_attestation(
-        &key,
-        input_handle,
-        authority.to_bytes(),
-        acl_domain.to_bytes(),
-    );
+    let attestation =
+        verified_input_attestation(&key, input_handle, user.to_bytes(), authority.to_bytes());
 
     let output_acl_record = host::acl_record_address(nonce_key, 0).0;
     let context = transient_context(
@@ -7335,11 +7323,11 @@ fn mollusk_fhe_eval_verified_input_propagates_public_decrypt_to_durable_output()
         attestation,
         scalar,
         context_id,
-        acl_domain,
+        authority,
         nonce_key,
         value_label,
         output_acl_record,
-        vec![AclSubjectEntry::user(authority)],
+        vec![AclSubjectEntry::user(user)],
     );
 
     assert_transaction_success(&context, &[eval_ix]);
@@ -7351,11 +7339,67 @@ fn mollusk_fhe_eval_verified_input_propagates_public_decrypt_to_durable_output()
         output_handle,
         nonce_key,
         0,
-        acl_domain,
+        authority,
         authority,
         value_label,
-        authority,
+        user,
         host::ACL_ROLE_ALL,
         context.mollusk.sysvars.clock.slot,
+    );
+}
+
+/// (f) Replay guard: a copied (public) attestation cannot be consumed by a signer other than the
+/// attested app authority. An attacker who lifts a victim's on-chain attestation and submits their
+/// own `fhe_eval` — claiming the derived output for themselves — is rejected because the output app
+/// account is forced to equal the attested `contract_address`, and the output app account must
+/// itself sign (here the attacker signs as themselves, not as the attested app). This is the
+/// non-replayable binding: only the attested app (signing directly or via CPI) can consume.
+#[test]
+fn mollusk_fhe_eval_verified_input_rejects_consumption_by_non_attested_app() {
+    let program_id = host::id();
+    let attacker = Pubkey::new_unique(); // signs the malicious eval (app_account_authority)
+    let attested_app = Pubkey::new_unique(); // the attested contract — the attacker does not control it
+    let user = Pubkey::new_unique(); // the attested input owner (the victim the proof was made for)
+    let key = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(attacker, evm_address_of(&key));
+
+    let value_label = label("verified-input-replay");
+    // The attacker binds the output domain to the attested app (so the domain pin passes) but owns
+    // the output themselves; the app_account == attested-contract check is what trips.
+    let nonce_key = host::acl_nonce_key(attested_app, attacker, value_label);
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    // A VALID attestation for (user, attested_app), as if copied from the victim's instruction data.
+    let attestation =
+        verified_input_attestation(&key, input_handle, user.to_bytes(), attested_app.to_bytes());
+
+    let output_acl_record = host::acl_record_address(nonce_key, 0).0;
+    let context = transient_context(
+        attacker,
+        vec![
+            (host_config, host_config_account),
+            (output_acl_record, system_account(0)),
+        ],
+    );
+
+    // attacker signs as app_account_authority/output_app_account (= `attacker`, != attested_app).
+    let eval_ix = verified_input_add_eval_ix(
+        program_id,
+        attacker,
+        host_config,
+        attestation,
+        amount_plaintext(2),
+        label("verified-input-frame"),
+        attested_app,
+        nonce_key,
+        value_label,
+        output_acl_record,
+        vec![AclSubjectEntry::use_only(user)],
+    );
+
+    let result = context.process_instruction(&eval_ix);
+    assert_instruction_custom_error(
+        &result,
+        host::errors::ZamaHostError::InputBindContractMismatch,
     );
 }

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -29,9 +29,10 @@ use zama_host::{
         HandleMaterialSealedEvent, InputVerifiedEvent, PublicDecryptAllowedEvent,
         TrivialEncryptEvent,
     },
-    AclPermission, AclRecord, AclSubjectEntry, DenySubjectRecord, FheBinaryOpCode, FheEvalArgs,
-    FheEvalOperand, FheEvalOutput, FheEvalStep, FheTernaryOpCode, HandleMaterialCommitment,
-    HostConfig, TransientCapabilityGrant, TransientSession, UserDecryptionDelegation,
+    AclPermission, AclRecord, AclSubjectEntry, CoprocessorInputAttestation, DenySubjectRecord,
+    FheBinaryOpCode, FheEvalArgs, FheEvalOperand, FheEvalOutput, FheEvalStep, FheTernaryOpCode,
+    HandleMaterialCommitment, HostConfig, TransientCapabilityGrant, TransientSession,
+    UserDecryptionDelegation,
 };
 
 #[test]
@@ -6447,7 +6448,10 @@ fn host_config_account_with_verifier(
                 test_authority: admin,
                 paused: false,
                 mock_input_enabled: false,
-                test_shims_enabled: false,
+                // Enable zero birth entropy (test_shims + local poc chain) so eval handle
+                // derivation is deterministic; the real secp256k1 verify path is still exercised
+                // because mock_input_enabled stays false.
+                test_shims_enabled: true,
                 grant_deny_list_enabled: false,
                 updated_slot: 0,
                 bump,
@@ -6876,4 +6880,397 @@ fn label(name: &str) -> [u8; 32] {
     assert!(bytes.len() <= out.len());
     out[..bytes.len()].copy_from_slice(bytes);
     out
+}
+
+// --- fhe_eval VerifiedInput operand: consume an attested input in-frame, no scratch PDA (#1539) ---
+
+/// Signs a coprocessor EIP-712 attestation over `[input_handle]` for (user, contract) and packs it
+/// into a `VerifiedInput` operand attestation. The attested `contract_address` is the input's
+/// acl_domain_key.
+fn verified_input_attestation(
+    key: &k256::ecdsa::SigningKey,
+    input_handle: [u8; 32],
+    user_address: [u8; 32],
+    contract_address: [u8; 32],
+) -> CoprocessorInputAttestation {
+    let ct_handles = vec![input_handle];
+    let contract_chain_id = 12345u64;
+    let extra_data = vec![0x00u8];
+    let digest = host::eip712::typed_data_digest(
+        &host::eip712::domain_separator(
+            b"InputVerification",
+            b"1",
+            GATEWAY_CHAIN_ID,
+            &INPUT_VERIFICATION_CONTRACT,
+        ),
+        &host::eip712::ciphertext_verification_struct_hash(
+            &ct_handles,
+            &user_address,
+            &contract_address,
+            contract_chain_id,
+            &extra_data,
+        ),
+    );
+    CoprocessorInputAttestation {
+        input_handle,
+        ct_handles,
+        handle_index: 0,
+        user_address,
+        contract_address,
+        contract_chain_id,
+        extra_data,
+        signatures: vec![sign_eip712(key, &digest)],
+    }
+}
+
+/// Builds a one-step `fhe_eval` that adds `scalar` to a `VerifiedInput` operand and binds a durable
+/// output ACL record under `acl_domain` (the `output_acl_record` PDA goes in `remaining_accounts`).
+#[allow(clippy::too_many_arguments)]
+fn verified_input_add_eval_ix(
+    program_id: Pubkey,
+    authority: Pubkey,
+    host_config: Pubkey,
+    attestation: CoprocessorInputAttestation,
+    scalar: [u8; 32],
+    context_id: [u8; 32],
+    acl_domain: Pubkey,
+    nonce_key: [u8; 32],
+    encrypted_value_label: [u8; 32],
+    output_acl_record: Pubkey,
+) -> Instruction {
+    let mut eval_ix = anchor_ix(
+        program_id,
+        host::accounts::FheEval {
+            payer: authority,
+            compute_subject: authority,
+            app_account_authority: authority,
+            host_config,
+            system_program: system_program::ID,
+            instructions_sysvar: None,
+            event_authority: event_authority(program_id),
+            program: program_id,
+        },
+        host::instruction::FheEval {
+            args: FheEvalArgs {
+                context_id,
+                steps: vec![FheEvalStep::Binary {
+                    op: FheBinaryOpCode::Add,
+                    lhs: FheEvalOperand::VerifiedInput { attestation },
+                    rhs: FheEvalOperand::Scalar(scalar),
+                    output_fhe_type: 5,
+                    output: FheEvalOutput::Durable {
+                        output_acl_record_index: 0,
+                        output_app_account_authority_index: None,
+                        output_nonce_key: nonce_key,
+                        output_nonce_sequence: 0,
+                        output_acl_domain_key: acl_domain,
+                        output_app_account: authority,
+                        output_encrypted_value_label: encrypted_value_label,
+                        output_subjects: vec![AclSubjectEntry::use_only(authority)],
+                        output_public_decrypt: false,
+                    },
+                }],
+            },
+        },
+    );
+    eval_ix
+        .accounts
+        .push(AccountMeta::new(output_acl_record, false));
+    eval_ix
+}
+
+/// (a) A verified input feeds a scalar add in one `fhe_eval`; the durable output binds the expected
+/// handle + AclRecord under the app-level acl_domain_key — no scratch PDA for the input.
+#[test]
+fn mollusk_fhe_eval_verified_input_scalar_add_binds_durable_output() {
+    let program_id = host::id();
+    let authority = Pubkey::new_unique();
+    let key = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(authority, evm_address_of(&key));
+
+    // The attested contract IS the app-level ACL domain key (#3).
+    let acl_domain = Pubkey::new_unique();
+    let encrypted_value_label = label("verified-input-add");
+    let nonce_key = host::acl_nonce_key(acl_domain, authority, encrypted_value_label);
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    let attestation = verified_input_attestation(
+        &key,
+        input_handle,
+        authority.to_bytes(),
+        acl_domain.to_bytes(),
+    );
+
+    let output_acl_record = host::acl_record_address(nonce_key, 0).0;
+    let context = transient_context(
+        authority,
+        vec![
+            (host_config, host_config_account),
+            (output_acl_record, system_account(0)),
+        ],
+    );
+
+    let scalar = amount_plaintext(2);
+    let context_id = label("verified-input-frame");
+    let output_handle = current_bound_eval_handle(
+        &context.mollusk,
+        FheBinaryOpCode::Add,
+        input_handle,
+        scalar,
+        true,
+        5,
+        context_id,
+        0,
+        nonce_key,
+        0,
+    );
+
+    let eval_ix = verified_input_add_eval_ix(
+        program_id,
+        authority,
+        host_config,
+        attestation,
+        scalar,
+        context_id,
+        acl_domain,
+        nonce_key,
+        encrypted_value_label,
+        output_acl_record,
+    );
+
+    assert_transaction_success(&context, &[eval_ix]);
+
+    let output_record =
+        read_acl_record(&context, output_acl_record).expect("expected durable output ACL");
+    assert_bound_acl_record(
+        &output_record,
+        output_handle,
+        nonce_key,
+        0,
+        acl_domain,
+        authority,
+        encrypted_value_label,
+        authority,
+        host::ACL_ROLE_USE,
+        context.mollusk.sysvars.clock.slot,
+    );
+}
+
+/// Builds a one-step `fhe_eval` that adds `scalar` to a *durable* input operand (its ACL record
+/// goes in `remaining_accounts`), producing a transient result. Used to show a verified input
+/// leaves behind no durable ACL a later instruction could ride on.
+fn durable_input_add_eval_ix(
+    program_id: Pubkey,
+    authority: Pubkey,
+    host_config: Pubkey,
+    input_handle: [u8; 32],
+    input_acl_record: Pubkey,
+    scalar: [u8; 32],
+    context_id: [u8; 32],
+) -> Instruction {
+    let mut eval_ix = anchor_ix(
+        program_id,
+        host::accounts::FheEval {
+            payer: authority,
+            compute_subject: authority,
+            app_account_authority: authority,
+            host_config,
+            system_program: system_program::ID,
+            instructions_sysvar: None,
+            event_authority: event_authority(program_id),
+            program: program_id,
+        },
+        host::instruction::FheEval {
+            args: FheEvalArgs {
+                context_id,
+                steps: vec![FheEvalStep::Binary {
+                    op: FheBinaryOpCode::Add,
+                    lhs: FheEvalOperand::Durable {
+                        handle: input_handle,
+                        acl_record_index: 0,
+                        permission_index: None,
+                    },
+                    rhs: FheEvalOperand::Scalar(scalar),
+                    output_fhe_type: 5,
+                    output: FheEvalOutput::Transient,
+                }],
+            },
+        },
+    );
+    eval_ix
+        .accounts
+        .push(AccountMeta::new_readonly(input_acl_record, false));
+    eval_ix
+}
+
+/// (b) An attestation signed by a key the host config does not trust as the coprocessor signer is
+/// rejected: VerifiedInput resolution enforces the secp256k1 verification in-frame, it is not
+/// assumed from the operand being present.
+#[test]
+fn mollusk_fhe_eval_verified_input_rejects_forged_attestation() {
+    let program_id = host::id();
+    let authority = Pubkey::new_unique();
+    let trusted = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let attacker = k256::ecdsa::SigningKey::from_bytes(&[0x99u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(authority, evm_address_of(&trusted));
+
+    let acl_domain = Pubkey::new_unique();
+    let value_label = label("verified-input-forged");
+    let nonce_key = host::acl_nonce_key(acl_domain, authority, value_label);
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    // Signed by the attacker, not the trusted coprocessor signer.
+    let attestation = verified_input_attestation(
+        &attacker,
+        input_handle,
+        authority.to_bytes(),
+        acl_domain.to_bytes(),
+    );
+
+    let output_acl_record = host::acl_record_address(nonce_key, 0).0;
+    let context = transient_context(
+        authority,
+        vec![
+            (host_config, host_config_account),
+            (output_acl_record, system_account(0)),
+        ],
+    );
+
+    let eval_ix = verified_input_add_eval_ix(
+        program_id,
+        authority,
+        host_config,
+        attestation,
+        amount_plaintext(2),
+        label("verified-input-frame"),
+        acl_domain,
+        nonce_key,
+        value_label,
+        output_acl_record,
+    );
+
+    let result = context.process_instruction(&eval_ix);
+    assert!(
+        result.raw_result.is_err(),
+        "forged attestation must be rejected"
+    );
+}
+
+/// (c) No leak: a verified input grants access only inside the instruction that carries its
+/// attestation. After it is consumed, no durable or scratch state persists, so a later instruction
+/// cannot reach the same input handle without re-supplying the attestation — this is what justifies
+/// resolving it in-frame with no PDA.
+#[test]
+fn mollusk_fhe_eval_verified_input_does_not_leak_to_a_later_instruction() {
+    let program_id = host::id();
+    let authority = Pubkey::new_unique();
+    let key = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(authority, evm_address_of(&key));
+
+    let acl_domain = Pubkey::new_unique();
+    let value_label = label("verified-input-noleak");
+    let nonce_key = host::acl_nonce_key(acl_domain, authority, value_label);
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    let attestation = verified_input_attestation(
+        &key,
+        input_handle,
+        authority.to_bytes(),
+        acl_domain.to_bytes(),
+    );
+
+    let output_acl_record = host::acl_record_address(nonce_key, 0).0;
+    // An empty account standing in for the ACL record the input would need but was never granted.
+    let absent_input_acl = Pubkey::new_unique();
+    let context = transient_context(
+        authority,
+        vec![
+            (host_config, host_config_account),
+            (output_acl_record, system_account(0)),
+            (absent_input_acl, system_account(0)),
+        ],
+    );
+    let context_id = label("verified-input-frame");
+
+    // 1) Consume the verified input in-frame: succeeds and binds the durable output.
+    let consume_ix = verified_input_add_eval_ix(
+        program_id,
+        authority,
+        host_config,
+        attestation,
+        amount_plaintext(2),
+        context_id,
+        acl_domain,
+        nonce_key,
+        value_label,
+        output_acl_record,
+    );
+    assert_transaction_success(&context, &[consume_ix]);
+
+    // 2) A separate instruction cannot use the same input handle durably — nothing persisted it.
+    let reuse_ix = durable_input_add_eval_ix(
+        program_id,
+        authority,
+        host_config,
+        input_handle,
+        absent_input_acl,
+        amount_plaintext(2),
+        label("verified-input-reuse"),
+    );
+    let result = context.process_instruction(&reuse_ix);
+    assert!(
+        result.raw_result.is_err(),
+        "verified input must not be reachable without re-verifying"
+    );
+}
+
+/// (d) The output of a verified input must bind the acl_domain_key the input was attested for.
+/// Binding the output under a different domain (a cross-domain move) is rejected — the only
+/// violation here is attested-domain != bound-domain (the output metadata is otherwise consistent).
+#[test]
+fn mollusk_fhe_eval_verified_input_rejects_wrong_output_acl_domain_key() {
+    let program_id = host::id();
+    let authority = Pubkey::new_unique();
+    let key = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(authority, evm_address_of(&key));
+
+    let attested_domain = Pubkey::new_unique();
+    let wrong_domain = Pubkey::new_unique();
+    let value_label = label("verified-input-domain");
+    // Output ACL metadata is internally consistent with the WRONG domain, isolating the failure to
+    // the verified-input domain binding rather than a nonce-key / metadata mismatch.
+    let nonce_key = host::acl_nonce_key(wrong_domain, authority, value_label);
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    let attestation = verified_input_attestation(
+        &key,
+        input_handle,
+        authority.to_bytes(),
+        attested_domain.to_bytes(),
+    );
+
+    let output_acl_record = host::acl_record_address(nonce_key, 0).0;
+    let context = transient_context(
+        authority,
+        vec![
+            (host_config, host_config_account),
+            (output_acl_record, system_account(0)),
+        ],
+    );
+
+    let eval_ix = verified_input_add_eval_ix(
+        program_id,
+        authority,
+        host_config,
+        attestation,
+        amount_plaintext(2),
+        label("verified-input-frame"),
+        wrong_domain,
+        nonce_key,
+        value_label,
+        output_acl_record,
+    );
+
+    let result = context.process_instruction(&eval_ix);
+    assert_instruction_custom_error(&result, host::errors::ZamaHostError::AclDomainKeyMismatch);
 }

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -7403,3 +7403,83 @@ fn mollusk_fhe_eval_verified_input_rejects_consumption_by_non_attested_app() {
         host::errors::ZamaHostError::InputBindContractMismatch,
     );
 }
+
+/// (g) Replay guard through a transient session: a verified-input-derived value cannot be parked in
+/// a transient-session capability. The capability does not carry the attested binding, so consuming
+/// it in a later instruction would mint a durable output free of the (user, contract) check — the
+/// exact bypass that would otherwise defeat (f). The attempt to write
+/// `VerifiedInput + Scalar -> TransientSession` is rejected up front.
+#[test]
+fn mollusk_fhe_eval_verified_input_rejects_transient_session_output() {
+    let program_id = host::id();
+    let authority = Pubkey::new_unique(); // signs the eval and opens the session
+    let user = Pubkey::new_unique(); // the attested input owner
+    let key = k256::ecdsa::SigningKey::from_bytes(&[0x44u8; 32].into()).unwrap();
+    let (host_config, host_config_account) =
+        host_config_account_with_verifier(authority, evm_address_of(&key));
+
+    let session_nonce = label("verified-input-session");
+    let (session, _) = host::transient_session_address(authority, session_nonce);
+    let context = transient_context(
+        authority,
+        vec![
+            (host_config, host_config_account),
+            (session, system_account(0)),
+        ],
+    );
+
+    // Open a real session owned by `authority`, as an attacker would before trying to park the input.
+    let create_ix = create_transient_session_ix(
+        program_id,
+        authority,
+        host_config,
+        session,
+        session_nonce,
+        authority,
+        0,
+        1,
+    );
+    context.process_and_validate_instruction(&create_ix, &[Check::success()]);
+
+    let input_handle = input_handle_for_chain(0x01, 0, 5);
+    let attestation =
+        verified_input_attestation(&key, input_handle, user.to_bytes(), authority.to_bytes());
+
+    let mut eval_ix = anchor_ix(
+        program_id,
+        host::accounts::FheEval {
+            payer: authority,
+            compute_subject: authority,
+            app_account_authority: authority,
+            host_config,
+            system_program: system_program::ID,
+            instructions_sysvar: None,
+            event_authority: event_authority(program_id),
+            program: program_id,
+        },
+        host::instruction::FheEval {
+            args: FheEvalArgs {
+                context_id: label("verified-input-frame"),
+                steps: vec![FheEvalStep::Binary {
+                    op: FheBinaryOpCode::Add,
+                    lhs: FheEvalOperand::VerifiedInput { attestation },
+                    rhs: FheEvalOperand::Scalar(amount_plaintext(2)),
+                    output_fhe_type: 5,
+                    output: FheEvalOutput::TransientSession {
+                        session_index: 0,
+                        capability: transient_capability(
+                            authority, program_id, authority, authority, true,
+                        ),
+                    },
+                }],
+            },
+        },
+    );
+    eval_ix.accounts.push(AccountMeta::new(session, false));
+
+    let result = context.process_instruction(&eval_ix);
+    assert_instruction_custom_error(
+        &result,
+        host::errors::ZamaHostError::InputBindTransientSessionUnsupported,
+    );
+}

--- a/solana/scripts/poc/full-vertical.sh
+++ b/solana/scripts/poc/full-vertical.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 KMS="$(cd "$ROOT/../../zama/kms" 2>/dev/null && pwd || echo /Users/work/code/zama/kms)"
 VALUE="${TE_VALUE:-55}"
+# Input-flow leg: encrypt IV (default 56) as an external input, then one fhe_eval adds ADD (default 2)
+# to it on-chain and the result is public-decrypted == IV+ADD (parametrized so it can't pass on a
+# trivial/hardcoded value).
+IV="${INPUT_VALUE:-56}"
+ADD="${INPUT_ADD:-2}"
 CTX="${SOLANA_UD_CONTEXT_ID:-3166189940082864718613269121331309980362851143201109172953918312716374638593}"
 # extraData = version 0x01 ‖ 32-byte BE gateway KMS context id. The gateway/KMS context is the
 # uint256 `0x07..01` (chain-type tag 0x07 in the high byte ‖ u64 id 1 in the low 8 bytes); the KMS
@@ -50,7 +55,7 @@ done
 iout="$(cd "$ROOT/test-suite/fhevm" && \
   IN_RELAYER_URL=http://127.0.0.1:3000 IN_CONTRACTS_CHAIN_ID="$SID" IN_ACL_PROGRAM="$ACL" \
   IN_CONTRACT="$USER" IN_USER="$USER" IN_CONTRACT_B58="$USER_B58" IN_USER_B58="$USER_B58" \
-  IN_VALUE=42 IN_TYPE=uint64 \
+  IN_VALUE="$IV" IN_TYPE=uint64 \
   node solana-input.ts 2>/dev/null || true)"
 ipost="$(printf '%s\n' "$iout" | grep -oE '"jobId":"[^"]+"' | head -1 | cut -d'"' -f4 || true)"
 [ -n "$ipost" ] || fail "input-proof POST failed (last client output: $(printf '%s\n' "$iout" | tail -2))"
@@ -112,6 +117,45 @@ echo "==> [user-decrypt] V2 path: public @fhevm/sdk/solana client -> relayer /v3
     cargo test -p kms --features non-wasm --test solana_user_decrypt_live -- --ignored --nocapture ) \
   || fail "user-decrypt test failed"
 echo "    user-decrypt cleartext=$VALUE OK (V2 ed25519 via public @fhevm/sdk/solana client)"
+
+# Input flow (#1539): compute on the VERIFIED external input itself. One fhe_eval adds $ADD to the
+# attested input in-frame (FheEvalOperand::VerifiedInput — re-verified on-chain via secp256k1, no
+# scratch PDA) and binds the result to a durable output ACL record under the attested acl_domain_key
+# ($USER). Reuses the proof captured above ($ih/$isig/$iextra, value $IV), so this proves the result
+# is a function of the encrypted input, not a fresh value.
+EXPECT=$((IV + ADD))
+echo "==> [input-flow] fhe_eval VerifiedInput($IV) + $ADD -> durable @ acl_domain_key -> public-decrypt (expect $EXPECT)"
+eout="$(cd "$ROOT/solana/scripts/poc/live-client" && \
+  FHE_EVAL_VERIFIED_INPUT=1 BIND_HANDLE="$ih" BIND_COPRO_SIG="$isig" BIND_USER="$USER" \
+  BIND_CONTRACT="$USER" BIND_CHAIN_ID="$SID" BIND_EXTRA="$iextra" TE_ADD="$ADD" TE_ALLOW=1 \
+  ./target/debug/poc-live-client 2>&1)"
+echo "$eout" | grep -E 'result handle|allow_for_decryption' || fail "fhe_eval verified-input: $eout"
+RH="$(echo "$eout" | grep -oE 'result handle 0x[0-9a-f]+' | grep -oE '0x[0-9a-f]+')"
+[ -n "$RH" ] || fail "no input-flow result handle"
+echo "    result handle=$RH"
+
+echo "==> [input-flow] wait for SNS commit (tfhe/sns-worker computes input + $ADD)"
+RHH="${RH#0x}"
+for i in $(seq 1 30); do
+  row="$(docker exec coprocessor-and-kms-db psql -U postgres -d coprocessor -tAc \
+    "SELECT ciphertext IS NOT NULL, ciphertext128 IS NOT NULL FROM ciphertext_digest WHERE handle=decode('$RHH','hex')" 2>/dev/null | tr -d '[:space:]')"
+  [ "$row" = "t|t" ] && { echo "    committed"; break; }
+  [ "$i" = 30 ] && fail "input-flow SNS commit timed out"; sleep 6
+done
+
+echo "==> [input-flow] public-decrypt result"
+ejob="$(curl -s -m15 localhost:3000/v2/public-decrypt -H 'content-type: application/json' \
+  -d "{\"ciphertextHandles\":[\"$RH\"],\"extraData\":\"$EXTRA\"}" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['jobId'])")"
+for i in $(seq 1 40); do
+  er="$(curl -s -m10 "localhost:3000/v2/public-decrypt/$ejob")"
+  est="$(echo "$er" | python3 -c "import sys,json;print(json.load(sys.stdin).get('status',''))" 2>/dev/null)"
+  [ "$est" = succeeded ] && break
+  [ "$est" = failed ] && fail "input-flow public-decrypt failed: $er"
+  [ "$i" = 40 ] && fail "input-flow public-decrypt timed out"; sleep 3
+done
+edv="$(echo "$er" | python3 -c "import sys,json;print(int(json.load(sys.stdin)['result']['decryptedValue'],16))")"
+[ "$edv" = "$EXPECT" ] && echo "    input-flow public-decrypt cleartext=$edv == $IV+$ADD OK" \
+  || fail "input-flow $edv != $EXPECT"
 
 echo "==> [consume] confidential mint + USDC; wrap -> burn -> release -> public-decrypt -> redeem(secp) + disclose(secp)"
 LCDIR="$ROOT/solana/scripts/poc/live-client"
@@ -200,4 +244,4 @@ disout="$(lc CONSUME_DISCLOSE=1 TS_ACL="$BURNED_ACL" TS_HANDLE="$BURNED_HANDLE" 
 echo "$disout" | grep -q 'OK disclose_amount_secp' || fail "disclose_amount_secp: $(echo "$disout" | tail -3)"
 echo "    disclose_amount_secp OK -- witness-bound secp256k1 KMS-cert verify emitted cleartext $CLEARTEXT"
 
-echo "==> FULL VERTICAL GREEN: input(ZK+secp bind) -> compute -> public-decrypt($VALUE) + user-decrypt($VALUE) -> consume redeem($CLEARTEXT)+disclose($CLEARTEXT) [secp256k1 KMS cert]"
+echo "==> FULL VERTICAL GREEN: input(ZK+secp bind) -> compute -> public-decrypt($VALUE) + user-decrypt($VALUE) -> input-flow(VerifiedInput $IV+$ADD -> public-decrypt $EXPECT) -> consume redeem($CLEARTEXT)+disclose($CLEARTEXT) [secp256k1 KMS cert]"

--- a/solana/scripts/poc/live-client/main.rs
+++ b/solana/scripts/poc/live-client/main.rs
@@ -64,6 +64,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
+    // FHE_EVAL_VERIFIED_INPUT drives the #1539 input flow in one fhe_eval: a Binary Add of a
+    // coprocessor-attested external input (FheEvalOperand::VerifiedInput, re-verified in-frame via
+    // secp256k1 with no scratch PDA) and a public scalar, binding the result to a durable output ACL
+    // record under the attested acl_domain_key. The attestation comes from the same relayer
+    // input-proof the BIND_INPUT leg uses (BIND_* env); TE_ADD is the scalar addend (default 2);
+    // TE_ALLOW makes the result publicly decryptable. Proves encrypt V -> +2 -> decrypt V+2.
+    if std::env::var("FHE_EVAL_VERIFIED_INPUT").is_ok() {
+        fhe_eval_verified_input_add(&host, &payer, host_config)?;
+        return Ok(());
+    }
+
     // CONSUME_WRAP: deposit public USDC into a confidential balance (wrap_usdc) — the balance
     // a subsequent confidential_burn draws from on the redeem path. MINT + WRAP_AMOUNT via env.
     if std::env::var("CONSUME_WRAP").is_ok() {
@@ -455,6 +466,156 @@ fn trivial_encrypt_eval(
     let handle_hex: String = record.handle.iter().map(|b| format!("{b:02x}")).collect();
     println!("  output ACL record {output_acl_record}");
     println!("  result handle 0x{handle_hex}  (tfhe-worker materializes this ciphertext)");
+
+    if std::env::var("TE_ALLOW").is_ok() {
+        let allow_sig = host
+            .request()
+            .accounts(zama_host::accounts::AllowForDecryption {
+                authority: payer.pubkey(),
+                authority_permission_record: None,
+                acl_record: output_acl_record,
+                host_config,
+                deny_subject_record: None,
+                event_authority: zama_event_authority,
+                program: zama_host::ID,
+            })
+            .args(zama_host::instruction::AllowForDecryption {
+                handle: record.handle,
+            })
+            .send()?;
+        println!("OK allow_for_decryption (public): {allow_sig}");
+    }
+    Ok(())
+}
+
+/// Input flow leg (#1539): one fhe_eval that adds a public scalar to a coprocessor-attested external
+/// input and binds the result to a durable output ACL record. The verified input is resolved in-frame
+/// (FheEvalOperand::VerifiedInput) — its attestation is re-verified on-chain via secp256k1 with no
+/// scratch PDA — and the durable output is pinned to the attested acl_domain_key (the input's domain;
+/// the on-chain binding rejects any other). The attestation is supplied via the same BIND_* env vars
+/// the standalone input-verify leg uses; TE_ADD is the scalar addend (default 2). The host-listener
+/// ingests the emitted FheBinaryOpEvent so the tfhe-worker materializes (input + TE_ADD); TE_ALLOW
+/// then makes the result publicly decryptable.
+fn fhe_eval_verified_input_add(
+    host: &Program<Rc<Keypair>>,
+    payer: &Rc<Keypair>,
+    host_config: Pubkey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use anchor_lang::solana_program::instruction::AccountMeta;
+
+    // Attestation from the relayer input-proof (same inputs as BIND_INPUT).
+    let input_handle: [u8; 32] = hexdec(&std::env::var("BIND_HANDLE")?)
+        .try_into()
+        .expect("BIND_HANDLE must be 32 bytes");
+    let signature: [u8; 65] = hexdec(&std::env::var("BIND_COPRO_SIG")?)
+        .try_into()
+        .expect("BIND_COPRO_SIG must be 65 bytes");
+    let user_address: [u8; 32] = hexdec(&std::env::var("BIND_USER")?)
+        .try_into()
+        .expect("BIND_USER must be 32 bytes");
+    let contract_address: [u8; 32] = hexdec(&std::env::var("BIND_CONTRACT")?)
+        .try_into()
+        .expect("BIND_CONTRACT must be 32 bytes");
+    let contract_chain_id: u64 = std::env::var("BIND_CHAIN_ID")?.parse()?;
+    let extra_data = std::env::var("BIND_EXTRA")
+        .map(|s| hexdec(&s))
+        .unwrap_or_else(|_| vec![0u8]);
+
+    // The attested contract IS the input's acl_domain_key; the durable output must bind that exact
+    // domain (the on-chain VerifiedInput -> durable binding enforces it). app_account is the signer.
+    let acl_domain_key = Pubkey::new_from_array(contract_address);
+    let app_account = payer.pubkey();
+
+    // Scalar addend (default 2). ClearConst reads big-endian, so place the u64 in the low bytes.
+    let addend: u64 = std::env::var("TE_ADD")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2);
+    let mut scalar = [0u8; 32];
+    scalar[24..32].copy_from_slice(&addend.to_be_bytes());
+    let fhe_type: u8 = 5; // euint64
+
+    // Label distinct from the trivial-encrypt legs ([1]/[2] markers) so output PDAs never collide;
+    // keyed on the input handle tail so distinct inputs derive distinct output records.
+    let mut encrypted_value_label = [3u8; 32];
+    encrypted_value_label[24..32].copy_from_slice(&input_handle[24..32]);
+    let output_nonce_key =
+        zama_host::acl_nonce_key(acl_domain_key, app_account, encrypted_value_label);
+    let output_nonce_sequence: u64 = 0;
+    let (output_acl_record, _) =
+        zama_host::acl_record_address(output_nonce_key, output_nonce_sequence);
+    let (zama_event_authority, _) =
+        Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &zama_host::ID);
+    // ACL_ROLE_ALL (user) grants USE | GRANT | PUBLIC_DECRYPT so the subject can later mark the
+    // result publicly decryptable. public_decrypt MUST be false at birth; allow_for_decryption flips
+    // it after.
+    let subjects = vec![zama_host::AclSubjectEntry::user(payer.pubkey())];
+
+    // Non-zero context-id domain separator for this eval's transient handles.
+    let mut context_id = [0u8; 32];
+    context_id[0] = 0xe0;
+    context_id[24..32].copy_from_slice(&input_handle[24..32]);
+
+    let attestation = zama_host::CoprocessorInputAttestation {
+        input_handle,
+        ct_handles: vec![input_handle],
+        handle_index: 0,
+        user_address,
+        contract_address,
+        contract_chain_id,
+        extra_data,
+        signatures: vec![signature],
+    };
+
+    let args = zama_host::FheEvalArgs {
+        context_id,
+        steps: vec![zama_host::FheEvalStep::Binary {
+            op: zama_host::FheBinaryOpCode::Add,
+            lhs: zama_host::FheEvalOperand::VerifiedInput { attestation },
+            rhs: zama_host::FheEvalOperand::Scalar(scalar),
+            output_fhe_type: fhe_type,
+            output: zama_host::FheEvalOutput::Durable {
+                output_acl_record_index: 0,
+                output_app_account_authority_index: None,
+                output_nonce_key,
+                output_nonce_sequence,
+                output_acl_domain_key: acl_domain_key,
+                output_app_account: app_account,
+                output_encrypted_value_label: encrypted_value_label,
+                output_subjects: subjects,
+                output_public_decrypt: false,
+            },
+        }],
+    };
+
+    let input_hex: String = input_handle.iter().map(|b| format!("{b:02x}")).collect();
+    println!("fhe_eval verified input 0x{input_hex} + {addend} (euint64)");
+    let sig = host
+        .request()
+        .accounts(zama_host::accounts::FheEval {
+            payer: payer.pubkey(),
+            compute_subject: payer.pubkey(),
+            app_account_authority: payer.pubkey(),
+            host_config,
+            system_program: system_program::ID,
+            instructions_sysvar: None,
+            event_authority: zama_event_authority,
+            program: zama_host::ID,
+        })
+        // The single durable output ACL record is remaining_accounts[0] (writable, created by the
+        // eval executor); referenced by output_acl_record_index: 0 in the plan.
+        .accounts(vec![AccountMeta::new(output_acl_record, false)])
+        .args(zama_host::instruction::FheEval { args })
+        .send_with_spinner_and_config(anchor_client::RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..Default::default()
+        })?;
+    println!("OK fhe_eval verified-input add: {sig}");
+
+    let record: zama_host::AclRecord = host.account(output_acl_record)?;
+    let handle_hex: String = record.handle.iter().map(|b| format!("{b:02x}")).collect();
+    println!("  output ACL record {output_acl_record}");
+    println!("  result handle 0x{handle_hex}  (tfhe-worker materializes input + {addend})");
 
     if std::env::var("TE_ALLOW").is_ok() {
         let allow_sig = host


### PR DESCRIPTION
## What

Implements the Solana input → compute → decrypt flow (fhevm-internal#1539): a verified external input becomes an **instruction-local** `fhe_eval` operand, so verify + compute + bind happen in one instruction with no app program and no scratch PDA.

### On-chain (`zama-host`)
- `FheEvalOperand::VerifiedInput { attestation }` — resolved in-frame by re-running the secp256k1 coprocessor attestation check (reuses the existing input-verifier), treated like the existing instruction-local `Transient` operand. No account, no PDA: the allow exists only for the instruction's execution.
- **Cross-domain binding:** a verified input carries its attested `acl_domain_key` forward as a per-lineage taint (mirroring the existing `public_decrypt_allowed` taint). Any durable output derived from it must bind that exact domain, else `AclDomainKeyMismatch`. This prevents moving an input attested for domain X into a different domain Y.
- The path is purely additive — no change to the existing durable / transient / transient-session operands.

### Tests (mollusk, must-have a–d)
- (a) verified input + scalar add → correct output handle + `AclRecord` under the attested `acl_domain_key`
- (b) forged / wrong-signer attestation → rejected (verification enforced, not assumed)
- (c) no-leak: the input is not usable in a later instruction without re-verifying — proves the allow is instruction-local and nothing persists (justifies no PDA)
- (d) binding the output under a wrong `acl_domain_key` → rejected

Full mollusk suite 65/65; `cargo test --workspace`, `clippy -D warnings`, `fmt --check` all green. Re-vendored the host-listener IDL for the new operand/attestation types.

### e2e (PoC scripts)
- `poc-live-client`: `FHE_EVAL_VERIFIED_INPUT` mode builds the one-step `fhe_eval[VerifiedInput + Scalar(ADD), Add → Durable @ acl_domain_key]` + `allow_for_decryption`, reusing the relayer attestation the input-verify leg already produces.
- `full-vertical.sh`: new input-flow leg — encrypt `IV` (default 56) → `fhe_eval(+2)` → public-decrypt, asserting `== IV+ADD` (parametrized on `IV` so it can't pass on a hardcoded value).

`acl_domain_key` stays the app-level `$USER` domain across the SDK input proof, the attestation `contract_address`, and the on-chain `output_acl_domain_key` (not the program id) — consistent at the three points by construction.

## Notes
- The full-vertical live leg is a local PoC run (not part of CI). CI here covers the on-chain program, unit tests, clippy/fmt, and the vendored-IDL drift check.
