### PR TITLE
feat(sdk): switch js-sdk testnet expectations to protocol v0.13

### DIFF
--- a/.github/workflows/js-sdk-dod.yml
+++ b/.github/workflows/js-sdk-dod.yml
@@ -75,7 +75,6 @@ jobs:
           - browser
           - cleartext-v12
           - cleartext-v13
-          - cleartext-latest
           - localstack-v11
           - localstack-v12
           - localstack-v13
@@ -180,8 +179,6 @@ jobs:
             flags: '--use-pack --foundry-profile=v12'
           - profile: v13
             flags: '--use-pack --foundry-profile=v13'
-          - profile: latest
-            flags: '--use-pack'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/sdk/js-sdk/docs/compatibility.md
+++ b/sdk/js-sdk/docs/compatibility.md
@@ -46,7 +46,7 @@ KMS `0.12.7` generated the PubKey/CRS in December 2025
 | Chain                 | Protocol | PubKey/CRS      |
 | --------------------- | -------- | --------------- |
 | Mainnet               | `0.11.0` | `1.4.0-alpha.3` |
-| Testnet               | `0.12.0` | `1.4.0-alpha.3` |
+| Testnet               | `0.13.0` | `1.4.0-alpha.3` |
 | Devnet                | `0.13.0` | `1.4.0-alpha.3` |
 | Polygon-Amoy (Devnet) | `0.13.0` | `1.4.0-alpha.3` |
 
@@ -77,7 +77,7 @@ KMS `0.12.7` generated the PubKey/CRS in December 2025
 | Chain   | Protocol | PubKey/CRS (TFHE) | TFHE 1.5.3 | TFHE 1.6.1 |
 | ------- | -------- | ----------------- | ---------- | ---------- |
 | Mainnet | `0.11.0` | `1.4.0-alpha.3`   | ✅         | ❌         |
-| Testnet | `0.12.0` | `1.4.0-alpha.3`   | ✅         | ❌         |
+| Testnet | `0.13.0` | `1.4.0-alpha.3`   | ✅         | ✅         |
 | Devnet  | `0.13.0` | `1.4.0-alpha.3`   | ✅         | ✅         |
 
 ## Localstack

--- a/sdk/js-sdk/test/fheTest/ethers/relayerAuthErrors.test.ts
+++ b/sdk/js-sdk/test/fheTest/ethers/relayerAuthErrors.test.ts
@@ -13,8 +13,9 @@ import { fetchFheEncryptionKeySource } from '../../../src/core/modules/relayer/m
 //
 // These hit the real hosted relayer `v2/keyurl` endpoint with deliberately
 // invalid credentials, so they only run against Zama-hosted endpoints
-// (*.zama.org) that enforce auth at the edge. Local/self-hosted relayers that
-// don't enforce auth are skipped.
+// (*.zama.org) that enforce auth at the edge. Sepolia/testnet currently serves
+// key metadata without auth, and local/self-hosted relayers may do the same, so
+// those environments are skipped.
 //
 // CHAIN=testnet npx vitest run --config test/fheTest/vitest.config.ts ethers/relayerAuthErrors.test.ts
 // CHAIN=mainnet npx vitest run --config test/fheTest/vitest.config.ts ethers/relayerAuthErrors.test.ts
@@ -31,8 +32,9 @@ function isZamaHostedRelayer(relayerUrl: string): boolean {
 
 const config: FheTestEthersConfig = getEthersTestConfig();
 const relayerUrl: string = config.fhevmChain.fhevm.relayerUrl;
+const shouldRunAuthErrorTests = isZamaHostedRelayer(relayerUrl) && config.chainName === 'mainnet';
 
-describe.runIf(isZamaHostedRelayer(relayerUrl))('Relayer auth-error surfacing (keyurl)', () => {
+describe.runIf(shouldRunAuthErrorTests)('Relayer auth-error surfacing (keyurl)', () => {
   let relayerClient: { relayerUrl: string; chainId: number };
 
   beforeAll(() => {

--- a/sdk/js-sdk/test/fheTest/setupCommon.ts
+++ b/sdk/js-sdk/test/fheTest/setupCommon.ts
@@ -66,8 +66,8 @@ export function isCleartext(chainName: FheTestChainName) {
 // ---------------------------------------------------------------------------
 
 const PROTOCOL_VERSION_BY_CHAIN: Readonly<Record<FheTestChainName, ProtocolVersion>> = {
-  sepolia: '0.12.0',
-  testnet: '0.12.0',
+  sepolia: '0.13.0',
+  testnet: '0.13.0',
   mainnet: '0.11.0',
   localcleartext: '0.13.0',
   localcleartext_v12: '0.12.0',


### PR DESCRIPTION
## Summary

This PR updates the JS SDK test fixtures and compatibility notes now that Sepolia/testnet resolves to FHEVM protocol `v0.13.0`.

It also restricts the live `v2/keyurl` auth-error E2E to mainnet. Sepolia/testnet currently serves key metadata without requiring auth, so invalid credentials no longer reliably produce the 401/403 responses that this test is meant to validate.

## Changes

- Updates Sepolia/testnet expected protocol version from `0.12.0` to `0.13.0`.
- Updates compatibility documentation for testnet protocol and TFHE compatibility.
- Skips hosted keyurl auth-error E2E outside mainnet.

## Testing

- `npm run test:full:testnet`