### PR TITLE
chore(common): revert faster mergify pr cancelation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,12 +21,6 @@ queue_rules:
     merge_method: squash
     update_method: rebase
     merge_conditions:
-      # Fail fast: this job throws on a failed docker build, so the batch is
-      # dequeued immediately instead of waiting on the never-emitted e2e check.
-      # `or check-skipped` keeps non-orchestrated contributor PRs (job skipped) green.
-      - or:
-        - check-success = create-e2e-tests-input
-        - check-skipped = create-e2e-tests-input
       - check-success = run-e2e-tests / fhevm-e2e-test
     queue_conditions:
       - base = main


### PR DESCRIPTION
Reverts zama-ai/fhevm#2829

Due to a flaky behavior of the e2e tests in Mergify branch (triggered twice because of the `cla-signed` labelling AFAIU, so one of the two get cancelled), we need to revert this until we fix this flakiness, or we'll get our PR blocked as for this [one](https://github.com/zama-ai/fhevm/pull/2843).