### PR TITLE
chore(common): faster mergify pr cancelation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,9 @@ queue_rules:
     merge_method: squash
     update_method: rebase
     merge_conditions:
+      # Fail fast: this job throws on a failed docker build, so the batch is
+      # dequeued immediately instead of waiting on the never-emitted e2e check.
+      # `or check-skipped` keeps non-orchestrated contributor PRs (job skipped) green.
       - or:
         - check-success = create-e2e-tests-input
         - check-skipped = create-e2e-tests-input

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,9 @@ queue_rules:
     merge_method: squash
     update_method: rebase
     merge_conditions:
+      - or:
+        - check-success = create-e2e-tests-input
+        - check-skipped = create-e2e-tests-input
       - check-success = run-e2e-tests / fhevm-e2e-test
     queue_conditions:
       - base = main


### PR DESCRIPTION
### What

This PR aims to speed up Mergify cancellation on docker build failures, such as in this [PR](https://github.com/zama-ai/fhevm/pull/2822).

### Why

The merge queue gates on `check-success = run-e2e-tests / fhevm-e2e-test`.
When a docker build fails in the batch, the `run-e2e-tests` job (a reusable workflow) is skipped, so its inner `fhevm-e2e-test` check is never created.
Mergify keeps waiting for a check that never arrives, leaving the batch stuck until the 12h `checks_timeout` instead of failing fast.

### Fix

Add `create-e2e-tests-input` as a merge condition.
Unlike `run-e2e-tests`, this job runs on `success() || failure()` and throws an error when a build fails, so it reports a definite failure and let Mergify dequeue immediately.

Because `create-e2e-tests-input` is a top-level job, it reports as skipped on regular contributor PRs (where the orchestrate workflow doesn't run). So to avoid flagging those PRs as failed, the condition is wrapped in an `or` with both `check-skipped` / `check-success`.

In the merge-queue batch PR, the job's `if` is always true (head ref starts with `mergify/merge-queue/`), so it's never skipped there, the fast-cancel-on-build-failure behavior is thus fully preserved, while individual PRs are not marked as failed.