### PR TITLE
chore(kms-connector): add metric for request checks

### DIFF
--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -280,6 +280,19 @@ Metrics for zkproof-worker are to be added in future releases, if/when needed. C
  - **Alarm**: If the counter increases over a period of time.
    - **Recommendation**: more than 60 failures in 1 minute, i.e. `sum(increase(counter[1m])) > 60`.
 
+#### Metric Name: `kms_connector_worker_request_check_errors`
+ - **Type**: Counter
+ - **Labels**:
+   - `check_type`: the family of pre-flight check that rejected the request:
+     - `acl`: ACL authorization checks and errors that prevent the ACL check from running (malformed handles, missing contract config...).
+     - `signature`: RFC-012/016 signature & request-validity checks (EIP-712/ERC-1271 signature, validity window, signature invalidation).
+     - `copro_consensus`: RFC-023 off-chain ciphertext-attestation consensus check.
+     - `kms_context`: KMS context/epoch validity check.
+     - `network`: network error (on-chain call or DB query) encountered while running any of the above checks.
+ - **Description**: Counts request pre-flight check failures. Mostly decryption checks (ACL, signature, copro consensus), but the `kms_context` family also covers key-management requests.
+ - **Alarm**: If the counter increases over a period of time.
+   - **Recommendation**: more than 60 failures in 1 minute, i.e. `sum(increase(counter[1m])) > 60`.
+
 #### Metric Name: `kms_connector_worker_decryption_latency_seconds`
  - **Type**: Histogram
  - **Labels**:

--- a/kms-connector/crates/gw-listener/src/monitoring/metrics.rs
+++ b/kms-connector/crates/gw-listener/src/monitoring/metrics.rs
@@ -7,7 +7,7 @@ pub static EVENT_RECEIVED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of events received by the GatewayListener",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_gw_listener_event_received_counter metric")
 });
 
 pub static EVENT_LISTENING_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -16,5 +16,5 @@ pub static EVENT_LISTENING_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of errors encountered by the GatewayListener while listening for events",
         &["contract"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_gw_listener_event_listening_errors metric")
 });

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::core::{
     config::{Config, CtAttestationConfig},
-    event_processor::ciphertext::COPROCESSOR_CONTEXT_ID,
+    event_processor::{RequestCheckKind, ciphertext::COPROCESSOR_CONTEXT_ID},
 };
 use alloy::{hex, primitives::B256, providers::Provider, transports::http::Client};
 use anyhow::{Context, anyhow};
@@ -28,7 +28,7 @@ pub struct CiphertextManager<P: Provider> {
     /// HTTP client for the attestation HEAD fan-out and the ciphertext retrieval.
     client: Client,
 
-    /// Off-chain ciphertext-attestation config.
+    /// Off-chain ciphertext-attestation verification config.
     config: CtAttestationConfig,
 
     /// Number of retries for S3 ciphertext retrieval.
@@ -69,6 +69,7 @@ where
         sns_materials: &[SnsCiphertextMaterial],
     ) -> anyhow::Result<Vec<TypedCiphertext>> {
         if let Err(e) = self.verify_attestations(sns_materials).await {
+            RequestCheckKind::CoproConsensus.inc_metric();
             warn!("{e:#}");
         }
 
@@ -86,10 +87,7 @@ where
     /// Fans HEAD requests out to every registered Coprocessor bucket and computes an off-chain
     /// consensus verdict for each handle. Stops at the first failing material: a single failed
     /// verification invalidates the whole decryption request.
-    pub async fn verify_attestations(
-        &self,
-        materials: &[SnsCiphertextMaterial],
-    ) -> anyhow::Result<()> {
+    async fn verify_attestations(&self, materials: &[SnsCiphertextMaterial]) -> anyhow::Result<()> {
         if !self.config.enabled {
             return Ok(());
         }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/context.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/context.rs
@@ -1,4 +1,7 @@
-use crate::core::{config::Config, event_processor::ProcessingError};
+use crate::core::{
+    config::Config,
+    event_processor::{RequestCheckError, RequestCheckKind},
+};
 use alloy::{primitives::U256, providers::Provider};
 use anyhow::anyhow;
 use connector_utils::types::extra_data::ExtraData;
@@ -11,7 +14,7 @@ pub trait ContextManager: Send + Sync {
     fn validate_context(
         &self,
         extra_data: &ExtraData,
-    ) -> impl Future<Output = Result<(), ProcessingError>> + Send;
+    ) -> impl Future<Output = Result<(), RequestCheckError>> + Send;
 }
 
 /// Outcome of the lookup in the local `kms_context` table.
@@ -35,7 +38,7 @@ pub struct DbContextManager<P> {
 
 impl<P: Provider> ContextManager for DbContextManager<P> {
     #[tracing::instrument(skip(self))]
-    async fn validate_context(&self, extra_data: &ExtraData) -> Result<(), ProcessingError> {
+    async fn validate_context(&self, extra_data: &ExtraData) -> Result<(), RequestCheckError> {
         let Some(context_id) = extra_data.context_id else {
             // Accepting request with no context for backwards compatibility with the relayer-sdk.
             // TODO: Remove once https://github.com/zama-ai/fhevm-internal/issues/1506 is resolved.
@@ -45,9 +48,10 @@ impl<P: Provider> ContextManager for DbContextManager<P> {
 
         match self.check_local_db(context_id, epoch_id).await? {
             LocalCheck::Valid => Ok(()),
-            LocalCheck::Destroyed => Err(ProcessingError::Irrecoverable(anyhow!(
-                "Context #{context_id} has been destroyed"
-            ))),
+            LocalCheck::Destroyed => Err(RequestCheckError::irrecoverable(
+                RequestCheckKind::KmsContext,
+                anyhow!("Context #{context_id} has been destroyed"),
+            )),
             LocalCheck::Unknown => self.validate_on_chain(context_id, epoch_id).await,
         }
     }
@@ -68,7 +72,7 @@ impl<P: Provider> DbContextManager<P> {
         &self,
         context_id: U256,
         epoch_id: Option<U256>,
-    ) -> Result<LocalCheck, ProcessingError> {
+    ) -> Result<LocalCheck, RequestCheckError> {
         let rows = sqlx::query!(
             "SELECT epoch_id, is_valid FROM kms_context WHERE id = $1",
             context_id.as_le_slice()
@@ -76,9 +80,7 @@ impl<P: Provider> DbContextManager<P> {
         .fetch_all(&self.db_pool)
         .await
         .map_err(|e| {
-            ProcessingError::Recoverable(anyhow!(
-                "Query to check context #{context_id} failed: {e}"
-            ))
+            RequestCheckError::network(anyhow!("Query to check context #{context_id} failed: {e}"))
         })?;
 
         // `is_valid = false` is only ever written by `KmsContextDestroyed`, which invalidates the
@@ -104,7 +106,7 @@ impl<P: Provider> DbContextManager<P> {
         &self,
         context_id: U256,
         epoch_id: Option<U256>,
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         info!("Context not found in DB, validating against ProtocolConfig...");
 
         let context_valid = self
@@ -113,14 +115,15 @@ impl<P: Provider> DbContextManager<P> {
             .call()
             .await
             .map_err(|e| {
-                ProcessingError::Recoverable(anyhow!(
+                RequestCheckError::network(anyhow!(
                     "isValidKmsContext(#{context_id}) call failed: {e}"
                 ))
             })?;
         if !context_valid {
-            return Err(ProcessingError::Recoverable(anyhow!(
-                "Context #{context_id} is not valid on-chain (yet?)"
-            )));
+            return Err(RequestCheckError::recoverable(
+                RequestCheckKind::KmsContext,
+                anyhow!("Context #{context_id} is not valid on-chain (yet?)"),
+            ));
         }
 
         let Some(epoch_id) = epoch_id else {
@@ -134,14 +137,15 @@ impl<P: Provider> DbContextManager<P> {
             .call()
             .await
             .map_err(|e| {
-                ProcessingError::Recoverable(anyhow!(
+                RequestCheckError::network(anyhow!(
                     "isValidEpochForContext(#{context_id}, #{epoch_id}) call failed: {e}"
                 ))
             })?;
         if !epoch_valid {
-            return Err(ProcessingError::Recoverable(anyhow!(
-                "Epoch #{epoch_id} of context #{context_id} is not active on-chain (yet?)"
-            )));
+            return Err(RequestCheckError::recoverable(
+                RequestCheckKind::KmsContext,
+                anyhow!("Epoch #{epoch_id} of context #{context_id} is not active on-chain (yet?)"),
+            ));
         }
 
         self.cache_valid_pair(context_id, epoch_id).await;

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -1,6 +1,9 @@
 use crate::core::{
     config::Config,
-    event_processor::{CiphertextManager, ProcessingError, context::ContextManager},
+    event_processor::{
+        CiphertextManager, ProcessingError, RequestCheckError, RequestCheckKind,
+        context::ContextManager,
+    },
 };
 use alloy::{
     consensus::Transaction,
@@ -88,7 +91,7 @@ where
     pub async fn check_ciphertexts_allowed_for_public_decryption(
         &self,
         sns_ciphertexts: &[SnsCiphertextMaterial],
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         info!(
             "Starting ACL check for {} handles...",
             sns_ciphertexts.len()
@@ -96,23 +99,24 @@ where
 
         for ct in sns_ciphertexts {
             let ct_chain_id = extract_chain_id_from_handle(ct.ctHandle.as_slice())
-                .map_err(ProcessingError::Irrecoverable)?;
-            let Some(acl_contract) = self.acl_contracts.get(&ct_chain_id) else {
-                return Err(ProcessingError::Recoverable(anyhow!(
-                    "No ACL contract config found for chain id {ct_chain_id}"
-                )));
-            };
+                .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
+            let acl_contract = self.acl_contracts.get(&ct_chain_id).ok_or_else(|| {
+                RequestCheckError::recoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!("No ACL contract config found for chain id {ct_chain_id}"),
+                )
+            })?;
 
             if !acl_contract
                 .isAllowedForDecryption(ct.ctHandle)
                 .call()
                 .await
-                .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?
+                .map_err(RequestCheckError::network)?
             {
-                return Err(ProcessingError::Recoverable(anyhow!(
-                    "{} is not allowed for decrypt!",
-                    hex::encode(ct.ctHandle)
-                )));
+                return Err(RequestCheckError::recoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!("{} is not allowed for decrypt!", hex::encode(ct.ctHandle)),
+                ));
             }
         }
 
@@ -126,7 +130,7 @@ where
         calldata: Vec<u8>,
         sns_ciphertexts: &[SnsCiphertextMaterial],
         user_address: Address,
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         info!(
             "Starting ACL check for {} handles...",
             sns_ciphertexts.len()
@@ -143,10 +147,13 @@ where
                         calldata.as_slice(),
                     )
                     .map_err(|e2| {
-                        ProcessingError::Irrecoverable(anyhow!(
-                            "Was not able to parse calldata for both userDecryptionRequestCall {e2} \
-                            and delegatedUserDecryptionRequestCall ({e})!"
-                        ))
+                        RequestCheckError::irrecoverable(
+                            RequestCheckKind::Acl,
+                            anyhow!(
+                                "Was not able to parse calldata for both userDecryptionRequestCall \
+                                {e2} and delegatedUserDecryptionRequestCall ({e})!"
+                            ),
+                        )
                     })?;
                     (parsed_calldata.ctHandleContractPairs, None)
                 }
@@ -159,17 +166,18 @@ where
         );
         for ct in sns_ciphertexts {
             let ct_chain_id = extract_chain_id_from_handle(ct.ctHandle.as_slice())
-                .map_err(ProcessingError::Irrecoverable)?;
+                .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
             let acl_contract = self.acl_contracts.get(&ct_chain_id).ok_or_else(|| {
-                ProcessingError::Recoverable(anyhow!(
-                    "No ACL contract config found for chain id {ct_chain_id}"
-                ))
+                RequestCheckError::recoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!("No ACL contract config found for chain id {ct_chain_id}"),
+                )
             })?;
             let contract_address = contracts_map.get(ct.ctHandle.as_slice()).ok_or_else(|| {
-                ProcessingError::Irrecoverable(anyhow!(
-                    "Could not find contract address for handle {}",
-                    hex::encode(ct.ctHandle)
-                ))
+                RequestCheckError::irrecoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!("Could not find contract address for handle {}", ct.ctHandle),
+                )
             })?;
 
             if let Some(delegator_addr) = delegator_address {
@@ -203,8 +211,7 @@ where
         user_address: Address,
         contract_address: Address,
         delegator_address: Address,
-    ) -> Result<(), ProcessingError> {
-        let handle_hex = hex::encode(handle);
+    ) -> Result<(), RequestCheckError> {
         let is_delegated = acl_contract
             .isHandleDelegatedForUserDecryption(
                 delegator_address,
@@ -214,13 +221,16 @@ where
             )
             .call()
             .await
-            .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?;
+            .map_err(RequestCheckError::network)?;
 
         if !is_delegated {
-            return Err(ProcessingError::Recoverable(anyhow!(
-                "{user_address} is not a delegate of {delegator_address} for contract \
-                    {contract_address} and handle {handle_hex}!",
-            )));
+            return Err(RequestCheckError::recoverable(
+                RequestCheckKind::Acl,
+                anyhow!(
+                    "{user_address} is not a delegate of {delegator_address} for contract \
+                    {contract_address} and handle {handle}!",
+                ),
+            ));
         }
 
         Ok(())
@@ -231,21 +241,29 @@ where
     /// same host chain id. Returns that shared chain id.
     fn validate_handles_and_extract_chain_id(
         request: &UserDecryptionRequestV2,
-    ) -> Result<u64, ProcessingError> {
+    ) -> Result<u64, RequestCheckError> {
         if request.handles.len() != request.snsCtMaterials.len() {
-            return Err(ProcessingError::Irrecoverable(anyhow!(
-                "handles/snsCtMaterials length mismatch: {} vs {}",
-                request.handles.len(),
-                request.snsCtMaterials.len(),
-            )));
+            return Err(RequestCheckError::irrecoverable(
+                RequestCheckKind::Acl,
+                anyhow!(
+                    "handles/snsCtMaterials length mismatch: {} vs {}",
+                    request.handles.len(),
+                    request.snsCtMaterials.len(),
+                ),
+            ));
         }
 
         let chain_id = request
             .handles
             .first()
-            .ok_or_else(|| ProcessingError::Irrecoverable(anyhow!("request contains no handles")))
+            .ok_or_else(|| {
+                RequestCheckError::irrecoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!("request contains no handles"),
+                )
+            })
             .map(|h| extract_chain_id_from_handle(h.handle.as_slice()))?
-            .map_err(ProcessingError::Irrecoverable)?;
+            .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
 
         for (i, (h, m)) in request
             .handles
@@ -254,24 +272,33 @@ where
             .enumerate()
         {
             if h.handle != m.ctHandle {
-                return Err(ProcessingError::Irrecoverable(anyhow!(
-                    "handles[{i}].handle ({}) != snsCtMaterials[{i}].ctHandle ({})",
-                    h.handle,
-                    m.ctHandle,
-                )));
+                return Err(RequestCheckError::irrecoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!(
+                        "handles[{i}].handle ({}) != snsCtMaterials[{i}].ctHandle ({})",
+                        h.handle,
+                        m.ctHandle,
+                    ),
+                ));
             }
             match extract_chain_id_from_handle(h.handle.as_slice()) {
                 Ok(id) if id == chain_id => (),
                 Ok(other) => {
-                    return Err(ProcessingError::Irrecoverable(anyhow!(
-                        "user decryption request handles span multiple chains ({chain_id}, {other})",
-                    )));
+                    return Err(RequestCheckError::irrecoverable(
+                        RequestCheckKind::Acl,
+                        anyhow!(
+                            "user decryption request handles span multiple chains ({chain_id}, {other})",
+                        ),
+                    ));
                 }
                 Err(e) => {
-                    return Err(ProcessingError::Irrecoverable(anyhow!(
-                        "Failed to extract chain_id from handle {}: {e}",
-                        hex::encode(h.handle),
-                    )));
+                    return Err(RequestCheckError::irrecoverable(
+                        RequestCheckKind::Acl,
+                        anyhow!(
+                            "Failed to extract chain_id from handle {}: {e}",
+                            hex::encode(h.handle),
+                        ),
+                    ));
                 }
             }
         }
@@ -295,7 +322,7 @@ where
     pub async fn check_user_decryption_request_v2(
         &self,
         request: &UserDecryptionRequestV2,
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         info!(
             "Starting RFC016 check for {} handles...",
             request.handles.len()
@@ -310,28 +337,38 @@ where
         let now = U256::from(Utc::now().timestamp() as u64);
         let end = start.saturating_add(payload.requestValidity.durationSeconds);
         if now < start {
-            return Err(ProcessingError::Recoverable(anyhow!(
-                "RFC016 user decryption request not yet valid: now {now} < startTimestamp {start}",
-            )));
+            return Err(RequestCheckError::recoverable(
+                RequestCheckKind::Signature,
+                anyhow!(
+                    "RFC016 user decryption request not yet valid: now {now} < startTimestamp {start}",
+                ),
+            ));
         }
         if now > end {
-            return Err(ProcessingError::Irrecoverable(anyhow!(
-                "RFC016 user decryption request validity window expired: now {now} > end {end}"
-            )));
+            return Err(RequestCheckError::irrecoverable(
+                RequestCheckKind::Signature,
+                anyhow!(
+                    "RFC016 user decryption request validity window expired: now {now} > end {end}"
+                ),
+            ));
         }
 
         // `userAddress` must not appear in a non-empty `allowedContracts` list.
         if payload.allowedContracts.contains(&payload.userAddress) {
-            return Err(ProcessingError::Irrecoverable(anyhow!(
-                "userAddress {} is listed in allowedContracts — request rejected",
-                payload.userAddress
-            )));
+            return Err(RequestCheckError::irrecoverable(
+                RequestCheckKind::Signature,
+                anyhow!(
+                    "userAddress {} is listed in allowedContracts — request rejected",
+                    payload.userAddress
+                ),
+            ));
         }
 
         let acl_contract = self.acl_contracts.get(&chain_id).ok_or_else(|| {
-            ProcessingError::Recoverable(anyhow!(
-                "No ACL contract config found for chain id {chain_id}"
-            ))
+            RequestCheckError::recoverable(
+                RequestCheckKind::Acl,
+                anyhow!("No ACL contract config found for chain id {chain_id}"),
+            )
         })?;
 
         // RFC-012: EIP-712 signature verification with ecrecover → ERC-1271 fallback.
@@ -363,7 +400,7 @@ where
                     self.erc1271_gas_limit,
                 )
                 .await
-                .map_err(ProcessingError::from)
+                .map_err(RequestCheckError::from)
             },
             self.inner_invalidation_check_for_user_decryption_v2(
                 acl_contract,
@@ -402,18 +439,19 @@ where
         acl_contract: &ACLInstance<HP>,
         entry: &HandleEntry,
         user_address: Address,
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         let handle_hex = hex::encode(entry.handle);
         if entry.ownerAddress == user_address {
             let user_allowed = acl_contract
                 .isAllowed(entry.handle, user_address)
                 .call()
                 .await
-                .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?;
+                .map_err(RequestCheckError::network)?;
             if !user_allowed {
-                return Err(ProcessingError::Recoverable(anyhow!(
-                    "{user_address} is not allowed to decrypt {handle_hex}",
-                )));
+                return Err(RequestCheckError::recoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!("{user_address} is not allowed to decrypt {handle_hex}"),
+                ));
             }
         } else {
             let is_delegated = acl_contract
@@ -425,13 +463,16 @@ where
                 )
                 .call()
                 .await
-                .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?;
+                .map_err(RequestCheckError::network)?;
             if !is_delegated {
-                return Err(ProcessingError::Recoverable(anyhow!(
-                    "{user_address} is not a delegate of {} for contract {} and handle {handle_hex}",
-                    entry.ownerAddress,
-                    entry.contractAddress,
-                )));
+                return Err(RequestCheckError::recoverable(
+                    RequestCheckKind::Acl,
+                    anyhow!(
+                        "{user_address} is not a delegate of {} for contract {} and handle {handle_hex}",
+                        entry.ownerAddress,
+                        entry.contractAddress,
+                    ),
+                ));
             }
         }
         Ok(())
@@ -445,7 +486,7 @@ where
         acl_contract: &ACLInstance<HP>,
         handle: FixedBytes<32>,
         allowed_contracts: &[Address],
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         if allowed_contracts.is_empty() {
             return Ok(());
         }
@@ -460,11 +501,14 @@ where
         if results.iter().any(|r| matches!(r, Ok(true))) {
             Ok(())
         } else {
-            Err(ProcessingError::Recoverable(anyhow!(
-                "No contract in allowedContracts is allowed to decrypt handle {} ({:?})",
-                hex::encode(handle),
-                results,
-            )))
+            // This branch covers both a genuine denial and an all-RPC-failed wave; the two can't
+            // be cleanly separated here, so it counts as a single ACL rejection.
+            Err(RequestCheckError::recoverable(
+                RequestCheckKind::Acl,
+                anyhow!(
+                    "No contract in allowedContracts is allowed to decrypt handle {handle} ({results:?})",
+                ),
+            ))
         }
     }
 
@@ -475,17 +519,21 @@ where
         acl_contract: &ACLInstance<HP>,
         user_address: Address,
         start_timestamp: U256,
-    ) -> Result<(), ProcessingError> {
+    ) -> Result<(), RequestCheckError> {
         let invalidation_ts = acl_contract
             .decryptionSignatureInvalidatedBefore(user_address)
             .call()
             .await
-            .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?;
+            .map_err(RequestCheckError::network)?;
         if start_timestamp < invalidation_ts {
-            return Err(ProcessingError::Irrecoverable(anyhow!(
-                "RFC016 signature invalidated: startTimestamp {start_timestamp} < \
-                 invalidatedBefore {invalidation_ts} for userAddress {user_address}"
-            )));
+            return Err(RequestCheckError::irrecoverable(
+                // TODO: reconsider Signature naming
+                RequestCheckKind::Signature,
+                anyhow!(
+                    "RFC016 signature invalidated: startTimestamp {start_timestamp} < \
+                     invalidatedBefore {invalidation_ts} for userAddress {user_address}"
+                ),
+            ));
         }
         Ok(())
     }
@@ -496,24 +544,25 @@ where
         handle: FixedBytes<32>,
         user_address: Address,
         contract_address: Address,
-    ) -> Result<(), ProcessingError> {
-        let handle_hex = hex::encode(handle);
+    ) -> Result<(), RequestCheckError> {
         let user_allowed_call = acl_contract.isAllowed(handle, user_address);
         let contract_allowed_call = acl_contract.isAllowed(handle, contract_address);
 
         let (user_allowed, contract_allowed) =
             tokio::try_join!(biased; user_allowed_call.call(), contract_allowed_call.call())
-                .map_err(|e| ProcessingError::Recoverable(anyhow::Error::from(e)))?;
+                .map_err(RequestCheckError::network)?;
 
         if !user_allowed {
-            return Err(ProcessingError::Recoverable(anyhow!(
-                "{user_address} is not allowed to decrypt {handle_hex}!",
-            )));
+            return Err(RequestCheckError::recoverable(
+                RequestCheckKind::Acl,
+                anyhow!("{user_address} is not allowed to decrypt {handle}!"),
+            ));
         }
         if !contract_allowed {
-            return Err(ProcessingError::Recoverable(anyhow!(
-                "{contract_address} is not allowed to decrypt {handle_hex}!",
-            )));
+            return Err(RequestCheckError::recoverable(
+                RequestCheckKind::Acl,
+                anyhow!("{contract_address} is not allowed to decrypt {handle}!"),
+            ));
         }
 
         Ok(())
@@ -541,7 +590,8 @@ where
             parse_extra_data(extra_data).map_err(ProcessingError::Irrecoverable)?;
         self.context_manager
             .validate_context(&parsed_extra_data)
-            .await?;
+            .await
+            .map_err(RequestCheckError::record)?;
 
         let ciphertexts = self.prepare_ciphertexts(&key_id, sns_materials).await?;
 
@@ -682,7 +732,7 @@ mod tests {
     struct MockContextManager;
 
     impl ContextManager for MockContextManager {
-        async fn validate_context(&self, _extra_data: &ExtraData) -> Result<(), ProcessingError> {
+        async fn validate_context(&self, _extra_data: &ExtraData) -> Result<(), RequestCheckError> {
             Ok(())
         }
     }
@@ -758,7 +808,8 @@ mod tests {
 
         let result = decryption_processor
             .check_ciphertexts_allowed_for_public_decryption(&sns_ciphertexts)
-            .await;
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -834,7 +885,8 @@ mod tests {
 
         let result = decryption_processor
             .check_ciphertexts_allowed_for_user_decryption(calldata, &sns_ciphertexts, user_address)
-            .await;
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -898,7 +950,8 @@ mod tests {
 
         let result = decryption_processor
             .check_ciphertexts_allowed_for_user_decryption(calldata, &sns_ciphertexts, user_address)
-            .await;
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -993,7 +1046,10 @@ mod tests {
             duration_secs,
         );
 
-        let result = processor.check_user_decryption_request_v2(&request).await;
+        let result = processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -1023,7 +1079,10 @@ mod tests {
             86400,
         );
 
-        let result = processor.check_user_decryption_request_v2(&request).await;
+        let result = processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .map_err(RequestCheckError::record);
         assert!(matches!(result, Err(ProcessingError::Irrecoverable(_))));
     }
 
@@ -1087,7 +1146,10 @@ mod tests {
             START_OFFSET_SECS,
             86400,
         );
-        let result = processor.check_user_decryption_request_v2(&request).await;
+        let result = processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -1154,7 +1216,10 @@ mod tests {
             -3600,
             86400,
         );
-        let result = processor.check_user_decryption_request_v2(&request).await;
+        let result = processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -1204,7 +1269,10 @@ mod tests {
             -3600,
             86400,
         );
-        let result = processor.check_user_decryption_request_v2(&request).await;
+        let result = processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .map_err(RequestCheckError::record);
 
         match expected {
             ExpectedOutcome::Ok => result.unwrap(),
@@ -1249,7 +1317,10 @@ mod tests {
         sig[0] ^= 0xFF;
         request.payload.signature = Bytes::from(sig);
 
-        let result = processor.check_user_decryption_request_v2(&request).await;
+        let result = processor
+            .check_user_decryption_request_v2(&request)
+            .await
+            .map_err(RequestCheckError::record);
         assert!(matches!(result, Err(ProcessingError::Irrecoverable(_))));
     }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -115,7 +115,7 @@ where
             {
                 return Err(RequestCheckError::recoverable(
                     RequestCheckKind::Acl,
-                    anyhow!("{} is not allowed for decrypt!", hex::encode(ct.ctHandle)),
+                    anyhow!("Decryption is not allowed for {}", ct.ctHandle),
                 ));
             }
         }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
@@ -82,24 +82,25 @@ impl RequestCheckKind {
 /// It is just a [`ProcessingError`] tagged with the check family that produced it. The metric
 /// increment is centralized in [`RequestCheckError::record`], called at each conversion boundary.
 #[derive(Debug, Error)]
-#[error("{cause}")]
+#[error("{source}")]
 pub struct RequestCheckError {
     kind: RequestCheckKind,
-    cause: ProcessingError,
+    #[source]
+    source: ProcessingError,
 }
 
 impl RequestCheckError {
-    pub fn recoverable(kind: RequestCheckKind, cause: anyhow::Error) -> Self {
+    pub fn recoverable(kind: RequestCheckKind, source: anyhow::Error) -> Self {
         Self {
             kind,
-            cause: ProcessingError::Recoverable(cause),
+            source: ProcessingError::Recoverable(source),
         }
     }
 
-    pub fn irrecoverable(kind: RequestCheckKind, cause: anyhow::Error) -> Self {
+    pub fn irrecoverable(kind: RequestCheckKind, source: anyhow::Error) -> Self {
         Self {
             kind,
-            cause: ProcessingError::Irrecoverable(cause),
+            source: ProcessingError::Irrecoverable(source),
         }
     }
 
@@ -107,14 +108,14 @@ impl RequestCheckError {
         // Network errors are always considered as recoverable
         Self {
             kind: RequestCheckKind::Network,
-            cause: ProcessingError::Recoverable(err.into()),
+            source: ProcessingError::Recoverable(err.into()),
         }
     }
 
     /// Records the error in [`REQUEST_CHECK_ERRORS`] and unwraps it into a [`ProcessingError`].
     pub fn record(self) -> ProcessingError {
         self.kind.inc_metric();
-        self.cause
+        self.source
     }
 }
 
@@ -122,11 +123,14 @@ impl From<Erc1271Error> for RequestCheckError {
     fn from(err: Erc1271Error) -> Self {
         let kind = match &err {
             Erc1271Error::Transport(_) => RequestCheckKind::Network,
-            _ => RequestCheckKind::Signature,
+            Erc1271Error::EmptySigOnEoa(_)
+            | Erc1271Error::EoaMismatchNoCode(_)
+            | Erc1271Error::Rejected(..)
+            | Erc1271Error::WrongMagic(..) => RequestCheckKind::Signature,
         };
         Self {
             kind,
-            cause: err.into(),
+            source: err.into(),
         }
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
@@ -1,0 +1,132 @@
+use crate::monitoring::metrics::REQUEST_CHECK_ERRORS;
+use anyhow::anyhow;
+use thiserror::Error;
+use tonic::Code;
+use user_decryption_signature::Erc1271Error;
+
+#[derive(Debug, Error)]
+pub enum ProcessingError {
+    #[error("Processing failed with irrecoverable error : {0}")]
+    Irrecoverable(anyhow::Error),
+    #[error("Processing failed: {0}")]
+    Recoverable(anyhow::Error),
+}
+
+impl ProcessingError {
+    /// Converts GRPC status of the polling of a KMS Response into a `ProcessingError`.
+    pub fn from_response_status(value: tonic::Status) -> Self {
+        let anyhow_error = anyhow!("KMS GRPC error: {value}");
+        match value.code() {
+            Code::DeadlineExceeded | Code::Unavailable | Code::ResourceExhausted => {
+                Self::Recoverable(anyhow_error)
+            }
+            _ => Self::Irrecoverable(anyhow_error),
+        }
+    }
+}
+
+// ERC-1271 (RFC-012) signature errors map onto `ProcessingError`. Missing code at an EOA is
+// terminal, but smart-account validation can depend on mutable wallet state, so negative ERC-1271
+// results (and transport blips) stay recoverable and are retried through the existing attempt and
+// validity-window limits.
+impl From<Erc1271Error> for ProcessingError {
+    fn from(err: Erc1271Error) -> Self {
+        match err {
+            Erc1271Error::EoaMismatchNoCode(_) | Erc1271Error::EmptySigOnEoa(_) => {
+                Self::Irrecoverable(anyhow::Error::new(err))
+            }
+            Erc1271Error::Transport(_)
+            | Erc1271Error::WrongMagic(..)
+            | Erc1271Error::Rejected(..) => Self::Recoverable(anyhow::Error::new(err)),
+        }
+    }
+}
+
+/// The family of request check that rejected a request.
+#[derive(Clone, Copy, Debug)]
+pub enum RequestCheckKind {
+    /// ACL authorization checks and related errors (malformed handles, missing config...).
+    Acl,
+    /// RFC-012/016 signature & request-validity checks (EIP-712/ERC-1271 signature, validity
+    /// window, signature invalidation).
+    Signature,
+    /// RFC-023 off-chain ciphertext-attestation consensus check.
+    CoproConsensus,
+    /// KMS context/epoch validity check.
+    KmsContext,
+    /// Network error (on-chain call or DB query) encountered while running any check.
+    Network,
+}
+
+impl RequestCheckKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Acl => "acl",
+            Self::Signature => "signature",
+            Self::CoproConsensus => "copro_consensus",
+            Self::KmsContext => "kms_context",
+            Self::Network => "network",
+        }
+    }
+
+    /// Increments [`REQUEST_CHECK_ERRORS`] for this check family.
+    pub fn inc_metric(self) {
+        REQUEST_CHECK_ERRORS
+            .with_label_values(&[self.as_str()])
+            .inc();
+    }
+}
+
+/// Error returned by the request pre-flight checks (ACL, KMS context, ...).
+///
+/// It is just a [`ProcessingError`] tagged with the check family that produced it. The metric
+/// increment is centralized in [`RequestCheckError::record`], called at each conversion boundary.
+#[derive(Debug, Error)]
+#[error("{cause}")]
+pub struct RequestCheckError {
+    kind: RequestCheckKind,
+    cause: ProcessingError,
+}
+
+impl RequestCheckError {
+    pub fn recoverable(kind: RequestCheckKind, cause: anyhow::Error) -> Self {
+        Self {
+            kind,
+            cause: ProcessingError::Recoverable(cause),
+        }
+    }
+
+    pub fn irrecoverable(kind: RequestCheckKind, cause: anyhow::Error) -> Self {
+        Self {
+            kind,
+            cause: ProcessingError::Irrecoverable(cause),
+        }
+    }
+
+    pub fn network(err: impl Into<anyhow::Error>) -> Self {
+        // Network errors are always considered as recoverable
+        Self {
+            kind: RequestCheckKind::Network,
+            cause: ProcessingError::Recoverable(err.into()),
+        }
+    }
+
+    /// Records the error in [`REQUEST_CHECK_ERRORS`] and unwraps it into a [`ProcessingError`].
+    pub fn record(self) -> ProcessingError {
+        self.kind.inc_metric();
+        self.cause
+    }
+}
+
+impl From<Erc1271Error> for RequestCheckError {
+    fn from(err: Erc1271Error) -> Self {
+        let kind = match &err {
+            Erc1271Error::Transport(_) => RequestCheckKind::Network,
+            _ => RequestCheckKind::Signature,
+        };
+        Self {
+            kind,
+            cause: err.into(),
+        }
+    }
+}

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms.rs
@@ -1,6 +1,6 @@
 use crate::core::{
     config::Config,
-    event_processor::{ContextManager, ProcessingError},
+    event_processor::{ContextManager, ProcessingError, RequestCheckError},
 };
 use alloy::primitives::U256;
 use connector_utils::types::{KmsGrpcRequest, extra_data::parse_extra_data, u256_to_request_id};
@@ -50,7 +50,8 @@ where
             .map_err(ProcessingError::Irrecoverable)?;
         self.context_manager
             .validate_context(&parsed_extra_data)
-            .await?;
+            .await
+            .map_err(RequestCheckError::record)?;
 
         Ok(KmsGrpcRequest::PrepKeygen(KeyGenPreprocRequest {
             request_id: Some(u256_to_request_id(prep_keygen_request.prepKeygenId)),
@@ -72,7 +73,8 @@ where
             parse_extra_data(&keygen_request.extraData).map_err(ProcessingError::Irrecoverable)?;
         self.context_manager
             .validate_context(&parsed_extra_data)
-            .await?;
+            .await
+            .map_err(RequestCheckError::record)?;
 
         Ok(KmsGrpcRequest::Keygen(KeyGenRequest {
             request_id: Some(u256_to_request_id(keygen_request.keyId)),
@@ -96,7 +98,8 @@ where
             parse_extra_data(&crsgen_request.extraData).map_err(ProcessingError::Irrecoverable)?;
         self.context_manager
             .validate_context(&parsed_extra_data)
-            .await?;
+            .await
+            .map_err(RequestCheckError::record)?;
 
         let max_num_bits = crsgen_request
             .maxBitLength

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Config, event_processor::processor::ProcessingError},
+    core::{Config, event_processor::ProcessingError},
     monitoring::metrics::{
         GRPC_REQUEST_SENT_COUNTER, GRPC_REQUEST_SENT_ERRORS, GRPC_RESPONSE_POLLED_COUNTER,
         GRPC_RESPONSE_POLLED_ERRORS,

--- a/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
@@ -1,6 +1,7 @@
 pub mod ciphertext;
 mod context;
 mod decryption;
+mod error;
 mod kms;
 mod kms_client;
 mod processor;
@@ -9,7 +10,8 @@ mod protocol_config;
 pub use ciphertext::CiphertextManager;
 pub use context::{ContextManager, DbContextManager};
 pub use decryption::DecryptionProcessor;
+pub use error::{ProcessingError, RequestCheckError, RequestCheckKind};
 pub use kms::KMSGenerationProcessor;
 pub use kms_client::KmsClient;
-pub use processor::{DbEventProcessor, EventProcessor, ProcessingError};
+pub use processor::{DbEventProcessor, EventProcessor};
 pub use protocol_config::{ProtocolConfigProcessor, compute_anchor_event_hash};

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -1,5 +1,5 @@
 use crate::core::event_processor::{
-    KmsClient,
+    KmsClient, ProcessingError, RequestCheckError,
     context::ContextManager,
     decryption::{DecryptionProcessor, UserDecryptionExtraData},
     kms::KMSGenerationProcessor,
@@ -11,10 +11,7 @@ use connector_utils::types::{
     KmsGrpcRequest, KmsGrpcResponse, KmsResponseKind, ProtocolEvent, ProtocolEventKind,
 };
 use sqlx::{Pool, Postgres};
-use thiserror::Error;
-use tonic::Code;
 use tracing::{error, info};
-use user_decryption_signature::Erc1271Error;
 
 /// Interface used to process Gateway's events.
 pub trait EventProcessor: Send {
@@ -97,31 +94,6 @@ where
     }
 }
 
-#[derive(Debug, Error)]
-pub enum ProcessingError {
-    #[error("Processing failed with irrecoverable error : {0}")]
-    Irrecoverable(anyhow::Error),
-    #[error("Processing failed: {0}")]
-    Recoverable(anyhow::Error),
-}
-
-/// ERC-1271 (RFC-012) signature errors map onto `ProcessingError` so callers can use the `?`
-/// operator. Missing code at an EOA is terminal, but smart-account validation can depend on
-/// mutable wallet state, so negative ERC-1271 results are retried through the existing attempt
-/// and validity-window limits.
-impl From<Erc1271Error> for ProcessingError {
-    fn from(err: Erc1271Error) -> Self {
-        match err {
-            Erc1271Error::EoaMismatchNoCode(_) | Erc1271Error::EmptySigOnEoa(_) => {
-                Self::Irrecoverable(anyhow::Error::new(err))
-            }
-            Erc1271Error::Transport(_)
-            | Erc1271Error::WrongMagic(..)
-            | Erc1271Error::Rejected(..) => Self::Recoverable(anyhow::Error::new(err)),
-        }
-    }
-}
-
 impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventProcessor<GP, HP, C> {
     pub fn new(
         kms_client: KmsClient,
@@ -151,7 +123,8 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
             ProtocolEventKind::PublicDecryption(req) => {
                 self.decryption_processor
                     .check_ciphertexts_allowed_for_public_decryption(&req.snsCtMaterials)
-                    .await?;
+                    .await
+                    .map_err(RequestCheckError::record)?;
 
                 self.decryption_processor
                     .prepare_decryption_request(
@@ -178,7 +151,8 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
                         &req.snsCtMaterials,
                         req.userAddress,
                     )
-                    .await?;
+                    .await
+                    .map_err(RequestCheckError::record)?;
                 self.decryption_processor
                     .prepare_decryption_request(
                         req.decryptionId,
@@ -196,7 +170,8 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
                 // need to re-fetch the transaction calldata.
                 self.decryption_processor
                     .check_user_decryption_request_v2(req)
-                    .await?;
+                    .await
+                    .map_err(RequestCheckError::record)?;
                 let payload = &req.payload;
                 self.decryption_processor
                     .prepare_decryption_request(
@@ -265,18 +240,5 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
         let processed_response =
             KmsResponseKind::process(grpc_response).map_err(ProcessingError::Irrecoverable)?;
         Ok(Some(processed_response))
-    }
-}
-
-impl ProcessingError {
-    /// Converts GRPC status of the polling of a KMS Response into a `ProcessingError`.
-    pub fn from_response_status(value: tonic::Status) -> Self {
-        let anyhow_error = anyhow!("KMS GRPC error: {value}");
-        match value.code() {
-            Code::DeadlineExceeded | Code::Unavailable | Code::ResourceExhausted => {
-                Self::Recoverable(anyhow_error)
-            }
-            _ => Self::Irrecoverable(anyhow_error),
-        }
     }
 }

--- a/kms-connector/crates/kms-worker/src/monitoring/metrics.rs
+++ b/kms-connector/crates/kms-worker/src/monitoring/metrics.rs
@@ -12,7 +12,7 @@ pub static EVENT_RECEIVED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of events received by the KmsWorker",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_event_received_counter metric")
 });
 
 pub static EVENT_RECEIVED_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -21,7 +21,7 @@ pub static EVENT_RECEIVED_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of errors encountered by the KmsWorker while listening for events",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_event_received_errors metric")
 });
 
 pub static GRPC_REQUEST_SENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -30,7 +30,7 @@ pub static GRPC_REQUEST_SENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(||
         "Number of successful GRPC requests sent by the KmsWorker to the KMS Core",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_grpc_request_sent_counter metric")
 });
 
 pub static GRPC_REQUEST_SENT_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -39,7 +39,7 @@ pub static GRPC_REQUEST_SENT_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| 
         "Number of errors encountered by the KmsWorker while sending grpc requests to the KMS Core",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_grpc_request_sent_errors metric")
 });
 
 pub static GRPC_RESPONSE_POLLED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -48,7 +48,7 @@ pub static GRPC_RESPONSE_POLLED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new
         "Number of responses successfully polled from the KMS Core via GRPC",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_grpc_response_polled_counter metric")
 });
 
 pub static GRPC_RESPONSE_POLLED_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -57,7 +57,7 @@ pub static GRPC_RESPONSE_POLLED_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(
         "Number of errors encountered by the KmsWorker while polling responses from the KMS Core",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_grpc_response_polled_errors metric")
 });
 
 pub static S3_CIPHERTEXT_RETRIEVAL_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
@@ -65,7 +65,7 @@ pub static S3_CIPHERTEXT_RETRIEVAL_COUNTER: LazyLock<IntCounter> = LazyLock::new
         "kms_connector_worker_s3_ciphertext_retrieval_counter",
         "Number of ciphertexts retrieved from S3 by the KmsWorker"
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_s3_ciphertext_retrieval_counter metric")
 });
 
 pub static S3_CIPHERTEXT_RETRIEVAL_ERRORS: LazyLock<IntCounter> = LazyLock::new(|| {
@@ -73,7 +73,7 @@ pub static S3_CIPHERTEXT_RETRIEVAL_ERRORS: LazyLock<IntCounter> = LazyLock::new(
         "kms_connector_worker_s3_ciphertext_retrieval_errors",
         "Number of errors encountered by the KmsWorker while retrieving ciphertexts from S3"
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_s3_ciphertext_retrieval_errors metric")
 });
 
 pub static REQUEST_CHECK_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -82,7 +82,7 @@ pub static REQUEST_CHECK_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Counts request pre-flight check failures, by check family",
         &["check_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_request_check_errors metric")
 });
 
 /// Histogram bucket boundaries (in seconds) for decryption latency measurements.
@@ -98,7 +98,7 @@ pub static DECRYPTION_LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(
         .buckets(DECRYPTION_LATENCY_BUCKETS.to_vec()),
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_worker_decryption_latency_seconds metric")
 });
 
 pub fn register_event_latency(event: &ProtocolEvent) {

--- a/kms-connector/crates/kms-worker/src/monitoring/metrics.rs
+++ b/kms-connector/crates/kms-worker/src/monitoring/metrics.rs
@@ -76,6 +76,15 @@ pub static S3_CIPHERTEXT_RETRIEVAL_ERRORS: LazyLock<IntCounter> = LazyLock::new(
     .unwrap()
 });
 
+pub static REQUEST_CHECK_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "kms_connector_worker_request_check_errors",
+        "Counts request pre-flight check failures, by check family",
+        &["check_type"]
+    )
+    .unwrap()
+});
+
 /// Histogram bucket boundaries (in seconds) for decryption latency measurements.
 /// Ranges from 10ms to 30s to capture both fast and slow decryption.
 const DECRYPTION_LATENCY_BUCKETS: &[f64] = &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0];

--- a/kms-connector/crates/kms-worker/tests/context.rs
+++ b/kms-connector/crates/kms-worker/tests/context.rs
@@ -25,7 +25,7 @@ use connector_utils::{
 };
 use kms_worker::core::{
     Config,
-    event_processor::{ContextManager, DbContextManager, ProcessingError},
+    event_processor::{ContextManager, DbContextManager, ProcessingError, RequestCheckError},
 };
 use mocktail::server::MockServer;
 use rstest::rstest;
@@ -319,6 +319,7 @@ async fn test_validate_context_pending_epoch_is_recoverable() -> anyhow::Result<
     let err = context_manager
         .validate_context(&extra_data)
         .await
+        .map_err(RequestCheckError::record)
         .unwrap_err();
     assert!(
         matches!(err, ProcessingError::Recoverable(_)),
@@ -355,6 +356,7 @@ async fn test_validate_context_destroyed_rejects_unknown_epoch() -> anyhow::Resu
     let err = context_manager
         .validate_context(&extra_data)
         .await
+        .map_err(RequestCheckError::record)
         .unwrap_err();
     assert!(
         matches!(err, ProcessingError::Irrecoverable(_)),

--- a/kms-connector/crates/tx-sender/src/monitoring/metrics.rs
+++ b/kms-connector/crates/tx-sender/src/monitoring/metrics.rs
@@ -20,7 +20,7 @@ pub static RESPONSE_RECEIVED_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(||
         "Number of responses received by the TransactionSender",
         &["response_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_tx_sender_response_received_counter metric")
 });
 
 pub static RESPONSE_RECEIVED_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -29,7 +29,7 @@ pub static RESPONSE_RECEIVED_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| 
         "Number of errors encountered by the TransactionSender while listening for responses",
         &["response_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_tx_sender_response_received_errors metric")
 });
 
 pub static GATEWAY_TX_SENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -38,7 +38,7 @@ pub static GATEWAY_TX_SENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of transactions sent by the TransactionSender to the Gateway",
         &["response_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_tx_sender_gateway_tx_sent_counter metric")
 });
 
 pub static GATEWAY_TX_SENT_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -47,7 +47,7 @@ pub static GATEWAY_TX_SENT_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "Number of errors encountered by the TransactionSender while sending transactions to the Gateway",
         &["response_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_tx_sender_gateway_tx_sent_errors metric")
 });
 
 const RESPONSE_FORWARDING_LATENCY_BUCKETS: &[f64] = &[0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0];
@@ -59,7 +59,7 @@ pub static RESPONSE_FORWARDING_LATENCY_HISTOGRAM: LazyLock<HistogramVec> = LazyL
         &["response_type"],
         RESPONSE_FORWARDING_LATENCY_BUCKETS.to_vec()
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_tx_sender_response_forwarding_latency_seconds metric")
 });
 
 pub fn register_response_forwarding_latency(response: &KmsResponse) {
@@ -79,7 +79,7 @@ static PENDING_EVENTS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         "Number of Gateway events not yet processed by any KmsWorker",
         &["event_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_pending_events metric")
 });
 
 static PENDING_RESPONSES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
@@ -88,7 +88,7 @@ static PENDING_RESPONSES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         "Number of KMS responses not yet processed by the TransactionSender",
         &["response_type"]
     )
-    .unwrap()
+    .expect("Failed to register kms_connector_pending_responses metric")
 });
 
 pub fn spawn_gauge_update_routine(

--- a/kms-connector/crates/utils/src/types/event.rs
+++ b/kms-connector/crates/utils/src/types/event.rs
@@ -3,7 +3,6 @@ use crate::{
     types::db::{OperationStatus, ParamsTypeDb, SnsCiphertextMaterialDbItem},
 };
 use alloy::{
-    hex,
     primitives::{Address, FixedBytes, U256},
     sol_types::SolValue,
 };
@@ -561,43 +560,31 @@ impl Display for ProtocolEventKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProtocolEventKind::PublicDecryption(e) => {
-                let hex_id = u256_to_be_hex(e.decryptionId);
-                write!(f, "PublicDecryptionRequest #{hex_id}")
+                write!(f, "PublicDecryptionRequest #{:#066x}", e.decryptionId)
             }
             ProtocolEventKind::UserDecryption(e) => {
-                let hex_id = u256_to_be_hex(e.decryptionId);
-                write!(f, "UserDecryptionRequest #{hex_id}")
+                write!(f, "UserDecryptionRequest #{:#066x}", e.decryptionId)
             }
             ProtocolEventKind::UserDecryptionV2(e) => {
-                let hex_id = u256_to_be_hex(e.decryptionId);
-                write!(f, "UserDecryptionRequest #{hex_id}")
+                write!(f, "UserDecryptionRequest #{:#066x}", e.decryptionId)
             }
             ProtocolEventKind::PrepKeygen(e) => {
-                let hex_id = u256_to_be_hex(e.prepKeygenId);
-                write!(f, "PrepKeygenRequest #{hex_id}")
+                write!(f, "PrepKeygenRequest #{:#066x}", e.prepKeygenId)
             }
             ProtocolEventKind::Keygen(e) => {
-                let hex_id = u256_to_be_hex(e.keyId);
-                write!(f, "KeygenRequest #{hex_id}")
+                write!(f, "KeygenRequest #{:#066x}", e.keyId)
             }
             ProtocolEventKind::Crsgen(e) => {
-                let hex_id = u256_to_be_hex(e.crsId);
-                write!(f, "CrsgenRequest #{hex_id}")
+                write!(f, "CrsgenRequest #{:#066x}", e.crsId)
             }
             ProtocolEventKind::NewKmsContext(e) => {
-                let hex_id = u256_to_be_hex(e.contextId);
-                write!(f, "NewKmsContext #{hex_id}")
+                write!(f, "NewKmsContext #{:#066x}", e.contextId)
             }
             ProtocolEventKind::NewKmsEpoch(e) => {
-                let hex_id = u256_to_be_hex(e.epochId);
-                write!(f, "NewKmsEpoch #{hex_id}")
+                write!(f, "NewKmsEpoch #{:#066x}", e.epochId)
             }
         }
     }
-}
-
-fn u256_to_be_hex(int: U256) -> String {
-    format!("0x{}", hex::encode(int.to_be_bytes::<32>()))
 }
 
 impl From<PublicDecryptionRequest> for ProtocolEventKind {

--- a/kms-connector/crates/utils/src/types/event.rs
+++ b/kms-connector/crates/utils/src/types/event.rs
@@ -3,6 +3,7 @@ use crate::{
     types::db::{OperationStatus, ParamsTypeDb, SnsCiphertextMaterialDbItem},
 };
 use alloy::{
+    hex,
     primitives::{Address, FixedBytes, U256},
     sol_types::SolValue,
 };
@@ -560,23 +561,43 @@ impl Display for ProtocolEventKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProtocolEventKind::PublicDecryption(e) => {
-                write!(f, "PublicDecryptionRequest #{}", e.decryptionId)
+                let hex_id = u256_to_be_hex(e.decryptionId);
+                write!(f, "PublicDecryptionRequest #{hex_id}")
             }
             ProtocolEventKind::UserDecryption(e) => {
-                write!(f, "UserDecryptionRequest #{}", e.decryptionId)
+                let hex_id = u256_to_be_hex(e.decryptionId);
+                write!(f, "UserDecryptionRequest #{hex_id}")
             }
             ProtocolEventKind::UserDecryptionV2(e) => {
-                write!(f, "UserDecryptionRequest #{}", e.decryptionId)
+                let hex_id = u256_to_be_hex(e.decryptionId);
+                write!(f, "UserDecryptionRequest #{hex_id}")
             }
             ProtocolEventKind::PrepKeygen(e) => {
-                write!(f, "PrepKeygenRequest #{}", e.prepKeygenId)
+                let hex_id = u256_to_be_hex(e.prepKeygenId);
+                write!(f, "PrepKeygenRequest #{hex_id}")
             }
-            ProtocolEventKind::Keygen(e) => write!(f, "KeygenRequest #{}", e.keyId),
-            ProtocolEventKind::Crsgen(e) => write!(f, "CrsgenRequest #{}", e.crsId),
-            ProtocolEventKind::NewKmsContext(e) => write!(f, "NewKmsContext #{}", e.contextId),
-            ProtocolEventKind::NewKmsEpoch(e) => write!(f, "NewKmsEpoch #{}", e.epochId),
+            ProtocolEventKind::Keygen(e) => {
+                let hex_id = u256_to_be_hex(e.keyId);
+                write!(f, "KeygenRequest #{hex_id}")
+            }
+            ProtocolEventKind::Crsgen(e) => {
+                let hex_id = u256_to_be_hex(e.crsId);
+                write!(f, "CrsgenRequest #{hex_id}")
+            }
+            ProtocolEventKind::NewKmsContext(e) => {
+                let hex_id = u256_to_be_hex(e.contextId);
+                write!(f, "NewKmsContext #{hex_id}")
+            }
+            ProtocolEventKind::NewKmsEpoch(e) => {
+                let hex_id = u256_to_be_hex(e.epochId);
+                write!(f, "NewKmsEpoch #{hex_id}")
+            }
         }
     }
+}
+
+fn u256_to_be_hex(int: U256) -> String {
+    format!("0x{}", hex::encode(int.to_be_bytes::<32>()))
 }
 
 impl From<PublicDecryptionRequest> for ProtocolEventKind {


### PR DESCRIPTION
## Summary

Add a `kms_connector_worker_request_check_errors` metric to count request pre-flight check failures in the `kms-worker`.

Closes https://github.com/zama-ai/fhevm-internal/issues/1341

## Other changes

### Error handling refactor

- Introduces a dedicated `event_processor/error.rs` module with:
  - `ProcessingError` (`Recoverable` / `Irrecoverable`), moved out of `processor.rs`.
  - `RequestCheckError`, a `ProcessingError` tagged with the `RequestCheckKind` that produced it. The metric increment is centralized in `RequestCheckError::record`, called at each conversion boundary, so each check failure is counted exactly once under the right family.

### Request ID tracing alignment

- Event `Display` impls now render request IDs as zero-padded big-endian hex (`0x...`, 32 bytes) via a new `u256_to_be_hex` helper, matching the request ID format used by kms-core for easier cross-log correlation.
- Closes https://github.com/zama-ai/fhevm-internal/issues/571

