### PR TITLE
fix(sdk): refetch coprocessor signers on stale verification failure

### DIFF
--- a/sdk/js-sdk/src/core/actions/base/readCoprocessorSignersContext.ts
+++ b/sdk/js-sdk/src/core/actions/base/readCoprocessorSignersContext.ts
@@ -12,9 +12,11 @@ export type ReadCoprocessorSignersContextReturnType = CoprocessorSignersContext;
 
 export async function readCoprocessorSignersContext(
   fhevm: Fhevm<FhevmChain>,
+  options?: { readonly forceRefresh?: boolean | undefined },
 ): Promise<ReadCoprocessorSignersContextReturnType> {
   return readCoprocessorSignersContext_(fhevm, {
     address: fhevm.chain.fhevm.contracts.inputVerifier.address as ChecksummedAddress,
+    forceRefresh: options?.forceRefresh,
   });
 }
 

--- a/sdk/js-sdk/src/core/actions/base/verifyHandlesCoprocessorSignatures.test.ts
+++ b/sdk/js-sdk/src/core/actions/base/verifyHandlesCoprocessorSignatures.test.ts
@@ -1,0 +1,138 @@
+import type { EthereumModule } from '../../modules/ethereum/types.js';
+import type { RelayerModule } from '../../modules/relayer/types.js';
+import type { InputHandle } from '../../types/encryptedTypes-p.js';
+import type { Bytes65Hex, BytesHex, ChecksummedAddress, Uint64BigInt } from '../../types/primitives.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRIVATE_ETHERS_TOKEN } from '../../../ethers/internal/ethers-p.js';
+import { sepolia } from '../../chains/definitions/sepolia.js';
+import { createCoreFhevm } from '../../runtime/CoreFhevm-p.js';
+import { createFhevmRuntime } from '../../runtime/CoreFhevmRuntime-p.js';
+import { DuplicateSignerError, UnknownSignerError } from '../../errors/SignersError.js';
+
+// Recovered signer set is derived from the EIP-712 signatures; mock it so each
+// test controls the recovered addresses directly.
+const { recoverSignersMock } = vi.hoisted(() => ({ recoverSignersMock: vi.fn() }));
+vi.mock('../../utils-p/runtime/recoverSigners.js', () => ({
+  recoverSigners: recoverSignersMock,
+}));
+
+import { verifyHandlesCoprocessorSignatures } from './verifyHandlesCoprocessorSignatures.js';
+
+////////////////////////////////////////////////////////////////////////////////
+
+const A = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as ChecksummedAddress;
+const B = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as ChecksummedAddress;
+const C = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC' as ChecksummedAddress;
+const D = '0x90F79bf6EB2c4f870365E785982E1f101E93b906' as ChecksummedAddress;
+const USER = '0x976EA74026E726554dB657fA54763abd0C3a0aa9' as ChecksummedAddress;
+const CONTRACT = '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65' as ChecksummedAddress;
+
+function makeReadContract(rounds: ReadonlyArray<{ threshold: number; signers: ChecksummedAddress[] }>): {
+  readContract: EthereumModule['readContract'];
+} {
+  const thresholds = rounds.map((r) => r.threshold);
+  const signers = rounds.map((r) => [...r.signers]);
+
+  const readContract = vi.fn(async (_trustedClient: unknown, parameters: { functionName: string }) => {
+    if (parameters.functionName === 'getThreshold') {
+      const t = thresholds.shift();
+      if (t === undefined) {
+        throw new Error('No more mocked thresholds');
+      }
+      return t;
+    }
+    if (parameters.functionName === 'getCoprocessorSigners') {
+      const s = signers.shift();
+      if (s === undefined) {
+        throw new Error('No more mocked signers');
+      }
+      return s;
+    }
+    throw new Error(`Unexpected functionName ${parameters.functionName}`);
+  }) as unknown as EthereumModule['readContract'];
+
+  return { readContract };
+}
+
+function makeFhevm(
+  readContract: EthereumModule['readContract'],
+): ReturnType<typeof createCoreFhevm<typeof sepolia, ReturnType<typeof createFhevmRuntime>, object>> {
+  const ethereum = { readContract } as unknown as EthereumModule;
+
+  const runtime = createFhevmRuntime(PRIVATE_ETHERS_TOKEN, {
+    ethereum,
+    relayer: {} as RelayerModule,
+    config: {},
+  });
+
+  return createCoreFhevm(PRIVATE_ETHERS_TOKEN, {
+    chain: sepolia,
+    client: {},
+    runtime,
+  });
+}
+
+function makeParameters() {
+  return {
+    coprocessorSignatures: [`0x${'11'.repeat(65)}`] as Bytes65Hex[],
+    inputHandles: [{ bytes32Hex: `0x${'ab'.repeat(32)}` } as unknown as InputHandle],
+    userAddress: USER,
+    contractAddress: CONTRACT,
+    chainId: 11155111n as Uint64BigInt,
+    extraData: '0x' as BytesHex,
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+describe('actions/base verifyHandlesCoprocessorSignatures — stale signer refetch', () => {
+  beforeEach(() => {
+    recoverSignersMock.mockReset();
+  });
+
+  it('passes without refetching when the cached signer set is already valid', async () => {
+    recoverSignersMock.mockResolvedValue([A, B, C]);
+    const { readContract } = makeReadContract([{ threshold: 3, signers: [A, B, C, D] }]);
+    const fhevm = makeFhevm(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(fhevm, makeParameters())).resolves.toBeUndefined();
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('force-refreshes and recovers on an unknown signer (rotated-in coprocessor)', async () => {
+    recoverSignersMock.mockResolvedValue([A, B, D]);
+    const { readContract } = makeReadContract([
+      { threshold: 3, signers: [A, B, C] }, // stale: D missing
+      { threshold: 3, signers: [A, B, C, D] }, // fresh: D present
+    ]);
+    const fhevm = makeFhevm(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(fhevm, makeParameters())).resolves.toBeUndefined();
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+
+  it('does NOT refetch on a duplicate recovered signer', async () => {
+    recoverSignersMock.mockResolvedValue([A, A]);
+    const { readContract } = makeReadContract([{ threshold: 1, signers: [A, B, C] }]);
+    const fhevm = makeFhevm(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(fhevm, makeParameters())).rejects.toBeInstanceOf(
+      DuplicateSignerError,
+    );
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries exactly once, surfacing the error when the fresh set is still invalid', async () => {
+    recoverSignersMock.mockResolvedValue([A, B, D]);
+    const { readContract } = makeReadContract([
+      { threshold: 3, signers: [A, B, C] },
+      { threshold: 3, signers: [A, B, C] }, // D still missing
+    ]);
+    const fhevm = makeFhevm(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(fhevm, makeParameters())).rejects.toBeInstanceOf(
+      UnknownSignerError,
+    );
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+});

--- a/sdk/js-sdk/src/core/actions/base/verifyHandlesCoprocessorSignatures.ts
+++ b/sdk/js-sdk/src/core/actions/base/verifyHandlesCoprocessorSignatures.ts
@@ -9,6 +9,7 @@ import { coprocessorEip712PrimaryType, coprocessorEip712Types } from '../../copr
 import { createCoprocessorEip712Domain } from '../../coprocessor/createCoprocessorEip712Domain.js';
 import { assertCoprocessorSignerThreshold } from '../../host-contracts/CoprocessorSignersContext-p.js';
 import { readCoprocessorSignersContext } from './readCoprocessorSignersContext.js';
+import { ThresholdSignerError, UnknownSignerError } from '../../errors/SignersError.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -53,8 +54,26 @@ export async function verifyHandlesCoprocessorSignatures(
     message,
   });
 
-  const coprocessorSignersContext: CoprocessorSignersContext = await readCoprocessorSignersContext(fhevm);
+  let coprocessorSignersContext: CoprocessorSignersContext = await readCoprocessorSignersContext(fhevm);
 
-  // 2. Verify signature threshold is reached
-  assertCoprocessorSignerThreshold(coprocessorSignersContext, recoveredAddresses);
+  // 2. Verify signature threshold is reached.
+  //
+  // The signer set/threshold comes from a 24h TTL cache, so a long-lived
+  // instance can hold a stale set after the coprocessor signers rotate on-chain
+  // (e.g. a multi-coprocessor rollout). If verification fails for a reason a
+  // refreshed signer set could fix — an unrecognized signer (UnknownSignerError)
+  // or an unmet threshold (ThresholdSignerError) — force one fresh on-chain read
+  // and re-verify before surfacing the error. A DuplicateSignerError reflects
+  // duplicate recovered addresses (a malicious-relayer signal independent of the
+  // on-chain config), so it is intentionally not retried.
+  try {
+    assertCoprocessorSignerThreshold(coprocessorSignersContext, recoveredAddresses);
+  } catch (e) {
+    if (e instanceof UnknownSignerError || e instanceof ThresholdSignerError) {
+      coprocessorSignersContext = await readCoprocessorSignersContext(fhevm, { forceRefresh: true });
+      assertCoprocessorSignerThreshold(coprocessorSignersContext, recoveredAddresses);
+    } else {
+      throw e;
+    }
+  }
 }

--- a/sdk/js-sdk/src/core/coprocessor/verifyHandlesCoprocessorSignatures.test.ts
+++ b/sdk/js-sdk/src/core/coprocessor/verifyHandlesCoprocessorSignatures.test.ts
@@ -1,0 +1,199 @@
+import type { EthereumModule } from '../modules/ethereum/types.js';
+import type { RelayerModule } from '../modules/relayer/types.js';
+import type { InputHandle } from '../types/encryptedTypes-p.js';
+import type { Bytes65Hex, BytesHex, ChecksummedAddress, Uint64BigInt } from '../types/primitives.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRIVATE_ETHERS_TOKEN } from '../../ethers/internal/ethers-p.js';
+import { sepolia } from '../chains/definitions/sepolia.js';
+import { createCoreFhevm } from '../runtime/CoreFhevm-p.js';
+import { createFhevmRuntime } from '../runtime/CoreFhevmRuntime-p.js';
+import { DuplicateSignerError, ThresholdSignerError, UnknownSignerError } from '../errors/SignersError.js';
+
+// The signer set is recovered from the EIP-712 signatures via on-chain-free
+// crypto. Mock it so each test controls exactly which addresses come back,
+// independent of the (irrelevant) signature bytes.
+const { recoverSignersMock } = vi.hoisted(() => ({ recoverSignersMock: vi.fn() }));
+vi.mock('../utils-p/runtime/recoverSigners.js', () => ({
+  recoverSigners: recoverSignersMock,
+}));
+
+import { verifyHandlesCoprocessorSignatures } from './verifyHandlesCoprocessorSignatures.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// Valid EIP-55 checksummed addresses (hardhat default accounts).
+////////////////////////////////////////////////////////////////////////////////
+
+const A = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as ChecksummedAddress;
+const B = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as ChecksummedAddress;
+const C = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC' as ChecksummedAddress;
+const D = '0x90F79bf6EB2c4f870365E785982E1f101E93b906' as ChecksummedAddress;
+const USER = '0x976EA74026E726554dB657fA54763abd0C3a0aa9' as ChecksummedAddress;
+const CONTRACT = '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65' as ChecksummedAddress;
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Mock `readContract` that serves the InputVerifier `getThreshold()` and
+ * `getCoprocessorSigners()` calls. Each call to the read path consumes one
+ * "round" (one threshold + one signers entry), so index 0 is the initial
+ * (possibly stale) read and index 1 is what a forced refresh would fetch.
+ */
+function makeReadContract(rounds: ReadonlyArray<{ threshold: number; signers: ChecksummedAddress[] }>): {
+  readContract: EthereumModule['readContract'];
+} {
+  const thresholds = rounds.map((r) => r.threshold);
+  const signers = rounds.map((r) => [...r.signers]);
+
+  const readContract = vi.fn(async (_trustedClient: unknown, parameters: { functionName: string }) => {
+    if (parameters.functionName === 'getThreshold') {
+      const t = thresholds.shift();
+      if (t === undefined) {
+        throw new Error('No more mocked thresholds');
+      }
+      return t;
+    }
+    if (parameters.functionName === 'getCoprocessorSigners') {
+      const s = signers.shift();
+      if (s === undefined) {
+        throw new Error('No more mocked signers');
+      }
+      return s;
+    }
+    throw new Error(`Unexpected functionName ${parameters.functionName}`);
+  }) as unknown as EthereumModule['readContract'];
+
+  return { readContract };
+}
+
+function makeContext(
+  readContract: EthereumModule['readContract'],
+): ReturnType<typeof createCoreFhevm<typeof sepolia, ReturnType<typeof createFhevmRuntime>, object>> {
+  const ethereum = { readContract } as unknown as EthereumModule;
+
+  const runtime = createFhevmRuntime(PRIVATE_ETHERS_TOKEN, {
+    ethereum,
+    relayer: {} as RelayerModule,
+    config: {},
+  });
+
+  return createCoreFhevm(PRIVATE_ETHERS_TOKEN, {
+    chain: sepolia,
+    client: {},
+    runtime,
+  });
+}
+
+function makeParameters() {
+  return {
+    coprocessorSignatures: [`0x${'11'.repeat(65)}`] as Bytes65Hex[],
+    handles: [{ bytes32Hex: `0x${'ab'.repeat(32)}` } as unknown as InputHandle],
+    userAddress: USER,
+    contractAddress: CONTRACT,
+    chainId: 11155111n as Uint64BigInt,
+    extraData: '0x' as BytesHex,
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+describe('verifyHandlesCoprocessorSignatures — stale signer refetch', () => {
+  beforeEach(() => {
+    recoverSignersMock.mockReset();
+  });
+
+  it('passes without refetching when the cached signer set is already valid', async () => {
+    recoverSignersMock.mockResolvedValue([A, B, C]);
+    const { readContract } = makeReadContract([{ threshold: 3, signers: [A, B, C, D] }]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).resolves.toBeUndefined();
+
+    // One round only: getThreshold + getCoprocessorSigners. No forced refresh.
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses the TTL cache across calls when verification keeps succeeding', async () => {
+    recoverSignersMock.mockResolvedValue([A, B, C]);
+    const { readContract } = makeReadContract([{ threshold: 3, signers: [A, B, C, D] }]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).resolves.toBeUndefined();
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).resolves.toBeUndefined();
+
+    // Second verification hits the cache — still only the initial 2 reads.
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('force-refreshes and recovers on an unknown signer (rotated-in coprocessor)', async () => {
+    // Recovered set includes D, which the stale on-chain snapshot does not know.
+    recoverSignersMock.mockResolvedValue([A, B, D]);
+    const { readContract } = makeReadContract([
+      { threshold: 3, signers: [A, B, C] }, // stale: D missing -> UnknownSignerError
+      { threshold: 3, signers: [A, B, C, D] }, // fresh: D present -> passes
+    ]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).resolves.toBeUndefined();
+
+    // 2 reads for the stale round + 2 for the forced refresh.
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+
+  it('force-refreshes and recovers when the cached threshold is stale', async () => {
+    recoverSignersMock.mockResolvedValue([A]);
+    const { readContract } = makeReadContract([
+      { threshold: 3, signers: [A, B, C] }, // stale: 1 < 3 -> ThresholdSignerError
+      { threshold: 1, signers: [A, B, C] }, // fresh: 1 >= 1 -> passes
+    ]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).resolves.toBeUndefined();
+
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+
+  it('retries exactly once, surfacing the error when the fresh set is still invalid', async () => {
+    recoverSignersMock.mockResolvedValue([A, B, D]);
+    const { readContract } = makeReadContract([
+      { threshold: 3, signers: [A, B, C] }, // stale: D missing
+      { threshold: 3, signers: [A, B, C] }, // fresh: D still missing -> rethrow
+    ]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).rejects.toBeInstanceOf(
+      UnknownSignerError,
+    );
+
+    // Exactly one refresh — not an unbounded loop.
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+
+  it('does NOT refetch on a duplicate recovered signer (malicious-relayer signal)', async () => {
+    // A appears twice in the recovered set — a relayer-side signal that a fresh
+    // on-chain read cannot fix, so it must throw without a refresh.
+    recoverSignersMock.mockResolvedValue([A, A]);
+    const { readContract } = makeReadContract([{ threshold: 1, signers: [A, B, C] }]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).rejects.toBeInstanceOf(
+      DuplicateSignerError,
+    );
+
+    // Only the initial read — no forced refresh.
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a ThresholdSignerError after the refresh also fails the threshold', async () => {
+    recoverSignersMock.mockResolvedValue([A]);
+    const { readContract } = makeReadContract([
+      { threshold: 3, signers: [A, B, C] },
+      { threshold: 2, signers: [A, B, C] }, // still 1 < 2
+    ]);
+    const context = makeContext(readContract);
+
+    await expect(verifyHandlesCoprocessorSignatures(context, makeParameters())).rejects.toBeInstanceOf(
+      ThresholdSignerError,
+    );
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+});

--- a/sdk/js-sdk/src/core/coprocessor/verifyHandlesCoprocessorSignatures.ts
+++ b/sdk/js-sdk/src/core/coprocessor/verifyHandlesCoprocessorSignatures.ts
@@ -9,6 +9,7 @@ import { coprocessorEip712PrimaryType, coprocessorEip712Types } from './coproces
 import { createCoprocessorEip712Domain } from './createCoprocessorEip712Domain.js';
 import { assertCoprocessorSignerThreshold } from '../host-contracts/CoprocessorSignersContext-p.js';
 import { readCoprocessorSignersContext } from '../host-contracts/readCoprocessorSignersContext-p.js';
+import { ThresholdSignerError, UnknownSignerError } from '../errors/SignersError.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -57,10 +58,33 @@ export async function verifyHandlesCoprocessorSignatures(context: Context, param
     message,
   });
 
-  const coprocessorSignersContext: CoprocessorSignersContext = await readCoprocessorSignersContext(context, {
-    address: context.chain.fhevm.contracts.inputVerifier.address as ChecksummedAddress,
+  const address = context.chain.fhevm.contracts.inputVerifier.address as ChecksummedAddress;
+
+  let coprocessorSignersContext: CoprocessorSignersContext = await readCoprocessorSignersContext(context, {
+    address,
   });
 
-  // 2. Verify signature threshold is reached
-  assertCoprocessorSignerThreshold(coprocessorSignersContext, recoveredAddresses);
+  // 2. Verify signature threshold is reached.
+  //
+  // The signer set/threshold comes from a 24h TTL cache, so a long-lived
+  // instance can hold a stale set after the coprocessor signers rotate on-chain
+  // (e.g. a multi-coprocessor rollout). If verification fails for a reason a
+  // refreshed signer set could fix — an unrecognized signer (UnknownSignerError)
+  // or an unmet threshold (ThresholdSignerError) — force one fresh on-chain read
+  // and re-verify before surfacing the error. A DuplicateSignerError reflects
+  // duplicate recovered addresses (a malicious-relayer signal independent of the
+  // on-chain config), so it is intentionally not retried.
+  try {
+    assertCoprocessorSignerThreshold(coprocessorSignersContext, recoveredAddresses);
+  } catch (e) {
+    if (e instanceof UnknownSignerError || e instanceof ThresholdSignerError) {
+      coprocessorSignersContext = await readCoprocessorSignersContext(context, {
+        address,
+        forceRefresh: true,
+      });
+      assertCoprocessorSignerThreshold(coprocessorSignersContext, recoveredAddresses);
+    } else {
+      throw e;
+    }
+  }
 }

--- a/sdk/js-sdk/src/core/host-contracts/getCoprocessorContextSignersAndThreshold-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/getCoprocessorContextSignersAndThreshold-p.ts
@@ -44,7 +44,7 @@ const cachedGetCoprocessorContextSignersAndThreshold = createCachedFetch<Context
  */
 export function getCoprocessorContextSignersAndThreshold(
   context: Context,
-  parameters: Parameters & { readonly forceRefresh?: boolean },
+  parameters: Parameters & { readonly forceRefresh?: boolean | undefined },
 ): Promise<ReturnType> {
   return cachedGetCoprocessorContextSignersAndThreshold.execute(context, parameters);
 }

--- a/sdk/js-sdk/src/core/host-contracts/readCoprocessorSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/readCoprocessorSignersContext-p.ts
@@ -14,6 +14,12 @@ type Context = {
 
 type Parameters = {
   readonly address: ChecksummedAddress;
+  /**
+   * If `true`, bypasses the TTL cache and forces a fresh on-chain read of the
+   * coprocessor signers and threshold. The fresh result is stored back in the
+   * cache. Used to recover from a stale signer set after a verification failure.
+   */
+  readonly forceRefresh?: boolean | undefined;
 };
 
 type ReturnType = CoprocessorSignersContext;


### PR DESCRIPTION
## Problem

The coprocessor signer set + threshold used to verify input proofs is sourced from the on-chain **InputVerifier** contract (`getCoprocessorSigners()` / `getThreshold()`) and served through a **24h TTL cache** (`getCoprocessorContextSignersAndThreshold-p.ts`).

On a signature-verification failure the verify path previously just threw — it never refetched. So a long-lived instance (open SPA tab, Node singleton) created before an on-chain signer rotation (e.g. a multi-coprocessor rollout that changes the signer set / threshold) holds a **stale snapshot** and fails *every* input verification until the 24h TTL expires or the instance is torn down. Within that window the failure is sticky: each retry reuses the same cached stale set.

The KMS signers path already self-heals via `forceRefresh`; the coprocessor path was never wired up to do the same.

## Fix

In `verifyHandlesCoprocessorSignatures` (both the `coprocessor/` and `actions/base/` layers), wrap the threshold assertion:

- On `UnknownSignerError` or `ThresholdSignerError` → force **one** fresh on-chain read (`forceRefresh: true`, bypassing the TTL cache) and re-verify before surfacing the error.
- `DuplicateSignerError` reflects duplicate *recovered* addresses — a malicious-relayer signal independent of on-chain config — so it is **not** retried and throws straight through.
- Any other error rethrows unchanged. The retry happens at most once (no loop).

This plumbs the existing `forceRefresh` flag (already supported end-to-end by `cachedFetch`) through the two read wrappers, mirroring the pattern in `readKmsSignersContext-p.ts`.

### Files
- `host-contracts/readCoprocessorSignersContext-p.ts` — accept & forward `forceRefresh`
- `host-contracts/getCoprocessorContextSignersAndThreshold-p.ts` — widen `forceRefresh` to `boolean | undefined` (matches KMS variants / `exactOptionalPropertyTypes`)
- `actions/base/readCoprocessorSignersContext.ts` — optional `{ forceRefresh }` on the no-param wrapper
- `coprocessor/verifyHandlesCoprocessorSignatures.ts` & `actions/base/verifyHandlesCoprocessorSignatures.ts` — the retry

## Behavior change

At most one extra RPC, only on the failure path. A coprocessor signer rotation now recovers on the next verification instead of staying broken for up to 24h.

## Tests

New unit tests for both verify layers (mock `recoverSigners`; assert RPC call counts to distinguish cache-hit `2` vs forced-refresh `4`):
- valid cached set → passes, no refresh
- TTL cache reused across repeated successes
- unknown signer (rotated-in coprocessor) → refresh recovers
- stale threshold → refresh recovers
- refresh still invalid → retries exactly once, rethrows
- duplicate recovered signer → **not** retried

### Verification
- **Unit (vitest):** 11 new tests pass; 50 existing in touched dirs; no type errors
- **Cleartext integration (pack):** v12 + v13 × (ethers + viem) all green against a deployed anvil stack using the prod-packed SDK
- prettier / eslint / `tsc -b` clean across the package