### PR TITLE
feat(sdk): add client-side seeded encryption for independent input verification

### DIFF
--- a/sdk/js-sdk/src/core/actions/encrypt/encryptSeeded.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/encryptSeeded.ts
@@ -1,0 +1,84 @@
+import type { RelayerInputProofOptions } from '../../types/relayer.js';
+import type { Fhevm } from '../../types/coreFhevmClient.js';
+import type { WithEncrypt } from '../../types/coreFhevmRuntime.js';
+import type { FhevmChain } from '../../types/fhevmChain.js';
+import type { Bytes, BytesHex } from '../../types/primitives.js';
+import type { EncryptedValue } from '../../types/encryptedTypes.js';
+import { addressToChecksummedAddress, assertIsAddress } from '../../base/address.js';
+import { assertIsEncryptionSeed, generateEncryptionSeed } from '../../base/random.js';
+import { createTypedValue } from '../../base/typedValue.js';
+import { encrypt as encrypt_ } from '../../coprocessor/encrypt.js';
+import { asFhevmWithTfheVersion } from '../../runtime/CoreFhevm-p.js';
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// encryptSeeded — deterministic ("seeded") public encryption.
+//
+// This is the distinct, explicitly-named "advanced/custody" entry point for
+// seeded encryption. It is intentionally SEPARATE from `encryptValues` so the
+// seeded path cannot be reached by accident on the default encrypt path.
+//
+// ⚠️  SECURITY: the returned `seed` is plaintext-equivalent. Anyone holding
+// (seed, ciphertext, public key) can recover the plaintext WITHOUT the FHE
+// secret key. Generate a fresh seed per encryption, never reuse it, never
+// derive it from the message, and transmit it only over a secure out-of-band
+// channel to a mutually-trusted verifier. The SDK never logs or persists it.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+export type EncryptSeededParameters = {
+  readonly values: ReadonlyArray<{ readonly type: string; readonly value: boolean | bigint | number | string }>;
+  readonly contractAddress: string;
+  readonly userAddress: string;
+  readonly options?: RelayerInputProofOptions | undefined;
+  /**
+   * Optional seed (>= 16 bytes). When omitted, a fresh CSPRNG seed is generated.
+   * Either way the seed actually used is returned and MUST be protected by the
+   * caller. Requires TFHE version `1.6.1`.
+   */
+  readonly seed?: Uint8Array | undefined;
+};
+
+export type EncryptSeededReturnType = {
+  readonly encryptedValues: readonly EncryptedValue[];
+  readonly inputProof: BytesHex;
+  /** The seed actually used (caller-supplied or CSPRNG-generated). Plaintext-equivalent. */
+  readonly seed: Bytes;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+export async function encryptSeeded(
+  fhevm: Fhevm<FhevmChain, WithEncrypt>,
+  parameters: EncryptSeededParameters,
+): Promise<EncryptSeededReturnType> {
+  const { contractAddress, userAddress, options } = parameters;
+
+  // CSPRNG by default; validate caller-supplied seeds (length / type).
+  const seed: Bytes = parameters.seed ?? generateEncryptionSeed();
+  assertIsEncryptionSeed(seed);
+
+  // Validates `values`
+  const values = parameters.values.map(createTypedValue);
+
+  assertIsAddress(contractAddress, {});
+  assertIsAddress(userAddress, {});
+
+  const f = asFhevmWithTfheVersion(fhevm);
+
+  const result = await encrypt_(f, {
+    contractAddress: addressToChecksummedAddress(contractAddress),
+    userAddress: addressToChecksummedAddress(userAddress),
+    values,
+    options,
+    seed,
+  });
+
+  return {
+    encryptedValues: result.inputHandles.map(
+      (encryptedValue) => encryptedValue.bytes32Hex as unknown as EncryptedValue,
+    ),
+    inputProof: result.inputProof,
+    seed,
+  };
+}

--- a/sdk/js-sdk/src/core/actions/encrypt/generateZkProof.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/generateZkProof.ts
@@ -13,6 +13,13 @@ export type GenerateZkProofParameters = {
   readonly contractAddress: string;
   readonly userAddress: string;
   readonly values: ReadonlyArray<{ readonly type: string; readonly value: boolean | bigint | number | string }>;
+  /**
+   * Optional seed for deterministic ("seeded") public encryption. When provided,
+   * the returned proof's ciphertext and input handles are byte-for-byte
+   * reproducible from the same seed + inputs — the basis for verify-by-reproduction.
+   * Requires TFHE version `1.6.1` and a seed of at least 16 bytes.
+   */
+  readonly seed?: Uint8Array | undefined;
 };
 
 export type GenerateZkProofReturnType = ZkProof;
@@ -23,7 +30,7 @@ export async function generateZkProof(
   fhevm: Fhevm<FhevmChain, WithEncrypt>,
   parameters: GenerateZkProofParameters,
 ): Promise<GenerateZkProofReturnType> {
-  const { values, contractAddress, userAddress } = parameters;
+  const { values, contractAddress, userAddress, seed } = parameters;
   const hardCodedExtraData = '0x00' as BytesHex;
 
   const builder = createZkProofBuilder();
@@ -37,5 +44,6 @@ export async function generateZkProof(
     contractAddress,
     userAddress,
     extraData: hardCodedExtraData,
+    seed,
   });
 }

--- a/sdk/js-sdk/src/core/actions/encrypt/index.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/index.ts
@@ -10,3 +10,19 @@ export { type GenerateZkProofParameters, type GenerateZkProofReturnType, generat
 export { type EncryptValueParameters, type EncryptValueReturnType, encryptValue } from './encryptValue.js';
 
 export { type EncryptValuesParameters, type EncryptValuesReturnType, encryptValues } from './encryptValues.js';
+
+export { type EncryptSeededParameters, type EncryptSeededReturnType, encryptSeeded } from './encryptSeeded.js';
+
+export {
+  type VerifySeededEncryptionParameters,
+  type VerifySeededEncryptionReturnType,
+  verifySeededEncryption,
+} from './verifySeededEncryption.js';
+
+export {
+  randomBytes,
+  generateEncryptionSeed,
+  assertIsEncryptionSeed,
+  MIN_ENCRYPTION_SEED_BYTES,
+  DEFAULT_ENCRYPTION_SEED_BYTES,
+} from '../../base/random.js';

--- a/sdk/js-sdk/src/core/actions/encrypt/verifySeededEncryption.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/verifySeededEncryption.ts
@@ -1,0 +1,117 @@
+import type { Fhevm } from '../../types/coreFhevmClient.js';
+import type { WithEncrypt } from '../../types/coreFhevmRuntime.js';
+import type { FhevmChain } from '../../types/fhevmChain.js';
+import type { BytesHex } from '../../types/primitives.js';
+import type { EncryptedValue } from '../../types/encryptedTypes.js';
+import { bytesToHexLarge, toBytes } from '../../base/bytes.js';
+import { assertIsEncryptionSeed } from '../../base/random.js';
+import { EncryptionError } from '../../errors/EncryptionError.js';
+import { generateZkProof } from './generateZkProof.js';
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// verifySeededEncryption
+//
+// Client-side encryption verifiability. An independent verifier re-runs the same
+// seeded encryption (same seed + plaintext values + public key/CRS + addresses)
+// and checks the reproduced ciphertext / input handles match the ones claimed by
+// the (potentially untrusted) encrypting machine. A byte-for-byte match proves
+// "this ciphertext encrypts exactly these values".
+//
+// Notes:
+// - Purely local: this does NOT contact the relayer/coprocessor.
+// - Compares against the CLIENT-side proven ciphertext and the locally-derived
+//   handles. The on-chain ciphertext is re-randomized by the coprocessor and is
+//   therefore not byte-comparable; the input handle (keccak over the client
+//   ciphertext) is the stable identifier and is reproduced here.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+export type VerifySeededEncryptionParameters = {
+  /** The secret seed shared between encryptor and verifier (>= 16 bytes). */
+  readonly seed: Uint8Array;
+  /** The plaintext values claimed to have been encrypted. */
+  readonly values: ReadonlyArray<{ readonly type: string; readonly value: boolean | bigint | number | string }>;
+  readonly contractAddress: string;
+  readonly userAddress: string;
+  /**
+   * Claimed input handles (e.g. `encryptedValues` returned by `encryptValues`).
+   * When provided, the reproduced handles must match these exactly.
+   */
+  readonly expectedEncryptedValues?: readonly EncryptedValue[] | undefined;
+  /**
+   * Claimed raw client-side proven ciphertext bytes (hex string or `Uint8Array`).
+   * When provided, the reproduced ciphertext must match byte-for-byte.
+   */
+  readonly expectedCiphertext?: BytesHex | Uint8Array | undefined;
+};
+
+export type VerifySeededEncryptionReturnType = {
+  /** `true` iff every provided expectation matched the reproduced artifacts. */
+  readonly verified: boolean;
+  /** The reproduced input handles. */
+  readonly encryptedValues: readonly EncryptedValue[];
+  /** The reproduced raw client-side proven ciphertext bytes, hex-encoded. */
+  readonly ciphertext: BytesHex;
+  /** Human-readable reasons for any mismatch (empty when `verified`). */
+  readonly mismatches: readonly string[];
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+export async function verifySeededEncryption(
+  fhevm: Fhevm<FhevmChain, WithEncrypt>,
+  parameters: VerifySeededEncryptionParameters,
+): Promise<VerifySeededEncryptionReturnType> {
+  const { seed, values, contractAddress, userAddress, expectedEncryptedValues, expectedCiphertext } = parameters;
+
+  assertIsEncryptionSeed(seed);
+
+  if (expectedEncryptedValues === undefined && expectedCiphertext === undefined) {
+    throw new EncryptionError({
+      message: 'verifySeededEncryption requires expectedEncryptedValues and/or expectedCiphertext to verify against.',
+    });
+  }
+
+  const zkProof = await generateZkProof(fhevm, { seed, values, contractAddress, userAddress });
+
+  const encryptedValues = zkProof.getInputHandles().map((h) => h.bytes32Hex as unknown as EncryptedValue);
+  const ciphertext = bytesToHexLarge(zkProof.ciphertextWithZkProof);
+
+  const mismatches: string[] = [];
+
+  if (expectedEncryptedValues !== undefined) {
+    if (expectedEncryptedValues.length !== encryptedValues.length) {
+      mismatches.push(
+        `handle count mismatch: expected ${expectedEncryptedValues.length}, reproduced ${encryptedValues.length}`,
+      );
+    } else {
+      for (let i = 0; i < encryptedValues.length; i++) {
+        if (!_eqHex(expectedEncryptedValues[i], encryptedValues[i])) {
+          mismatches.push(`handle[${i}] mismatch`);
+        }
+      }
+    }
+  }
+
+  if (expectedCiphertext !== undefined) {
+    const expectedHex = bytesToHexLarge(toBytes(expectedCiphertext, { subject: 'expectedCiphertext' }));
+    if (!_eqHex(expectedHex, ciphertext)) {
+      mismatches.push('ciphertext bytes mismatch');
+    }
+  }
+
+  return {
+    verified: mismatches.length === 0,
+    encryptedValues,
+    ciphertext,
+    mismatches,
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/** Case-insensitive hex-string equality (handles differ only by `0x` casing). */
+function _eqHex(a: string | undefined, b: string | undefined): boolean {
+  return a !== undefined && a.toLowerCase() === b?.toLowerCase();
+}

--- a/sdk/js-sdk/src/core/base/random.test.ts
+++ b/sdk/js-sdk/src/core/base/random.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  randomBytes,
+  generateEncryptionSeed,
+  assertIsEncryptionSeed,
+  MIN_ENCRYPTION_SEED_BYTES,
+  DEFAULT_ENCRYPTION_SEED_BYTES,
+} from './random.js';
+
+describe('randomBytes', () => {
+  it('returns a Uint8Array of the requested length', () => {
+    const b = randomBytes(24);
+    expect(b).toBeInstanceOf(Uint8Array);
+    expect(b.length).toBe(24);
+  });
+
+  it('is overwhelmingly unlikely to repeat', () => {
+    const a = randomBytes(32);
+    const b = randomBytes(32);
+    expect(Array.from(a)).not.toEqual(Array.from(b));
+  });
+
+  it('rejects non-positive / non-integer lengths', () => {
+    expect(() => randomBytes(0)).toThrow();
+    expect(() => randomBytes(-1)).toThrow();
+    expect(() => randomBytes(1.5)).toThrow();
+  });
+});
+
+describe('generateEncryptionSeed', () => {
+  it('defaults to DEFAULT_ENCRYPTION_SEED_BYTES', () => {
+    expect(generateEncryptionSeed().length).toBe(DEFAULT_ENCRYPTION_SEED_BYTES);
+  });
+
+  it('accepts a custom length at or above the minimum', () => {
+    expect(generateEncryptionSeed(MIN_ENCRYPTION_SEED_BYTES).length).toBe(MIN_ENCRYPTION_SEED_BYTES);
+  });
+
+  it('rejects lengths below the minimum', () => {
+    expect(() => generateEncryptionSeed(MIN_ENCRYPTION_SEED_BYTES - 1)).toThrow();
+  });
+});
+
+describe('assertIsEncryptionSeed', () => {
+  it('passes for a Uint8Array of at least the minimum length', () => {
+    expect(() => assertIsEncryptionSeed(new Uint8Array(MIN_ENCRYPTION_SEED_BYTES))).not.toThrow();
+  });
+
+  it('throws for too-short seeds', () => {
+    expect(() => assertIsEncryptionSeed(new Uint8Array(MIN_ENCRYPTION_SEED_BYTES - 1))).toThrow();
+  });
+
+  it('throws for non-Uint8Array input', () => {
+    expect(() => assertIsEncryptionSeed('not-bytes')).toThrow();
+    expect(() => assertIsEncryptionSeed(undefined)).toThrow();
+  });
+});

--- a/sdk/js-sdk/src/core/base/random.ts
+++ b/sdk/js-sdk/src/core/base/random.ts
@@ -1,0 +1,78 @@
+import type { Bytes } from '../types/primitives.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// Random
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Minimum seed length (in bytes) accepted by TFHE-rs seeded public encryption.
+ *
+ * The seed is prefixed with an 8-byte domain separator and expanded through an
+ * AES-CTR XOF inside TFHE-rs. TFHE-rs requires the raw seed to be at least
+ * 16 bytes; the WASM bindings do not validate this for us, so callers must.
+ */
+export const MIN_ENCRYPTION_SEED_BYTES = 16;
+
+/**
+ * Default length (in bytes) of a freshly generated encryption seed.
+ *
+ * 32 bytes provides a comfortable margin above {@link MIN_ENCRYPTION_SEED_BYTES}.
+ */
+export const DEFAULT_ENCRYPTION_SEED_BYTES = 32;
+
+/**
+ * Returns `length` cryptographically secure random bytes.
+ *
+ * Isomorphic: relies on the Web Crypto `crypto.getRandomValues`, available in
+ * browsers, web workers, and Node.js (globalThis.crypto, Node 18+).
+ *
+ * @param length - Number of random bytes to generate. Must be a positive integer.
+ * @throws If `length` is not a positive integer.
+ */
+export function randomBytes(length: number): Bytes {
+  if (!Number.isInteger(length) || length <= 0) {
+    throw new Error(`randomBytes: length must be a positive integer, got ${String(length)}`);
+  }
+  const out = new Uint8Array(length);
+  crypto.getRandomValues(out);
+  return out;
+}
+
+/**
+ * Generates a fresh CSPRNG seed suitable for {@link https://docs.zama.ai | seeded encryption}.
+ *
+ * The returned seed is the secret shared between an encrypting machine and an
+ * independent verifier: both feed the same seed (plus the same plaintext, public
+ * key, and metadata) into seeded encryption and compare the resulting bytes. The
+ * seed must be kept secret from the outside world — knowledge of it can break the
+ * encryption — and is never transmitted with the ciphertext to the relayer.
+ *
+ * @param length - Seed length in bytes. Defaults to {@link DEFAULT_ENCRYPTION_SEED_BYTES}.
+ *   Must be at least {@link MIN_ENCRYPTION_SEED_BYTES}.
+ * @throws If `length` is below {@link MIN_ENCRYPTION_SEED_BYTES}.
+ */
+export function generateEncryptionSeed(length: number = DEFAULT_ENCRYPTION_SEED_BYTES): Bytes {
+  if (!Number.isInteger(length) || length < MIN_ENCRYPTION_SEED_BYTES) {
+    throw new Error(
+      `generateEncryptionSeed: length must be an integer >= ${String(MIN_ENCRYPTION_SEED_BYTES)}, got ${String(length)}`,
+    );
+  }
+  return randomBytes(length);
+}
+
+/**
+ * Asserts that `seed` is a valid encryption seed (a `Uint8Array` of at least
+ * {@link MIN_ENCRYPTION_SEED_BYTES} bytes). Returns nothing; throws on failure.
+ *
+ * @throws If `seed` is not a `Uint8Array` or is shorter than the minimum length.
+ */
+export function assertIsEncryptionSeed(seed: unknown): asserts seed is Bytes {
+  if (!(seed instanceof Uint8Array)) {
+    throw new Error('Encryption seed must be a Uint8Array');
+  }
+  if (seed.length < MIN_ENCRYPTION_SEED_BYTES) {
+    throw new Error(
+      `Encryption seed must be at least ${String(MIN_ENCRYPTION_SEED_BYTES)} bytes, got ${String(seed.length)}`,
+    );
+  }
+}

--- a/sdk/js-sdk/src/core/clients/decorators/encrypt.ts
+++ b/sdk/js-sdk/src/core/clients/decorators/encrypt.ts
@@ -12,6 +12,16 @@ import {
   type EncryptValuesParameters,
   type EncryptValuesReturnType,
 } from '../../actions/encrypt/encryptValues.js';
+import {
+  encryptSeeded,
+  type EncryptSeededParameters,
+  type EncryptSeededReturnType,
+} from '../../actions/encrypt/encryptSeeded.js';
+import {
+  verifySeededEncryption,
+  type VerifySeededEncryptionParameters,
+  type VerifySeededEncryptionReturnType,
+} from '../../actions/encrypt/verifySeededEncryption.js';
 import { assertIsFhevmClientWith } from '../../runtime/CoreFhevm-p.js';
 import { _initEncrypt } from './encrypt-p.js';
 
@@ -20,6 +30,10 @@ import { _initEncrypt } from './encrypt-p.js';
 type EncryptActionMethods = {
   readonly encryptValue: (parameters: EncryptValueParameters) => Promise<EncryptValueReturnType>;
   readonly encryptValues: (parameters: EncryptValuesParameters) => Promise<EncryptValuesReturnType>;
+  readonly encryptSeeded: (parameters: EncryptSeededParameters) => Promise<EncryptSeededReturnType>;
+  readonly verifySeededEncryption: (
+    parameters: VerifySeededEncryptionParameters,
+  ) => Promise<VerifySeededEncryptionReturnType>;
 };
 
 export type EncryptActions = EncryptActionMethods & WithTfheVersion;
@@ -30,6 +44,8 @@ function _encryptActions(fhevm: Fhevm<FhevmChain, WithEncrypt>): EncryptActionMe
   return {
     encryptValue: (parameters) => encryptValue(fhevm, parameters),
     encryptValues: (parameters) => encryptValues(fhevm, parameters),
+    encryptSeeded: (parameters) => encryptSeeded(fhevm, parameters),
+    verifySeededEncryption: (parameters) => verifySeededEncryption(fhevm, parameters),
   };
 }
 

--- a/sdk/js-sdk/src/core/coprocessor/ZkProofBuilder-p.ts
+++ b/sdk/js-sdk/src/core/coprocessor/ZkProofBuilder-p.ts
@@ -145,10 +145,12 @@ class ZkProofBuilderImpl implements ZkProofBuilder {
       contractAddress,
       userAddress,
       extraData,
+      seed,
     }: {
       readonly contractAddress: string;
       readonly userAddress: string;
       readonly extraData: string;
+      readonly seed?: Uint8Array | undefined;
     },
   ): Promise<ZkProof> {
     // Fetch the FheEncryptionKey (in wasm format) from the global cache.
@@ -222,6 +224,7 @@ class ZkProofBuilderImpl implements ZkProofBuilder {
         metaData,
         extraData: asBytesHex(extraData),
         tfheVersion: context.tfheVersion,
+        seed,
       });
 
     return toZkProof(
@@ -282,9 +285,10 @@ export async function createZkProof(
     readonly contractAddress: ChecksummedAddress;
     readonly userAddress: ChecksummedAddress;
     readonly extraData: BytesHex;
+    readonly seed?: Uint8Array | undefined;
   },
 ): Promise<ZkProof> {
-  const { contractAddress, userAddress, values, extraData } = parameters;
+  const { contractAddress, userAddress, values, extraData, seed } = parameters;
 
   const builder = new ZkProofBuilderImpl(PRIVATE_TOKEN, {
     ciphertextCapacity: TFHE_ZKPROOF_CIPHERTEXT_CAPACITY,
@@ -299,6 +303,7 @@ export async function createZkProof(
     contractAddress,
     userAddress,
     extraData,
+    seed,
   });
 
   return zkProof;

--- a/sdk/js-sdk/src/core/coprocessor/encrypt.ts
+++ b/sdk/js-sdk/src/core/coprocessor/encrypt.ts
@@ -22,6 +22,12 @@ type Parameters = {
   readonly userAddress: ChecksummedAddress;
   readonly values: readonly TypedValue[];
   readonly options?: RelayerInputProofOptions | undefined;
+  /**
+   * Optional seed for deterministic ("seeded") public encryption. When provided,
+   * the ciphertext is byte-for-byte reproducible from the same seed + inputs.
+   * Requires TFHE version 1.6.1 and a seed of at least 16 bytes.
+   */
+  readonly seed?: Uint8Array | undefined;
 };
 
 type ReturnType = {

--- a/sdk/js-sdk/src/core/modules/encrypt/mock.seeded.test.ts
+++ b/sdk/js-sdk/src/core/modules/encrypt/mock.seeded.test.ts
@@ -1,0 +1,86 @@
+import type { FheEncryptionKeyWasm } from '../../types/fheEncryptionKey.js';
+import type { BytesHex, UintNumber } from '../../types/primitives.js';
+import { describe, it, expect } from 'vitest';
+import { bytesToHexLarge } from '../../base/bytes.js';
+import { createTypedValue } from '../../base/typedValue.js';
+import { buildWithProofPacked, deserializeFheEncryptionPublicKey, deserializeFheEncryptionCrs } from './mock.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/modules/encrypt/mock.seeded.test.ts
+//
+// Exercises the seeded-encryption branch threaded through the (cleartext) mock
+// module: gating, validation, and the core determinism contract — same seed +
+// inputs => identical bytes; no seed => non-deterministic.
+////////////////////////////////////////////////////////////////////////////////
+
+const TFHE_VERSION = '1.6.1' as const;
+
+async function makeKey(): Promise<FheEncryptionKeyWasm> {
+  const publicKey = await deserializeFheEncryptionPublicKey({
+    publicKeyBytes: { id: 'pk', bytes: new Uint8Array([1, 2, 3]) },
+    tfheVersion: TFHE_VERSION,
+  });
+  const crs = await deserializeFheEncryptionCrs({
+    crsBytes: { id: 'crs', capacity: 2048 as UintNumber, bytes: new Uint8Array([4, 5, 6]) },
+    tfheVersion: TFHE_VERSION,
+  });
+  return { publicKey, crs, metadata: { relayerUrl: 'http://mock', chainId: 1234 }, tfheVersion: TFHE_VERSION };
+}
+
+function commonParams(fheEncryptionKey: FheEncryptionKeyWasm) {
+  return {
+    fheEncryptionKey,
+    typedValues: [createTypedValue({ type: 'uint64', value: 42n }), createTypedValue({ type: 'bool', value: true })],
+    metaData: new Uint8Array(92).fill(7),
+    extraData: '0x00' as BytesHex,
+    tfheVersion: TFHE_VERSION,
+  };
+}
+
+describe('mock seeded encryption', () => {
+  it('is deterministic: same seed + inputs => identical ciphertext bytes', async () => {
+    const key = await makeKey();
+    const seed = new Uint8Array(32).fill(9);
+
+    const a = await buildWithProofPacked({ ...commonParams(key), seed });
+    const b = await buildWithProofPacked({ ...commonParams(key), seed });
+
+    expect(bytesToHexLarge(a.ciphertextWithZKProofBytes)).toBe(bytesToHexLarge(b.ciphertextWithZKProofBytes));
+  });
+
+  it('different seeds => different ciphertext bytes', async () => {
+    const key = await makeKey();
+
+    const a = await buildWithProofPacked({ ...commonParams(key), seed: new Uint8Array(32).fill(1) });
+    const b = await buildWithProofPacked({ ...commonParams(key), seed: new Uint8Array(32).fill(2) });
+
+    expect(bytesToHexLarge(a.ciphertextWithZKProofBytes)).not.toBe(bytesToHexLarge(b.ciphertextWithZKProofBytes));
+  });
+
+  it('no seed => non-deterministic (random nonce path unchanged)', async () => {
+    const key = await makeKey();
+
+    const a = await buildWithProofPacked(commonParams(key));
+    const b = await buildWithProofPacked(commonParams(key));
+
+    expect(bytesToHexLarge(a.ciphertextWithZKProofBytes)).not.toBe(bytesToHexLarge(b.ciphertextWithZKProofBytes));
+  });
+
+  it('rejects seeds shorter than 16 bytes', async () => {
+    const key = await makeKey();
+    await expect(buildWithProofPacked({ ...commonParams(key), seed: new Uint8Array(15) })).rejects.toThrow(
+      /at least 16 bytes/,
+    );
+  });
+
+  it('rejects seeded encryption on non-1.6.1 TFHE versions', async () => {
+    const key = await makeKey();
+    await expect(
+      buildWithProofPacked({
+        ...commonParams(key),
+        tfheVersion: '1.5.3',
+        seed: new Uint8Array(32).fill(3),
+      }),
+    ).rejects.toThrow(/requires TFHE version 1\.6\.1/);
+  });
+});

--- a/sdk/js-sdk/src/core/modules/encrypt/mock.ts
+++ b/sdk/js-sdk/src/core/modules/encrypt/mock.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/require-await */
 import type { TfheVersion } from '../../../wasm/tfhe/TfheApi.js';
+import { keccak_256 } from '@noble/hashes/sha3.js';
 import { concatBytes, hexToBytes32 } from '../../base/bytes.js';
 import { remove0x } from '../../base/string.js';
+import { EncryptionError } from '../../errors/EncryptionError.js';
 import { typedValueToBytes32Hex } from '../../base/typedValue.js';
 import type { FhevmRuntime } from '../../types/coreFhevmRuntime.js';
 import type {
@@ -157,9 +159,31 @@ export async function buildWithProofPacked(
   const typedValuesBytes32HexNo0x = typedValues.map(typedValueToBytes32Hex).map(remove0x).join('');
   const cleartextExtraData = `0x${typedValuesBytes32HexNo0x}${remove0x(extraData)}` as BytesHex;
 
-  // Per typedValue: random nonce (8 bytes) || metaData || value bytes (32).
-  const perValueBlobs = typedValues.map((tv) => {
-    const nonce = crypto.getRandomValues(new Uint8Array(new ArrayBuffer(8)));
+  // Deterministic ("seeded") encryption — mirror the real api-p.ts gating/validation
+  // so unit tests exercising the seeded path stay consistent with production behavior.
+  const seed = parameters.seed;
+  if (seed !== undefined) {
+    if (parameters.tfheVersion !== '1.6.1') {
+      throw new EncryptionError({
+        message: `Seeded encryption requires TFHE version 1.6.1, got ${parameters.tfheVersion}.`,
+      });
+    }
+    if (seed.length < 16) {
+      throw new EncryptionError({
+        message: `Seeded encryption seed must be at least 16 bytes, got ${seed.length}.`,
+      });
+    }
+  }
+
+  // Per typedValue: nonce (8 bytes) || metaData || value bytes (32).
+  // Without a seed the nonce is random (non-deterministic). With a seed the nonce
+  // is derived deterministically from it, mirroring the determinism guarantee of
+  // real seeded encryption: same seed + inputs => identical bytes.
+  const perValueBlobs = typedValues.map((tv, i) => {
+    const nonce =
+      seed === undefined
+        ? crypto.getRandomValues(new Uint8Array(new ArrayBuffer(8)))
+        : keccak_256(concatBytes(seed, new Uint8Array([i]))).subarray(0, 8);
     const valueBytes = hexToBytes32(typedValueToBytes32Hex(tv));
     return concatBytes(nonce, metaData, valueBytes);
   });

--- a/sdk/js-sdk/src/core/modules/encrypt/module/api-p.ts
+++ b/sdk/js-sdk/src/core/modules/encrypt/module/api-p.ts
@@ -281,11 +281,33 @@ export async function buildWithProofPacked(
       }
     }
 
-    tfheProvenCompactCiphertextList = fheCompactCiphertextListBuilderWasm.build_with_proof_packed(
-      compactPkeCrsWasm,
-      metaData,
-      tfheLib.ZkComputeLoad.Verify,
-    );
+    if (parameters.seed !== undefined) {
+      // Deterministic ("seeded") public encryption — see BuildWithProofPackedParameters.seed.
+      // The seeded builder methods exist only in the v1.6.1 WASM (absent in v1.5.3),
+      // and TFHE-rs requires a seed of at least 16 bytes (the WASM does not validate this).
+      if (parameters.tfheVersion !== '1.6.1') {
+        throw new EncryptionError({
+          message: `Seeded encryption requires TFHE version 1.6.1, got ${parameters.tfheVersion}.`,
+        });
+      }
+      if (parameters.seed.length < 16) {
+        throw new EncryptionError({
+          message: `Seeded encryption seed must be at least 16 bytes, got ${parameters.seed.length}.`,
+        });
+      }
+      tfheProvenCompactCiphertextList = fheCompactCiphertextListBuilderWasm.build_with_proof_packed_seeded(
+        compactPkeCrsWasm,
+        metaData,
+        tfheLib.ZkComputeLoad.Verify,
+        parameters.seed,
+      );
+    } else {
+      tfheProvenCompactCiphertextList = fheCompactCiphertextListBuilderWasm.build_with_proof_packed(
+        compactPkeCrsWasm,
+        metaData,
+        tfheLib.ZkComputeLoad.Verify,
+      );
+    }
 
     ciphertextWithZKProofBytes = tfheProvenCompactCiphertextList.safe_serialize(SERIALIZED_SIZE_LIMIT_CIPHERTEXT);
 

--- a/sdk/js-sdk/src/core/modules/encrypt/types.ts
+++ b/sdk/js-sdk/src/core/modules/encrypt/types.ts
@@ -139,6 +139,17 @@ export type BuildWithProofPackedParameters = {
   readonly metaData: Uint8Array;
   readonly extraData: BytesHex;
   readonly tfheVersion: TfheVersion;
+  /**
+   * Optional seed for deterministic ("seeded") public encryption.
+   *
+   * When provided, encryption noise is derived from this seed instead of the
+   * OS RNG, making the resulting ciphertext byte-for-byte reproducible. Used for
+   * client-side encryption verifiability: an independent verifier re-runs the
+   * same seeded encryption and compares bytes. Requires TFHE version `1.6.1`
+   * and a seed of at least 16 bytes. When omitted, the normal (non-deterministic)
+   * encryption path is used and behavior is unchanged.
+   */
+  readonly seed?: Uint8Array | undefined;
 };
 
 export type BuildWithProofPackedReturnType = {

--- a/sdk/js-sdk/src/core/types/zkProofBuilder-p.ts
+++ b/sdk/js-sdk/src/core/types/zkProofBuilder-p.ts
@@ -32,6 +32,7 @@ export interface ZkProofBuilder {
       readonly contractAddress: string;
       readonly userAddress: string;
       readonly extraData: string;
+      readonly seed?: Uint8Array | undefined;
     },
   ): Promise<ZkProof>;
 }

--- a/sdk/js-sdk/test/fheTest/ethers-common/clientEncrypt.encryptDecrypt.slow.tests.ts
+++ b/sdk/js-sdk/test/fheTest/ethers-common/clientEncrypt.encryptDecrypt.slow.tests.ts
@@ -27,9 +27,18 @@ export function defineClientEncryptDecryptSlowTests(parameters: {
   readonly createFhevmEncryptClient: CreateEthersEncryptClientFn;
   readonly createFhevmDecryptClient: CreateEthersDecryptClientFn;
   readonly moduleVersions?: FhevmModuleVersions | undefined;
+  /**
+   * When provided, encryption uses deterministic ("seeded") public encryption
+   * with this seed, and the test additionally asserts verify-by-reproduction
+   * (an independent verifier reproduces identical handles). When omitted, the
+   * normal (non-deterministic) path is exercised, unchanged.
+   */
+  readonly seed?: Uint8Array | undefined;
 }): void {
+  const seed = parameters.seed;
+
   describe.runIf(parameters.runIf)(
-    'Encrypt-Decrypt',
+    `Encrypt-Decrypt${seed !== undefined ? ' (seeded)' : ''}`,
     () => {
       let config: FheTestEthersConfig;
 
@@ -47,7 +56,7 @@ export function defineClientEncryptDecryptSlowTests(parameters: {
         });
       });
 
-      it('should encrypt, submit on-chain, and decrypt all types', async () => {
+      it('should encrypt, submit on-chain, and decrypt all types', async (ctx) => {
         // ┌─────────────────────────────────────────────────────────────────────┐
         // │  Phase 1: ENCRYPT                                                   │
         // │  Client-side encryption of all FHE types into external handles      │
@@ -59,15 +68,64 @@ export function defineClientEncryptDecryptSlowTests(parameters: {
         });
         await client.ready;
 
-        const result = await client.encryptValues({
-          contractAddress: config.fheTestAddress,
-          userAddress: config.wallet.address,
-          values: encryptTestCases,
-        });
+        // Seeded encryption is a TFHE 1.6.1 feature; on older chains (e.g.
+        // localstack v11/v12 → tfhe 1.5.3) `encryptSeeded` is a hard error, so
+        // skip the seeded variant there. The non-seeded variant always runs.
+        if (seed !== undefined && client.tfheVersion !== '1.6.1') {
+          ctx.skip();
+          return;
+        }
+
+        // Seeded mode uses the distinct `encryptSeeded` API; the default path
+        // (`encryptValues`) is unchanged and never sees a seed.
+        const result =
+          seed !== undefined
+            ? await client.encryptSeeded({
+                contractAddress: config.fheTestAddress,
+                userAddress: config.wallet.address,
+                values: encryptTestCases,
+                seed,
+              })
+            : await client.encryptValues({
+                contractAddress: config.fheTestAddress,
+                userAddress: config.wallet.address,
+                values: encryptTestCases,
+              });
 
         expect(result.encryptedValues).toHaveLength(encryptTestCases.length);
         expect(result.inputProof).toBeDefined();
         expect(result.inputProof.startsWith('0x')).toBe(true);
+
+        // ┌─────────────────────────────────────────────────────────────────────┐
+        // │  Phase 1b: VERIFY-BY-REPRODUCTION (seeded only)                     │
+        // │  An independent verifier re-runs the same seeded encryption and     │
+        // │  must reproduce byte-identical handles. A different seed must not.   │
+        // └─────────────────────────────────────────────────────────────────────┘
+        if (seed !== undefined) {
+          // encryptSeeded echoes back the seed it used.
+          expect('seed' in result && result.seed).toBeDefined();
+
+          const verification = await client.verifySeededEncryption({
+            seed,
+            values: encryptTestCases,
+            contractAddress: config.fheTestAddress,
+            userAddress: config.wallet.address,
+            expectedEncryptedValues: result.encryptedValues,
+          });
+          expect(verification.mismatches).toEqual([]);
+          expect(verification.verified).toBe(true);
+
+          // Negative control: a different seed must NOT reproduce the same handles.
+          const wrongSeed = new Uint8Array(seed.length).fill((seed[0]! + 1) & 0xff);
+          const bad = await client.verifySeededEncryption({
+            seed: wrongSeed,
+            values: encryptTestCases,
+            contractAddress: config.fheTestAddress,
+            userAddress: config.wallet.address,
+            expectedEncryptedValues: result.encryptedValues,
+          });
+          expect(bad.verified).toBe(false);
+        }
 
         for (let i = 0; i < encryptTestCases.length; i++) {
           const tc = encryptTestCases[i]!;

--- a/sdk/js-sdk/test/fheTest/ethers/clientEncrypt.encryptDecrypt.seeded.slow.test.ts
+++ b/sdk/js-sdk/test/fheTest/ethers/clientEncrypt.encryptDecrypt.seeded.slow.test.ts
@@ -1,0 +1,30 @@
+import { createFhevmEncryptClient, createFhevmDecryptClient } from '@fhevm/sdk/ethers';
+import { getEthersTestConfig } from '../setup-ethers.js';
+import { isCleartext } from '../setupCommon.js';
+import { defineClientEncryptDecryptSlowTests } from '../ethers-common/clientEncrypt.encryptDecrypt.slow.tests.js';
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Seeded ("deterministic") public encryption — full round-trip + verify-by-reproduction.
+//
+// This is the empirical check that a SEEDED proven compact list verifies and
+// expands end-to-end on the deployed coprocessor (the serialization format is
+// identical to the non-seeded path, but this proves it). Requires a real backend
+// (tfhe-rs 1.6.1) — skipped on cleartext chains, like the non-seeded slow test.
+//
+// CHAIN=localstack     npx vitest run --config test/fheTest/vitest.config.ts ethers/clientEncrypt.encryptDecrypt.seeded.slow.test.ts
+// CHAIN=devnet         npx vitest run --config test/fheTest/vitest.config.ts ethers/clientEncrypt.encryptDecrypt.seeded.slow.test.ts
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Fixed 32-byte seed: determinism is the whole point — a constant seed keeps the
+// test reproducible. (In production the seed is generated per-encryption via
+// generateEncryptionSeed() and kept secret, shared only with the verifier.)
+const SEED = new Uint8Array(32).fill(0xa5);
+
+defineClientEncryptDecryptSlowTests({
+  runIf: !isCleartext(getEthersTestConfig().chainName),
+  createFhevmEncryptClient: (params) => createFhevmEncryptClient(params),
+  createFhevmDecryptClient: (params) => createFhevmDecryptClient(params),
+  seed: SEED,
+});


### PR DESCRIPTION
## Summary

Adds **client-side seeded (deterministic) public encryption** to `@fhevm/sdk`, enabling independent verification of an encrypted input: a trusted off-band party can confirm an input ciphertext commits to the value it claims, without using the protocol's decryption path or the FHE secret key.

The encryptor derives the input ciphertext deterministically from a secret seed; a verifier given `(plaintext, seed)` out-of-band re-runs the same seeded encryption and confirms a byte-for-byte match. The on-chain artifact (ciphertext + ZK proof) and the protocol are unchanged. Motivated by institutional custody workflows (a co-signer that must validate the encrypted payload before signing).

All changes are confined to `sdk/js-sdk`.

## What's new

- **`encryptSeeded`** — a distinct, opt-in action (separate from the default `encryptValues`, so the seeded path can't be reached by accident). Auto-generates a CSPRNG seed when none is supplied, validates a caller-supplied one, and **returns the seed actually used**.
- **`verifySeededEncryption`** — reproduction-and-compare helper. Purely local (no relayer); re-runs seeded encryption and compares the reproduced handles/ciphertext against the claimed ones.
- **Seed helpers** — `randomBytes`, `generateEncryptionSeed` (CSPRNG, default 32 bytes), `assertIsEncryptionSeed`, exported from `@fhevm/sdk/actions/encrypt`.
- Internal plumbing threads an optional `seed` through `buildWithProofPacked` → `ZkProofBuilder` → the coprocessor encrypt path, calling TFHE-rs `build_with_proof_packed_seeded`.

## Constraints & safety

- Gated to **TFHE-rs ≥ 1.6.1** (the v1.5.3 WASM has no seeded builder); a hard error otherwise.
- Seed must be **≥ 16 bytes** (TFHE-rs requirement; WASM doesn't validate it, so the SDK does).
- The mock encrypt module mirrors the seeded branch so unit tests stay consistent.
- ⚠️ **The seed is plaintext-equivalent.** Anyone holding `(seed, ciphertext, public key)` can recover the plaintext without the FHE secret key. It must be freshly generated per encryption, never reused, never message-derived, and shared only over a secure channel. The SDK never logs or persists it. This is documented inline; a dedicated security review is warranted before this is promoted beyond an opt-in/advanced capability.

## Testing

- New unit tests: seed helper (`random.test.ts`) and seeded determinism/gating/validation through the mock (`mock.seeded.test.ts`).
- New seeded end-to-end round-trip test (`clientEncrypt.encryptDecrypt.seeded.slow.test.ts`) — encrypt → submit on-chain → decrypt, plus verify-by-reproduction with a wrong-seed negative control.
- Full unit suite green (774 tests), typecheck clean, eslint/prettier clean.

## Not yet done

- **Live coprocessor round-trip not yet run.** The serialized seeded `ProvenCompactCiphertextList` is the same format as the non-seeded path, and the coprocessor pins tfhe-rs `=1.6.1` with no code path that rejects seeded by construction — but acceptance at `deserialize → verify_and_expand` must be confirmed against localstack/testnet before finalizing the API. The seeded `.slow` test is the vehicle for that check.
- User-facing docs for the seeded API and seed-handling requirements.
