### PR TITLE
chore(common): faster mergify pr cancelation

### DIFF
--- a/.github/workflows/test-suite-orchestrate-e2e-tests.yml
+++ b/.github/workflows/test-suite-orchestrate-e2e-tests.yml
@@ -11,17 +11,21 @@ permissions: {}
 
 concurrency:
   group: test-suite-orchestrate-e2e-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Do NOT cancel on `labeled` events: a Mergify merge-queue PR receives the
+  # `cla-signed` label moments after it's opened, on the same ref/concurrency
+  # group as the real run. Cancelling there would kill the in-flight e2e run.
+  # Only real code pushes (synchronize/opened/reopened) should cancel.
+  cancel-in-progress: ${{ github.event.action != 'labeled' && github.ref != 'refs/heads/main' }}
 
 jobs:
   resolve-baseline:
     name: resolve-baseline
     if: &build-trigger-condition |
-      startsWith(github.head_ref, 'mergify/merge-queue/') ||
-      startsWith(github.base_ref, 'release/') ||
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e orchestrate test') &&
       (
-        contains(github.event.pull_request.labels.*.name, 'e2e orchestrate test') &&
-        (github.event.action != 'labeled' || github.event.label.name == 'e2e orchestrate test')
+        startsWith(github.head_ref, 'mergify/merge-queue/') ||
+        startsWith(github.base_ref, 'release/') ||
+        contains(github.event.pull_request.labels.*.name, 'e2e orchestrate test')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -141,13 +145,11 @@ jobs:
       - relayer-docker-build
       - test-suite-docker-build
     if: |
-      (success() || failure()) && (
+      (success() || failure()) &&
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e orchestrate test') && (
         startsWith(github.head_ref, 'mergify/merge-queue/') ||
         startsWith(github.base_ref, 'release/') ||
-        (
-          contains(github.event.pull_request.labels.*.name, 'e2e orchestrate test') &&
-          (github.event.action != 'labeled' || github.event.label.name == 'e2e orchestrate test')
-        )
+        contains(github.event.pull_request.labels.*.name, 'e2e orchestrate test')
       )
     env:
       NEW_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,12 @@ queue_rules:
     merge_method: squash
     update_method: rebase
     merge_conditions:
+      # Fail fast: this job throws on a failed docker build, so the batch is
+      # dequeued immediately instead of waiting on the never-emitted e2e check.
+      # `or check-skipped` keeps non-orchestrated contributor PRs (job skipped) green.
+      - or:
+        - check-success = create-e2e-tests-input
+        - check-skipped = create-e2e-tests-input
       - check-success = run-e2e-tests / fhevm-e2e-test
     queue_conditions:
       - base = main


### PR DESCRIPTION
## What

Fixes the merge-queue flakiness where orchestrated e2e tests on a Mergify batch PR were cancelled mid-run, leaving the queue stuck (see #2843).
Re-lands the fast-cancel-on-build-failure change from #2829 (reverted in #2846), now that it's safe.

## Why

A Mergify merge-queue PR receives two `pull_request` events almost simultaneously, on the same `github.ref` and hence the same concurrency group:
- the PR being opened/synchronized (the real e2e run)
- the `cla-signed` label being added (a `labeled` event)

Because the workflow cancelled in-progress runs for any non-`main` ref, the `cla-signed` run cancelled the real one.
This was tolerable until #2829 added `create-e2e-tests-input` as a required merge condition: a cancelled run reports that check as `cancelled`, which satisfies neither `check-success` nor `check-skipped`, so the cancel flipped from "annoying re-run" to "hard-blocks the queue".
#2846 reverted #2829 temporarily; this PR fixes the root cause and brings #2829 back.

## How

Two changes in `test-suite-orchestrate-e2e-tests.yml`, needed together:

1. **Don't cancel on `labeled` events** — `cancel-in-progress` now excludes the `labeled` action, so the `cla-signed` run queues behind the in-flight run instead of cancelling it. Cancellation on real code pushes (synchronize/opened/reopened) is preserved.
2. **Make non-trigger `labeled` events a true no-op** — the `action != 'labeled' || label.name == 'e2e orchestrate test'` guard is hoisted so it applies to all branches (merge-queue and `release/*` included), not just the contributor-label path. The same guard is mirrored on `create-e2e-tests-input`.

Both are required: change 1 alone would still run the full e2e a second time (job `if` stays true on merge-queue); change 2 alone wouldn't help because cancellation happens at run creation, before the job `if` is evaluated. 

Then in `.mergify.yml`, bring #2829 back.