### PR TITLE
ci(sdk): drop unsupported cleartext-latest dod job

### DIFF
--- a/.github/workflows/js-sdk-dod.yml
+++ b/.github/workflows/js-sdk-dod.yml
@@ -75,7 +75,6 @@ jobs:
           - browser
           - cleartext-v12
           - cleartext-v13
-          - cleartext-latest
           - localstack-v11
           - localstack-v12
           - localstack-v13
@@ -180,8 +179,6 @@ jobs:
             flags: '--use-pack --foundry-profile=v12'
           - profile: v13
             flags: '--use-pack --foundry-profile=v13'
-          - profile: latest
-            flags: '--use-pack'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
## Summary

Fixes the always-failing **`dod cleartext latest`** CI job.

The `js-sdk-dod` workflow's `cleartext` matrix had a `latest` leg that passed `flags: '--use-pack'` with **no** `--foundry-profile`. But `test/scripts/localcleartext-run-tests.sh` requires a profile and exits 1 otherwise:

```
Error: --foundry-profile is required. Expected: v12 or v13.
```

So that job failed on every run.

## Why remove it (rather than map it to a profile)

- The runner only supports `v12` and `v13` foundry profiles; there is no "latest" cleartext profile (the newest cleartext contracts are `v0.13.0`).
- `dod.mjs` — which this workflow mirrors job-for-job — runs cleartext only for **v12** and **v13** (no `latest`).
- The `cleartext-latest` leg was introduced in #2853 by analogy with the `localstack-latest` leg, but unlike localstack (where `latest` maps to the default chain), cleartext has no distinct "latest" target. Mapping it to `v13` would just duplicate the existing `v13` job.

So the leg is spurious. This removes it from both the real `cleartext` matrix and the `dry-run` name list, leaving `cleartext v12` + `v13` — matching `dod.mjs`.

## Validation

- YAML parses; `cleartext v12`/`v13` jobs unchanged.
- This PR touches `sdk/js-sdk`, so the `js-sdk-dod` workflow runs on it — the `dod cleartext latest` job should now be absent rather than failing.
