### PR TITLE
fix(sdk): correct Signcrypted typos breaking lint on devex/js-sdk

### DIFF
--- a/sdk/js-sdk/src/core/actions/decrypt/decryptKmsSigncryptedShares.ts
+++ b/sdk/js-sdk/src/core/actions/decrypt/decryptKmsSigncryptedShares.ts
@@ -23,11 +23,11 @@ export type DecryptKmsSigncryptedSharesReturnType = readonly TypedValue[];
 
 export async function decryptKmsSigncryptedShares(
   fhevm: Fhevm<FhevmChain, WithDecrypt>,
-  parameters: DecryptKmsSignedcryptedSharesParameters,
-): Promise<DecryptKmsSignedcryptedSharesReturnType> {
+  parameters: DecryptKmsSigncryptedSharesParameters,
+): Promise<DecryptKmsSigncryptedSharesReturnType> {
   const f = asFhevmWithTkmsVersion(fhevm);
 
-  const clearValues = await decryptKmsSignedcryptedShares_(f, parameters);
+  const clearValues = await decryptKmsSigncryptedShares_(f, parameters);
 
   const originToken = Symbol('decryptKmsSigncryptedShares');
   return clearValues.map((cv) => clearValueToTypedValue(cv, originToken));


### PR DESCRIPTION
## Problem

`devex/js-sdk` is currently red on its own CI (`js-sdk-tests`) at the `lint` step inside `npm run build:prod`, so every SDK PR fails too (PRs are tested against the merge with this base).

`src/core/actions/decrypt/decryptKmsSigncryptedShares.ts` references three misspelled identifiers — `Signedcrypted` (extra `ed`) instead of `Signcrypted`:

- `DecryptKmsSignedcryptedSharesParameters` (line 26)
- `DecryptKmsSignedcryptedSharesReturnType` (line 27)
- `decryptKmsSignedcryptedShares_` (line 30)

None of these exist, so they become error-typed, producing **5 eslint errors**:

```
7:41   'decryptKmsSigncryptedShares_' is defined but never used   @typescript-eslint/no-unused-vars
30:9   Unsafe assignment of an error typed value                  @typescript-eslint/no-unsafe-assignment
30:29  Unsafe call of a type that could not be resolved           @typescript-eslint/no-unsafe-call
33:10  Unsafe call of a type that could not be resolved           @typescript-eslint/no-unsafe-call
33:22  Unsafe member access .map ...                              @typescript-eslint/no-unsafe-member-access
```

## Fix

Correct the three typos to the names the file already declares (the type aliases on lines 15/20 and the import alias on line 7 are all spelled `Signcrypted`). Minimal, behavior-preserving.

## Verification

`npm run lint` (eslint + `tsc -b`) passes locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)