### PR TITLE
feat(sdk): add protocol version auto-resolution and epochId tracking in KMS extra-data (RFC-005)

### DIFF
--- a/.github/workflows/js-sdk-tests.yml
+++ b/.github/workflows/js-sdk-tests.yml
@@ -6,15 +6,15 @@ on:
       - devex/js-sdk
       - main
     paths:
-      - '.github/workflows/js-sdk-*.yml'
-      - 'sdk/js-sdk/**'
+      - ".github/workflows/js-sdk-*.yml"
+      - "sdk/js-sdk/**"
   push:
     branches:
       - devex/js-sdk
   workflow_dispatch:
     inputs:
       release:
-        description: 'Set to true for release tagging'
+        description: "Set to true for release tagging"
         required: false
         default: false
 
@@ -29,8 +29,8 @@ jobs:
       run:
         working-directory: ./sdk/js-sdk
     permissions:
-      contents: 'read' # Required to checkout repository code
-      id-token: 'write' # Required for OIDC / npm provenance attestation
+      contents: "read" # Required to checkout repository code
+      id-token: "write" # Required for OIDC / npm provenance attestation
     steps:
       # -----------------------------------------------------------------------
       # 1. Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          persist-credentials: 'false'
+          persist-credentials: "false"
 
       # -----------------------------------------------------------------------
       # 2. Node.js setup
@@ -95,39 +95,13 @@ jobs:
         run: npm ci
 
       # -----------------------------------------------------------------------
-      # 7. Build
-      #    The top-level "build" script does more than transpilation:
-      #      - clean           → remove prior tsbuildinfo and generated outputs
-      #      - prettier:check  → formatting validation
-      #      - prettier:ext    → repo-specific style/import checks
-      #      - codegen:loaders:check:dev → fail if generated WASM loaders/API declarations are stale
-      #      - lint            → eslint + full TypeScript noEmit check
-      #      - build:cjs       → CommonJS output under src/_cjs
-      #      - build:esm       → ES module output under src/_esm
-      #      - build:types     → declaration output under src/_types
-      #      - build:tests     → compile-check the test TypeScript project
-      #    The CJS/ESM builds each invoke their corresponding WASM copy step, so
-      #    running "build" prepares the package contents under src/ before pack.
-      # -----------------------------------------------------------------------
-      - name: Build package (CJS + ESM + types)
-        run: npm run build:prod
-
-      # -----------------------------------------------------------------------
-      # 8. Unit tests
-      #    Runs fast, isolated unit tests (src/**/*.test.ts) with type-checking.
-      #    No network or chain required.
-      # -----------------------------------------------------------------------
-      - name: Run unit tests
-        run: npm run test:unit
-
-      # -----------------------------------------------------------------------
-      # 9. Locahost cleartext chain Test
-      #    package.json maps "test" to the local cleartext integration runner,
-      #    which starts Anvil, deploys the FHEVM stack, runs only
-      #    test/fheTest/viem-cleartext, and then tears the local chain down.
+      # 7. DoD: everything we can test "quickly"
       # -----------------------------------------------------------------------
       - name: Setup Forge Soldeer
         run: cd contracts && forge soldeer install
+
+      - name: Setup playwright
+        run: cd test/browser && npx playwright install --with-deps
 
       - name: Set .env
         run: |
@@ -137,4 +111,4 @@ jobs:
       - name: Run cleartext tests with manual package
         run: |
           ulimit -n 65536
-          npm run test:localcleartext:pack
+          npm run dod

--- a/sdk/js-sdk/DRAFT_RFC_016.md
+++ b/sdk/js-sdk/DRAFT_RFC_016.md
@@ -1,0 +1,528 @@
+## Naming Problem: Decryption Permit Signing
+
+### Context
+
+Protocol v14 introduces a new unified EIP-712 payload for user decryption.
+
+Before v14, user decryption uses two EIP-712 shapes:
+
+- `KmsUserDecryptEip712`
+- `KmsDelegatedUserDecryptEip712`
+
+In v14, these are replaced by a unified shape:
+
+- `KmsUserDecryptEip712V2`
+
+The current user-facing API is:
+
+- `signDecryptionPermit`
+
+Today, this API produces the v13-and-below permit format. Starting with protocol v14, the preferred permit format changes: the inner EIP-712 payload should be `KmsUserDecryptEip712V2`.
+
+### Problem
+
+The name `signDecryptionPermit` is the best user-facing name. It describes the user's intent without exposing protocol details.
+
+However, the meaning of the permit changes between protocol versions:
+
+- v13 and below need the old user/delegated EIP-712 formats.
+- v14 and above need the unified EIP-712 format.
+
+Both formats must coexist for some time because protocol v13 will remain deployed on-chain while protocol v14 is introduced.
+
+The SDK therefore needs a migration strategy that:
+
+- Keeps `signDecryptionPermit` as the natural high-level API.
+- Allows v13 and v14 chains to coexist.
+- Avoids forcing dApp developers to manually detect protocol versions.
+- Keeps protocol-specific helpers stable and explicit.
+
+### Constraint
+
+The dApp SDK user should be able to call one function.
+
+The SDK should dynamically resolve the protocol version and produce the correct permit format under the hood. Moving the protocol version check and branching logic to the dApp is not ideal.
+
+In other words, this is not only a naming problem. It is also an API responsibility problem:
+
+- The user wants to sign a decryption permit.
+- The SDK knows, or can discover, which protocol version is active.
+- The SDK should choose the correct EIP-712 format.
+
+### Missing Protocol Version API
+
+The SDK is missing an explicit protocol version resolver:
+
+```ts
+getProtocolVersion(...): Promise<string>
+```
+
+This function should resolve the active host-contract/protocol version for the target chain or contract context.
+The returned string should follow the SemVer specification.
+
+Examples:
+
+- `"0.13.0"`
+- `"0.14.0"`
+- `"0.14.1"`
+
+It should be used by:
+
+- `signDecryptionPermit`, to decide whether to produce a v1 or v2 permit;
+- HyperWasmResolver, to select behavior that depends on protocol version;
+- future protocol-aware SDK APIs that need to branch between protocol versions.
+
+This keeps protocol detection centralized instead of duplicating version checks across SDK features.
+
+For now, protocol version resolution can be derived from the `ACL` host-contract version.
+The compatibility table currently uses `0.x.0` protocol versions, and the `ACL` minor version is enough to determine the protocol version precisely.
+
+Current mapping:
+
+| ACL version | Protocol version |
+| ----------- | ---------------- |
+| `0.2.0`     | `0.11.0`         |
+| `0.3.0`     | `0.12.0`         |
+| `0.4.0`     | `0.13.0`         |
+| `0.5.0`     | `0.14.0`         |
+
+As long as this invariant holds, the mapping can be expressed as:
+
+```ts
+protocolVersion = `0.${aclVersion.minor + 9}.0`;
+```
+
+The resolver should still fail loudly if the `ACL` version shape stops matching this assumption.
+
+```ts
+function protocolVersionFromAclVersion(aclVersion): string {
+  if (aclVersion.contractName !== 'ACL') {
+    throw new Error(`Expected ACL version, got ${aclVersion.contractName}.`);
+  }
+
+  if (aclVersion.major !== 0 || aclVersion.patch !== 0) {
+    throw new Error(`Unsupported ACL version ${aclVersion.version}.`);
+  }
+
+  return `0.${aclVersion.minor + 9}.0`;
+}
+```
+
+`getProtocolVersion` should require only:
+
+- a base runtime with the default `ethereum` module;
+- a chain definition;
+- a native client for the host-chain RPC call.
+
+It should not depend on the encrypt/decrypt modules or on any resolved WASM version.
+
+### Runtime Protocol Version State
+
+`CoreFhevmImpl` should store the resolved protocol version using the same pattern as `tfheVersion` and `tkmsVersion`.
+
+Add:
+
+```ts
+type ProtocolVersion = string;
+
+type WithProtocolVersion = {
+  readonly protocolVersion: ProtocolVersion;
+};
+```
+
+Then make resolved WASM-version contexts include the protocol version:
+
+```ts
+type WithTfheVersion = WithProtocolVersion & {
+  readonly tfheVersion: TfheVersion;
+};
+
+type WithTkmsVersion = WithProtocolVersion & {
+  readonly tkmsVersion: TkmsVersion;
+};
+```
+
+This reflects the runtime model:
+
+- protocol version is a base chain/client fact;
+- TFHE/TKMS versions are derived from protocol version unless explicitly overridden;
+- protocol-aware APIs can reuse the same resolved value.
+
+Add helpers mirroring TFHE/TKMS:
+
+```ts
+getResolvedProtocolVersion(fhevm): ProtocolVersion | undefined
+setResolvedProtocolVersion(fhevm, protocolVersion): void
+resolveFhevmProtocolVersion(fhevm): Promise<ProtocolVersion>
+```
+
+### HyperWasmResolver Integration
+
+`HyperWasmResolver` should stop owning ACL-version detection directly.
+
+Instead, it should use the protocol version resolver:
+
+```ts
+const protocolVersion = await resolveFhevmProtocolVersion(fhevm);
+```
+
+Then it can map protocol version to WASM versions:
+
+```ts
+if (isSemverStrictlyBefore(protocolVersion, '0.13.0')) {
+  return '1.5.3';
+}
+
+return '1.6.1';
+```
+
+for TFHE, and similarly:
+
+```ts
+if (isSemverStrictlyBefore(protocolVersion, '0.13.0')) {
+  return '0.13.10';
+}
+
+return '0.13.20-0';
+```
+
+for TKMS.
+
+This keeps the compatibility policy centralized:
+
+- ACL host-contract version -> protocol SemVer;
+- protocol SemVer -> WASM module versions;
+- protocol SemVer -> permit format.
+
+### Possible API Shape
+
+Use versioned functions for explicit protocol-specific behavior:
+
+- `signDecryptionPermitV1`
+- `signDecryptionPermitV2`
+- `signDecryptionPermitV3`
+- `signDecryptionPermitVx`
+
+Each versioned function must be stable. Its behavior should never change once published.
+
+Use the unversioned function as the recommended high-level API:
+
+- `signDecryptionPermit`
+
+This function should not be a simple permanent alias to the latest version if the SDK needs to support multiple deployed protocol versions at the same time.
+
+Instead, it should likely be a protocol-aware dispatcher:
+
+- Detect the protocol version.
+- Build the matching EIP-712 payload.
+- Sign it.
+- Return the matching signed permit type.
+
+### Transition Model
+
+During the transition, the API could look like this:
+
+#### Period 1
+
+- `signDecryptionPermit`: current v13-and-below behavior.
+- `signDecryptionPermitV2`: new v14 unified behavior.
+
+#### Period 2
+
+- `signDecryptionPermit`: protocol-aware default behavior.
+- `signDecryptionPermitV1`: explicit v13-and-below behavior.
+- `signDecryptionPermitV2`: explicit v14 unified behavior.
+
+#### Period 3
+
+- `signDecryptionPermit`: protocol-aware default behavior.
+- `signDecryptionPermitV1`: still available for explicit legacy usage, possibly deprecated.
+- `signDecryptionPermitV2`: still available for explicit v14 usage.
+
+#### Period 4
+
+- `signDecryptionPermit`: protocol-aware default behavior.
+- Old explicit helpers can be removed only when the corresponding protocol versions are no longer supported.
+
+### Open Question
+
+Should `signDecryptionPermit` return a discriminated union such as:
+
+- `SignedDecryptionPermitV1 | SignedDecryptionPermitV2`
+
+or should the SDK hide that difference behind a common signed permit abstraction?
+
+The answer depends on how much downstream code needs to inspect the permit internals.
+
+## Draft API Proposal
+
+### Public Functions
+
+Expose one high-level protocol-aware function:
+
+```ts
+signDecryptionPermit(parameters): Promise<SignedDecryptionPermit>
+```
+
+Expose explicit protocol-specific helpers:
+
+```ts
+signDecryptionPermitV1(parameters): Promise<SignedDecryptionPermitV1>
+signDecryptionPermitV2(parameters): Promise<SignedDecryptionPermitV2>
+```
+
+Future protocol-specific helpers can follow the same pattern:
+
+```ts
+signDecryptionPermitV3(parameters): Promise<SignedDecryptionPermitV3>
+```
+
+### Recommended Usage
+
+dApp users should normally call:
+
+```ts
+const permit = await fhevm.signDecryptionPermit({
+  userAddress,
+  publicKey,
+  handles,
+  allowedContracts,
+  durationSeconds,
+});
+```
+
+The SDK should resolve the protocol version and route internally:
+
+```ts
+async function signDecryptionPermit(parameters): Promise<SignedDecryptionPermit> {
+  const protocolVersion = await resolveProtocolVersion(parameters);
+
+  if (isSemverStrictlyBefore(protocolVersion, '0.14.0')) {
+    return signDecryptionPermitV1(parameters);
+  }
+
+  return signDecryptionPermitV2(parameters);
+}
+```
+
+## Existing API
+
+```ts
+type SignDecryptionPermitCommonParameters = {
+  readonly contractAddresses: readonly string[];
+  readonly startTimestamp: number;
+  readonly durationDays: number;
+  readonly signerAddress: string;
+  readonly signer: NativeSigner;
+  readonly transportKeyPair: TransportKeyPair;
+};
+
+export type SignSelfDecryptionPermitParameters = SignDecryptionPermitCommonParameters & {
+  readonly delegatorAddress?: undefined;
+};
+
+export type SignDelegatedDecryptionPermitParameters = SignDecryptionPermitCommonParameters & {
+  readonly delegatorAddress: string;
+};
+
+export type SignDecryptionPermitParameters =
+  | SignSelfDecryptionPermitParameters
+  | SignDelegatedDecryptionPermitParameters;
+```
+
+## New API
+
+To avoid as much breaking changes as possible, we could introduce:
+
+```ts
+type SignDecryptionPermitParameters = {
+  readonly contractAddresses: readonly string[];
+  readonly startTimestamp: number;
+  // Conversion to seconds if v14 or later
+  readonly durationDays: number;
+  // An unsigned integer value.
+  // Missing: what is the max supported value ?
+  // (See backend rust code for more info on that)
+  readonly durationSeconds?: number | bigint;
+  readonly signerAddress: string;
+  readonly signer: NativeSigner;
+  // `delegatorAddress` could be renamed as `encryptedDataOwnerAddress`
+  // to follow the new `ownerAddress` naming in unified EIP712
+  readonly delegatorAddress?: string | undefined;
+  readonly transportKeyPair: TransportKeyPair;
+};
+```
+
+Type validation should be performed according to Protocol Version which can be accessed
+using:
+
+`client.protocolVersion` or `context.protocolVersion`
+
+The `protocolVersion` property is now resolved at client `init` time.
+
+The files impacted:
+
+- sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
+- sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
+- sdk/js-sdk/src/core/actions/base/signDecryptionPermit.ts
+
+### Versioned Helpers
+
+Versioned helpers are useful for:
+
+- tests;
+- explicit compatibility code;
+- debugging;
+- users who already know they are targeting one protocol version;
+- avoiding ambiguity when the caller wants a fixed EIP-712 shape.
+
+They should not dynamically switch behavior.
+
+```ts
+signDecryptionPermitV1(parameters);
+```
+
+Always produces the v13-and-below permit format:
+
+- `KmsUserDecryptEip712`
+- `KmsDelegatedUserDecryptEip712`
+
+```ts
+signDecryptionPermitV2(parameters);
+```
+
+Always produces the v14 unified permit format:
+
+- `KmsUserDecryptEip712V2`
+
+### Return Types
+
+The protocol-aware return type can be a discriminated union:
+
+```ts
+type SignedDecryptionPermit = SignedDecryptionPermitV1 | SignedDecryptionPermitV2;
+```
+
+Each permit should expose a stable discriminator:
+
+```ts
+type SignedDecryptionPermitV1 = {
+  readonly version: 1;
+  readonly eip712: KmsUserDecryptEip712 | KmsDelegatedUserDecryptEip712;
+  readonly signature: string;
+};
+
+type SignedDecryptionPermitV2 = {
+  readonly version: 2;
+  readonly eip712: KmsUserDecryptEip712V2;
+  readonly signature: string;
+};
+```
+
+This keeps the high-level API simple while still allowing downstream code to inspect the exact permit shape when needed.
+
+### Optional Override
+
+The high-level function may accept a protocol override for tests and advanced users:
+
+```ts
+type SignDecryptionPermitParameters = {
+  readonly protocolVersion?: 'auto' | string;
+};
+```
+
+Default:
+
+```ts
+protocolVersion: 'auto';
+```
+
+If this override is added, it should be documented as an advanced option. The normal user path should remain automatic.
+
+### Duration Input
+
+The old permit format uses `durationDays`.
+
+The v14 unified permit format uses `durationSeconds`.
+
+The high-level `signDecryptionPermit` API can support both as user input, but they should be mutually exclusive:
+
+```ts
+type DecryptionPermitDuration =
+  | {
+      readonly durationDays: number;
+      readonly durationSeconds?: never;
+    }
+  | {
+      readonly durationSeconds: number | bigint;
+      readonly durationDays?: never;
+    };
+```
+
+This gives users a smooth transition:
+
+- Existing users can keep passing `durationDays`.
+- New users can pass `durationSeconds`.
+- The SDK can normalize the duration according to the resolved protocol version.
+
+Suggested behavior:
+
+- If the target protocol is v13 or below:
+  - `durationDays` is kept as-is.
+  - `durationSeconds` is accepted only if it is a whole number of days.
+  - No silent rounding should happen.
+- If the target protocol is v14 or above:
+  - `durationSeconds` is kept as-is.
+  - `durationDays` is converted to seconds.
+
+This conversion can live in an internal helper:
+
+```ts
+function resolveDecryptionPermitDuration(
+  parameters: DecryptionPermitDuration,
+  protocolVersion: string,
+): { readonly durationDays: number } | { readonly durationSeconds: bigint } {
+  if ('durationDays' in parameters) {
+    if (isSemverStrictlyBefore(protocolVersion, '0.14.0')) {
+      return { durationDays: parameters.durationDays };
+    }
+
+    return {
+      durationSeconds: BigInt(parameters.durationDays) * 86_400n,
+    };
+  }
+
+  const durationSeconds = BigInt(parameters.durationSeconds);
+
+  if (isSemverStrictlyBefore(protocolVersion, '0.14.0')) {
+    if (durationSeconds % 86_400n !== 0n) {
+      throw new Error('Protocol v13 requires durationSeconds to be a whole number of days.');
+    }
+
+    return {
+      durationDays: Number(durationSeconds / 86_400n),
+    };
+  }
+
+  return { durationSeconds };
+}
+```
+
+This helper should probably stay internal unless users need duration normalization outside permit signing.
+
+### Naming Rule
+
+The unversioned function is intent-based:
+
+```ts
+signDecryptionPermit;
+```
+
+The versioned functions are format-based:
+
+```ts
+signDecryptionPermitV1;
+signDecryptionPermitV2;
+```
+
+Once published, a versioned function's behavior should never change. Only the internal dispatch behavior of `signDecryptionPermit` may evolve as new protocol versions are introduced.

--- a/sdk/js-sdk/DRAFT_RFC_016.md
+++ b/sdk/js-sdk/DRAFT_RFC_016.md
@@ -526,3 +526,65 @@ signDecryptionPermitV2;
 ```
 
 Once published, a versioned function's behavior should never change. Only the internal dispatch behavior of `signDecryptionPermit` may evolve as new protocol versions are introduced.
+
+## New Base Client
+
+in order to access the protocol version, the new base client must be initialized following decrypt and encrypt clients behaviours. Protocol Version computation will call on-chain view functions.
+
+Example:
+
+This is ok:
+
+```ts
+const client = createFhevmBaseClient(args);
+await client.init();
+const protocolVersion = client.protocolVersion;
+```
+
+This is not ok:
+
+```ts
+const client = createFhevmBaseClient(args);
+// throw an exception, missing call to init!
+const protocolVersion = client.protocolVersion;
+```
+
+### `client.signDecryptionPermit`
+
+The `signDecryptionPermit` should start with a lazy init if needed
+
+```ts
+/////////////////////
+// Existing code
+/////////////////////
+export async function signDecryptionPermit(
+  context: SignDecryptionPermitContext,
+  parameters: SignDecryptionPermitParameters,
+): Promise<SignedDecryptionPermit> {
+  const kmsSignersContext = await readKmsSignersContext(context, {
+    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+  });
+
+  const extraData: BytesHex = kmsSignersContextToExtraData(kmsSignersContext);
+
+  ...
+}
+
+/////////////////////
+// New code
+/////////////////////
+export async function signDecryptionPermit(
+  context: SignDecryptionPermitContext,
+  parameters: SignDecryptionPermitParameters,
+): Promise<SignedDecryptionPermit> {
+  const protocolVersion = await ensureResolvedProtocolVersion(context);
+
+  const kmsSignersContext = await readKmsSignersContext(context, {
+    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+  });
+
+  const extraData: BytesHex = kmsSignersContextToExtraData(kmsSignersContext);
+
+  ...
+}
+```

--- a/sdk/js-sdk/contracts/scripts/fhetest-deploy.sh
+++ b/sdk/js-sdk/contracts/scripts/fhetest-deploy.sh
@@ -94,6 +94,7 @@ fi
 
 acl_addr="$(fhevm_chain_address ${chain} acl)"
 kms_verifier_addr="$(fhevm_chain_address ${chain} kmsVerifier)"
+protocol_config_addr="$(fhevm_chain_address ${chain} protocolConfig)"
 
 # If this call fails, the ACL proxy isn't deployed (or hasn't been upgraded
 # past the empty UUPS impl) — that's the FHEVM host stack's job, not ours.
@@ -106,20 +107,21 @@ if ! coprocessor_addr="$(cast call "$acl_addr" "getFHEVMExecutorAddress()(addres
     exit 1
 fi
 
-echo "rpc-url:       $rpc_url"
-echo "ACL:           $acl_addr"
-echo "KMSVerifier:   $kms_verifier_addr"
-echo "Coprocessor:   $coprocessor_addr"
+echo "rpc-url:        $rpc_url"
+echo "ACL:            $acl_addr"
+echo "KMSVerifier:    $kms_verifier_addr"
+echo "ProtocolConfig: $protocol_config_addr"
+echo "Coprocessor:    $coprocessor_addr"
 
 # ==============================================================================
 
 private_key=$(cast wallet private-key --mnemonic "${fhevm_mnemonic}" --mnemonic-derivation-path "${fhevm_mnemonic_path}")
 deployer_addr=$(cast wallet address --private-key "${private_key}")
 
-echo "deployer:      $deployer_addr"
+echo "deployer:       $deployer_addr"
 
 deployer_balance_wei="$(cast balance "$deployer_addr" --rpc-url "$rpc_url")"
-echo "balance:       ${deployer_balance_wei} wei"
+echo "balance:        ${deployer_balance_wei} wei"
 
 if [[ "$dry_run" == true ]]; then
     # Predict the FHETest CREATE address: keccak256(rlp(deployer, nonce))[12:].
@@ -163,7 +165,7 @@ cast send "$fhe_test_addr" \
     --rpc-url "$rpc_url" --private-key "${private_key}" >/dev/null
 
 echo "✅ initFheTest"
-echo "✅ FheTest:   ${fhe_test_addr}"
+echo "✅ FheTest:     ${fhe_test_addr}"
 
 # ==============================================================================
 #

--- a/sdk/js-sdk/docs/compatibility.md
+++ b/sdk/js-sdk/docs/compatibility.md
@@ -11,15 +11,20 @@ There is no on-chain or relayer-side signal that tells the SDK the minimum `tfhe
 
 ## Heuristic
 
-Lacking a direct signal, the SDK derives the right `tfhe.wasm` version from the on-chain `ACL` contract version:
+Lacking a direct signal, the SDK derives the right `tfhe.wasm` version from a protocol context:
 
-1. Read `ACL.version` on the host chain.
-2. Map it to a wasm version:
-   - `ACL.version < 0.4.0` (Protocol ≤ `v0.12.0`) → `tfhe.wasm@v1.5.3`
-   - `ACL.version = 0.4.0` (Protocol ≥ `v0.13.0`) → `tfhe.wasm@v1.6.1`
-   - `ACL.version ≥ 0.5.0` (Protocol ≥ `v0.14.0`) → ?
+1. Read `ACL.version` on the host chain and map it to a protocol version.
+2. Resolve the PubKey/CRS version from what this SDK knows at the time it is written:
+   - for known public relayers, use the PubKey/CRS version they are known to serve at SDK release time;
+   - otherwise, use the PubKey/CRS version expected when fresh key material is generated for that protocol line.
+3. Map `(protocol version, PubKey/CRS version)` to a wasm version:
+   - Protocol `< v0.13.0` with PubKey/CRS `< v1.6.0` → `tfhe.wasm@v1.5.3`
+   - Protocol `≥ v0.13.0` with PubKey/CRS `< v1.6.0` → `tfhe.wasm@v1.6.1` by default, while `v1.5.3` remains compatible for the current legacy public PubKey/CRS.
+   - Protocol `≥ v0.13.0` with PubKey/CRS `≥ v1.6.0` → `tfhe.wasm@v1.6.1`
 
-This works as long as every protocol release bumps at least one host-contract version. See [the open question on this assumption](#open-question) below if it ever breaks.
+The PubKey/CRS part is a release-time snapshot, not a future-proof signal. After the SDK is published, key rotation or CRS removal can change the material served by a relayer. The SDK cannot guess those future changes without a direct on-chain or relayer-side version signal.
+
+The protocol-version part works as long as every protocol release bumps at least one host-contract version. See [the open question on this assumption](#open-question) below if it ever breaks.
 
 **In the future: add view functions in InputVerifier.sol and KMSVerifier.sol or ProtocolConfig.sol**
 

--- a/sdk/js-sdk/package.json
+++ b/sdk/js-sdk/package.json
@@ -45,14 +45,14 @@
     "test:localstack:v13": "./test/scripts/localstack-run-tests.sh --chain localstack_v13 --fhevm-cli-profile v0.13.0.json",
     "test:localcleartext:v12": "./test/scripts/localcleartext-run-tests.sh --foundry-profile=v12",
     "test:localcleartext:v13": "./test/scripts/localcleartext-run-tests.sh --foundry-profile=v13",
-    "test:localcleartext": "./test/scripts/localcleartext-run-tests.sh",
-    "test:localcleartext:pack": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack",
     "test:localcleartext:pack:v12": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v12",
     "test:localcleartext:pack:v13": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v13",
-    "test": "npm run test:unit && npm run test:localcleartext:pack && npm run test:browser",
+    "test": "npm run test:unit && npm run test:localcleartext:pack:v12 && npm run test:localcleartext:pack:v13 && npm run test:browser",
     "dod": "node test/scripts/dod.mjs",
     "dod:full": "node test/scripts/dod.mjs --full",
-    "version": "node ./scripts/generate-version.cjs"
+    "version": "node ./scripts/generate-version.cjs",
+    "start:localcleartext:v12": "./test/scripts/fhevm-anvil.sh --ethlib none --foundry-profile=v12",
+    "start:localcleartext:v13": "./test/scripts/fhevm-anvil.sh --ethlib none --foundry-profile=v13"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/sdk/js-sdk/src/core/actions/base/canDecryptPublicValue.ts
+++ b/sdk/js-sdk/src/core/actions/base/canDecryptPublicValue.ts
@@ -20,7 +20,7 @@ export async function canDecryptPublicValue(
   parameters: CanDecryptPublicValueParameters,
 ): Promise<CanDecryptPublicValueReturnType> {
   const results = await isAllowedForDecryption(fhevm, {
-    address: fhevm.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+    aclAddress: fhevm.chain.fhevm.contracts.acl.address as ChecksummedAddress,
     handles: [toFhevmHandle(parameters.encryptedValue)],
   });
 

--- a/sdk/js-sdk/src/core/actions/base/canDecryptPublicValues.ts
+++ b/sdk/js-sdk/src/core/actions/base/canDecryptPublicValues.ts
@@ -22,7 +22,7 @@ export async function canDecryptPublicValues(
   const handles = parameters.encryptedValues.map(toFhevmHandle);
 
   return isAllowedForDecryption(fhevm, {
-    address: fhevm.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+    aclAddress: fhevm.chain.fhevm.contracts.acl.address as ChecksummedAddress,
     handles,
   });
 }

--- a/sdk/js-sdk/src/core/actions/base/readKmsSignersContext.ts
+++ b/sdk/js-sdk/src/core/actions/base/readKmsSignersContext.ts
@@ -12,7 +12,8 @@ export type ReadKmsSignersContextReturnType = KmsSignersContext;
 
 export async function readKmsSignersContext(fhevm: Fhevm<FhevmChain>): Promise<ReadKmsSignersContextReturnType> {
   return readKmsSignersContext_(fhevm, {
-    address: fhevm.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    kmsVerifierAddress: fhevm.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    protocolConfigAddress: fhevm.chain.fhevm.contracts.protocolConfig?.address as ChecksummedAddress | undefined,
   });
 }
 

--- a/sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
+++ b/sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
@@ -2,7 +2,7 @@ import type { Fhevm } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
 import type { SignedDecryptionPermit } from '../../types/signedDecryptionPermit.js';
 import type { TransportKeyPair } from '../../kms/TransportKeyPair-p.js';
-import type { KmsDecryptEip712Like } from '../../types/kms.js';
+import type { Eip712Like } from '../../types/kms.js';
 import { parseSignedDecryptionPermit as parseSignedDecryptionPermit_ } from '../../kms/SignedDecryptionPermit-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10,7 +10,7 @@ import { parseSignedDecryptionPermit as parseSignedDecryptionPermit_ } from '../
 export type ParseSignedDecryptionPermitParameters = {
   /** The serialized permit — a previously parsed permit object. */
   readonly serializedPermit: {
-    readonly eip712: KmsDecryptEip712Like;
+    readonly eip712: Eip712Like;
     readonly signature: string;
     readonly signerAddress: string;
   };

--- a/sdk/js-sdk/src/core/actions/host/readFhevmExecutorContractData.ts
+++ b/sdk/js-sdk/src/core/actions/host/readFhevmExecutorContractData.ts
@@ -10,7 +10,7 @@ import { getAclAddress } from '../../host-contracts/getAclAddress-p.js';
 import { getHandleVersion } from '../../host-contracts/getHandleVersion-p.js';
 import { getHcuLimitAddress } from '../../host-contracts/getHcuLimitAddress-p.js';
 import { assertIsHostContractVersionOf } from '../../host-contracts/HostContractVersion-p.js';
-import { getVersion } from '../../host-contracts/HostContractVersion-p.js';
+import { getHostContractVersion } from '../../host-contracts/HostContractVersion-p.js';
 import { getInputVerifierAddress } from '../../host-contracts/getInputVerifierAddress-p.js';
 
 export type ReadFhevmExecutorContractDataParameters = {
@@ -36,7 +36,7 @@ export async function readFhevmExecutorContractData(
   ////////////////////////////////////////////////////////////////////////////
 
   const rpcCalls = [
-    () => getVersion(fhevm, parameters),
+    () => getHostContractVersion(fhevm, parameters),
     () => getAclAddress(fhevm, parameters),
     () => getHcuLimitAddress(fhevm, parameters),
     () => getInputVerifierAddress(fhevm, parameters),

--- a/sdk/js-sdk/src/core/actions/host/readFhevmExecutorContractData.ts
+++ b/sdk/js-sdk/src/core/actions/host/readFhevmExecutorContractData.ts
@@ -22,7 +22,7 @@ export async function readFhevmExecutorContractData(
   fhevm: Fhevm,
   parameters: ReadFhevmExecutorContractDataParameters,
 ): Promise<ReadFhevmExecutorContractDataReturnType> {
-  const fhevmExecutorContractAddress = parameters.address;
+  const fhevmExecutorAddress = parameters.address;
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -37,10 +37,10 @@ export async function readFhevmExecutorContractData(
 
   const rpcCalls = [
     () => getHostContractVersion(fhevm, parameters),
-    () => getAclAddress(fhevm, parameters),
-    () => getHcuLimitAddress(fhevm, parameters),
-    () => getInputVerifierAddress(fhevm, parameters),
-    () => getHandleVersion(fhevm, parameters),
+    () => getAclAddress(fhevm, { fhevmExecutorAddress }),
+    () => getHcuLimitAddress(fhevm, { fhevmExecutorAddress }),
+    () => getInputVerifierAddress(fhevm, { fhevmExecutorAddress }),
+    () => getHandleVersion(fhevm, { fhevmExecutorAddress }),
   ];
 
   const res = await executeWithBatching<unknown>(rpcCalls, fhevm.options.batchRpcCalls);
@@ -63,7 +63,7 @@ export async function readFhevmExecutorContractData(
 
   const data = createFhevmExecutorContractData(new WeakRef(fhevm.runtime), {
     version: contractVersion,
-    address: fhevmExecutorContractAddress,
+    address: fhevmExecutorAddress,
     aclContractAddress,
     inputVerifierContractAddress,
     hcuLimitContractAddress,

--- a/sdk/js-sdk/src/core/actions/host/readInputVerifierContractData.ts
+++ b/sdk/js-sdk/src/core/actions/host/readInputVerifierContractData.ts
@@ -6,7 +6,7 @@ import type { CoprocessorSignersContext } from '../../types/coprocessorSignersCo
 import { eip712Domain, type Eip712DomainReturnType } from '../../host-contracts/eip712Domain-p.js';
 import { assertIsHostContractVersionOf } from '../../host-contracts/HostContractVersion-p.js';
 import { readCoprocessorSignersContext } from '../../host-contracts/readCoprocessorSignersContext-p.js';
-import { getVersion } from '../../host-contracts/HostContractVersion-p.js';
+import { getHostContractVersion } from '../../host-contracts/HostContractVersion-p.js';
 import { executeWithBatching } from '../../base/promise.js';
 import { assertIsCoprocessorEip712Domain } from '../../coprocessor/assertIsCoprocessorEip712Domain.js';
 import { createInputVerifierContractData } from '../../host-contracts/InputVerifierContractData-p.js';
@@ -39,7 +39,7 @@ export async function readInputVerifierContractData(
   ////////////////////////////////////////////////////////////////////////////
 
   const rpcCalls = [
-    () => getVersion(fhevm, parameters),
+    () => getHostContractVersion(fhevm, parameters),
     () => eip712Domain(fhevm, parameters),
     () => readCoprocessorSignersContext(fhevm, parameters),
   ];

--- a/sdk/js-sdk/src/core/actions/host/readKmsVerifierContractData.ts
+++ b/sdk/js-sdk/src/core/actions/host/readKmsVerifierContractData.ts
@@ -16,6 +16,7 @@ import { readKmsSignersContext } from '../../host-contracts/readKmsSignersContex
 
 export type ReadKmsVerifierContractDataParameters = {
   readonly address: ChecksummedAddress;
+  readonly protocolConfigAddress: ChecksummedAddress | undefined;
 };
 
 export type ReadKmsVerifierContractDataReturnType = KmsVerifierContractData;
@@ -26,7 +27,8 @@ export async function readKmsVerifierContractData(
   fhevm: Fhevm,
   parameters: ReadKmsVerifierContractDataParameters,
 ): Promise<ReadKmsVerifierContractDataReturnType> {
-  const kmsVerifierContractAddress = parameters.address;
+  const kmsVerifierAddress = parameters.address;
+  const protocolConfigAddress = parameters.protocolConfigAddress;
 
   ////////////////////////////////////////////////////////////////////////////
   //
@@ -42,7 +44,7 @@ export async function readKmsVerifierContractData(
   const rpcCalls = [
     () => getHostContractVersion(fhevm, parameters),
     () => eip712Domain(fhevm, parameters),
-    () => readKmsSignersContext(fhevm, parameters),
+    () => readKmsSignersContext(fhevm, { kmsVerifierAddress, protocolConfigAddress }),
   ];
 
   const res = await executeWithBatching<unknown>(rpcCalls, fhevm.options.batchRpcCalls);
@@ -59,13 +61,13 @@ export async function readKmsVerifierContractData(
     throw new Error(`Invalid KMSVerifier EIP-712 domain.`, { cause: e });
   }
 
-  if (eip712DomainRes.verifyingContract.toLowerCase() === kmsVerifierContractAddress.toLowerCase()) {
+  if (eip712DomainRes.verifyingContract.toLowerCase() === kmsVerifierAddress.toLowerCase()) {
     throw new Error(`Invalid KMSVerifier EIP-712 domain. Unexpected verifyingContract.`);
   }
 
   const data = createKmsVerifierContractData(new WeakRef(fhevm.runtime), {
     version: contractVersion,
-    address: kmsVerifierContractAddress,
+    address: kmsVerifierAddress,
     eip712Domain: eip712DomainRes,
     kmsSignerThreshold: kmsSignersContext.threshold,
     kmsSigners: kmsSignersContext.signers,

--- a/sdk/js-sdk/src/core/actions/host/readKmsVerifierContractData.ts
+++ b/sdk/js-sdk/src/core/actions/host/readKmsVerifierContractData.ts
@@ -9,7 +9,7 @@ import { createKmsVerifierContractData } from '../../host-contracts/KmsVerifierC
 import { assertIsKmsEip712Domain } from '../../kms/createKmsEip712Domain.js';
 import { eip712Domain } from '../../host-contracts/eip712Domain-p.js';
 import { assertIsHostContractVersionOf } from '../../host-contracts/HostContractVersion-p.js';
-import { getVersion } from '../../host-contracts/HostContractVersion-p.js';
+import { getHostContractVersion } from '../../host-contracts/HostContractVersion-p.js';
 import { readKmsSignersContext } from '../../host-contracts/readKmsSignersContext-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -40,7 +40,7 @@ export async function readKmsVerifierContractData(
   ////////////////////////////////////////////////////////////////////////////
 
   const rpcCalls = [
-    () => getVersion(fhevm, parameters),
+    () => getHostContractVersion(fhevm, parameters),
     () => eip712Domain(fhevm, parameters),
     () => readKmsSignersContext(fhevm, parameters),
   ];

--- a/sdk/js-sdk/src/core/actions/host/resolveFhevmConfig.ts
+++ b/sdk/js-sdk/src/core/actions/host/resolveFhevmConfig.ts
@@ -159,7 +159,7 @@ async function _resolveFhevmExecutor(
 
   if (acl !== undefined) {
     const aclFhevmExecutor = await getFhevmExecutorAddress(fhevm, {
-      address: addressToChecksummedAddress(acl),
+      aclAddress: addressToChecksummedAddress(acl),
     });
     if (fhevmExecutor !== undefined) {
       if (aclFhevmExecutor !== fhevmExecutor) {

--- a/sdk/js-sdk/src/core/actions/host/resolveFhevmConfig.ts
+++ b/sdk/js-sdk/src/core/actions/host/resolveFhevmConfig.ts
@@ -29,6 +29,7 @@ export type ResolveFhevmConfigParameters = {
       readonly hcuLimit?: OptionalChainContract | undefined;
       readonly inputVerifier?: OptionalChainContract | undefined;
       readonly kmsVerifier: { readonly address: string };
+      readonly protocolConfig: OptionalChainContract | undefined;
     };
     readonly gateway?:
       | {
@@ -52,6 +53,7 @@ export type ResolveFhevmConfigReturnType = {
   readonly fhevmExecutor: FhevmExecutorContractData;
   readonly inputVerifier: InputVerifierContractData;
   readonly kmsVerifier: KmsVerifierContractData;
+  readonly protocolConfig: ChecksummedAddress | undefined;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,6 +65,11 @@ export async function resolveFhevmConfig(
   // Input is loose
   const kmsVerifierAddress = parameters.fhevm.contracts.kmsVerifier.address;
   assertIsAddress(kmsVerifierAddress, {});
+
+  const protocolConfigAddress = parameters.fhevm.contracts.protocolConfig?.address;
+  if (protocolConfigAddress !== undefined) {
+    assertIsAddress(protocolConfigAddress, {});
+  }
 
   const id: Uint64BigInt = await resolveChainId(fhevm, parameters);
   const fhevmExecutorData = await _resolveFhevmExecutor(fhevm, parameters.fhevm.contracts);
@@ -86,6 +93,7 @@ export async function resolveFhevmConfig(
     () =>
       readKmsVerifierContractData(fhevm, {
         address: addressToChecksummedAddress(kmsVerifierAddress),
+        protocolConfigAddress: protocolConfigAddress ? addressToChecksummedAddress(protocolConfigAddress) : undefined,
       }),
   ];
 
@@ -120,6 +128,7 @@ export async function resolveFhevmConfig(
     fhevmExecutor: fhevmExecutorData,
     inputVerifier: inputVerifierData,
     kmsVerifier: kmsVerifierData,
+    protocolConfig: protocolConfigAddress ? addressToChecksummedAddress(protocolConfigAddress) : undefined,
   };
 
   return Object.freeze(returnValue);

--- a/sdk/js-sdk/src/core/base/object.ts
+++ b/sdk/js-sdk/src/core/base/object.ts
@@ -17,6 +17,44 @@ export function simpleDeepFreeze<T extends object>(obj: T): Readonly<T> {
 }
 
 /**
+ * Recursively compares two JSON-like values.
+ *
+ * Arrays are order-sensitive. Objects must have the same own enumerable string keys, but key
+ * insertion order does not matter.
+ */
+export function isDeepEqual(value: unknown, expected: unknown): boolean {
+  if (value === expected) {
+    return true;
+  }
+
+  if (Array.isArray(expected)) {
+    return (
+      Array.isArray(value) &&
+      value.length === expected.length &&
+      expected.every((expectedItem, index) => isDeepEqual(value[index], expectedItem))
+    );
+  }
+
+  if (expected === null || typeof expected !== 'object') {
+    return value === expected;
+  }
+
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  const expectedRecord = expected as Record<string, unknown>;
+  const keys = Object.keys(record);
+  const expectedKeys = Object.keys(expectedRecord);
+
+  return (
+    keys.length === expectedKeys.length &&
+    expectedKeys.every((key) => Object.hasOwn(record, key) && isDeepEqual(record[key], expectedRecord[key]))
+  );
+}
+
+/**
  * Defines a non-enumerable, non-writable, non-configurable property on the target object.
  * The property is hidden from `Object.keys()` / `Object.entries()` and cannot be
  * overwritten or reconfigured after creation.

--- a/sdk/js-sdk/src/core/base/semver.test.ts
+++ b/sdk/js-sdk/src/core/base/semver.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { isSemverInInterval, semverComparatorImpliesRange } from './semver.js';
+
+describe('isSemverInInterval', () => {
+  it('handles half-open intervals', () => {
+    const interval = {
+      lowerBound: { version: '0.4.0', comparator: 'ge' },
+      upperBound: { version: '0.5.0', comparator: 'lt' },
+    } as const;
+
+    expect(isSemverInInterval('0.3.9', interval)).toBe(false);
+    expect(isSemverInInterval('0.4.0', interval)).toBe(true);
+    expect(isSemverInInterval('0.4.1', interval)).toBe(true);
+    expect(isSemverInInterval('0.5.0', interval)).toBe(false);
+  });
+
+  it('handles open-ended intervals', () => {
+    expect(isSemverInInterval('0.4.0', { lowerBound: { version: '0.4.0', comparator: 'ge' } })).toBe(true);
+    expect(isSemverInInterval('0.3.9', { lowerBound: { version: '0.4.0', comparator: 'ge' } })).toBe(false);
+
+    expect(isSemverInInterval('0.4.0', { upperBound: { version: '0.4.0', comparator: 'le' } })).toBe(true);
+    expect(isSemverInInterval('0.4.1', { upperBound: { version: '0.4.0', comparator: 'le' } })).toBe(false);
+  });
+});
+
+describe('semverComparatorImpliesRange', () => {
+  it('handles exact constraints', () => {
+    expect(semverComparatorImpliesRange('0.13.0', 'eq', { version: '0.13.0', comparator: 'eq' })).toBe(true);
+    expect(semverComparatorImpliesRange('0.13.0', 'eq', { version: '0.12.0', comparator: 'gt' })).toBe(true);
+    expect(semverComparatorImpliesRange('0.13.0', 'eq', { version: '0.13.0', comparator: 'gt' })).toBe(false);
+  });
+
+  it('handles lower-bound constraints', () => {
+    expect(semverComparatorImpliesRange('0.14.0', 'gt', { version: '0.13.0', comparator: 'ge' })).toBe(true);
+    expect(semverComparatorImpliesRange('0.13.0', 'gt', { version: '0.13.0', comparator: 'gt' })).toBe(true);
+    expect(semverComparatorImpliesRange('0.13.0', 'ge', { version: '0.13.0', comparator: 'gt' })).toBe(false);
+    expect(semverComparatorImpliesRange('0.12.0', 'gt', { version: '0.13.0', comparator: 'ge' })).toBe(false);
+  });
+
+  it('handles upper-bound constraints', () => {
+    expect(semverComparatorImpliesRange('0.11.0', 'lt', { version: '0.13.0', comparator: 'lt' })).toBe(true);
+    expect(semverComparatorImpliesRange('0.13.0', 'lt', { version: '0.13.0', comparator: 'lt' })).toBe(true);
+    expect(semverComparatorImpliesRange('0.13.0', 'le', { version: '0.13.0', comparator: 'lt' })).toBe(false);
+    expect(semverComparatorImpliesRange('0.14.0', 'lt', { version: '0.13.0', comparator: 'lt' })).toBe(false);
+  });
+});

--- a/sdk/js-sdk/src/core/base/semver.ts
+++ b/sdk/js-sdk/src/core/base/semver.ts
@@ -1,0 +1,231 @@
+import type { UintNumber } from '../types/primitives.js';
+import { assertIsUintNumber } from './uint.js';
+
+////////////////////////////////////////////////////////////////////////////////
+
+export type Semver = {
+  readonly version: string;
+  readonly major: UintNumber;
+  readonly minor: UintNumber;
+  readonly patch: UintNumber;
+  readonly prerelease?: readonly string[] | undefined;
+  readonly build?: readonly string[] | undefined;
+};
+
+export type SemverComparator = 'lt' | 'le' | 'gt' | 'ge' | 'eq';
+
+export type SemverRange = {
+  readonly version: string;
+  readonly comparator: SemverComparator;
+};
+
+export type SemverIntervalLowerBound = {
+  readonly version: string;
+  readonly comparator: 'gt' | 'ge';
+};
+
+export type SemverIntervalUpperBound = {
+  readonly version: string;
+  readonly comparator: 'lt' | 'le';
+};
+
+export type SemverInterval = {
+  readonly lowerBound?: SemverIntervalLowerBound | undefined;
+  readonly upperBound?: SemverIntervalUpperBound | undefined;
+};
+
+const SEMVER_REGEX =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+export function parseSemver(version: string): Semver {
+  const match = SEMVER_REGEX.exec(version);
+  if (match === null) {
+    throw new Error(`Invalid SemVer version: "${version}".`);
+  }
+
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+
+  assertIsUintNumber(major, {});
+  assertIsUintNumber(minor, {});
+  assertIsUintNumber(patch, {});
+
+  return Object.freeze({
+    version,
+    major,
+    minor,
+    patch,
+    prerelease: match[4]?.split('.'),
+    build: match[5]?.split('.'),
+  });
+}
+
+export function isSemverStrictlyBefore(version: string, before: string): boolean {
+  return compareSemver(version, before) < 0;
+}
+
+export function isSemverInRange(version: string, range: SemverRange): boolean {
+  const comparison = compareSemver(version, range.version);
+
+  switch (range.comparator) {
+    case 'lt':
+      return comparison < 0;
+    case 'le':
+      return comparison <= 0;
+    case 'gt':
+      return comparison > 0;
+    case 'ge':
+      return comparison >= 0;
+    case 'eq':
+      return comparison === 0;
+    default: {
+      const exhaustiveCheck: never = range.comparator;
+      throw new Error(`Unsupported SemVer comparator "${exhaustiveCheck}".`);
+    }
+  }
+}
+
+export function isSemverInInterval(version: string, interval: SemverInterval): boolean {
+  if (interval.lowerBound !== undefined && !isSemverInRange(version, interval.lowerBound)) {
+    return false;
+  }
+  if (interval.upperBound !== undefined && !isSemverInRange(version, interval.upperBound)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns whether a SemVer comparator constraint implies a SemVer range.
+ *
+ * Mathematically: for every SemVer `x`, if `x comparator version` is true,
+ * then `x range.comparator range.version` is also true.
+ */
+export function semverComparatorImpliesRange(
+  version: string,
+  comparator: SemverComparator,
+  range: SemverRange,
+): boolean {
+  if (comparator === 'eq') {
+    return isSemverInRange(version, range);
+  }
+
+  const comparison = compareSemver(version, range.version);
+
+  switch (comparator) {
+    case 'lt':
+      return range.comparator === 'lt' || range.comparator === 'le' ? comparison <= 0 : false;
+    case 'le':
+      if (range.comparator === 'lt') {
+        return comparison < 0;
+      }
+      return range.comparator === 'le' ? comparison <= 0 : false;
+    case 'gt':
+      return range.comparator === 'gt' || range.comparator === 'ge' ? comparison >= 0 : false;
+    case 'ge':
+      if (range.comparator === 'gt') {
+        return comparison > 0;
+      }
+      return range.comparator === 'ge' ? comparison >= 0 : false;
+    default: {
+      const exhaustiveCheck: never = comparator;
+      throw new Error(`Unsupported SemVer comparator "${exhaustiveCheck}".`);
+    }
+  }
+}
+
+export function compareSemver(a: string, b: string): -1 | 0 | 1 {
+  const left = parseSemver(a);
+  const right = parseSemver(b);
+
+  const releaseComparison = _compareNumbers(
+    [left.major, left.minor, left.patch],
+    [right.major, right.minor, right.patch],
+  );
+  if (releaseComparison !== 0) {
+    return releaseComparison;
+  }
+
+  return _comparePrerelease(left.prerelease, right.prerelease);
+}
+
+function _compareNumbers(a: readonly number[], b: readonly number[]): -1 | 0 | 1 {
+  for (let i = 0; i < a.length; ++i) {
+    const left = a[i];
+    const right = b[i];
+    if (left === undefined) {
+      return right === undefined ? 0 : -1;
+    }
+    if (right === undefined) {
+      return 1;
+    }
+    if (left < right) {
+      return -1;
+    }
+    if (left > right) {
+      return 1;
+    }
+  }
+  return a.length === b.length ? 0 : -1;
+}
+
+function _comparePrerelease(a: readonly string[] | undefined, b: readonly string[] | undefined): -1 | 0 | 1 {
+  if (a === undefined && b === undefined) {
+    return 0;
+  }
+  if (a === undefined) {
+    return 1;
+  }
+  if (b === undefined) {
+    return -1;
+  }
+
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; ++i) {
+    const left = a[i];
+    const right = b[i];
+
+    if (left === undefined) {
+      return -1;
+    }
+    if (right === undefined) {
+      return 1;
+    }
+
+    const comparison = _comparePrereleaseIdentifier(left, right);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+function _comparePrereleaseIdentifier(a: string, b: string): -1 | 0 | 1 {
+  const aIsNumeric = _isNumericIdentifier(a);
+  const bIsNumeric = _isNumericIdentifier(b);
+
+  if (aIsNumeric && bIsNumeric) {
+    return _compareNumbers([Number(a)], [Number(b)]);
+  }
+
+  if (aIsNumeric) {
+    return -1;
+  }
+  if (bIsNumeric) {
+    return 1;
+  }
+
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
+function _isNumericIdentifier(value: string): boolean {
+  return /^(0|[1-9]\d*)$/.test(value);
+}

--- a/sdk/js-sdk/src/core/base/uint.ts
+++ b/sdk/js-sdk/src/core/base/uint.ts
@@ -668,7 +668,7 @@ export function assertRecordUintBigIntProperty<K extends string>(
   property: K,
   recordName: string,
   options: ErrorMetadataParams,
-): asserts record is RecordWithPropertyType<K, number> {
+): asserts record is RecordWithPropertyType<K, bigint> {
   if (typeofProperty(record, property) !== 'bigint' || !isUintBigInt((record as Record<string, unknown>)[property])) {
     throw new InvalidPropertyError(
       {

--- a/sdk/js-sdk/src/core/base/uint.ts
+++ b/sdk/js-sdk/src/core/base/uint.ts
@@ -116,6 +116,13 @@ export function isUintBigInt(value: unknown, max?: bigint | number): value is Ui
   return typeof value === 'bigint' && value >= 0 && (max === undefined || value <= max);
 }
 
+export function isUintString(value: unknown, max?: number | bigint): value is string {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return tryParseUintBigIntString(value, max) !== undefined;
+}
+
 export function isUintForType(value: unknown, typeName?: UintTypeName): value is Uint {
   return isUint(value, typeName !== undefined ? MAX_UINT_FOR_TYPE[typeName] : undefined);
 }
@@ -324,6 +331,22 @@ export function assertIsUintBigInt(
         subject: options.subject,
         type: typeof value,
         expectedType: 'uintBigInt',
+      },
+      options,
+    );
+  }
+}
+
+export function assertIsUintString(
+  value: unknown,
+  options: { max?: bigint | number; subject?: string } & ErrorMetadataParams,
+): asserts value is string {
+  if (!isUintString(value, options.max)) {
+    throw new InvalidTypeError(
+      {
+        subject: options.subject,
+        type: typeof value,
+        expectedType: 'uintString',
       },
       options,
     );
@@ -659,17 +682,23 @@ export function assertRecordUintBigIntProperty<K extends string>(
   }
 }
 
-export function parseUintBigIntString(value: string): bigint | undefined {
+/**
+ * Tries to parse a canonical unsigned decimal string as a bigint.
+ *
+ * Returns `undefined` instead of throwing when `value` is not parseable, is negative, is not in
+ * canonical decimal form, or exceeds `max`.
+ */
+export function tryParseUintBigIntString(value: string, max?: number | bigint): UintBigInt | undefined {
   let parsed: bigint;
   try {
     parsed = BigInt(value);
   } catch {
     return undefined;
   }
-  if (parsed < 0n || parsed.toString() !== value) {
+  if (parsed < 0n || parsed.toString() !== value || (max !== undefined && parsed > BigInt(max))) {
     return undefined;
   }
-  return parsed;
+  return parsed as UintBigInt;
 }
 
 /** Returns `count` unique integers drawn uniformly from [0, n-1]. Mock/debug only. */

--- a/sdk/js-sdk/src/core/chains/definitions/localTestnet.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/localTestnet.ts
@@ -13,6 +13,9 @@ export const localTestnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11',
       },
+      protocolConfig: {
+        address: '0x52054F36036811ca418be59e41Fc6DD1b9e4F4c8',
+      },
     },
     relayerUrl: 'http://localhost:9000',
     gateway: {

--- a/sdk/js-sdk/src/core/chains/definitions/mainnet.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/mainnet.ts
@@ -13,6 +13,7 @@ export const mainnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0x77627828a55156b04Ac0DC0eb30467f1a552BB03',
       },
+      protocolConfig: undefined, // To be filled
     },
     relayerUrl: 'https://relayer.mainnet.zama.org',
     gateway: {

--- a/sdk/js-sdk/src/core/chains/definitions/sepolia.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/sepolia.ts
@@ -1,5 +1,4 @@
 import type { FhevmChain } from '../../types/fhevmChain.js';
-import type { ChecksummedAddress } from '../../types/primitives.js';
 import { defineFhevmChain } from '../utils.js';
 
 export const sepolia: FhevmChain = /*#__PURE__*/ defineFhevmChain({
@@ -7,24 +6,25 @@ export const sepolia: FhevmChain = /*#__PURE__*/ defineFhevmChain({
   fhevm: {
     contracts: {
       acl: {
-        address: '0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D' as ChecksummedAddress,
+        address: '0xf0Ffdc93b7E186bC2f8CB3dAA75D86d1930A433D',
       },
       inputVerifier: {
-        address: '0xBBC1fFCdc7C316aAAd72E807D9b0272BE8F84DA0' as ChecksummedAddress,
+        address: '0xBBC1fFCdc7C316aAAd72E807D9b0272BE8F84DA0',
       },
       kmsVerifier: {
-        address: '0xbE0E383937d564D7FF0BC3b46c51f0bF8d5C311A' as ChecksummedAddress,
+        address: '0xbE0E383937d564D7FF0BC3b46c51f0bF8d5C311A',
       },
+      protocolConfig: undefined, // To be filled
     },
     relayerUrl: 'https://relayer.testnet.zama.org',
     gateway: {
       id: 10_901,
       contracts: {
         decryption: {
-          address: '0x5D8BD78e2ea6bbE41f26dFe9fdaEAa349e077478' as ChecksummedAddress,
+          address: '0x5D8BD78e2ea6bbE41f26dFe9fdaEAa349e077478',
         },
         inputVerification: {
-          address: '0x483b9dE06E4E4C7D35CCf5837A1668487406D955' as ChecksummedAddress,
+          address: '0x483b9dE06E4E4C7D35CCf5837A1668487406D955',
         },
       },
     },

--- a/sdk/js-sdk/src/core/clients/decorators/base.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/base.ts
@@ -1,8 +1,3 @@
-import {
-  assertIsFhevmBaseClient,
-  resolveFhevmProtocolVersion,
-  setResolvedProtocolVersion,
-} from '../../runtime/CoreFhevm-p.js';
 import type { Fhevm, FhevmBase, FhevmExtension } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
 import type {
@@ -13,6 +8,7 @@ import type {
   SerializeTransportKeyPairParameters,
   SerializeTransportKeyPairReturnType,
 } from '../../actions/chain/serializeTransportKeyPair.js';
+import { assertIsFhevmBaseClient } from '../../runtime/CoreFhevm-p.js';
 import {
   signDecryptionPermit,
   type SignSelfDecryptionPermitParameters,
@@ -54,6 +50,7 @@ import {
   type DecryptPublicValuesWithSignaturesParameters,
   type DecryptPublicValuesWithSignaturesReturnType,
 } from '../../actions/base/decryptPublicValuesWithSignatures.js';
+import { ensureResolvedProtocolVersion } from '../../runtime/resolveFhevmVersions-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -198,8 +195,7 @@ function _baseActions(fhevm: Fhevm<FhevmChain>): BaseActions {
 ////////////////////////////////////////////////////////////////////////////////
 
 async function _initBase(fhevm: FhevmBase<FhevmChain>): Promise<void> {
-  const protocolVersion = await resolveFhevmProtocolVersion(fhevm);
-  setResolvedProtocolVersion(fhevm, protocolVersion);
+  await ensureResolvedProtocolVersion(fhevm);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sdk/js-sdk/src/core/clients/decorators/base.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/base.ts
@@ -1,3 +1,8 @@
+import {
+  assertIsFhevmBaseClient,
+  resolveFhevmProtocolVersion,
+  setResolvedProtocolVersion,
+} from '../../runtime/CoreFhevm-p.js';
 import type { Fhevm, FhevmBase, FhevmExtension } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
 import type {
@@ -8,7 +13,6 @@ import type {
   SerializeTransportKeyPairParameters,
   SerializeTransportKeyPairReturnType,
 } from '../../actions/chain/serializeTransportKeyPair.js';
-import { assertIsFhevmBaseClient } from '../../runtime/CoreFhevm-p.js';
 import {
   signDecryptionPermit,
   type SignSelfDecryptionPermitParameters,
@@ -193,11 +197,18 @@ function _baseActions(fhevm: Fhevm<FhevmChain>): BaseActions {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+async function _initBase(fhevm: FhevmBase<FhevmChain>): Promise<void> {
+  const protocolVersion = await resolveFhevmProtocolVersion(fhevm);
+  setResolvedProtocolVersion(fhevm, protocolVersion);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 export function baseActions(fhevm: FhevmBase<FhevmChain>): FhevmExtension<BaseActions> {
   assertIsFhevmBaseClient(fhevm);
   return {
     actions: _baseActions(fhevm),
     runtime: fhevm.runtime,
-    // no init required, no prefetch of the FheEncryptionKey. This is the whole purpose of the fetchFheEncryptionKeyBytes action
+    init: _initBase,
   };
 }

--- a/sdk/js-sdk/src/core/clients/decorators/decrypt-p.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/decrypt-p.ts
@@ -1,20 +1,14 @@
 import type { FhevmBase } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
-import {
-  asFhevmClientWith,
-  resolveFhevmProtocolVersion,
-  resolveFhevmTkmsVersion,
-  setResolvedProtocolVersion,
-  setResolvedTkmsVersion,
-} from '../../runtime/CoreFhevm-p.js';
+import { asFhevmClientWith, setResolvedTkmsVersion } from '../../runtime/CoreFhevm-p.js';
+import { ensureResolvedProtocolVersion, resolveFhevmTkmsVersion } from '../../runtime/resolveFhevmVersions-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function _initDecrypt(fhevm: FhevmBase<FhevmChain>): Promise<void> {
   const f = asFhevmClientWith(fhevm, 'decrypt');
 
-  const protocolVersion = await resolveFhevmProtocolVersion(f);
-  setResolvedProtocolVersion(f, protocolVersion);
+  await ensureResolvedProtocolVersion(f);
 
   const tkmsVersion = await resolveFhevmTkmsVersion(f);
 

--- a/sdk/js-sdk/src/core/clients/decorators/decrypt-p.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/decrypt-p.ts
@@ -1,11 +1,20 @@
 import type { FhevmBase } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
-import { asFhevmClientWith, resolveFhevmTkmsVersion, setResolvedTkmsVersion } from '../../runtime/CoreFhevm-p.js';
+import {
+  asFhevmClientWith,
+  resolveFhevmProtocolVersion,
+  resolveFhevmTkmsVersion,
+  setResolvedProtocolVersion,
+  setResolvedTkmsVersion,
+} from '../../runtime/CoreFhevm-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function _initDecrypt(fhevm: FhevmBase<FhevmChain>): Promise<void> {
   const f = asFhevmClientWith(fhevm, 'decrypt');
+
+  const protocolVersion = await resolveFhevmProtocolVersion(f);
+  setResolvedProtocolVersion(f, protocolVersion);
 
   const tkmsVersion = await resolveFhevmTkmsVersion(f);
 

--- a/sdk/js-sdk/src/core/clients/decorators/encrypt-p.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/encrypt-p.ts
@@ -1,12 +1,21 @@
 import type { FhevmBase } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
-import { asFhevmClientWith, resolveFhevmTfheVersion, setResolvedTfheVersion } from '../../runtime/CoreFhevm-p.js';
+import {
+  asFhevmClientWith,
+  resolveFhevmProtocolVersion,
+  resolveFhevmTfheVersion,
+  setResolvedProtocolVersion,
+  setResolvedTfheVersion,
+} from '../../runtime/CoreFhevm-p.js';
 import { fetchFheEncryptionKeyBytes } from '../../key/fetchFheEncryptionKeyBytes.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function _initEncrypt(fhevm: FhevmBase<FhevmChain>): Promise<void> {
   const f = asFhevmClientWith(fhevm, 'encrypt');
+
+  const protocolVersion = await resolveFhevmProtocolVersion(f);
+  setResolvedProtocolVersion(f, protocolVersion);
 
   const tfheVersion = await resolveFhevmTfheVersion(f);
 

--- a/sdk/js-sdk/src/core/clients/decorators/encrypt-p.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/encrypt-p.ts
@@ -1,21 +1,15 @@
 import type { FhevmBase } from '../../types/coreFhevmClient.js';
 import type { FhevmChain } from '../../types/fhevmChain.js';
-import {
-  asFhevmClientWith,
-  resolveFhevmProtocolVersion,
-  resolveFhevmTfheVersion,
-  setResolvedProtocolVersion,
-  setResolvedTfheVersion,
-} from '../../runtime/CoreFhevm-p.js';
+import { asFhevmClientWith, setResolvedTfheVersion } from '../../runtime/CoreFhevm-p.js';
 import { fetchFheEncryptionKeyBytes } from '../../key/fetchFheEncryptionKeyBytes.js';
+import { ensureResolvedProtocolVersion, resolveFhevmTfheVersion } from '../../runtime/resolveFhevmVersions-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function _initEncrypt(fhevm: FhevmBase<FhevmChain>): Promise<void> {
   const f = asFhevmClientWith(fhevm, 'encrypt');
 
-  const protocolVersion = await resolveFhevmProtocolVersion(f);
-  setResolvedProtocolVersion(f, protocolVersion);
+  await ensureResolvedProtocolVersion(fhevm);
 
   const tfheVersion = await resolveFhevmTfheVersion(f);
 

--- a/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.test.ts
+++ b/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.test.ts
@@ -6,7 +6,7 @@ import { PRIVATE_ETHERS_TOKEN } from '../../ethers/internal/ethers-p.js';
 import { sepolia } from '../chains/definitions/sepolia.js';
 import { createCoreFhevm } from '../runtime/CoreFhevm-p.js';
 import { createFhevmRuntime } from '../runtime/CoreFhevmRuntime-p.js';
-import { getVersion, invalidateVersionCache } from './HostContractVersion-p.js';
+import { getHostContractVersion, invalidateVersionCache } from './HostContractVersion-p.js';
 
 const ACL_ADDRESS = sepolia.fhevm.contracts.acl.address as ChecksummedAddress;
 const KMS_VERIFIER_ADDRESS = sepolia.fhevm.contracts.kmsVerifier.address as ChecksummedAddress;
@@ -58,16 +58,20 @@ describe('HostContractVersion cache', () => {
     );
     const client = makeClient(readContract);
 
-    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.1.0' });
-    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+    await expect(getHostContractVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({
+      version: 'ACL v0.1.0',
+    });
+    await expect(getHostContractVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
       version: 'KMSVerifier v0.1.0',
     });
     expect(readContract).toHaveBeenCalledTimes(2);
 
     invalidateVersionCache(client, { address: ACL_ADDRESS });
 
-    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.2.0' });
-    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+    await expect(getHostContractVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({
+      version: 'ACL v0.2.0',
+    });
+    await expect(getHostContractVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
       version: 'KMSVerifier v0.1.0',
     });
     expect(readContract).toHaveBeenCalledTimes(3);
@@ -82,16 +86,20 @@ describe('HostContractVersion cache', () => {
     );
     const client = makeClient(readContract);
 
-    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.1.0' });
-    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+    await expect(getHostContractVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({
+      version: 'ACL v0.1.0',
+    });
+    await expect(getHostContractVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
       version: 'KMSVerifier v0.1.0',
     });
     expect(readContract).toHaveBeenCalledTimes(2);
 
     invalidateVersionCache();
 
-    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.2.0' });
-    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+    await expect(getHostContractVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({
+      version: 'ACL v0.2.0',
+    });
+    await expect(getHostContractVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
       version: 'KMSVerifier v0.2.0',
     });
     expect(readContract).toHaveBeenCalledTimes(4);

--- a/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.test.ts
+++ b/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.test.ts
@@ -1,0 +1,99 @@
+import type { EthereumModule } from '../modules/ethereum/types.js';
+import type { RelayerModule } from '../modules/relayer/types.js';
+import type { ChecksummedAddress } from '../types/primitives.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRIVATE_ETHERS_TOKEN } from '../../ethers/internal/ethers-p.js';
+import { sepolia } from '../chains/definitions/sepolia.js';
+import { createCoreFhevm } from '../runtime/CoreFhevm-p.js';
+import { createFhevmRuntime } from '../runtime/CoreFhevmRuntime-p.js';
+import { getVersion, invalidateVersionCache } from './HostContractVersion-p.js';
+
+const ACL_ADDRESS = sepolia.fhevm.contracts.acl.address as ChecksummedAddress;
+const KMS_VERIFIER_ADDRESS = sepolia.fhevm.contracts.kmsVerifier.address as ChecksummedAddress;
+
+function makeClient(
+  readContract: EthereumModule['readContract'],
+): ReturnType<typeof createCoreFhevm<typeof sepolia, ReturnType<typeof createFhevmRuntime>, object>> {
+  const ethereum = {
+    readContract,
+  } as unknown as EthereumModule;
+
+  const runtime = createFhevmRuntime(PRIVATE_ETHERS_TOKEN, {
+    ethereum,
+    relayer: {} as RelayerModule,
+    config: {},
+  });
+
+  return createCoreFhevm(PRIVATE_ETHERS_TOKEN, {
+    chain: sepolia,
+    client: {},
+    runtime,
+  });
+}
+
+function makeReadContract(
+  versionsByAddress: ReadonlyMap<ChecksummedAddress, string[]>,
+): EthereumModule['readContract'] {
+  return vi.fn(async (_trustedClient, parameters) => {
+    const versions = versionsByAddress.get(parameters.address);
+    const version = versions?.shift();
+    if (version === undefined) {
+      throw new Error(`No mocked version for ${parameters.address}`);
+    }
+    return version;
+  });
+}
+
+describe('HostContractVersion cache', () => {
+  beforeEach(() => {
+    invalidateVersionCache({ includeInflight: true });
+  });
+
+  it('invalidates one cached host contract version entry', async () => {
+    const readContract = makeReadContract(
+      new Map<ChecksummedAddress, string[]>([
+        [ACL_ADDRESS, ['ACL v0.1.0', 'ACL v0.2.0']],
+        [KMS_VERIFIER_ADDRESS, ['KMSVerifier v0.1.0', 'KMSVerifier v0.2.0']],
+      ]),
+    );
+    const client = makeClient(readContract);
+
+    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.1.0' });
+    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+      version: 'KMSVerifier v0.1.0',
+    });
+    expect(readContract).toHaveBeenCalledTimes(2);
+
+    invalidateVersionCache(client, { address: ACL_ADDRESS });
+
+    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.2.0' });
+    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+      version: 'KMSVerifier v0.1.0',
+    });
+    expect(readContract).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates all cached host contract version entries', async () => {
+    const readContract = makeReadContract(
+      new Map<ChecksummedAddress, string[]>([
+        [ACL_ADDRESS, ['ACL v0.1.0', 'ACL v0.2.0']],
+        [KMS_VERIFIER_ADDRESS, ['KMSVerifier v0.1.0', 'KMSVerifier v0.2.0']],
+      ]),
+    );
+    const client = makeClient(readContract);
+
+    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.1.0' });
+    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+      version: 'KMSVerifier v0.1.0',
+    });
+    expect(readContract).toHaveBeenCalledTimes(2);
+
+    invalidateVersionCache();
+
+    await expect(getVersion(client, { address: ACL_ADDRESS })).resolves.toMatchObject({ version: 'ACL v0.2.0' });
+    await expect(getVersion(client, { address: KMS_VERIFIER_ADDRESS })).resolves.toMatchObject({
+      version: 'KMSVerifier v0.2.0',
+    });
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+});

--- a/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.ts
@@ -165,7 +165,8 @@ function parseVersion(version: string): HostContractVersion {
     contractName !== 'FHEVMExecutor' &&
     contractName !== 'InputVerifier' &&
     contractName !== 'KMSVerifier' &&
-    contractName !== 'HCULimit'
+    contractName !== 'HCULimit' &&
+    contractName !== 'ProtocolConfig'
   ) {
     throw new Error(err);
   }

--- a/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.ts
@@ -64,7 +64,7 @@ function _getVersionCacheKey(context: Context, parameters: Parameters): string {
  *   Use this after a known contract upgrade to ensure all subsequent callers
  *   see the updated version.
  */
-export function getVersion(
+export function getHostContractVersion(
   context: Context,
   parameters: Parameters & { readonly forceRefresh?: boolean },
 ): Promise<ReturnType> {

--- a/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/HostContractVersion-p.ts
@@ -19,15 +19,33 @@ type Parameters = {
 };
 
 type ReturnType = HostContractVersion;
+type InvalidateVersionCacheOptions = {
+  readonly includeInflight?: boolean | undefined;
+};
+type InvalidateVersionCacheParameters = Parameters & InvalidateVersionCacheOptions;
 
 ////////////////////////////////////////////////////////////////////////////////
 
 const cachedGetVersion = createCachedFetch<Context, Parameters, ReturnType>({
   executeFn: _getVersion,
-  cacheKeyFn: (context, params) => `${context.runtime.uid.toLowerCase()}:${params.address.toLowerCase()}`,
+  cacheKeyFn: _getVersionCacheKey,
   // Host contract versions are immutable per deployment, so a long TTL is safe.
   ttlMs: CACHE_TTL_24H,
 });
+
+/**
+ * Builds the cache key for a host contract version lookup.
+ *
+ * The runtime UID scopes the entry to one SDK runtime instance, while the
+ * address scopes it to one deployed host contract within that runtime.
+ *
+ * Host-contract addresses are treated as globally unique deployment
+ * identifiers across supported chains. If that invariant changes, include the
+ * chain id in this key.
+ */
+function _getVersionCacheKey(context: Context, parameters: Parameters): string {
+  return `${context.runtime.uid.toLowerCase()}:${parameters.address.toLowerCase()}`;
+}
 
 /**
  * Reads the version of a host contract at the given address.
@@ -51,6 +69,44 @@ export function getVersion(
   parameters: Parameters & { readonly forceRefresh?: boolean },
 ): Promise<ReturnType> {
   return cachedGetVersion.execute(context, parameters);
+}
+
+/**
+ * Invalidates cached host contract versions.
+ *
+ * When called with `context` and `address`, only that runtime/address entry is
+ * invalidated. When called without arguments, all settled host-version cache
+ * entries in the current JS realm are invalidated.
+ *
+ * In-flight entries are kept by default. Pass `includeInflight: true` to also
+ * discard in-flight fetches; existing callers still receive their promises, but
+ * those results will no longer be stored in the cache.
+ */
+export function invalidateVersionCache(options?: InvalidateVersionCacheOptions): void;
+export function invalidateVersionCache(context: Context, parameters: InvalidateVersionCacheParameters): void;
+export function invalidateVersionCache(
+  contextOrOptions?: Context | InvalidateVersionCacheOptions,
+  parameters?: InvalidateVersionCacheParameters,
+): void {
+  if (parameters === undefined) {
+    const options = contextOrOptions as InvalidateVersionCacheOptions | undefined;
+    cachedGetVersion.clear(_makeClearOptions(options));
+    return;
+  }
+
+  cachedGetVersion.clear({
+    key: _getVersionCacheKey(contextOrOptions as Context, parameters),
+    ..._makeClearOptions(parameters),
+  });
+}
+
+function _makeClearOptions(
+  options: InvalidateVersionCacheOptions | undefined,
+): { readonly includeInflight?: boolean } | undefined {
+  if (options?.includeInflight === undefined) {
+    return undefined;
+  }
+  return { includeInflight: options.includeInflight };
 }
 
 async function _getVersion(context: Context, parameters: Parameters): Promise<HostContractVersion> {

--- a/sdk/js-sdk/src/core/host-contracts/KmsSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/KmsSignersContext-p.ts
@@ -7,7 +7,13 @@ import { InvalidTypeError } from '../base/errors/InvalidTypeError.js';
 import { addressToChecksummedAddress } from '../base/address.js';
 import { DuplicateSignerError, ThresholdSignerError, UnknownSignerError } from '../errors/SignersError.js';
 import { assertOwnedBy } from '../runtime/CoreFhevmRuntime-p.js';
-import { assertIsKmsExtraData, toKmsExtraData } from '../kms/kmsExtraData.js';
+import {
+  assertIsKmsExtraData,
+  EXTRA_DATA_V0,
+  EXTRA_DATA_V1,
+  EXTRA_DATA_V2,
+  toKmsExtraData,
+} from '../kms/kmsExtraData.js';
 import { assertIsNonEmptyString, ensure0x } from '../base/string.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -25,6 +31,7 @@ class KmsSignersContextImpl implements KmsSignersContext {
   readonly #owner: WeakRef<FhevmRuntime>;
   readonly #address: ChecksummedAddress;
   readonly #kmsContextId: Uint256BigInt;
+  readonly #kmsEpochId: Uint256BigInt;
   readonly #kmsSigners: ChecksummedAddress[];
   readonly #kmsSignersSet: Set<string>;
   readonly #kmsSignerThreshold: Uint8Number;
@@ -35,6 +42,7 @@ class KmsSignersContextImpl implements KmsSignersContext {
     parameters: {
       readonly address: ChecksummedAddress;
       readonly kmsContextId: Uint256BigInt;
+      readonly kmsEpochId: Uint256BigInt;
       readonly kmsSigners: ChecksummedAddress[];
       readonly kmsSignerThreshold: Uint8Number;
     },
@@ -45,6 +53,7 @@ class KmsSignersContextImpl implements KmsSignersContext {
     this.#owner = owner;
     this.#address = parameters.address;
     this.#kmsContextId = parameters.kmsContextId;
+    this.#kmsEpochId = parameters.kmsEpochId;
     this.#kmsSigners = [...parameters.kmsSigners];
     this.#kmsSignerThreshold = parameters.kmsSignerThreshold;
     this.#kmsSignersSet = new Set(this.#kmsSigners.map((addr) => addr.toLowerCase()));
@@ -59,6 +68,10 @@ class KmsSignersContextImpl implements KmsSignersContext {
 
   public get id(): Uint256BigInt {
     return this.#kmsContextId;
+  }
+
+  public get epochId(): Uint256BigInt {
+    return this.#kmsEpochId;
   }
 
   public get signers(): ChecksummedAddress[] {
@@ -102,16 +115,19 @@ Object.freeze(KmsSignersContextImpl);
 export function createKmsSignersContext(
   owner: WeakRef<FhevmRuntime>,
   parameters: {
-    readonly address: ChecksummedAddress;
+    readonly kmsVerifierAddress: ChecksummedAddress;
     readonly kmsContextId: Uint256BigInt;
+    readonly kmsEpochId: Uint256BigInt;
     readonly kmsSigners: readonly ChecksummedAddress[];
     readonly kmsSignerThreshold: Uint8Number;
   },
 ): KmsSignersContext {
-  const { address, kmsContextId, kmsSigners, kmsSignerThreshold } = parameters;
+  const { kmsVerifierAddress: address, kmsContextId, kmsEpochId, kmsSigners, kmsSignerThreshold } = parameters;
+
   return new KmsSignersContextImpl(PRIVATE_TOKEN, owner, {
     address: addressToChecksummedAddress(address),
     kmsContextId,
+    kmsEpochId,
     kmsSignerThreshold: Number(kmsSignerThreshold) as Uint8Number,
     kmsSigners: kmsSigners.map(addressToChecksummedAddress),
   });
@@ -121,12 +137,27 @@ export function createKmsSignersContext(
 
 export function kmsSignersContextToExtraData(kmsSignersContext: KmsSignersContext): BytesHex {
   assertIsKmsSignersContext(kmsSignersContext, {});
+
   if (kmsSignersContext.id === 0n) {
-    return '0x00' as BytesHex;
+    return toKmsExtraData({
+      version: EXTRA_DATA_V0,
+      kmsContextId: 0n as Uint256BigInt,
+      kmsEpochId: 0n as Uint256BigInt,
+    });
   }
+
+  if (kmsSignersContext.epochId === 0n) {
+    return toKmsExtraData({
+      version: EXTRA_DATA_V1,
+      kmsContextId: kmsSignersContext.id,
+      kmsEpochId: 0n as Uint256BigInt,
+    });
+  }
+
   return toKmsExtraData({
-    version: 1 as Uint8Number,
+    version: EXTRA_DATA_V2,
     kmsContextId: kmsSignersContext.id,
+    kmsEpochId: kmsSignersContext.epochId,
   });
 }
 

--- a/sdk/js-sdk/src/core/host-contracts/abi-fragments/fragments.ts
+++ b/sdk/js-sdk/src/core/host-contracts/abi-fragments/fragments.ts
@@ -309,6 +309,34 @@ export const getSignersForKmsContextAbi: readonly [
   },
 ] as const;
 
+////////////////////////////////////////////////////////////////////////////////
+// ProtocolConfig.getCurrentKmsContextAndEpoch()
+// Protocol version >= 0.14
+////////////////////////////////////////////////////////////////////////////////
+
+export const getCurrentKmsContextAndEpochAbi: readonly [
+  Record<string, unknown> & { readonly name: 'getCurrentKmsContextAndEpoch' },
+] = [
+  {
+    inputs: [],
+    name: 'getCurrentKmsContextAndEpoch',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'contextId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'epochId',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
 //getSignersForKmsContext
 ////////////////////////////////////////////////////////////////////////////////
 // InputVerifier.getCoprocessorSigners()

--- a/sdk/js-sdk/src/core/host-contracts/canDecryptValuesFromPairs.ts
+++ b/sdk/js-sdk/src/core/host-contracts/canDecryptValuesFromPairs.ts
@@ -82,7 +82,7 @@ export async function canDecryptValuesFromPairs(context: Context, parameters: Pa
   }
 
   const details = await isUserDecryptable(context, {
-    address: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+    aclAddress: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
     userAddress,
     handleContractPairs,
   });

--- a/sdk/js-sdk/src/core/host-contracts/checkAllowedForDecryption.ts
+++ b/sdk/js-sdk/src/core/host-contracts/checkAllowedForDecryption.ts
@@ -15,21 +15,21 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly handles: readonly Handle[];
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function checkAllowedForDecryption(context: Context, parameters: Parameters): Promise<void> {
-  const { handles } = parameters;
+  const { aclAddress, handles } = parameters;
 
   const results = await isAllowedForDecryption(context, parameters);
 
   const failedHandles = handles.filter((_, i) => results[i] !== true).map((h) => h.bytes32Hex);
   if (failedHandles.length > 0) {
     throw new AclPublicDecryptionError({
-      contractAddress: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+      contractAddress: aclAddress,
       handles: failedHandles,
     });
   }

--- a/sdk/js-sdk/src/core/host-contracts/checkDelegation.ts
+++ b/sdk/js-sdk/src/core/host-contracts/checkDelegation.ts
@@ -15,7 +15,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly delegator: ChecksummedAddress;
   readonly delegate: ChecksummedAddress;
   readonly handleContractPairs: ReadonlyArray<{
@@ -27,7 +27,7 @@ type Parameters = {
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function checkDelegation(context: Context, parameters: Parameters): Promise<void> {
-  const { address, delegator, delegate, handleContractPairs } = parameters;
+  const { aclAddress, delegator, delegate, handleContractPairs } = parameters;
 
   if (handleContractPairs.length === 0) {
     throw new Error('checkDelegation requires at least one (handle, contractAddress) pair');
@@ -41,7 +41,7 @@ export async function checkDelegation(context: Context, parameters: Parameters):
   // 1. Verify rule: delegator !== delegate
   if (delegator.toLowerCase() === delegate.toLowerCase()) {
     throw new AclUserDecryptionError({
-      contractAddress: address,
+      contractAddress: aclAddress,
       message: `delegator ${delegator} cannot be equal to delegate`,
     });
   }
@@ -49,13 +49,13 @@ export async function checkDelegation(context: Context, parameters: Parameters):
   // 2. Verify rule: delegate !== WILDCARD_CONTRACT
   if (delegate.toLowerCase() === WILDCARD_DELEGATION_ADDRESS.toLowerCase()) {
     throw new AclUserDecryptionError({
-      contractAddress: address,
+      contractAddress: aclAddress,
       message: `delegate cannot be equal to wildcard contract address`,
     });
   }
   if (delegator.toLowerCase() === WILDCARD_DELEGATION_ADDRESS.toLowerCase()) {
     throw new AclUserDecryptionError({
-      contractAddress: address,
+      contractAddress: aclAddress,
       message: `delegator cannot be equal to wildcard contract address`,
     });
   }
@@ -64,13 +64,13 @@ export async function checkDelegation(context: Context, parameters: Parameters):
   for (const pair of handleContractPairs) {
     if (delegator.toLowerCase() === pair.contractAddress.toLowerCase()) {
       throw new AclUserDecryptionError({
-        contractAddress: address,
+        contractAddress: aclAddress,
         message: `delegator ${delegator} cannot be equal to contractAddress`,
       });
     }
     if (delegate.toLowerCase() === pair.contractAddress.toLowerCase()) {
       throw new AclUserDecryptionError({
-        contractAddress: address,
+        contractAddress: aclAddress,
         message: `delegate ${delegate} cannot be equal to contractAddress`,
       });
     }
@@ -98,7 +98,7 @@ export async function checkDelegation(context: Context, parameters: Parameters):
 
   // 5. Single batched RPC call for all unique checks
   const allResults = await isHandleDelegatedForUserDecryption(context, {
-    address,
+    aclAddress,
     delegator,
     delegate,
     pairs: allChecks,
@@ -121,7 +121,7 @@ export async function checkDelegation(context: Context, parameters: Parameters):
     const key = getKey(pair.contractAddress, pair.handle.bytes32Hex);
     if (resultMap.get(key) !== true) {
       throw new AclUserDecryptionError({
-        contractAddress: address,
+        contractAddress: aclAddress,
         message: `Delegate ${delegate} is not delegated by ${delegator} to user decrypt handle ${pair.handle.bytes32Hex} on contract ${pair.contractAddress}!`,
       });
     }

--- a/sdk/js-sdk/src/core/host-contracts/checkPersistAllowed.ts
+++ b/sdk/js-sdk/src/core/host-contracts/checkPersistAllowed.ts
@@ -14,7 +14,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly userAddress: ChecksummedAddress;
   readonly handleContractPairs: ReadonlyArray<{
     readonly handle: Handle;
@@ -25,7 +25,7 @@ type Parameters = {
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function checkPersistAllowed(context: Context, parameters: Parameters): Promise<void> {
-  const { address, userAddress, handleContractPairs } = parameters;
+  const { aclAddress, userAddress, handleContractPairs } = parameters;
 
   if (handleContractPairs.length === 0) {
     throw new Error('checkPersistAllowed requires at least one (handle, contractAddress) pair');
@@ -38,9 +38,9 @@ export async function checkPersistAllowed(context: Context, parameters: Paramete
 
   // 1. Verify rule: userAddress !== contractAddress
   for (const pair of handleContractPairs) {
-    if (parameters.userAddress.toLowerCase() === pair.contractAddress.toLowerCase()) {
+    if (userAddress.toLowerCase() === pair.contractAddress.toLowerCase()) {
       throw new AclUserDecryptionError({
-        contractAddress: address,
+        contractAddress: aclAddress,
         message: `userAddress ${userAddress} should not be equal to contractAddress when requesting user decryption!`,
       });
     }
@@ -52,12 +52,12 @@ export async function checkPersistAllowed(context: Context, parameters: Paramete
 
   for (const pair of handleContractPairs) {
     // User check (runtime defensive check, use lowercase)
-    const userKey = getKey(parameters.userAddress, pair.handle.bytes32Hex);
+    const userKey = getKey(userAddress, pair.handle.bytes32Hex);
     if (!seenKeys.has(userKey)) {
       seenKeys.add(userKey);
       allChecks.push({
         handle: pair.handle,
-        account: parameters.userAddress,
+        account: userAddress,
       });
     }
     // Contract check (runtime defensive check, use lowercase)
@@ -77,7 +77,7 @@ export async function checkPersistAllowed(context: Context, parameters: Paramete
 
   // 3. Single batched RPC call for all unique checks
   const allResults = await persistAllowed(context, {
-    address,
+    aclAddress,
     pairs: allChecks,
   });
 
@@ -98,8 +98,8 @@ export async function checkPersistAllowed(context: Context, parameters: Paramete
     const userKey = getKey(parameters.userAddress, pair.handle.bytes32Hex);
     if (resultMap.get(userKey) !== true) {
       throw new AclUserDecryptionError({
-        contractAddress: address,
-        message: `User ${parameters.userAddress} is not authorized to decrypt handle ${pair.handle.bytes32Hex}!`,
+        contractAddress: aclAddress,
+        message: `User ${userAddress} is not authorized to decrypt handle ${pair.handle.bytes32Hex}!`,
       });
     }
 
@@ -107,7 +107,7 @@ export async function checkPersistAllowed(context: Context, parameters: Paramete
     const contractKey = getKey(pair.contractAddress, pair.handle.bytes32Hex);
     if (resultMap.get(contractKey) !== true) {
       throw new AclUserDecryptionError({
-        contractAddress: address,
+        contractAddress: aclAddress,
         message: `Dapp contract ${pair.contractAddress} is not authorized to user decrypt handle ${pair.handle.bytes32Hex}!`,
       });
     }

--- a/sdk/js-sdk/src/core/host-contracts/getAclAddress-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getAclAddress-p.ts
@@ -12,7 +12,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly fhevmExecutorAddress: ChecksummedAddress;
 };
 
 type ReturnType = ChecksummedAddress;
@@ -26,10 +26,9 @@ type ReturnType = ChecksummedAddress;
  */
 export async function getAclAddress(context: Context, parameters: Parameters): Promise<ReturnType> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.fhevmExecutorAddress,
     abi: getACLAddressAbi,
     args: [],
     functionName: getACLAddressAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getCurrentKmsContextAndEpoch-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getCurrentKmsContextAndEpoch-p.ts
@@ -1,0 +1,92 @@
+import type { ChecksummedAddress, Uint256BigInt } from '../types/primitives.js';
+import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
+import { getCurrentKmsContextAndEpochAbi } from './abi-fragments/fragments.js';
+import { getTrustedClient } from '../runtime/CoreFhevm-p.js';
+import { getHostContractVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
+import { assertIsUint256 } from '../base/uint.js';
+import { CACHE_TTL_24H, createCachedFetch } from '../base/cachedFetch.js';
+
+////////////////////////////////////////////////////////////////////////////////
+
+type Context = {
+  readonly runtime: FhevmRuntime;
+  readonly client: NonNullable<object>;
+};
+
+type Parameters = {
+  readonly protocolConfigAddress: ChecksummedAddress;
+};
+
+type ReturnType = { readonly contextId: Uint256BigInt; readonly epochId: Uint256BigInt };
+
+////////////////////////////////////////////////////////////////////////////////
+
+const cachedGetCurrentKmsContextAndEpoch = createCachedFetch<Context, Parameters, ReturnType>({
+  executeFn: _getCurrentKmsContextAndEpoch,
+  cacheKeyFn: (context, params) => `${context.runtime.uid.toLowerCase()}:${params.protocolConfigAddress.toLowerCase()}`,
+  // Host contract values are immutable per deployment, so a long TTL is safe.
+  ttlMs: CACHE_TTL_24H,
+});
+
+/**
+ * Reads the current KMS context ID and epoch ID from a ProtocolConfig contract.
+ *
+ * Requires ProtocolConfig >= v0.2.0 (protocol v0.14.0).
+ *
+ * Results are cached per (runtime, address) with a 24-hour TTL.
+ * Concurrent callers share a single in-flight RPC request (deduplication).
+ *
+ * @param parameters.address - The checksummed address of the ProtocolConfig contract.
+ * @param parameters.forceRefresh - If `true`, invalidates the cached entry and
+ *   makes a fresh RPC call. The new result is stored back in the cache.
+ */
+export function getCurrentKmsContextAndEpoch(
+  context: Context,
+  parameters: Parameters & { readonly forceRefresh?: boolean | undefined },
+): Promise<ReturnType> {
+  return cachedGetCurrentKmsContextAndEpoch.execute(context, parameters);
+}
+
+async function _getCurrentKmsContextAndEpoch(context: Context, parameters: Parameters): Promise<ReturnType> {
+  const protocolConfigVersion = await getHostContractVersion(context, { address: parameters.protocolConfigAddress });
+
+  // getCurrentKmsContextAndEpoch requires ProtocolConfig >= v0.2.0 (protocol v0.14.0)
+  if (isVersionStrictlyBefore(protocolConfigVersion, { major: 0, minor: 2 })) {
+    throw new Error(
+      'ProtocolConfig.getCurrentKmsContextAndEpoch() requires ProtocolConfig >= v0.2.0 (protocol v0.14.0)',
+    );
+  }
+
+  const trustedClient = getTrustedClient(context);
+
+  const res = await context.runtime.ethereum.readContract(trustedClient, {
+    address: parameters.protocolConfigAddress,
+    abi: getCurrentKmsContextAndEpochAbi,
+    args: [],
+    functionName: getCurrentKmsContextAndEpochAbi[0].name,
+  });
+
+  if (!Array.isArray(res) || res.length < 2) {
+    throw new Error(`Invalid getCurrentKmsContextAndEpoch result.`);
+  }
+
+  const unknownContextId = res[0] as unknown;
+  const unknownEpochId = res[1] as unknown;
+
+  try {
+    assertIsUint256(unknownContextId, {});
+  } catch (e) {
+    throw new Error(`Invalid KMS Context Id.`, { cause: e });
+  }
+
+  try {
+    assertIsUint256(unknownEpochId, {});
+  } catch (e) {
+    throw new Error(`Invalid KMS Epoch Id.`, { cause: e });
+  }
+
+  return Object.freeze({
+    contextId: BigInt(unknownContextId) as Uint256BigInt,
+    epochId: BigInt(unknownEpochId) as Uint256BigInt,
+  });
+}

--- a/sdk/js-sdk/src/core/host-contracts/getCurrentKmsContextId-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getCurrentKmsContextId-p.ts
@@ -14,7 +14,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly kmsVerifierAddress: ChecksummedAddress;
 };
 
 type ReturnType = Uint256BigInt;
@@ -23,7 +23,7 @@ type ReturnType = Uint256BigInt;
 
 const cachedGetCurrentKmsContextId = createCachedFetch<Context, Parameters, ReturnType>({
   executeFn: _getCurrentKmsContextId,
-  cacheKeyFn: (context, params) => `${context.runtime.uid.toLowerCase()}:${params.address.toLowerCase()}`,
+  cacheKeyFn: (context, params) => `${context.runtime.uid.toLowerCase()}:${params.kmsVerifierAddress.toLowerCase()}`,
   // Host contract versions are immutable per deployment, so a long TTL is safe.
   ttlMs: CACHE_TTL_24H,
 });
@@ -46,17 +46,17 @@ export function getCurrentKmsContextId(
 }
 
 async function _getCurrentKmsContextId(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const version = await getHostContractVersion(context, parameters);
-  // getCurrentKmsContextId has been introduced in KMSVerifier.sol v0.2.0
-  if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
+  const kmsVerifierVersion = await getHostContractVersion(context, { address: parameters.kmsVerifierAddress });
+
+  // getCurrentKmsContextId has been introduced in protocol v0.12.0 (KMSVerifier v0.2.0)
+  if (isVersionStrictlyBefore(kmsVerifierVersion, { major: 0, minor: 2 })) {
     return 0n as Uint256BigInt;
   }
 
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.kmsVerifierAddress,
     abi: getCurrentKmsContextIdAbi,
     args: [],
     functionName: getCurrentKmsContextIdAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getCurrentKmsContextId-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getCurrentKmsContextId-p.ts
@@ -2,7 +2,7 @@ import type { ChecksummedAddress, Uint256BigInt } from '../types/primitives.js';
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
 import { getCurrentKmsContextIdAbi } from './abi-fragments/fragments.js';
 import { getTrustedClient } from '../runtime/CoreFhevm-p.js';
-import { getVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
+import { getHostContractVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
 import { assertIsUint256 } from '../base/uint.js';
 import { CACHE_TTL_24H, createCachedFetch } from '../base/cachedFetch.js';
 
@@ -46,7 +46,7 @@ export function getCurrentKmsContextId(
 }
 
 async function _getCurrentKmsContextId(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const version = await getVersion(context, parameters);
+  const version = await getHostContractVersion(context, parameters);
   // getCurrentKmsContextId has been introduced in KMSVerifier.sol v0.2.0
   if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
     return 0n as Uint256BigInt;

--- a/sdk/js-sdk/src/core/host-contracts/getFhevmExecutorAddress-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getFhevmExecutorAddress-p.ts
@@ -12,7 +12,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
 };
 
 type ReturnType = ChecksummedAddress;
@@ -26,7 +26,7 @@ type ReturnType = ChecksummedAddress;
  */
 export async function getFhevmExecutorAddress(context: Context, parameters: Parameters): Promise<ReturnType> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
+  const address = parameters.aclAddress;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
     address: address,

--- a/sdk/js-sdk/src/core/host-contracts/getHandleVersion-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getHandleVersion-p.ts
@@ -12,7 +12,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly fhevmExecutorAddress: ChecksummedAddress;
 };
 
 type ReturnType = Uint8Number;
@@ -26,10 +26,9 @@ type ReturnType = Uint8Number;
  */
 export async function getHandleVersion(context: Context, parameters: Parameters): Promise<ReturnType> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.fhevmExecutorAddress,
     abi: getHandleVersionAbi,
     args: [],
     functionName: getHandleVersionAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getHcuLimitAddress-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getHcuLimitAddress-p.ts
@@ -12,7 +12,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly fhevmExecutorAddress: ChecksummedAddress;
 };
 
 type ReturnType = ChecksummedAddress;
@@ -26,10 +26,9 @@ type ReturnType = ChecksummedAddress;
  */
 export async function getHcuLimitAddress(context: Context, parameters: Parameters): Promise<ReturnType> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.fhevmExecutorAddress,
     abi: getHCULimitAddressAbi,
     args: [],
     functionName: getHCULimitAddressAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getInputVerifierAddress-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getInputVerifierAddress-p.ts
@@ -12,7 +12,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly fhevmExecutorAddress: ChecksummedAddress;
 };
 
 type ReturnType = ChecksummedAddress;
@@ -26,10 +26,9 @@ type ReturnType = ChecksummedAddress;
  */
 export async function getInputVerifierAddress(context: Context, parameters: Parameters): Promise<ReturnType> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.fhevmExecutorAddress,
     abi: getInputVerifierAddressAbi,
     args: [],
     functionName: getInputVerifierAddressAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThreshold-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThreshold-p.ts
@@ -18,7 +18,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly kmsVerifierAddress: ChecksummedAddress;
 };
 
 type ReturnType = {
@@ -30,7 +30,7 @@ type ReturnType = {
 
 const cachedGetKmsContextSignersAndThreshold = createCachedFetch<Context, Parameters, ReturnType>({
   executeFn: _getKmsContextSignersAndThreshold,
-  cacheKeyFn: (context, params) => `${context.runtime.uid.toLowerCase()}:${params.address.toLowerCase()}`,
+  cacheKeyFn: (context, params) => `${context.runtime.uid.toLowerCase()}:${params.kmsVerifierAddress.toLowerCase()}`,
   // Host contract versions are immutable per deployment, so a long TTL is safe.
   ttlMs: CACHE_TTL_24H,
 });
@@ -64,8 +64,8 @@ export function getKmsSignersAndThreshold(
 ////////////////////////////////////////////////////////////////////////////////
 
 async function _getKmsContextSignersAndThreshold(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const version = await getHostContractVersion(context, { address: parameters.address });
-  if (!isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
+  const kmsVerifierVersion = await getHostContractVersion(context, { address: parameters.kmsVerifierAddress });
+  if (!isVersionStrictlyBefore(kmsVerifierVersion, { major: 0, minor: 2 })) {
     throw new Error('getContextSignersAndThreshold requires KMSVerifier < v0.2.0');
   }
   ////////////////////////////////////////////////////////////////////////////
@@ -108,10 +108,9 @@ async function _getKmsContextSignersAndThreshold(context: Context, parameters: P
 
 async function _getThreshold(context: Context, parameters: Parameters): Promise<Uint8Number> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.kmsVerifierAddress,
     abi: getThresholdAbi,
     args: [],
     functionName: getThresholdAbi[0].name,
@@ -128,10 +127,9 @@ async function _getThreshold(context: Context, parameters: Parameters): Promise<
 
 async function _getKmsSigners(context: Context, parameters: Parameters): Promise<ChecksummedAddress[]> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.kmsVerifierAddress,
     abi: getKmsSignersAbi,
     args: [],
     functionName: getKmsSignersAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThreshold-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThreshold-p.ts
@@ -2,7 +2,7 @@ import type { ChecksummedAddress, Uint8Number } from '../types/primitives.js';
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
 import { assertIsChecksummedAddressArray } from '../base/address.js';
 import { asUint8Number, isUint8 } from '../base/uint.js';
-import { getVersion } from './HostContractVersion-p.js';
+import { getHostContractVersion } from './HostContractVersion-p.js';
 import { isVersionStrictlyBefore } from '../host-contracts/HostContractVersion-p.js';
 import { executeWithBatching } from '../base/promise.js';
 import { getTrustedClient } from '../runtime/CoreFhevm-p.js';
@@ -64,7 +64,7 @@ export function getKmsSignersAndThreshold(
 ////////////////////////////////////////////////////////////////////////////////
 
 async function _getKmsContextSignersAndThreshold(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const version = await getVersion(context, { address: parameters.address });
+  const version = await getHostContractVersion(context, { address: parameters.address });
   if (!isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
     throw new Error('getContextSignersAndThreshold requires KMSVerifier < v0.2.0');
   }

--- a/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThresholdFromExtraData-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThresholdFromExtraData-p.ts
@@ -1,6 +1,6 @@
 import type { BytesHex, ChecksummedAddress, Uint8Number } from '../types/primitives.js';
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
-import { getVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
+import { getHostContractVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
 import { createCachedFetch } from '../base/cachedFetch.js';
 import { assertIsKmsExtraData, fromKmsExtraData } from '../kms/kmsExtraData.js';
 import { assertIsChecksummedAddressArray } from '../base/address.js';
@@ -69,7 +69,7 @@ async function _getKmsContextSignersAndThresholdFromExtraData(
   context: Context,
   parameters: Parameters,
 ): Promise<ReturnType> {
-  const version = await getVersion(context, { address: parameters.address });
+  const version = await getHostContractVersion(context, { address: parameters.address });
   if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
     throw new Error('getContextSignersAndThresholdFromExtraData requires KMSVerifier >= v0.2.0');
   }

--- a/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThresholdFromExtraData-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getKmsContextSignersAndThresholdFromExtraData-p.ts
@@ -16,7 +16,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly kmsVerifierAddress: ChecksummedAddress;
   readonly extraData: BytesHex;
 };
 
@@ -32,7 +32,7 @@ const cachedGetKmsContextSignersAndThresholdFromExtraData = createCachedFetch<Co
   cacheKeyFn: (context, params) => {
     const { kmsContextId } = fromKmsExtraData(params.extraData);
     const contextIdHex = kmsContextId.toString(16).padStart(64, '0');
-    return `${context.runtime.uid.toLowerCase()}:${params.address.toLowerCase()}:${contextIdHex}`;
+    return `${context.runtime.uid.toLowerCase()}:${params.kmsVerifierAddress.toLowerCase()}:${contextIdHex}`;
   },
   // Permanent cache: signers and threshold are immutable per context ID.
 });
@@ -69,16 +69,15 @@ async function _getKmsContextSignersAndThresholdFromExtraData(
   context: Context,
   parameters: Parameters,
 ): Promise<ReturnType> {
-  const version = await getHostContractVersion(context, { address: parameters.address });
-  if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
+  const kmsVerifierVersion = await getHostContractVersion(context, { address: parameters.kmsVerifierAddress });
+  if (isVersionStrictlyBefore(kmsVerifierVersion, { major: 0, minor: 2 })) {
     throw new Error('getContextSignersAndThresholdFromExtraData requires KMSVerifier >= v0.2.0');
   }
 
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.kmsVerifierAddress,
     abi: getContextSignersAndThresholdFromExtraDataAbi,
     args: [parameters.extraData],
     functionName: getContextSignersAndThresholdFromExtraDataAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/getSignersForKmsContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getSignersForKmsContext-p.ts
@@ -1,6 +1,6 @@
 import type { ChecksummedAddress, Uint256BigInt } from '../types/primitives.js';
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
-import { getVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
+import { getHostContractVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
 import { getTrustedClient } from '../runtime/CoreFhevm-p.js';
 import { getKmsSignersAbi, getSignersForKmsContextAbi } from './abi-fragments/fragments.js';
 import { assertIsChecksummedAddressArray } from '../base/address.js';
@@ -34,7 +34,7 @@ type ReturnType = ChecksummedAddress[];
  * @param parameters.kmsContextId - The context ID to query signers for.
  */
 export async function getSignersForKmsContext(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const version = await getVersion(context, parameters);
+  const version = await getHostContractVersion(context, parameters);
   // getCurrentKmsContextId has been introduced in KMSVerifier.sol v0.2.0
   if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
     if (parameters.kmsContextId === 0n) {

--- a/sdk/js-sdk/src/core/host-contracts/getSignersForKmsContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getSignersForKmsContext-p.ts
@@ -13,7 +13,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly kmsVerifierAddress: ChecksummedAddress;
   readonly kmsContextId: Uint256BigInt;
 };
 
@@ -30,11 +30,11 @@ type ReturnType = ChecksummedAddress[];
  * Returns an empty array for KMSVerifier versions before v0.2.0 (where
  * per-context signers were not yet supported).
  *
- * @param parameters.address - The checksummed address of the KMSVerifier contract.
+ * @param parameters.kmsVerifierAddress - The checksummed address of the KMSVerifier contract.
  * @param parameters.kmsContextId - The context ID to query signers for.
  */
 export async function getSignersForKmsContext(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const version = await getHostContractVersion(context, parameters);
+  const version = await getHostContractVersion(context, { address: parameters.kmsVerifierAddress });
   // getCurrentKmsContextId has been introduced in KMSVerifier.sol v0.2.0
   if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
     if (parameters.kmsContextId === 0n) {
@@ -44,10 +44,9 @@ export async function getSignersForKmsContext(context: Context, parameters: Para
   }
 
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.kmsVerifierAddress,
     abi: getSignersForKmsContextAbi,
     args: [parameters.kmsContextId],
     functionName: getSignersForKmsContextAbi[0].name,
@@ -69,10 +68,9 @@ export async function getKmsSigners(
   parameters: Omit<Parameters, 'kmsContextId'>,
 ): Promise<ReturnType> {
   const trustedClient = getTrustedClient(context);
-  const address = parameters.address;
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: parameters.kmsVerifierAddress,
     abi: getKmsSignersAbi,
     args: [],
     functionName: getKmsSignersAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/isAllowedForDecryption.ts
+++ b/sdk/js-sdk/src/core/host-contracts/isAllowedForDecryption.ts
@@ -14,7 +14,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly handles: readonly Handle[];
 };
 
@@ -23,12 +23,12 @@ type ReturnType = boolean[];
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function isAllowedForDecryption(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const { address, handles } = parameters;
+  const { aclAddress, handles } = parameters;
 
   const rpcCalls = handles.map(
     (handle) => () =>
       _isAllowedForDecryption(context, {
-        address,
+        aclAddress,
         handle,
       }),
   );
@@ -43,15 +43,15 @@ export async function isAllowedForDecryption(context: Context, parameters: Param
 async function _isAllowedForDecryption(
   context: Context,
   parameters: {
-    readonly address: ChecksummedAddress;
+    readonly aclAddress: ChecksummedAddress;
     readonly handle: Handle;
   },
 ): Promise<boolean> {
-  const { address, handle } = parameters;
+  const { aclAddress, handle } = parameters;
   const trustedClient = getTrustedClient(context);
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: aclAddress,
     abi: isAllowedForDecryptionAbi,
     args: [handle.bytes32Hex],
     functionName: isAllowedForDecryptionAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/isHandleDelegatedForUserDecryption-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/isHandleDelegatedForUserDecryption-p.ts
@@ -15,7 +15,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly delegate: ChecksummedAddress;
   readonly delegator: ChecksummedAddress;
   readonly pairs: readonly HandleContractPair[];
@@ -29,12 +29,12 @@ export async function isHandleDelegatedForUserDecryption(
   context: Context,
   parameters: Parameters,
 ): Promise<ReturnType> {
-  const { address, delegate, delegator, pairs } = parameters;
+  const { aclAddress, delegate, delegator, pairs } = parameters;
 
   const rpcCalls = pairs.map(
     (pair) => () =>
       _isHandleDelegatedForUserDecryption(context, {
-        address,
+        aclAddress,
         delegate,
         delegator,
         handle: pair.handle,
@@ -52,25 +52,25 @@ export async function isHandleDelegatedForUserDecryption(
 async function _isHandleDelegatedForUserDecryption(
   context: Context,
   parameters: {
-    readonly address: ChecksummedAddress;
+    readonly aclAddress: ChecksummedAddress;
     readonly delegator: ChecksummedAddress;
     readonly delegate: ChecksummedAddress;
     readonly contractAddress: ChecksummedAddress;
     readonly handle: Handle;
   },
 ): Promise<boolean> {
-  const { address, delegator, delegate, contractAddress, handle } = parameters;
+  const { aclAddress, delegator, delegate, contractAddress, handle } = parameters;
   const trustedClient = getTrustedClient(context);
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: aclAddress,
     abi: isHandleDelegatedForUserDecryptionAbi,
     args: [delegator, delegate, contractAddress, handle.bytes32Hex],
     functionName: isHandleDelegatedForUserDecryptionAbi[0].name,
   });
 
   if (typeof res !== 'boolean') {
-    throw new Error(`Invalid isHandleDelegatedForUserDecryptionAbi result.`);
+    throw new Error(`Invalid isHandleDelegatedForUserDecryption result.`);
   }
 
   return res;

--- a/sdk/js-sdk/src/core/host-contracts/isUserDecryptable.ts
+++ b/sdk/js-sdk/src/core/host-contracts/isUserDecryptable.ts
@@ -13,7 +13,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly userAddress: ChecksummedAddress;
   readonly handleContractPairs: ReadonlyArray<{
     readonly handle: Handle;
@@ -33,7 +33,7 @@ type ReturnType = ReadonlyArray<{
  * See FHE.sol : isUserDecryptable()
  */
 export async function isUserDecryptable(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const { address, userAddress, handleContractPairs } = parameters;
+  const { aclAddress, userAddress, handleContractPairs } = parameters;
 
   function getKey(addr: string, handleBytes32Hex: string): string {
     return `${addr}:${handleBytes32Hex}`.toLowerCase();
@@ -63,7 +63,7 @@ export async function isUserDecryptable(context: Context, parameters: Parameters
   }
 
   const dedupedResults = await persistAllowed(context, {
-    address,
+    aclAddress,
     pairs: dedupedChecks,
   });
 

--- a/sdk/js-sdk/src/core/host-contracts/persistAllowed.ts
+++ b/sdk/js-sdk/src/core/host-contracts/persistAllowed.ts
@@ -15,7 +15,7 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly aclAddress: ChecksummedAddress;
   readonly pairs: readonly HandleAccountPair[];
 };
 
@@ -24,12 +24,12 @@ type ReturnType = boolean[];
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function persistAllowed(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const { address, pairs } = parameters;
+  const { aclAddress, pairs } = parameters;
 
   const rpcCalls = pairs.map(
     (pair) => () =>
       _persistAllowed(context, {
-        address,
+        aclAddress,
         handle: pair.handle,
         account: pair.account,
       }),
@@ -45,16 +45,16 @@ export async function persistAllowed(context: Context, parameters: Parameters): 
 async function _persistAllowed(
   context: Context,
   parameters: {
-    readonly address: ChecksummedAddress;
+    readonly aclAddress: ChecksummedAddress;
     readonly handle: Handle;
     readonly account: ChecksummedAddress;
   },
 ): Promise<boolean> {
-  const { address, handle, account } = parameters;
+  const { aclAddress, handle, account } = parameters;
   const trustedClient = getTrustedClient(context);
 
   const res = await context.runtime.ethereum.readContract(trustedClient, {
-    address: address,
+    address: aclAddress,
     abi: persistAllowedAbi,
     args: [handle.bytes32Hex, account],
     functionName: persistAllowedAbi[0].name,

--- a/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
@@ -7,7 +7,7 @@ import {
   kmsSignersContextToExtraData,
 } from './KmsSignersContext-p.js';
 import { getCurrentKmsContextId } from './getCurrentKmsContextId-p.js';
-import { getVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
+import { getHostContractVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
 import { assertIsKmsExtraData, fromKmsExtraData, toKmsExtraData } from '../kms/kmsExtraData.js';
 import { getKmsContextSignersAndThresholdFromExtraData } from './getKmsContextSignersAndThresholdFromExtraData-p.js';
 import { getKmsSignersAndThreshold } from './getKmsContextSignersAndThreshold-p.js';
@@ -34,7 +34,7 @@ export async function readKmsSignersContext(context: Context, parameters: Parame
   const kmsVerifierContractAddress = parameters.address;
 
   // TTL-cached
-  const version = await getVersion(context, {
+  const version = await getHostContractVersion(context, {
     address: kmsVerifierContractAddress,
   });
 

--- a/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
@@ -1,5 +1,5 @@
 import type { KmsSignersContext } from '../types/kmsSignersContext.js';
-import type { BytesHex, ChecksummedAddress, Uint256BigInt, Uint8Number } from '../types/primitives.js';
+import type { BytesHex, ChecksummedAddress, Uint256BigInt } from '../types/primitives.js';
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
 import {
   assertIsKmsSignersContext,
@@ -7,8 +7,15 @@ import {
   kmsSignersContextToExtraData,
 } from './KmsSignersContext-p.js';
 import { getCurrentKmsContextId } from './getCurrentKmsContextId-p.js';
+import { getCurrentKmsContextAndEpoch } from './getCurrentKmsContextAndEpoch-p.js';
 import { getHostContractVersion, isVersionStrictlyBefore } from './HostContractVersion-p.js';
-import { assertIsKmsExtraData, fromKmsExtraData, toKmsExtraData } from '../kms/kmsExtraData.js';
+import {
+  assertIsKmsExtraData,
+  EXTRA_DATA_V1,
+  EXTRA_DATA_V2,
+  fromKmsExtraData,
+  toKmsExtraData,
+} from '../kms/kmsExtraData.js';
 import { getKmsContextSignersAndThresholdFromExtraData } from './getKmsContextSignersAndThresholdFromExtraData-p.js';
 import { getKmsSignersAndThreshold } from './getKmsContextSignersAndThreshold-p.js';
 
@@ -21,9 +28,11 @@ type Context = {
 };
 
 type Parameters = {
-  readonly address: ChecksummedAddress;
+  readonly kmsVerifierAddress: ChecksummedAddress;
+  readonly protocolConfigAddress: ChecksummedAddress | undefined;
   readonly forceRefresh?: boolean | undefined;
   readonly kmsContextId?: Uint256BigInt | undefined;
+  readonly kmsEpochId?: Uint256BigInt | undefined;
 };
 
 type ReturnType = KmsSignersContext;
@@ -31,25 +40,30 @@ type ReturnType = KmsSignersContext;
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function readKmsSignersContext(context: Context, parameters: Parameters): Promise<ReturnType> {
-  const kmsVerifierContractAddress = parameters.address;
-
   // TTL-cached
-  const version = await getHostContractVersion(context, {
-    address: kmsVerifierContractAddress,
+  const kmsVerifierVersion = await getHostContractVersion(context, {
+    address: parameters.kmsVerifierAddress,
   });
 
-  if (isVersionStrictlyBefore(version, { major: 0, minor: 2 })) {
-    return _readKmsSignersContextV1(context, parameters);
-  } else {
-    return _readKmsSignersContext(context, parameters);
+  if (isVersionStrictlyBefore(kmsVerifierVersion, { major: 0, minor: 2 })) {
+    return _readKmsSignersContext_Protocol_11(context, parameters);
   }
+
+  if (isVersionStrictlyBefore(kmsVerifierVersion, { major: 0, minor: 4 })) {
+    return _readKmsSignersContext_Protocol_12_13(context, parameters);
+  }
+
+  return _readKmsSignersContext_Protocol_14(context, parameters);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async function _readKmsSignersContextV1(context: Context, parameters: Parameters): Promise<ReturnType> {
+// Protocol v0.11.0 (KMSVerifier < v0.2.0) had no context ID support, so the only valid
+// context ID is 0. Any other value is invalid and should throw.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+async function _readKmsSignersContext_Protocol_11(context: Context, parameters: Parameters): Promise<ReturnType> {
   if (parameters.kmsContextId !== undefined && parameters.kmsContextId !== 0n) {
-    throw new Error('Impossible on v1');
+    throw new Error('Impossible on protocol v0.11.0');
   }
 
   // TTL-Cached
@@ -58,6 +72,7 @@ async function _readKmsSignersContextV1(context: Context, parameters: Parameters
   const data = createKmsSignersContext(new WeakRef(context.runtime), {
     ...parameters,
     kmsContextId: 0n as Uint256BigInt,
+    kmsEpochId: 0n as Uint256BigInt,
     kmsSigners: c.signers,
     kmsSignerThreshold: c.threshold,
   });
@@ -67,32 +82,28 @@ async function _readKmsSignersContextV1(context: Context, parameters: Parameters
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async function _readKmsSignersContext(context: Context, parameters: Parameters): Promise<ReturnType> {
-  let kmsContextId: Uint256BigInt;
-  if (parameters.kmsContextId !== undefined) {
-    if (parameters.kmsContextId === 0n) {
-      throw new Error('Impossible on v2');
-    }
-    kmsContextId = parameters.kmsContextId;
-  } else {
-    // TTL-Cached
-    kmsContextId = await getCurrentKmsContextId(context, parameters);
+// Protocol v0.12.0 / v0.13.0 (KMSVerifier = v0.2.0 / v0.3.0)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+async function _readKmsSignersContext_Protocol_12_13(context: Context, parameters: Parameters): Promise<ReturnType> {
+  if (parameters.kmsEpochId !== undefined && parameters.kmsEpochId !== 0n) {
+    throw new Error('kmsEpochId should be 0 on protocol v0.12.0 / v0.13.0');
   }
 
-  return _readKmsSignersContextForContextId(context, {
-    ...parameters,
-    kmsContextId,
-  });
-}
+  let kmsContextId: Uint256BigInt;
+  if (parameters.kmsContextId === undefined) {
+    // TTL-Cached
+    kmsContextId = await getCurrentKmsContextId(context, parameters);
+  } else {
+    if (parameters.kmsContextId === 0n) {
+      throw new Error('kmsContextId cannot be 0 on protocol v0.12.0 / v0.13.0');
+    }
+    kmsContextId = parameters.kmsContextId;
+  }
 
-async function _readKmsSignersContextForContextId(
-  context: Context,
-  parameters: Parameters & { readonly kmsContextId: Uint256BigInt },
-): Promise<ReturnType> {
-  const { kmsContextId } = parameters;
   const extraData = toKmsExtraData({
-    version: 1 as Uint8Number,
+    version: EXTRA_DATA_V1,
     kmsContextId,
+    kmsEpochId: 0n as Uint256BigInt,
   });
 
   // Permanent-Cached
@@ -101,14 +112,66 @@ async function _readKmsSignersContextForContextId(
     extraData,
   });
 
-  const data = createKmsSignersContext(new WeakRef(context.runtime), {
+  return createKmsSignersContext(new WeakRef(context.runtime), {
     ...parameters,
     kmsContextId,
+    kmsEpochId: 0n as Uint256BigInt,
     kmsSigners: c.signers,
     kmsSignerThreshold: c.threshold,
   });
+}
 
-  return data;
+////////////////////////////////////////////////////////////////////////////////
+
+// Protocol v0.14.0+ (KMSVerifier = v0.4.0+)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+async function _readKmsSignersContext_Protocol_14(context: Context, parameters: Parameters): Promise<ReturnType> {
+  if (parameters.protocolConfigAddress === undefined) {
+    throw new Error('protocolConfigAddress is required on protocol v0.14.0+');
+  }
+  const protocolConfigAddress = parameters.protocolConfigAddress;
+
+  let kmsContextId: Uint256BigInt;
+  if (parameters.kmsContextId === undefined) {
+    // TTL-Cached
+    ({ contextId: kmsContextId } = await getCurrentKmsContextAndEpoch(context, { protocolConfigAddress }));
+  } else {
+    if (parameters.kmsContextId === 0n) {
+      throw new Error('kmsContextId cannot be 0 on protocol v0.14.0+');
+    }
+    kmsContextId = parameters.kmsContextId;
+  }
+
+  let kmsEpochId: Uint256BigInt;
+  if (parameters.kmsEpochId === undefined) {
+    // TTL-Cached
+    ({ epochId: kmsEpochId } = await getCurrentKmsContextAndEpoch(context, { protocolConfigAddress }));
+  } else {
+    if (parameters.kmsEpochId === 0n) {
+      throw new Error('kmsEpochId cannot be 0 on protocol v0.14.0+');
+    }
+    kmsEpochId = parameters.kmsEpochId;
+  }
+
+  const extraData = toKmsExtraData({
+    version: EXTRA_DATA_V2,
+    kmsContextId,
+    kmsEpochId,
+  });
+
+  // Permanent-Cached
+  const c = await getKmsContextSignersAndThresholdFromExtraData(context, {
+    ...parameters,
+    extraData,
+  });
+
+  return createKmsSignersContext(new WeakRef(context.runtime), {
+    ...parameters,
+    kmsContextId,
+    kmsEpochId,
+    kmsSigners: c.signers,
+    kmsSignerThreshold: c.threshold,
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -135,9 +198,9 @@ async function _readKmsSignersContextForContextId(
  * `extraData` is versioned independently from the host-contract package. The
  * currently supported combinations are:
  *
- * - host-contracts v11 and v12 support `extraData` v0.
- * - host-contracts v13 supports `extraData` v0 and v1.
- * - host-contracts v14 supports `extraData` v0, v1, and v2.
+ * - host-contracts v11 support `extraData` v0.
+ * - host-contracts v12 and v13 support `extraData` v0 and v1.
+ * - host-contracts v14 support `extraData` v0, v1, and v2.
  *
  * ### Resolution (checked in order)
  *
@@ -157,8 +220,10 @@ async function _readKmsSignersContextForContextId(
  *
  * - `'exact'` — Accept only step 1 (byte-for-byte `extraData` equality).
  *   Rejects any relayer/context drift without parsing or on-chain recovery.
- * - `'strict'` — Accept step 1 (exact match) or `relayerKmsContextId === currentKmsContextId`.
- *   Rejects valid-but-not-current contexts.
+ * - `'strict'` — Accept step 1 (exact match) or both `relayerKmsContextId === currentKmsContextId`
+ *   and `relayerKmsEpochId === currentKmsEpochId`. Rejects valid-but-not-current contexts.
+ *   The epoch check is required because RFC 005 introduces same-context epoch rotations
+ *   (new shares, same party set) — a stale epoch must be rejected even if the context matches.
  * - `'loose'` — Accept any on-chain valid context (non-destroyed, in range),
  *   regardless of whether it is current. Covers context rotations in either direction.
  */
@@ -170,13 +235,14 @@ export type ReconcileMode = 'exact' | 'strict' | 'loose';
 export async function reconcileKmsSignersContext(
   context: Context,
   parameters: {
-    readonly address: ChecksummedAddress;
+    readonly kmsVerifierAddress: ChecksummedAddress;
+    readonly protocolConfigAddress: ChecksummedAddress | undefined;
     readonly requestedKmsSignersContext: KmsSignersContext;
     readonly relayerExtraData: BytesHex;
     readonly mode: ReconcileMode;
   },
 ): Promise<KmsSignersContext> {
-  const { address, requestedKmsSignersContext, relayerExtraData, mode } = parameters;
+  const { kmsVerifierAddress, protocolConfigAddress, requestedKmsSignersContext, relayerExtraData, mode } = parameters;
 
   assertIsKmsExtraData(relayerExtraData, {});
   assertIsKmsSignersContext(requestedKmsSignersContext, {});
@@ -210,17 +276,19 @@ export async function reconcileKmsSignersContext(
 
   // Versions match but context IDs differ — verify the relayer's context on-chain.
   const relayerKmsContextId = relayerKmsExtraData.kmsContextId;
+  const relayerKmsEpochId = relayerKmsExtraData.kmsEpochId;
 
   // 2. In strict mode, only accept if the relayer used the current on-chain context.
   if (mode === 'strict') {
     // `readKmsSignersContext` with `forceRefresh` fetches the current context.
     // If `relayerKmsContextId` matches current, we're good.
     const currentContext = await readKmsSignersContext(context, {
-      address,
+      kmsVerifierAddress,
+      protocolConfigAddress,
       forceRefresh: true,
     });
 
-    if (currentContext.id !== relayerKmsContextId) {
+    if (currentContext.id !== relayerKmsContextId || currentContext.epochId !== relayerKmsEpochId) {
       throw new Error(
         `Strict reconciliation failed: relayer used context ${relayerKmsContextId}, ` +
           `but the current on-chain context is ${currentContext.id}.`,
@@ -231,11 +299,13 @@ export async function reconcileKmsSignersContext(
   }
 
   // 3. Loose mode — accept any valid (non-destroyed, in-range) context.
-  //    `readKmsSignersContext` with `forceRefresh` + specific `kmsContextId` will
+  //    `readKmsSignersContext` with `forceRefresh` + specific `kmsContextId`/`kmsEpochId` will
   //    throw if the context is destroyed or out of range.
   return readKmsSignersContext(context, {
-    address,
+    kmsVerifierAddress,
+    protocolConfigAddress,
     kmsContextId: relayerKmsContextId,
+    kmsEpochId: relayerKmsEpochId,
     forceRefresh: true,
   });
 }

--- a/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
@@ -130,13 +130,24 @@ async function _readKmsSignersContextForContextId(
  * - `requestedExtraData` — `kmsSignersContextToExtraData(requestedKmsSignersContext)`.
  * - `relayerKmsContextId` — `fromKmsExtraData(relayerExtraData).kmsContextId`.
  *
+ * ### Host-Contract Compatibility
+ *
+ * `extraData` is versioned independently from the host-contract package. The
+ * currently supported combinations are:
+ *
+ * - host-contracts v11 and v12 support `extraData` v0.
+ * - host-contracts v13 supports `extraData` v0 and v1.
+ * - host-contracts v14 supports `extraData` v0, v1, and v2.
+ *
  * ### Resolution (checked in order)
  *
  * 1. `relayerExtraData === requestedExtraData` → exact byte match, return
  *    `requestedKmsSignersContext`. This is the **only** path that trusts cached data.
- * 2. Serialization version mismatch → **always throw**. The SDK and relayer must
+ * 2. In `'exact'` mode, any byte mismatch → **always throw**. This mode does
+ *    not parse, refresh, or reconcile different `extraData`.
+ * 3. Serialization version mismatch → **always throw**. The SDK and relayer must
  *    agree on the `extraData` encoding format, even if the context ID is the same.
- * 3. Context IDs differ → **full on-chain refetch**. The cached context is never
+ * 4. Context IDs differ → **full on-chain refetch**. The cached context is never
  *    reused, because any mismatch means on-chain state may have diverged
  *    (rotation, destruction, signer changes, etc.).
  *    - Context is **valid** on-chain (current or non-destroyed) → return it.
@@ -144,6 +155,8 @@ async function _readKmsSignersContextForContextId(
  *
  * ### Modes
  *
+ * - `'exact'` — Accept only step 1 (byte-for-byte `extraData` equality).
+ *   Rejects any relayer/context drift without parsing or on-chain recovery.
  * - `'strict'` — Accept step 1 (exact match) or `relayerKmsContextId === currentKmsContextId`.
  *   Rejects valid-but-not-current contexts.
  * - `'loose'` — Accept any on-chain valid context (non-destroyed, in range),
@@ -152,7 +165,7 @@ async function _readKmsSignersContextForContextId(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export type ReconcileMode = 'strict' | 'loose';
+export type ReconcileMode = 'exact' | 'strict' | 'loose';
 
 export async function reconcileKmsSignersContext(
   context: Context,
@@ -173,6 +186,13 @@ export async function reconcileKmsSignersContext(
   // 1. Exact match — the relayer used the same context as the SDK.
   if (relayerExtraData === requestedExtraData) {
     return requestedKmsSignersContext;
+  }
+
+  if (mode === 'exact') {
+    throw new Error(
+      `Exact reconciliation failed: relayer extraData ${relayerExtraData} ` +
+        `does not match requested extraData ${requestedExtraData}.`,
+    );
   }
 
   // Bytes differ — extract and compare serialization versions.

--- a/sdk/js-sdk/src/core/kms/KmsSigncryptedShares-p.ts
+++ b/sdk/js-sdk/src/core/kms/KmsSigncryptedShares-p.ts
@@ -145,7 +145,8 @@ export async function createKmsSigncryptedShares(
 
   // Reconcile KMS signer context using 'loose' mode.
   const reconciledKmsSignersContext: KmsSignersContext = await reconcileKmsSignersContext(context, {
-    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    kmsVerifierAddress: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    protocolConfigAddress: context.chain.fhevm.contracts.protocolConfig?.address as ChecksummedAddress | undefined,
     relayerExtraData,
     requestedKmsSignersContext: metadata.kmsSignersContext,
     mode: 'loose',

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
@@ -132,6 +132,10 @@ abstract class SignedDecryptionPermitBaseImpl {
   public get kmsContextId(): Uint256BigInt {
     return fromKmsExtraData(this.#eip712.message.extraData).kmsContextId;
   }
+
+  public get kmsEpochId(): Uint256BigInt {
+    return fromKmsExtraData(this.#eip712.message.extraData).kmsEpochId;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -343,7 +347,8 @@ export async function signDecryptionPermit(
   parameters: SignDecryptionPermitParameters,
 ): Promise<SignedDecryptionPermit> {
   const kmsSignersContext = await readKmsSignersContext(context, {
-    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    kmsVerifierAddress: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    protocolConfigAddress: context.chain.fhevm.contracts.protocolConfig?.address as ChecksummedAddress | undefined,
   });
 
   const extraData: BytesHex = kmsSignersContextToExtraData(kmsSignersContext);

--- a/sdk/js-sdk/src/core/kms/createKmsUserDecryptEip712V2.ts
+++ b/sdk/js-sdk/src/core/kms/createKmsUserDecryptEip712V2.ts
@@ -1,61 +1,68 @@
 import type { ErrorMetadataParams } from '../base/errors/ErrorBase.js';
-import type { KmsEip712Domain, KmsUserDecryptEip712 } from '../types/kms.js';
+import type { KmsUserDecryptEip712V2 } from '../types/kms.js';
 import type { BytesHex } from '../types/primitives.js';
-import type { KmsUserDecryptEip712Message } from '../types/kms.js';
+import type { KmsUserDecryptEip712V2Message } from '../types/kms.js';
 import {
   addressToChecksummedAddress,
   assertIsAddress,
   assertIsAddressArray,
+  assertRecordAddressProperty,
   assertRecordChecksummedAddressArrayProperty,
 } from '../base/address.js';
 import { assertIsKmsEip712Domain, createKmsEip712Domain } from './createKmsEip712Domain.js';
 import { asBytesHex, assertIsBytesHex, assertRecordBytesHexProperty, bytesToHexLarge } from '../base/bytes.js';
+import { isDeepEqual } from '../base/object.js';
 import { assertRecordNonNullableProperty } from '../base/record.js';
 import { assertRecordStringProperty, ensure0x } from '../base/string.js';
-import { assertIsUint64, assertIsUintNumber } from '../base/uint.js';
+import { assertIsUint256, assertIsUint64, assertIsUintString, MAX_UINT256 } from '../base/uint.js';
 import { assertIsKmsExtraData } from './kmsExtraData.js';
-import { kmsUserDecryptEip712Types } from './kmsUserDecryptEip712Types.js';
-import { isDeepEqual } from '../base/object.js';
+import { kmsUserDecryptEip712V2Types } from './kmsUserDecryptEip712V2Types.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export type CreateKmsUserDecryptEip712Parameters = {
+export type CreateKmsUserDecryptEip712V2Parameters = {
   readonly verifyingContractAddressDecryption: string;
   readonly chainId: number | bigint;
+  readonly userAddress: string;
   readonly publicKey: string | Uint8Array;
-  readonly contractAddresses: readonly string[];
-  readonly startTimestamp: number;
-  readonly durationDays: number;
+  readonly allowedContracts: readonly string[];
+  readonly startTimestamp: number | bigint;
+  readonly durationSeconds: number | bigint;
   readonly extraData: string;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-// createKmsUserDecryptEip712
+// createKmsUserDecryptEip712V2 (RFC-016)
 ////////////////////////////////////////////////////////////////////////////////
 
-export function createKmsUserDecryptEip712(parameters: CreateKmsUserDecryptEip712Parameters): KmsUserDecryptEip712 {
+export function createKmsUserDecryptEip712V2(
+  parameters: CreateKmsUserDecryptEip712V2Parameters,
+): KmsUserDecryptEip712V2 {
   const {
     verifyingContractAddressDecryption,
     chainId,
+    userAddress,
     publicKey,
-    contractAddresses,
+    allowedContracts,
     startTimestamp,
-    durationDays,
+    durationSeconds,
     extraData,
   } = parameters;
   const publicKeyBytesHex = _verifyPublicKeyArg(publicKey);
 
   assertIsUint64(chainId, {});
   assertIsAddress(verifyingContractAddressDecryption, {});
-  assertIsAddressArray(contractAddresses, {});
-  assertIsUintNumber(startTimestamp, {});
-  assertIsUintNumber(durationDays, {});
+  assertIsAddress(userAddress, {});
+  assertIsAddressArray(allowedContracts, {});
+  assertIsUint256(startTimestamp, {});
+  assertIsUint256(durationSeconds, {});
   assertIsBytesHex(extraData, {});
   assertIsKmsExtraData(extraData, {});
 
-  const checksummedContractAddresses = contractAddresses.map(addressToChecksummedAddress);
+  const checksummedUserAddress = addressToChecksummedAddress(userAddress);
+  const checksummedContractAddresses = allowedContracts.map(addressToChecksummedAddress);
 
-  const primaryType: KmsUserDecryptEip712['primaryType'] = 'UserDecryptRequestVerification';
+  const primaryType: KmsUserDecryptEip712V2['primaryType'] = 'UserDecryptRequestVerification';
 
   const domain = createKmsEip712Domain({
     chainId,
@@ -64,15 +71,16 @@ export function createKmsUserDecryptEip712(parameters: CreateKmsUserDecryptEip71
 
   const eip712 = {
     domain,
-    types: kmsUserDecryptEip712Types,
+    types: kmsUserDecryptEip712V2Types,
     primaryType,
     message: {
+      userAddress: checksummedUserAddress,
       publicKey: publicKeyBytesHex,
-      contractAddresses: checksummedContractAddresses,
+      allowedContracts: checksummedContractAddresses,
       startTimestamp: startTimestamp.toString(),
-      durationDays: durationDays.toString(),
+      durationSeconds: durationSeconds.toString(),
       extraData,
-    },
+    } satisfies KmsUserDecryptEip712V2Message,
   };
 
   Object.freeze(eip712);
@@ -81,76 +89,51 @@ export function createKmsUserDecryptEip712(parameters: CreateKmsUserDecryptEip71
   Object.freeze(eip712.types.EIP712Domain);
   Object.freeze(eip712.types.UserDecryptRequestVerification);
   Object.freeze(eip712.message);
-  Object.freeze(eip712.message.contractAddresses);
+  Object.freeze(eip712.message.allowedContracts);
 
   return eip712;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export function assertIsKmsUserDecryptEip712(
+export function assertIsKmsUserDecryptEip712V2(
   value: unknown,
   name: string,
   options: ErrorMetadataParams,
-): asserts value is KmsUserDecryptEip712 {
-  _assertIsKmsUserDecryptEip712Base(
-    value,
-    name,
-    'UserDecryptRequestVerification' satisfies KmsUserDecryptEip712['primaryType'],
-    options,
-  );
-}
-
-/**
- * Validates the common structure shared by both
- * {@link KmsUserDecryptEip712} and {@link KmsDelegatedUserDecryptEIP712}:
- * domain, types, primaryType, and base message fields.
- */
-export function _assertIsKmsUserDecryptEip712Base(
-  value: unknown,
-  name: string,
-  primaryType: string,
-  options: ErrorMetadataParams,
-): asserts value is {
-  readonly domain: KmsEip712Domain;
-  readonly types: object;
-  readonly primaryType: string;
-  readonly message: KmsUserDecryptEip712Message;
-} {
+): asserts value is KmsUserDecryptEip712V2 {
   assertRecordNonNullableProperty(value, 'domain', name, options);
   assertIsKmsEip712Domain((value as Record<string, unknown>).domain, `${name}.domain`, options);
 
   assertRecordNonNullableProperty(value, 'types', name, options);
-  if (!isDeepEqual(value.types, kmsUserDecryptEip712Types)) {
-    throw new Error('Unexpected KmsUserDecryptEip712Types');
+  if (!isDeepEqual(value.types, kmsUserDecryptEip712V2Types)) {
+    throw new Error('Unexpected KmsUserDecryptEip712V2Types');
   }
 
   assertRecordStringProperty(value, 'primaryType', name, {
-    expectedValue: primaryType,
+    expectedValue: 'UserDecryptRequestVerification',
     ...options,
   });
 
   assertRecordNonNullableProperty(value, 'message', name, options);
   const msg = (value as Record<string, unknown>).message as Record<string, unknown>;
-  _assertIsKmsUserDecryptEip712Message(msg, `${name}.message`, options);
+  _assertIsKmsUserDecryptEip712V2Message(msg, `${name}.message`, options);
 }
 
-/**
- * Validates the common message fields shared by both
- * {@link KmsUserDecryptEip712} and {@link KmsDelegatedUserDecryptEIP712}.
- */
-function _assertIsKmsUserDecryptEip712Message(
+function _assertIsKmsUserDecryptEip712V2Message(
   msg: unknown,
   msgName: string,
   options: ErrorMetadataParams,
-): asserts msg is KmsUserDecryptEip712Message {
-  type MessageType = KmsUserDecryptEip712['message'];
+): asserts msg is KmsUserDecryptEip712V2Message {
+  type MessageType = KmsUserDecryptEip712V2['message'];
+  assertRecordAddressProperty(msg, 'userAddress' satisfies keyof MessageType, msgName, options);
   assertRecordBytesHexProperty(msg, 'publicKey' satisfies keyof MessageType, msgName, options);
-  assertRecordChecksummedAddressArrayProperty(msg, 'contractAddresses' satisfies keyof MessageType, msgName, options);
+  assertRecordChecksummedAddressArrayProperty(msg, 'allowedContracts' satisfies keyof MessageType, msgName, options);
   assertRecordStringProperty(msg, 'startTimestamp' satisfies keyof MessageType, msgName, options);
-  assertRecordStringProperty(msg, 'durationDays' satisfies keyof MessageType, msgName, options);
+  assertRecordStringProperty(msg, 'durationSeconds' satisfies keyof MessageType, msgName, options);
   assertRecordBytesHexProperty(msg, 'extraData' satisfies keyof MessageType, msgName, options);
   assertIsKmsExtraData(msg.extraData, options);
+  assertIsUintString(msg.startTimestamp, { max: MAX_UINT256 });
+  assertIsUintString(msg.durationSeconds, { max: MAX_UINT256 });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sdk/js-sdk/src/core/kms/fetchKmsSigncryptedShares-p.ts
+++ b/sdk/js-sdk/src/core/kms/fetchKmsSigncryptedShares-p.ts
@@ -157,7 +157,8 @@ export async function fetchKmsSigncryptedShares(context: Context, parameters: Pa
   // though the context ID matches. Consider comparing the decoded `kmsContextId`
   // instead of the raw `extraData` bytes.
   const requestedKmsSignersContext: KmsSignersContext = await readKmsSignersContext(context, {
-    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    kmsVerifierAddress: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    protocolConfigAddress: context.chain.fhevm.contracts.protocolConfig?.address as ChecksummedAddress | undefined,
   });
 
   assertExtraDataMatchesKmsSingersContext(

--- a/sdk/js-sdk/src/core/kms/fetchKmsSigncryptedShares-p.ts
+++ b/sdk/js-sdk/src/core/kms/fetchKmsSigncryptedShares-p.ts
@@ -126,14 +126,14 @@ export async function fetchKmsSigncryptedShares(context: Context, parameters: Pa
   // 7. Check: ACL permissions (user is signer or delegatorAddress)
   if (signedPermit.isDelegated) {
     await checkDelegation(context, {
-      address: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+      aclAddress: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
       delegate: signerAddress,
       delegator: encryptedDataOwnerAddress,
       handleContractPairs,
     });
   } else {
     await checkPersistAllowed(context, {
-      address: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+      aclAddress: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
       userAddress: encryptedDataOwnerAddress,
       handleContractPairs,
     });

--- a/sdk/js-sdk/src/core/kms/fetchKmsSigncryptedShares-p.ts
+++ b/sdk/js-sdk/src/core/kms/fetchKmsSigncryptedShares-p.ts
@@ -16,7 +16,7 @@ import { checkPersistAllowed } from '../host-contracts/checkPersistAllowed.js';
 import { assertExtraDataMatchesKmsSingersContext } from '../host-contracts/KmsSignersContext-p.js';
 import { createKmsEip712Domain } from './createKmsEip712Domain.js';
 import { checkDelegation } from '../host-contracts/checkDelegation.js';
-import { resolveFhevmTkmsVersion } from '../runtime/CoreFhevm-p.js';
+import { resolveFhevmTkmsVersion } from '../runtime/resolveFhevmVersions-p.js';
 
 /*
     See: in KMS (eip712Domain)

--- a/sdk/js-sdk/src/core/kms/kmsExtraData.ts
+++ b/sdk/js-sdk/src/core/kms/kmsExtraData.ts
@@ -1,49 +1,115 @@
-import type { ByteLength, Bytes32Hex, BytesHex, Uint256BigInt, Uint8Number } from '../types/primitives.js';
+import type { Bytes32Hex, BytesHex, Uint256BigInt, Uint8Number } from '../types/primitives.js';
 import type { ErrorMetadataParams } from '../base/errors/ErrorBase.js';
 import { asUint256BigInt, asUint8Number } from '../base/uint.js';
 import { asBytes32Hex, assertIsBytesHex } from '../base/bytes.js';
 
-const EXTRA_DATA_V1 = 0x01;
+export const EXTRA_DATA_V0: Uint8Number = 0x00 as Uint8Number; // 0x00
+export const EXTRA_DATA_V1: Uint8Number = 0x01 as Uint8Number; // 1 version byte + 32-byte big-endian context ID = 33 bytes
+export const EXTRA_DATA_V2: Uint8Number = 0x02 as Uint8Number; // 1 version byte + 32-byte big-endian context ID + 32-byte big-endian epoch ID = 65 bytes
 
 export function fromKmsExtraData(extraData: BytesHex): {
   version: Uint8Number;
   kmsContextId: Uint256BigInt;
+  kmsEpochId: Uint256BigInt;
 } {
   if ((extraData as string) === '0x00' || (extraData as string) === '0x') {
     return {
-      version: 0 as Uint8Number,
+      version: EXTRA_DATA_V0,
       kmsContextId: 0n as Uint256BigInt,
+      kmsEpochId: 0n as Uint256BigInt,
     };
   }
 
+  if (extraData.length <= 4) {
+    throw new Error(`Unsupported extraData length ${extraData.length}: must be more than 4 bytes`);
+  }
+
   // First byte = version (characters 2-3 after '0x')
-  const version = asUint8Number(parseInt(extraData.slice(2, 4), 16));
+  const version = asUint8Number(Number('0x' + extraData.slice(2, 4)));
 
   if (version === EXTRA_DATA_V1) {
-    // 1 version byte + 32 contextId bytes = 33 bytes = 66 hex chars + 2 for '0x' = 68
-    if (extraData.length < 68) {
-      throw new Error(`extraData too short for v1: expected at least 33 bytes, got ${(extraData.length - 2) / 2}`);
+    // ExtraData v1 format: 1 version byte + 32-byte big-endian context ID = 33 bytes = 66 hex chars + 2 for '0x' = 68
+    // 0x01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    // ↑   ↑                                                               ↑
+    // 0   4                                                               68
+    // 0         1         2         3         4         5         6
+    // 01234567890123456789012345678901234567890123456789012345678901234567
+
+    if (extraData.length != 68) {
+      throw new Error(`Invalid extraData length for v1: expected 68, got ${extraData.length}`);
     }
     // 32-byte contextId starts at byte 1 (hex chars 4..67)
     const contextIdBytes32Hex: Bytes32Hex = asBytes32Hex(`0x${extraData.slice(4, 68)}`);
     const kmsContextId = asUint256BigInt(BigInt(contextIdBytes32Hex));
-    return { version, kmsContextId };
+    return { version, kmsContextId, kmsEpochId: 0n as Uint256BigInt };
+  }
+
+  if (version === EXTRA_DATA_V2) {
+    // ExtraData v2 format: 1 version byte + 32-byte big-endian context ID + 32-byte big-endian epoch ID = 65 bytes = 130 hex chars + 2 for '0x' = 132
+    // 0x01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    // ↑   ↑                                                               ↑                                                               ↑
+    // 0   4                                                               68                                                              132
+    // 0         1         2         3         4         5         6         7         8         9         0         1         2         3
+    // 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901
+
+    if (extraData.length != 132) {
+      throw new Error(`Invalid extraData length for v2: expected 132, got ${extraData.length}`);
+    }
+    // 32-byte contextId starts at byte 1 (hex chars 4..67)
+    const contextIdBytes32Hex: Bytes32Hex = asBytes32Hex(`0x${extraData.slice(4, 68)}`);
+    const kmsContextId = asUint256BigInt(BigInt(contextIdBytes32Hex));
+
+    // 32-byte epochId starts at byte 33 (hex chars 68..131)
+    const epochIdBytes32Hex: Bytes32Hex = asBytes32Hex(`0x${extraData.slice(68, 132)}`);
+    const kmsEpochId = asUint256BigInt(BigInt(epochIdBytes32Hex));
+
+    return { version, kmsContextId, kmsEpochId };
   }
 
   throw new Error(`Unsupported extraData version ${version}`);
 }
 
 /**
- * Encodes a KMS context ID into the v1 extraData format.
- * Layout: `0x` + `01` (version byte) + 32-byte big-endian context ID.
+ * Encodes a KMS context into an extraData format.
+ * v0: `0x00`
+ * v1: `0x01` + 32-byte big-endian context ID.
+ * v2: `0x02` + 32-byte big-endian context ID + 32-byte big-endian epoch ID.
  */
 export function toKmsExtraData(args: {
   readonly version: Uint8Number;
   readonly kmsContextId: Uint256BigInt;
+  readonly kmsEpochId: Uint256BigInt;
 }): BytesHex {
   const v = args.version.toString(16).padStart(2, '0');
-  const id = args.kmsContextId.toString(16).padStart(64, '0');
-  return `0x${v}${id}` as BytesHex;
+
+  switch (args.version) {
+    case EXTRA_DATA_V0: {
+      return `0x${v}` as BytesHex;
+    }
+    case EXTRA_DATA_V1: {
+      if (args.kmsContextId === 0n) {
+        throw new Error('kmsContextId cannot be 0 for v1 extraData');
+      }
+      if (args.kmsEpochId !== 0n) {
+        throw new Error('kmsEpochId must be 0 for v1 extraData');
+      }
+      const contextId = args.kmsContextId.toString(16).padStart(64, '0');
+      return `0x${v}${contextId}` as BytesHex;
+    }
+    case EXTRA_DATA_V2: {
+      if (args.kmsContextId === 0n) {
+        throw new Error('kmsContextId cannot be 0 for v2 extraData');
+      }
+      if (args.kmsEpochId === 0n) {
+        throw new Error('kmsEpochId cannot be 0 for v2 extraData');
+      }
+      const contextId = args.kmsContextId.toString(16).padStart(64, '0');
+      const epochId = args.kmsEpochId.toString(16).padStart(64, '0');
+      return `0x${v}${contextId}${epochId}` as BytesHex;
+    }
+    default:
+      throw new Error(`Unsupported extraData version ${args.version}`);
+  }
 }
 
 export function assertIsKmsExtraData(
@@ -53,6 +119,9 @@ export function assertIsKmsExtraData(
   if (value === '0x00' || value === '0x') {
     return;
   }
-  assertIsBytesHex(value, { ...options, byteLength: 33 as ByteLength });
+
+  assertIsBytesHex(value, options);
+
+  // Will valid extraData length too
   fromKmsExtraData(value);
 }

--- a/sdk/js-sdk/src/core/kms/kmsUserDecryptEip712V2Types.ts
+++ b/sdk/js-sdk/src/core/kms/kmsUserDecryptEip712V2Types.ts
@@ -1,0 +1,31 @@
+import type { KmsUserDecryptEip712V2Types } from '../types/kms.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// KmsUserDecryptEIP712V2Types (RFC-016)
+////////////////////////////////////////////////////////////////////////////////
+
+export const kmsUserDecryptEip712V2Types: KmsUserDecryptEip712V2Types = {
+  EIP712Domain: [
+    { name: 'name', type: 'string' },
+    { name: 'version', type: 'string' },
+    { name: 'chainId', type: 'uint256' },
+    { name: 'verifyingContract', type: 'address' },
+  ] as const,
+  // CRITICAL: Field order is authoritative — it determines the EIP-712 type hash.
+  // Changing the order will produce a different signature and break on-chain verification.
+  // Must match the Solidity struct definition exactly.
+  UserDecryptRequestVerification: [
+    { name: 'userAddress', type: 'address' },
+    { name: 'publicKey', type: 'bytes' },
+    { name: 'allowedContracts', type: 'address[]' },
+    { name: 'startTimestamp', type: 'uint256' },
+    { name: 'durationSeconds', type: 'uint256' },
+    { name: 'extraData', type: 'bytes' },
+  ] as const,
+} as const;
+
+Object.freeze(kmsUserDecryptEip712V2Types);
+Object.freeze(kmsUserDecryptEip712V2Types.EIP712Domain);
+Object.freeze(kmsUserDecryptEip712V2Types.UserDecryptRequestVerification);
+kmsUserDecryptEip712V2Types.EIP712Domain.forEach(Object.freeze);
+kmsUserDecryptEip712V2Types.UserDecryptRequestVerification.forEach(Object.freeze);

--- a/sdk/js-sdk/src/core/kms/publicDecrypt.ts
+++ b/sdk/js-sdk/src/core/kms/publicDecrypt.ts
@@ -65,7 +65,7 @@ export async function publicDecrypt(context: Context, parameters: Parameters): P
 
   // 4. Check: ACL permissions
   await checkAllowedForDecryption(context, {
-    address: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+    aclAddress: context.chain.fhevm.contracts.acl.address as ChecksummedAddress,
     handles: orderedHandles,
   });
 

--- a/sdk/js-sdk/src/core/kms/publicDecrypt.ts
+++ b/sdk/js-sdk/src/core/kms/publicDecrypt.ts
@@ -39,7 +39,8 @@ export async function publicDecrypt(context: Context, parameters: Parameters): P
   // EIP-712 signature from the user, so the SDK can safely fetch the current
   // context ID and build the extraData transparently to the user.
   const requestedKmsSignersContext = await readKmsSignersContext(context, {
-    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    kmsVerifierAddress: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    protocolConfigAddress: context.chain.fhevm.contracts.protocolConfig?.address as ChecksummedAddress | undefined,
   });
 
   const requestedExtraData: BytesHex = kmsSignersContextToExtraData(requestedKmsSignersContext);
@@ -84,7 +85,8 @@ export async function publicDecrypt(context: Context, parameters: Parameters): P
 
   // 6. Reconcile KMS signer context using 'loose' mode
   const reconciledKmsSignersContext: KmsSignersContext = await reconcileKmsSignersContext(context, {
-    address: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    kmsVerifierAddress: context.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
+    protocolConfigAddress: context.chain.fhevm.contracts.protocolConfig?.address as ChecksummedAddress | undefined,
     relayerExtraData,
     requestedKmsSignersContext: requestedKmsSignersContext,
     mode: 'loose',

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchDelegatedUserDecrypt.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchDelegatedUserDecrypt.ts
@@ -7,7 +7,7 @@ import type {
   RelayerClientWithRuntime,
 } from '../types.js';
 import { remove0x } from '../../../base/string.js';
-import { asUint32BigInt, parseUintBigIntString, randomUniqueUints } from '../../../base/uint.js';
+import { asUint32BigInt, tryParseUintBigIntString, randomUniqueUints } from '../../../base/uint.js';
 import { getTrustedClient } from '../../../runtime/CoreFhevm-p.js';
 import { userDecryptResultToKmsSigncryptedShares } from '../utils.js';
 import { getKmsSignersPrivateKeyMap } from './signers.js';
@@ -139,7 +139,7 @@ export async function fetchDelegatedUserDecrypt(
 ////////////////////////////////////////////////////////////////////////////////
 
 function _parseUintBigIntString(label: string, value: string): bigint {
-  const bn = parseUintBigIntString(value);
+  const bn = tryParseUintBigIntString(value);
   if (bn === undefined) {
     throw new Error(`${label} is not a valid uint string, got ${JSON.stringify(value)}`);
   }

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchUserDecrypt.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchUserDecrypt.ts
@@ -3,7 +3,7 @@ import type { FetchUserDecryptResultItem } from '../../../types/relayer.js';
 import type { CleartextEthereumModule } from '../../ethereum/types-ct.js';
 import type { FetchUserDecryptParameters, FetchUserDecryptReturnType, RelayerClientWithRuntime } from '../types.js';
 import { remove0x } from '../../../base/string.js';
-import { asUint32BigInt, parseUintBigIntString, randomUniqueUints } from '../../../base/uint.js';
+import { asUint32BigInt, tryParseUintBigIntString, randomUniqueUints } from '../../../base/uint.js';
 import { getTrustedClient } from '../../../runtime/CoreFhevm-p.js';
 import { userDecryptResultToKmsSigncryptedShares } from '../utils.js';
 import { getKmsSignersPrivateKeyMap } from './signers.js';
@@ -133,7 +133,7 @@ export async function fetchUserDecrypt(
 ////////////////////////////////////////////////////////////////////////////////
 
 function _parseUintBigIntString(label: string, value: string): bigint {
-  const bn = parseUintBigIntString(value);
+  const bn = tryParseUintBigIntString(value);
   if (bn === undefined) {
     throw new Error(`${label} is not a valid uint string, got ${JSON.stringify(value)}`);
   }

--- a/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
+++ b/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
@@ -8,7 +8,6 @@ import type {
   FhevmOptions,
   NativeClient,
   OptionalNativeClient,
-  FhevmProtocolContext,
   ProtocolVersionResolution,
   ResolvedFhevmOptions,
   WithProtocolVersion,
@@ -24,7 +23,6 @@ import { uid } from '../base/uid.js';
 import { createTrustedClient } from '../modules/ethereum/createTrustedClient.js';
 import { asFhevmRuntimeWith, assertIsFhevmRuntime, assertIsFhevmRuntimeWith } from './CoreFhevmRuntime-p.js';
 import { globalFheEncryptionKeyCache } from '../key/FheEncryptionKeyCache-p.js';
-import { hyperWasmResolveTfheModuleVersion, hyperWasmResolveTkmsModuleVersion } from './HyperWasmSolver-p.js';
 import { cloneModuleVersions } from '../runtimeConfig-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -616,6 +614,8 @@ export function setResolvedTkmsVersion(fhevm: FhevmBase, tkmsVersion: TkmsVersio
   f[SET_TKMS_VERSION](tkmsVersion);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
 export function getResolvedProtocolVersion(fhevm: unknown): ProtocolVersionResolution | undefined {
   const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [GET_PROTOCOL_VERSION]: GetProtocolVersionFn };
   return f[GET_PROTOCOL_VERSION]();
@@ -631,42 +631,4 @@ export function getResolvedTkmsVersion(fhevm: unknown): TkmsVersion | undefined 
   return f[GET_TKMS_VERSION]();
 }
 
-export async function resolveFhevmProtocolVersion(fhevm: unknown): Promise<ProtocolVersionResolution> {
-  return (await resolveFhevmProtocolContext(fhevm)).protocolVersion;
-}
-
-export async function resolveFhevmProtocolContext(fhevm: unknown): Promise<FhevmProtocolContext> {
-  assertIsFhevmBaseClient(fhevm);
-
-  const protocolVersion = getResolvedProtocolVersion(fhevm);
-  if (protocolVersion !== undefined) {
-    const { pubKeyCrsVersionFromProtocolVersion } = await import('./ProtocolVersionResolver-p.js');
-    return Object.freeze({
-      protocolVersion,
-      pubKeyCrsVersion: pubKeyCrsVersionFromProtocolVersion(fhevm.chain, protocolVersion),
-    });
-  }
-
-  const { resolveProtocolContext } = await import('./ProtocolVersionResolver-p.js');
-  return resolveProtocolContext(fhevm);
-}
-
-export async function resolveFhevmTfheVersion(fhevm: unknown): Promise<TfheVersion> {
-  const protocolContext = await resolveFhevmProtocolContext(fhevm);
-  const tfheVersion = getResolvedTfheVersion(fhevm);
-  if (tfheVersion !== undefined) {
-    return tfheVersion;
-  }
-  assertIsFhevmBaseClient(fhevm);
-  return hyperWasmResolveTfheModuleVersion(fhevm, protocolContext);
-}
-
-export async function resolveFhevmTkmsVersion(fhevm: unknown): Promise<TkmsVersion> {
-  const protocolContext = await resolveFhevmProtocolContext(fhevm);
-  const tkmsVersion = getResolvedTkmsVersion(fhevm);
-  if (tkmsVersion !== undefined) {
-    return tkmsVersion;
-  }
-  assertIsFhevmBaseClient(fhevm);
-  return hyperWasmResolveTkmsModuleVersion(fhevm, protocolContext);
-}
+////////////////////////////////////////////////////////////////////////////////

--- a/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
+++ b/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
@@ -8,7 +8,10 @@ import type {
   FhevmOptions,
   NativeClient,
   OptionalNativeClient,
+  FhevmProtocolContext,
+  ProtocolVersionResolution,
   ResolvedFhevmOptions,
+  WithProtocolVersion,
   WithTfheVersion,
   WithTkmsVersion,
 } from '../types/coreFhevmClient.js';
@@ -27,18 +30,24 @@ import { cloneModuleVersions } from '../runtimeConfig-p.js';
 ////////////////////////////////////////////////////////////////////////////////
 
 const PRIVATE_TOKEN = Symbol('CoreFhevmHostClient.token');
+const GET_PROTOCOL_VERSION = Symbol('CoreFhevmHostClient.getProtocolVersion');
 const GET_TFHE_VERSION = Symbol('CoreFhevmHostClient.getTfheVersion');
 const GET_TKMS_VERSION = Symbol('CoreFhevmHostClient.getTkmsVersion');
+const SET_PROTOCOL_VERSION = Symbol('CoreFhevmHostClient.setProtocolVersion');
 const SET_TFHE_VERSION = Symbol('CoreFhevmHostClient.setTfheVersion');
 const SET_TKMS_VERSION = Symbol('CoreFhevmHostClient.setTkmsVersion');
 
+const UNRESOLVED_PROTOCOL_VERSION_MESSAGE =
+  'Protocol version has not been resolved. Await client.ready before reading protocolVersion.';
 const UNRESOLVED_TFHE_VERSION_MESSAGE =
   'TFHE version has not been resolved. Await client.ready before reading tfheVersion.';
 const UNRESOLVED_TKMS_VERSION_MESSAGE =
   'TKMS version has not been resolved. Await client.ready before reading tkmsVersion.';
 
+type GetProtocolVersionFn = () => ProtocolVersionResolution | undefined;
 type GetTfheVersionFn = () => TfheVersion | undefined;
 type GetTkmsVersionFn = () => TkmsVersion | undefined;
+type SetProtocolVersionFn = (protocolVersion: ProtocolVersionResolution) => void;
 type SetTfheVersionFn = (tfheVersion: TfheVersion) => void;
 type SetTkmsVersionFn = (tkmsVersion: TkmsVersion) => void;
 
@@ -53,6 +62,7 @@ class CoreFhevmImpl<
 > implements Fhevm<chain, FhevmRuntime, client> {
   // Private fields (truly inaccessible from outside)
   readonly #uid: string;
+  #protocolVersion: ProtocolVersionResolution | undefined;
   #tfheVersion: TfheVersion | undefined;
   #tkmsVersion: TkmsVersion | undefined;
   readonly #runtime: runtime;
@@ -65,6 +75,7 @@ class CoreFhevmImpl<
   // Declared for TypeScript — defined at runtime via Object.defineProperties
   declare readonly uid: string;
   declare readonly chain: chain;
+  declare readonly protocolVersion: ProtocolVersionResolution;
   declare readonly tfheVersion: TfheVersion;
   declare readonly tkmsVersion: TkmsVersion;
   declare readonly options: ResolvedFhevmOptions;
@@ -95,6 +106,7 @@ class CoreFhevmImpl<
 
     this.#runtime = parameters.runtime;
     this.#uid = uid();
+    this.#protocolVersion = undefined;
     this.#tfheVersion = undefined;
     this.#tkmsVersion = undefined;
     this.#trustedClient =
@@ -111,6 +123,16 @@ class CoreFhevmImpl<
     Object.defineProperties(this, {
       uid: {
         get: () => this.#uid,
+        configurable: false,
+        enumerable: true,
+      },
+      protocolVersion: {
+        get: () => {
+          if (this.#protocolVersion === undefined) {
+            throw new Error(UNRESOLVED_PROTOCOL_VERSION_MESSAGE);
+          }
+          return this.#protocolVersion;
+        },
         configurable: false,
         enumerable: true,
       },
@@ -175,6 +197,12 @@ class CoreFhevmImpl<
         enumerable: false,
         writable: false,
       },
+      [GET_PROTOCOL_VERSION]: {
+        value: (): ProtocolVersionResolution | undefined => this.#protocolVersion,
+        configurable: false,
+        enumerable: false,
+        writable: false,
+      },
       [GET_TFHE_VERSION]: {
         value: (): TfheVersion | undefined => this.#tfheVersion,
         configurable: false,
@@ -183,6 +211,24 @@ class CoreFhevmImpl<
       },
       [GET_TKMS_VERSION]: {
         value: (): TkmsVersion | undefined => this.#tkmsVersion,
+        configurable: false,
+        enumerable: false,
+        writable: false,
+      },
+      [SET_PROTOCOL_VERSION]: {
+        value: (protocolVersion: ProtocolVersionResolution): void => {
+          if (
+            this.#protocolVersion !== undefined &&
+            !_sameProtocolVersionResolution(this.#protocolVersion, protocolVersion)
+          ) {
+            throw new Error(
+              `Protocol version already resolved as ${_formatProtocolVersionResolution(
+                this.#protocolVersion,
+              )}; cannot set ${_formatProtocolVersionResolution(protocolVersion)}.`,
+            );
+          }
+          this.#protocolVersion = protocolVersion;
+        },
         configurable: false,
         enumerable: false,
         writable: false,
@@ -333,6 +379,21 @@ export function asFhevmClientWith<
 
 ////////////////////////////////////////////////////////////////////////////////
 
+export function asFhevmWithProtocolVersion<
+  chain extends FhevmChain | undefined = FhevmChain | undefined,
+  runtime extends FhevmRuntime = FhevmRuntime,
+  client extends OptionalNativeClient = NativeClient,
+>(
+  fhevm: FhevmBase<chain, runtime, client>,
+): Fhevm<chain & FhevmChain, runtime, client & NativeClient> & WithProtocolVersion {
+  assertIsFhevmBaseClient(fhevm);
+  const f = fhevm as Fhevm<chain & FhevmChain, runtime, client & NativeClient> & WithProtocolVersion;
+  if (getResolvedProtocolVersion(f) === undefined) {
+    throw new Error(UNRESOLVED_PROTOCOL_VERSION_MESSAGE);
+  }
+  return f;
+}
+
 export function asFhevmWithTfheVersion<
   chain extends FhevmChain | undefined = FhevmChain | undefined,
   runtime extends FhevmRuntime = FhevmRuntime,
@@ -346,6 +407,9 @@ export function asFhevmWithTfheVersion<
     client & NativeClient
   > &
     WithTfheVersion;
+  if (getResolvedProtocolVersion(f) === undefined) {
+    throw new Error(UNRESOLVED_PROTOCOL_VERSION_MESSAGE);
+  }
   if (getResolvedTfheVersion(f) === undefined) {
     throw new Error(UNRESOLVED_TFHE_VERSION_MESSAGE);
   }
@@ -365,6 +429,9 @@ export function asFhevmWithTkmsVersion<
     client & NativeClient
   > &
     WithTkmsVersion;
+  if (getResolvedProtocolVersion(f) === undefined) {
+    throw new Error(UNRESOLVED_PROTOCOL_VERSION_MESSAGE);
+  }
   if (getResolvedTkmsVersion(f) === undefined) {
     throw new Error(UNRESOLVED_TKMS_VERSION_MESSAGE);
   }
@@ -524,6 +591,21 @@ function resolveOptions(options: FhevmOptions | undefined): ResolvedFhevmOptions
 
 ////////////////////////////////////////////////////////////////////////////////
 
+function _sameProtocolVersionResolution(a: ProtocolVersionResolution, b: ProtocolVersionResolution): boolean {
+  return a.version === b.version && a.comparator === b.comparator;
+}
+
+function _formatProtocolVersionResolution(protocolVersion: ProtocolVersionResolution): string {
+  return `${protocolVersion.comparator}:${protocolVersion.version}`;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+export function setResolvedProtocolVersion(fhevm: FhevmBase, protocolVersion: ProtocolVersionResolution): void {
+  const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [SET_PROTOCOL_VERSION]: SetProtocolVersionFn };
+  f[SET_PROTOCOL_VERSION](protocolVersion);
+}
+
 export function setResolvedTfheVersion(fhevm: FhevmBase, tfheVersion: TfheVersion): void {
   const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [SET_TFHE_VERSION]: SetTfheVersionFn };
   f[SET_TFHE_VERSION](tfheVersion);
@@ -532,6 +614,11 @@ export function setResolvedTfheVersion(fhevm: FhevmBase, tfheVersion: TfheVersio
 export function setResolvedTkmsVersion(fhevm: FhevmBase, tkmsVersion: TkmsVersion): void {
   const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [SET_TKMS_VERSION]: SetTkmsVersionFn };
   f[SET_TKMS_VERSION](tkmsVersion);
+}
+
+export function getResolvedProtocolVersion(fhevm: unknown): ProtocolVersionResolution | undefined {
+  const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [GET_PROTOCOL_VERSION]: GetProtocolVersionFn };
+  return f[GET_PROTOCOL_VERSION]();
 }
 
 export function getResolvedTfheVersion(fhevm: unknown): TfheVersion | undefined {
@@ -544,20 +631,42 @@ export function getResolvedTkmsVersion(fhevm: unknown): TkmsVersion | undefined 
   return f[GET_TKMS_VERSION]();
 }
 
+export async function resolveFhevmProtocolVersion(fhevm: unknown): Promise<ProtocolVersionResolution> {
+  return (await resolveFhevmProtocolContext(fhevm)).protocolVersion;
+}
+
+export async function resolveFhevmProtocolContext(fhevm: unknown): Promise<FhevmProtocolContext> {
+  assertIsFhevmBaseClient(fhevm);
+
+  const protocolVersion = getResolvedProtocolVersion(fhevm);
+  if (protocolVersion !== undefined) {
+    const { pubKeyCrsVersionFromProtocolVersion } = await import('./ProtocolVersionResolver-p.js');
+    return Object.freeze({
+      protocolVersion,
+      pubKeyCrsVersion: pubKeyCrsVersionFromProtocolVersion(fhevm.chain, protocolVersion),
+    });
+  }
+
+  const { resolveProtocolContext } = await import('./ProtocolVersionResolver-p.js');
+  return resolveProtocolContext(fhevm);
+}
+
 export async function resolveFhevmTfheVersion(fhevm: unknown): Promise<TfheVersion> {
+  const protocolContext = await resolveFhevmProtocolContext(fhevm);
   const tfheVersion = getResolvedTfheVersion(fhevm);
   if (tfheVersion !== undefined) {
     return tfheVersion;
   }
   assertIsFhevmBaseClient(fhevm);
-  return hyperWasmResolveTfheModuleVersion(fhevm);
+  return hyperWasmResolveTfheModuleVersion(fhevm, protocolContext);
 }
 
 export async function resolveFhevmTkmsVersion(fhevm: unknown): Promise<TkmsVersion> {
+  const protocolContext = await resolveFhevmProtocolContext(fhevm);
   const tkmsVersion = getResolvedTkmsVersion(fhevm);
   if (tkmsVersion !== undefined) {
     return tkmsVersion;
   }
   assertIsFhevmBaseClient(fhevm);
-  return hyperWasmResolveTkmsModuleVersion(fhevm);
+  return hyperWasmResolveTkmsModuleVersion(fhevm, protocolContext);
 }

--- a/sdk/js-sdk/src/core/runtime/HyperWasmSolver-p.test.ts
+++ b/sdk/js-sdk/src/core/runtime/HyperWasmSolver-p.test.ts
@@ -1,20 +1,31 @@
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
-import type { ResolvedFhevmOptions } from '../types/coreFhevmClient.js';
+import type { FhevmProtocolContext, ResolvedFhevmOptions } from '../types/coreFhevmClient.js';
+import type { HostContractVersion } from '../types/hostContract.js';
 import type { FhevmModuleVersions } from '../types/moduleVersions.js';
-import { describe, expect, it } from 'vitest';
+import type { UintNumber } from '../types/primitives.js';
+import { describe, expect, it, vi } from 'vitest';
 import { sepolia } from '../chains/definitions/sepolia.js';
 import { hyperWasmResolveTfheModuleVersion, hyperWasmResolveTkmsModuleVersion } from './HyperWasmSolver-p.js';
+import { protocolContextFromAclVersion } from './ProtocolVersionResolver-p.js';
+
+const KNOWN_EXACT_ACL_WASM_CASES = [
+  { acl: [0, 2, 0], tfhe: '1.5.3', kms: '0.13.10' },
+  { acl: [0, 3, 0], tfhe: '1.5.3', kms: '0.13.10' },
+  { acl: [0, 4, 0], tfhe: '1.6.1', kms: '0.13.20-0' },
+  { acl: [0, 5, 0], tfhe: '1.6.1', kms: '0.13.20-0' },
+] as const;
 
 type ResolveParameters = Parameters<typeof hyperWasmResolveTfheModuleVersion>[0];
 
 function makeParameters(parameters: {
   readonly clientModuleVersions?: FhevmModuleVersions | undefined;
   readonly runtimeModuleVersions?: FhevmModuleVersions | undefined;
+  readonly logger?: FhevmRuntime['config']['logger'] | undefined;
 }): ResolveParameters {
   return {
-    chain: sepolia,
     runtime: {
       config: {
+        logger: parameters.logger,
         moduleVersions: parameters.runtimeModuleVersions,
       },
     } as unknown as FhevmRuntime,
@@ -25,48 +36,348 @@ function makeParameters(parameters: {
   };
 }
 
+function makeProtocolContext(parameters: {
+  readonly protocolVersion: FhevmProtocolContext['protocolVersion'];
+  readonly pubKeyCrsVersion: FhevmProtocolContext['pubKeyCrsVersion'];
+}): FhevmProtocolContext {
+  return Object.freeze({
+    protocolVersion: parameters.protocolVersion,
+    pubKeyCrsVersion: parameters.pubKeyCrsVersion,
+  });
+}
+
+function makeAclVersion(major: number, minor: number, patch: number): HostContractVersion<'ACL'> {
+  return {
+    version: `ACL v${major}.${minor}.${patch}`,
+    contractName: 'ACL',
+    major: major as UintNumber,
+    minor: minor as UintNumber,
+    patch: patch as UintNumber,
+  };
+}
+
+function makeChain(relayerUrl: string): typeof sepolia {
+  return {
+    ...sepolia,
+    fhevm: {
+      ...sepolia.fhevm,
+      relayerUrl,
+    },
+  };
+}
+
 describe('HyperWasmSolver', () => {
-  it('prefers client TFHE module version over runtime fallback', async () => {
-    await expect(
+  it('prefers client tfhe module version over runtime fallback', () => {
+    expect(
       hyperWasmResolveTfheModuleVersion(
         makeParameters({
           clientModuleVersions: { tfhe: '1.6.1' },
           runtimeModuleVersions: { tfhe: '1.5.3' },
         }),
       ),
-    ).resolves.toBe('1.6.1');
+    ).toBe('1.6.1');
   });
 
-  it('uses runtime TFHE fallback when client module version is missing that field', async () => {
-    await expect(
+  it('uses runtime tfhe fallback when client module version is missing that field', () => {
+    expect(
       hyperWasmResolveTfheModuleVersion(
         makeParameters({
           clientModuleVersions: { kms: '0.13.20-0' },
           runtimeModuleVersions: { tfhe: '1.5.3' },
         }),
       ),
-    ).resolves.toBe('1.5.3');
+    ).toBe('1.5.3');
   });
 
-  it('prefers client TKMS module version over runtime fallback', async () => {
-    await expect(
+  it('prefers client kms module version over runtime fallback', () => {
+    expect(
       hyperWasmResolveTkmsModuleVersion(
         makeParameters({
           clientModuleVersions: { kms: '0.13.20-0' },
           runtimeModuleVersions: { kms: '0.13.10' },
         }),
       ),
-    ).resolves.toBe('0.13.20-0');
+    ).toBe('0.13.20-0');
   });
 
-  it('bypasses runtime fallback when client module versions are auto', async () => {
-    await expect(
+  it('bypasses runtime fallback when client module versions are auto', () => {
+    expect(() =>
       hyperWasmResolveTfheModuleVersion(
         makeParameters({
           clientModuleVersions: 'auto',
           runtimeModuleVersions: { tfhe: '1.5.3' },
         }),
       ),
-    ).rejects.toThrow('Cannot auto-resolve TFHE WASM version without a native client.');
+    ).toThrow('Cannot auto-resolve tfhe WASM version without a resolved protocol context.');
+  });
+
+  it('throws by default when an explicit client tfhe module version is incompatible', () => {
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.12.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.5.4', comparator: 'eq' },
+    });
+
+    expect(() =>
+      hyperWasmResolveTfheModuleVersion(
+        makeParameters({
+          clientModuleVersions: { tfhe: '1.6.1' },
+        }),
+        protocolContext,
+      ),
+    ).toThrow('Explicit tfhe WASM version "1.6.1" is not compatible');
+  });
+
+  it('throws by default when an explicit runtime kms module version is incompatible', () => {
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.12.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.5.4', comparator: 'eq' },
+    });
+
+    expect(() =>
+      hyperWasmResolveTkmsModuleVersion(
+        makeParameters({
+          runtimeModuleVersions: { kms: '0.13.20-0' },
+        }),
+        protocolContext,
+      ),
+    ).toThrow('Explicit kms WASM version "0.13.20-0" is not compatible');
+  });
+
+  it('allows compatible non-canonical explicit module versions', () => {
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.13.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.4.0-alpha.3', comparator: 'eq' },
+    });
+
+    expect(
+      hyperWasmResolveTfheModuleVersion(
+        makeParameters({
+          clientModuleVersions: { tfhe: '1.5.3' },
+        }),
+        protocolContext,
+      ),
+    ).toBe('1.5.3');
+  });
+
+  it('honors warn and off explicit module-version compatibility modes', () => {
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.12.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.5.4', comparator: 'eq' },
+    });
+    const warn = vi.fn();
+    const logger = {
+      debug: vi.fn(),
+      warn,
+      error: vi.fn(),
+    };
+
+    expect(
+      hyperWasmResolveTfheModuleVersion(
+        makeParameters({
+          clientModuleVersions: { tfhe: '1.6.1', checkCompatibility: 'warn' },
+          logger,
+        }),
+        protocolContext,
+      ),
+    ).toBe('1.6.1');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Explicit tfhe WASM version "1.6.1"'));
+
+    expect(
+      hyperWasmResolveTfheModuleVersion(
+        makeParameters({
+          clientModuleVersions: { tfhe: '1.6.1', checkCompatibility: 'off' },
+          logger,
+        }),
+        protocolContext,
+      ),
+    ).toBe('1.6.1');
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps WASM compatibility rules partitioned for supported protocol contexts', () => {
+    const parameters = makeParameters({});
+
+    const unambiguousCases = [
+      {
+        protocolContext: makeProtocolContext({
+          protocolVersion: { version: '0.12.0', comparator: 'eq' },
+          pubKeyCrsVersion: { version: '1.5.4', comparator: 'eq' },
+        }),
+        tfhe: '1.5.3',
+        kms: '0.13.10',
+      },
+      {
+        protocolContext: makeProtocolContext({
+          protocolVersion: { version: '0.13.0', comparator: 'lt' },
+          pubKeyCrsVersion: { version: '1.6.0', comparator: 'lt' },
+        }),
+        tfhe: '1.5.3',
+        kms: '0.13.10',
+      },
+      {
+        protocolContext: makeProtocolContext({
+          protocolVersion: { version: '0.13.0', comparator: 'eq' },
+          pubKeyCrsVersion: { version: '1.4.0-alpha.3', comparator: 'eq' },
+        }),
+        tfhe: '1.6.1',
+        kms: '0.13.20-0',
+      },
+      {
+        protocolContext: makeProtocolContext({
+          protocolVersion: { version: '0.13.0', comparator: 'eq' },
+          pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+        }),
+        tfhe: '1.6.1',
+        kms: '0.13.20-0',
+      },
+      {
+        protocolContext: makeProtocolContext({
+          protocolVersion: { version: '0.13.0', comparator: 'gt' },
+          pubKeyCrsVersion: { version: '1.6.1', comparator: 'gt' },
+        }),
+        tfhe: '1.6.1',
+        kms: '0.13.20-0',
+      },
+    ] as const satisfies ReadonlyArray<{
+      readonly protocolContext: FhevmProtocolContext;
+      readonly tfhe: ReturnType<typeof hyperWasmResolveTfheModuleVersion>;
+      readonly kms: ReturnType<typeof hyperWasmResolveTkmsModuleVersion>;
+    }>;
+
+    for (const { protocolContext, tfhe, kms } of unambiguousCases) {
+      expect(hyperWasmResolveTfheModuleVersion(parameters, protocolContext)).toBe(tfhe);
+      expect(hyperWasmResolveTkmsModuleVersion(parameters, protocolContext)).toBe(kms);
+    }
+
+    const ambiguousCases = [
+      makeProtocolContext({
+        protocolVersion: { version: '0.12.0', comparator: 'gt' },
+        pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+      }),
+      makeProtocolContext({
+        protocolVersion: { version: '0.14.0', comparator: 'lt' },
+        pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+      }),
+      makeProtocolContext({
+        protocolVersion: { version: '0.13.0', comparator: 'eq' },
+        pubKeyCrsVersion: { version: '1.6.1', comparator: 'lt' },
+      }),
+    ] as const satisfies readonly FhevmProtocolContext[];
+
+    for (const protocolContext of ambiguousCases) {
+      expect(() => hyperWasmResolveTfheModuleVersion(parameters, protocolContext)).toThrow(
+        'Cannot auto-resolve tfhe WASM version from protocol context',
+      );
+      expect(() => hyperWasmResolveTkmsModuleVersion(parameters, protocolContext)).toThrow(
+        'Cannot auto-resolve kms WASM version from protocol context',
+      );
+    }
+  });
+
+  it('auto-resolves WASM versions for every exact protocol context emitted by the protocol resolver', () => {
+    const parameters = makeParameters({});
+    const localstackLikeChain = makeChain('http://localhost:3000');
+
+    for (const { acl, tfhe, kms } of KNOWN_EXACT_ACL_WASM_CASES) {
+      const protocolContext = protocolContextFromAclVersion(
+        localstackLikeChain,
+        makeAclVersion(acl[0], acl[1], acl[2]),
+      );
+
+      expect(protocolContext.protocolVersion.comparator).toBe('eq');
+      expect(protocolContext.pubKeyCrsVersion.comparator).toBe('eq');
+      expect(hyperWasmResolveTfheModuleVersion(parameters, protocolContext)).toBe(tfhe);
+      expect(hyperWasmResolveTkmsModuleVersion(parameters, protocolContext)).toBe(kms);
+    }
+  });
+
+  it('maps protocol versions before 0.13.0 to legacy WASM versions', () => {
+    const parameters = makeParameters({});
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.12.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.5.4', comparator: 'eq' },
+    });
+
+    expect(hyperWasmResolveTfheModuleVersion(parameters, protocolContext)).toBe('1.5.3');
+    expect(hyperWasmResolveTkmsModuleVersion(parameters, protocolContext)).toBe('0.13.10');
+  });
+
+  it('maps protocol versions from 0.13.0 with current PubKey/CRS to current WASM versions', () => {
+    const parameters = makeParameters({});
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.13.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+    });
+
+    expect(hyperWasmResolveTfheModuleVersion(parameters, protocolContext)).toBe('1.6.1');
+    expect(hyperWasmResolveTkmsModuleVersion(parameters, protocolContext)).toBe('0.13.20-0');
+  });
+
+  it('maps protocol versions from 0.13.0 with legacy PubKey/CRS to current canonical WASM versions', () => {
+    const parameters = makeParameters({});
+    const protocolContext = makeProtocolContext({
+      protocolVersion: { version: '0.13.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.4.0-alpha.3', comparator: 'eq' },
+    });
+
+    expect(hyperWasmResolveTfheModuleVersion(parameters, protocolContext)).toBe('1.6.1');
+    expect(hyperWasmResolveTkmsModuleVersion(parameters, protocolContext)).toBe('0.13.20-0');
+  });
+
+  it('uses bounded protocol-context comparators when they are enough to select WASM versions', () => {
+    const parameters = makeParameters({});
+
+    const newerContext = makeProtocolContext({
+      protocolVersion: { version: '0.14.0', comparator: 'gt' },
+      pubKeyCrsVersion: { version: '1.6.1', comparator: 'gt' },
+    });
+    expect(hyperWasmResolveTfheModuleVersion(parameters, newerContext)).toBe('1.6.1');
+    expect(hyperWasmResolveTkmsModuleVersion(parameters, newerContext)).toBe('0.13.20-0');
+
+    const olderContext = makeProtocolContext({
+      protocolVersion: { version: '0.11.0', comparator: 'lt' },
+      pubKeyCrsVersion: { version: '1.6.0', comparator: 'lt' },
+    });
+    expect(hyperWasmResolveTfheModuleVersion(parameters, olderContext)).toBe('1.5.3');
+    expect(hyperWasmResolveTkmsModuleVersion(parameters, olderContext)).toBe('0.13.10');
+
+    const beforeSwitchContext = makeProtocolContext({
+      protocolVersion: { version: '0.13.0', comparator: 'lt' },
+      pubKeyCrsVersion: { version: '1.6.0', comparator: 'lt' },
+    });
+    expect(hyperWasmResolveTfheModuleVersion(parameters, beforeSwitchContext)).toBe('1.5.3');
+    expect(hyperWasmResolveTkmsModuleVersion(parameters, beforeSwitchContext)).toBe('0.13.10');
+  });
+
+  it('throws when bounded protocol context comparators leave WASM auto-resolution ambiguous', () => {
+    const parameters = makeParameters({});
+
+    expect(() =>
+      hyperWasmResolveTfheModuleVersion(
+        parameters,
+        makeProtocolContext({
+          protocolVersion: { version: '0.12.0', comparator: 'gt' },
+          pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+        }),
+      ),
+    ).toThrow('Cannot auto-resolve tfhe WASM version from protocol context');
+    expect(() =>
+      hyperWasmResolveTkmsModuleVersion(
+        parameters,
+        makeProtocolContext({
+          protocolVersion: { version: '0.14.0', comparator: 'lt' },
+          pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+        }),
+      ),
+    ).toThrow('Cannot auto-resolve kms WASM version from protocol context');
+    expect(() =>
+      hyperWasmResolveTfheModuleVersion(
+        parameters,
+        makeProtocolContext({
+          protocolVersion: { version: '0.13.0', comparator: 'eq' },
+          pubKeyCrsVersion: { version: '1.6.1', comparator: 'lt' },
+        }),
+      ),
+    ).toThrow('Cannot auto-resolve tfhe WASM version from protocol context protocol=eq:0.13.0, pubKeyCrs=lt:1.6.1.');
   });
 });

--- a/sdk/js-sdk/src/core/runtime/HyperWasmSolver-p.ts
+++ b/sdk/js-sdk/src/core/runtime/HyperWasmSolver-p.ts
@@ -1,93 +1,417 @@
-import type { TfheVersion, TkmsVersion } from '../types/moduleVersions.js';
+import type { ModuleVersionCompatibilityCheck, TfheVersion, TkmsVersion } from '../types/moduleVersions.js';
 import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
-import type { FhevmChain } from '../types/fhevmChain.js';
-import type { HostContractVersion } from '../types/hostContract.js';
-import type { NativeClient, OptionalNativeClient, ResolvedFhevmOptions } from '../types/coreFhevmClient.js';
-import { asAddress, addressToChecksummedAddress } from '../base/address.js';
-import {
-  assertIsHostContractVersionOf,
-  getVersion,
-  isVersionStrictlyBefore,
-} from '../host-contracts/HostContractVersion-p.js';
+import type { FhevmProtocolContext, ResolvedFhevmOptions, VersionResolution } from '../types/coreFhevmClient.js';
+import type { SemverRange } from '../base/semver.js';
+import type { Logger } from '../types/logger.js';
+import { semverComparatorImpliesRange } from '../base/semver.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
 type ResolveParameters = {
   readonly runtime: FhevmRuntime;
-  readonly chain: FhevmChain;
-  readonly client?: OptionalNativeClient;
   readonly options: ResolvedFhevmOptions;
 };
 
+type WasmModuleVersionByKey = {
+  readonly tfhe: TfheVersion;
+  readonly kms: TkmsVersion;
+};
+
+type WasmModuleKey = keyof WasmModuleVersionByKey;
+
+type WasmModuleVersion<K extends WasmModuleKey> = WasmModuleVersionByKey[K];
+
+type WasmCompatibilityRule = {
+  readonly protocol: SemverRange;
+  readonly pubKeyCrs: SemverRange;
+  readonly tfhe: {
+    readonly canonical: TfheVersion;
+    readonly compatible: readonly [TfheVersion, ...TfheVersion[]];
+  };
+  readonly kms: {
+    readonly canonical: TkmsVersion;
+    readonly compatible: readonly [TkmsVersion, ...TkmsVersion[]];
+  };
+};
+
+type HyperWasmSolverConfig = {
+  readonly compatibilityRules: readonly WasmCompatibilityRule[];
+};
+
+type ResolveWasmCompatibilityRuleOptions<ExplicitVersion extends string = TfheVersion | TkmsVersion> =
+  | {
+      readonly purpose: 'auto';
+    }
+  | {
+      readonly purpose: 'explicit';
+      readonly explicitVersion: ExplicitVersion;
+      readonly checkCompatibility: ModuleVersionCompatibilityCheck | undefined;
+    };
+
+type ExplicitResolveWasmCompatibilityRuleOptions<ExplicitVersion extends string = TfheVersion | TkmsVersion> = Extract<
+  ResolveWasmCompatibilityRuleOptions<ExplicitVersion>,
+  { readonly purpose: 'explicit' }
+>;
+
+const HYPER_WASM_SOLVER_CONFIG = {
+  /**
+   * Protocol-context to WASM-version compatibility mapping.
+   *
+   * Warning: auto-resolution requires exactly one rule to be implied by the
+   * resolved protocol and PubKey/CRS-version comparators. The table does not
+   * need to be sorted, but its ranges must be mutually exclusive for every
+   * supported protocol context; overlapping implied ranges and missing ranges
+   * both make auto-resolution ambiguous and throw.
+   *
+   * `canonical` is the version selected by auto-resolution. `compatible` is the
+   * full allowlist for explicit module-version compatibility checks.
+   */
+  compatibilityRules: [
+    {
+      // protocol.version <= 0.12.x
+      protocol: { version: '0.13.0', comparator: 'lt' },
+      // pubKeyCrs.version <= 1.5.x (ex: mainnet 1.4.0-alpha.3)
+      pubKeyCrs: { version: '1.6.0', comparator: 'lt' },
+      tfhe: {
+        canonical: '1.5.3',
+        compatible: ['1.5.3'],
+      },
+      kms: {
+        canonical: '0.13.10',
+        compatible: ['0.13.10'],
+      },
+    },
+    {
+      // protocol.version >= 0.13.0
+      protocol: { version: '0.13.0', comparator: 'ge' },
+      // pubKeyCrs.version <= 1.5.x (ex: mainnet 1.4.0-alpha.3)
+      pubKeyCrs: { version: '1.6.0', comparator: 'lt' },
+      tfhe: {
+        canonical: '1.6.1',
+        compatible: ['1.5.3', '1.6.1'],
+      },
+      kms: {
+        canonical: '0.13.20-0',
+        compatible: ['0.13.10', '0.13.20-0'],
+      },
+    },
+    {
+      // protocol.version >= 0.13.0
+      protocol: { version: '0.13.0', comparator: 'ge' },
+      // pubKeyCrs.version >= 1.6.0 (ex: localstack_v13)
+      pubKeyCrs: { version: '1.6.0', comparator: 'ge' },
+      tfhe: {
+        canonical: '1.6.1',
+        compatible: ['1.6.1'],
+      },
+      kms: {
+        canonical: '0.13.20-0',
+        compatible: ['0.13.10', '0.13.20-0'],
+      },
+    },
+  ],
+} as const satisfies HyperWasmSolverConfig;
+
+const WASM_COMPATIBILITY_RULES = HYPER_WASM_SOLVER_CONFIG.compatibilityRules;
+
 ////////////////////////////////////////////////////////////////////////////////
 
-export async function hyperWasmResolveTfheModuleVersion(parameters: ResolveParameters): Promise<TfheVersion> {
+/**
+ * Resolves the tfhe WASM module version to load for an encryption-capable client.
+ *
+ * Resolution order:
+ *
+ * 1. Client option `moduleVersions: 'auto'` forces protocol-based auto-resolution
+ *    and deliberately ignores the runtime fallback.
+ * 2. Client option `moduleVersions.tfhe` wins over every fallback, then is
+ *    checked against the protocol-context compatibility allowlist.
+ * 3. Runtime config `moduleVersions.tfhe` is used as a global fallback, then is
+ *    checked against the protocol-context compatibility allowlist.
+ * 4. Otherwise, the SDK auto-resolves from the resolved protocol version.
+ *
+ * `checkCompatibility` only applies to explicit `tfhe` overrides. It does not
+ * change auto-resolution.
+ *
+ * Examples:
+ *
+ * - Client override:
+ *   `{ options.moduleVersions: { tfhe: '1.6.1' } }` -> `'1.6.1'`.
+ * - Runtime fallback:
+ *   `{ options.moduleVersions: undefined, runtime.config.moduleVersions: { tfhe: '1.5.3' } }` -> `'1.5.3'`.
+ * - Client auto bypassing runtime fallback:
+ *   `{ options.moduleVersions: 'auto', runtime.config.moduleVersions: { tfhe: '1.5.3' } }`
+ *   resolves from `protocolContext`, not from `'1.5.3'`.
+ * - Protocol-context auto-resolution:
+ *   `protocolVersion = eq:0.12.0, pubKeyCrsVersion = eq:1.5.4` -> `'1.5.3'`.
+ *   `protocolVersion = eq:0.13.0, pubKeyCrsVersion = eq:1.4.0-alpha.3` -> `'1.6.1'`.
+ *   `protocolVersion = eq:0.13.0, pubKeyCrsVersion = eq:1.6.1` -> `'1.6.1'`.
+ */
+export function hyperWasmResolveTfheModuleVersion(
+  parameters: ResolveParameters,
+  protocolContext?: FhevmProtocolContext,
+): TfheVersion {
+  const resolveRuleOptions = _resolveWasmCompatibilityRuleOptions(parameters, 'tfhe');
+
+  const rule = _resolveWasmCompatibilityRule(protocolContext, 'tfhe', resolveRuleOptions);
+
+  if (resolveRuleOptions.purpose === 'explicit') {
+    _handleModuleVersionCompatibilityIssue(
+      'tfhe',
+      parameters.runtime.config.logger,
+      protocolContext,
+      rule,
+      resolveRuleOptions,
+    );
+    return resolveRuleOptions.explicitVersion;
+  }
+
+  if (rule === undefined) {
+    throw new Error('Cannot auto-resolve tfhe WASM version without a resolved compatibility rule.');
+  }
+
+  return rule.tfhe.canonical;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Resolves the tkms WASM module version to load for a decryption-capable client.
+ *
+ * Resolution order:
+ *
+ * 1. Client option `moduleVersions: 'auto'` forces protocol-based auto-resolution
+ *    and deliberately ignores the runtime fallback.
+ * 2. Client option `moduleVersions.kms` wins over every fallback, then is
+ *    checked against the protocol-context compatibility allowlist.
+ * 3. Runtime config `moduleVersions.kms` is used as a global fallback, then is
+ *    checked against the protocol-context compatibility allowlist.
+ * 4. Otherwise, the SDK auto-resolves from the resolved protocol version.
+ *
+ * `checkCompatibility` only applies to explicit `kms` overrides. It does not
+ * change auto-resolution.
+ *
+ * Examples:
+ *
+ * - Client override:
+ *   `{ options.moduleVersions: { kms: '0.13.20-0' } }` -> `'0.13.20-0'`.
+ * - Runtime fallback:
+ *   `{ options.moduleVersions: undefined, runtime.config.moduleVersions: { kms: '0.13.10' } }` -> `'0.13.10'`.
+ * - Client auto bypassing runtime fallback:
+ *   `{ options.moduleVersions: 'auto', runtime.config.moduleVersions: { kms: '0.13.10' } }`
+ *   resolves from `protocolContext`, not from `'0.13.10'`.
+ * - Protocol-context auto-resolution:
+ *   `protocolVersion = eq:0.12.0, pubKeyCrsVersion = eq:1.5.4` -> `'0.13.10'`.
+ *   `protocolVersion = eq:0.13.0, pubKeyCrsVersion = eq:1.4.0-alpha.3` -> `'0.13.20-0'`.
+ *   `protocolVersion = eq:0.13.0, pubKeyCrsVersion = eq:1.6.1` -> `'0.13.20-0'`.
+ */
+export function hyperWasmResolveTkmsModuleVersion(
+  parameters: ResolveParameters,
+  protocolContext?: FhevmProtocolContext,
+): TkmsVersion {
+  const resolveRuleOptions = _resolveWasmCompatibilityRuleOptions(parameters, 'kms');
+
+  const rule = _resolveWasmCompatibilityRule(protocolContext, 'kms', resolveRuleOptions);
+
+  if (resolveRuleOptions.purpose === 'explicit') {
+    _handleModuleVersionCompatibilityIssue(
+      'kms',
+      parameters.runtime.config.logger,
+      protocolContext,
+      rule,
+      resolveRuleOptions,
+    );
+    return resolveRuleOptions.explicitVersion;
+  }
+
+  if (rule === undefined) {
+    throw new Error('Cannot auto-resolve kms WASM version without a resolved compatibility rule.');
+  }
+
+  return rule.kms.canonical;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Helpers
+//
+////////////////////////////////////////////////////////////////////////////////
+
+function _resolveWasmCompatibilityRuleOptions<K extends WasmModuleKey>(
+  parameters: ResolveParameters,
+  moduleKey: K,
+): ResolveWasmCompatibilityRuleOptions<WasmModuleVersion<K>> {
   const clientVersions = parameters.options.moduleVersions;
-  if (clientVersions === 'auto') {
-    return _autoResolveTfheModuleVersion(parameters);
+  if (clientVersions !== 'auto') {
+    if (clientVersions?.[moduleKey] !== undefined) {
+      return {
+        purpose: 'explicit',
+        explicitVersion: clientVersions[moduleKey] as WasmModuleVersion<K>,
+        checkCompatibility: clientVersions.checkCompatibility,
+      };
+    }
+
+    const runtimeVersions = parameters.runtime.config.moduleVersions;
+    if (runtimeVersions !== 'auto' && runtimeVersions?.[moduleKey] !== undefined) {
+      return {
+        purpose: 'explicit',
+        explicitVersion: runtimeVersions[moduleKey] as WasmModuleVersion<K>,
+        checkCompatibility: runtimeVersions.checkCompatibility,
+      };
+    }
   }
 
-  if (clientVersions?.tfhe !== undefined) {
-    return clientVersions.tfhe;
-  }
-
-  const runtimeVersions = parameters.runtime.config.moduleVersions;
-  if (runtimeVersions !== 'auto' && runtimeVersions?.tfhe !== undefined) {
-    return runtimeVersions.tfhe;
-  }
-
-  return _autoResolveTfheModuleVersion(parameters);
+  return { purpose: 'auto' };
 }
 
-async function _autoResolveTfheModuleVersion(parameters: ResolveParameters): Promise<TfheVersion> {
-  const aclVersion = await _resolveAclVersion(parameters, 'TFHE');
-  return isVersionStrictlyBefore(aclVersion, { major: 0, minor: 4 }) ? '1.5.3' : '1.6.1';
+function _resolveWasmCompatibilityRule(
+  protocolContext: FhevmProtocolContext | undefined,
+  moduleKey: WasmModuleKey,
+  options: ResolveWasmCompatibilityRuleOptions,
+): WasmCompatibilityRule | undefined {
+  if (options.purpose === 'explicit' && _resolveModuleVersionCompatibilityCheck(options.checkCompatibility) === 'off') {
+    return undefined;
+  }
+  if (protocolContext === undefined) {
+    if (options.purpose === 'auto') {
+      throw new Error(`Cannot auto-resolve ${moduleKey} WASM version without a resolved protocol context.`);
+    }
+    return undefined;
+  }
+
+  const rules = _findWasmCompatibilityRules(protocolContext);
+  const rule = rules[0];
+  if (rules.length === 1 && rule !== undefined) {
+    return rule;
+  }
+
+  const message = _ambiguousWasmCompatibilityRuleMessage(protocolContext, moduleKey, options.purpose);
+  if (options.purpose === 'auto') {
+    throw new Error(message);
+  }
+
+  return undefined;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-export async function hyperWasmResolveTkmsModuleVersion(parameters: ResolveParameters): Promise<TkmsVersion> {
-  const clientVersions = parameters.options.moduleVersions;
-  if (clientVersions === 'auto') {
-    return _autoResolveTkmsModuleVersion(parameters);
-  }
-
-  if (clientVersions?.kms !== undefined) {
-    return clientVersions.kms;
-  }
-
-  const runtimeVersions = parameters.runtime.config.moduleVersions;
-  if (runtimeVersions !== 'auto' && runtimeVersions?.kms !== undefined) {
-    return runtimeVersions.kms;
-  }
-
-  return _autoResolveTkmsModuleVersion(parameters);
+function _findWasmCompatibilityRules(protocolContext: FhevmProtocolContext): WasmCompatibilityRule[] {
+  return WASM_COMPATIBILITY_RULES.filter(
+    (entry) =>
+      _versionResolutionImpliesRange(protocolContext.protocolVersion, entry.protocol) &&
+      _versionResolutionImpliesRange(protocolContext.pubKeyCrsVersion, entry.pubKeyCrs),
+  );
 }
 
-async function _autoResolveTkmsModuleVersion(parameters: ResolveParameters): Promise<TkmsVersion> {
-  const aclVersion = await _resolveAclVersion(parameters, 'TKMS');
-  return isVersionStrictlyBefore(aclVersion, { major: 0, minor: 4 }) ? '0.13.10' : '0.13.20-0';
+function _versionResolutionImpliesRange(versionResolution: VersionResolution<string>, range: SemverRange): boolean {
+  return semverComparatorImpliesRange(versionResolution.version, versionResolution.comparator, range);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Shared ACL version probe. No caching layer here — `getVersion` already
-// caches results for 24h (see HostContractVersion-p.ts), and a `forceRefresh`
-// at that layer correctly invalidates downstream callers.
+function _resolveModuleVersionCompatibilityCheck(
+  checkCompatibility: ModuleVersionCompatibilityCheck | undefined,
+): ModuleVersionCompatibilityCheck {
+  return checkCompatibility ?? 'throw';
+}
 
-async function _resolveAclVersion(parameters: ResolveParameters, label: 'TFHE' | 'TKMS'): Promise<HostContractVersion> {
-  if (parameters.client === undefined) {
-    throw new Error(`Cannot auto-resolve ${label} WASM version without a native client.`);
+function _handleModuleVersionCompatibilityIssue(
+  moduleKey: WasmModuleKey,
+  logger: FhevmRuntime['config']['logger'],
+  protocolContext: FhevmProtocolContext | undefined,
+  rule: WasmCompatibilityRule | undefined,
+  options: ExplicitResolveWasmCompatibilityRuleOptions,
+): void {
+  if (_resolveModuleVersionCompatibilityCheck(options.checkCompatibility) === 'off' || protocolContext === undefined) {
+    return;
   }
 
-  // Identity preservation: `parameters` is a CoreFhevmImpl from the caller,
-  // and downstream `getVersion` -> `getTrustedClient` does an `instanceof
-  // CoreFhevmImpl` check. Don't build a new object — narrow the type instead.
-  const context = parameters as ResolveParameters & { readonly client: NativeClient };
+  if (rule === undefined) {
+    _handleModuleVersionCompatibilityPolicy(
+      options.checkCompatibility,
+      logger,
+      _ambiguousWasmCompatibilityRuleMessage(protocolContext, moduleKey, options.purpose),
+    );
+    return;
+  }
 
-  const aclAddress = addressToChecksummedAddress(asAddress(context.chain.fhevm.contracts.acl.address));
-  const aclVersion = await getVersion(context, { address: aclAddress });
+  const compatibleVersions = _getCompatibleModuleVersions(moduleKey, rule);
+  if (!compatibleVersions.includes(options.explicitVersion)) {
+    _handleModuleVersionCompatibilityPolicy(
+      options.checkCompatibility,
+      logger,
+      _incompatibleModuleVersionMessage(moduleKey, options.explicitVersion, compatibleVersions, protocolContext),
+    );
+  }
+}
 
-  assertIsHostContractVersionOf(aclVersion, 'ACL');
+function _handleModuleVersionCompatibilityPolicy(
+  checkCompatibility: ModuleVersionCompatibilityCheck | undefined,
+  logger: Logger | undefined,
+  message: string,
+): void {
+  const resolvedCheckCompatibility = _resolveModuleVersionCompatibilityCheck(checkCompatibility);
+  switch (resolvedCheckCompatibility) {
+    case 'throw':
+      throw new Error(message);
+    case 'warn':
+      if (logger?.warn !== undefined) {
+        logger.warn(message);
+      } else {
+        console.warn(message);
+      }
+      return;
+    case 'off':
+      return;
+    default: {
+      const exhaustiveCheck: never = resolvedCheckCompatibility;
+      throw new Error(`Unsupported module version compatibility check "${exhaustiveCheck}".`);
+    }
+  }
+}
 
-  return aclVersion;
+function _getCompatibleModuleVersions(moduleKey: WasmModuleKey, rule: WasmCompatibilityRule): readonly string[] {
+  switch (moduleKey) {
+    case 'tfhe':
+      return rule.tfhe.compatible;
+    case 'kms':
+      return rule.kms.compatible;
+    default: {
+      const exhaustiveCheck: never = moduleKey;
+      throw new Error(`Unsupported WASM module "${exhaustiveCheck}".`);
+    }
+  }
+}
+
+function _incompatibleModuleVersionMessage(
+  moduleKey: WasmModuleKey,
+  version: string,
+  compatibleVersions: readonly string[],
+  protocolContext: FhevmProtocolContext | undefined,
+): string {
+  const context =
+    protocolContext === undefined
+      ? 'without a resolved protocol context'
+      : `with protocol context protocol=${_formatVersionResolution(protocolContext.protocolVersion)}, ` +
+        `pubKeyCrs=${_formatVersionResolution(protocolContext.pubKeyCrsVersion)}`;
+
+  return (
+    `Explicit ${moduleKey} WASM version "${version}" is not compatible ${context}. ` +
+    `Compatible versions: ${compatibleVersions.join(', ')}.`
+  );
+}
+
+function _ambiguousWasmCompatibilityRuleMessage(
+  protocolContext: FhevmProtocolContext,
+  moduleKey: WasmModuleKey,
+  purpose: 'auto' | 'explicit',
+): string {
+  const action =
+    purpose === 'auto' ? `auto-resolve ${moduleKey} WASM version` : `check ${moduleKey} WASM version compatibility`;
+
+  return (
+    `Cannot ${action} from protocol context ` +
+    `protocol=${_formatVersionResolution(protocolContext.protocolVersion)}, ` +
+    `pubKeyCrs=${_formatVersionResolution(protocolContext.pubKeyCrsVersion)}. ` +
+    `The resolved context does not prove exactly one WASM compatibility rule.`
+  );
+}
+
+function _formatVersionResolution(versionResolution: VersionResolution<string>): string {
+  return `${versionResolution.comparator}:${versionResolution.version}`;
 }

--- a/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.test.ts
+++ b/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.test.ts
@@ -1,0 +1,203 @@
+import type { EthereumModule } from '../modules/ethereum/types.js';
+import type { RelayerModule } from '../modules/relayer/types.js';
+import type { HostContractVersion } from '../types/hostContract.js';
+import type { ChecksummedAddress, UintNumber } from '../types/primitives.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRIVATE_ETHERS_TOKEN } from '../../ethers/internal/ethers-p.js';
+import { sepolia } from '../chains/definitions/sepolia.js';
+import { baseActions } from '../clients/decorators/base.js';
+import { invalidateVersionCache } from '../host-contracts/HostContractVersion-p.js';
+import { createFhevmRuntime } from './CoreFhevmRuntime-p.js';
+import { createCoreFhevm, getResolvedProtocolVersion } from './CoreFhevm-p.js';
+import {
+  protocolContextFromAclVersion,
+  protocolVersionFromAclVersion,
+  pubKeyCrsVersionFromProtocolVersion,
+  resolveProtocolContext,
+  resolveProtocolVersion,
+} from './ProtocolVersionResolver-p.js';
+
+const ACL_ADDRESS = sepolia.fhevm.contracts.acl.address as ChecksummedAddress;
+const KNOWN_EXACT_ACL_PROTOCOL_CASES = [
+  { acl: [0, 2, 0], protocolVersion: '0.11.0', pubKeyCrsVersion: '1.5.1' },
+  { acl: [0, 3, 0], protocolVersion: '0.12.0', pubKeyCrsVersion: '1.5.4' },
+  { acl: [0, 4, 0], protocolVersion: '0.13.0', pubKeyCrsVersion: '1.6.1' },
+  { acl: [0, 5, 0], protocolVersion: '0.14.0', pubKeyCrsVersion: '1.6.1' },
+] as const;
+
+function makeClient(
+  readContract: EthereumModule['readContract'],
+): ReturnType<typeof createCoreFhevm<typeof sepolia, ReturnType<typeof createFhevmRuntime>, object>> {
+  const ethereum = {
+    readContract,
+  } as unknown as EthereumModule;
+
+  const runtime = createFhevmRuntime(PRIVATE_ETHERS_TOKEN, {
+    ethereum,
+    relayer: {} as RelayerModule,
+    config: {},
+  });
+
+  return createCoreFhevm(PRIVATE_ETHERS_TOKEN, {
+    chain: sepolia,
+    client: {},
+    runtime,
+  });
+}
+
+function makeAclVersion(major: number, minor: number, patch: number): HostContractVersion<'ACL'> {
+  return {
+    version: `ACL v${major}.${minor}.${patch}`,
+    contractName: 'ACL',
+    major: major as UintNumber,
+    minor: minor as UintNumber,
+    patch: patch as UintNumber,
+  };
+}
+
+function makeChain(relayerUrl: string): typeof sepolia {
+  return {
+    ...sepolia,
+    fhevm: {
+      ...sepolia.fhevm,
+      relayerUrl,
+    },
+  };
+}
+
+describe('ProtocolVersionResolver', () => {
+  beforeEach(() => {
+    invalidateVersionCache({ includeInflight: true });
+  });
+
+  it('maps ACL host-contract versions to protocol versions', () => {
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 2, 0))).toEqual({ version: '0.11.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 2, 1))).toEqual({ version: '0.11.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 3, 0))).toEqual({ version: '0.12.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 3, 1))).toEqual({ version: '0.12.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 4, 0))).toEqual({ version: '0.13.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 4, 1))).toEqual({ version: '0.13.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 5, 0))).toEqual({ version: '0.14.0', comparator: 'eq' });
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 5, 1))).toEqual({ version: '0.14.0', comparator: 'eq' });
+  });
+
+  it('uses the highest known protocol version as lower bound for unknown newer ACL versions', () => {
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 6, 0))).toEqual({ version: '0.14.0', comparator: 'gt' });
+  });
+
+  it('uses the lowest known protocol version as upper bound for unknown older ACL versions', () => {
+    expect(protocolVersionFromAclVersion(makeAclVersion(0, 1, 0))).toEqual({ version: '0.11.0', comparator: 'lt' });
+  });
+
+  it('maps ACL host-contract versions to protocol context', () => {
+    const localstackLikeChain = makeChain('http://localhost:3000');
+
+    expect(protocolContextFromAclVersion(localstackLikeChain, makeAclVersion(0, 1, 0))).toEqual({
+      protocolVersion: { version: '0.11.0', comparator: 'lt' },
+      pubKeyCrsVersion: { version: '1.5.1', comparator: 'lt' },
+    });
+    expect(protocolContextFromAclVersion(localstackLikeChain, makeAclVersion(0, 2, 0))).toEqual({
+      protocolVersion: { version: '0.11.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.5.1', comparator: 'eq' },
+    });
+    expect(protocolContextFromAclVersion(localstackLikeChain, makeAclVersion(0, 3, 0))).toEqual({
+      protocolVersion: { version: '0.12.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.5.4', comparator: 'eq' },
+    });
+    expect(protocolContextFromAclVersion(localstackLikeChain, makeAclVersion(0, 4, 0))).toEqual({
+      protocolVersion: { version: '0.13.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.6.1', comparator: 'eq' },
+    });
+    expect(protocolContextFromAclVersion(localstackLikeChain, makeAclVersion(0, 6, 0))).toEqual({
+      protocolVersion: { version: '0.14.0', comparator: 'gt' },
+      pubKeyCrsVersion: { version: '1.6.1', comparator: 'gt' },
+    });
+  });
+
+  it('keeps the current public-chain PubKey/CRS version override separate from protocol resolution', () => {
+    expect(protocolContextFromAclVersion(sepolia, makeAclVersion(0, 4, 0))).toEqual({
+      protocolVersion: { version: '0.13.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.4.0-alpha.3', comparator: 'eq' },
+    });
+  });
+
+  it('does not infer cleartext PubKey/CRS context from a localhost relayer URL', () => {
+    expect(
+      pubKeyCrsVersionFromProtocolVersion(makeChain('http://localhost:8545'), {
+        version: '0.13.0',
+        comparator: 'eq',
+      }),
+    ).toEqual({
+      version: '1.6.1',
+      comparator: 'eq',
+    });
+  });
+
+  it('keeps exact ACL protocol mappings covered by exact generated PubKey/CRS intervals', () => {
+    const localstackLikeChain = makeChain('http://localhost:3000');
+
+    for (const { acl, protocolVersion: expectedProtocolVersion, pubKeyCrsVersion } of KNOWN_EXACT_ACL_PROTOCOL_CASES) {
+      const aclVersion = makeAclVersion(acl[0], acl[1], acl[2]);
+      const protocolVersion = protocolVersionFromAclVersion(aclVersion);
+
+      expect(protocolVersion).toEqual({
+        version: expectedProtocolVersion,
+        comparator: 'eq',
+      });
+      expect(pubKeyCrsVersionFromProtocolVersion(localstackLikeChain, protocolVersion)).toEqual({
+        version: pubKeyCrsVersion,
+        comparator: 'eq',
+      });
+      expect(protocolContextFromAclVersion(localstackLikeChain, aclVersion)).toEqual({
+        protocolVersion: {
+          version: expectedProtocolVersion,
+          comparator: 'eq',
+        },
+        pubKeyCrsVersion: {
+          version: pubKeyCrsVersion,
+          comparator: 'eq',
+        },
+      });
+    }
+  });
+
+  it('resolves protocol version from the ACL host contract', async () => {
+    const readContract = vi.fn(() => Promise.resolve('ACL v0.4.0')) satisfies EthereumModule['readContract'];
+    const client = makeClient(readContract);
+
+    expect(getResolvedProtocolVersion(client)).toBeUndefined();
+
+    await expect(resolveProtocolVersion(client)).resolves.toEqual({ version: '0.13.0', comparator: 'eq' });
+
+    expect(getResolvedProtocolVersion(client)).toBeUndefined();
+    expect(readContract).toHaveBeenCalledWith(expect.anything(), {
+      address: ACL_ADDRESS,
+      abi: expect.any(Array) as unknown,
+      args: [],
+      functionName: 'getVersion',
+    });
+  });
+
+  it('resolves protocol context from the ACL host contract', async () => {
+    const readContract = vi.fn(() => Promise.resolve('ACL v0.4.0')) satisfies EthereumModule['readContract'];
+    const client = makeClient(readContract);
+
+    await expect(resolveProtocolContext(client)).resolves.toEqual({
+      protocolVersion: { version: '0.13.0', comparator: 'eq' },
+      pubKeyCrsVersion: { version: '1.4.0-alpha.3', comparator: 'eq' },
+    });
+  });
+
+  it('resolves protocol version during base client init', async () => {
+    const readContract = vi.fn(() => Promise.resolve('ACL v0.4.0')) satisfies EthereumModule['readContract'];
+    const client = makeClient(readContract).extend(baseActions);
+
+    expect(getResolvedProtocolVersion(client)).toBeUndefined();
+
+    await client.ready;
+
+    expect(client.protocolVersion).toEqual({ version: '0.13.0', comparator: 'eq' });
+    expect(getResolvedProtocolVersion(client)).toEqual({ version: '0.13.0', comparator: 'eq' });
+    expect(readContract).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.ts
+++ b/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.ts
@@ -216,10 +216,10 @@ export function protocolContextFromAclVersion(
  * known protocol version as the SDK's strict upper bound.
  *
  * Examples:
- * - `ACL v0.4.0` -> `{ version: '0.13.0', comparator: 'eq' }`
- * - `ACL v0.4.1` -> `{ version: '0.13.0', comparator: 'eq' }`
- * - `ACL v0.6.0` -> `{ version: '0.14.0', comparator: 'gt' }`
- * - `ACL v0.1.0` -> `{ version: '0.11.0', comparator: 'lt' }`
+ * - `ACL v0.4.0` → `{ version: '0.13.0', comparator: 'eq' }`
+ * - `ACL v0.4.1` → `{ version: '0.13.0', comparator: 'eq' }`
+ * - `ACL v0.6.0` → `{ version: '0.14.0', comparator: 'gt' }`
+ * - `ACL v0.1.0` → `{ version: '0.11.0', comparator: 'lt' }`
  */
 export function protocolVersionFromAclVersion(aclVersion: HostContractVersion<'ACL'>): ProtocolVersionResolution {
   const aclSemver = _formatAclVersion(aclVersion);

--- a/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.ts
+++ b/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.ts
@@ -1,0 +1,463 @@
+import type {
+  FhevmBase,
+  FhevmProtocolContext,
+  ProtocolVersion,
+  ProtocolVersionResolution,
+  PubKeyCrsVersion,
+  PubKeyCrsVersionResolution,
+} from '../types/coreFhevmClient.js';
+import type { FhevmChain } from '../types/fhevmChain.js';
+import type { HostContractVersion } from '../types/hostContract.js';
+import type { SemverInterval, SemverIntervalLowerBound, SemverIntervalUpperBound } from '../base/semver.js';
+import { asAddress, addressToChecksummedAddress } from '../base/address.js';
+import { compareSemver, isSemverInInterval, semverComparatorImpliesRange } from '../base/semver.js';
+import { mainnet } from '../chains/definitions/mainnet.js';
+import { sepolia } from '../chains/definitions/sepolia.js';
+import { assertIsHostContractVersionOf, getVersion } from '../host-contracts/HostContractVersion-p.js';
+
+////////////////////////////////////////////////////////////////////////////////
+
+export type ResolveProtocolVersionParameters = FhevmBase<FhevmChain>;
+export type ResolveProtocolContextParameters = ResolveProtocolVersionParameters;
+
+export async function resolveProtocolContext(
+  parameters: ResolveProtocolContextParameters,
+): Promise<FhevmProtocolContext> {
+  const aclAddress = addressToChecksummedAddress(asAddress(parameters.chain.fhevm.contracts.acl.address));
+  const aclVersion = await getVersion(parameters, { address: aclAddress });
+
+  assertIsHostContractVersionOf(aclVersion, 'ACL');
+
+  return protocolContextFromAclVersion(parameters.chain, aclVersion);
+}
+
+export async function resolveProtocolVersion(
+  parameters: ResolveProtocolVersionParameters,
+): Promise<ProtocolVersionResolution> {
+  return (await resolveProtocolContext(parameters)).protocolVersion;
+}
+
+type AclVersionInterval = SemverInterval & {
+  readonly lowerBound: SemverIntervalLowerBound & { readonly comparator: 'ge' };
+  readonly upperBound: SemverIntervalUpperBound & { readonly comparator: 'lt' };
+};
+
+type ProtocolVersionByAclVersionRule = {
+  readonly acl: AclVersionInterval;
+  readonly protocolVersion: ProtocolVersion;
+};
+
+type AclProtocolVersionTableEntry = {
+  readonly acl: SemverInterval;
+  readonly protocolVersion: ProtocolVersion;
+};
+
+type PubKeyCrsVersionByProtocolVersionRule = {
+  readonly protocol: SemverInterval;
+  readonly pubKeyCrsVersion: PubKeyCrsVersion;
+};
+
+type PubKeyCrsVersionByRelayerUrlRule = {
+  readonly relayerUrl: string;
+  readonly pubKeyCrsVersion: PubKeyCrsVersion;
+};
+
+type ProtocolContextResolverConfig = {
+  readonly acl: {
+    readonly sortedProtocolByVersion: readonly ProtocolVersionByAclVersionRule[];
+  };
+  readonly pubKeyCrs: {
+    readonly knownByRelayerUrl: readonly PubKeyCrsVersionByRelayerUrlRule[];
+    readonly generatedByProtocolVersion: readonly PubKeyCrsVersionByProtocolVersionRule[];
+  };
+};
+
+const PROTOCOL_CONTEXT_RESOLVER_CONFIG = {
+  acl: {
+    /**
+     * Known ACL-version to protocol-version mapping.
+     *
+     * Warning: this table must stay sorted by ascending non-overlapping ACL
+     * intervals. Each rule must use a closed lower bound and an open upper
+     * bound, so the first rule also defines the oldest ACL version this SDK
+     * knows.
+     */
+    sortedProtocolByVersion: [
+      {
+        acl: {
+          lowerBound: { version: '0.2.0', comparator: 'ge' },
+          upperBound: { version: '0.3.0', comparator: 'lt' },
+        },
+        protocolVersion: '0.11.0',
+      },
+      {
+        acl: {
+          lowerBound: { version: '0.3.0', comparator: 'ge' },
+          upperBound: { version: '0.4.0', comparator: 'lt' },
+        },
+        protocolVersion: '0.12.0',
+      },
+      {
+        acl: {
+          lowerBound: { version: '0.4.0', comparator: 'ge' },
+          upperBound: { version: '0.5.0', comparator: 'lt' },
+        },
+        protocolVersion: '0.13.0',
+      },
+      {
+        acl: {
+          lowerBound: { version: '0.5.0', comparator: 'ge' },
+          upperBound: { version: '0.6.0', comparator: 'lt' },
+        },
+        protocolVersion: '0.14.0',
+      },
+    ],
+  },
+  pubKeyCrs: {
+    /**
+     * PubKey/CRS versions known to be served by specific relayers.
+     *
+     * This table is intentionally limited to stable, public relayer URLs. Local
+     * URLs are not mode signals: a localhost endpoint can run cleartext,
+     * localstack, or a custom setup.
+     *
+     * This is a snapshot of what those relayers serve when this SDK is
+     * released. After release, key rotation can change the PubKey version, and
+     * CRS removal can change the PubKey/CRS material this table describes.
+     *
+     * This override is not meant to exist forever. It is a compatibility bridge
+     * until the SDK can resolve the PubKey/CRS version from a robust source,
+     * such as a relayer response, a key endpoint, or an on-chain protocol
+     * configuration signal. A URL match below returns an exact resolution only
+     * because the SDK release knows what that relayer served at publication
+     * time; it does not prove that the relayer still serves the same key
+     * material after future key rotations, CRS removal, or protocol upgrades.
+     */
+    knownByRelayerUrl: [
+      {
+        relayerUrl: mainnet.fhevm.relayerUrl,
+        pubKeyCrsVersion: '1.4.0-alpha.3',
+      },
+      {
+        relayerUrl: sepolia.fhevm.relayerUrl,
+        pubKeyCrsVersion: '1.4.0-alpha.3',
+      },
+      {
+        relayerUrl: 'https://relayer.dev.zama.cloud',
+        pubKeyCrsVersion: '1.4.0-alpha.3',
+      },
+    ],
+    /**
+     * PubKey/CRS version produced when new key material is generated for a
+     * protocol line.
+     *
+     * This is not a chain override. It answers: "if the KMS generated fresh
+     * PubKey/CRS material for this protocol, which serialized format would it
+     * produce?"
+     *
+     * Warning: these intervals must describe known protocol lines without
+     * overlaps. Unknown older/newer protocol bounds intentionally fall back to
+     * bounded PubKey/CRS resolutions instead of being treated as exact.
+     */
+    generatedByProtocolVersion: [
+      {
+        protocol: {
+          lowerBound: { version: '0.11.0', comparator: 'ge' },
+          upperBound: { version: '0.12.0', comparator: 'lt' },
+        },
+        pubKeyCrsVersion: '1.5.1',
+      },
+      {
+        protocol: {
+          lowerBound: { version: '0.12.0', comparator: 'ge' },
+          upperBound: { version: '0.13.0', comparator: 'lt' },
+        },
+        pubKeyCrsVersion: '1.5.4',
+      },
+      {
+        protocol: {
+          lowerBound: { version: '0.13.0', comparator: 'ge' },
+          upperBound: { version: '0.14.0', comparator: 'le' },
+        },
+        pubKeyCrsVersion: '1.6.1',
+      },
+    ],
+  },
+} as const satisfies ProtocolContextResolverConfig;
+
+const SORTED_PROTOCOL_VERSION_BY_ACL_VERSION = PROTOCOL_CONTEXT_RESOLVER_CONFIG.acl.sortedProtocolByVersion;
+_assertSortedContiguousAclProtocolTable(SORTED_PROTOCOL_VERSION_BY_ACL_VERSION);
+
+const GENERATED_PUB_KEY_CRS_VERSION_BY_PROTOCOL_VERSION =
+  PROTOCOL_CONTEXT_RESOLVER_CONFIG.pubKeyCrs.generatedByProtocolVersion;
+_assertSortedContiguousGeneratedPubKeyCrsProtocolTable(GENERATED_PUB_KEY_CRS_VERSION_BY_PROTOCOL_VERSION);
+
+export function protocolContextFromAclVersion(
+  chain: FhevmChain,
+  aclVersion: HostContractVersion<'ACL'>,
+): FhevmProtocolContext {
+  const protocolVersion = protocolVersionFromAclVersion(aclVersion);
+  return Object.freeze({
+    protocolVersion,
+    pubKeyCrsVersion: pubKeyCrsVersionFromProtocolVersion(chain, protocolVersion),
+  });
+}
+
+/**
+ * Maps an ACL host-contract version to a protocol-version resolution known by
+ * this SDK release.
+ *
+ * This function is intentionally table-driven: it must not infer future
+ * protocol versions from ACL version arithmetic. If the ACL version is newer
+ * than the SDK's table, it returns `{ comparator: 'gt' }` with the highest
+ * known protocol version as the SDK's strict lower bound: the exact protocol
+ * version is unknown, but it is greater than that value. If the ACL version is
+ * older than the SDK's table, it returns `{ comparator: 'lt' }` with the lowest
+ * known protocol version as the SDK's strict upper bound.
+ *
+ * Examples:
+ * - `ACL v0.4.0` -> `{ version: '0.13.0', comparator: 'eq' }`
+ * - `ACL v0.4.1` -> `{ version: '0.13.0', comparator: 'eq' }`
+ * - `ACL v0.6.0` -> `{ version: '0.14.0', comparator: 'gt' }`
+ * - `ACL v0.1.0` -> `{ version: '0.11.0', comparator: 'lt' }`
+ */
+export function protocolVersionFromAclVersion(aclVersion: HostContractVersion<'ACL'>): ProtocolVersionResolution {
+  const aclSemver = _formatAclVersion(aclVersion);
+
+  const known = SORTED_PROTOCOL_VERSION_BY_ACL_VERSION.find((entry) => isSemverInInterval(aclSemver, entry.acl));
+  if (known !== undefined) {
+    return Object.freeze({ version: known.protocolVersion, comparator: 'eq' });
+  }
+
+  const oldestKnownProtocol = _getOldestKnownProtocolVersion();
+  if (_isSemverBeforeLowerBound(aclSemver, oldestKnownProtocol.acl.lowerBound)) {
+    // The ACL is older than the first interval, so the actual protocol is
+    // strictly lower than the oldest protocol this SDK knows.
+    return Object.freeze({ version: oldestKnownProtocol.protocolVersion, comparator: 'lt' });
+  }
+
+  const newestKnownProtocol = _getNewestKnownProtocolVersion();
+  if (_isSemverAfterUpperBound(aclSemver, newestKnownProtocol.acl.upperBound)) {
+    // The ACL is newer than the last interval, so the actual protocol is
+    // strictly greater than the newest protocol this SDK knows.
+    return Object.freeze({ version: newestKnownProtocol.protocolVersion, comparator: 'gt' });
+  }
+
+  throw new Error(
+    `Cannot resolve protocol version from ACL version ${aclSemver}: the ACL compatibility table has a gap.`,
+  );
+}
+
+function _getOldestKnownProtocolVersion(): (typeof SORTED_PROTOCOL_VERSION_BY_ACL_VERSION)[number] {
+  return _getFirstConfiguredEntry(SORTED_PROTOCOL_VERSION_BY_ACL_VERSION, 'No known ACL protocol versions configured.');
+}
+
+function _getNewestKnownProtocolVersion(): (typeof SORTED_PROTOCOL_VERSION_BY_ACL_VERSION)[number] {
+  return _getLastConfiguredEntry(SORTED_PROTOCOL_VERSION_BY_ACL_VERSION, 'No known ACL protocol versions configured.');
+}
+
+function _formatAclVersion(version: {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function _assertSortedContiguousAclProtocolTable(entries: readonly AclProtocolVersionTableEntry[]): void {
+  if (entries.length === 0) {
+    throw new Error('No known ACL protocol versions configured.');
+  }
+
+  let previousUpperBound: SemverIntervalUpperBound | undefined;
+  let previousProtocolVersion: ProtocolVersion | undefined;
+
+  for (const [index, entry] of entries.entries()) {
+    const lowerBound = entry.acl.lowerBound;
+    const upperBound = entry.acl.upperBound;
+
+    if (lowerBound === undefined || upperBound === undefined) {
+      throw new Error(`ACL protocol rule at index ${index} must define both lower and upper bounds.`);
+    }
+    if (lowerBound.comparator !== 'ge' || upperBound.comparator !== 'lt') {
+      throw new Error(`ACL protocol rule at index ${index} must use a [lower, upper) interval.`);
+    }
+    if (compareSemver(lowerBound.version, upperBound.version) >= 0) {
+      throw new Error(`ACL protocol rule at index ${index} has an invalid interval.`);
+    }
+    if (previousUpperBound !== undefined && compareSemver(previousUpperBound.version, lowerBound.version) !== 0) {
+      throw new Error(`ACL protocol rules must be contiguous at index ${index}.`);
+    }
+    if (previousProtocolVersion !== undefined && compareSemver(previousProtocolVersion, entry.protocolVersion) >= 0) {
+      throw new Error(`ACL protocol versions must be strictly ascending at index ${index}.`);
+    }
+
+    previousUpperBound = upperBound;
+    previousProtocolVersion = entry.protocolVersion;
+  }
+}
+
+function _assertSortedContiguousGeneratedPubKeyCrsProtocolTable(
+  entries: readonly PubKeyCrsVersionByProtocolVersionRule[],
+): void {
+  if (entries.length === 0) {
+    throw new Error('No known generated PubKey/CRS versions configured.');
+  }
+
+  let previousUpperBound: SemverIntervalUpperBound | undefined;
+  let previousPubKeyCrsVersion: PubKeyCrsVersion | undefined;
+
+  for (const [index, entry] of entries.entries()) {
+    const lowerBound = entry.protocol.lowerBound;
+    const upperBound = entry.protocol.upperBound;
+    const isLastEntry = index === entries.length - 1;
+
+    if (lowerBound === undefined || upperBound === undefined) {
+      throw new Error(`Generated PubKey/CRS protocol rule at index ${index} must define both lower and upper bounds.`);
+    }
+    if (lowerBound.comparator !== 'ge') {
+      throw new Error(`Generated PubKey/CRS protocol rule at index ${index} must use a closed lower bound.`);
+    }
+    if (!isLastEntry && upperBound.comparator !== 'lt') {
+      throw new Error(
+        `Generated PubKey/CRS protocol rule at index ${index} must use an open upper bound, except the final rule may use a closed upper bound.`,
+      );
+    }
+    if (compareSemver(lowerBound.version, upperBound.version) >= 0) {
+      throw new Error(`Generated PubKey/CRS protocol rule at index ${index} has an invalid interval.`);
+    }
+    if (previousUpperBound !== undefined && compareSemver(previousUpperBound.version, lowerBound.version) !== 0) {
+      throw new Error(`Generated PubKey/CRS protocol rules must be contiguous at index ${index}.`);
+    }
+    // The bounded fallback treats the first/last entries as the oldest/newest
+    // PubKey/CRS versions, so the values must increase with the protocol line.
+    if (
+      previousPubKeyCrsVersion !== undefined &&
+      compareSemver(previousPubKeyCrsVersion, entry.pubKeyCrsVersion) >= 0
+    ) {
+      throw new Error(`Generated PubKey/CRS versions must be strictly ascending at index ${index}.`);
+    }
+
+    previousUpperBound = upperBound;
+    previousPubKeyCrsVersion = entry.pubKeyCrsVersion;
+  }
+}
+
+function _isSemverBeforeLowerBound(version: string, lowerBound: SemverIntervalLowerBound): boolean {
+  const comparison = compareSemver(version, lowerBound.version);
+  return lowerBound.comparator === 'ge' ? comparison < 0 : comparison <= 0;
+}
+
+function _isSemverAfterUpperBound(version: string, upperBound: SemverIntervalUpperBound): boolean {
+  const comparison = compareSemver(version, upperBound.version);
+  return upperBound.comparator === 'lt' ? comparison >= 0 : comparison > 0;
+}
+
+export function pubKeyCrsVersionFromProtocolVersion(
+  chain: FhevmChain,
+  protocolVersion: ProtocolVersionResolution,
+): PubKeyCrsVersionResolution {
+  const relayerUrl = _normalizeRelayerUrl(chain.fhevm.relayerUrl);
+  const knownByRelayerUrl = PROTOCOL_CONTEXT_RESOLVER_CONFIG.pubKeyCrs.knownByRelayerUrl.find(
+    (entry) => _normalizeRelayerUrl(entry.relayerUrl) === relayerUrl,
+  );
+  if (knownByRelayerUrl !== undefined) {
+    return _actualPubKeyCrsEquals(knownByRelayerUrl.pubKeyCrsVersion);
+  }
+
+  const known = GENERATED_PUB_KEY_CRS_VERSION_BY_PROTOCOL_VERSION.filter((entry) =>
+    _protocolVersionResolutionImpliesInterval(protocolVersion, entry.protocol),
+  );
+  const knownRule = known[0];
+  if (known.length === 1 && knownRule !== undefined) {
+    return _actualPubKeyCrsEquals(knownRule.pubKeyCrsVersion);
+  }
+  if (known.length > 1) {
+    throw new Error(
+      `Ambiguous generated PubKey/CRS version for protocol ${protocolVersion.comparator}:${protocolVersion.version}.`,
+    );
+  }
+
+  return _boundedPubKeyCrsVersionFromUnknownProtocolVersion(protocolVersion);
+}
+
+function _protocolVersionResolutionImpliesInterval(
+  protocolVersion: ProtocolVersionResolution,
+  interval: SemverInterval,
+): boolean {
+  if (
+    interval.lowerBound !== undefined &&
+    !semverComparatorImpliesRange(protocolVersion.version, protocolVersion.comparator, interval.lowerBound)
+  ) {
+    return false;
+  }
+  if (
+    interval.upperBound !== undefined &&
+    !semverComparatorImpliesRange(protocolVersion.version, protocolVersion.comparator, interval.upperBound)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function _boundedPubKeyCrsVersionFromUnknownProtocolVersion(
+  protocolVersion: ProtocolVersionResolution,
+): PubKeyCrsVersionResolution {
+  const oldestKnownProtocolVersion = _getOldestKnownProtocolVersion().protocolVersion;
+  const newestKnownProtocolVersion = _getNewestKnownProtocolVersion().protocolVersion;
+
+  if (protocolVersion.comparator === 'lt' && compareSemver(protocolVersion.version, oldestKnownProtocolVersion) <= 0) {
+    return Object.freeze({ version: _getOldestKnownPubKeyCrsVersion(), comparator: 'lt' });
+  }
+  if (protocolVersion.comparator === 'gt' && compareSemver(protocolVersion.version, newestKnownProtocolVersion) >= 0) {
+    return Object.freeze({ version: _getNewestKnownPubKeyCrsVersion(), comparator: 'gt' });
+  }
+  if (protocolVersion.comparator === 'eq' && compareSemver(protocolVersion.version, oldestKnownProtocolVersion) < 0) {
+    return Object.freeze({ version: _getOldestKnownPubKeyCrsVersion(), comparator: 'lt' });
+  }
+  if (protocolVersion.comparator === 'eq' && compareSemver(protocolVersion.version, newestKnownProtocolVersion) > 0) {
+    return Object.freeze({ version: _getNewestKnownPubKeyCrsVersion(), comparator: 'gt' });
+  }
+
+  throw new Error(
+    `Cannot resolve generated PubKey/CRS version from ambiguous protocol ${protocolVersion.comparator}:${protocolVersion.version}.`,
+  );
+}
+
+function _getOldestKnownPubKeyCrsVersion(): PubKeyCrsVersion {
+  return _getFirstConfiguredEntry(
+    GENERATED_PUB_KEY_CRS_VERSION_BY_PROTOCOL_VERSION,
+    'No known PubKey/CRS versions configured.',
+  ).pubKeyCrsVersion;
+}
+
+function _getNewestKnownPubKeyCrsVersion(): PubKeyCrsVersion {
+  return _getLastConfiguredEntry(
+    GENERATED_PUB_KEY_CRS_VERSION_BY_PROTOCOL_VERSION,
+    'No known PubKey/CRS versions configured.',
+  ).pubKeyCrsVersion;
+}
+
+function _getFirstConfiguredEntry<T>(entries: readonly T[], errorMessage: string): T {
+  const entry = entries[0];
+  if (entry === undefined) {
+    throw new Error(errorMessage);
+  }
+  return entry;
+}
+
+function _getLastConfiguredEntry<T>(entries: readonly T[], errorMessage: string): T {
+  const entry = entries[entries.length - 1];
+  if (entry === undefined) {
+    throw new Error(errorMessage);
+  }
+  return entry;
+}
+
+function _actualPubKeyCrsEquals(version: PubKeyCrsVersion): PubKeyCrsVersionResolution {
+  return Object.freeze({ version, comparator: 'eq' });
+}
+
+function _normalizeRelayerUrl(relayerUrl: string): string {
+  return relayerUrl.replace(/\/+$/, '');
+}

--- a/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.ts
+++ b/sdk/js-sdk/src/core/runtime/ProtocolVersionResolver-p.ts
@@ -13,7 +13,7 @@ import { asAddress, addressToChecksummedAddress } from '../base/address.js';
 import { compareSemver, isSemverInInterval, semverComparatorImpliesRange } from '../base/semver.js';
 import { mainnet } from '../chains/definitions/mainnet.js';
 import { sepolia } from '../chains/definitions/sepolia.js';
-import { assertIsHostContractVersionOf, getVersion } from '../host-contracts/HostContractVersion-p.js';
+import { assertIsHostContractVersionOf, getHostContractVersion } from '../host-contracts/HostContractVersion-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -24,7 +24,7 @@ export async function resolveProtocolContext(
   parameters: ResolveProtocolContextParameters,
 ): Promise<FhevmProtocolContext> {
   const aclAddress = addressToChecksummedAddress(asAddress(parameters.chain.fhevm.contracts.acl.address));
-  const aclVersion = await getVersion(parameters, { address: aclAddress });
+  const aclVersion = await getHostContractVersion(parameters, { address: aclAddress });
 
   assertIsHostContractVersionOf(aclVersion, 'ACL');
 

--- a/sdk/js-sdk/src/core/runtime/resolveFhevmVersions-p.ts
+++ b/sdk/js-sdk/src/core/runtime/resolveFhevmVersions-p.ts
@@ -14,7 +14,7 @@ import { pubKeyCrsVersionFromProtocolVersion, resolveProtocolContext } from './P
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * Resolves this client's FHEVM protocol version once and memoizes it on the
+ * Resolves this client's FHEVM protocol version once and memorizes it on the
  * client instance.
  *
  * Idempotent: the first call resolves the protocol version from the on-chain ACL

--- a/sdk/js-sdk/src/core/runtime/resolveFhevmVersions-p.ts
+++ b/sdk/js-sdk/src/core/runtime/resolveFhevmVersions-p.ts
@@ -1,0 +1,85 @@
+import type { FhevmProtocolContext, ProtocolVersionResolution } from '../types/coreFhevmClient.js';
+import type { TfheVersion, TkmsVersion } from '../types/moduleVersions.js';
+import {
+  asCoreClientFhevm,
+  assertIsFhevmBaseClient,
+  getResolvedProtocolVersion,
+  getResolvedTfheVersion,
+  getResolvedTkmsVersion,
+  setResolvedProtocolVersion,
+} from './CoreFhevm-p.js';
+import { hyperWasmResolveTfheModuleVersion, hyperWasmResolveTkmsModuleVersion } from './HyperWasmSolver-p.js';
+import { pubKeyCrsVersionFromProtocolVersion, resolveProtocolContext } from './ProtocolVersionResolver-p.js';
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Resolves this client's FHEVM protocol version once and memoizes it on the
+ * client instance.
+ *
+ * Idempotent: the first call resolves the protocol version from the on-chain ACL
+ * contract version and stores it on the client; subsequent calls reuse the stored
+ * value, it is safe to call from multiple init paths and from hot paths.
+ *
+ * This is the canonical way to ensure {@link getResolvedProtocolVersion} is
+ * populated.
+ *
+ * @param fhevm - A core FHEVM base client.
+ * @returns The resolved protocol version (exact or SDK-bounded).
+ */
+export async function ensureResolvedProtocolVersion(fhevm: unknown): Promise<ProtocolVersionResolution> {
+  const f = asCoreClientFhevm(fhevm);
+
+  const protocolVersion = await resolveFhevmProtocolVersion(f);
+  setResolvedProtocolVersion(f, protocolVersion);
+
+  return protocolVersion;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+export async function resolveFhevmProtocolVersion(fhevm: unknown): Promise<ProtocolVersionResolution> {
+  return (await _resolveFhevmProtocolContext(fhevm)).protocolVersion;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+async function _resolveFhevmProtocolContext(fhevm: unknown): Promise<FhevmProtocolContext> {
+  assertIsFhevmBaseClient(fhevm);
+
+  const protocolVersion = getResolvedProtocolVersion(fhevm);
+  if (protocolVersion !== undefined) {
+    return Object.freeze({
+      protocolVersion,
+      pubKeyCrsVersion: pubKeyCrsVersionFromProtocolVersion(fhevm.chain, protocolVersion),
+    });
+  }
+
+  return resolveProtocolContext(fhevm);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+export async function resolveFhevmTfheVersion(fhevm: unknown): Promise<TfheVersion> {
+  const protocolContext = await _resolveFhevmProtocolContext(fhevm);
+  const tfheVersion = getResolvedTfheVersion(fhevm);
+  if (tfheVersion !== undefined) {
+    return tfheVersion;
+  }
+  assertIsFhevmBaseClient(fhevm);
+  return hyperWasmResolveTfheModuleVersion(fhevm, protocolContext);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+export async function resolveFhevmTkmsVersion(fhevm: unknown): Promise<TkmsVersion> {
+  const protocolContext = await _resolveFhevmProtocolContext(fhevm);
+  const tkmsVersion = getResolvedTkmsVersion(fhevm);
+  if (tkmsVersion !== undefined) {
+    return tkmsVersion;
+  }
+  assertIsFhevmBaseClient(fhevm);
+  return hyperWasmResolveTkmsModuleVersion(fhevm, protocolContext);
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/sdk/js-sdk/src/core/types/coreFhevmClient.ts
+++ b/sdk/js-sdk/src/core/types/coreFhevmClient.ts
@@ -40,11 +40,68 @@ export type NativeClient = NonNullable<object>;
 export type OptionalNativeClient = NativeClient | undefined;
 export type OptionalFhevmChain = FhevmChain | undefined;
 
-export type WithTfheVersion = {
+/**
+ * Semver-compatible FHEVM protocol version.
+ *
+ * The protocol version describes the on-chain FHEVM protocol used by a given
+ * chain.
+ *
+ * Example: `'0.14.0'`.
+ */
+export type ProtocolVersion = string;
+export type PubKeyCrsVersion = string;
+
+/**
+ * Comparator between an actual resolved version and the version known by this
+ * SDK.
+ *
+ * - `'eq'`: actual version equals the returned version.
+ * - `'gt'`: actual version is strictly greater than the returned version.
+ * - `'lt'`: actual version is strictly lower than the returned version.
+ */
+export type VersionResolutionComparator = 'eq' | 'lt' | 'gt';
+
+/**
+ * Result of resolving a version that may be exact or bounded by this SDK's
+ * compatibility table.
+ *
+ * This structure is deliberately "honest": when the SDK cannot identify the
+ * exact version, it returns a bounded relationship instead of
+ * pretending that the version string is exact. Consumers that only need feature
+ * gating should inspect both `version` and `comparator`.
+ */
+export type VersionResolution<version extends string> = {
+  /**
+   * The version known by this SDK.
+   *
+   * Interpret this value through {@link VersionResolution.comparator}; it may
+   * be exact, a lower bound, or an upper bound.
+   */
+  readonly version: version;
+  /**
+   * Describes how the actual resolved version compares to
+   * {@link VersionResolution.version}.
+   */
+  readonly comparator: VersionResolutionComparator;
+};
+
+export type ProtocolVersionResolution = VersionResolution<ProtocolVersion>;
+export type PubKeyCrsVersionResolution = VersionResolution<PubKeyCrsVersion>;
+
+export type FhevmProtocolContext = {
+  readonly protocolVersion: ProtocolVersionResolution;
+  readonly pubKeyCrsVersion: PubKeyCrsVersionResolution;
+};
+
+export type WithProtocolVersion = {
+  readonly protocolVersion: ProtocolVersionResolution;
+};
+
+export type WithTfheVersion = WithProtocolVersion & {
   readonly tfheVersion: TfheVersion;
 };
 
-export type WithTkmsVersion = {
+export type WithTkmsVersion = WithProtocolVersion & {
   readonly tkmsVersion: TkmsVersion;
 };
 
@@ -74,6 +131,7 @@ export interface Fhevm<
   runtime extends FhevmRuntime = FhevmRuntime,
   client extends OptionalNativeClient = NativeClient,
 > extends FhevmBase<chain, runtime, client> {
+  readonly protocolVersion: ProtocolVersionResolution;
   readonly extend: <const actions extends Record<string, unknown>, extendedRuntime extends FhevmRuntime>(
     actionsFactory: (client: FhevmBase<chain, FhevmRuntime, client>) => FhevmExtension<actions, extendedRuntime>,
   ) => this & actions & { readonly runtime: extendedRuntime };

--- a/sdk/js-sdk/src/core/types/fhevmChain.ts
+++ b/sdk/js-sdk/src/core/types/fhevmChain.ts
@@ -12,6 +12,7 @@ export type FhevmChain = {
  *       acl: "0xdeadbeef..."
  *       inputVerifier: "0xdeadbeef..."
  *       kmsVerifier: "0xdeadbeef..."
+ *       protocolConfig: "0xdeadbeef..."
  *     },
  *     relayerUrl: "http://foo",
  *     gateway?: {
@@ -42,6 +43,7 @@ export type FhevmChainContracts = {
   readonly acl: ChainContract;
   readonly inputVerifier: ChainContract;
   readonly kmsVerifier: ChainContract;
+  readonly protocolConfig: ChainContract | undefined;
 };
 
 export type FhevmGatewayChain = {
@@ -75,6 +77,7 @@ type ResolvedFhevmChainContracts = {
   readonly acl: ResolvedChainContract;
   readonly inputVerifier: ResolvedChainContract;
   readonly kmsVerifier: ResolvedChainContract;
+  readonly protocolConfig?: ResolvedChainContract | undefined;
 };
 
 type ResolvedFhevmGatewayChain = {

--- a/sdk/js-sdk/src/core/types/hostContract.ts
+++ b/sdk/js-sdk/src/core/types/hostContract.ts
@@ -6,6 +6,7 @@ export type HostContractNameMap = {
   readonly HCULimit: 'HCULimit';
   readonly InputVerifier: 'InputVerifier';
   readonly KMSVerifier: 'KMSVerifier';
+  readonly ProtocolConfig: 'ProtocolConfig';
 };
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents

--- a/sdk/js-sdk/src/core/types/index.ts
+++ b/sdk/js-sdk/src/core/types/index.ts
@@ -1,5 +1,5 @@
 export type { TypedValue } from './primitives.js';
 export type { EncryptedValue, EncryptedValueLike } from './encryptedTypes.js';
-export type { KmsDecryptEip712Like } from './kms.js';
+export type { Eip712Like } from './kms.js';
 export type { FhevmEncryptClient, FhevmDecryptClient } from './fhevmClient.js';
 export { asEncryptedValue, isEncryptedValue } from '../handle/EncryptedValue.js';

--- a/sdk/js-sdk/src/core/types/kms.ts
+++ b/sdk/js-sdk/src/core/types/kms.ts
@@ -66,6 +66,24 @@ export type KmsDelegateUserDecryptEip712Types = {
   ];
 };
 
+export type KmsUserDecryptEip712V2Types = {
+  readonly EIP712Domain: readonly [
+    { readonly name: 'name'; readonly type: 'string' },
+    { readonly name: 'version'; readonly type: 'string' },
+    { readonly name: 'chainId'; readonly type: 'uint256' },
+    { readonly name: 'verifyingContract'; readonly type: 'address' },
+  ];
+  // CRITICAL: Field order is authoritative — determines the EIP-712 type hash.
+  readonly UserDecryptRequestVerification: readonly [
+    { readonly name: 'userAddress'; readonly type: 'address' },
+    { readonly name: 'publicKey'; readonly type: 'bytes' },
+    { readonly name: 'allowedContracts'; readonly type: 'address[]' },
+    { readonly name: 'startTimestamp'; readonly type: 'uint256' },
+    { readonly name: 'durationSeconds'; readonly type: 'uint256' },
+    { readonly name: 'extraData'; readonly type: 'bytes' },
+  ];
+};
+
 export type KmsPublicDecryptEip712Types = {
   readonly EIP712Domain: readonly [
     { readonly name: 'name'; readonly type: 'string' },
@@ -100,24 +118,14 @@ export type KmsPublicDecryptEip712Message = Readonly<{
   extraData: BytesHex;
 }>;
 
-export type KmsDecryptEip712Like = {
-  readonly domain: {
-    readonly name: string;
-    readonly version: string;
-    readonly chainId: number | bigint;
-    readonly verifyingContract: string;
-  };
-  readonly primaryType?: string | undefined;
-  readonly types: Record<string, ReadonlyArray<{ readonly name: string; readonly type: string }>>;
-  readonly message: {
-    readonly publicKey: string | Uint8Array;
-    readonly contractAddresses: string[];
-    readonly startTimestamp: number;
-    readonly durationDays: number;
-    readonly extraData: string | Uint8Array;
-    readonly delegatorAddress?: string | undefined;
-  };
-};
+export type KmsUserDecryptEip712V2Message = Readonly<{
+  userAddress: ChecksummedAddress;
+  publicKey: BytesHex;
+  allowedContracts: readonly ChecksummedAddress[];
+  startTimestamp: string;
+  durationSeconds: string;
+  extraData: BytesHex;
+}>;
 
 export type KmsUserDecryptEip712 = Prettify<{
   readonly domain: KmsEip712Domain;
@@ -140,6 +148,13 @@ export type KmsPublicDecryptEip712 = Prettify<{
   readonly message: KmsPublicDecryptEip712Message;
 }>;
 
+export type KmsUserDecryptEip712V2 = Prettify<{
+  readonly domain: KmsEip712Domain;
+  readonly types: KmsUserDecryptEip712V2Types;
+  readonly primaryType: 'UserDecryptRequestVerification';
+  readonly message: KmsUserDecryptEip712V2Message;
+}>;
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // KmsSigncryptedShares
@@ -151,3 +166,16 @@ export interface KmsSigncryptedShares {
   readonly tkmsVersion: TkmsVersion;
   readonly [KmsSigncryptedSharesBrand]: never;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Eip712Like
+//
+////////////////////////////////////////////////////////////////////////////////
+
+export type Eip712Like = {
+  readonly domain: Record<string, unknown>;
+  readonly primaryType?: string | undefined;
+  readonly types: Record<string, ReadonlyArray<{ readonly name: string; readonly type: string }>>;
+  readonly message: Record<string, unknown>;
+};

--- a/sdk/js-sdk/src/core/types/kmsSignersContext.ts
+++ b/sdk/js-sdk/src/core/types/kmsSignersContext.ts
@@ -12,6 +12,12 @@ import type { ChecksummedAddress, Uint256BigInt, Uint8Number } from './primitive
  *   sequential (each new context = previous ID + 1). The valid range is
  *   `[MIN_ID, currentKmsContextId]`. Two different contexts can never
  *   share the same ID.
+ * - `epoch_id` — The epoch identifier linked to this context. Created together
+ *   with `id` by `defineNewKmsContextAndEpoch()`. Becomes **active** only after
+ *   Phase 2 of the context-switch protocol (key resharing MPC) completes and
+ *   all KMS signers call `confirmEpochActivation`. Until then,
+ *   `getCurrentKmsContextAndEpoch()` still returns the previous
+ *   `(contextId, epochId)` pair.
  * - `signers` — The ordered list of KMS node addresses responsible for
  *   decrypting encrypted values under this context. No duplicates or null
  *   addresses are allowed (enforced on-chain).
@@ -39,6 +45,8 @@ export type KmsSignersContext = {
   readonly address: ChecksummedAddress;
   /** The unique, immutable context identifier. See {@link KmsSignersContext} for valid range. */
   readonly id: Uint256BigInt;
+  /** Epoch identifier linked to this context. Active only after Phase 2 key resharing completes. See {@link KmsSignersContext}. */
+  readonly epochId: Uint256BigInt;
   /** Ordered list of KMS node addresses for this context. No duplicates or null addresses. */
   readonly signers: readonly ChecksummedAddress[];
   /** Minimum number of KMS decryption shares required. Non-zero, at most `signers.length`. */

--- a/sdk/js-sdk/src/core/types/logger.ts
+++ b/sdk/js-sdk/src/core/types/logger.ts
@@ -1,4 +1,5 @@
 export type Logger = {
   readonly debug: (message: string) => void;
+  readonly warn?: ((message: string) => void) | undefined;
   readonly error: (message: string, cause: unknown) => void;
 };

--- a/sdk/js-sdk/src/core/types/moduleVersions.ts
+++ b/sdk/js-sdk/src/core/types/moduleVersions.ts
@@ -3,6 +3,13 @@ import type { TfheVersion } from '../../wasm/tfhe/TfheApi.js';
 
 export type { TkmsVersion, TfheVersion };
 
+/**
+ * Controls how explicit WASM module-version overrides are checked against the
+ * resolved protocol compatibility table.
+ *
+ * This option only applies when a concrete `tfhe` or `kms` version is provided.
+ * It does not affect auto-resolution.
+ */
 export type ModuleVersionCompatibilityCheck = 'throw' | 'warn' | 'off';
 
 export type FhevmEncryptModuleVersions =

--- a/sdk/js-sdk/test/browser-ui/src/main.ts
+++ b/sdk/js-sdk/test/browser-ui/src/main.ts
@@ -448,6 +448,7 @@ function resolveChain(target: ChainTarget): FhevmChain {
             acl: { address: '0x05fD9B5EFE0a996095f42Ed7e77c390810CF660c' },
             inputVerifier: { address: '0x857Ca72A957920Fa0FB138602995839866Bd4005' },
             kmsVerifier: { address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11' },
+            protocolConfig: undefined, // To be filled
           },
           relayerUrl: LOCALSTACK_RELAYER_URL,
           gateway: {
@@ -467,6 +468,7 @@ function resolveChain(target: ChainTarget): FhevmChain {
             acl: { address: '0x50157CFfD6bBFA2DECe204a89ec419c23ef5755D' },
             inputVerifier: { address: '0x36772142b74871f255CbD7A3e89B401d3e45825f' },
             kmsVerifier: { address: '0x901F8942346f7AB3a01F6D7613119Bca447Bb030' },
+            protocolConfig: undefined, // To be filled
           },
           relayerUrl: 'http://localhost:8545',
           gateway: {

--- a/sdk/js-sdk/test/browser/scripts/multiWasmHarness.ts
+++ b/sdk/js-sdk/test/browser/scripts/multiWasmHarness.ts
@@ -253,6 +253,7 @@ export function makeDummyChain(relayerUrl: string): FhevmChain {
         acl: { address: DUMMY_CONTRACT_ADDRESS },
         inputVerifier: { address: DUMMY_USER_ADDRESS },
         kmsVerifier: { address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11' },
+        protocolConfig: undefined, // To be filled
       },
       relayerUrl,
       gateway: {

--- a/sdk/js-sdk/test/chains/chain-defaults.json
+++ b/sdk/js-sdk/test/chains/chain-defaults.json
@@ -5,6 +5,18 @@
     "fheTestAddress": "0x61a8e950161daCCA06b0b623Efa2b7237BaBD4a0",
     "fheTestVersion": "v2"
   },
+  "localcleartext_v12": {
+    "rpcUrl": "http://127.0.0.1:8544",
+    "mnemonic": "test test test test test test test future home engine virtual motion",
+    "fheTestAddress": "0x61a8e950161daCCA06b0b623Efa2b7237BaBD4a0",
+    "fheTestVersion": "v2"
+  },
+  "localcleartext_v13": {
+    "rpcUrl": "http://127.0.0.1:8544",
+    "mnemonic": "test test test test test test test future home engine virtual motion",
+    "fheTestAddress": "0x61a8e950161daCCA06b0b623Efa2b7237BaBD4a0",
+    "fheTestVersion": "v2"
+  },
   "localstack": {
     "rpcUrl": "http://localhost:8545",
     "mnemonic": "test test test test test test test future home engine virtual motion",

--- a/sdk/js-sdk/test/chains/devnet.ts
+++ b/sdk/js-sdk/test/chains/devnet.ts
@@ -13,6 +13,7 @@ export const devnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0x3F3819BeBE4bD0EFEf8078Df6f9B574ADa80CCA4',
       },
+      protocolConfig: undefined, // To be filled
     },
     relayerUrl: 'https://relayer.dev.zama.cloud',
     gateway: {

--- a/sdk/js-sdk/test/chains/localcleartext.ts
+++ b/sdk/js-sdk/test/chains/localcleartext.ts
@@ -13,6 +13,9 @@ export const localcleartext = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0x901F8942346f7AB3a01F6D7613119Bca447Bb030',
       },
+      protocolConfig: {
+        address: '0x44aA028fd264C76BF4A8f8B4d8A5272f6AE25CAc',
+      },
     },
     relayerUrl: 'http://localhost:8545',
     gateway: {

--- a/sdk/js-sdk/test/chains/localstack.ts
+++ b/sdk/js-sdk/test/chains/localstack.ts
@@ -13,6 +13,9 @@ export const localstack = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11',
       },
+      protocolConfig: {
+        address: '0x52054F36036811ca418be59e41Fc6DD1b9e4F4c8',
+      },
     },
     relayerUrl: 'http://localhost:3000',
     gateway: {

--- a/sdk/js-sdk/test/chains/localstack_v11.ts
+++ b/sdk/js-sdk/test/chains/localstack_v11.ts
@@ -13,6 +13,9 @@ export const localstack_v11 = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11',
       },
+      protocolConfig: {
+        address: '0x52054F36036811ca418be59e41Fc6DD1b9e4F4c8',
+      },
     },
     relayerUrl: 'http://localhost:3000',
     gateway: {

--- a/sdk/js-sdk/test/chains/localstack_v12.ts
+++ b/sdk/js-sdk/test/chains/localstack_v12.ts
@@ -13,6 +13,9 @@ export const localstack_v12 = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11',
       },
+      protocolConfig: {
+        address: '0x52054F36036811ca418be59e41Fc6DD1b9e4F4c8',
+      },
     },
     relayerUrl: 'http://localhost:3000',
     gateway: {

--- a/sdk/js-sdk/test/chains/localstack_v13.ts
+++ b/sdk/js-sdk/test/chains/localstack_v13.ts
@@ -13,6 +13,9 @@ export const localstack_v13 = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11',
       },
+      protocolConfig: {
+        address: '0x52054F36036811ca418be59e41Fc6DD1b9e4F4c8',
+      },
     },
     relayerUrl: 'http://localhost:3000',
     gateway: {

--- a/sdk/js-sdk/test/chains/localstack_v14.ts
+++ b/sdk/js-sdk/test/chains/localstack_v14.ts
@@ -13,6 +13,9 @@ export const localstack_v14 = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xa1880e99d86F081E8D3868A8C4732C8f65dfdB11',
       },
+      protocolConfig: {
+        address: '0x52054F36036811ca418be59e41Fc6DD1b9e4F4c8',
+      },
     },
     relayerUrl: 'http://localhost:3000',
     gateway: {

--- a/sdk/js-sdk/test/chains/polygon_devnet.ts
+++ b/sdk/js-sdk/test/chains/polygon_devnet.ts
@@ -13,6 +13,7 @@ export const polygon_devnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xBC4845A34ac1bfDa56644CA093084911Da86E57c',
       },
+      protocolConfig: undefined, // To be filled
     },
     relayerUrl: 'https://relayer.dev.zama.cloud',
     gateway: {

--- a/sdk/js-sdk/test/fheTest/setup-viem.ts
+++ b/sdk/js-sdk/test/fheTest/setup-viem.ts
@@ -1,4 +1,9 @@
 import type { FhevmChain } from '@fhevm/sdk/chains';
+import type {
+  createFhevmBaseClient as createViemFhevmBaseClient,
+  createFhevmDecryptClient as createViemFhevmDecryptClient,
+  createFhevmEncryptClient as createViemFhevmEncryptClient,
+} from '@fhevm/sdk/viem';
 import type { FhevmDecryptOptions, FhevmEncryptOptions, FhevmOptions } from '../../src/core/types/coreFhevmClient.js';
 import type { FhevmModuleVersions } from '../../src/core/types/moduleVersions.js';
 import type { FheTestBaseEnv, FheTestChainName } from './setupCommon.js';
@@ -29,6 +34,7 @@ export type FheTestViemConfig = {
   };
   readonly zamaApiKey: string;
   readonly fheTestAddress: string;
+  readonly protocolVersion: FheTestBaseEnv['protocolVersion'];
   readonly fheEncryptionKeyTfheVersion: string;
   readonly moduleVersions?: FhevmModuleVersions | undefined;
 };
@@ -42,19 +48,19 @@ export type CreateViemBaseClientFn = (
   params: CreateViemClientParameters & {
     readonly options?: FhevmOptions | undefined;
   },
-) => any;
+) => ReturnType<typeof createViemFhevmBaseClient>;
 
 export type CreateViemEncryptClientFn = (
   params: CreateViemClientParameters & {
     readonly options?: FhevmEncryptOptions | undefined;
   },
-) => any;
+) => ReturnType<typeof createViemFhevmEncryptClient>;
 
 export type CreateViemDecryptClientFn = (
   params: CreateViemClientParameters & {
     readonly options?: FhevmDecryptOptions | undefined;
   },
-) => any;
+) => ReturnType<typeof createViemFhevmDecryptClient>;
 
 // ---------------------------------------------------------------------------
 // Build config
@@ -100,6 +106,7 @@ function _buildConfig(env: FheTestBaseEnv): FheTestViemConfig {
     },
     zamaApiKey: env.zamaApiKey,
     fheTestAddress: env.fheTestAddress,
+    protocolVersion: env.protocolVersion,
     fheEncryptionKeyTfheVersion: env.fheEncryptionKeyTfheVersion,
     moduleVersions: env.moduleVersions,
   };

--- a/sdk/js-sdk/test/fheTest/setupCommon.ts
+++ b/sdk/js-sdk/test/fheTest/setupCommon.ts
@@ -1,5 +1,6 @@
 import type { FhevmChain } from '@fhevm/sdk/chains';
 import type { EncryptedValue, TypedValue } from '@fhevm/sdk/types';
+import type { ProtocolVersion } from '../../src/core/types/coreFhevmClient.js';
 import type { FhevmModuleVersions } from '../../src/core/types/moduleVersions.js';
 import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
@@ -25,6 +26,8 @@ export const FHE_TEST_CHAIN_NAMES = [
   'mainnet',
   'devnet',
   'localcleartext',
+  'localcleartext_v12',
+  'localcleartext_v13',
   'localstack',
   'localstack_v11',
   'localstack_v12',
@@ -45,6 +48,7 @@ export type FheTestBaseEnv = {
   readonly zamaApiKey: string;
   readonly fheTestAddress: string;
   readonly fheTestVersion: FheTestVersion;
+  readonly protocolVersion: ProtocolVersion;
   readonly fheEncryptionKeyTfheVersion: string;
   readonly moduleVersions?: FhevmModuleVersions | undefined;
 };
@@ -54,7 +58,31 @@ export type FheTestBaseEnv = {
 // ---------------------------------------------------------------------------
 
 export function isCleartext(chainName: FheTestChainName) {
-  return chainName === 'localcleartext';
+  return chainName === 'localcleartext' || chainName.startsWith('localcleartext_');
+}
+
+// ---------------------------------------------------------------------------
+// Protocol version per chain
+// ---------------------------------------------------------------------------
+
+const PROTOCOL_VERSION_BY_CHAIN: Readonly<Record<FheTestChainName, ProtocolVersion>> = {
+  sepolia: '0.12.0',
+  testnet: '0.12.0',
+  mainnet: '0.11.0',
+  localcleartext: '0.13.0',
+  localcleartext_v12: '0.12.0',
+  localcleartext_v13: '0.13.0',
+  localstack: '0.14.0',
+  localstack_v11: '0.11.0',
+  localstack_v12: '0.12.0',
+  localstack_v13: '0.13.0',
+  localstack_v14: '0.14.0',
+  devnet: '0.13.0',
+  polygon_devnet: '0.13.0',
+};
+
+export function getExpectedProtocolVersion(chainName: FheTestChainName): ProtocolVersion {
+  return PROTOCOL_VERSION_BY_CHAIN[chainName];
 }
 
 // ---------------------------------------------------------------------------
@@ -67,6 +95,9 @@ const TFHE_VERSION_BY_CHAIN: Readonly<Record<FheTestChainName, TfheVersion | und
   sepolia: '1.5.3',
   testnet: '1.5.3', // alias for sepolia
   mainnet: '1.5.3',
+  localcleartext: undefined,
+  localcleartext_v12: undefined,
+  localcleartext_v13: undefined,
   localstack_v11: '1.5.3',
   localstack_v12: '1.5.3',
   devnet: '1.6.1',
@@ -74,7 +105,6 @@ const TFHE_VERSION_BY_CHAIN: Readonly<Record<FheTestChainName, TfheVersion | und
   localstack: '1.6.1',
   localstack_v13: '1.6.1',
   localstack_v14: '1.6.1',
-  localcleartext: undefined,
 };
 
 /** Returns the TFHE wasm version for a given test chain, or `undefined` for cleartext chains. */
@@ -86,6 +116,8 @@ const FHE_ENCRYPTION_KEY_TFHE_VERSION_BY_CHAIN: Readonly<Partial<Record<FheTestC
   sepolia: '1.4.0-alpha.3',
   testnet: '1.4.0-alpha.3',
   localcleartext: 'cleartext',
+  localcleartext_v12: 'cleartext',
+  localcleartext_v13: 'cleartext',
   localstack_v11: '1.5.1',
   localstack_v12: '1.5.4',
   localstack_v13: '1.6.1',
@@ -206,8 +238,12 @@ function foundryCastEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
+function isLocalCleartextChain(chainName: FheTestChainName): boolean {
+  return chainName === 'localcleartext' || chainName.startsWith('localcleartext_');
+}
+
 function isLocalAnvilChain(chainName: FheTestChainName): boolean {
-  return chainName === 'localcleartext' || chainName.startsWith('localstack');
+  return isLocalCleartextChain(chainName) || chainName.startsWith('localstack');
 }
 
 function tryFoundryCast(args: readonly string[]): string | undefined {
@@ -403,7 +439,11 @@ export function prepareChains(): FheTestBaseEnv[] {
 function _prepareChain(chainName: FheTestChainName): FheTestBaseEnv {
   const testDir = resolve(__dirname, '..');
   const isLocalstack = chainName.startsWith('localstack');
-  const envFilename = isLocalstack ? '.env.localstack' : `.env.${chainName}`;
+  const envFilename = isLocalCleartextChain(chainName)
+    ? '.env.localcleartext'
+    : isLocalstack
+      ? '.env.localstack'
+      : `.env.${chainName}`;
 
   // Load shared secrets
   const sharedEnv = parseEnvFile(resolve(testDir, '.env'));
@@ -441,6 +481,8 @@ function _prepareChain(chainName: FheTestChainName): FheTestBaseEnv {
     localstack_v13,
     localstack_v14,
     localcleartext,
+    localcleartext_v12: localcleartext,
+    localcleartext_v13: localcleartext,
     polygon_devnet,
     sepolia,
     mainnet,
@@ -466,6 +508,7 @@ function _prepareChain(chainName: FheTestChainName): FheTestBaseEnv {
     zamaApiKey,
     fheTestAddress,
     fheTestVersion,
+    protocolVersion: getExpectedProtocolVersion(chainName),
     fheEncryptionKeyTfheVersion: getFheEncryptionKeyTfheVersion(chainName),
     moduleVersions: tfheVersion === undefined ? undefined : { tfhe: tfheVersion },
   };

--- a/sdk/js-sdk/test/fheTest/viem-common/clientBase.decryptPublicValue.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientBase.decryptPublicValue.tests.ts
@@ -4,7 +4,7 @@ import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 import {
   getViemClientOptions,
   getViemTestConfig,
-  type CreateFhevmViemBaseClientFn,
+  type CreateViemBaseClientFn,
   type FheTestViemConfig,
 } from '../setup-viem.js';
 import { FHETestABI } from '../FheTest-abi-v2.js';
@@ -22,7 +22,7 @@ import { asEncryptedValue, type EncryptedValue } from '@fhevm/sdk/types';
 
 export function defineClientBaseDecryptPublicValueTests(parameters: {
   readonly runIf: boolean;
-  readonly createFhevmBaseClient: CreateFhevmViemBaseClientFn;
+  readonly createFhevmBaseClient: CreateViemBaseClientFn;
 }): void {
   describe.runIf(parameters.runIf)('Base client — decryptPublicValue', () => {
     let config: FheTestViemConfig;

--- a/sdk/js-sdk/test/fheTest/viem-common/clientBase.decryptPublicValue.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientBase.decryptPublicValue.tests.ts
@@ -4,7 +4,7 @@ import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
 import {
   getViemClientOptions,
   getViemTestConfig,
-  type CreateViemBaseClientFn,
+  type CreateFhevmViemBaseClientFn,
   type FheTestViemConfig,
 } from '../setup-viem.js';
 import { FHETestABI } from '../FheTest-abi-v2.js';
@@ -22,7 +22,7 @@ import { asEncryptedValue, type EncryptedValue } from '@fhevm/sdk/types';
 
 export function defineClientBaseDecryptPublicValueTests(parameters: {
   readonly runIf: boolean;
-  readonly createFhevmBaseClient: CreateViemBaseClientFn;
+  readonly createFhevmBaseClient: CreateFhevmViemBaseClientFn;
 }): void {
   describe.runIf(parameters.runIf)('Base client — decryptPublicValue', () => {
     let config: FheTestViemConfig;

--- a/sdk/js-sdk/test/fheTest/viem-common/clientBase.multichain.decryptPublicValue.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientBase.multichain.decryptPublicValue.tests.ts
@@ -1,5 +1,5 @@
 import type { Hex } from 'viem';
-import type { CreateFhevmViemBaseClientFn, FheTestViemConfig } from '../setup-viem.js';
+import type { CreateViemBaseClientFn, FheTestViemConfig } from '../setup-viem.js';
 import type { EncryptedValue } from '@fhevm/sdk/types';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
@@ -16,7 +16,7 @@ import { asEncryptedValue } from '@fhevm/sdk/types';
 
 export function defineClientBaseMultichainDecryptPublicValueTests(parameters: {
   readonly runIf: boolean;
-  readonly createFhevmBaseClient: CreateFhevmViemBaseClientFn;
+  readonly createFhevmBaseClient: CreateViemBaseClientFn;
 }): void {
   describe.runIf(parameters.runIf)('Base client — decryptPublicValue', () => {
     let configs: FheTestViemConfig[];

--- a/sdk/js-sdk/test/fheTest/viem-common/clientBase.multichain.decryptPublicValue.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientBase.multichain.decryptPublicValue.tests.ts
@@ -1,5 +1,5 @@
 import type { Hex } from 'viem';
-import type { CreateViemBaseClientFn, FheTestViemConfig } from '../setup-viem.js';
+import type { CreateFhevmViemBaseClientFn, FheTestViemConfig } from '../setup-viem.js';
 import type { EncryptedValue } from '@fhevm/sdk/types';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
@@ -16,7 +16,7 @@ import { asEncryptedValue } from '@fhevm/sdk/types';
 
 export function defineClientBaseMultichainDecryptPublicValueTests(parameters: {
   readonly runIf: boolean;
-  readonly createFhevmBaseClient: CreateViemBaseClientFn;
+  readonly createFhevmBaseClient: CreateFhevmViemBaseClientFn;
 }): void {
   describe.runIf(parameters.runIf)('Base client — decryptPublicValue', () => {
     let configs: FheTestViemConfig[];

--- a/sdk/js-sdk/test/fheTest/viem-common/clientBase.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientBase.tests.ts
@@ -129,6 +129,21 @@ export function defineClientBaseTests(
       expect(readyPromise).toBe(initPromise);
     });
 
+    it('should detect the protocolVersion for the configured chain', async () => {
+      const client = options.createClient({
+        chain: config.fhevmChain,
+        publicClient: config.publicClient,
+        options: getViemClientOptions(config),
+      });
+
+      await client.ready;
+
+      expect(client.protocolVersion).toEqual({
+        version: config.protocolVersion,
+        comparator: 'eq',
+      });
+    });
+
     it('should fetch FheEncryptionKey in bytes format', async () => {
       clearKeyCache(config.chainName);
 

--- a/sdk/js-sdk/test/scripts/dod.mjs
+++ b/sdk/js-sdk/test/scripts/dod.mjs
@@ -41,7 +41,6 @@ const commands = [
   './test/scripts/rebuild_sdk_and_pack.sh --build-profile=skip',
   './test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v12',
   './test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v13',
-  './test/scripts/localcleartext-run-tests.sh --use-pack',
   //'node test/multi-wasm/run.mjs',
 ];
 

--- a/sdk/js-sdk/test/scripts/localcleartext-run-tests.sh
+++ b/sdk/js-sdk/test/scripts/localcleartext-run-tests.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 #
 # Run cleartext FHEVM tests against an Anvil node.
 #
-# Usage: run-localcleartext.sh [--ethlib ethers|viem|ethers,viem|none] [--foundry-profile <name>] [--verbose] [--help]
+# Usage: run-localcleartext.sh [--ethlib ethers|viem|ethers,viem|none] --foundry-profile <name> [--verbose] [--help]
 #
 # Flow:
-#   1. Parse --ethlib (default: ethers,viem) and --foundry-profile (default: latest).
+#   1. Parse --ethlib (default: ethers,viem) and the required --foundry-profile.
 #   2. If Anvil is already running on RPC_URL, reuse it; otherwise start one.
 #   3. Deploy the cleartext FHEVM stack (skipped when reusing).
 #   4. Run the requested test suites sequentially against the same node.
@@ -27,17 +27,16 @@ Options:
   --ethlib viem            Run only the viem test suite.
   --ethlib ethers,viem     Run both suites (default).
   --ethlib none            Start Anvil + deploy only; wait for Anvil to exit (no tests run).
-  --foundry-profile <name> Foundry profile to use (default: latest, possible values: v11, v12, v13).
+  --foundry-profile <name> Required Foundry profile to use. Expected: v12 or v13.
   --use-pack               Use vitest-manual-pack.config.ts instead of vitest.config.ts.
   --verbose                Print Anvil logs to the console instead of redirecting to a file.
   --help                   Print this help message and exit.
 
-Environment variables (all optional, CLI flags take precedence):
+Environment variables:
   PORT             Anvil port          (default: 8544)
   RPC_URL          Anvil RPC URL       (default: http://127.0.0.1:\$PORT)
   CHAIN_ID         Anvil chain ID      (default: 31337)
   READY_TIMEOUT    Ready timeout       (default: 30s)
-  FOUNDRY_PROFILE  Foundry profile     (default: latest; overridden by --foundry-profile)
 EOF
 }
 
@@ -112,6 +111,18 @@ case "$LIB" in
         ;;
 esac
 
+case "$PROFILE" in
+    v12|v13) ;;
+    "")
+        echo "Error: --foundry-profile is required. Expected: v12 or v13." >&2
+        exit 1
+        ;;
+    *)
+        echo "Error: unsupported --foundry-profile '$PROFILE'. Expected: v12 or v13." >&2
+        exit 1
+        ;;
+esac
+
 # ------------------------------------------------------------------------------
 # Anvil helpers
 # ------------------------------------------------------------------------------
@@ -130,7 +141,8 @@ anvil_setup_vars() {
     RPC_URL="${RPC_URL:-http://127.0.0.1:${PORT}}"
     CHAIN_ID="${CHAIN_ID:-31337}"
     READY_TIMEOUT="${READY_TIMEOUT:-30}"
-    export FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-latest}"
+    export FOUNDRY_PROFILE="$PROFILE"
+    CLEAR_TEXT_CHAIN="localcleartext_${PROFILE}"
 }
 
 anvil_check_deps() {
@@ -213,8 +225,6 @@ anvil_deploy_cleartext() {
 # ------------------------------------------------------------------------------
 
 anvil_setup_dirs
-# Let --foundry-profile override FOUNDRY_PROFILE before anvil_setup_vars reads it.
-[[ -n "$PROFILE" ]] && FOUNDRY_PROFILE="$PROFILE"
 anvil_setup_vars
 anvil_check_deps
 anvil_check_scripts
@@ -275,7 +285,7 @@ run_suite() {
     echo "🧪 Running cleartext ${lib} tests..."
     (
         cd "$JS_SDK_DIR"
-        CHAIN=localcleartext npx vitest run --config "$config" "test/fheTest/${lib}-cleartext"
+        CHAIN="$CLEAR_TEXT_CHAIN" npx vitest run --config "$config" "test/fheTest/${lib}-cleartext"
     )
     echo "✅ cleartext-${lib} tests passed."
 }


### PR DESCRIPTION
First two commits have been written by @0xalexbel 

### feat(sdk): add protocol version auto resolver (`8ad99451`)
Introduces `ProtocolVersionResolver`, a module that detects and resolves the FHEVM protocol version at runtime by querying on-chain host contract data. Adds semver parsing utilities, a `createKmsUserDecryptEip712V2` path for the v2 EIP-712 flow, and expands `HyperWasmSolver` for multi-version dispatch. Includes `DRAFT_RFC_016.md`, full test coverage, and updated compatibility docs.

### fix(sdk): add ensureResolvedProtocolVersion, remove circular dep (`442319cf`)
Extracts version-resolution logic into a dedicated `resolveFhevmVersions-p.ts` module to break a circular dependency introduced by the previous commit. Adds `ensureResolvedProtocolVersion` as a guard invoked by client decorators before any encrypt/decrypt operation.

### feat(sdk): add ProtocolConfig contract infos (`cb8a7228`)
Adds the `ProtocolConfig` contract address to all chain definitions (`localTestnet`, `mainnet`, `sepolia`, `devnet`, localstack variants) and to the `FhevmChain` / `HostContract` types. Wires up `resolveFhevmConfig` to read the address, adds the relevant ABI fragments, and updates deploy scripts.

### fix(sdk): fix for assertRecordUintBigIntProperty (`de5bfda0`)
One-line fix in `uint.ts`: corrects a type guard in `assertRecordUintBigIntProperty` that was incorrectly narrowing the checked value.

### chore(sdk): rename getVersion into getHostContractVersion (`0d6937f5`)
Renames `getVersion` on host contract readers to the more descriptive `getHostContractVersion` across all call-sites — host action readers, `HostContractVersion-p`, KMS context helpers, `ProtocolVersionResolver`, and related tests. No behaviour change.

### chore(sdk): use specific contract name instead of just 'address' (`cfc3a616`)
Replaces generic `address` field/variable names with contract-specific names (e.g. `aclAddress`, `fhevmExecutorAddress`) throughout host-contract helpers, ACL checks, delegation, and KMS share fetching. No behaviour change — purely a readability improvement.

### feat(sdk): add epochId support to extraData (RFC-005) (`fe2915e5`)
Implements `epochId` tracking in the KMS extra-data layer per RFC-005. Adds `getCurrentKmsContextAndEpoch-p` to fetch both the current KMS context ID and its epoch in one call, updates `kmsExtraData` encode/decode for the epoch field, and propagates the value through `KmsSignersContext`, `SignedDecryptionPermit`, and the signcrypted-shares fetch path. Handles both legacy (no epoch) and epoch-aware protocol versions.
