### PR TITLE
fix(sdk): fix _assertIsKmsUserDecryptEip712Base and toTransportKeyPair functions

### DIFF
--- a/.github/workflows/common-pull-request-lint.yml
+++ b/.github/workflows/common-pull-request-lint.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title  }}
         run: |
-          npm install @commitlint/config-conventional@^18 conventional-changelog-conventionalcommits @commitlint/types@^18
+          npm install @commitlint/config-conventional@^18 conventional-changelog-conventionalcommits@^7 @commitlint/types@^18
           npm install -g @commitlint/cli@^18
           echo "$PR_TITLE" | npx commitlint --config .github/config/commitlint.config.js --verbose
 

--- a/sdk/js-sdk/src/core/kms/TransportKeyPair-p.ts
+++ b/sdk/js-sdk/src/core/kms/TransportKeyPair-p.ts
@@ -237,11 +237,6 @@ export async function toTransportKeyPair(
     expectedType: 'Bytes | BytesHex',
     ...options,
   });
-  assertRecordNonNullableProperty(value, 'tkmsVersion', name, {
-    expectedType: 'string',
-    ...options,
-  });
-
   const rawPublicKey = value.publicKey;
   const rawPrivateKey = value.privateKey;
   const rawTkmsVersion = value.tkmsVersion;

--- a/sdk/js-sdk/src/core/kms/createKmsUserDecryptEip712.ts
+++ b/sdk/js-sdk/src/core/kms/createKmsUserDecryptEip712.ts
@@ -16,6 +16,7 @@ import { assertIsUint64, assertIsUintNumber } from '../base/uint.js';
 import { assertIsKmsExtraData } from './kmsExtraData.js';
 import { kmsUserDecryptEip712Types } from './kmsUserDecryptEip712Types.js';
 import { isDeepEqual } from '../base/object.js';
+import { kmsDelegatedUserDecryptEip712Types } from './kmsDelegatedUserDecryptEip712Types.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -121,7 +122,13 @@ export function _assertIsKmsUserDecryptEip712Base(
   assertIsKmsEip712Domain((value as Record<string, unknown>).domain, `${name}.domain`, options);
 
   assertRecordNonNullableProperty(value, 'types', name, options);
-  if (!isDeepEqual(value.types, kmsUserDecryptEip712Types)) {
+
+  const expectedTypes =
+    primaryType === 'DelegatedUserDecryptRequestVerification'
+      ? kmsDelegatedUserDecryptEip712Types
+      : kmsUserDecryptEip712Types;
+
+  if (!isDeepEqual(value.types, expectedTypes)) {
     throw new Error('Unexpected KmsUserDecryptEip712Types');
   }
 


### PR DESCRIPTION
This pull request makes improvements to the EIP-712 type validation logic and simplifies property assertions in the KMS core. The main changes include dynamic selection of EIP-712 types for delegated user decryption requests and cleanup of redundant property checks.

### EIP-712 Type Validation Improvements

* [`sdk/js-sdk/src/core/kms/createKmsUserDecryptEip712.ts`](diffhunk://#diff-4fa3789411c23a8dbeb475f36e1ccb734ffa0ca5addca6e8d688063ff7115e8aR19): Added import for `kmsDelegatedUserDecryptEip712Types` and updated the `_assertIsKmsUserDecryptEip712Base` function to dynamically select the expected types based on the `primaryType`, supporting both standard and delegated user decrypt requests. [[1]](diffhunk://#diff-4fa3789411c23a8dbeb475f36e1ccb734ffa0ca5addca6e8d688063ff7115e8aR19) [[2]](diffhunk://#diff-4fa3789411c23a8dbeb475f36e1ccb734ffa0ca5addca6e8d688063ff7115e8aL124-R131)

### Code Simplification

* [`sdk/js-sdk/src/core/kms/TransportKeyPair-p.ts`](diffhunk://#diff-5ae4297cd4f3475a93389b6f93fb61adb732d6a920d09b880edd8be7bd1402e9L240-L244): Removed a redundant `assertRecordNonNullableProperty` check for the `tkmsVersion` property, as this validation is no longer necessary at this point.