### PR TITLE
fix(test-suite): retry confidential bridge e2e txs on `NONCE_EXPIRED`

### DIFF
--- a/test-suite/e2e/test/bridge/confidentialBridge.ts
+++ b/test-suite/e2e/test/bridge/confidentialBridge.ts
@@ -14,7 +14,7 @@ import {
   forgeDelivery,
   relayBridgeMessage,
   relayCompose,
-  resyncNonce,
+  sendWithNonceRetry,
   waitForBridgedHandles,
 } from './relay';
 
@@ -98,9 +98,9 @@ describe('Confidential Bridge', function () {
     });
     const fn = addend === undefined ? 'makeHandle' : 'makeComputedHandle';
     const args = addend === undefined ? [enc.handles[0], enc.inputProof] : [enc.handles[0], enc.inputProof, addend];
-    resyncNonce(end.alice);
-    const receipt = await (await end.app.connect(end.alice).getFunction(fn)(...args, { gasLimit: 5_000_000 })).wait();
-    if (!receipt) throw new Error('mint transaction was dropped');
+    const receipt = await sendWithNonceRetry(end.alice, () =>
+      end.app.connect(end.alice).getFunction(fn)(...args, { gasLimit: 5_000_000 }),
+    );
     const minted = receipt.logs
       .map((log: ethers.Log) => {
         try {
@@ -120,14 +120,12 @@ describe('Confidential Bridge', function () {
     const fromBlock = await getProvider(dst.cfg).getBlockNumber();
     const dstApp = ethers.zeroPadValue(dst.appAddr, 32);
     const bridgeContract = new ethers.Contract(src.bridge, BRIDGE_SEND_ABI, src.alice);
-    resyncNonce(src.alice);
-    const sendReceipt = await (
-      await bridgeContract.send(dst.cfg.chainId, dstApp, payload, handles, LZ_COMPOSE_GAS, {
+    const sendReceipt = await sendWithNonceRetry(src.alice, () =>
+      bridgeContract.send(dst.cfg.chainId, dstApp, payload, handles, LZ_COMPOSE_GAS, {
         value: 0,
         gasLimit: 5_000_000,
-      })
-    ).wait();
-    if (!sendReceipt) throw new Error('bridge send transaction was dropped');
+      }),
+    );
 
     if (USE_REAL_LZ) {
       const dstHandles = await waitForBridgedHandles(

--- a/test-suite/e2e/test/bridge/relay.ts
+++ b/test-suite/e2e/test/bridge/relay.ts
@@ -29,10 +29,22 @@ const BRIDGE_EVENTS_ABI = [
 const endpointIface = new ethers.Interface(ENDPOINT_ABI);
 const bridgeIface = new ethers.Interface(BRIDGE_EVENTS_ABI);
 
-// Re-sync a shared NonceManager's cached nonce from chain before sending (safe: every tx is awaited+mined).
-export function resyncNonce(signer: ethers.Signer) {
-  const nonceManager = signer as Partial<ethers.NonceManager>;
-  if (typeof nonceManager.reset === 'function') nonceManager.reset();
+// Sends a tx and waits for the receipt, retrying on NONCE_EXPIRED
+export async function sendWithNonceRetry(
+  signer: ethers.Signer,
+  send: () => Promise<ethers.TransactionResponse>,
+): Promise<ethers.TransactionReceipt> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      (signer as Partial<ethers.NonceManager>).reset?.();
+      const receipt = await (await send()).wait();
+      if (!receipt) throw new Error('transaction was dropped or replaced');
+      return receipt;
+    } catch (error) {
+      if ((error as { code?: string })?.code !== 'NONCE_EXPIRED' || attempt >= 5) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+  }
 }
 
 function parseEvent(logs: readonly ethers.Log[], iface: ethers.Interface, name: string, address?: string) {
@@ -73,15 +85,13 @@ async function deliver(
   packet: { encodedPacket: string; origin: { srcEid: number; sender: string; nonce: bigint }; guid: string; message: string },
   skipCompose: boolean,
 ): Promise<{ dstHandles: string[]; compose: PendingCompose }> {
-  resyncNonce(ctx.dstSigner);
   const endpoint = new ethers.Contract(ctx.dstEndpoint, ENDPOINT_ABI, ctx.dstSigner);
   const lib = new ethers.Contract(await endpoint.defaultReceiveLibrary(packet.origin.srcEid), MSGLIB_ABI, ctx.dstSigner);
-  await (await lib.validatePacket(packet.encodedPacket)).wait();
+  await sendWithNonceRetry(ctx.dstSigner, () => lib.validatePacket(packet.encodedPacket));
 
-  const recvReceipt = await (
-    await endpoint.lzReceive(packet.origin, ctx.dstBridge, packet.guid, packet.message, '0x')
-  ).wait();
-  if (!recvReceipt) throw new Error('relay: lzReceive transaction was dropped');
+  const recvReceipt = await sendWithNonceRetry(ctx.dstSigner, () =>
+    endpoint.lzReceive(packet.origin, ctx.dstBridge, packet.guid, packet.message, '0x'),
+  );
   const dstHandles = parseEvent(recvReceipt.logs, bridgeIface, 'HandleBridged', ctx.dstBridge).map(
     (e) => e.args.dstHandle as string,
   );
@@ -118,11 +128,10 @@ export async function relayBridgeMessage(
 
 /** Delivers the compose leg captured by {@link relayBridgeMessage} (runs the dst app's onConfidentialBridgeReceived). */
 export async function relayCompose(ctx: RelayContext, compose: PendingCompose): Promise<void> {
-  resyncNonce(ctx.dstSigner);
   const endpoint = new ethers.Contract(ctx.dstEndpoint, ENDPOINT_ABI, ctx.dstSigner);
-  await (
-    await endpoint.lzCompose(compose.from, compose.to, compose.guid, compose.index, compose.message, '0x')
-  ).wait();
+  await sendWithNonceRetry(ctx.dstSigner, () =>
+    endpoint.lzCompose(compose.from, compose.to, compose.guid, compose.index, compose.message, '0x'),
+  );
 }
 
 /** Encodes a LayerZero V2 packet (inverse of {@link decodePacket}). */


### PR DESCRIPTION
### Summary

- Adds a `sendWithNonceRetry` wrapper (reset + retry on NONCE_EXPIRED) applied to the bridge send and relay txs.
- Fixes NONCE_EXPIRED failures in the confidential bridge e2e on the multi-coprocessor scenario.