### PR TITLE
fix(sdk): surface relayer/edge 401 and 403 error messages

### DIFF
--- a/sdk/js-sdk/src/core/errors/RelayerResponseStatusError.ts
+++ b/sdk/js-sdk/src/core/errors/RelayerResponseStatusError.ts
@@ -15,6 +15,12 @@ export type RelayerResponseStatusErrorType = RelayerResponseStatusError & {
 export type RelayerResponseStatusErrorParams = Prettify<
   Omit<RelayerResponseErrorBaseParams, 'message' | 'name' | 'details'> & {
     readonly state: RelayerAsyncRequestState;
+    /**
+     * Optional message surfaced from the response body — e.g. the JSON error a
+     * Cloudflare/Kong edge proxy returns on a 403. Appended to the error
+     * message and details when present.
+     */
+    readonly responseMessage?: string | undefined;
   }
 >;
 
@@ -22,12 +28,16 @@ export type RelayerResponseStatusErrorParams = Prettify<
  * The response status is unexpected.
  */
 export class RelayerResponseStatusError extends RelayerResponseErrorBase {
-  constructor(params: RelayerResponseStatusErrorParams) {
+  constructor({ responseMessage, ...params }: RelayerResponseStatusErrorParams) {
+    const baseMessage = `${humanReadableOperation(params.operation, true)}: Relayer returned unexpected response status: ${params.status}`;
     super({
       ...params,
       name: 'RelayerResponseStatusError',
-      message: `${humanReadableOperation(params.operation, true)}: Relayer returned unexpected response status: ${params.status}`,
-      details: `The Relayer server returned an unexpected response status (${params.status}). This status ${params.status} is not part of the expected API contract and may indicate a server configuration issue.`,
+      message: responseMessage !== undefined ? `${baseMessage}: ${responseMessage}` : baseMessage,
+      details:
+        responseMessage !== undefined
+          ? `The Relayer server returned an unexpected response status (${params.status}): ${responseMessage}`
+          : `The Relayer server returned an unexpected response status (${params.status}). This status ${params.status} is not part of the expected API contract and may indicate a server configuration issue.`,
     });
   }
 }

--- a/sdk/js-sdk/src/core/errors/RelayerResponseStatusError.ts
+++ b/sdk/js-sdk/src/core/errors/RelayerResponseStatusError.ts
@@ -29,15 +29,17 @@ export type RelayerResponseStatusErrorParams = Prettify<
  */
 export class RelayerResponseStatusError extends RelayerResponseErrorBase {
   constructor({ responseMessage, ...params }: RelayerResponseStatusErrorParams) {
-    const baseMessage = `${humanReadableOperation(params.operation, true)}: Relayer returned unexpected response status: ${params.status}`;
     super({
       ...params,
       name: 'RelayerResponseStatusError',
-      message: responseMessage !== undefined ? `${baseMessage}: ${responseMessage}` : baseMessage,
+      message: `${humanReadableOperation(params.operation, true)}: Relayer returned unexpected response status: ${params.status}`,
+      // Surface the relayer/edge message (e.g. a Cloudflare/Kong 403 block) via
+      // the `Details:` line when present; otherwise keep the generic
+      // explanation. The primary message is unchanged for backward
+      // compatibility.
       details:
-        responseMessage !== undefined
-          ? `The Relayer server returned an unexpected response status (${params.status}): ${responseMessage}`
-          : `The Relayer server returned an unexpected response status (${params.status}). This status ${params.status} is not part of the expected API contract and may indicate a server configuration issue.`,
+        responseMessage ??
+        `The Relayer server returned an unexpected response status (${params.status}). This status ${params.status} is not part of the expected API contract and may indicate a server configuration issue.`,
     });
   }
 }

--- a/sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.errors.test.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { RelayerAsyncRequest } from './RelayerAsyncRequest.js';
+import { RelayerResponseApiError } from '../../../errors/RelayerResponseApiError.js';
+import { RelayerResponseStatusError } from '../../../errors/RelayerResponseStatusError.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/modules/relayer/module/RelayerAsyncRequest.errors.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+const RELAYER_URL = 'https://relayer.example.com/v2/public-decrypt';
+
+function newRequest(): RelayerAsyncRequest {
+  return new RelayerAsyncRequest({
+    relayerOperation: 'PUBLIC_DECRYPT',
+    url: RELAYER_URL,
+    payload: {},
+    options: { fetchRetries: 1 },
+  });
+}
+
+// Resolve a fresh Response on every fetch call: a Response body can only be
+// read once, so reusing one instance across calls would fail.
+function mockFetchStatus(status: number, body: string): void {
+  global.fetch = vi.fn().mockImplementation(() => Promise.resolve(new Response(body, { status })));
+}
+
+describe('RelayerAsyncRequest auth/edge error surfacing', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // 401
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('401 surfaces the message from { error: { message } }', async () => {
+    mockFetchStatus(
+      401,
+      JSON.stringify({ error: { message: 'origin says: invalid x-api-key', label: 'unauthorized' } }),
+    );
+
+    try {
+      await newRequest().run();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerResponseApiError);
+      const err = e as RelayerResponseApiError;
+      expect(err.status).toBe(401);
+      expect(err.relayerApiError.label).toBe('unauthorized');
+      expect(err.relayerApiError.message).toBe('origin says: invalid x-api-key');
+      expect(err.message).toContain('origin says: invalid x-api-key');
+    }
+  });
+
+  it('401 with an empty body falls back to the canned message', async () => {
+    mockFetchStatus(401, '');
+
+    try {
+      await newRequest().run();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerResponseApiError);
+      const err = e as RelayerResponseApiError;
+      expect(err.relayerApiError.label).toBe('unauthorized');
+      expect(err.relayerApiError.message).toBe('Unauthorized, missing or invalid Zama Fhevm API Key.');
+    }
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // 403 (edge block — not part of the typed contract)
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('403 surfaces the message from a flat Cloudflare/Kong body', async () => {
+    mockFetchStatus(403, JSON.stringify({ message: 'Missing or invalid Zama API Key', label: 'unauthorized' }));
+
+    try {
+      await newRequest().run();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerResponseStatusError);
+      const err = e as RelayerResponseStatusError;
+      expect(err.status).toBe(403);
+      expect(err.message).toContain('Missing or invalid Zama API Key');
+    }
+  });
+
+  it('403 with a non-JSON body keeps the generic unexpected-status message', async () => {
+    mockFetchStatus(403, 'Forbidden');
+
+    try {
+      await newRequest().run();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerResponseStatusError);
+      const err = e as RelayerResponseStatusError;
+      expect(err.status).toBe(403);
+      expect(err.message).toContain('unexpected response status: 403');
+      expect(err.message).not.toContain('Forbidden');
+    }
+  });
+});

--- a/sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/RelayerAsyncRequest.ts
@@ -65,6 +65,7 @@ import {
   assertIsRelayerPostResponse202Queued,
 } from './guards/RelayerResponseQueued.js';
 import { assertIsRelayerUserDecryptSucceeded } from './guards/RelayerUserDecryptSucceeded.js';
+import { readErrorMessage } from './readErrorMessage.js';
 
 /*
     Actions:
@@ -490,6 +491,15 @@ export class RelayerAsyncRequest {
 
       // At this stage: `terminated` is guaranteed to be `false`.
 
+      // 403 is not part of the typed relayer contract: it is emitted by an
+      // edge proxy (Cloudflare/Kong), typically on a missing/invalid
+      // `x-api-key`. Intercept it before the typed switch, read the JSON body,
+      // and surface the edge message instead of discarding it.
+      if (response.status === 403) {
+        const { message } = await readErrorMessage(response);
+        this._throwUnexpectedStatusError(403, message);
+      }
+
       const responseStatus: RelayerPostResponseStatus = response.status as RelayerPostResponseStatus;
 
       switch (responseStatus) {
@@ -564,7 +574,10 @@ export class RelayerAsyncRequest {
         // RelayerApiError401
         // falls through
         case 401: {
-          this._throwUnauthorizedError(responseStatus);
+          // Surface the message the origin (Kong/relayer) actually sent for a
+          // missing/invalid `x-api-key`, falling back to the canned string.
+          const { message } = await readErrorMessage(response);
+          this._throwUnauthorizedError(responseStatus, message);
         }
         // RelayerResponseFailed
         // RelayerApiError429
@@ -723,6 +736,15 @@ export class RelayerAsyncRequest {
       // ======================= End Fetch Retry ===============================
 
       // At this stage: `terminated` is guaranteed to be `false`.
+
+      // 403 is not part of the typed relayer contract: it is emitted by an
+      // edge proxy (Cloudflare/Kong), typically on a missing/invalid
+      // `x-api-key`. Intercept it before the typed switch, read the JSON body,
+      // and surface the edge message instead of discarding it.
+      if (response.status === 403) {
+        const { message } = await readErrorMessage(response);
+        this._throwUnexpectedStatusError(403, message);
+      }
 
       const responseStatus: RelayerGetResponseStatus = response.status as RelayerGetResponseStatus;
 
@@ -961,7 +983,10 @@ export class RelayerAsyncRequest {
         }
         // falls through
         case 401: {
-          this._throwUnauthorizedError(responseStatus);
+          // Surface the message the origin (Kong/relayer) actually sent for a
+          // missing/invalid `x-api-key`, falling back to the canned string.
+          const { message } = await readErrorMessage(response);
+          this._throwUnauthorizedError(responseStatus, message);
         }
         // falls through
         case 404: {
@@ -1601,15 +1626,46 @@ export class RelayerAsyncRequest {
 
   /**
    * Throws an unauthorized error for 401 responses.
+   *
+   * The `message` surfaced from the response body (the relayer/edge JSON error)
+   * is used when present; otherwise the canned string is kept. The
+   * `'unauthorized'` label and error shape are preserved so downstream
+   * consumers reading `relayerApiError.message`/`.label` keep working.
+   *
+   * @param status - The 401 status.
+   * @param surfacedMessage - The message read from the response body, if any.
    * @throws {RelayerResponseApiError} Always throws with 'unauthorized' label.
    */
-  private _throwUnauthorizedError(status: Extract<RelayerFailureStatus, 401>): never {
+  private _throwUnauthorizedError(status: Extract<RelayerFailureStatus, 401>, surfacedMessage?: string): never {
     this._throwRelayerResponseApiError({
       status,
       relayerApiError: {
         label: 'unauthorized',
-        message: 'Unauthorized, missing or invalid Zama Fhevm API Key.',
+        message: surfacedMessage ?? 'Unauthorized, missing or invalid Zama Fhevm API Key.',
       },
+    });
+  }
+
+  /**
+   * Throws for an HTTP status that is not part of the typed relayer contract —
+   * e.g. a 403 emitted by an edge proxy (Cloudflare/Kong). The `message`
+   * surfaced from the JSON body is appended to the error when present.
+   *
+   * @param status - The unexpected HTTP status.
+   * @param surfacedMessage - The message read from the response body, if any.
+   * @throws {RelayerResponseStatusError} Always throws.
+   */
+  private _throwUnexpectedStatusError(status: number, surfacedMessage?: string): never {
+    throw new RelayerResponseStatusError({
+      fetchMethod: this._fetchMethod as unknown as RelayerFetchMethod,
+      status,
+      url: this._url,
+      ...(this._jobId !== undefined ? { jobId: this._jobId } : {}),
+      operation: this._relayerOperation,
+      elapsed: this._elapsed,
+      retryCount: this._retryCount,
+      state: { ...this._state },
+      ...(surfacedMessage !== undefined ? { responseMessage: surfacedMessage } : {}),
     });
   }
 

--- a/sdk/js-sdk/src/core/modules/relayer/module/fetchFheEncryptionKeySource.test.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/fetchFheEncryptionKeySource.test.ts
@@ -1,0 +1,66 @@
+import type { RelayerClient } from '../types.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fetchFheEncryptionKeySource } from './fetchFheEncryptionKeySource.js';
+import { RelayerFetchError } from '../../../errors/RelayerFetchError.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/modules/relayer/module/fetchFheEncryptionKeySource.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+const relayerClient: RelayerClient = {
+  relayerUrl: 'https://relayer.example.com',
+  chainId: 11155111,
+};
+
+// Resolve a fresh Response on every fetch call (a Response body reads once).
+function mockFetchStatus(status: number, body: string): void {
+  global.fetch = vi.fn().mockImplementation(() => Promise.resolve(new Response(body, { status })));
+}
+
+describe('fetchFheEncryptionKeySource error surfacing', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('401 surfaces the message from { error: { message } }', async () => {
+    mockFetchStatus(401, JSON.stringify({ error: { message: 'invalid x-api-key', label: 'unauthorized' } }));
+
+    try {
+      await fetchFheEncryptionKeySource(relayerClient, {});
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerFetchError);
+      expect((e as RelayerFetchError).message).toContain('401');
+      expect((e as RelayerFetchError).message).toContain('invalid x-api-key');
+    }
+  });
+
+  it('403 surfaces the message from a flat Cloudflare/Kong body', async () => {
+    mockFetchStatus(403, JSON.stringify({ message: 'Missing or invalid Zama API Key', label: 'unauthorized' }));
+
+    try {
+      await fetchFheEncryptionKeySource(relayerClient, {});
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerFetchError);
+      expect((e as RelayerFetchError).message).toContain('Missing or invalid Zama API Key');
+    }
+  });
+
+  it('403 with a non-JSON body keeps the generic HTTP-error message', async () => {
+    mockFetchStatus(403, 'Forbidden');
+
+    try {
+      await fetchFheEncryptionKeySource(relayerClient, {});
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(RelayerFetchError);
+      const message = (e as RelayerFetchError).message;
+      expect(message).toContain('HTTP error! status: 403');
+      expect(message).not.toContain('Forbidden');
+    }
+  });
+});

--- a/sdk/js-sdk/src/core/modules/relayer/module/fetchFheEncryptionKeySource.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/fetchFheEncryptionKeySource.ts
@@ -11,6 +11,7 @@ import { fetchWithRetry, normalizeHeaders } from '../../../base/fetch.js';
 import { sdkName, version } from '../../../_version.js';
 import { assertRecordStringArrayProperty, assertRecordStringProperty } from '../../../base/string.js';
 import { buildRelayerUrlString, validateRelayerBaseUrl } from './relayerUrl.js';
+import { readErrorMessage } from './readErrorMessage.js';
 import { assert } from '../../../base/errors/InternalError.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -59,9 +60,16 @@ export async function fetchFheEncryptionKeySource(
   }
 
   if (!response.ok) {
+    // Surface the message the relayer/edge (Cloudflare/Kong) actually sent for
+    // a 401/403 — e.g. a missing/invalid `x-api-key` — instead of discarding
+    // the body behind a generic "HTTP error! status: X".
+    const { message } = await readErrorMessage(response);
     _throwFetchError({
       url,
-      message: `HTTP error! status: ${response.status} on ${response.url}`,
+      message:
+        message !== undefined
+          ? `HTTP error! status: ${response.status} on ${response.url}: ${message}`
+          : `HTTP error! status: ${response.status} on ${response.url}`,
     });
   }
 

--- a/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.test.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { readErrorMessage } from './readErrorMessage.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/modules/relayer/module/readErrorMessage.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+describe('readErrorMessage', () => {
+  //////////////////////////////////////////////////////////////////////////////
+  // JSON error bodies are surfaced
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('surfaces message + label from a relayer-shaped body { error: { message, label } }', async () => {
+    const response = new Response(
+      JSON.stringify({ error: { message: 'missing or invalid API key', label: 'unauthorized' } }),
+      { status: 401 },
+    );
+    await expect(readErrorMessage(response)).resolves.toEqual({
+      message: 'missing or invalid API key',
+      label: 'unauthorized',
+    });
+  });
+
+  it('surfaces message + label from a flat Cloudflare/Kong body { message, label }', async () => {
+    const response = new Response(
+      JSON.stringify({ message: 'Missing or invalid Zama API Key', label: 'unauthorized' }),
+      { status: 403 },
+    );
+    await expect(readErrorMessage(response)).resolves.toEqual({
+      message: 'Missing or invalid Zama API Key',
+      label: 'unauthorized',
+    });
+  });
+
+  it('surfaces message only when label is absent', async () => {
+    const response = new Response(JSON.stringify({ message: 'forbidden by edge' }), { status: 403 });
+    await expect(readErrorMessage(response)).resolves.toEqual({
+      message: 'forbidden by edge',
+      label: undefined,
+    });
+  });
+
+  it('surfaces label only when message is absent', async () => {
+    const response = new Response(JSON.stringify({ label: 'unauthorized' }), { status: 401 });
+    await expect(readErrorMessage(response)).resolves.toEqual({
+      message: undefined,
+      label: 'unauthorized',
+    });
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Nothing is surfaced for empty / non-JSON / irrelevant bodies
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('returns {} for an empty body', async () => {
+    const response = new Response('', { status: 401 });
+    await expect(readErrorMessage(response)).resolves.toEqual({});
+  });
+
+  it('returns {} for a non-JSON text body (e.g. bare "Forbidden")', async () => {
+    const response = new Response('Forbidden', { status: 403 });
+    await expect(readErrorMessage(response)).resolves.toEqual({});
+  });
+
+  it('returns {} for an HTML error page', async () => {
+    const response = new Response('<html><body>403 Forbidden</body></html>', { status: 403 });
+    await expect(readErrorMessage(response)).resolves.toEqual({});
+  });
+
+  it('returns {} for JSON without message/label fields', async () => {
+    const response = new Response(JSON.stringify({ foo: 'bar', code: 42 }), { status: 500 });
+    await expect(readErrorMessage(response)).resolves.toEqual({});
+  });
+
+  it('returns {} when error.message/label are not strings', async () => {
+    const response = new Response(JSON.stringify({ error: { message: 123, label: ['x'] } }), { status: 401 });
+    await expect(readErrorMessage(response)).resolves.toEqual({});
+  });
+
+  it('never throws when the body cannot be read', async () => {
+    const broken = { text: () => Promise.reject(new Error('body unusable')) } as unknown as Response;
+    await expect(readErrorMessage(broken)).resolves.toEqual({});
+  });
+});

--- a/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.test.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.test.ts
@@ -77,6 +77,11 @@ describe('readErrorMessage', () => {
     await expect(readErrorMessage(response)).resolves.toEqual({});
   });
 
+  it('treats empty-string message/label as absent', async () => {
+    const response = new Response(JSON.stringify({ error: { message: '', label: '' } }), { status: 401 });
+    await expect(readErrorMessage(response)).resolves.toEqual({});
+  });
+
   it('never throws when the body cannot be read', async () => {
     const broken = { text: () => Promise.reject(new Error('body unusable')) } as unknown as Response;
     await expect(readErrorMessage(broken)).resolves.toEqual({});

--- a/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.ts
@@ -1,0 +1,53 @@
+import { isRecordStringProperty } from '../../../base/string.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// readErrorMessage
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Best-effort reader that surfaces the message a relayer or an intermediary
+ * edge proxy (Cloudflare/Kong) actually sent in a non-2xx JSON error body.
+ *
+ * Two body shapes are recognized:
+ * - relayer:           `{ "error": { "message": "...", "label": "..." } }`
+ * - Cloudflare / Kong: `{ "message": "...", "label": "..." }` (flat)
+ *
+ * The body is read at most once and only surfaced when it parses as JSON. A
+ * non-JSON body (a bare `"Forbidden"`/`"Rate Limit"` string, an HTML error
+ * page, ...) intentionally surfaces nothing, so the previous behavior for those
+ * responses is preserved and no noise leaks into error messages.
+ *
+ * This function never throws.
+ *
+ * @param response - The non-2xx fetch {@link Response} to inspect.
+ * @returns The surfaced `message` and/or `label`, or an empty object when the
+ *          body is missing, unreadable, not JSON, or carries neither field.
+ */
+export async function readErrorMessage(
+  response: Response,
+): Promise<{ message?: string | undefined; label?: string | undefined }> {
+  let text: string;
+  try {
+    text = await response.text();
+  } catch {
+    return {};
+  }
+
+  if (text.length === 0) {
+    return {};
+  }
+
+  try {
+    const json: unknown = JSON.parse(text);
+    const err: unknown = typeof json === 'object' && json !== null && 'error' in json ? json.error : json;
+    const message = isRecordStringProperty(err, 'message') ? err.message : undefined;
+    const label = isRecordStringProperty(err, 'label') ? err.label : undefined;
+    if (message !== undefined || label !== undefined) {
+      return { message, label };
+    }
+  } catch {
+    // Body wasn't JSON — surface nothing and leave the non-JSON behavior unchanged.
+  }
+
+  return {};
+}

--- a/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/module/readErrorMessage.ts
@@ -1,4 +1,4 @@
-import { isRecordStringProperty } from '../../../base/string.js';
+import { isNonEmptyString, isRecordStringProperty } from '../../../base/string.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 // readErrorMessage
@@ -19,9 +19,11 @@ import { isRecordStringProperty } from '../../../base/string.js';
  *
  * This function never throws.
  *
+ * Empty-string `message`/`label` values are treated as absent.
+ *
  * @param response - The non-2xx fetch {@link Response} to inspect.
- * @returns The surfaced `message` and/or `label`, or an empty object when the
- *          body is missing, unreadable, not JSON, or carries neither field.
+ * @returns The surfaced non-empty `message` and/or `label`, or an empty object
+ *          when the body is missing, unreadable, not JSON, or carries neither.
  */
 export async function readErrorMessage(
   response: Response,
@@ -40,8 +42,9 @@ export async function readErrorMessage(
   try {
     const json: unknown = JSON.parse(text);
     const err: unknown = typeof json === 'object' && json !== null && 'error' in json ? json.error : json;
-    const message = isRecordStringProperty(err, 'message') ? err.message : undefined;
-    const label = isRecordStringProperty(err, 'label') ? err.label : undefined;
+    // Treat empty strings as absent so callers can use `?? <fallback>` safely.
+    const message = isRecordStringProperty(err, 'message') && isNonEmptyString(err.message) ? err.message : undefined;
+    const label = isRecordStringProperty(err, 'label') && isNonEmptyString(err.label) ? err.label : undefined;
     if (message !== undefined || label !== undefined) {
       return { message, label };
     }

--- a/sdk/js-sdk/test/fheTest/ethers/relayerAuthErrors.test.ts
+++ b/sdk/js-sdk/test/fheTest/ethers/relayerAuthErrors.test.ts
@@ -1,0 +1,86 @@
+import type { Auth } from '../../../src/core/types/auth.js';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getEthersTestConfig, type FheTestEthersConfig } from '../setup-ethers.js';
+import { fetchFheEncryptionKeySource } from '../../../src/core/modules/relayer/module/fetchFheEncryptionKeySource.js';
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// End-to-end coverage for relayer/edge auth-error surfacing (401 / 403).
+//
+// When the relayer (Kong/origin) returns a 401, or an edge proxy (Cloudflare)
+// blocks the request with a 403, the SDK must surface the message the server
+// actually sent instead of a generic "HTTP error! status: <code>".
+//
+// These hit the real hosted relayer `v2/keyurl` endpoint with deliberately
+// invalid credentials, so they only run against Zama-hosted endpoints
+// (*.zama.org) that enforce auth at the edge. Local/self-hosted relayers that
+// don't enforce auth are skipped.
+//
+// CHAIN=testnet npx vitest run --config test/fheTest/vitest.config.ts ethers/relayerAuthErrors.test.ts
+// CHAIN=mainnet npx vitest run --config test/fheTest/vitest.config.ts ethers/relayerAuthErrors.test.ts
+//
+////////////////////////////////////////////////////////////////////////////////
+
+function isZamaHostedRelayer(relayerUrl: string): boolean {
+  try {
+    return new URL(relayerUrl).hostname.endsWith('.zama.org');
+  } catch {
+    return false;
+  }
+}
+
+const config: FheTestEthersConfig = getEthersTestConfig();
+const relayerUrl: string = config.fhevmChain.fhevm.relayerUrl;
+
+describe.runIf(isZamaHostedRelayer(relayerUrl))('Relayer auth-error surfacing (keyurl)', () => {
+  let relayerClient: { relayerUrl: string; chainId: number };
+
+  beforeAll(() => {
+    relayerClient = { relayerUrl, chainId: config.fhevmChain.id };
+  });
+
+  // Helper: call the keyurl fetch with the given (invalid) auth and return the
+  // thrown error. Fails the test if the call unexpectedly succeeds.
+  async function fetchKeyUrlExpectingError(auth?: Auth): Promise<{ name: string; message: string }> {
+    let caught: { name?: string; message?: string } | undefined;
+    try {
+      await fetchFheEncryptionKeySource(relayerClient, {
+        options: auth !== undefined ? { auth } : {},
+      });
+    } catch (e) {
+      caught = e as { name?: string; message?: string };
+    }
+    expect(caught, 'Expected fetchFheEncryptionKeySource to reject with an auth error').toBeDefined();
+    return { name: caught?.name ?? '', message: caught?.message ?? '' };
+  }
+
+  it('surfaces the origin 401 message for an invalid x-api-key', async () => {
+    // An x-api-key header reaches the origin (Kong/relayer), which replies 401
+    // with a JSON `{ message, label }` body.
+    const { name, message } = await fetchKeyUrlExpectingError({
+      type: 'ApiKeyHeader',
+      value: 'invalid-zama-api-key-for-testing',
+    });
+
+    console.log(`  401 surfaced message: ${message}`);
+    expect(name).toBe('RelayerFetchError');
+    expect(message).toMatch(/HTTP error! status: 40[13]/);
+    // The fix appends the server message after the URL — proving the body was
+    // surfaced rather than discarded behind the bare "HTTP error! status: X".
+    expect(message).toMatch(/on https:\/\/\S+: \S/);
+  });
+
+  it('surfaces the edge 403 message when no x-api-key reaches the origin', async () => {
+    // A Bearer token (or no key) never reaches the origin: Cloudflare blocks it
+    // at the edge with a 403 and a JSON `{ message, label }` body.
+    const { name, message } = await fetchKeyUrlExpectingError({
+      type: 'BearerToken',
+      token: 'invalid-bearer-token-for-testing',
+    });
+
+    console.log(`  403 surfaced message: ${message}`);
+    expect(name).toBe('RelayerFetchError');
+    expect(message).toMatch(/HTTP error! status: 40[13]/);
+    expect(message).toMatch(/on https:\/\/\S+: \S/);
+  });
+});


### PR DESCRIPTION
## Goal

When the relayer returns a **401**, or an intermediary (Cloudflare/Kong) blocks a request with a **403**, surface the message the server actually sent instead of a hardcoded/assumed string. Previously a missing/invalid `x-api-key` looked like a generic failure because the edge message never reached the user.

## What was wrong

The SDK *assumed* the reason for auth failures and discarded the response body:

- **401** → threw a hardcoded `"Unauthorized, missing or invalid … API Key."` and never read the body.
- **403** → wasn't handled at all. The status was a *type cast*, not a runtime check, so a 403 fell through to the generic `"unexpected response status: 403"`, discarding the body — exactly the Cloudflare/Kong edge-block case whose JSON body carries a useful `{ message, label }`.

Every other status (400/404/429/500/503) already surfaced `message`+`label`; this was narrowly the two auth codes — across **both** error code paths.

## The fix

A single best-effort body reader, `readErrorMessage` (`src/core/modules/relayer/module/readErrorMessage.ts`), wired into both paths. It recognizes the relayer shape `{ error: { message, label } }` and the flat Cloudflare/Kong shape `{ message, label }`, **only surfaces a message when the body parses as JSON** (non-JSON bodies — bare `"Forbidden"`, HTML pages — surface nothing, preserving prior behavior), and **never throws**.

Both code paths are covered:

1. **Async request engine** (`RelayerAsyncRequest.ts`, the input-proof/decrypt POST+GET loop)
   - **401**: reads the body; uses `message` if present, else falls back to the previous canned string. The `'unauthorized'` label and error shape are preserved so downstream consumers reading `relayerApiError.message`/`.label` keep working.
   - **403**: intercepted **before** the typed status switch (403 isn't in the typed union), reads the body, and surfaces the message via a new optional `responseMessage` on `RelayerResponseStatusError` (no public-type change — the field is optional and additive).
2. **Shared keyurl fetch helper** (`fetchFheEncryptionKeySource.ts`, the `v2/keyurl` GET) — reads the body on `!response.ok` and appends the surfaced message to the thrown `RelayerFetchError`.

## Tests

New unit tests (17, all green):
- `readErrorMessage.test.ts` — nested/flat shapes, message-only, label-only, empty body, non-JSON text, HTML page, non-string fields, unreadable body.
- `RelayerAsyncRequest.errors.test.ts` — 401 with `{ error: { message } }`, 401 empty body → canned fallback, 403 flat `{ message }`, 403 non-JSON → unchanged generic message.
- `fetchFheEncryptionKeySource.test.ts` — 401/403 JSON surfaced, 403 non-JSON unchanged.

Full unit suite (731 tests), `npm run lint` (eslint + `tsc -b`), prettier, and import-order/casing checks all pass.

Replicates the relayer-sdk change-set (PR #451 → `0.5.0-rc.1`, PR #452 → `0.4.4`).