### PR TITLE
fix(common): pin conventional-changelog-conventionalcommits to ^7

### DIFF
--- a/.github/workflows/common-pull-request-lint.yml
+++ b/.github/workflows/common-pull-request-lint.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title  }}
         run: |
-          npm install @commitlint/config-conventional@^18 conventional-changelog-conventionalcommits @commitlint/types@^18
+          npm install @commitlint/config-conventional@^18 conventional-changelog-conventionalcommits@^7 @commitlint/types@^18
           npm install -g @commitlint/cli@^18
           echo "$PR_TITLE" | npx commitlint --config .github/config/commitlint.config.js --verbose
 


### PR DESCRIPTION
Backport of #2920 to release/0.13.x: pins the parser preset to ^7 so commitlint v18 can load it, fixing the PR-title lint on all PRs targeting this branch.