### PR TITLE
test(sdk): fix fhevm-cli for protocol v0.13

### DIFF
--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -220,7 +220,9 @@ describe("compat", () => {
     ).toBe(false);
   });
 
-  test("does not require legacy host chain seed shim for v0.13 coprocessor images", () => {
+  test("requires legacy host chain seed shim for v0.13.0 coprocessor images", () => {
+    // initialize_db.sh gained declarative seeding after v0.13.0 was cut;
+    // all v0.13.0-N Docker builds still need the harness shim.
     expect(
       requiresLegacyHostChainSeedShim({
         versions: {
@@ -229,6 +231,22 @@ describe("compat", () => {
           env: {
             COPROCESSOR_DB_MIGRATION_VERSION: "v0.13.0-6",
             COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.13.0-6",
+          } as Record<string, string>,
+          sources: [],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("does not require legacy host chain seed shim for v0.13.1+ coprocessor images", () => {
+    expect(
+      requiresLegacyHostChainSeedShim({
+        versions: {
+          target: "latest-supported",
+          lockName: "v0.13.1.json",
+          env: {
+            COPROCESSOR_DB_MIGRATION_VERSION: "v0.13.1",
+            COPROCESSOR_ZKPROOF_WORKER_VERSION: "v0.13.1",
           } as Record<string, string>,
           sources: [],
         },

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -265,16 +265,18 @@ export const supportsCoprocessorDbStateRevert = (state: Pick<CompatState, "versi
  *
  * The host_chains table only exists from v0.12.0 onward (the remove_tenants
  * migration splits it out of the old `tenants` table); v0.11.x images have no
- * such table, so seeding it would fail. Within [0.12.0, 0.13.0) the table
+ * such table, so seeding it would fail. Within [0.12.0, 0.13.1) the table
  * exists but the runtime does not reliably seed it before zkproof caches it, so
- * the harness seeds it manually. From v0.13.0 the runtime self-seeds.
+ * the harness seeds it manually. Declarative seeding was added to
+ * initialize_db.sh after v0.13.0 was cut, so all v0.13.0-N Docker builds still
+ * need the manual shim; v0.13.1+ images self-seed.
  */
 export const requiresLegacyHostChainSeedShim = (state: Pick<CompatState, "versions">) => {
   const dbMigrationVersion = state.versions.env.COPROCESSOR_DB_MIGRATION_VERSION ?? "";
   const hostChainsTableExists = !versionBeforeReleaseFamily(dbMigrationVersion, [0, 12, 0], { unparsed: "modern" });
   const runtimeNeedsManualSeed =
-    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 0], { unparsed: "modern" }) ||
-    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 0], {
+    versionBeforeReleaseFamily(dbMigrationVersion, [0, 13, 1], { unparsed: "modern" }) ||
+    versionBeforeReleaseFamily(state.versions.env.COPROCESSOR_ZKPROOF_WORKER_VERSION ?? "", [0, 13, 1], {
       unparsed: "modern",
     });
   return hostChainsTableExists && runtimeNeedsManualSeed;


### PR DESCRIPTION
test-suite/fhevm/src/compat/compat.ts — requiresLegacyHostChainSeedShim thresholds changed from [0, 13, 0] to [0, 13, 1], comment updated to explain that declarative seeding was added after v0.13.0 was cut so all v0.13.0-N builds need the shim.

test-suite/fhevm/src/compat.test.ts — The v0.13.0-6 test renamed to "requires legacy host chain seed shim for v0.13.0 coprocessor images" and changed to toBe(true). Added a new v0.13.1 test expecting false.

This restores the fix from af45e6763 that was lost when the merge commit (98797025a) resolved the compat.ts conflict by picking main's [0, 13, 0] over the devex branch's [0, 13, 1]. With this fix, running nr test:localstack:v13 will trigger the host_chains seeding shim for the v0.13.0-2 Docker images, so the zkproof worker can verify proofs and the relayer will complete decrypt requests instead of queuing them indefinitely.