### PR TITLE
fix: fix aws lib features

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1619,6 +1619,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http-client"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1053b5e587e6fa40ce5a79ea27957b04ba660baa02b28b7436f64850152234f1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-json"
 version = "0.61.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1678,7 @@ checksum = "40ab99739082da5347660c556689256438defae3bcefd66c52b095905730e404"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1695,6 +1720,7 @@ dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
+ "futures-core",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -1707,6 +1733,8 @@ dependencies = [
  "ryu",
  "serde",
  "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3467,6 +3495,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1445,8 +1445,6 @@ checksum = "8bc1b40fb26027769f16960d2f4a6bc20c4bb755d403e552c8c1a73af433c246"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1457,14 +1455,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
  "http 1.3.1",
- "ring",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -1530,50 +1525,6 @@ name = "aws-sdk-kms"
 version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e7ef7189e532a6d7654befd668b535d31f261c61342397da47ccfa3fb0505a"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.87.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4af747ffcb5aa8da8be8f0679ef6940f1afdb8c2e10c36738c9ebeb8d17b95e"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.89.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695dc67bb861ccb8426c9129b91c30e266a0e3d85650cafdf62fcca14c8fd338"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1445,6 +1445,8 @@ checksum = "8bc1b40fb26027769f16960d2f4a6bc20c4bb755d403e552c8c1a73af433c246"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1455,11 +1457,14 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
+ "hex",
  "http 1.3.1",
+ "ring",
  "time",
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -1525,6 +1530,50 @@ name = "aws-sdk-kms"
 version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e7ef7189e532a6d7654befd668b535d31f261c61342397da47ccfa3fb0505a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.87.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4af747ffcb5aa8da8be8f0679ef6940f1afdb8c2e10c36738c9ebeb8d17b95e"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.89.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695dc67bb861ccb8426c9129b91c30e266a0e3d85650cafdf62fcca14c8fd338"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1347,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3534,7 +3534,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4898,7 +4898,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4907,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4935,9 +4935,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5363,7 +5363,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6204,7 +6204,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -39,9 +39,13 @@ alloy = { version = "=1.0.38", default-features = false, features = [
 anyhow = { version = "=1.0.100", default-features = false }
 async-trait = { version = "=0.1.89", default-features = false }
 aws-config = { version = "=1.8.6", default-features = false, features = [
+    "default-https-client",
     "rt-tokio",
 ] }
-aws-sdk-kms = { version = "=1.86.0", default-features = false }
+aws-sdk-kms = { version = "=1.86.0", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
 aws-sdk-s3 = { version = "=1.105.0", default-features = true }
 clap = { version = "=4.5.47", default-features = true, features = [
     "cargo",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -38,10 +38,7 @@ alloy = { version = "=1.0.38", default-features = false, features = [
 ] }
 anyhow = { version = "=1.0.100", default-features = false }
 async-trait = { version = "=0.1.89", default-features = false }
-aws-config = { version = "=1.8.6", default-features = false, features = [
-    "default-https-client",
-    "rt-tokio",
-] }
+aws-config = { version = "=1.8.6", default-features = true }
 aws-sdk-kms = { version = "=1.86.0", default-features = false, features = [
     "default-https-client",
     "rt-tokio",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -38,7 +38,9 @@ alloy = { version = "=1.0.38", default-features = false, features = [
 ] }
 anyhow = { version = "=1.0.100", default-features = false }
 async-trait = { version = "=0.1.89", default-features = false }
-aws-config = { version = "=1.8.6", default-features = true }
+aws-config = { version = "=1.8.6", default-features = false, features = [
+    "rt-tokio",
+] }
 aws-sdk-kms = { version = "=1.86.0", default-features = false, features = [
     "default-https-client",
     "rt-tokio",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -39,6 +39,7 @@ alloy = { version = "=1.0.38", default-features = false, features = [
 anyhow = { version = "=1.0.100", default-features = false }
 async-trait = { version = "=0.1.89", default-features = false }
 aws-config = { version = "=1.8.6", default-features = false, features = [
+    "default-https-client",
     "rt-tokio",
 ] }
 aws-sdk-kms = { version = "=1.86.0", default-features = false, features = [


### PR DESCRIPTION
Connection version v0.13.0 drops the features for aws lib that leads to 
```
error=dispatch failure: other: No HTTP client was available to send this request. Enable the `default-https-client` crate feature or configure an HTTP client to fix this.
```
This PR set back this feature.