### PR TITLE
feat(listener): add Yellowstone gRPC integration

### DIFF
--- a/.github/workflows/solana-e2e.yml
+++ b/.github/workflows/solana-e2e.yml
@@ -95,3 +95,100 @@ jobs:
         if: ${{ always() }}
         working-directory: test-suite/fhevm
         run: ./fhevm-cli clean || true
+
+  # Adjacent run: the SAME full vertical, but with zama-host compiled EMITLESS (no
+  # `emit-events`) and the coprocessor fed purely by gRPC off-chain RECONSTRUCTION
+  # (Yellowstone geyser plugin on the validator) instead of on-chain emit-decode. Proves
+  # the decrypt vertical stands alone on reconstruction once the program stops emitting.
+  # Same trigger/scenario; the deltas are the geyser-image build step + RECONSTRUCT=1, which
+  # the Solana side-stack (setup-solana-side.sh) keys off of.
+  solana-e2e-reconstruct:
+    name: solana-e2e/full-vertical-reconstruct
+    runs-on: large_ubuntu_32
+    timeout-minutes: 120
+    permissions:
+      contents: "read" # checkout
+      packages: "read" # pull repo-owned images from ghcr.io
+    env:
+      TE_VALUE: ${{ inputs.te-value }}
+      RECONSTRUCT: "1"
+      GEYSER_IMAGE: poc-solana-validator-yellowstone:ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: "false"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+
+      - name: Setup Foundry
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Setup Solana + Anchor toolchain
+        run: |
+          set -euo pipefail
+          rustup target add wasm32-unknown-unknown
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+          cargo install --git https://github.com/coral-xyz/anchor --tag v0.31.1 anchor-cli --locked
+
+      - name: Build Yellowstone geyser validator image
+        # Bakes the pinned Yellowstone plugin (v5.0.1+solana.2.1.21, Dockerfile default) into the
+        # matching amd64 Agave 2.1.21 validator; the side-stack runs this image with gRPC :10000.
+        run: |
+          docker build \
+            --build-arg SOLANA_VALIDATOR_IMAGE=anzaxyz/agave:v2.1.21 \
+            -t "$GEYSER_IMAGE" \
+            solana/geyser
+
+      - name: Login to ghcr.io
+        uses: zama-ai/ci-templates/.github/actions/retry@542103e14b9ae6a9aea27787b8724b3b35bb3918 # v1.0.9
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }} # zizmor: ignore[secrets-outside-env] registry read token, same pattern as test-suite-e2e workflows
+        with:
+          run: |
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+      - name: Login to cgr.dev
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CGR_USERNAME }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as test-suite-e2e workflows
+          password: ${{ secrets.CGR_PASSWORD }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as test-suite-e2e workflows
+
+      - name: Install SDK deps (TKMS WASM consumers; pure-SDK user-decrypt)
+        run: cd sdk/js-sdk && npm ci
+
+      - name: Bring up fresh stack + Solana side (clean-e2e.sh)
+        run: bash solana/scripts/poc/clean-e2e.sh
+
+      - name: Drive the Solana decrypt vertical (full-vertical.sh)
+        run: bash solana/scripts/poc/full-vertical.sh
+
+      - name: Collect stack logs on failure
+        if: ${{ failure() }}
+        run: |
+          mkdir -p /tmp/solana-e2e-logs
+          cp /tmp/solana-*.log /tmp/solana-e2e-logs/ 2>/dev/null || true
+          docker ps -a > /tmp/solana-e2e-logs/docker-ps.txt 2>&1 || true
+          docker logs solana-e2e-validator > /tmp/solana-e2e-logs/geyser-validator.log 2>&1 || true
+
+      - name: Upload failure logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: solana-e2e-reconstruct-logs
+          path: /tmp/solana-e2e-logs
+          retention-days: 7
+
+      - name: Tear down the stack
+        if: ${{ always() }}
+        working-directory: test-suite/fhevm
+        run: |
+          docker rm -f solana-e2e-validator || true
+          ./fhevm-cli clean || true

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -1958,6 +1958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "aws-config"
 version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,6 +5235,7 @@ version = "0.7.0"
 dependencies = [
  "alloy",
  "alloy-primitives 1.5.2",
+ "anchor-lang",
  "anyhow",
  "async-trait",
  "aws-config",
@@ -5262,11 +5272,14 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
  "union-find",
  "url",
+ "yellowstone-grpc-proto",
+ "zama-host",
 ]
 
 [[package]]
@@ -7331,6 +7344,15 @@ dependencies = [
  "once_cell",
  "protobuf-support",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]
@@ -12524,6 +12546,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -12541,6 +12564,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -13916,6 +13940,19 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yellowstone-grpc-proto"
+version = "5.0.0+solana.2.1.21"
+source = "git+https://github.com/rpcpool/yellowstone-grpc?tag=v5.0.1%2Bsolana.2.1.21#eeaab8a1c40d5779fff012be87e0e647e440ba20"
+dependencies = [
+ "anyhow",
+ "prost",
+ "prost-types",
+ "protobuf-src",
+ "tonic",
+ "tonic-build",
+]
 
 [[package]]
 name = "yoke"

--- a/coprocessor/fhevm-engine/host-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/host-listener/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [features]
 default = []
 test_bypass_key_extraction = []
+solana-grpc = ["dep:yellowstone-grpc-proto", "dep:tonic"]
+solana-reconstruct = ["dep:zama-host", "dep:anchor-lang"]
 
 [[bin]]
 path = "src/bin/main.rs"
@@ -73,6 +75,21 @@ solana-client = "3.0"
 solana-commitment-config = "3.1"
 solana-sdk = "3.0"
 solana-transaction-status = "3.0"
+
+# Yellowstone gRPC transport (optional; enabled via the `solana-grpc` feature).
+tonic = { workspace = true, optional = true }
+# Pinned to the SAME tag as the baked plugin so client proto == server proto.
+# default-features=false drops the `convert` feature, which would otherwise pull
+# solana-sdk 2.1.x and clash with the solana 3.0 crates above. We drive the tonic
+# GeyserClient directly (no yellowstone-grpc-client, which would re-enable convert).
+yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc", tag = "v5.0.1+solana.2.1.21", default-features = false, features = ["tonic", "tonic-compression"], optional = true }
+
+# Phase 2 reconstruction (optional; enabled via the `solana-reconstruct` feature).
+# no-entrypoint builds the program crate as a host library so we can call its
+# deterministic computed_*_handle functions directly (parity, not a copy).
+zama-host = { path = "../../../solana/programs/zama-host", default-features = false, features = ["no-entrypoint"], optional = true }
+# AnchorDeserialize for reusing zama-host's FheEvalArgs to decode the fhe_eval plan.
+anchor-lang = { version = "1.0.2", optional = true }
 
 # local dependencies
 fhevm-engine-common = { path = "../fhevm-engine-common" }

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -21,6 +21,9 @@ RUN cp host-contracts/.env.example host-contracts/.env && \
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
 ARG CARGO_PROFILE=release
+# Extra cargo features for `-p host-listener` (empty for the mainline EVM build;
+# the Solana stack passes `solana-grpc` to compile the Yellowstone transport).
+ARG CARGO_FEATURES=""
 
 USER root
 
@@ -42,8 +45,11 @@ WORKDIR /app/coprocessor/fhevm-engine
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    if echo "${CARGO_FEATURES}" | grep -q solana-grpc; then \
+        apt-get update && apt-get install -y --no-install-recommends cmake protobuf-compiler && rm -rf /var/lib/apt/lists/*; \
+    fi && \
     cargo fetch && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener && \
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener ${CARGO_FEATURES:+--features "${CARGO_FEATURES}"} && \
     cp target/${CARGO_PROFILE}/host_listener /tmp/host_listener && \
     cp target/${CARGO_PROFILE}/host_listener_poller /tmp/host_listener_poller && \
     cp target/${CARGO_PROFILE}/host_listener_consumer /tmp/host_listener_consumer && \

--- a/coprocessor/fhevm-engine/host-listener/build.rs
+++ b/coprocessor/fhevm-engine/host-listener/build.rs
@@ -462,6 +462,9 @@ fn rust_type(idl_type: &Value) -> String {
             }
             return format!("Vec<[u8; {len}]>");
         }
+        if let Some(defined) = vec_inner["defined"]["name"].as_str() {
+            return format!("Vec<{defined}>");
+        }
         panic!("unsupported IDL vec inner type {vec_inner}");
     }
     if let Some(defined) = idl_type["defined"]["name"].as_str() {
@@ -500,6 +503,9 @@ fn read_expr(idl_type: &Value) -> String {
                 panic!("unsupported IDL vec array element type {element}");
             }
             return format!("cursor.read_vec_array::<{len}>()");
+        }
+        if let Some(defined) = vec_inner["defined"]["name"].as_str() {
+            return format!("cursor.read_vec(read_{})", snake_case(defined));
         }
         panic!("unsupported IDL vec inner type {vec_inner}");
     }
@@ -606,10 +612,342 @@ fn build_contracts() {
     println!("Ran npx hardhat compile successfully");
 }
 
+/// zama-host instructions whose raw (discriminator + borsh args) data we decode
+/// off-chain to reconstruct events without relying on `emit_cpi!`/`emit!`. Curated
+/// so the generator never trips over arg types used only by unrelated instructions;
+/// a listed instruction with an unexpected arg type fails the build loudly.
+const ZAMA_HOST_INSTRUCTION_ALLOWLIST: &[&str] = &[
+    "trivial_encrypt_and_bind",
+    "fhe_binary_op",
+    "fhe_binary_op_and_bind_output",
+    "fhe_ternary_op_and_bind_output",
+    "fhe_rand_and_bind",
+    "fhe_rand_bounded_and_bind",
+    "allow_for_decryption",
+    "allow_acl_subjects",
+    "commit_handle_material",
+];
+
+fn generate_zama_host_instructions() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let idl_path = manifest_dir.join("idl").join("zama_host.json");
+    println!("cargo:rerun-if-changed={}", idl_path.display());
+    let idl = fs::read_to_string(&idl_path).unwrap_or_else(|err| {
+        panic!("failed to read {}: {err}", idl_path.display())
+    });
+    let idl: Value = serde_json::from_str(&idl).unwrap_or_else(|err| {
+        panic!("failed to parse {}: {err}", idl_path.display())
+    });
+
+    let types = idl["types"]
+        .as_array()
+        .expect("Anchor IDL must contain types")
+        .iter()
+        .map(|ty| (ty["name"].as_str().expect("IDL type must have a name"), ty))
+        .collect::<HashMap<_, _>>();
+
+    let instructions = idl["instructions"]
+        .as_array()
+        .expect("Anchor IDL must contain instructions")
+        .iter()
+        .filter(|ins| {
+            ZAMA_HOST_INSTRUCTION_ALLOWLIST
+                .contains(&ins["name"].as_str().unwrap_or_default())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        instructions.len(),
+        ZAMA_HOST_INSTRUCTION_ALLOWLIST.len(),
+        "every allowlisted zama-host instruction must exist in the IDL"
+    );
+
+    // Defined enums + structs referenced by the allowlisted args (in first-seen order).
+    let mut enums = Vec::<&str>::new();
+    let mut structs = Vec::<&str>::new();
+    for ins in &instructions {
+        for arg in ins["args"].as_array().expect("instruction args") {
+            collect_defined_types(&types, &arg["type"], &mut enums, &mut structs);
+        }
+    }
+
+    let mut output = String::from(
+        "// Generated from `host-listener/idl/zama_host.json` by `host-listener/build.rs`.\n// Do not edit by hand.\n\n",
+    );
+
+    for name in &enums {
+        output.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq)]\npub enum ");
+        output.push_str(name);
+        output.push_str(" {\n");
+        for variant in enum_variants(&types, name) {
+            output.push_str("    ");
+            output.push_str(variant);
+            output.push_str(",\n");
+        }
+        output.push_str("}\n\n");
+    }
+
+    for name in &structs {
+        output.push_str("#[derive(Clone, Debug, PartialEq, Eq)]\npub struct ");
+        output.push_str(name);
+        output.push_str(" {\n");
+        for field in fields_for_event(&types, name) {
+            output.push_str("    pub ");
+            output.push_str(field["name"].as_str().expect("field name"));
+            output.push_str(": ");
+            output.push_str(&rust_type(&field["type"]));
+            output.push_str(",\n");
+        }
+        output.push_str("}\n\n");
+    }
+
+    for ins in &instructions {
+        let pascal = pascal_case(ins["name"].as_str().unwrap());
+        output.push_str("#[derive(Clone, Debug, PartialEq, Eq)]\npub struct ");
+        output.push_str(&pascal);
+        output.push_str("Args {\n");
+        for arg in ins["args"].as_array().unwrap() {
+            output.push_str("    pub ");
+            output.push_str(arg["name"].as_str().expect("arg name"));
+            output.push_str(": ");
+            output.push_str(&rust_type(&arg["type"]));
+            output.push_str(",\n");
+        }
+        output.push_str("}\n\n");
+    }
+
+    output.push_str("#[derive(Clone, Debug, PartialEq, Eq)]\npub enum ZamaHostInstruction {\n");
+    for ins in &instructions {
+        let pascal = pascal_case(ins["name"].as_str().unwrap());
+        output.push_str("    ");
+        output.push_str(&pascal);
+        output.push('(');
+        output.push_str(&pascal);
+        output.push_str("Args),\n");
+    }
+    output.push_str("}\n\n");
+
+    output.push_str(
+        "pub fn decode_zama_host_instruction(data: &[u8]) -> Option<ZamaHostInstruction> {\n    if data.len() < 8 {\n        return None;\n    }\n    let (discriminator, payload) = data.split_at(8);\n\n",
+    );
+    for ins in &instructions {
+        let name = ins["name"].as_str().unwrap();
+        let pascal = pascal_case(name);
+        let discriminator = ins["discriminator"]
+            .as_array()
+            .expect("instruction must contain discriminator");
+        output.push_str("    if discriminator == ");
+        output.push_str(&byte_array(discriminator));
+        output.push_str(" {\n        return decode_");
+        output.push_str(name);
+        output.push_str("_args(payload).map(ZamaHostInstruction::");
+        output.push_str(&pascal);
+        output.push_str(");\n    }\n");
+    }
+    output.push_str("\n    None\n}\n\n");
+
+    for ins in &instructions {
+        let name = ins["name"].as_str().unwrap();
+        let pascal = pascal_case(name);
+        output.push_str("fn decode_");
+        output.push_str(name);
+        output.push_str("_args(payload: &[u8]) -> Option<");
+        output.push_str(&pascal);
+        output.push_str("Args> {\n    let mut cursor = Cursor::new(payload);\n    let args = ");
+        output.push_str(&pascal);
+        output.push_str("Args {\n");
+        for arg in ins["args"].as_array().unwrap() {
+            output.push_str("        ");
+            output.push_str(arg["name"].as_str().unwrap());
+            output.push_str(": ");
+            output.push_str(&read_expr(&arg["type"]));
+            output.push_str("?,\n");
+        }
+        output.push_str("    };\n    cursor.is_finished().then_some(args)\n}\n\n");
+    }
+
+    for name in &enums {
+        output.push_str("fn read_");
+        output.push_str(&snake_case(name));
+        output.push_str("(cursor: &mut Cursor<'_>) -> Option<");
+        output.push_str(name);
+        output.push_str("> {\n    match cursor.read_u8()? {\n");
+        for (index, variant) in enum_variants(&types, name).iter().enumerate() {
+            output.push_str("        ");
+            output.push_str(&index.to_string());
+            output.push_str(" => Some(");
+            output.push_str(name);
+            output.push_str("::");
+            output.push_str(variant);
+            output.push_str("),\n");
+        }
+        output.push_str("        _ => None,\n    }\n}\n\n");
+    }
+
+    for name in &structs {
+        output.push_str("fn read_");
+        output.push_str(&snake_case(name));
+        output.push_str("(cursor: &mut Cursor<'_>) -> Option<");
+        output.push_str(name);
+        output.push_str("> {\n    Some(");
+        output.push_str(name);
+        output.push_str(" {\n");
+        for field in fields_for_event(&types, name) {
+            output.push_str("        ");
+            output.push_str(field["name"].as_str().unwrap());
+            output.push_str(": ");
+            output.push_str(&read_expr(&field["type"]));
+            output.push_str("?,\n");
+        }
+        output.push_str("    })\n}\n\n");
+    }
+
+    output.push_str(
+        r#"struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn is_finished(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+
+    fn read_u8(&mut self) -> Option<u8> {
+        let byte = *self.bytes.get(self.offset)?;
+        self.offset += 1;
+        Some(byte)
+    }
+
+    fn read_bool(&mut self) -> Option<bool> {
+        match self.read_u8()? {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }
+    }
+
+    fn read_u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.read_array::<4>()?))
+    }
+
+    fn read_u64(&mut self) -> Option<u64> {
+        Some(u64::from_le_bytes(self.read_array::<8>()?))
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Option<[u8; N]> {
+        let end = self.offset.checked_add(N)?;
+        let bytes = self.bytes.get(self.offset..end)?;
+        self.offset = end;
+        bytes.try_into().ok()
+    }
+
+    // Borsh `Vec<T>`: u32 little-endian length, then `len` elements decoded by `f`.
+    fn read_vec<T>(
+        &mut self,
+        mut f: impl FnMut(&mut Cursor<'a>) -> Option<T>,
+    ) -> Option<Vec<T>> {
+        let len = self.read_u32()? as usize;
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            out.push(f(self)?);
+        }
+        Some(out)
+    }
+}
+"#,
+    );
+
+    let out_path =
+        Path::new(&env::var("OUT_DIR").expect("OUT_DIR must be set"))
+            .join("zama_host_instructions.rs");
+    fs::write(&out_path, output).unwrap_or_else(|err| {
+        panic!("failed to write {}: {err}", out_path.display())
+    });
+}
+
+/// Collects defined enums and structs referenced by an IDL type (recursing into
+/// `vec` inners and struct fields), classifying each by its IDL `kind`.
+fn collect_defined_types<'a>(
+    types: &'a HashMap<&str, &'a Value>,
+    idl_type: &'a Value,
+    enums: &mut Vec<&'a str>,
+    structs: &mut Vec<&'a str>,
+) {
+    if let Some(vec_inner) = idl_type.get("vec") {
+        collect_defined_types(types, vec_inner, enums, structs);
+        return;
+    }
+    if let Some(defined) = idl_type["defined"]["name"].as_str() {
+        let ty = types
+            .get(defined)
+            .unwrap_or_else(|| panic!("IDL must define {defined}"));
+        match ty["type"]["kind"].as_str() {
+            Some("enum") => {
+                if !enums.contains(&defined) {
+                    enums.push(defined);
+                }
+            }
+            Some("struct") => {
+                if !structs.contains(&defined) {
+                    structs.push(defined);
+                    for field in fields_for_event(types, defined) {
+                        collect_defined_types(
+                            types,
+                            &field["type"],
+                            enums,
+                            structs,
+                        );
+                    }
+                }
+            }
+            other => panic!("unsupported IDL defined kind {other:?} for {defined}"),
+        }
+    }
+}
+
+fn enum_variants<'a>(
+    types: &'a HashMap<&str, &'a Value>,
+    name: &str,
+) -> Vec<&'a str> {
+    types[name]["type"]["variants"]
+        .as_array()
+        .unwrap_or_else(|| panic!("IDL type {name} must be an enum"))
+        .iter()
+        .map(|variant| {
+            if variant.get("fields").is_some() {
+                panic!("enum {name} must use fieldless variants")
+            }
+            variant["name"].as_str().expect("enum variant must have a name")
+        })
+        .collect()
+}
+
+/// `trivial_encrypt_and_bind` -> `TrivialEncryptAndBind`.
+fn pascal_case(snake: &str) -> String {
+    let mut out = String::new();
+    let mut upper = true;
+    for ch in snake.chars() {
+        if ch == '_' {
+            upper = true;
+        } else if upper {
+            out.push(ch.to_ascii_uppercase());
+            upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
 fn main() {
     println!("cargo::warning=build.rs run ...");
     generate_zama_host_events();
     generate_confidential_token_events();
+    generate_zama_host_instructions();
     generate_solana_abi_schema_hashes();
     build_contracts();
     // build tests contracts

--- a/coprocessor/fhevm-engine/host-listener/build.rs
+++ b/coprocessor/fhevm-engine/host-listener/build.rs
@@ -666,7 +666,12 @@ fn generate_zama_host_instructions() {
     let mut structs = Vec::<&str>::new();
     for ins in &instructions {
         for arg in ins["args"].as_array().expect("instruction args") {
-            collect_defined_types(&types, &arg["type"], &mut enums, &mut structs);
+            collect_defined_types(
+                &types,
+                &arg["type"],
+                &mut enums,
+                &mut structs,
+            );
         }
     }
 
@@ -675,7 +680,9 @@ fn generate_zama_host_instructions() {
     );
 
     for name in &enums {
-        output.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq)]\npub enum ");
+        output.push_str(
+            "#[derive(Clone, Copy, Debug, PartialEq, Eq)]\npub enum ",
+        );
         output.push_str(name);
         output.push_str(" {\n");
         for variant in enum_variants(&types, name) {
@@ -762,7 +769,9 @@ fn generate_zama_host_instructions() {
             output.push_str(&read_expr(&arg["type"]));
             output.push_str("?,\n");
         }
-        output.push_str("    };\n    cursor.is_finished().then_some(args)\n}\n\n");
+        output.push_str(
+            "    };\n    cursor.is_finished().then_some(args)\n}\n\n",
+        );
     }
 
     for name in &enums {
@@ -904,7 +913,9 @@ fn collect_defined_types<'a>(
                     }
                 }
             }
-            other => panic!("unsupported IDL defined kind {other:?} for {defined}"),
+            other => {
+                panic!("unsupported IDL defined kind {other:?} for {defined}")
+            }
         }
     }
 }
@@ -921,7 +932,9 @@ fn enum_variants<'a>(
             if variant.get("fields").is_some() {
                 panic!("enum {name} must use fieldless variants")
             }
-            variant["name"].as_str().expect("enum variant must have a name")
+            variant["name"]
+                .as_str()
+                .expect("enum variant must have a name")
         })
         .collect()
 }

--- a/coprocessor/fhevm-engine/host-listener/src/bin/solana_host_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/solana_host_listener.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
@@ -53,6 +53,34 @@ struct Args {
 
     #[arg(long, default_value = "solana-host-listener")]
     service_name: String,
+
+    /// Event transport: `rpc` (poll getSignaturesForAddress) or `grpc`
+    /// (subscribe to a Yellowstone gRPC endpoint). `grpc` requires building
+    /// with `--features solana-grpc`.
+    #[arg(long, value_enum, default_value_t = Transport::Rpc)]
+    transport: Transport,
+
+    /// Yellowstone gRPC endpoint (used when --transport=grpc).
+    #[arg(long, default_value = "http://127.0.0.1:10000")]
+    grpc_url: String,
+
+    /// Optional `x-token` auth metadata for the gRPC endpoint.
+    #[arg(long)]
+    grpc_x_token: Option<String>,
+
+    /// Ingest events REBUILT off-chain from instructions instead of emit-decoded
+    /// events (the reconstruction swap). Handle-derivation params (chain_id and
+    /// the zero-birth-entropy rule) are auto-detected from the on-chain HostConfig.
+    /// Without it, ingestion stays purely emit-based (the Phase 1 transport).
+    /// Requires `--features solana-grpc,solana-reconstruct`.
+    #[arg(long, default_value_t = false)]
+    reconstruct: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum Transport {
+    Rpc,
+    Grpc,
 }
 
 #[tokio::main]
@@ -77,16 +105,6 @@ async fn main() -> Result<()> {
             .await
             .context("connect coprocessor database")?;
 
-    let commitment = CommitmentConfig::confirmed();
-    let rpc = RpcClient::new_with_commitment(args.url.clone(), commitment);
-
-    let config = SolanaListenerConfig {
-        rpc_url: args.url,
-        program_id,
-        poll_interval: Duration::from_millis(args.poll_interval_ms),
-        commitment,
-    };
-
     let cancel = CancellationToken::new();
     let signal_cancel = cancel.clone();
     tokio::spawn(async move {
@@ -96,5 +114,90 @@ async fn main() -> Result<()> {
         }
     });
 
-    run(&db, &rpc, &config, cancel).await
+    match args.transport {
+        Transport::Rpc => {
+            let commitment = CommitmentConfig::confirmed();
+            let rpc =
+                RpcClient::new_with_commitment(args.url.clone(), commitment);
+            let config = SolanaListenerConfig {
+                rpc_url: args.url,
+                program_id,
+                poll_interval: Duration::from_millis(args.poll_interval_ms),
+                commitment,
+            };
+            run(&db, &rpc, &config, cancel).await
+        }
+        Transport::Grpc => run_grpc(&db, &args, program_id, cancel).await,
+    }
+}
+
+#[cfg(feature = "solana-grpc")]
+async fn run_grpc(
+    db: &Database,
+    args: &Args,
+    program_id: Pubkey,
+    cancel: CancellationToken,
+) -> Result<()> {
+    use host_listener::solana_grpc_listener::{
+        run as grpc_run, SolanaGrpcListenerConfig,
+    };
+    use yellowstone_grpc_proto::prelude::CommitmentLevel;
+
+    #[allow(unused_mut)]
+    let mut config = SolanaGrpcListenerConfig {
+        grpc_url: args.grpc_url.clone(),
+        x_token: args.grpc_x_token.clone(),
+        rpc_fallback_url: args.url.clone(),
+        program_id: program_id.to_string(),
+        commitment: CommitmentLevel::Confirmed,
+        // Auto-detected from the on-chain HostConfig below (reconstruct mode only).
+        chain_id: 0,
+        zero_birth_entropy: false,
+        reconstruct: args.reconstruct,
+    };
+
+    // In reconstruct mode, source the handle-derivation params (chain_id and the
+    // zero-birth-entropy rule) from the on-chain HostConfig instead of CLI flags.
+    #[cfg(feature = "solana-reconstruct")]
+    if args.reconstruct {
+        use host_listener::solana_reconstruct::{
+            parse_host_config, HOST_CONFIG_SEED,
+        };
+        // Confirmed (not the RpcClient default of finalized) so a freshly created
+        // HostConfig is visible without waiting for finalization; matches the
+        // gRPC subscription's commitment.
+        let rpc = RpcClient::new_with_commitment(
+            args.url.clone(),
+            CommitmentConfig::confirmed(),
+        );
+        let (host_config_pda, _) =
+            Pubkey::find_program_address(&[HOST_CONFIG_SEED], &program_id);
+        let account = rpc
+            .get_account(&host_config_pda)
+            .await
+            .with_context(|| format!("fetch HostConfig {host_config_pda}"))?;
+        let (chain_id, zero_birth_entropy) = parse_host_config(&account.data)?;
+        info!(
+            %host_config_pda,
+            chain_id,
+            zero_birth_entropy,
+            "auto-detected handle-derivation params from HostConfig"
+        );
+        config.chain_id = chain_id;
+        config.zero_birth_entropy = zero_birth_entropy;
+    }
+
+    grpc_run(db, &config, cancel).await
+}
+
+#[cfg(not(feature = "solana-grpc"))]
+async fn run_grpc(
+    _db: &Database,
+    _args: &Args,
+    _program_id: Pubkey,
+    _cancel: CancellationToken,
+) -> Result<()> {
+    anyhow::bail!(
+        "--transport=grpc requires building host-listener with --features solana-grpc"
+    )
 }

--- a/coprocessor/fhevm-engine/host-listener/src/generated/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/generated/mod.rs
@@ -16,6 +16,10 @@ pub mod solana_abi_schema_hashes {
     include!(concat!(env!("OUT_DIR"), "/solana_abi_schema_hashes.rs"));
 }
 
+pub mod zama_host_instructions {
+    include!(concat!(env!("OUT_DIR"), "/zama_host_instructions.rs"));
+}
+
 pub use confidential_token_events::{
     decode_anchor_cpi_event as decode_confidential_token_anchor_cpi_event,
     decode_anchor_event as decode_confidential_token_anchor_event,
@@ -29,4 +33,7 @@ pub use zama_host_events::{
     AclAllowedEvent, FheBinaryOpCode, FheBinaryOpEvent, FheRandBoundedEvent,
     FheRandEvent, FheTernaryOpCode, FheTernaryOpEvent, InputVerifiedEvent,
     TrivialEncryptEvent, ZamaHostEvent, ANCHOR_EVENT_IX_TAG_LE, EVENT_VERSION,
+};
+pub use zama_host_instructions::{
+    decode_zama_host_instruction, ZamaHostInstruction,
 };

--- a/coprocessor/fhevm-engine/host-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/lib.rs
@@ -8,4 +8,9 @@ pub mod kms_generation;
 pub mod poller;
 pub mod solana_adapter;
 pub mod solana_finalized_account_fetcher;
+#[cfg(feature = "solana-grpc")]
+pub mod solana_grpc_listener;
 pub mod solana_listener;
+#[cfg(feature = "solana-reconstruct")]
+pub mod solana_reconstruct;
+pub mod solana_slot_hashes;

--- a/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
@@ -570,7 +570,7 @@ fn account_fetches_from_solana_events(
         .collect()
 }
 
-fn acl_record_fetch(
+pub(crate) fn acl_record_fetch(
     acl_record: [u8; 32],
     handle: [u8; 32],
     reason: &'static str,
@@ -601,7 +601,7 @@ fn acl_permission_fetch(
     }
 }
 
-fn material_fetch(
+pub(crate) fn material_fetch(
     material_commitment: [u8; 32],
     acl_record: [u8; 32],
     handle: [u8; 32],

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -21,9 +21,9 @@ use futures_util::stream::StreamExt;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use time::{OffsetDateTime, PrimitiveDateTime};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
 #[cfg(feature = "solana-reconstruct")]
 use tracing::warn;
+use tracing::{debug, error, info};
 
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::transport::Channel;
@@ -301,7 +301,10 @@ async fn ingest_transaction(
 ) -> Result<()> {
     #[cfg(not(feature = "solana-reconstruct"))]
     let _ = (slot_bank_hash, slot_clock_ts); // only used by the shadow-compare
-    let meta = info.meta.as_ref().ok_or_else(|| anyhow!("tx has no meta"))?;
+    let meta = info
+        .meta
+        .as_ref()
+        .ok_or_else(|| anyhow!("tx has no meta"))?;
     let tx = info
         .transaction
         .as_ref()
@@ -336,7 +339,10 @@ async fn ingest_transaction(
             let program = account_keys
                 .get(ix.program_id_index as usize)
                 .ok_or_else(|| {
-                    anyhow!("program_id_index {} out of range", ix.program_id_index)
+                    anyhow!(
+                        "program_id_index {} out of range",
+                        ix.program_id_index
+                    )
                 })?;
             inner.push((program.clone(), ix.data.clone()));
         }
@@ -379,10 +385,9 @@ async fn ingest_transaction(
             .iter()
             .map(|ix| decode(ix.program_id_index, &ix.data, &ix.accounts))
             .chain(meta.inner_instructions.iter().flat_map(|group| {
-                group
-                    .instructions
-                    .iter()
-                    .map(|ix| decode(ix.program_id_index, &ix.data, &ix.accounts))
+                group.instructions.iter().map(|ix| {
+                    decode(ix.program_id_index, &ix.data, &ix.accounts)
+                })
             }))
             .collect()
     };
@@ -579,7 +584,8 @@ async fn reconstruct_events_for_insert(
         else {
             continue;
         };
-        let Some(acl_record) = ix.accounts.get(COMMIT_ACL_RECORD_INDEX).copied()
+        let Some(acl_record) =
+            ix.accounts.get(COMMIT_ACL_RECORD_INDEX).copied()
         else {
             continue;
         };
@@ -634,8 +640,7 @@ async fn reconstruct_events_for_insert(
                     }
                 }
             }
-        } else if let Some(instruction) =
-            decode_zama_host_instruction(&ix.data)
+        } else if let Some(instruction) = decode_zama_host_instruction(&ix.data)
         {
             if let Some(evs) = reconstruct_instruction_events(
                 &instruction,

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -1,0 +1,666 @@
+//! Yellowstone gRPC transport for the Solana host listener (Phase 1).
+//!
+//! Drop-in transport alternative to [`crate::solana_listener`]: instead of
+//! RPC-polling `getSignaturesForAddress`, it subscribes to a Yellowstone gRPC
+//! endpoint for transactions touching the tracked program, then feeds the SAME
+//! shared decoder ([`decode_solana_transaction_events`]) and inserter
+//! ([`insert_solana_events`]) the RPC path uses. On-chain events are still
+//! emitted (`emit_cpi!`/`emit!`); only the transport differs, so ingested rows
+//! match the RPC path by construction.
+//!
+//! gRPC transaction updates do not carry block time, so we track a
+//! `slot -> block_time` map from `blocks_meta` updates and fall back to a single
+//! RPC `getBlockTime` on a miss.
+#![cfg(feature = "solana-grpc")]
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use futures_util::stream::StreamExt;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use time::{OffsetDateTime, PrimitiveDateTime};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info};
+#[cfg(feature = "solana-reconstruct")]
+use tracing::warn;
+
+use tonic::metadata::{Ascii, MetadataValue};
+use tonic::transport::Channel;
+use yellowstone_grpc_proto::geyser::geyser_client::GeyserClient;
+use yellowstone_grpc_proto::prelude::{
+    subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
+    SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta,
+    SubscribeRequestFilterTransactions, SubscribeUpdateTransactionInfo,
+};
+
+use crate::database::tfhe_event_propagate::Database;
+use crate::solana_adapter::{
+    decode_solana_transaction_events, insert_solana_events,
+    solana_transaction_id, SolanaBlockMeta,
+};
+use crate::solana_slot_hashes::{
+    clock_unix_timestamp, previous_bank_hash_from_slot_hashes, CLOCK_SYSVAR,
+    SLOT_HASHES_SYSVAR,
+};
+
+const MAX_DECODING_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub struct SolanaGrpcListenerConfig {
+    /// Yellowstone gRPC endpoint, e.g. `http://poc-solana-validator:10000`.
+    pub grpc_url: String,
+    /// Optional `x-token` auth metadata (None for a local validator).
+    pub x_token: Option<String>,
+    /// RPC endpoint used only as a `getBlockTime` fallback for block timestamps.
+    pub rpc_fallback_url: String,
+    /// Base58 program id whose CPI/log events are ingested (the zama-host id).
+    pub program_id: String,
+    /// Commitment level for the subscription.
+    pub commitment: CommitmentLevel,
+    /// On-chain HostConfig chain_id used in handle derivation (distinct from the
+    /// coprocessor host-chain id). Used by the reconstruction path.
+    pub chain_id: u64,
+    /// True when the on-chain HostConfig enables zero-birth entropy (test/PoC):
+    /// derivation uses previous_bank_hash=[0;32] instead of the SlotHashes value.
+    pub zero_birth_entropy: bool,
+    /// When true, ingest events REBUILT off-chain from instructions (compute
+    /// events + acl_record_bound fetches) instead of the emit-decoded events —
+    /// the swap that lets on-chain emits eventually be removed. When false, ingest
+    /// stays emit-based and reconstruction only runs as a shadow-compare.
+    pub reconstruct: bool,
+}
+
+/// Connects, subscribes, and ingests until `cancel` fires. Reconnects with a
+/// `from_slot` cursor on stream errors; inserts are idempotent so replay is safe.
+pub async fn run(
+    db: &Database,
+    config: &SolanaGrpcListenerConfig,
+    cancel: CancellationToken,
+) -> Result<()> {
+    info!(
+        program_id = %config.program_id,
+        grpc_url = %config.grpc_url,
+        "Starting Solana host listener (Yellowstone gRPC transport)"
+    );
+
+    // Confirmed (not the RpcClient default of finalized) so on-chain reads —
+    // getBlockTime and the acl_record read for commit_handle_material — see
+    // recently-created state, matching the gRPC subscription commitment.
+    let rpc = RpcClient::new_with_commitment(
+        config.rpc_fallback_url.clone(),
+        solana_commitment_config::CommitmentConfig::confirmed(),
+    );
+    // TODO(unbounded-cache): these per-slot maps are insert/get only — never
+    // evicted — so they grow without bound in this long-lived process. Only recent
+    // slots are ever read (txs arrive near the tip), so prune on insert (retain
+    // slots >= newest - WINDOW) or use a bounded/LRU map.
+    let mut slot_time: HashMap<u64, PrimitiveDateTime> = HashMap::new();
+    // `slot -> previous_bank_hash` sourced from the SlotHashes sysvar stream;
+    // consumed by the reconstruction path (recompute of trivial/rand/fhe_eval).
+    let mut slot_bank_hash: HashMap<u64, [u8; 32]> = HashMap::new();
+    // `slot -> Clock.unix_timestamp` from the Clock sysvar stream (the value the
+    // program uses in handle derivation, which differs from getBlockTime).
+    let mut slot_clock_ts: HashMap<u64, i64> = HashMap::new();
+    let mut from_slot: Option<u64> = None;
+
+    loop {
+        if cancel.is_cancelled() {
+            return Ok(());
+        }
+        match subscribe_loop(
+            db,
+            &rpc,
+            config,
+            &mut slot_time,
+            &mut slot_bank_hash,
+            &mut slot_clock_ts,
+            &mut from_slot,
+            &cancel,
+        )
+        .await
+        {
+            Ok(()) => return Ok(()), // cancelled
+            Err(err) => {
+                error!(error = %err, from_slot = ?from_slot, "gRPC subscription dropped; reconnecting");
+                tokio::select! {
+                    _ = cancel.cancelled() => return Ok(()),
+                    _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn subscribe_loop(
+    db: &Database,
+    rpc: &RpcClient,
+    config: &SolanaGrpcListenerConfig,
+    slot_time: &mut HashMap<u64, PrimitiveDateTime>,
+    slot_bank_hash: &mut HashMap<u64, [u8; 32]>,
+    slot_clock_ts: &mut HashMap<u64, i64>,
+    from_slot: &mut Option<u64>,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    let channel = Channel::from_shared(config.grpc_url.clone())
+        .context("invalid grpc url")?
+        .connect()
+        .await
+        .context("connect grpc endpoint")?;
+
+    let token: Option<MetadataValue<Ascii>> = config
+        .x_token
+        .as_ref()
+        .map(|t| t.parse())
+        .transpose()
+        .context("invalid x-token")?;
+
+    let mut client = GeyserClient::with_interceptor(
+        channel,
+        move |mut req: tonic::Request<()>| {
+            if let Some(token) = &token {
+                req.metadata_mut().insert("x-token", token.clone());
+            }
+            Ok(req)
+        },
+    )
+    .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
+
+    let request = build_subscribe_request(config, *from_slot);
+    let outbound = futures_util::stream::once(async move { request })
+        .chain(futures_util::stream::pending::<SubscribeRequest>());
+
+    let mut stream = client
+        .subscribe(outbound)
+        .await
+        .context("subscribe")?
+        .into_inner();
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return Ok(()),
+            msg = stream.message() => {
+                let Some(update) = msg.context("grpc stream")? else { return Ok(()); };
+                match update.update_oneof {
+                    Some(UpdateOneof::BlockMeta(bm)) => {
+                        if let Some(ts) = bm.block_time.and_then(|t| unix_to_pdt(t.timestamp)) {
+                            slot_time.insert(bm.slot, ts);
+                        }
+                    }
+                    Some(UpdateOneof::Account(acc)) => {
+                        // Cache per-slot derivation inputs from the sysvar stream:
+                        // SlotHashes -> previous_bank_hash, Clock -> unix_timestamp.
+                        if let Some(info) = acc.account {
+                            let pubkey =
+                                bs58::encode(&info.pubkey).into_string();
+                            if pubkey == SLOT_HASHES_SYSVAR {
+                                if let Some(prev) =
+                                    previous_bank_hash_from_slot_hashes(
+                                        &info.data, acc.slot,
+                                    )
+                                {
+                                    slot_bank_hash.insert(acc.slot, prev);
+                                }
+                            } else if pubkey == CLOCK_SYSVAR {
+                                if let Some(ts) =
+                                    clock_unix_timestamp(&info.data)
+                                {
+                                    slot_clock_ts.insert(acc.slot, ts);
+                                }
+                            }
+                        }
+                    }
+                    Some(UpdateOneof::Transaction(txu)) => {
+                        let slot = txu.slot;
+                        if let Some(info) = txu.transaction {
+                            if info.is_vote {
+                                continue;
+                            }
+                            if let Err(err) = ingest_transaction(
+                                db, rpc, config, slot, &info, slot_time,
+                                &*slot_bank_hash, &*slot_clock_ts,
+                            )
+                            .await
+                            {
+                                // Do not advance from_slot past a failed ingest.
+                                error!(slot, error = %err, "failed to ingest gRPC transaction");
+                                continue;
+                            }
+                        }
+                        *from_slot = Some(slot);
+                    }
+                    Some(UpdateOneof::Ping(_)) => debug!("grpc ping"),
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn build_subscribe_request(
+    config: &SolanaGrpcListenerConfig,
+    from_slot: Option<u64>,
+) -> SubscribeRequest {
+    let mut transactions = HashMap::new();
+    transactions.insert(
+        "zama_host".to_string(),
+        SubscribeRequestFilterTransactions {
+            vote: Some(false),
+            failed: Some(false),
+            signature: None,
+            account_include: vec![config.program_id.clone()],
+            account_exclude: vec![],
+            account_required: vec![],
+        },
+    );
+
+    let mut blocks_meta = HashMap::new();
+    blocks_meta.insert("meta".to_string(), SubscribeRequestFilterBlocksMeta {});
+
+    // Stream the SlotHashes + Clock sysvar accounts to source
+    // `previous_bank_hash` and `unix_timestamp` per slot for handle reconstruction.
+    let mut accounts = HashMap::new();
+    accounts.insert(
+        "sysvars".to_string(),
+        SubscribeRequestFilterAccounts {
+            account: vec![
+                SLOT_HASHES_SYSVAR.to_string(),
+                CLOCK_SYSVAR.to_string(),
+            ],
+            owner: vec![],
+            filters: vec![],
+            nonempty_txn_signature: None,
+        },
+    );
+
+    SubscribeRequest {
+        accounts,
+        slots: HashMap::new(),
+        transactions,
+        transactions_status: HashMap::new(),
+        blocks: HashMap::new(),
+        blocks_meta,
+        entry: HashMap::new(),
+        commitment: Some(config.commitment as i32),
+        accounts_data_slice: vec![],
+        ping: None,
+        from_slot,
+    }
+}
+
+async fn ingest_transaction(
+    db: &Database,
+    rpc: &RpcClient,
+    config: &SolanaGrpcListenerConfig,
+    slot: u64,
+    info: &SubscribeUpdateTransactionInfo,
+    slot_time: &mut HashMap<u64, PrimitiveDateTime>,
+    slot_bank_hash: &HashMap<u64, [u8; 32]>,
+    slot_clock_ts: &HashMap<u64, i64>,
+) -> Result<()> {
+    #[cfg(not(feature = "solana-reconstruct"))]
+    let _ = (slot_bank_hash, slot_clock_ts); // only used by the shadow-compare
+    let meta = info.meta.as_ref().ok_or_else(|| anyhow!("tx has no meta"))?;
+    let tx = info
+        .transaction
+        .as_ref()
+        .ok_or_else(|| anyhow!("tx has no transaction"))?;
+    let message = tx
+        .message
+        .as_ref()
+        .ok_or_else(|| anyhow!("tx has no message"))?;
+
+    // Resolved account-key list: static keys ++ ALT writable ++ ALT readonly,
+    // the order `program_id_index` indexes into (matches solana_listener).
+    let mut account_keys: Vec<String> = message
+        .account_keys
+        .iter()
+        .map(|k| bs58::encode(k).into_string())
+        .collect();
+    account_keys.extend(
+        meta.loaded_writable_addresses
+            .iter()
+            .map(|k| bs58::encode(k).into_string()),
+    );
+    account_keys.extend(
+        meta.loaded_readonly_addresses
+            .iter()
+            .map(|k| bs58::encode(k).into_string()),
+    );
+
+    // Inner instructions == CPI frames carrying emit_cpi! event bytes.
+    let mut inner: Vec<(String, Vec<u8>)> = Vec::new();
+    for group in &meta.inner_instructions {
+        for ix in &group.instructions {
+            let program = account_keys
+                .get(ix.program_id_index as usize)
+                .ok_or_else(|| {
+                    anyhow!("program_id_index {} out of range", ix.program_id_index)
+                })?;
+            inner.push((program.clone(), ix.data.clone()));
+        }
+    }
+
+    // Reconstruction needs each instruction's RESOLVED accounts by address, so
+    // build the account-key list in raw 32-byte form (same order as the base58
+    // list: static keys ++ ALT writable ++ ALT readonly).
+    #[cfg(feature = "solana-reconstruct")]
+    let account_keys_bytes: Vec<[u8; 32]> = message
+        .account_keys
+        .iter()
+        .chain(meta.loaded_writable_addresses.iter())
+        .chain(meta.loaded_readonly_addresses.iter())
+        .map(|k| <[u8; 32]>::try_from(k.as_slice()).unwrap_or([0u8; 32]))
+        .collect();
+
+    // Top-level + inner instruction invocations with resolved accounts (a
+    // zama-host instruction is called directly as top-level, or via CPI as inner
+    // for token flows); scanned by the reconstruction shadow-compare and ingest.
+    #[cfg(feature = "solana-reconstruct")]
+    let all_instructions: Vec<DecodedInstruction> = {
+        let resolve = |idxs: &[u8]| -> Vec<[u8; 32]> {
+            idxs.iter()
+                .filter_map(|&i| account_keys_bytes.get(i as usize).copied())
+                .collect()
+        };
+        let decode = |program_id_index: u32, data: &[u8], accounts: &[u8]| {
+            DecodedInstruction {
+                program: account_keys
+                    .get(program_id_index as usize)
+                    .cloned()
+                    .unwrap_or_default(),
+                data: data.to_vec(),
+                accounts: resolve(accounts),
+            }
+        };
+        message
+            .instructions
+            .iter()
+            .map(|ix| decode(ix.program_id_index, &ix.data, &ix.accounts))
+            .chain(meta.inner_instructions.iter().flat_map(|group| {
+                group
+                    .instructions
+                    .iter()
+                    .map(|ix| decode(ix.program_id_index, &ix.data, &ix.accounts))
+            }))
+            .collect()
+    };
+
+    // emit! events arrive as `Program data:` log lines.
+    let logs: Vec<String> = if meta.log_messages_none {
+        Vec::new()
+    } else {
+        meta.log_messages.clone()
+    };
+
+    let emit_events = decode_solana_transaction_events(
+        &logs,
+        inner.iter().map(|(p, d)| (p.as_str(), d.as_slice())),
+        &config.program_id,
+    )
+    .context("decode host events")?;
+
+    // Choose the event set to ingest. In `--reconstruct` mode, rebuild it off-chain
+    // (compute events + acl_record_bound fetches) from the instructions and ingest
+    // THAT in place of emit-decode — the swap that lets on-chain emits be removed
+    // (#7). With emits off, emit-decode yields nothing, so reconstruction is decided
+    // here, BEFORE the empty gate below; we fall back to emit-decode only when
+    // reconstruction produces nothing (e.g. instruction families not yet covered).
+    #[cfg(feature = "solana-reconstruct")]
+    let events = if config.reconstruct {
+        match reconstruct_events_for_insert(
+            config,
+            &all_instructions,
+            slot,
+            slot_bank_hash,
+            slot_clock_ts,
+            rpc,
+        )
+        .await
+        {
+            Some(reconstructed) if !reconstructed.is_empty() => {
+                info!(
+                    slot,
+                    reconstructed = reconstructed.len(),
+                    emit_decoded = emit_events.len(),
+                    "ingesting reconstructed events (emit-decode swapped out)"
+                );
+                reconstructed
+            }
+            Some(_) | None => {
+                if !emit_events.is_empty() {
+                    warn!(
+                        slot,
+                        "reconstruction unavailable/empty; falling back to emit-decode"
+                    );
+                }
+                emit_events
+            }
+        }
+    } else {
+        emit_events
+    };
+    #[cfg(not(feature = "solana-reconstruct"))]
+    let events = emit_events;
+
+    if events.is_empty() {
+        return Ok(());
+    }
+
+    let block_timestamp = match slot_time.get(&slot) {
+        Some(ts) => *ts,
+        None => {
+            let ts = rpc
+                .get_block_time(slot)
+                .await
+                .context("getBlockTime fallback")?;
+            let pdt = unix_to_pdt(ts)
+                .ok_or_else(|| anyhow!("invalid block_time {ts}"))?;
+            slot_time.insert(slot, pdt);
+            pdt
+        }
+    };
+    let block = SolanaBlockMeta {
+        block_number: slot,
+        block_timestamp,
+    };
+
+    let transaction_id = solana_transaction_id(&info.signature);
+    let mut db_tx = db.new_transaction().await.context("open db tx")?;
+    let stats =
+        insert_solana_events(db, &mut db_tx, events, transaction_id, block)
+            .await
+            .context("insert_solana_events")?;
+    db_tx.commit().await.context("commit db tx")?;
+
+    info!(
+        slot,
+        signature = %bs58::encode(&info.signature).into_string(),
+        tfhe_events = stats.tfhe_events,
+        acl_events = stats.acl_events,
+        inserted_rows = stats.inserted_rows,
+        "ingested Solana host events (gRPC)"
+    );
+    Ok(())
+}
+
+fn unix_to_pdt(ts: i64) -> Option<PrimitiveDateTime> {
+    let dt = OffsetDateTime::from_unix_timestamp(ts).ok()?;
+    Some(PrimitiveDateTime::new(dt.date(), dt.time()))
+}
+
+/// A decoded instruction invocation: program id (base58), instruction data, and
+/// resolved account addresses (raw 32-byte) in the instruction's account order.
+#[cfg(feature = "solana-reconstruct")]
+struct DecodedInstruction {
+    program: String,
+    data: Vec<u8>,
+    accounts: Vec<[u8; 32]>,
+}
+
+/// Builds the handle-derivation context for `slot` from the streamed sysvars,
+/// applying the zero-birth-entropy rule. Returns `None` until both the Clock and
+/// (in production mode) the SlotHashes value for the slot have been cached.
+#[cfg(feature = "solana-reconstruct")]
+fn reconstruct_context(
+    config: &SolanaGrpcListenerConfig,
+    slot: u64,
+    slot_bank_hash: &HashMap<u64, [u8; 32]>,
+    slot_clock_ts: &HashMap<u64, i64>,
+) -> Option<crate::solana_reconstruct::ReconstructContext> {
+    let unix_timestamp = slot_clock_ts.get(&slot).copied()?;
+    // Zero-birth-entropy (test/PoC) configs derive with previous_bank_hash=[0;32]
+    // (host_config.zero_birth_entropy_allowed()); production uses the
+    // SlotHashes-sourced value for the tx's slot.
+    let previous_bank_hash = if config.zero_birth_entropy {
+        [0u8; 32]
+    } else {
+        slot_bank_hash.get(&slot).copied()?
+    };
+    Some(crate::solana_reconstruct::ReconstructContext {
+        chain_id: config.chain_id,
+        previous_bank_hash,
+        unix_timestamp,
+    })
+}
+
+/// Rebuilds the ingestable event set off-chain from a transaction's instructions,
+/// for `--reconstruct` mode (the swap that replaces emit-decoding). Covers
+/// `fhe_eval`: one compute event per step, plus an `acl_record_bound` allow-fetch
+/// for each `Durable` step (handle = the step result, ACL record = the step's
+/// `remaining_accounts` entry) — matching what the program's bind emits, so
+/// `is_allowed` and the fetch row land identically.
+///
+/// Returns `None` if the slot's derivation context is not yet cached. Direct
+/// zama-host compute/bind instructions, `allow_for_decryption`,
+/// `commit_handle_material`, and token fetches are not yet reconstructed for
+/// ingestion (follow-ups); the caller falls back to emit-decode when this yields
+/// nothing.
+#[cfg(feature = "solana-reconstruct")]
+async fn reconstruct_events_for_insert(
+    config: &SolanaGrpcListenerConfig,
+    instructions: &[DecodedInstruction],
+    slot: u64,
+    slot_bank_hash: &HashMap<u64, [u8; 32]>,
+    slot_clock_ts: &HashMap<u64, i64>,
+    rpc: &RpcClient,
+) -> Option<Vec<crate::solana_adapter::SolanaHostEvent>> {
+    use crate::generated::{decode_zama_host_instruction, ZamaHostInstruction};
+    use crate::solana_adapter::SolanaHostEvent;
+    use crate::solana_reconstruct::{
+        decode_fhe_eval_args, parse_acl_record_handle,
+        reconstruct_acl_record_bound_fetch, reconstruct_fhe_eval_steps,
+        reconstruct_instruction_events,
+    };
+    use solana_sdk::pubkey::Pubkey;
+
+    // fhe_eval named accounts: payer, compute_subject, app_account_authority,
+    // host_config, system_program, instructions_sysvar, then event_cpi's
+    // event_authority + program = 8; remaining_accounts (ACL records) follow.
+    const COMPUTE_SUBJECT_INDEX: usize = 1;
+    const FHE_EVAL_REMAINING_BASE: usize = 8;
+    // commit_handle_material's acl_record (account 3): its emitted handle comes from
+    // that record's account state, so it must be read on-chain.
+    const COMMIT_ACL_RECORD_INDEX: usize = 3;
+
+    let ctx = reconstruct_context(config, slot, slot_bank_hash, slot_clock_ts)?;
+
+    // Pre-read acl_record.handle for any commit_handle_material in this tx: the
+    // handle is account state, not in the instruction args. Restart-safe RPC read,
+    // mirroring the HostConfig startup fetch.
+    let mut acl_handles: HashMap<[u8; 32], [u8; 32]> = HashMap::new();
+    for ix in instructions {
+        if ix.program != config.program_id {
+            continue;
+        }
+        let Some(ZamaHostInstruction::CommitHandleMaterial(_)) =
+            decode_zama_host_instruction(&ix.data)
+        else {
+            continue;
+        };
+        let Some(acl_record) = ix.accounts.get(COMMIT_ACL_RECORD_INDEX).copied()
+        else {
+            continue;
+        };
+        if acl_handles.contains_key(&acl_record) {
+            continue;
+        }
+        match rpc.get_account(&Pubkey::from(acl_record)).await {
+            Ok(account) => {
+                if let Some(handle) = parse_acl_record_handle(&account.data) {
+                    acl_handles.insert(acl_record, handle);
+                }
+            }
+            Err(err) => warn!(
+                slot,
+                error = %err,
+                "reconstruct: failed to read acl_record for commit_handle_material"
+            ),
+        }
+    }
+
+    let mut events: Vec<SolanaHostEvent> = Vec::new();
+    for ix in instructions {
+        if ix.program != config.program_id {
+            continue;
+        }
+        if let Some(plan) = decode_fhe_eval_args(&ix.data) {
+            let subject = ix
+                .accounts
+                .get(COMPUTE_SUBJECT_INDEX)
+                .copied()
+                .unwrap_or([0u8; 32]);
+            let Some(steps) = reconstruct_fhe_eval_steps(&plan, subject, &ctx)
+            else {
+                continue;
+            };
+            for step in steps {
+                let handle = compute_result_handle(&step.event);
+                events.push(step.event);
+                if let (Some(index), Some(handle)) =
+                    (step.durable_acl_record_index, handle)
+                {
+                    if let Some(acl_record) = ix
+                        .accounts
+                        .get(FHE_EVAL_REMAINING_BASE + index as usize)
+                    {
+                        events.push(SolanaHostEvent::FinalizedAccountFetch(
+                            reconstruct_acl_record_bound_fetch(
+                                *acl_record,
+                                handle,
+                            ),
+                        ));
+                    }
+                }
+            }
+        } else if let Some(instruction) =
+            decode_zama_host_instruction(&ix.data)
+        {
+            if let Some(evs) = reconstruct_instruction_events(
+                &instruction,
+                &ix.accounts,
+                &ctx,
+                &acl_handles,
+            ) {
+                events.extend(evs);
+            }
+        }
+    }
+    Some(events)
+}
+
+#[cfg(feature = "solana-reconstruct")]
+fn compute_result_handle(
+    event: &crate::solana_adapter::SolanaHostEvent,
+) -> Option<[u8; 32]> {
+    use crate::solana_adapter::SolanaHostEvent as E;
+    match event {
+        E::FheBinaryOp(e) => Some(e.result),
+        E::FheTernaryOp(e) => Some(e.result),
+        E::TrivialEncrypt(e) => Some(e.result),
+        E::FheRand(e) => Some(e.result),
+        E::FheRandBounded(e) => Some(e.result),
+        E::FinalizedAccountFetch(_) | E::AclAllowed(_) => None,
+    }
+}

--- a/coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
@@ -21,17 +21,19 @@ use anchor_lang::AnchorDeserialize;
 use zama_host::state::{
     computed_bound_eval_handle, computed_bound_eval_rand_seed,
     computed_bound_eval_ternary_handle, computed_bound_eval_trivial_handle,
-    computed_eval_handle, computed_eval_rand_seed, computed_eval_ternary_handle,
-    computed_eval_trivial_handle, computed_rand_bounded_handle,
-    computed_rand_handle, computed_rand_seed, computed_trivial_handle,
-    FheBinaryOpCode as PgmBinaryOpCode, FheEvalArgs, FheEvalOperand,
-    FheEvalOutput, FheEvalStep, FheTernaryOpCode as PgmTernaryOpCode,
+    computed_eval_handle, computed_eval_rand_seed,
+    computed_eval_ternary_handle, computed_eval_trivial_handle,
+    computed_rand_bounded_handle, computed_rand_handle, computed_rand_seed,
+    computed_trivial_handle, FheBinaryOpCode as PgmBinaryOpCode, FheEvalArgs,
+    FheEvalOperand, FheEvalOutput, FheEvalStep,
+    FheTernaryOpCode as PgmTernaryOpCode,
 };
 
 use crate::generated::zama_host_instructions::{
     AllowForDecryptionArgs, FheBinaryOpCode as InstrBinaryOpCode,
-    FheTernaryOpCode as InstrTernaryOpCode, FheRandAndBindArgs,
-    FheRandBoundedAndBindArgs, TrivialEncryptAndBindArgs, ZamaHostInstruction,
+    FheRandAndBindArgs, FheRandBoundedAndBindArgs,
+    FheTernaryOpCode as InstrTernaryOpCode, TrivialEncryptAndBindArgs,
+    ZamaHostInstruction,
 };
 use crate::generated::{
     FheBinaryOpCode, FheBinaryOpEvent, FheRandBoundedEvent, FheRandEvent,
@@ -218,22 +220,49 @@ pub fn reconstruct_instruction_events(
         // Compute (+ optional durable bind): (compute_subject index, Some(
         // output_acl_record index) if it binds, subject count). fhe_binary_op is
         // non-bind (compute_subject at 0, no durable output).
-        I::FheBinaryOp(_) => compute_with_bind(instruction, accounts, ctx, 0, None, 0),
-        I::TrivialEncryptAndBind(a) => {
-            compute_with_bind(instruction, accounts, ctx, 1, Some(4), a.output_subjects.len())
+        I::FheBinaryOp(_) => {
+            compute_with_bind(instruction, accounts, ctx, 0, None, 0)
         }
-        I::FheBinaryOpAndBindOutput(a) => {
-            compute_with_bind(instruction, accounts, ctx, 1, Some(8), a.output_subjects.len())
-        }
-        I::FheTernaryOpAndBindOutput(a) => {
-            compute_with_bind(instruction, accounts, ctx, 1, Some(10), a.output_subjects.len())
-        }
-        I::FheRandAndBind(a) => {
-            compute_with_bind(instruction, accounts, ctx, 1, Some(4), a.output_subjects.len())
-        }
-        I::FheRandBoundedAndBind(a) => {
-            compute_with_bind(instruction, accounts, ctx, 1, Some(4), a.output_subjects.len())
-        }
+        I::TrivialEncryptAndBind(a) => compute_with_bind(
+            instruction,
+            accounts,
+            ctx,
+            1,
+            Some(4),
+            a.output_subjects.len(),
+        ),
+        I::FheBinaryOpAndBindOutput(a) => compute_with_bind(
+            instruction,
+            accounts,
+            ctx,
+            1,
+            Some(8),
+            a.output_subjects.len(),
+        ),
+        I::FheTernaryOpAndBindOutput(a) => compute_with_bind(
+            instruction,
+            accounts,
+            ctx,
+            1,
+            Some(10),
+            a.output_subjects.len(),
+        ),
+        I::FheRandAndBind(a) => compute_with_bind(
+            instruction,
+            accounts,
+            ctx,
+            1,
+            Some(4),
+            a.output_subjects.len(),
+        ),
+        I::FheRandBoundedAndBind(a) => compute_with_bind(
+            instruction,
+            accounts,
+            ctx,
+            1,
+            Some(4),
+            a.output_subjects.len(),
+        ),
         // Allow instructions: fetch-only (no compute event). The handle was computed
         // by an earlier instruction; these only flip its allow state.
         // allow_for_decryption accounts: authority, authority_permission_record,
@@ -253,11 +282,13 @@ pub fn reconstruct_instruction_events(
             Some(
                 (0..args.subjects.len())
                     .map(|_| {
-                        SolanaHostEvent::FinalizedAccountFetch(acl_record_fetch(
-                            acl_record,
-                            args.handle,
-                            "acl_subject_allowed",
-                        ))
+                        SolanaHostEvent::FinalizedAccountFetch(
+                            acl_record_fetch(
+                                acl_record,
+                                args.handle,
+                                "acl_subject_allowed",
+                            ),
+                        )
                     })
                     .collect(),
             )
@@ -337,7 +368,11 @@ fn compute_with_bind(
         ));
         for _ in 0..subject_count {
             events.push(SolanaHostEvent::FinalizedAccountFetch(
-                acl_record_fetch(output_acl_record, result, "acl_subject_allowed"),
+                acl_record_fetch(
+                    output_acl_record,
+                    result,
+                    "acl_subject_allowed",
+                ),
             ));
         }
     }
@@ -384,8 +419,7 @@ pub fn reconstruct_public_decrypt_allowed_fetch(
 }
 
 /// Discriminator for the `fhe_eval` instruction (sha256("global:fhe_eval")[..8]).
-const FHE_EVAL_DISCRIMINATOR: [u8; 8] =
-    [176, 42, 63, 177, 244, 167, 120, 109];
+const FHE_EVAL_DISCRIMINATOR: [u8; 8] = [176, 42, 63, 177, 244, 167, 120, 109];
 
 /// Decodes a `fhe_eval` instruction's data into the program's own `FheEvalArgs`
 /// step plan, reusing the zama-host type (so there is no bespoke decoder to drift
@@ -580,18 +614,20 @@ pub fn reconstruct_fhe_eval_steps(
                         *output_nonce_key,
                         *output_nonce_sequence,
                     ),
-                    FheEvalOutput::AllowedLocal => computed_eval_ternary_handle(
-                        *op,
-                        c,
-                        t,
-                        f,
-                        *output_fhe_type,
-                        ctx.chain_id,
-                        ctx.previous_bank_hash,
-                        ctx.unix_timestamp,
-                        context_id,
-                        op_index,
-                    ),
+                    FheEvalOutput::AllowedLocal => {
+                        computed_eval_ternary_handle(
+                            *op,
+                            c,
+                            t,
+                            f,
+                            *output_fhe_type,
+                            ctx.chain_id,
+                            ctx.previous_bank_hash,
+                            ctx.unix_timestamp,
+                            context_id,
+                            op_index,
+                        )
+                    }
                 };
                 produced.push(result);
                 SolanaHostEvent::FheTernaryOp(FheTernaryOpEvent {
@@ -625,15 +661,17 @@ pub fn reconstruct_fhe_eval_steps(
                         *output_nonce_key,
                         *output_nonce_sequence,
                     ),
-                    FheEvalOutput::AllowedLocal => computed_eval_trivial_handle(
-                        *plaintext,
-                        *fhe_type,
-                        ctx.chain_id,
-                        ctx.previous_bank_hash,
-                        ctx.unix_timestamp,
-                        context_id,
-                        op_index,
-                    ),
+                    FheEvalOutput::AllowedLocal => {
+                        computed_eval_trivial_handle(
+                            *plaintext,
+                            *fhe_type,
+                            ctx.chain_id,
+                            ctx.previous_bank_hash,
+                            ctx.unix_timestamp,
+                            context_id,
+                            op_index,
+                        )
+                    }
                 };
                 produced.push(result);
                 SolanaHostEvent::TrivialEncrypt(TrivialEncryptEvent {
@@ -805,7 +843,8 @@ mod tests {
     fn handles_are_pinned() {
         let t = reconstruct_trivial_encrypt(&trivial_args(), SUBJECT, &ctx());
         let r = reconstruct_fhe_rand(&rand_args(), SUBJECT, &ctx());
-        let rb = reconstruct_fhe_rand_bounded(&rand_bounded_args(), SUBJECT, &ctx());
+        let rb =
+            reconstruct_fhe_rand_bounded(&rand_bounded_args(), SUBJECT, &ctx());
         assert_eq!(t.subject, SUBJECT);
         assert_eq!(t.fhe_type, 5);
         assert_eq!(t.result, GOLDEN_TRIVIAL);
@@ -822,15 +861,14 @@ mod tests {
 
     #[test]
     fn binary_op_takes_result_from_args() {
-        let args =
-            crate::generated::zama_host_instructions::FheBinaryOpArgs {
-                op: InstrBinaryOpCode::Add,
-                lhs: [2u8; 32],
-                rhs: [3u8; 32],
-                scalar: false,
-                output_fhe_type: 5,
-                result: [42u8; 32],
-            };
+        let args = crate::generated::zama_host_instructions::FheBinaryOpArgs {
+            op: InstrBinaryOpCode::Add,
+            lhs: [2u8; 32],
+            rhs: [3u8; 32],
+            scalar: false,
+            output_fhe_type: 5,
+            result: [42u8; 32],
+        };
         let ev = reconstruct_compute_event(
             &ZamaHostInstruction::FheBinaryOp(args),
             SUBJECT,
@@ -958,8 +996,8 @@ mod tests {
                 },
             ],
         };
-        let events = reconstruct_fhe_eval_events(&plan, SUBJECT, &ctx())
-            .expect("walk");
+        let events =
+            reconstruct_fhe_eval_events(&plan, SUBJECT, &ctx()).expect("walk");
         assert_eq!(events.len(), 2);
         let step0 = match &events[0] {
             SolanaHostEvent::TrivialEncrypt(e) => {
@@ -1076,8 +1114,13 @@ mod tests {
             &HashMap::new(),
         )
         .expect("rand bounded bind reconstructs");
-        assert_eq!(evs.len(), 3, "compute + acl_record_bound + acl_subject_allowed");
-        for (i, reason) in [(1usize, "acl_record_bound"), (2, "acl_subject_allowed")]
+        assert_eq!(
+            evs.len(),
+            3,
+            "compute + acl_record_bound + acl_subject_allowed"
+        );
+        for (i, reason) in
+            [(1usize, "acl_record_bound"), (2, "acl_subject_allowed")]
         {
             match &evs[i] {
                 SolanaHostEvent::FinalizedAccountFetch(f) => {
@@ -1170,7 +1213,7 @@ mod tests {
         let mut accounts = vec![[0u8; 32]; 6];
         accounts[3] = [0x33u8; 32]; // acl_record
         accounts[4] = [0x44u8; 32]; // material_commitment
-        // handle comes from acl_record account state, pre-fetched by the caller.
+                                    // handle comes from acl_record account state, pre-fetched by the caller.
         let mut acl_handles = HashMap::new();
         acl_handles.insert([0x33u8; 32], [0x99u8; 32]);
         let evs = reconstruct_instruction_events(
@@ -1180,7 +1223,11 @@ mod tests {
             &acl_handles,
         )
         .expect("commit_handle_material reconstructs");
-        assert_eq!(evs.len(), 3, "material committed + sealed + acl_record sealed");
+        assert_eq!(
+            evs.len(),
+            3,
+            "material committed + sealed + acl_record sealed"
+        );
         match &evs[0] {
             SolanaHostEvent::FinalizedAccountFetch(f) => {
                 assert_eq!(f.account_key, [0x44u8; 32]); // material_commitment
@@ -1202,5 +1249,4 @@ mod tests {
             o => panic!("expected acl_record fetch, got {o:?}"),
         }
     }
-
 }

--- a/coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
@@ -1,0 +1,1206 @@
+//! Phase 2: reconstruct zama-host compute events from decoded instruction data +
+//! block context, WITHOUT relying on on-chain `emit_cpi!`/`emit!`.
+//!
+//! Lean by design — recompute a result handle ONLY when it is neither carried in
+//! the instruction args nor authoritatively stored elsewhere:
+//!   * `trivial_encrypt_and_bind`, `fhe_rand_and_bind`, `fhe_rand_bounded_and_bind`
+//!     compute their result on-chain and do NOT pass it as an arg, so we recompute
+//!     it here.
+//!   * `fhe_binary_op*` / `fhe_ternary_op*` pass `result` as a (program-verified)
+//!     arg — read it from args, no recompute (handled by the caller, not here).
+//!   * token balance/total-supply handles come from on-chain `fhe_eval` and are
+//!     read from account state (the account-witness route), not recomputed.
+//!
+//! Recomputation reuses the program's OWN `computed_*_handle` functions (the
+//! `zama-host` crate built with `no-entrypoint`) so the derived handles are
+//! byte-identical to what the program emits on-chain — parity a hand-copied
+//! implementation could silently lose.
+#![cfg(feature = "solana-reconstruct")]
+
+use anchor_lang::AnchorDeserialize;
+use zama_host::state::{
+    computed_bound_eval_handle, computed_bound_eval_rand_seed,
+    computed_bound_eval_ternary_handle, computed_bound_eval_trivial_handle,
+    computed_eval_handle, computed_eval_rand_seed, computed_eval_ternary_handle,
+    computed_eval_trivial_handle, computed_rand_bounded_handle,
+    computed_rand_handle, computed_rand_seed, computed_trivial_handle,
+    FheBinaryOpCode as PgmBinaryOpCode, FheEvalArgs, FheEvalOperand,
+    FheEvalOutput, FheEvalStep, FheTernaryOpCode as PgmTernaryOpCode,
+};
+
+use crate::generated::zama_host_instructions::{
+    AllowForDecryptionArgs, FheBinaryOpCode as InstrBinaryOpCode,
+    FheTernaryOpCode as InstrTernaryOpCode, FheRandAndBindArgs,
+    FheRandBoundedAndBindArgs, TrivialEncryptAndBindArgs, ZamaHostInstruction,
+};
+use crate::generated::{
+    FheBinaryOpCode, FheBinaryOpEvent, FheRandBoundedEvent, FheRandEvent,
+    FheTernaryOpCode, FheTernaryOpEvent, TrivialEncryptEvent, EVENT_VERSION,
+};
+use std::collections::HashMap;
+
+use crate::solana_adapter::{
+    acl_record_fetch, material_fetch, SolanaFinalizedAccountFetch,
+    SolanaHostEvent,
+};
+
+/// Block + config context the deterministic handle derivation needs, taken from
+/// the transaction's slot/block (`previous_bank_hash`, `unix_timestamp`) and the
+/// host's on-chain config (`chain_id`).
+#[derive(Clone, Copy, Debug)]
+pub struct ReconstructContext {
+    pub chain_id: u64,
+    pub previous_bank_hash: [u8; 32],
+    pub unix_timestamp: i64,
+}
+
+/// Reconstructs the `TrivialEncryptEvent` a `trivial_encrypt_and_bind` instruction
+/// emits, deriving the result handle exactly as the program does on-chain.
+/// `subject` is the compute subject (derived from the instruction signer by the
+/// caller and threaded in, not re-derived here).
+pub fn reconstruct_trivial_encrypt(
+    args: &TrivialEncryptAndBindArgs,
+    subject: [u8; 32],
+    ctx: &ReconstructContext,
+) -> TrivialEncryptEvent {
+    let result = computed_trivial_handle(
+        args.plaintext,
+        args.fhe_type,
+        ctx.chain_id,
+        ctx.previous_bank_hash,
+        ctx.unix_timestamp,
+        args.output_nonce_key,
+        args.output_nonce_sequence,
+    );
+    TrivialEncryptEvent {
+        version: EVENT_VERSION,
+        subject,
+        plaintext: args.plaintext,
+        fhe_type: args.fhe_type,
+        result,
+    }
+}
+
+/// Reconstructs the `FheRandEvent` a `fhe_rand_and_bind` instruction emits. The
+/// seed and result handle are both computed on-chain (not passed as args), so we
+/// recompute both via the program's functions.
+pub fn reconstruct_fhe_rand(
+    args: &FheRandAndBindArgs,
+    subject: [u8; 32],
+    ctx: &ReconstructContext,
+) -> FheRandEvent {
+    let seed = computed_rand_seed(
+        ctx.chain_id,
+        ctx.previous_bank_hash,
+        ctx.unix_timestamp,
+        args.output_nonce_key,
+        args.output_nonce_sequence,
+    );
+    let result = computed_rand_handle(seed, args.fhe_type, ctx.chain_id);
+    FheRandEvent {
+        version: EVENT_VERSION,
+        subject,
+        seed,
+        fhe_type: args.fhe_type,
+        result,
+    }
+}
+
+/// Reconstructs the `FheRandBoundedEvent` a `fhe_rand_bounded_and_bind`
+/// instruction emits.
+pub fn reconstruct_fhe_rand_bounded(
+    args: &FheRandBoundedAndBindArgs,
+    subject: [u8; 32],
+    ctx: &ReconstructContext,
+) -> FheRandBoundedEvent {
+    let seed = computed_rand_seed(
+        ctx.chain_id,
+        ctx.previous_bank_hash,
+        ctx.unix_timestamp,
+        args.output_nonce_key,
+        args.output_nonce_sequence,
+    );
+    let result = computed_rand_bounded_handle(
+        args.upper_bound,
+        seed,
+        args.fhe_type,
+        ctx.chain_id,
+    );
+    FheRandBoundedEvent {
+        version: EVENT_VERSION,
+        subject,
+        upper_bound: args.upper_bound,
+        seed,
+        fhe_type: args.fhe_type,
+        result,
+    }
+}
+
+/// Maps a decoded zama-host instruction to the compute event it would emit.
+///
+/// Recompute for `trivial_encrypt`/`fhe_rand[_bounded]` (handle not in args);
+/// `result`-from-args for binary/ternary (program-verified on success). Returns
+/// `None` for instructions that produce only ACL/fetch records — those are
+/// reconstructed from `output_subjects`/account state in a separate path.
+/// `subject` is the compute subject (derived from the instruction signer by the
+/// caller and threaded in).
+pub fn reconstruct_compute_event(
+    instruction: &ZamaHostInstruction,
+    subject: [u8; 32],
+    ctx: &ReconstructContext,
+) -> Option<SolanaHostEvent> {
+    use ZamaHostInstruction as I;
+    Some(match instruction {
+        I::TrivialEncryptAndBind(a) => SolanaHostEvent::TrivialEncrypt(
+            reconstruct_trivial_encrypt(a, subject, ctx),
+        ),
+        I::FheRandAndBind(a) => {
+            SolanaHostEvent::FheRand(reconstruct_fhe_rand(a, subject, ctx))
+        }
+        I::FheRandBoundedAndBind(a) => SolanaHostEvent::FheRandBounded(
+            reconstruct_fhe_rand_bounded(a, subject, ctx),
+        ),
+        I::FheBinaryOp(a) => SolanaHostEvent::FheBinaryOp(FheBinaryOpEvent {
+            version: EVENT_VERSION,
+            op: map_binary_op(a.op),
+            subject,
+            lhs: a.lhs,
+            rhs: a.rhs,
+            scalar: a.scalar,
+            result: a.result,
+        }),
+        I::FheBinaryOpAndBindOutput(a) => {
+            SolanaHostEvent::FheBinaryOp(FheBinaryOpEvent {
+                version: EVENT_VERSION,
+                op: map_binary_op(a.op),
+                subject,
+                lhs: a.lhs,
+                rhs: a.rhs,
+                scalar: a.scalar,
+                result: a.result,
+            })
+        }
+        I::FheTernaryOpAndBindOutput(a) => {
+            SolanaHostEvent::FheTernaryOp(FheTernaryOpEvent {
+                version: EVENT_VERSION,
+                op: map_ternary_op(a.op),
+                subject,
+                control: a.control,
+                if_true: a.if_true,
+                if_false: a.if_false,
+                result: a.result,
+            })
+        }
+        // Produce ACL/fetch records, not compute events; handled elsewhere.
+        I::AllowForDecryption(_)
+        | I::AllowAclSubjects(_)
+        | I::CommitHandleMaterial(_) => return None,
+    })
+}
+
+/// Reconstructs the full ingestable event set (compute event + ACL allow-fetches)
+/// for a decoded zama-host instruction, resolving the ACL-record account from the
+/// instruction's `accounts` (raw 32-byte, in account order). Mirrors what the
+/// program's emits decode to, so ingest is byte-identical.
+///
+/// Wired for `trivial_encrypt_and_bind`; other (already-decodable) instructions
+/// return `None` until their per-instruction account layout + fetches are added
+/// (the caller falls back to emit-decode for those while emits are still on). New
+/// `ZamaHostInstruction` variants must be handled explicitly — no wildcard arm.
+pub fn reconstruct_instruction_events(
+    instruction: &ZamaHostInstruction,
+    accounts: &[[u8; 32]],
+    ctx: &ReconstructContext,
+    acl_handles: &HashMap<[u8; 32], [u8; 32]>,
+) -> Option<Vec<SolanaHostEvent>> {
+    use ZamaHostInstruction as I;
+    match instruction {
+        // Compute (+ optional durable bind): (compute_subject index, Some(
+        // output_acl_record index) if it binds, subject count). fhe_binary_op is
+        // non-bind (compute_subject at 0, no durable output).
+        I::FheBinaryOp(_) => compute_with_bind(instruction, accounts, ctx, 0, None, 0),
+        I::TrivialEncryptAndBind(a) => {
+            compute_with_bind(instruction, accounts, ctx, 1, Some(4), a.output_subjects.len())
+        }
+        I::FheBinaryOpAndBindOutput(a) => {
+            compute_with_bind(instruction, accounts, ctx, 1, Some(8), a.output_subjects.len())
+        }
+        I::FheTernaryOpAndBindOutput(a) => {
+            compute_with_bind(instruction, accounts, ctx, 1, Some(10), a.output_subjects.len())
+        }
+        I::FheRandAndBind(a) => {
+            compute_with_bind(instruction, accounts, ctx, 1, Some(4), a.output_subjects.len())
+        }
+        I::FheRandBoundedAndBind(a) => {
+            compute_with_bind(instruction, accounts, ctx, 1, Some(4), a.output_subjects.len())
+        }
+        // Allow instructions: fetch-only (no compute event). The handle was computed
+        // by an earlier instruction; these only flip its allow state.
+        // allow_for_decryption accounts: authority, authority_permission_record,
+        // acl_record(2), host_config, deny_subject_record.
+        I::AllowForDecryption(args) => {
+            let acl_record = accounts.get(2).copied()?;
+            Some(vec![SolanaHostEvent::FinalizedAccountFetch(
+                reconstruct_public_decrypt_allowed_fetch(args, acl_record),
+            )])
+        }
+        // allow_acl_subjects accounts: payer, authority, authority_permission_record,
+        // acl_record(3), host_config, deny_subject_record, system_program. One
+        // `acl_subject_allowed` fetch per subject (the `AclAllowed` event maps to no
+        // DB row, omitted; overflow permission records not handled here).
+        I::AllowAclSubjects(args) => {
+            let acl_record = accounts.get(3).copied()?;
+            Some(
+                (0..args.subjects.len())
+                    .map(|_| {
+                        SolanaHostEvent::FinalizedAccountFetch(acl_record_fetch(
+                            acl_record,
+                            args.handle,
+                            "acl_subject_allowed",
+                        ))
+                    })
+                    .collect(),
+            )
+        }
+        // commit_handle_material: fetch-only, but the handle comes from the
+        // acl_record's account STATE (acl_record.handle), pre-fetched by the caller
+        // into `acl_handles`. accounts: payer, material_authority, host_config,
+        // acl_record(3), material_commitment(4), system_program. Emits both
+        // HandleMaterialCommitted + HandleMaterialSealed → three fetches.
+        I::CommitHandleMaterial(_) => {
+            let acl_record = accounts.get(3).copied()?;
+            let material_commitment = accounts.get(4).copied()?;
+            let handle = acl_handles.get(&acl_record).copied()?;
+            Some(vec![
+                SolanaHostEvent::FinalizedAccountFetch(material_fetch(
+                    material_commitment,
+                    acl_record,
+                    handle,
+                    "handle_material_committed",
+                )),
+                SolanaHostEvent::FinalizedAccountFetch(material_fetch(
+                    material_commitment,
+                    acl_record,
+                    handle,
+                    "handle_material_sealed",
+                )),
+                SolanaHostEvent::FinalizedAccountFetch(acl_record_fetch(
+                    acl_record,
+                    handle,
+                    "handle_material_sealed",
+                )),
+            ])
+        }
+    }
+}
+
+/// Parses the `handle` field from an on-chain `AclRecord` account's data, reusing
+/// the program's own `AclRecord` type. The transport reads this for instructions
+/// whose emitted handle comes from account state (e.g. `commit_handle_material`),
+/// not the instruction args.
+pub fn parse_acl_record_handle(account_data: &[u8]) -> Option<[u8; 32]> {
+    use anchor_lang::AccountDeserialize;
+    zama_host::state::AclRecord::try_deserialize(&mut &account_data[..])
+        .ok()
+        .map(|record| record.handle)
+}
+
+/// Builds a compute instruction's events: the compute event (via
+/// [`reconstruct_compute_event`]) plus, for a durable bind, an `acl_record_bound`
+/// fetch and one `acl_subject_allowed` fetch per output subject (same record +
+/// handle; the `AclAllowed` event maps to no DB row and is omitted).
+fn compute_with_bind(
+    instruction: &ZamaHostInstruction,
+    accounts: &[[u8; 32]],
+    ctx: &ReconstructContext,
+    subject_index: usize,
+    output_acl_record_index: Option<usize>,
+    subject_count: usize,
+) -> Option<Vec<SolanaHostEvent>> {
+    let subject = accounts.get(subject_index).copied()?;
+    let compute = reconstruct_compute_event(instruction, subject, ctx)?;
+    let result = match &compute {
+        SolanaHostEvent::FheBinaryOp(e) => e.result,
+        SolanaHostEvent::FheTernaryOp(e) => e.result,
+        SolanaHostEvent::TrivialEncrypt(e) => e.result,
+        SolanaHostEvent::FheRand(e) => e.result,
+        SolanaHostEvent::FheRandBounded(e) => e.result,
+        SolanaHostEvent::FinalizedAccountFetch(_)
+        | SolanaHostEvent::AclAllowed(_) => return None,
+    };
+
+    let mut events = vec![compute];
+    if let Some(index) = output_acl_record_index {
+        let output_acl_record = accounts.get(index).copied()?;
+        events.push(SolanaHostEvent::FinalizedAccountFetch(
+            reconstruct_acl_record_bound_fetch(output_acl_record, result),
+        ));
+        for _ in 0..subject_count {
+            events.push(SolanaHostEvent::FinalizedAccountFetch(
+                acl_record_fetch(output_acl_record, result, "acl_subject_allowed"),
+            ));
+        }
+    }
+    Some(events)
+}
+
+/// The instruction and event IDLs define the same opcode enum; map between the
+/// two generated copies by variant (a build-time exhaustiveness check guards drift).
+fn map_binary_op(op: InstrBinaryOpCode) -> FheBinaryOpCode {
+    match op {
+        InstrBinaryOpCode::Add => FheBinaryOpCode::Add,
+        InstrBinaryOpCode::Sub => FheBinaryOpCode::Sub,
+        InstrBinaryOpCode::Ge => FheBinaryOpCode::Ge,
+    }
+}
+
+fn map_ternary_op(op: InstrTernaryOpCode) -> FheTernaryOpCode {
+    match op {
+        InstrTernaryOpCode::IfThenElse => FheTernaryOpCode::IfThenElse,
+    }
+}
+
+/// The `acl_record_bound` allow-fetch a `*_and_bind` instruction produces: the
+/// bound handle (identical to the reconstructed compute event's `result`) keyed
+/// by the AclRecord PDA the instruction wrote. This allow-reason is what flips
+/// `is_allowed=true` on the same-tx compute row so the tfhe-worker materializes
+/// the ciphertext. `acl_record` is the AclRecord account address, resolved from
+/// the instruction's accounts by the caller (the transport wiring).
+pub fn reconstruct_acl_record_bound_fetch(
+    acl_record: [u8; 32],
+    bound_handle: [u8; 32],
+) -> SolanaFinalizedAccountFetch {
+    acl_record_fetch(acl_record, bound_handle, "acl_record_bound")
+}
+
+/// The `public_decrypt_allowed` allow-fetch an `allow_for_decryption` instruction
+/// produces. The handle is the instruction arg; `acl_record` is resolved from the
+/// instruction's accounts by the caller.
+pub fn reconstruct_public_decrypt_allowed_fetch(
+    args: &AllowForDecryptionArgs,
+    acl_record: [u8; 32],
+) -> SolanaFinalizedAccountFetch {
+    acl_record_fetch(acl_record, args.handle, "public_decrypt_allowed")
+}
+
+/// Discriminator for the `fhe_eval` instruction (sha256("global:fhe_eval")[..8]).
+const FHE_EVAL_DISCRIMINATOR: [u8; 8] =
+    [176, 42, 63, 177, 244, 167, 120, 109];
+
+/// Decodes a `fhe_eval` instruction's data into the program's own `FheEvalArgs`
+/// step plan, reusing the zama-host type (so there is no bespoke decoder to drift
+/// from the on-chain layout). The decoded plan is the input to the eval walk that
+/// reconstructs one compute event per step — a separate pass that recomputes each
+/// step's handle and therefore depends on `previous_bank_hash`.
+pub fn decode_fhe_eval_args(instruction_data: &[u8]) -> Option<FheEvalArgs> {
+    let payload = instruction_data.strip_prefix(&FHE_EVAL_DISCRIMINATOR)?;
+    FheEvalArgs::try_from_slice(payload).ok()
+}
+
+// `previous_bank_hash` sourcing lives in `solana_slot_hashes` (feature-independent
+// so the gRPC transport can use it too); re-exported here for the reconstruction API.
+pub use crate::solana_slot_hashes::{
+    previous_bank_hash_from_slot_hashes, SLOT_HASHES_SYSVAR,
+};
+
+/// Seed for the singleton HostConfig PDA (`PDA("host-config")`), re-exported so the
+/// transport can derive its address to fetch the on-chain config.
+pub use zama_host::constants::HOST_CONFIG_SEED;
+
+/// Reads the on-chain `HostConfig` account and returns the
+/// `(chain_id, zero_birth_entropy)` pair handle derivation needs, reusing the
+/// program's own `HostConfig` type (no bespoke layout to drift from).
+///
+/// `zero_birth_entropy` mirrors `HostConfig::zero_birth_entropy_allowed()` =
+/// `test_shims_enabled && POC_FEATURE_ENABLED && chain_id == SOLANA_POC_CHAIN_ID`.
+/// The listener cannot read the program's compile-time `POC_FEATURE_ENABLED`, but
+/// it need not: the program rejects `chain_id == SOLANA_POC_CHAIN_ID` at init
+/// unless built with `poc`, so an on-chain `chain_id == SOLANA_POC_CHAIN_ID`
+/// already implies `POC_FEATURE_ENABLED`. The check below is therefore exact.
+pub fn parse_host_config(account_data: &[u8]) -> anyhow::Result<(u64, bool)> {
+    use anchor_lang::AccountDeserialize;
+    let config =
+        zama_host::state::HostConfig::try_deserialize(&mut &account_data[..])
+            .map_err(|e| anyhow::anyhow!("decode HostConfig account: {e}"))?;
+    let zero_birth_entropy = config.test_shims_enabled
+        && config.chain_id == zama_host::constants::SOLANA_POC_CHAIN_ID;
+    Ok((config.chain_id, zero_birth_entropy))
+}
+
+/// Resolves an eval operand to its handle by reusing already-produced step
+/// results — no on-chain account reads. `Scalar` is only valid as a binary rhs
+/// (handled by [`resolve_rhs`]); seeing it here means a malformed plan.
+fn resolve_operand(
+    operand: &FheEvalOperand,
+    produced: &[[u8; 32]],
+) -> Option<[u8; 32]> {
+    match operand {
+        FheEvalOperand::AllowedDurable { handle, .. } => Some(*handle),
+        FheEvalOperand::AllowedLocal { producer_index } => {
+            produced.get(*producer_index as usize).copied()
+        }
+        // The verified-input handle is known from the operand itself; the
+        // program resolves it to `attestation.input_handle` (admission re-verifies
+        // the attestation authoritatively, but the operand handle is structural).
+        FheEvalOperand::VerifiedInput { attestation } => {
+            Some(attestation.input_handle)
+        }
+        FheEvalOperand::Scalar(_) => None,
+    }
+}
+
+/// Resolves a binary rhs operand, reporting whether it is a scalar (the program
+/// sets `scalar = true` only for a `Scalar` rhs).
+fn resolve_rhs(
+    operand: &FheEvalOperand,
+    produced: &[[u8; 32]],
+) -> Option<([u8; 32], bool)> {
+    match operand {
+        FheEvalOperand::Scalar(bytes) => Some((*bytes, true)),
+        other => resolve_operand(other, produced).map(|h| (h, false)),
+    }
+}
+
+fn map_pgm_binary_op(op: PgmBinaryOpCode) -> FheBinaryOpCode {
+    match op {
+        PgmBinaryOpCode::Add => FheBinaryOpCode::Add,
+        PgmBinaryOpCode::Sub => FheBinaryOpCode::Sub,
+        PgmBinaryOpCode::Ge => FheBinaryOpCode::Ge,
+    }
+}
+
+fn map_pgm_ternary_op(op: PgmTernaryOpCode) -> FheTernaryOpCode {
+    match op {
+        PgmTernaryOpCode::IfThenElse => FheTernaryOpCode::IfThenElse,
+    }
+}
+
+/// Reconstructs the per-step compute events a `fhe_eval` plan emits, mirroring
+/// the program's `walk_eval_frame`: walk steps in order, resolve operands
+/// (`Transient` referring to earlier steps' produced handles), recompute each
+/// step's result handle via the program's eval primitives (`Durable` output →
+/// bound variant, otherwise unbound), and record one event per step.
+///
+/// Returns `None` on a malformed plan (operand referencing a not-yet-produced
+/// step, or a `Scalar` where only an encrypted operand is valid). `context_id`
+/// comes from the plan; `ctx` supplies chain_id / previous_bank_hash /
+/// unix_timestamp; `subject` is the compute subject.
+pub fn reconstruct_fhe_eval_steps(
+    plan: &FheEvalArgs,
+    subject: [u8; 32],
+    ctx: &ReconstructContext,
+) -> Option<Vec<ReconstructedEvalStep>> {
+    let context_id = plan.context_id;
+    let mut produced: Vec<[u8; 32]> = Vec::with_capacity(plan.steps.len());
+    let mut steps_out: Vec<ReconstructedEvalStep> =
+        Vec::with_capacity(plan.steps.len());
+
+    for (index, step) in plan.steps.iter().enumerate() {
+        let op_index = index as u16;
+        let event = match step {
+            FheEvalStep::Binary {
+                op,
+                lhs,
+                rhs,
+                output_fhe_type,
+                output,
+            } => {
+                let lhs_handle = resolve_operand(lhs, &produced)?;
+                let (rhs_handle, scalar) = resolve_rhs(rhs, &produced)?;
+                let result = match output {
+                    FheEvalOutput::AllowedDurable {
+                        output_nonce_key,
+                        output_nonce_sequence,
+                        ..
+                    } => computed_bound_eval_handle(
+                        *op,
+                        lhs_handle,
+                        rhs_handle,
+                        scalar,
+                        *output_fhe_type,
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                        *output_nonce_key,
+                        *output_nonce_sequence,
+                    ),
+                    FheEvalOutput::AllowedLocal => computed_eval_handle(
+                        *op,
+                        lhs_handle,
+                        rhs_handle,
+                        scalar,
+                        *output_fhe_type,
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                    ),
+                };
+                produced.push(result);
+                SolanaHostEvent::FheBinaryOp(FheBinaryOpEvent {
+                    version: EVENT_VERSION,
+                    op: map_pgm_binary_op(*op),
+                    subject,
+                    lhs: lhs_handle,
+                    rhs: rhs_handle,
+                    scalar,
+                    result,
+                })
+            }
+            FheEvalStep::Ternary {
+                op,
+                control,
+                if_true,
+                if_false,
+                output_fhe_type,
+                output,
+            } => {
+                let c = resolve_operand(control, &produced)?;
+                let t = resolve_operand(if_true, &produced)?;
+                let f = resolve_operand(if_false, &produced)?;
+                let result = match output {
+                    FheEvalOutput::AllowedDurable {
+                        output_nonce_key,
+                        output_nonce_sequence,
+                        ..
+                    } => computed_bound_eval_ternary_handle(
+                        *op,
+                        c,
+                        t,
+                        f,
+                        *output_fhe_type,
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                        *output_nonce_key,
+                        *output_nonce_sequence,
+                    ),
+                    FheEvalOutput::AllowedLocal => computed_eval_ternary_handle(
+                        *op,
+                        c,
+                        t,
+                        f,
+                        *output_fhe_type,
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                    ),
+                };
+                produced.push(result);
+                SolanaHostEvent::FheTernaryOp(FheTernaryOpEvent {
+                    version: EVENT_VERSION,
+                    op: map_pgm_ternary_op(*op),
+                    subject,
+                    control: c,
+                    if_true: t,
+                    if_false: f,
+                    result,
+                })
+            }
+            FheEvalStep::TrivialEncrypt {
+                plaintext,
+                fhe_type,
+                output,
+            } => {
+                let result = match output {
+                    FheEvalOutput::AllowedDurable {
+                        output_nonce_key,
+                        output_nonce_sequence,
+                        ..
+                    } => computed_bound_eval_trivial_handle(
+                        *plaintext,
+                        *fhe_type,
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                        *output_nonce_key,
+                        *output_nonce_sequence,
+                    ),
+                    FheEvalOutput::AllowedLocal => computed_eval_trivial_handle(
+                        *plaintext,
+                        *fhe_type,
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                    ),
+                };
+                produced.push(result);
+                SolanaHostEvent::TrivialEncrypt(TrivialEncryptEvent {
+                    version: EVENT_VERSION,
+                    subject,
+                    plaintext: *plaintext,
+                    fhe_type: *fhe_type,
+                    result,
+                })
+            }
+            FheEvalStep::Rand { fhe_type, output } => {
+                let seed = match output {
+                    FheEvalOutput::AllowedDurable {
+                        output_nonce_key,
+                        output_nonce_sequence,
+                        ..
+                    } => computed_bound_eval_rand_seed(
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                        *output_nonce_key,
+                        *output_nonce_sequence,
+                    ),
+                    FheEvalOutput::AllowedLocal => computed_eval_rand_seed(
+                        ctx.chain_id,
+                        ctx.previous_bank_hash,
+                        ctx.unix_timestamp,
+                        context_id,
+                        op_index,
+                    ),
+                };
+                let result =
+                    computed_rand_handle(seed, *fhe_type, ctx.chain_id);
+                produced.push(result);
+                SolanaHostEvent::FheRand(FheRandEvent {
+                    version: EVENT_VERSION,
+                    subject,
+                    seed,
+                    fhe_type: *fhe_type,
+                    result,
+                })
+            }
+        };
+        let durable_acl_record_index = match fhe_eval_step_output(step) {
+            FheEvalOutput::AllowedDurable {
+                output_acl_record_index,
+                ..
+            } => Some(*output_acl_record_index),
+            FheEvalOutput::AllowedLocal => None,
+        };
+        steps_out.push(ReconstructedEvalStep {
+            event,
+            durable_acl_record_index,
+        });
+    }
+    Some(steps_out)
+}
+
+/// One reconstructed `fhe_eval` step: the compute event plus, for a `Durable`
+/// output, the `remaining_accounts` index of the output ACL record PDA. The
+/// transport resolves that index to an account address to rebuild the
+/// `acl_record_bound` allow-fetch (the same record the program's bind emitted),
+/// which flips `is_allowed=true` on the compute row.
+pub struct ReconstructedEvalStep {
+    pub event: SolanaHostEvent,
+    pub durable_acl_record_index: Option<u16>,
+}
+
+/// The output policy of an eval step, independent of step kind.
+fn fhe_eval_step_output(step: &FheEvalStep) -> &FheEvalOutput {
+    match step {
+        FheEvalStep::Binary { output, .. }
+        | FheEvalStep::Ternary { output, .. }
+        | FheEvalStep::TrivialEncrypt { output, .. }
+        | FheEvalStep::Rand { output, .. } => output,
+    }
+}
+
+/// Reconstructs just the per-step compute events (without ACL-record indices) —
+/// the shape the shadow-compare consumes. Thin wrapper over
+/// [`reconstruct_fhe_eval_steps`].
+pub fn reconstruct_fhe_eval_events(
+    plan: &FheEvalArgs,
+    subject: [u8; 32],
+    ctx: &ReconstructContext,
+) -> Option<Vec<SolanaHostEvent>> {
+    Some(
+        reconstruct_fhe_eval_steps(plan, subject, ctx)?
+            .into_iter()
+            .map(|step| step.event)
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SUBJECT: [u8; 32] = [1u8; 32];
+
+    fn ctx() -> ReconstructContext {
+        ReconstructContext {
+            chain_id: 12345,
+            previous_bank_hash: [3u8; 32],
+            unix_timestamp: 1_700_000_000,
+        }
+    }
+
+    fn trivial_args() -> TrivialEncryptAndBindArgs {
+        TrivialEncryptAndBindArgs {
+            plaintext: [7u8; 32],
+            fhe_type: 5,
+            output_nonce_key: [9u8; 32],
+            output_nonce_sequence: 42,
+            output_acl_domain_key: [0u8; 32],
+            output_app_account: [0u8; 32],
+            output_encrypted_value_label: [0u8; 32],
+            output_subjects: Vec::new(),
+            output_public_decrypt: false,
+        }
+    }
+
+    fn rand_args() -> FheRandAndBindArgs {
+        FheRandAndBindArgs {
+            fhe_type: 5,
+            output_nonce_key: [9u8; 32],
+            output_nonce_sequence: 42,
+            output_acl_domain_key: [0u8; 32],
+            output_app_account: [0u8; 32],
+            output_encrypted_value_label: [0u8; 32],
+            output_subjects: Vec::new(),
+            output_public_decrypt: false,
+        }
+    }
+
+    fn rand_bounded_args() -> FheRandBoundedAndBindArgs {
+        FheRandBoundedAndBindArgs {
+            upper_bound: [4u8; 32],
+            fhe_type: 5,
+            output_nonce_key: [9u8; 32],
+            output_nonce_sequence: 42,
+            output_acl_domain_key: [0u8; 32],
+            output_app_account: [0u8; 32],
+            output_encrypted_value_label: [0u8; 32],
+            output_subjects: Vec::new(),
+            output_public_decrypt: false,
+        }
+    }
+
+    // Golden vectors: pin the program's on-chain derivation so any change to
+    // zama-host's computed_*_handle (which would desync reconstruction from
+    // emission) breaks these tests loudly. Captured from a first run.
+    const GOLDEN_TRIVIAL: [u8; 32] = [
+        91, 123, 147, 51, 77, 108, 124, 18, 206, 116, 17, 238, 84, 157, 204,
+        183, 145, 232, 243, 169, 74, 255, 0, 0, 0, 0, 0, 0, 48, 57, 5, 0,
+    ];
+    const GOLDEN_RAND: [u8; 32] = [
+        53, 128, 99, 77, 114, 224, 136, 138, 99, 172, 88, 145, 172, 101, 179,
+        182, 81, 120, 194, 48, 85, 255, 0, 0, 0, 0, 0, 0, 48, 57, 5, 0,
+    ];
+    const GOLDEN_RAND_BOUNDED: [u8; 32] = [
+        103, 194, 68, 202, 243, 135, 241, 40, 137, 170, 183, 235, 26, 236, 71,
+        222, 188, 240, 224, 67, 213, 255, 0, 0, 0, 0, 0, 0, 48, 57, 5, 0,
+    ];
+
+    #[test]
+    fn handles_are_pinned() {
+        let t = reconstruct_trivial_encrypt(&trivial_args(), SUBJECT, &ctx());
+        let r = reconstruct_fhe_rand(&rand_args(), SUBJECT, &ctx());
+        let rb = reconstruct_fhe_rand_bounded(&rand_bounded_args(), SUBJECT, &ctx());
+        assert_eq!(t.subject, SUBJECT);
+        assert_eq!(t.fhe_type, 5);
+        assert_eq!(t.result, GOLDEN_TRIVIAL);
+        assert_eq!(r.result, GOLDEN_RAND);
+        assert_eq!(rb.result, GOLDEN_RAND_BOUNDED);
+    }
+
+    #[test]
+    fn handles_are_deterministic() {
+        let a = reconstruct_trivial_encrypt(&trivial_args(), SUBJECT, &ctx());
+        let b = reconstruct_trivial_encrypt(&trivial_args(), SUBJECT, &ctx());
+        assert_eq!(a.result, b.result);
+    }
+
+    #[test]
+    fn binary_op_takes_result_from_args() {
+        let args =
+            crate::generated::zama_host_instructions::FheBinaryOpArgs {
+                op: InstrBinaryOpCode::Add,
+                lhs: [2u8; 32],
+                rhs: [3u8; 32],
+                scalar: false,
+                output_fhe_type: 5,
+                result: [42u8; 32],
+            };
+        let ev = reconstruct_compute_event(
+            &ZamaHostInstruction::FheBinaryOp(args),
+            SUBJECT,
+            &ctx(),
+        )
+        .expect("binary op yields a compute event");
+        match ev {
+            SolanaHostEvent::FheBinaryOp(e) => {
+                assert_eq!(e.op, FheBinaryOpCode::Add);
+                assert_eq!(e.subject, SUBJECT);
+                // result is taken verbatim from the (program-verified) arg, not recomputed.
+                assert_eq!(e.result, [42u8; 32]);
+            }
+            other => panic!("expected FheBinaryOp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatcher_routes_trivial_encrypt() {
+        let ev = reconstruct_compute_event(
+            &ZamaHostInstruction::TrivialEncryptAndBind(trivial_args()),
+            SUBJECT,
+            &ctx(),
+        )
+        .expect("trivial encrypt yields a compute event");
+        match ev {
+            SolanaHostEvent::TrivialEncrypt(e) => {
+                assert_eq!(e.result, GOLDEN_TRIVIAL)
+            }
+            other => panic!("expected TrivialEncrypt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allow_for_decryption_has_no_compute_event() {
+        let args =
+            crate::generated::zama_host_instructions::AllowForDecryptionArgs {
+                handle: [1u8; 32],
+            };
+        assert!(reconstruct_compute_event(
+            &ZamaHostInstruction::AllowForDecryption(args),
+            SUBJECT,
+            &ctx(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn acl_record_bound_fetch_matches_event_path() {
+        use crate::solana_adapter::SolanaFinalizedAccountFetchKind;
+        let acl_record = [8u8; 32];
+        let handle = [9u8; 32];
+        let f = reconstruct_acl_record_bound_fetch(acl_record, handle);
+        // Identical shape to the AclRecordBound event-decode path (acl_record_fetch).
+        assert_eq!(f.account_key, acl_record);
+        assert_eq!(f.kind, SolanaFinalizedAccountFetchKind::AclRecord);
+        assert_eq!(f.reason, "acl_record_bound");
+        assert!(f.handle.is_some());
+        assert_eq!(f.related_account, None);
+        assert_eq!(f.subject, None);
+    }
+
+    #[test]
+    fn public_decrypt_allowed_fetch_uses_arg_handle() {
+        use crate::solana_adapter::SolanaFinalizedAccountFetchKind;
+        let args = AllowForDecryptionArgs { handle: [5u8; 32] };
+        let acl_record = [8u8; 32];
+        let f = reconstruct_public_decrypt_allowed_fetch(&args, acl_record);
+        assert_eq!(f.account_key, acl_record);
+        assert_eq!(f.kind, SolanaFinalizedAccountFetchKind::AclRecord);
+        assert_eq!(f.reason, "public_decrypt_allowed");
+        assert!(f.handle.is_some());
+    }
+
+    #[test]
+    fn fhe_eval_plan_round_trips_via_program_type() {
+        use anchor_lang::AnchorSerialize;
+        use zama_host::state::{
+            FheBinaryOpCode as PgmBinaryOp, FheEvalArgs, FheEvalOperand,
+            FheEvalOutput, FheEvalStep,
+        };
+        let plan = FheEvalArgs {
+            context_id: [1u8; 32],
+            steps: vec![
+                FheEvalStep::TrivialEncrypt {
+                    plaintext: [7u8; 32],
+                    fhe_type: 5,
+                    output: FheEvalOutput::AllowedLocal,
+                },
+                FheEvalStep::Binary {
+                    op: PgmBinaryOp::Add,
+                    lhs: FheEvalOperand::AllowedLocal { producer_index: 0 },
+                    rhs: FheEvalOperand::Scalar([2u8; 32]),
+                    output_fhe_type: 5,
+                    output: FheEvalOutput::AllowedLocal,
+                },
+            ],
+        };
+        // Serialize like the on-chain instruction: discriminator + borsh args.
+        let mut bytes = FHE_EVAL_DISCRIMINATOR.to_vec();
+        plan.serialize(&mut bytes).expect("serialize plan");
+        let decoded = decode_fhe_eval_args(&bytes).expect("decode plan");
+        assert_eq!(decoded, plan);
+        assert_eq!(decoded.steps.len(), 2);
+        // Wrong/missing discriminator -> None.
+        assert!(decode_fhe_eval_args(&bytes[1..]).is_none());
+    }
+
+    #[test]
+    fn fhe_eval_walk_chains_transient_handles() {
+        let plan = FheEvalArgs {
+            context_id: [1u8; 32],
+            steps: vec![
+                FheEvalStep::TrivialEncrypt {
+                    plaintext: [7u8; 32],
+                    fhe_type: 5,
+                    output: FheEvalOutput::AllowedLocal,
+                },
+                FheEvalStep::Binary {
+                    op: PgmBinaryOpCode::Add,
+                    lhs: FheEvalOperand::AllowedLocal { producer_index: 0 },
+                    rhs: FheEvalOperand::Scalar([2u8; 32]),
+                    output_fhe_type: 5,
+                    output: FheEvalOutput::AllowedLocal,
+                },
+            ],
+        };
+        let events = reconstruct_fhe_eval_events(&plan, SUBJECT, &ctx())
+            .expect("walk");
+        assert_eq!(events.len(), 2);
+        let step0 = match &events[0] {
+            SolanaHostEvent::TrivialEncrypt(e) => {
+                assert_eq!(e.plaintext, [7u8; 32]);
+                e.result
+            }
+            other => panic!("expected TrivialEncrypt, got {other:?}"),
+        };
+        match &events[1] {
+            SolanaHostEvent::FheBinaryOp(e) => {
+                assert_eq!(e.op, FheBinaryOpCode::Add);
+                assert!(e.scalar);
+                assert_eq!(e.rhs, [2u8; 32]);
+                // The Transient operand resolved to step 0's produced handle.
+                assert_eq!(e.lhs, step0);
+            }
+            other => panic!("expected FheBinaryOp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fhe_eval_walk_rejects_forward_transient_reference() {
+        // A first step referencing a not-yet-produced step -> None.
+        let plan = FheEvalArgs {
+            context_id: [1u8; 32],
+            steps: vec![FheEvalStep::Binary {
+                op: PgmBinaryOpCode::Add,
+                lhs: FheEvalOperand::AllowedLocal { producer_index: 5 },
+                rhs: FheEvalOperand::Scalar([2u8; 32]),
+                output_fhe_type: 5,
+                output: FheEvalOutput::AllowedLocal,
+            }],
+        };
+        assert!(reconstruct_fhe_eval_events(&plan, SUBJECT, &ctx()).is_none());
+    }
+
+    #[test]
+    fn instruction_events_non_bind_binary_has_no_fetch() {
+        // fhe_binary_op: compute_subject=0, no durable output -> compute event only.
+        let args = crate::generated::zama_host_instructions::FheBinaryOpArgs {
+            op: InstrBinaryOpCode::Add,
+            lhs: [2u8; 32],
+            rhs: [3u8; 32],
+            scalar: false,
+            output_fhe_type: 5,
+            result: [42u8; 32],
+        };
+        let accounts = vec![[0x10u8; 32]]; // accounts[0] = compute_subject
+        let evs = reconstruct_instruction_events(
+            &ZamaHostInstruction::FheBinaryOp(args),
+            &accounts,
+            &ctx(),
+            &HashMap::new(),
+        )
+        .expect("binary op reconstructs");
+        assert_eq!(evs.len(), 1, "non-bind: compute event only, no fetch");
+        match &evs[0] {
+            SolanaHostEvent::FheBinaryOp(e) => {
+                assert_eq!(e.subject, [0x10u8; 32]);
+                assert_eq!(e.result, [42u8; 32]);
+            }
+            o => panic!("expected FheBinaryOp, got {o:?}"),
+        }
+    }
+
+    #[test]
+    fn instruction_events_rand_bind_resolves_accounts() {
+        use crate::solana_adapter::SolanaFinalizedAccountFetchKind;
+        // fhe_rand_and_bind: compute_subject=1, output_acl_record=4; no subjects.
+        let mut accounts = vec![[0u8; 32]; 6];
+        accounts[1] = [0x11u8; 32];
+        accounts[4] = [0x44u8; 32];
+        let evs = reconstruct_instruction_events(
+            &ZamaHostInstruction::FheRandAndBind(rand_args()),
+            &accounts,
+            &ctx(),
+            &HashMap::new(),
+        )
+        .expect("rand bind reconstructs");
+        assert_eq!(evs.len(), 2, "compute + acl_record_bound (no subjects)");
+        match &evs[0] {
+            SolanaHostEvent::FheRand(e) => {
+                assert_eq!(e.subject, [0x11u8; 32]); // accounts[1]
+                assert_eq!(e.result, GOLDEN_RAND); // subject-independent
+            }
+            o => panic!("expected FheRand, got {o:?}"),
+        }
+        match &evs[1] {
+            SolanaHostEvent::FinalizedAccountFetch(f) => {
+                assert_eq!(f.account_key, [0x44u8; 32]); // accounts[4]
+                assert_eq!(f.kind, SolanaFinalizedAccountFetchKind::AclRecord);
+                assert_eq!(f.reason, "acl_record_bound");
+            }
+            o => panic!("expected FinalizedAccountFetch, got {o:?}"),
+        }
+    }
+
+    #[test]
+    fn instruction_events_each_subject_yields_acl_subject_allowed() {
+        // One output subject -> one extra acl_subject_allowed fetch (same record).
+        let mut args = rand_bounded_args();
+        args.output_subjects =
+            vec![crate::generated::zama_host_instructions::AclSubjectEntry {
+                pubkey: [0x55u8; 32],
+                role_flags: 1,
+            }];
+        let mut accounts = vec![[0u8; 32]; 6];
+        accounts[1] = [0x11u8; 32];
+        accounts[4] = [0x44u8; 32];
+        let evs = reconstruct_instruction_events(
+            &ZamaHostInstruction::FheRandBoundedAndBind(args),
+            &accounts,
+            &ctx(),
+            &HashMap::new(),
+        )
+        .expect("rand bounded bind reconstructs");
+        assert_eq!(evs.len(), 3, "compute + acl_record_bound + acl_subject_allowed");
+        for (i, reason) in [(1usize, "acl_record_bound"), (2, "acl_subject_allowed")]
+        {
+            match &evs[i] {
+                SolanaHostEvent::FinalizedAccountFetch(f) => {
+                    assert_eq!(f.account_key, [0x44u8; 32]);
+                    assert_eq!(f.reason, reason);
+                }
+                o => panic!("expected fetch at {i}, got {o:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn instruction_events_allow_for_decryption_is_public_decrypt_fetch() {
+        use crate::solana_adapter::SolanaFinalizedAccountFetchKind;
+        // Fetch-only (no compute event); acl_record is account index 2.
+        let args =
+            crate::generated::zama_host_instructions::AllowForDecryptionArgs {
+                handle: [7u8; 32],
+            };
+        let mut accounts = vec![[0u8; 32]; 5];
+        accounts[2] = [0x22u8; 32];
+        let evs = reconstruct_instruction_events(
+            &ZamaHostInstruction::AllowForDecryption(args),
+            &accounts,
+            &ctx(),
+            &HashMap::new(),
+        )
+        .expect("allow_for_decryption reconstructs");
+        assert_eq!(evs.len(), 1, "fetch-only, no compute event");
+        match &evs[0] {
+            SolanaHostEvent::FinalizedAccountFetch(f) => {
+                assert_eq!(f.account_key, [0x22u8; 32]); // accounts[2]
+                assert_eq!(f.kind, SolanaFinalizedAccountFetchKind::AclRecord);
+                assert_eq!(f.reason, "public_decrypt_allowed");
+            }
+            o => panic!("expected FinalizedAccountFetch, got {o:?}"),
+        }
+    }
+
+    #[test]
+    fn instruction_events_allow_acl_subjects_one_fetch_per_subject() {
+        // Fetch-only; acl_record is account index 3; one fetch per subject.
+        let args =
+            crate::generated::zama_host_instructions::AllowAclSubjectsArgs {
+                handle: [7u8; 32],
+                subjects: vec![
+                    crate::generated::zama_host_instructions::AclSubjectEntry {
+                        pubkey: [1u8; 32],
+                        role_flags: 1,
+                    },
+                    crate::generated::zama_host_instructions::AclSubjectEntry {
+                        pubkey: [2u8; 32],
+                        role_flags: 1,
+                    },
+                ],
+            };
+        let mut accounts = vec![[0u8; 32]; 7];
+        accounts[3] = [0x33u8; 32];
+        let evs = reconstruct_instruction_events(
+            &ZamaHostInstruction::AllowAclSubjects(args),
+            &accounts,
+            &ctx(),
+            &HashMap::new(),
+        )
+        .expect("allow_acl_subjects reconstructs");
+        assert_eq!(evs.len(), 2, "one acl_subject_allowed fetch per subject");
+        for e in &evs {
+            match e {
+                SolanaHostEvent::FinalizedAccountFetch(f) => {
+                    assert_eq!(f.account_key, [0x33u8; 32]); // accounts[3]
+                    assert_eq!(f.reason, "acl_subject_allowed");
+                }
+                o => panic!("expected FinalizedAccountFetch, got {o:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn instruction_events_commit_handle_material_reads_acl_handle() {
+        use crate::solana_adapter::SolanaFinalizedAccountFetchKind;
+        let args =
+            crate::generated::zama_host_instructions::CommitHandleMaterialArgs {
+                key_id: [1u8; 32],
+                ciphertext_digest: [2u8; 32],
+                sns_ciphertext_digest: [3u8; 32],
+                coprocessor_set_digest: [4u8; 32],
+            };
+        // accounts: payer, material_authority, host_config, acl_record(3),
+        // material_commitment(4), system_program.
+        let mut accounts = vec![[0u8; 32]; 6];
+        accounts[3] = [0x33u8; 32]; // acl_record
+        accounts[4] = [0x44u8; 32]; // material_commitment
+        // handle comes from acl_record account state, pre-fetched by the caller.
+        let mut acl_handles = HashMap::new();
+        acl_handles.insert([0x33u8; 32], [0x99u8; 32]);
+        let evs = reconstruct_instruction_events(
+            &ZamaHostInstruction::CommitHandleMaterial(args),
+            &accounts,
+            &ctx(),
+            &acl_handles,
+        )
+        .expect("commit_handle_material reconstructs");
+        assert_eq!(evs.len(), 3, "material committed + sealed + acl_record sealed");
+        match &evs[0] {
+            SolanaHostEvent::FinalizedAccountFetch(f) => {
+                assert_eq!(f.account_key, [0x44u8; 32]); // material_commitment
+                assert_eq!(
+                    f.kind,
+                    SolanaFinalizedAccountFetchKind::HandleMaterialCommitment
+                );
+                assert_eq!(f.reason, "handle_material_committed");
+                assert_eq!(f.related_account, Some([0x33u8; 32])); // acl_record
+            }
+            o => panic!("expected material fetch, got {o:?}"),
+        }
+        match &evs[2] {
+            SolanaHostEvent::FinalizedAccountFetch(f) => {
+                assert_eq!(f.account_key, [0x33u8; 32]); // acl_record
+                assert_eq!(f.kind, SolanaFinalizedAccountFetchKind::AclRecord);
+                assert_eq!(f.reason, "handle_material_sealed");
+            }
+            o => panic!("expected acl_record fetch, got {o:?}"),
+        }
+    }
+
+}

--- a/coprocessor/fhevm-engine/host-listener/src/solana_slot_hashes.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_slot_hashes.rs
@@ -1,0 +1,91 @@
+//! SlotHashes sysvar sourcing for off-chain handle derivation.
+//!
+//! The zama-host program derives compute handles using `previous_bank_hash` —
+//! the bank hash of the most recent slot below the executing slot, read from the
+//! SlotHashes sysvar. To recompute handles off-chain (the reconstruction path),
+//! the listener streams the SlotHashes sysvar account over Yellowstone and parses
+//! the same layout here. Kept feature-independent so the gRPC transport can
+//! source it without pulling the reconstruction (`solana-reconstruct`) deps.
+
+/// Address of the SlotHashes sysvar account (subscribe to this over Yellowstone).
+pub const SLOT_HASHES_SYSVAR: &str =
+    "SysvarS1otHashes111111111111111111111111111";
+
+/// Address of the Clock sysvar account. Handle derivation uses
+/// `Clock.unix_timestamp`, which differs from the RPC `getBlockTime`/block-meta
+/// value, so the reconstruction path must source it from this account's data.
+pub const CLOCK_SYSVAR: &str =
+    "SysvarC1ock11111111111111111111111111111111";
+
+/// Parses `Clock.unix_timestamp` (i64) from the Clock sysvar account data.
+/// Layout: slot u64, epoch_start_timestamp i64, epoch u64,
+/// leader_schedule_epoch u64, then `unix_timestamp` i64 at offset 32.
+pub fn clock_unix_timestamp(data: &[u8]) -> Option<i64> {
+    Some(i64::from_le_bytes(data.get(32..40)?.try_into().ok()?))
+}
+
+/// Extracts the `previous_bank_hash` the program would read for a transaction at
+/// `current_slot`, from a snapshot of the SlotHashes sysvar account data.
+///
+/// SlotHashes is laid out as `[u64 count][(u64 slot, [u8; 32] hash) * count]`,
+/// ordered newest-first, where `hash` is the bank hash of that slot. The program
+/// (`zama_host::state::previous_bank_hash`) returns the hash of the most recent
+/// entry whose slot is below `current_slot`; this mirrors that scan off-chain.
+/// Returns `None` if no prior slot exists or the buffer is short/malformed.
+pub fn previous_bank_hash_from_slot_hashes(
+    data: &[u8],
+    current_slot: u64,
+) -> Option<[u8; 32]> {
+    const ENTRY_LEN: usize = 40; // u64 slot + 32-byte hash
+    let count = u64::from_le_bytes(data.get(0..8)?.try_into().ok()?) as usize;
+    for index in 0..count {
+        let offset = 8 + index * ENTRY_LEN;
+        let slot =
+            u64::from_le_bytes(data.get(offset..offset + 8)?.try_into().ok()?);
+        if slot < current_slot {
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(data.get(offset + 8..offset + ENTRY_LEN)?);
+            return Some(hash);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot_hashes_buf(entries: &[(u64, [u8; 32])]) -> Vec<u8> {
+        let mut buf = (entries.len() as u64).to_le_bytes().to_vec();
+        for (slot, hash) in entries {
+            buf.extend_from_slice(&slot.to_le_bytes());
+            buf.extend_from_slice(hash);
+        }
+        buf
+    }
+
+    #[test]
+    fn previous_bank_hash_picks_newest_prior_slot() {
+        // Newest-first; slot 9 is skipped.
+        let buf = slot_hashes_buf(&[
+            (10, [10u8; 32]),
+            (8, [8u8; 32]),
+            (7, [7u8; 32]),
+        ]);
+        // tx at slot 11 -> newest prior is slot 10.
+        assert_eq!(
+            previous_bank_hash_from_slot_hashes(&buf, 11),
+            Some([10u8; 32])
+        );
+        // tx at slot 10 -> 10 is not < 10, so newest prior is slot 8 (9 skipped).
+        assert_eq!(
+            previous_bank_hash_from_slot_hashes(&buf, 10),
+            Some([8u8; 32])
+        );
+        // No slot below 7.
+        assert_eq!(previous_bank_hash_from_slot_hashes(&buf, 7), None);
+        // Short / empty buffers fail closed.
+        assert_eq!(previous_bank_hash_from_slot_hashes(&[], 5), None);
+        assert_eq!(previous_bank_hash_from_slot_hashes(&[0u8; 4], 5), None);
+    }
+}

--- a/coprocessor/fhevm-engine/host-listener/src/solana_slot_hashes.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_slot_hashes.rs
@@ -14,8 +14,7 @@ pub const SLOT_HASHES_SYSVAR: &str =
 /// Address of the Clock sysvar account. Handle derivation uses
 /// `Clock.unix_timestamp`, which differs from the RPC `getBlockTime`/block-meta
 /// value, so the reconstruction path must source it from this account's data.
-pub const CLOCK_SYSVAR: &str =
-    "SysvarC1ock11111111111111111111111111111111";
+pub const CLOCK_SYSVAR: &str = "SysvarC1ock11111111111111111111111111111111";
 
 /// Parses `Clock.unix_timestamp` (i64) from the Clock sysvar account data.
 /// Layout: slot u64, epoch_start_timestamp i64, epoch u64,

--- a/solana/geyser/Dockerfile
+++ b/solana/geyser/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+# Global build args (declared before any FROM so they can be used in FROM lines).
+# YELLOWSTONE_REF MUST match the validator's Agave patch (Geyser ABI is patch-coupled).
+# SOLANA_VALIDATOR_IMAGE MUST be the SAME Agave patch as YELLOWSTONE_REF.
+ARG YELLOWSTONE_REF=v5.0.1+solana.2.1.21
+ARG SOLANA_VALIDATOR_IMAGE
+
+# Stage 1 — build the Yellowstone geyser plugin from the pinned upstream tag.
+FROM rust:1-bookworm AS plugin-builder
+ARG YELLOWSTONE_REF
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git protobuf-compiler libprotobuf-dev pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+RUN git clone --depth 1 --branch "${YELLOWSTONE_REF}" \
+        https://github.com/rpcpool/yellowstone-grpc .
+# yellowstone's own rust-toolchain.toml pins the exact rustc; rustup honors it.
+RUN cargo build --release -p yellowstone-grpc-geyser \
+    && test -f target/release/libyellowstone_grpc_geyser.so
+
+# Stage 2 — bake plugin + config into the matching 2.1.x validator image.
+FROM ${SOLANA_VALIDATOR_IMAGE}
+COPY --from=plugin-builder \
+     /src/target/release/libyellowstone_grpc_geyser.so \
+     /plugins/libyellowstone_grpc_geyser.so
+COPY yellowstone-config.json /plugins/yellowstone-config.json
+# Base image sets ENTRYPOINT=/usr/bin/solana-run.sh; clear it so the compose
+# `command:` (solana-test-validator …) runs as the container command.
+ENTRYPOINT []

--- a/solana/geyser/Dockerfile.dev-arm64
+++ b/solana/geyser/Dockerfile.dev-arm64
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+#
+# DEV-ONLY (local Apple Silicon / aarch64). NOT for production.
+# Prod/CI uses ./Dockerfile (Yellowstone plugin baked into amd64 anzaxyz/agave:v2.1.21),
+# which can't run on Apple Silicon (Solana needs x86 AVX; Rosetta lacks it). This dev
+# image builds everything NATIVELY for aarch64 Linux so it runs in OrbStack with no
+# emulation. Same versions as prod (Agave 2.1.21, yellowstone v5.0.1+solana.2.1.21).
+ARG AGAVE_REF=v2.1.21
+ARG YELLOWSTONE_REF=v5.0.1+solana.2.1.21
+
+# Stage 1 — Yellowstone geyser plugin (aarch64 .so).
+FROM rust:1-bookworm AS plugin-builder
+ARG YELLOWSTONE_REF
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git protobuf-compiler libprotobuf-dev pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+RUN git clone --depth 1 --branch "${YELLOWSTONE_REF}" https://github.com/rpcpool/yellowstone-grpc .
+RUN cargo build --release -p yellowstone-grpc-geyser \
+    && test -f target/release/libyellowstone_grpc_geyser.so
+
+# Stage 2 — solana-test-validator + solana CLI from Agave source (aarch64; no AVX gate on arm64).
+FROM rust:1-bookworm AS validator-builder
+ARG AGAVE_REF
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git build-essential clang cmake pkg-config libssl-dev libudev-dev protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /agave
+RUN git clone --depth 1 --branch "${AGAVE_REF}" https://github.com/anza-xyz/agave .
+RUN cargo build --release --bin solana-test-validator --bin solana \
+    && test -f target/release/solana-test-validator
+
+# Stage 3 — slim runtime.
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 libudev1 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=validator-builder /agave/target/release/solana-test-validator /usr/bin/solana-test-validator
+COPY --from=validator-builder /agave/target/release/solana /usr/bin/solana
+COPY --from=plugin-builder /src/target/release/libyellowstone_grpc_geyser.so /plugins/libyellowstone_grpc_geyser.so
+COPY yellowstone-config.json /plugins/yellowstone-config.json

--- a/solana/geyser/parity-harness.sh
+++ b/solana/geyser/parity-harness.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# DEV-ONLY: minimal gRPC-vs-RPC parity harness for the Solana host-listener.
+#
+# Proves the Yellowstone gRPC transport ingests the SAME coprocessor DB rows as
+# the RPC-polling transport, WITHOUT the full fhevm stack (no gateway/KMS/relayer).
+#
+# Pipeline:
+#   1. Postgres (docker) + coprocessor schema (psql migrations), two DBs.
+#   2. dev-arm64 solana-test-validator + Yellowstone plugin (docker, 8899+10000).
+#   3. anchor keys sync (TEMPORARY, reverted) + build (poc) + deploy zama_host & confidential_token.
+#   4. Start BOTH listeners (gRPC only gets future updates, so they must run before emit).
+#   5. Emit zama-host events gateway-free (SPL mint + live-client default path).
+#   6. Diff computations + solana_finalized_account_fetches between the two DBs.
+#
+# Requires: docker, anchor, cargo build-sbf, spl-token, solana (funded ~/.config/solana/id.json),
+#           psql, cargo. KEEP=1 leaves the stack up.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOLANA="$ROOT/solana"
+HL="$ROOT/coprocessor/fhevm-engine"
+PG=parity-pg
+VAL=parity-validator
+PGPORT=5433
+RPC=http://127.0.0.1:8899
+GRPC=http://127.0.0.1:10000
+SID_I64=-9223372036854763463
+SID_U64=9223372036854788153   # SID_I64 reinterpreted as u64 (on-chain HostConfig.chain_id)
+# Dummy gateway/KMS values for BOOTSTRAP (config-only step; trivial-encrypt parity
+# never exercises gateway/KMS verification).
+GATEWAY_CHAIN_ID=1
+INPUT_VERIFICATION_ADDRESS=0x1111111111111111111111111111111111111111
+COPROCESSOR_SIGNER=0x2222222222222222222222222222222222222222
+DECRYPTION_ADDRESS=0x3333333333333333333333333333333333333333
+KMS_SIGNERS=0x4444444444444444444444444444444444444444
+IMG=poc-solana-validator-yellowstone:dev-arm64
+KEEP="${KEEP:-0}"
+# EMITS=on  -> build zama_host WITH emits; copro_rpc=emit-decode, copro_grpc=reconstruct,
+#             diffed in-run (same slots => identical rows). Establishes the write count.
+# EMITS=off -> build zama_host WITHOUT emits (#7); copro_rpc=0, copro_grpc=reconstruct only.
+EMITS="${EMITS:-off}"
+export PGPASSWORD=postgres
+PSQL="psql -h 127.0.0.1 -p $PGPORT -U postgres -v ON_ERROR_STOP=1 -q"
+
+RPCPID=""; GRPCPID=""; SYNCED=0
+log(){ echo; echo "==> $*"; }
+cleanup(){
+  [ -n "$RPCPID" ] && kill "$RPCPID" 2>/dev/null || true
+  [ -n "$GRPCPID" ] && kill "$GRPCPID" 2>/dev/null || true
+  if [ "$SYNCED" = 1 ]; then
+    git -C "$ROOT" checkout -- solana/programs/zama-host/src/lib.rs \
+      solana/programs/confidential-token/src/lib.rs \
+      solana/programs/confidential-token-receiver/src/lib.rs solana/Anchor.toml 2>/dev/null || true
+    echo "   reverted anchor keys sync (declare_id/Anchor.toml restored)"
+  fi
+  if [ "$KEEP" != 1 ]; then docker rm -f "$PG" "$VAL" >/dev/null 2>&1 || true; fi
+}
+trap cleanup EXIT
+
+# ---- 1. Postgres + schema ----
+log "[1/6] postgres + coprocessor schema"
+docker rm -f "$PG" >/dev/null 2>&1 || true
+docker run -d --name "$PG" -e POSTGRES_PASSWORD=postgres -p $PGPORT:5432 postgres:16 >/dev/null
+until $PSQL -c 'select 1' >/dev/null 2>&1; do sleep 1; done
+$PSQL -c "CREATE DATABASE copro_rpc;"
+n=0
+for f in "$HL/db-migration/migrations"/*.sql; do
+  $PSQL -d copro_rpc -f "$f" >/dev/null 2>>/tmp/parity-migrate.log || { echo "   migration FAILED: $(basename "$f") (see /tmp/parity-migrate.log)"; exit 1; }
+  n=$((n+1))
+done
+echo "   applied $n migrations"
+
+# ---- 2. validator + plugin ----
+log "[2/6] dev-arm64 validator + Yellowstone plugin"
+docker rm -f "$VAL" >/dev/null 2>&1 || true
+docker run -d --name "$VAL" --platform linux/arm64 -p 8899:8899 -p 10000:10000 "$IMG" \
+  solana-test-validator --reset --rpc-port 8899 --bind-address 0.0.0.0 \
+  --geyser-plugin-config /plugins/yellowstone-config.json >/dev/null
+for _ in $(seq 1 60); do
+  solana cluster-version -u $RPC >/dev/null 2>&1 && break
+  [ -z "$(docker ps -q -f name=$VAL -f status=running)" ] && { echo "   validator died:"; docker logs "$VAL" 2>&1 | tail -15; exit 1; }
+  sleep 2
+done
+echo "   RPC healthy: $(solana cluster-version -u $RPC 2>/dev/null)"
+solana airdrop 100 -u $RPC >/dev/null 2>&1 || true
+
+# ---- 3. align ids (temp) + build (poc) + deploy ----
+log "[3/6] anchor keys sync (temp) + build poc + deploy"
+( cd "$SOLANA" && NO_DNA=1 anchor build --ignore-keys >/tmp/parity-anchor.log 2>&1 ) || { echo "   anchor build failed"; tail -20 /tmp/parity-anchor.log; exit 1; }
+( cd "$SOLANA" && anchor keys sync >>/tmp/parity-anchor.log 2>&1 ) && SYNCED=1
+# EMITS=off (#7) drops `emit-events` via --no-default-features so the deployed
+# zama_host emits NOTHING (reconstruction is the sole source); EMITS=on keeps emits.
+if [ "$EMITS" = on ]; then ZH_FEATURES="--features poc"; else ZH_FEATURES="--no-default-features --features poc"; fi
+echo "   building zama_host with EMITS=$EMITS ($ZH_FEATURES)"
+( cd "$SOLANA" && NO_DNA=1 anchor build --ignore-keys --no-idl -p zama_host -- $ZH_FEATURES >>/tmp/parity-anchor.log 2>&1 ) || { echo "   zama_host poc build failed"; tail -20 /tmp/parity-anchor.log; exit 1; }
+( cd "$SOLANA" && NO_DNA=1 anchor build --ignore-keys --no-idl -p confidential_token -- --features poc >>/tmp/parity-anchor.log 2>&1 ) || { echo "   confidential_token poc build failed"; tail -20 /tmp/parity-anchor.log; exit 1; }
+ZAMA_HOST=$(solana address -k "$SOLANA/target/deploy/zama_host-keypair.json")
+echo "   deployed program id (synced): $ZAMA_HOST"
+for p in zama_host confidential_token; do
+  # --use-rpc: send the deploy via RPC (8899) instead of the TPU client, which would
+  # need the validator's websocket/TPU ports (not mapped from the container).
+  solana program deploy -u $RPC --use-rpc --program-id "$SOLANA/target/deploy/$p-keypair.json" "$SOLANA/target/deploy/$p.so" >/dev/null \
+    || { echo "   deploy $p failed"; exit 1; }
+done
+
+# seed host_chains in DB(s) with the ACTUAL deployed id, then clone the second DB
+$PSQL -d copro_rpc -c "INSERT INTO host_chains (chain_id,name,acl_contract_address) VALUES ($SID_I64,'solana','$ZAMA_HOST') ON CONFLICT DO NOTHING;"
+$PSQL -c "CREATE DATABASE copro_grpc TEMPLATE copro_rpc;"
+DB_RPC="postgres://postgres:postgres@127.0.0.1:$PGPORT/copro_rpc"
+DB_GRPC="postgres://postgres:postgres@127.0.0.1:$PGPORT/copro_grpc"
+
+# ---- 4. configure zama-host (HostConfig only) BEFORE starting the listeners ----
+# The listener queries the HostConfig PDA at startup, so zama-host MUST already be
+# configured when it starts. BOOTSTRAP is the canonical standalone config (no
+# compute): it initializes HostConfig + the KMS context. Its txs emit only config
+# events the coprocessor ignores, so they add no DB rows. test-shims OFF ⇒
+# zero_birth_entropy=false ⇒ this exercises the REAL SlotHashes bank-hash path.
+# initialize_mint is a workload op and runs in the test (step 5), not here.
+log "[4/6] bootstrap zama-host (HostConfig + KMS) before listeners"
+LC="$SOLANA/scripts/poc/live-client/target/release/poc-live-client"
+( cd "$SOLANA/scripts/poc/live-client" && cargo build --release >/tmp/parity-lc-build.log 2>&1 ) \
+  || { echo "   live-client build failed"; tail -20 /tmp/parity-lc-build.log; exit 1; }
+BOOTSTRAP=1 \
+  GATEWAY_CHAIN_ID="$GATEWAY_CHAIN_ID" \
+  INPUT_VERIFICATION_ADDRESS="$INPUT_VERIFICATION_ADDRESS" \
+  COPROCESSOR_SIGNER="$COPROCESSOR_SIGNER" \
+  DECRYPTION_ADDRESS="$DECRYPTION_ADDRESS" \
+  KMS_SIGNERS="$KMS_SIGNERS" \
+  SOLANA_HOST_CHAIN_ID="$SID_U64" \
+  "$LC" >/tmp/parity-lc-config.log 2>&1 \
+  || { echo "   bootstrap failed"; tail -20 /tmp/parity-lc-config.log; exit 1; }
+echo "   zama-host bootstrapped (HostConfig chain=$SID_U64, test-shims OFF ⇒ real bank-hash)"
+
+# ---- 5. start BOTH listeners, then produce the captured fhe_eval ----
+log "[5/6] build host-listener + start both transports, then emit fhe_eval"
+( cd "$HL" && SQLX_OFFLINE=true cargo build -p host-listener --features solana-grpc,solana-reconstruct --bin solana_host_listener >/tmp/parity-hl-build.log 2>&1 ) \
+  || { echo "   host-listener build failed"; tail -20 /tmp/parity-hl-build.log; exit 1; }
+BIN="$HL/target/debug/solana_host_listener"
+"$BIN" --transport rpc  --database-url "$DB_RPC"  --url $RPC --program-id "$ZAMA_HOST" --host-chain-id="$SID_I64" >/tmp/parity-hl-rpc.log 2>&1 &
+RPCPID=$!
+# --reconstruct so the gRPC listener INGESTS off-chain-reconstructed events
+# (compute + acl_record_bound fetches) instead of emit-decoded ones. The
+# handle-derivation params (chain_id + zero-birth-entropy) are auto-detected by
+# querying the HostConfig PDA at startup — no manual flags (HostConfig was created
+# in step 4, so the startup fetch succeeds).
+"$BIN" --transport grpc --database-url "$DB_GRPC" --grpc-url $GRPC --url $RPC --program-id "$ZAMA_HOST" --host-chain-id="$SID_I64" --reconstruct >/tmp/parity-hl-grpc.log 2>&1 &
+GRPCPID=$!
+echo "   listeners up (rpc pid $RPCPID -> copro_rpc, grpc pid $GRPCPID -> copro_grpc); settling 5s"
+sleep 5
+# Workload: four compute ops, all post-listener (both transports see them):
+#  (1) initialize_mint — host<->token CPI total-supply trivial-encrypt (fhe_eval).
+#      Default path; ensure_host_config skips (already bootstrapped in step 4).
+#  (2) TRIVIAL_ENCRYPT_EVAL — eval-plan trivial encrypt, durable output (fhe_eval).
+#  (3) TRIVIAL_ENCRYPT — direct trivial_encrypt_and_bind (compute + acl_record_bound
+#      + per-subject acl_subject_allowed).
+#  (4) CONSUME_AMOUNT — create_random_amount CPIs fhe_rand_bounded_and_bind (the only
+#      Group A direct instruction with an on-chain caller). Its RandomAmountCreatedEvent
+#      is a confidential_token event the zama_host listener ignores.
+UNDER=$(spl-token create-token -u $RPC --output json 2>/dev/null | python3 -c "import json,sys;d=json.load(sys.stdin);print(d.get('commandOutput',{}).get('address') or d.get('address'))" 2>/dev/null)
+[ -z "$UNDER" ] && UNDER=$(spl-token create-token -u $RPC 2>/dev/null | awk '/Address:|Creating token/{print $NF}' | head -1)
+echo "   underlying mint: $UNDER"
+# initialize_mint prints "confidential mint <ADDR>"; consume_amount needs that
+# confidential mint (a confidential_token-owned account), not the underlying SPL mint.
+minit=$(UNDERLYING_MINT="$UNDER" "$LC" 2>&1); echo "$minit" >/tmp/parity-lc-mint.log
+CMINT=$(echo "$minit" | grep -oE 'confidential mint +[A-Za-z0-9]{32,44}' | awk '{print $NF}' | head -1)
+echo "   confidential mint: $CMINT"
+# TE_ALLOW=1 follows the eval with allow_for_decryption (Section B): a separate tx
+# that adds a public_decrypt_allowed fetch on the eval output's ACL record. It
+# collides on (account_key, kind) with the eval's acl_record_bound, so it doesn't
+# add a row — but the byte-identical row diff (which compares fetch `reason`)
+# validates that reconstruction produces the public_decrypt_allowed fetch.
+TRIVIAL_ENCRYPT_EVAL=1 TE_ALLOW=1 "$LC" >/tmp/parity-lc-eval.log 2>&1 \
+  || { echo "   live-client fhe_eval run returned nonzero (continuing); tail:"; tail -15 /tmp/parity-lc-eval.log; }
+TRIVIAL_ENCRYPT=1 "$LC" >/tmp/parity-lc-te.log 2>&1 \
+  || { echo "   live-client trivial_encrypt_and_bind run returned nonzero (continuing); tail:"; tail -15 /tmp/parity-lc-te.log; }
+MINT="$CMINT" CONSUME_AMOUNT=1 "$LC" >/tmp/parity-lc-rand.log 2>&1 \
+  || { echo "   live-client fhe_rand_bounded run returned nonzero (continuing); tail:"; tail -15 /tmp/parity-lc-rand.log; }
+sigs=$(solana transaction-history "$ZAMA_HOST" -u $RPC 2>/dev/null | grep -cE '^[1-9A-HJ-NP-Za-km-z]{60,}' || true)
+echo "   zama_host signatures on chain: $sigs"
+echo "   ingesting 25s…"; sleep 25
+kill "$RPCPID" "$GRPCPID" 2>/dev/null || true; RPCPID=""; GRPCPID=""
+
+# ---- 6. validation ----
+log "[6/6] validation (EMITS=$EMITS)"
+RPC_C=$($PSQL -d copro_rpc  -Atc "select count(*) from computations" 2>/dev/null)
+RPC_F=$($PSQL -d copro_rpc  -Atc "select count(*) from solana_finalized_account_fetches" 2>/dev/null)
+GRPC_C=$($PSQL -d copro_grpc -Atc "select count(*) from computations" 2>/dev/null)
+GRPC_F=$($PSQL -d copro_grpc -Atc "select count(*) from solana_finalized_account_fetches" 2>/dev/null)
+GRPC_ALLOWED=$($PSQL -d copro_grpc -Atc "select count(*) from computations where is_allowed" 2>/dev/null)
+echo "   copro_rpc  (emit-decode): computations=$RPC_C  fetches=$RPC_F"
+echo "   copro_grpc (reconstruct): computations=$GRPC_C  fetches=$GRPC_F  (is_allowed=$GRPC_ALLOWED)"
+PASS=1
+if [ "$EMITS" = on ]; then
+  # Emits ON: both DBs ingest the SAME txs at the SAME slots, so emit-decode
+  # (copro_rpc) and reconstruct (copro_grpc) rows must be byte-identical.
+  for db in copro_rpc copro_grpc; do
+    $PSQL -d $db -Atc "select encode(output_handle,'hex'),fhe_operation,is_allowed from computations order by 1" > /tmp/parity-$db-comp.txt 2>/dev/null || true
+    $PSQL -d $db -Atc "select encode(account_key,'hex'),kind,reason,encode(handle,'hex') from solana_finalized_account_fetches order by 1,3" > /tmp/parity-$db-fetch.txt 2>/dev/null || true
+  done
+  [ "${RPC_C:-0}" -gt 0 ] || { echo "   FAIL: emit-decode ingested no computations (expected emits ON)"; PASS=0; }
+  diff -q /tmp/parity-copro_rpc-comp.txt /tmp/parity-copro_grpc-comp.txt >/dev/null 2>&1 || { echo "   FAIL: computations differ (emit vs reconstruct):"; diff /tmp/parity-copro_rpc-comp.txt /tmp/parity-copro_grpc-comp.txt | head; PASS=0; }
+  diff -q /tmp/parity-copro_rpc-fetch.txt /tmp/parity-copro_grpc-fetch.txt >/dev/null 2>&1 || { echo "   FAIL: fetches differ (emit vs reconstruct):"; diff /tmp/parity-copro_rpc-fetch.txt /tmp/parity-copro_grpc-fetch.txt | head; PASS=0; }
+  if [ "$PASS" = 1 ]; then
+    echo "   EMITS-ON PASS: emit-decode == reconstruct (computations=$RPC_C, fetches=$RPC_F identical across both transports)"
+  else
+    echo "   EMITS-ON FAIL (see above)"
+  fi
+else
+  # Emits OFF (#7): emit-decode ingests nothing; reconstruction is the sole source.
+  { [ "${RPC_C:-x}" = "0" ] && [ "${RPC_F:-x}" = "0" ]; } || { echo "   FAIL: emits not gated off — RPC emit-decode ingested rows"; PASS=0; }
+  # 5 reconstructed computes: initialize_mint, fhe_eval, trivial_encrypt_and_bind,
+  # and CONSUME_AMOUNT's two (encrypted-zero balance + fhe_rand_bounded random amount).
+  { [ "${GRPC_C:-0}" = "5" ] && [ "${GRPC_ALLOWED:-0}" = "5" ]; } || { echo "   FAIL: expected 5 reconstructed allowed computations, got C=$GRPC_C allowed=$GRPC_ALLOWED"; PASS=0; }
+  [ "${GRPC_F:-0}" -ge 5 ] || { echo "   FAIL: expected >=5 reconstructed fetches, got $GRPC_F"; PASS=0; }
+  if [ "$PASS" = 1 ]; then
+    echo "   EMITS-OFF PASS: emits gated off (RPC empty) AND reconstruction is the sole source (gRPC: $GRPC_C computations is_allowed, $GRPC_F fetches)"
+  else
+    echo "   EMITS-OFF FAIL (see above)"
+  fi
+fi
+echo "   WRITE COUNTS (EMITS=$EMITS): emit-decode rpc(C=$RPC_C,F=$RPC_F)  reconstruct grpc(C=$GRPC_C,F=$GRPC_F)"
+echo
+echo "logs: /tmp/parity-hl-rpc.log /tmp/parity-hl-grpc.log /tmp/parity-lc-eval.log /tmp/parity-lc-te.log"

--- a/solana/geyser/smoke-macos.sh
+++ b/solana/geyser/smoke-macos.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Local macOS (Apple Silicon) smoke test for the Yellowstone gRPC geyser plugin.
+#
+# Why this exists:
+#   The CI/production artifact bakes the plugin into an amd64 solana-test-validator
+#   Docker image (Agave 2.1.21) — see ./Dockerfile + ../scripts/poc/docker-compose.solana.yml.
+#   That image CANNOT run on Apple Silicon: Solana validators require x86 AVX, which
+#   Rosetta (used by Docker/OrbStack to run amd64 here) does not provide, so the
+#   validator aborts on startup ("Incompatible CPU detected: missing AVX support").
+#
+#   Locally we therefore go fully native arm64: build the Yellowstone plugin as a
+#   macOS .dylib pinned to the LOCAL validator's 3.1.x line, and load it into the
+#   native solana-test-validator already installed on this machine. This validates
+#   the gRPC mechanism locally; the exact 2.1.21 amd64 artifact is validated on
+#   x86_64 hardware via the Docker path.
+set -euo pipefail
+
+# Yellowstone tag — must match the local validator's Agave line (ABI-coupled).
+# Local validator is 3.1.x; the geyser ABI is stable across 3.1 patch releases.
+REF="${YELLOWSTONE_REF:-v12.1.0+solana.3.1.10}"
+WORK="${WORK:-$HOME/.cache/yellowstone-macos}"
+GRPC_ADDR="${GRPC_ADDR:-127.0.0.1:10000}"
+GRPC_PORT="${GRPC_ADDR##*:}"
+RPC_PORT="${RPC_PORT:-8899}"
+LEDGER="${LEDGER:-/tmp/yellowstone-smoke-ledger}"
+KEEP="${KEEP:-0}"   # KEEP=1 leaves the validator running after the checks
+
+echo "==> local validator: $(solana-test-validator --version)"
+
+# 1. Build the plugin as a native macOS .dylib.
+mkdir -p "$WORK"
+if [ ! -e "$WORK/src/Cargo.toml" ]; then
+  echo "==> cloning yellowstone-grpc $REF"
+  rm -rf "$WORK/src"
+  git clone --depth 1 --branch "$REF" https://github.com/rpcpool/yellowstone-grpc "$WORK/src"
+fi
+echo "==> building yellowstone-grpc-geyser (.dylib, native arm64)…"
+( cd "$WORK/src" && cargo build --release -p yellowstone-grpc-geyser )
+DYLIB="$WORK/src/target/release/libyellowstone_grpc_geyser.dylib"
+test -f "$DYLIB" || { echo "ERROR: .dylib not produced at $DYLIB" >&2; exit 1; }
+echo "==> plugin: $DYLIB"
+
+# 2. Generate the geyser config (absolute libpath; machine-specific, not committed).
+CFG="$WORK/yellowstone-config.json"
+cat > "$CFG" <<JSON
+{
+  "libpath": "$DYLIB",
+  "log": { "level": "info" },
+  "grpc": { "address": "$GRPC_ADDR" }
+}
+JSON
+echo "==> config: $CFG"
+
+# 3. Launch the native validator with the plugin (background).
+rm -rf "$LEDGER"
+echo "==> starting native solana-test-validator + plugin…"
+solana-test-validator --reset --rpc-port "$RPC_PORT" --ledger "$LEDGER" \
+  --geyser-plugin-config "$CFG" > "$WORK/run.log" 2>&1 &
+VPID=$!
+trap '[ "$KEEP" = "1" ] || kill "$VPID" 2>/dev/null || true' EXIT
+
+# 4. Wait for RPC health.
+echo "==> waiting for RPC health…"
+healthy=no
+for _ in $(seq 1 60); do
+  if solana cluster-version -u "http://127.0.0.1:$RPC_PORT" >/dev/null 2>&1; then healthy=yes; break; fi
+  if ! kill -0 "$VPID" 2>/dev/null; then
+    echo "ERROR: validator exited early; last log lines:" >&2
+    tail -25 "$LEDGER/validator.log" 2>/dev/null || tail -25 "$WORK/run.log" >&2
+    exit 1
+  fi
+  sleep 2
+done
+[ "$healthy" = yes ] || { echo "ERROR: RPC not healthy in time" >&2; tail -25 "$LEDGER/validator.log" 2>/dev/null; exit 1; }
+echo "    RPC healthy."
+
+# 5. Plugin-load + gRPC checks.
+echo "==> plugin-load / gRPC lines in validator log:"
+grep -iE "geyser|plugin|grpc|started server" "$LEDGER/validator.log" 2>/dev/null | head -10 || true
+
+echo "==> gRPC endpoint check ($GRPC_ADDR):"
+if command -v grpcurl >/dev/null 2>&1; then
+  grpcurl -plaintext "127.0.0.1:$GRPC_PORT" geyser.Geyser/GetVersion 2>&1 | head -5 || \
+    echo "    (GetVersion via reflection failed — yellowstone may not expose reflection; relying on port check)"
+fi
+if nc -z 127.0.0.1 "$GRPC_PORT" 2>/dev/null; then
+  echo "    port $GRPC_PORT is listening ✓"
+else
+  echo "ERROR: gRPC port $GRPC_PORT not listening" >&2
+  exit 1
+fi
+
+echo "==> SMOKE PASS: validator up, plugin loaded, gRPC port $GRPC_PORT listening."
+if [ "$KEEP" = "1" ]; then
+  echo "==> KEEP=1: validator left running (pid $VPID), gRPC at $GRPC_ADDR. Stop with: kill $VPID"
+  wait "$VPID"
+fi

--- a/solana/geyser/yellowstone-config.json
+++ b/solana/geyser/yellowstone-config.json
@@ -1,0 +1,28 @@
+{
+  "libpath": "/plugins/libyellowstone_grpc_geyser.so",
+  "log": { "level": "info" },
+  "tokio": { "worker_threads": 4, "affinity": null },
+  "grpc": {
+    "address": "0.0.0.0:10000",
+    "compression": { "accept": ["gzip", "zstd"], "send": ["gzip", "zstd"] },
+    "max_decoding_message_size": "4_194_304",
+    "snapshot_client_channel_capacity": "50_000_000",
+    "channel_capacity": "100_000",
+    "unary_concurrency_limit": 100,
+    "unary_disabled": false,
+    "replay_stored_slots": 0,
+    "filter_name_size_limit": 128,
+    "filter_names_size_limit": 4096,
+    "filter_names_cleanup_interval": "1s",
+    "filter_limits": {
+      "accounts": { "max": 1, "any": false, "account_max": 10, "account_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"], "owner_max": 10, "owner_reject": ["11111111111111111111111111111111"], "data_slice_max": 2 },
+      "slots": { "max": 1 },
+      "transactions": { "max": 1, "any": false, "account_include_max": 10, "account_include_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"], "account_exclude_max": 10, "account_required_max": 10 },
+      "transactions_status": { "max": 1, "any": false, "account_include_max": 10, "account_include_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"], "account_exclude_max": 10, "account_required_max": 10 },
+      "blocks": { "max": 1, "account_include_max": 10, "account_include_any": false, "account_include_reject": ["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"], "include_transactions": true, "include_accounts": false, "include_entries": false },
+      "blocks_meta": { "max": 1 },
+      "entries": { "max": 1 }
+    }
+  },
+  "prometheus": { "address": "0.0.0.0:8999" }
+}

--- a/solana/programs/zama-host/Cargo.toml
+++ b/solana/programs/zama-host/Cargo.toml
@@ -11,13 +11,17 @@ crate-type = ["cdylib", "lib"]
 name = "zama_host"
 
 [features]
-default = []
+default = ["emit-events"]
 cpi = ["no-entrypoint"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
 poc = []
+# Emit on-chain events (`emit_cpi!`/`emit!`). Default-on so all existing builds
+# behave identically; disable with `--no-default-features` to let off-chain
+# reconstruction be the sole event source (Yellowstone gRPC path).
+emit-events = []
 
 [dependencies]
 anchor-lang = { version = "1.0.2", features = ["event-cpi"] }

--- a/solana/programs/zama-host/src/instructions/allow_acl_subjects.rs
+++ b/solana/programs/zama-host/src/instructions/allow_acl_subjects.rs
@@ -75,11 +75,13 @@ pub fn allow_acl_subjects<'info>(
     )?;
     let updated_slot = Clock::get()?.slot;
     for update in allowed_subjects {
+        #[cfg(feature = "emit-events")]
         emit_cpi!(AclAllowedEvent {
             version: EVENT_VERSION,
             handle,
             subject: update.subject.pubkey.to_bytes(),
         });
+        #[cfg(feature = "emit-events")]
         emit!(AclSubjectAllowedEvent {
             version: EVENT_VERSION,
             acl_record: record_key,

--- a/solana/programs/zama-host/src/instructions/allow_for_decryption.rs
+++ b/solana/programs/zama-host/src/instructions/allow_for_decryption.rs
@@ -57,6 +57,7 @@ pub fn allow_for_decryption(ctx: Context<AllowForDecryption>, handle: [u8; 32]) 
     if !ctx.accounts.acl_record.public_decrypt {
         let clock = Clock::get()?;
         ctx.accounts.acl_record.public_decrypt = true;
+        #[cfg(feature = "emit-events")]
         emit_cpi!(PublicDecryptAllowedEvent {
             version: EVENT_VERSION,
             acl_record: record_key,

--- a/solana/programs/zama-host/src/instructions/commit_handle_material.rs
+++ b/solana/programs/zama-host/src/instructions/commit_handle_material.rs
@@ -113,6 +113,7 @@ pub fn commit_handle_material(
     acl_record.material_commitment_hash = commitment_hash;
     acl_record.material_key_id = key_id;
 
+    #[cfg(feature = "emit-events")]
     emit_cpi!(HandleMaterialCommittedEvent {
         version: EVENT_VERSION,
         material_commitment: material_commitment_key,
@@ -125,6 +126,7 @@ pub fn commit_handle_material(
         material_commitment_hash: commitment_hash,
         created_slot,
     });
+    #[cfg(feature = "emit-events")]
     emit_cpi!(HandleMaterialSealedEvent {
         version: EVENT_VERSION,
         material_commitment: material_commitment_key,

--- a/solana/programs/zama-host/src/instructions/common.rs
+++ b/solana/programs/zama-host/src/instructions/common.rs
@@ -3,9 +3,13 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::{program::invoke_signed, system_instruction, system_program};
 
+// AclRecordBoundEvent / AclSubjectAllowedEvent are only used by the emit funnels,
+// which are no-ops when `emit-events` is off.
+#[cfg(feature = "emit-events")]
+use crate::events::{AclRecordBoundEvent, AclSubjectAllowedEvent};
 use crate::{
     errors::ZamaHostError,
-    events::{AclRecordBoundEvent, AclSubjectAllowedEvent, HostConfigUpdatedEvent},
+    events::HostConfigUpdatedEvent,
     state::{
         acl_nonce_key, acl_permission_address, acl_record_address,
         acl_record_subject_slots_are_canonical, assert_handle_for_chain, deny_subject_address,
@@ -78,6 +82,7 @@ pub(super) fn assert_test_shim_authority(
 }
 
 pub(super) fn emit_config_updated(config: &HostConfig, admin: Pubkey) {
+    #[cfg(feature = "emit-events")]
     emit!(HostConfigUpdatedEvent {
         version: EVENT_VERSION,
         config: crate::state::host_config_address().0,
@@ -731,6 +736,12 @@ pub(super) fn write_account<T: AccountSerialize>(info: &AccountInfo, account: &T
     Ok(())
 }
 
+/// With `emit-events` disabled, off-chain reconstruction is the sole event source,
+/// so the ACL-record-bound emit is a no-op.
+#[cfg(not(feature = "emit-events"))]
+pub(super) fn emit_record_bound(_record_key: Pubkey, _record: &AclRecord) {}
+
+#[cfg(feature = "emit-events")]
 pub(super) fn emit_record_bound(record_key: Pubkey, record: &AclRecord) {
     emit!(AclRecordBoundEvent {
         version: EVENT_VERSION,
@@ -747,6 +758,18 @@ pub(super) fn emit_record_bound(record_key: Pubkey, record: &AclRecord) {
     });
 }
 
+/// With `emit-events` disabled, off-chain reconstruction is the sole event source,
+/// so the ACL-subject-allowed emit is a no-op.
+#[cfg(not(feature = "emit-events"))]
+pub(super) fn emit_subject_event(
+    _record_key: Pubkey,
+    _handle: [u8; 32],
+    _subject: AclSubjectEntry,
+    _overflow_permission_record: Pubkey,
+) {
+}
+
+#[cfg(feature = "emit-events")]
 pub(super) fn emit_subject_event(
     record_key: Pubkey,
     handle: [u8; 32],

--- a/solana/programs/zama-host/src/instructions/define_kms_context.rs
+++ b/solana/programs/zama-host/src/instructions/define_kms_context.rs
@@ -75,6 +75,7 @@ pub fn define_kms_context(
     kms_context.bump = ctx.bumps.kms_context;
     ctx.accounts.host_config.current_kms_context_id = context_id;
 
+    #[cfg(feature = "emit-events")]
     emit!(NewKmsContextEvent {
         version: EVENT_VERSION,
         kms_context_id: context_id,

--- a/solana/programs/zama-host/src/instructions/delegate_for_user_decryption.rs
+++ b/solana/programs/zama-host/src/instructions/delegate_for_user_decryption.rs
@@ -116,6 +116,7 @@ pub fn delegate_for_user_decryption(
             bump,
         },
     )?;
+    #[cfg(feature = "emit-events")]
     emit!(UserDecryptionDelegationUpdatedEvent {
         version: EVENT_VERSION,
         delegator,

--- a/solana/programs/zama-host/src/instructions/destroy_kms_context.rs
+++ b/solana/programs/zama-host/src/instructions/destroy_kms_context.rs
@@ -36,6 +36,7 @@ pub fn destroy_kms_context(ctx: Context<DestroyKmsContext>, context_id: u64) -> 
     );
     ctx.accounts.kms_context.destroyed = true;
 
+    #[cfg(feature = "emit-events")]
     emit!(KmsContextDestroyedEvent {
         version: EVENT_VERSION,
         kms_context_id: context_id,

--- a/solana/programs/zama-host/src/instructions/fhe_binary_op.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_binary_op.rs
@@ -107,6 +107,7 @@ pub fn fhe_binary_op(
         ZamaHostError::ComputedHandleMismatch
     );
 
+    #[cfg(feature = "emit-events")]
     emit_cpi!(FheBinaryOpEvent {
         version: EVENT_VERSION,
         op,

--- a/solana/programs/zama-host/src/instructions/fhe_binary_op_and_bind_output.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_binary_op_and_bind_output.rs
@@ -178,6 +178,7 @@ pub fn fhe_binary_op_and_bind_output(
         result == expected_result,
         ZamaHostError::ComputedHandleMismatch
     );
+    #[cfg(feature = "emit-events")]
     emit_cpi!(FheBinaryOpEvent {
         version: EVENT_VERSION,
         op,
@@ -207,6 +208,7 @@ pub fn fhe_binary_op_and_bind_output(
         &ctx.accounts.output_acl_record,
     );
     for output_subject in output_subjects {
+        #[cfg(feature = "emit-events")]
         emit_cpi!(AclAllowedEvent {
             version: EVENT_VERSION,
             handle: result,

--- a/solana/programs/zama-host/src/instructions/fhe_eval/event_transport.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/event_transport.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "emit-events")]
 use super::event_budget::should_emit_eval_events_as_cpi;
 use super::*;
 
+// With `emit-events` off the funnel is a no-op, so these payloads are built (in
+// the walk) but never read — expected in that config.
+#[cfg_attr(not(feature = "emit-events"), allow(dead_code))]
 pub(super) enum EvalEvent {
     Binary(FheBinaryOpEvent),
     Ternary(FheTernaryOpEvent),
@@ -11,6 +15,17 @@ pub(super) enum EvalEvent {
     AclSubjectAllowed(AclSubjectAllowedEvent),
 }
 
+/// With `emit-events` disabled, off-chain reconstruction (Yellowstone gRPC) is the
+/// sole event source for `fhe_eval`, so this is a no-op.
+#[cfg(not(feature = "emit-events"))]
+pub(super) fn emit_eval_events<'info>(
+    _ctx: &Context<'info, FheEval<'info>>,
+    _events: Vec<EvalEvent>,
+) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(feature = "emit-events")]
 pub(super) fn emit_eval_events<'info>(
     ctx: &Context<'info, FheEval<'info>>,
     events: Vec<EvalEvent>,

--- a/solana/programs/zama-host/src/instructions/fhe_rand_and_bind.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_rand_and_bind.rs
@@ -90,6 +90,7 @@ pub fn fhe_rand_and_bind(
         ctx.bumps.output_acl_record,
     );
 
+    #[cfg(feature = "emit-events")]
     emit_cpi!(FheRandEvent {
         version: EVENT_VERSION,
         subject: subject.to_bytes(),
@@ -102,6 +103,7 @@ pub fn fhe_rand_and_bind(
         &ctx.accounts.output_acl_record,
     );
     for output_subject in output_subjects {
+        #[cfg(feature = "emit-events")]
         emit_cpi!(AclAllowedEvent {
             version: EVENT_VERSION,
             handle: result,

--- a/solana/programs/zama-host/src/instructions/fhe_rand_bounded_and_bind.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_rand_bounded_and_bind.rs
@@ -101,6 +101,7 @@ pub fn fhe_rand_bounded_and_bind(
         ctx.bumps.output_acl_record,
     );
 
+    #[cfg(feature = "emit-events")]
     emit_cpi!(FheRandBoundedEvent {
         version: EVENT_VERSION,
         subject: subject.to_bytes(),
@@ -114,6 +115,7 @@ pub fn fhe_rand_bounded_and_bind(
         &ctx.accounts.output_acl_record,
     );
     for output_subject in output_subjects {
+        #[cfg(feature = "emit-events")]
         emit_cpi!(AclAllowedEvent {
             version: EVENT_VERSION,
             handle: result,

--- a/solana/programs/zama-host/src/instructions/fhe_ternary_op_and_bind_output.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_ternary_op_and_bind_output.rs
@@ -218,6 +218,7 @@ pub fn fhe_ternary_op_and_bind_output(
         result == expected_result,
         ZamaHostError::ComputedHandleMismatch
     );
+    #[cfg(feature = "emit-events")]
     emit_cpi!(FheTernaryOpEvent {
         version: EVENT_VERSION,
         op,
@@ -247,6 +248,7 @@ pub fn fhe_ternary_op_and_bind_output(
         &ctx.accounts.output_acl_record,
     );
     for output_subject in output_subjects {
+        #[cfg(feature = "emit-events")]
         emit_cpi!(AclAllowedEvent {
             version: EVENT_VERSION,
             handle: result,

--- a/solana/programs/zama-host/src/instructions/initialize_host_config.rs
+++ b/solana/programs/zama-host/src/instructions/initialize_host_config.rs
@@ -52,6 +52,7 @@ pub fn initialize_host_config(
     config.grant_deny_list_enabled = args.grant_deny_list_enabled;
     config.updated_slot = updated_slot;
     config.bump = ctx.bumps.host_config;
+    #[cfg(feature = "emit-events")]
     emit!(HostConfigInitializedEvent {
         version: EVENT_VERSION,
         config: config_key,

--- a/solana/programs/zama-host/src/instructions/revoke_delegation_for_user_decryption.rs
+++ b/solana/programs/zama-host/src/instructions/revoke_delegation_for_user_decryption.rs
@@ -68,6 +68,7 @@ pub fn revoke_delegation_for_user_decryption(
     ctx.accounts.delegation_record.expiration_slot = 0;
     ctx.accounts.delegation_record.delegation_counter = delegation_counter;
     ctx.accounts.delegation_record.last_update_slot = clock.slot;
+    #[cfg(feature = "emit-events")]
     emit!(UserDecryptionDelegationUpdatedEvent {
         version: EVENT_VERSION,
         delegator: ctx.accounts.delegation_record.delegator,

--- a/solana/programs/zama-host/src/instructions/set_deny_subject.rs
+++ b/solana/programs/zama-host/src/instructions/set_deny_subject.rs
@@ -57,6 +57,7 @@ pub fn set_deny_subject(ctx: Context<SetDenySubject>, subject: Pubkey, denied: b
             bump,
         },
     )?;
+    #[cfg(feature = "emit-events")]
     emit!(DenySubjectUpdatedEvent {
         version: EVENT_VERSION,
         deny_subject_record: ctx.accounts.deny_subject_record.key(),

--- a/solana/programs/zama-host/src/instructions/test_emit_acl_allowed.rs
+++ b/solana/programs/zama-host/src/instructions/test_emit_acl_allowed.rs
@@ -31,6 +31,7 @@ pub fn test_emit_acl_allowed(
 ) -> Result<()> {
     assert_no_remaining_accounts(ctx.remaining_accounts)?;
     assert_test_shim_authority(&ctx.accounts.host_config, ctx.accounts.test_authority.key())?;
+    #[cfg(feature = "emit-events")]
     emit_cpi!(AclAllowedEvent {
         version: EVENT_VERSION,
         handle,

--- a/solana/programs/zama-host/src/instructions/test_emit_fhe_rand.rs
+++ b/solana/programs/zama-host/src/instructions/test_emit_fhe_rand.rs
@@ -16,6 +16,7 @@ pub fn test_emit_fhe_rand(
 ) -> Result<()> {
     assert_no_remaining_accounts(ctx.remaining_accounts)?;
     assert_test_shim_authority(&ctx.accounts.host_config, ctx.accounts.test_authority.key())?;
+    #[cfg(feature = "emit-events")]
     emit_cpi!(FheRandEvent {
         version: EVENT_VERSION,
         subject: subject.to_bytes(),

--- a/solana/programs/zama-host/src/instructions/test_emit_input_verified.rs
+++ b/solana/programs/zama-host/src/instructions/test_emit_input_verified.rs
@@ -16,6 +16,7 @@ pub fn test_emit_input_verified(
 ) -> Result<()> {
     assert_no_remaining_accounts(ctx.remaining_accounts)?;
     assert_test_shim_authority(&ctx.accounts.host_config, ctx.accounts.test_authority.key())?;
+    #[cfg(feature = "emit-events")]
     emit_cpi!(InputVerifiedEvent {
         version: EVENT_VERSION,
         input_handle,

--- a/solana/programs/zama-host/src/instructions/test_emit_trivial_encrypt.rs
+++ b/solana/programs/zama-host/src/instructions/test_emit_trivial_encrypt.rs
@@ -16,6 +16,7 @@ pub fn test_emit_trivial_encrypt(
 ) -> Result<()> {
     assert_no_remaining_accounts(ctx.remaining_accounts)?;
     assert_test_shim_authority(&ctx.accounts.host_config, ctx.accounts.test_authority.key())?;
+    #[cfg(feature = "emit-events")]
     emit_cpi!(TrivialEncryptEvent {
         version: EVENT_VERSION,
         subject: subject.to_bytes(),

--- a/solana/programs/zama-host/src/instructions/trivial_encrypt_and_bind.rs
+++ b/solana/programs/zama-host/src/instructions/trivial_encrypt_and_bind.rs
@@ -3,10 +3,9 @@
 use anchor_lang::prelude::*;
 
 use super::common::*;
-use crate::{
-    events::{AclAllowedEvent, TrivialEncryptEvent},
-    state::*,
-};
+#[cfg(feature = "emit-events")]
+use crate::events::{AclAllowedEvent, TrivialEncryptEvent};
+use crate::state::*;
 
 /// Accounts for trivial encryption plus initial ACL record birth.
 #[derive(Accounts)]
@@ -57,6 +56,8 @@ pub fn trivial_encrypt_and_bind(
     assert_no_remaining_accounts(ctx.remaining_accounts)?;
     assert_not_paused(&ctx.accounts.host_config)?;
     assert_supported_fhe_type(fhe_type)?;
+    // Only used by the gated TrivialEncryptEvent emit below.
+    #[cfg(feature = "emit-events")]
     let subject = ctx.accounts.compute_subject.key();
     assert_output_acl_metadata(
         ctx.accounts.app_account_authority.key(),
@@ -97,6 +98,7 @@ pub fn trivial_encrypt_and_bind(
         ctx.bumps.output_acl_record,
     );
 
+    #[cfg(feature = "emit-events")]
     emit_cpi!(TrivialEncryptEvent {
         version: EVENT_VERSION,
         subject: subject.to_bytes(),
@@ -109,6 +111,7 @@ pub fn trivial_encrypt_and_bind(
         &ctx.accounts.output_acl_record,
     );
     for output_subject in output_subjects {
+        #[cfg(feature = "emit-events")]
         emit_cpi!(AclAllowedEvent {
             version: EVENT_VERSION,
             handle: result,

--- a/solana/programs/zama-host/src/instructions/verify_coprocessor_input.rs
+++ b/solana/programs/zama-host/src/instructions/verify_coprocessor_input.rs
@@ -143,6 +143,7 @@ pub fn verify_coprocessor_input(
     // (user, contract)", which we surface as the receipt below. No ACL is created here — durable
     // permission on an input-derived handle is a separate, explicit app grant (EVM parity).
     // `acl_domain_key` carries the attested contract identity, the natural ACL domain for the input.
+    #[cfg(feature = "emit-events")]
     emit_cpi!(InputVerifiedEvent {
         version: EVENT_VERSION,
         input_handle,

--- a/solana/scripts/poc/clean-e2e.sh
+++ b/solana/scripts/poc/clean-e2e.sh
@@ -61,7 +61,10 @@ PY
 
 # 3. Bring the Solana side-stack online against the freshly-deployed live backend.
 #    Reads gateway addresses + KMS/coprocessor signer set live, so it tracks the new signer.
-SKIP_BUILD=1 "$ROOT/solana/scripts/poc/setup-solana-side.sh"
+#    RECONSTRUCT=1 (adjacent CI run) deploys an emitless zama-host on the geyser-plugin
+#    validator and ingests via gRPC reconstruction; it force-builds emitless, so SKIP_BUILD
+#    is moot there. Default (unset) keeps the SKIP_BUILD=1 native/emit path unchanged.
+RECONSTRUCT="${RECONSTRUCT:-0}" SKIP_BUILD=1 "$ROOT/solana/scripts/poc/setup-solana-side.sh"
 
 echo "[clean-e2e] stack ready. Drive the full vertical (input -> compute -> public/user-decrypt ->"
 echo "  input-flow -> consume), user-decrypt is now PURE-SDK (no kms checkout):"

--- a/solana/scripts/poc/docker-compose.solana.dev-arm64.yml
+++ b/solana/scripts/poc/docker-compose.solana.dev-arm64.yml
@@ -1,0 +1,11 @@
+# DEV-ONLY override for local arm64 (Apple Silicon). NOT for production.
+# Builds solana-test-validator + the Yellowstone plugin natively for aarch64 Linux
+# (no Rosetta/AVX). Use together with the base file:
+#   docker compose -f docker-compose.solana.yml -f docker-compose.solana.dev-arm64.yml up -d --build
+# Command / ports / healthcheck / networks are inherited from the base file.
+services:
+  solana-validator:
+    platform: linux/arm64
+    image: poc-solana-validator-yellowstone:dev-arm64
+    build:
+      dockerfile: Dockerfile.dev-arm64

--- a/solana/scripts/poc/setup-solana-side.sh
+++ b/solana/scripts/poc/setup-solana-side.sh
@@ -29,6 +29,18 @@ VALIDATOR_RPC="http://127.0.0.1:8899"
 SID_U64=9223372036854788153
 SID_I64=-9223372036854763463
 
+# Reconstruct mode (adjacent CI run, see solana-e2e.yml). When 1, deploy an EMITLESS
+# zama-host (no `emit-events`) and feed the coprocessor purely via the gRPC Yellowstone
+# transport with off-chain event RECONSTRUCTION — no on-chain emit-decode. That needs the
+# geyser plugin on the validator, so the validator runs from the prebuilt geyser Docker
+# image (RPC 8899 + gRPC 10000) instead of a native solana-test-validator. The dockerized
+# KMS worker still reaches RPC over host.docker.internal:8899 (published to the host), so
+# the rest of the fhevm-cli stack is unaffected. Default 0 = unchanged native/emit path.
+RECONSTRUCT="${RECONSTRUCT:-0}"
+GEYSER_IMAGE="${GEYSER_IMAGE:-poc-solana-validator-yellowstone:ci}"
+GRPC_URL="${GRPC_URL:-http://127.0.0.1:10000}"
+VAL_CONTAINER="${VAL_CONTAINER:-solana-e2e-validator}"
+
 echo "==> [1/5] gathering live gateway addresses + ProtocolConfig signer set"
 # shellcheck disable=SC1091
 source "$ROOT/.fhevm/runtime/addresses/gateway/.env.gateway"  # GATEWAY_CONFIG_ADDRESS, INPUT_VERIFICATION_ADDRESS, DECRYPTION_ADDRESS, ...
@@ -38,34 +50,69 @@ KMS_SIGNERS="$(cast call "$GATEWAY_CONFIG_ADDRESS" 'getKmsSigners()(address[])' 
 echo "    gateway_chain_id=$GATEWAY_CHAIN_ID input_verification=$INPUT_VERIFICATION_ADDRESS"
 echo "    decryption=$DECRYPTION_ADDRESS coprocessor_signer=$COPROCESSOR_SIGNER kms_signers=$KMS_SIGNERS"
 
-echo "==> [2/5] fresh validator + program deploy"
-pkill -f solana-test-validator 2>/dev/null || true
-sleep 2
-LEDGER="$ROOT/.solana-test-ledger"
-rm -rf "$LEDGER"
-# Bind 0.0.0.0 so the dockerized KMS worker can read ACL records from the validator over RPC
-# (via host.docker.internal); host-side clients still target 127.0.0.1:8899. Local only — no
-# mainnet exposure.
-solana-test-validator --reset --rpc-port 8899 --bind-address 0.0.0.0 --ledger "$LEDGER" >/tmp/solana-validator.log 2>&1 &
-until curl -s -m2 "$VALIDATOR_RPC" -X POST -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' 2>/dev/null | grep -q '"ok"'; do sleep 1; done
-solana airdrop 500 >/dev/null 2>&1 || true
-# Seed the committed well-known PoC program keypairs so build-sbf reuses them and the deployed
+echo "==> [2/5] fresh validator + program deploy (reconstruct=$RECONSTRUCT)"
+# Seed the committed well-known PoC program keypairs so the build reuses them and the deployed
 # program IDs match each `declare_id!` (see scripts/poc/test-keypairs/README.md). `-n` keeps any
 # pre-existing local keypair; on a fresh checkout it seeds the committed test keys.
 mkdir -p "$SOLANA/target/deploy"
 for p in zama_host confidential_token confidential_token_receiver; do
   cp -n "$SOLANA/scripts/poc/test-keypairs/$p-keypair.json" "$SOLANA/target/deploy/$p-keypair.json" 2>/dev/null || true
 done
-# SKIP_BUILD reuses the already-built program .so (SBF bytecode is portable across
-# validator versions); useful when the active build toolchain differs from the
-# validator (e.g. building under one Agave release, running the validator on another).
-if [ "${SKIP_BUILD:-0}" != "1" ]; then
-  ( cd "$SOLANA" && cargo build-sbf --tools-version v1.52 )
+
+if [ "$RECONSTRUCT" = 1 ]; then
+  # Validator with the Yellowstone geyser plugin (gRPC :10000) from the prebuilt image
+  # (the workflow docker-builds solana/geyser/Dockerfile). Publish 8899+10000 to the host;
+  # the dockerized KMS worker reaches RPC the same way as the native validator — over
+  # host.docker.internal:8899. Local only — no mainnet exposure.
+  docker rm -f "$VAL_CONTAINER" >/dev/null 2>&1 || true
+  docker run -d --name "$VAL_CONTAINER" -p 8899:8899 -p 10000:10000 "$GEYSER_IMAGE" \
+    solana-test-validator --reset --rpc-port 8899 --bind-address 0.0.0.0 \
+    --geyser-plugin-config /plugins/yellowstone-config.json >/dev/null
+  until curl -s -m2 "$VALIDATOR_RPC" -X POST -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' 2>/dev/null | grep -q '"ok"'; do
+    [ -z "$(docker ps -q -f name="$VAL_CONTAINER" -f status=running)" ] \
+      && { echo "[setup] geyser validator container died:" >&2; docker logs "$VAL_CONTAINER" 2>&1 | tail -20 >&2; exit 1; }
+    sleep 1
+  done
+  solana airdrop 500 >/dev/null 2>&1 || true
+  # EMITLESS build: drop the default `emit-events` feature on zama-host so the deployed
+  # program emits NOTHING — off-chain reconstruction from instructions is the sole event
+  # source. anchor build gives per-crate feature control (cargo build-sbf builds the whole
+  # workspace, so it can't disable defaults for just one crate); anchor-cli is installed by
+  # the workflow. The other programs keep their defaults, matching the emit-decode run.
+  echo "    building EMITLESS zama_host (--no-default-features) + default-feature deps"
+  ( cd "$SOLANA" \
+      && anchor build --ignore-keys --no-idl -p zama_host -- --no-default-features \
+      && anchor build --ignore-keys --no-idl -p confidential_token \
+      && anchor build --ignore-keys --no-idl -p confidential_token_receiver ) \
+    || { echo "[setup] emitless anchor build failed" >&2; exit 1; }
+  # --use-rpc: deploy over RPC (8899) since the container doesn't publish the TPU ports.
+  for p in zama_host confidential_token confidential_token_receiver; do
+    solana program deploy -u "$VALIDATOR_RPC" --use-rpc \
+      --program-id "$SOLANA/target/deploy/$p-keypair.json" "$SOLANA/target/deploy/$p.so" >/dev/null
+  done
+else
+  pkill -f solana-test-validator 2>/dev/null || true
+  sleep 2
+  LEDGER="$ROOT/.solana-test-ledger"
+  rm -rf "$LEDGER"
+  # Bind 0.0.0.0 so the dockerized KMS worker can read ACL records from the validator over RPC
+  # (via host.docker.internal); host-side clients still target 127.0.0.1:8899. Local only — no
+  # mainnet exposure.
+  solana-test-validator --reset --rpc-port 8899 --bind-address 0.0.0.0 --ledger "$LEDGER" >/tmp/solana-validator.log 2>&1 &
+  until curl -s -m2 "$VALIDATOR_RPC" -X POST -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' 2>/dev/null | grep -q '"ok"'; do sleep 1; done
+  solana airdrop 500 >/dev/null 2>&1 || true
+  # SKIP_BUILD reuses the already-built program .so (SBF bytecode is portable across
+  # validator versions); useful when the active build toolchain differs from the
+  # validator (e.g. building under one Agave release, running the validator on another).
+  if [ "${SKIP_BUILD:-0}" != "1" ]; then
+    ( cd "$SOLANA" && cargo build-sbf --tools-version v1.52 )
+  fi
+  for p in zama_host confidential_token confidential_token_receiver; do
+    solana program deploy --program-id "$SOLANA/target/deploy/$p-keypair.json" "$SOLANA/target/deploy/$p.so" >/dev/null
+  done
 fi
-for p in zama_host confidential_token confidential_token_receiver; do
-  solana program deploy --program-id "$SOLANA/target/deploy/$p-keypair.json" "$SOLANA/target/deploy/$p.so" >/dev/null
-done
 ZAMA_HOST_ID="$(solana address -k "$SOLANA/target/deploy/zama_host-keypair.json")"
 echo "    zama_host=$ZAMA_HOST_ID deployed"
 
@@ -135,11 +182,24 @@ sleep 1
 # (build.rs -> OUT_DIR) from the program IDLs, so a stale prebuilt binary silently decodes zero
 # events when the program's event layout has moved (it drops every event whose generated struct
 # no longer matches), leaving the coprocessor with no work and the vertical hanging at SNS commit.
-( cd "$ROOT/coprocessor/fhevm-engine" && cargo build -p host-listener --bin solana_host_listener >/tmp/solana-host-listener-build.log 2>&1 ) \
-  || { echo "[setup] host-listener build failed; see /tmp/solana-host-listener-build.log" >&2; tail -20 /tmp/solana-host-listener-build.log >&2; exit 1; }
-( "$ROOT/coprocessor/fhevm-engine/target/debug/solana_host_listener" \
-    --database-url "$DBURL" --url "$VALIDATOR_RPC" --program-id "$ZAMA_HOST_ID" \
-    --host-chain-id="$SID_I64" >/tmp/solana-host-listener.log 2>&1 & )
+if [ "$RECONSTRUCT" = 1 ]; then
+  # gRPC transport + off-chain reconstruction: the listener INGESTS events rebuilt from
+  # the tx instructions (the program emits nothing), so this leg stands in for the whole
+  # Yellowstone effort end-to-end. Handle-derivation params are auto-detected from the
+  # on-chain HostConfig PDA at startup — no --chain-id / --zero-birth-entropy flags.
+  ( cd "$ROOT/coprocessor/fhevm-engine" && cargo build -p host-listener --features solana-grpc,solana-reconstruct --bin solana_host_listener >/tmp/solana-host-listener-build.log 2>&1 ) \
+    || { echo "[setup] host-listener (grpc,reconstruct) build failed; see /tmp/solana-host-listener-build.log" >&2; tail -20 /tmp/solana-host-listener-build.log >&2; exit 1; }
+  ( "$ROOT/coprocessor/fhevm-engine/target/debug/solana_host_listener" \
+      --transport grpc --grpc-url "$GRPC_URL" \
+      --database-url "$DBURL" --url "$VALIDATOR_RPC" --program-id "$ZAMA_HOST_ID" \
+      --host-chain-id="$SID_I64" --reconstruct >/tmp/solana-host-listener.log 2>&1 & )
+else
+  ( cd "$ROOT/coprocessor/fhevm-engine" && cargo build -p host-listener --bin solana_host_listener >/tmp/solana-host-listener-build.log 2>&1 ) \
+    || { echo "[setup] host-listener build failed; see /tmp/solana-host-listener-build.log" >&2; tail -20 /tmp/solana-host-listener-build.log >&2; exit 1; }
+  ( "$ROOT/coprocessor/fhevm-engine/target/debug/solana_host_listener" \
+      --database-url "$DBURL" --url "$VALIDATOR_RPC" --program-id "$ZAMA_HOST_ID" \
+      --host-chain-id="$SID_I64" >/tmp/solana-host-listener.log 2>&1 & )
+fi
 
 # The Solana decrypt pipeline is two-stage: the host-listener ingests events and, for
 # PublicDecryptAllowed / disclose+redeem request events, QUEUES a finalized-account fetch rather

--- a/typos.toml
+++ b/typos.toml
@@ -161,3 +161,9 @@ BA = "BA"                 # used in test variable names (e.g., wrongOrderBAInste
 
 # Doc
 PN = "PN"                 # abbreviation P1, ..., PN
+
+[default.extend-identifiers]
+# Solana SlotHashes sysvar address — a base58 "vanity" pubkey that reads as
+# "SysvarSlotHashes" with a digit 1 in place of the l; whitelist the whole
+# identifier so typos doesn't split it and flag the "ot" fragment.
+SysvarS1otHashes111111111111111111111111111 = "SysvarS1otHashes111111111111111111111111111"


### PR DESCRIPTION
# Solana host-listener: Yellowstone gRPC + off-chain event reconstruction

## Summary

Adds a Yellowstone gRPC transport to the Solana host-listener and **reconstructs
coprocessor events off-chain from instruction data** (+ minimal account reads),
so on-chain `emit_cpi!`/`emit!` can eventually be removed. All behind feature
flags — mainline/EVM builds are unchanged.

Proven equivalent to the existing emit-decode path: **reconstructed DB rows are
byte-identical to emit-decoded rows**, and with emits gated off, reconstruction is
the sole source.

## What's done

| Area | What | Validated by |
|---|---|---|
| Transport | gRPC (`--transport grpc`), reconnect + `from_slot` cursor | live parity vs RPC |
| Reconstruct | `fhe_eval` plan walk; Group A (trivial / binary / ternary / rand bind); B (`allow_for_decryption`, `allow_acl_subjects`); C (`commit_handle_material`, reads `acl_record.handle` via RPC) | EMITS=on byte-identical + 16 unit tests |
| Ingest swap | `--reconstruct` ingests reconstructed events in place of emit-decode | harness DB diff |
| Emit gating | all 34 `emit!`/`emit_cpi!` behind `emit-events` (default-on); off-build emits nothing | both configs compile; EMITS=off ⇒ `copro_rpc=0` |
| Config | HostConfig auto-detect (`chain_id` + zero-birth-entropy) via PDA read at startup; `--chain-id`/`--zero-birth-entropy` flags removed | harness |
| Isolation | features `solana-grpc`, `solana-reconstruct`, `emit-events`; `default-features=false` on listener's `zama-host` dep | mainline unaffected |

Covers `initialize_mint` + `fhe_eval` + `trivial_encrypt_and_bind` + `allow_for_decryption`
+ `fhe_rand_bounded_and_bind`. Uses **real SlotHashes bank-hash** entropy (BOOTSTRAP
config, test-shims off) — first full-parity test of the production entropy path.

## Wiring `clean-e2e.sh` (Not done right now, expect to finish on Monday after self review)

The full Solana vertical (`clean-e2e.sh` → `full-vertical.sh`) is correct but runs
the host-listener as gRPC **emit-decode**. To exercise reconstruction:

1. `docker-compose.solana.yml` → `solana-host-listener`:
   - `CARGO_FEATURES: solana-grpc,solana-reconstruct`
   - add `--reconstruct` to `command`
   - (no `--chain-id` / `--zero-birth-entropy` — auto-detected from HostConfig)
2. Validator base (`SOLANA_VALIDATOR_IMAGE`): x86 agave on CI; dev-arm64 build locally.
3. Program deploy — run in two passes:
   - **emits-on + `--reconstruct`** (safe: uncovered instructions fall back to emit-decode) → validate vertical;
   - **emits-off** (`zama_host` built `--no-default-features`) → reconstruction is the sole source.
4. **Run on x86** (CI / x86 Linux): the FHE workers + validator need AVX.
5. Expected: `full-vertical.sh` compute→public-decrypt passes identically to the
   emit-decode baseline (DB rows already proven equal).

> Functional readiness: nothing blocks step 3-pass-1 functionally — reconstruction
> is equivalent to emit-decode for everything the listener consumes. Only tooling
> (AVX/x86) and the wiring above remain.
[ ] Requires #2847 to be merged