### PR TITLE
feat(library-solidity): add confidential bridge send and receive wrappers

### DIFF
--- a/library-solidity/codegen.config.json
+++ b/library-solidity/codegen.config.json
@@ -4,7 +4,8 @@
   "noHostContracts": true,
   "lib": {
     "outDir": "./lib",
-    "fheTypeDir": "./lib"
+    "fheTypeDir": "./lib",
+    "bridge": true
   },
   "tests": {
     "numberOfTestSplits": 12,

--- a/library-solidity/codegen/src/config.ts
+++ b/library-solidity/codegen/src/config.ts
@@ -55,6 +55,10 @@ export type HostContractsUserConfig = {
 export type LibUserConfig = {
   outDir?: string;
   fheTypeDir?: string;
+  // generate the confidential-bridge wrappers (FHE.bridge/quoteBridge, Impl helpers,
+  // IConfidentialBridge.sol). Off by default so packages that also depend on LayerZero
+  // (e.g. host-contracts) do not redeclare its messaging structs.
+  bridge?: boolean;
 };
 
 export type TestsUserConfig = {
@@ -76,6 +80,8 @@ export type LibConfig = {
   outDir: string;
   // directory where the FheType.sol file is located
   fheTypeDir: string;
+  // whether to generate the confidential-bridge wrappers
+  bridge: boolean;
 };
 
 export type TestsConfig = {
@@ -212,6 +218,7 @@ function resolveLibConfig(userLibConfig: LibUserConfig | undefined): LibConfig {
   const p: LibConfig = {
     fheTypeDir: userLibConfig?.fheTypeDir ?? outDir,
     outDir,
+    bridge: userLibConfig?.bridge ?? false,
   };
   assertRelative(p.fheTypeDir);
   assertRelative(p.outDir);
@@ -273,6 +280,7 @@ function toAbsoluteLibConfig(resolved: LibConfig, baseDir: string): LibConfig {
   return {
     outDir: toAbsoluteDirectory(resolved.outDir, baseDir),
     fheTypeDir: toAbsoluteDirectory(resolved.fheTypeDir, baseDir),
+    bridge: resolved.bridge,
   };
 }
 

--- a/library-solidity/codegen/src/main.ts
+++ b/library-solidity/codegen/src/main.ts
@@ -23,7 +23,7 @@ import { generateSolidityHCULimit } from './hcuLimitGenerator';
 import { ALL_OPERATORS } from './operators';
 import { ALL_OPERATORS_PRICES } from './operatorsPrices';
 import { fromDirToFile, fromFileToFile, isDirectory } from './paths';
-import { generateFhevmECDSALib, generateSolidityFHELib } from './templateFHEDotSol';
+import { generateFhevmECDSALib, generateIConfidentialBridgeLib, generateSolidityFHELib } from './templateFHEDotSol';
 import { generateSolidityFheType } from './templateFheTypeDotSol';
 import { generateSolidityImplLib } from './templateImpDotSol';
 import {
@@ -148,6 +148,7 @@ export async function commandGenerateAllFiles(options: any) {
   const fheTypesDotSol = `${path.join(absConfig.lib.fheTypeDir, 'FheType.sol')}`;
   const implDotSol = `${path.join(absConfig.lib.outDir, 'Impl.sol')}`;
   const ecdsaDotSol = `${path.join(absConfig.lib.outDir, 'cryptography', 'FhevmECDSA.sol')}`;
+  const iConfidentialBridgeDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'IConfidentialBridge.sol')}`;
   const fheDotSol = `${path.join(absConfig.lib.outDir, 'FHE.sol')}`;
   const hcuLimitDotSol = `${path.join(absConfig.hostContracts.outDir, 'HCULimit.sol')}`;
 
@@ -199,13 +200,14 @@ export async function commandGenerateAllFiles(options: any) {
 
   if (config.noLib !== true) {
     const fheTypesCode = generateSolidityFheType(ALL_FHE_TYPE_INFOS);
-    const implCode = generateSolidityImplLib(ALL_OPERATORS, implRelFheTypesDotSol);
+    const implCode = generateSolidityImplLib(ALL_OPERATORS, implRelFheTypesDotSol, absConfig.lib.bridge);
     const fheCode = generateSolidityFHELib({
       operators: ALL_OPERATORS,
       fheTypes: ALL_FHE_TYPE_INFOS,
       fheTypeDotSol: fheRelFheTypesDotSol,
       implDotSol: fheRelImplDotSol,
       ecdsaDotSol: fheRelEcdsaDotSol,
+      bridge: absConfig.lib.bridge,
     });
     const ecdsaCode = generateFhevmECDSALib();
 
@@ -219,6 +221,13 @@ export async function commandGenerateAllFiles(options: any) {
     await formatAndWriteFile(`${implDotSol}`, implCode);
     await formatAndWriteFile(`${ecdsaDotSol}`, ecdsaCode);
     await formatAndWriteFile(`${fheDotSol}`, fheCode);
+
+    // The bridge interface is only needed (and only safe — it redeclares LayerZero structs)
+    // when the bridge wrappers are generated.
+    if (absConfig.lib.bridge) {
+      mkDir(path.dirname(iConfidentialBridgeDotSol));
+      await formatAndWriteFile(`${iConfidentialBridgeDotSol}`, generateIConfidentialBridgeLib());
+    }
   } else {
     debugLog(`Skipping lib generation.`);
   }

--- a/library-solidity/codegen/src/main.ts
+++ b/library-solidity/codegen/src/main.ts
@@ -23,7 +23,14 @@ import { generateSolidityHCULimit } from './hcuLimitGenerator';
 import { ALL_OPERATORS } from './operators';
 import { ALL_OPERATORS_PRICES } from './operatorsPrices';
 import { fromDirToFile, fromFileToFile, isDirectory } from './paths';
-import { generateFhevmECDSALib, generateIConfidentialBridgeLib, generateSolidityFHELib } from './templateFHEDotSol';
+import {
+  generateConfidentialOAppCoreLib,
+  generateConfidentialOAppReceiverLib,
+  generateConfidentialOAppSenderLib,
+  generateFhevmECDSALib,
+  generateIConfidentialBridgeLib,
+  generateSolidityFHELib,
+} from './templateFHEDotSol';
 import { generateSolidityFheType } from './templateFheTypeDotSol';
 import { generateSolidityImplLib } from './templateImpDotSol';
 import {
@@ -149,6 +156,9 @@ export async function commandGenerateAllFiles(options: any) {
   const implDotSol = `${path.join(absConfig.lib.outDir, 'Impl.sol')}`;
   const ecdsaDotSol = `${path.join(absConfig.lib.outDir, 'cryptography', 'FhevmECDSA.sol')}`;
   const iConfidentialBridgeDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'IConfidentialBridge.sol')}`;
+  const oAppCoreDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOAppCore.sol')}`;
+  const oAppSenderDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOAppSender.sol')}`;
+  const oAppReceiverDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOAppReceiver.sol')}`;
   const fheDotSol = `${path.join(absConfig.lib.outDir, 'FHE.sol')}`;
   const hcuLimitDotSol = `${path.join(absConfig.hostContracts.outDir, 'HCULimit.sol')}`;
 
@@ -227,6 +237,9 @@ export async function commandGenerateAllFiles(options: any) {
     if (absConfig.lib.bridge) {
       mkDir(path.dirname(iConfidentialBridgeDotSol));
       await formatAndWriteFile(`${iConfidentialBridgeDotSol}`, generateIConfidentialBridgeLib());
+      await formatAndWriteFile(`${oAppCoreDotSol}`, generateConfidentialOAppCoreLib());
+      await formatAndWriteFile(`${oAppSenderDotSol}`, generateConfidentialOAppSenderLib());
+      await formatAndWriteFile(`${oAppReceiverDotSol}`, generateConfidentialOAppReceiverLib());
     }
   } else {
     debugLog(`Skipping lib generation.`);

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -20,6 +20,27 @@ export function generateIConfidentialBridgeLib() {
   return code;
 }
 
+export function generateConfidentialOAppCoreLib() {
+  const file = resolveTemplatePath('ConfidentialOAppCore.sol-template');
+  const template = readFileSync(file, 'utf8');
+  let code = removeTemplateComments(template);
+  return code;
+}
+
+export function generateConfidentialOAppSenderLib() {
+  const file = resolveTemplatePath('ConfidentialOAppSender.sol-template');
+  const template = readFileSync(file, 'utf8');
+  let code = removeTemplateComments(template);
+  return code;
+}
+
+export function generateConfidentialOAppReceiverLib() {
+  const file = resolveTemplatePath('ConfidentialOAppReceiver.sol-template');
+  const template = readFileSync(file, 'utf8');
+  let code = removeTemplateComments(template);
+  return code;
+}
+
 export function generateSolidityFHELib({
   operators,
   fheTypes,

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -13,18 +13,27 @@ export function generateFhevmECDSALib() {
   return code;
 }
 
+export function generateIConfidentialBridgeLib() {
+  const file = resolveTemplatePath('IConfidentialBridge.sol-template');
+  const template = readFileSync(file, 'utf8');
+  let code = removeTemplateComments(template);
+  return code;
+}
+
 export function generateSolidityFHELib({
   operators,
   fheTypes,
   fheTypeDotSol,
   implDotSol,
   ecdsaDotSol,
+  bridge,
 }: {
   operators: Operator[];
   fheTypes: FheTypeInfo[];
   fheTypeDotSol: string;
   implDotSol: string;
   ecdsaDotSol: string;
+  bridge: boolean;
 }): string {
   // Placeholders:
   // =============
@@ -49,8 +58,92 @@ export function generateSolidityFHELib({
   code = code.replace('$${FHEOperators}$$', generateFHEOperators(operators, adjustedFheTypes));
   code = code.replace('$${ACLFunctions}$$', generateSolidityACLMethods(adjustedFheTypes));
   code = code.replace('$${FHEtoBytes32}$$', generateToBytes32(adjustedFheTypes));
+  code = code.replace('$${FHEBridge}$$', bridge ? generateBridgeFunctions(adjustedFheTypes) : '');
 
   return code;
+}
+
+/**
+ * Generates per-type `bridge` / `quoteBridge` overloads: a single-handle and a
+ * homogeneous-list variant for every encrypted type. The type-agnostic low-level
+ * `bytes32[]` + `options` overloads live as literal text in the template.
+ */
+function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
+  const res: string[] = [];
+  fheTypes.forEach((fheType: AdjustedFheType) => {
+    const t = `e${fheType.type.toLowerCase()}`;
+    res.push(`
+    /**
+     * @notice Bridges a single encrypted \`${t}\` handle plus an app-defined \`payload\` to
+     *         \`dstApp\` on the chain at \`dstEid\`, via the host \`ConfidentialBridge\`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from \`lzComposeGas\`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t} handle, uint128 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = ${t}.unwrap(handle);
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "", nativeFee);
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted \`${t}\` handles in a single message.
+     * @dev    The payload must reference the handles by their position in \`handles\`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t}[] memory handles, uint128 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = ${t}.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "", nativeFee);
+    }
+
+    /// @notice Quotes the native fee for a single-\`${t}\` {bridge} call.
+    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t} handle, uint128 lzComposeGas) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = ${t}.unwrap(handle);
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "");
+    }
+
+    /// @notice Quotes the native fee for bridging a list of \`${t}\` handles.
+    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t}[] memory handles, uint128 lzComposeGas) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = ${t}.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "");
+    }
+`);
+  });
+
+  // Type-agnostic low-level escape hatch: explicit `bytes32` handle list + raw LayerZero
+  // `options`, with a `bytes32` destination app (for mixed-type or non-EVM payloads).
+  res.push(`
+    /**
+     * @notice Low-level bridge of an explicit \`bytes32\` handle list with full control over
+     *         LayerZero \`options\` (mixed handle types or advanced payloads).
+     * @dev    When \`options\` is empty the bridge builds defaults from \`lzComposeGas\`; when
+     *         non-empty, \`lzComposeGas\` must be 0 (enforced host-side). The caller must
+     *         already hold ACL allowance on every handle.
+     * @param dstEid        Destination LayerZero endpoint id.
+     * @param dstApp        Destination app as bytes32 (EVM address left-padded, or native id).
+     * @param payload       Opaque app payload.
+     * @param handleList    Raw \`bytes32\` handles to bridge.
+     * @param lzComposeGas  Gas budget for the destination \`onConfidentialBridgeReceived\` (lzCompose leg).
+     * @param options       LayerZero options; empty to derive defaults from \`lzComposeGas\`.
+     * @param nativeFee     LayerZero native fee to forward as msg.value (query via {quoteBridge}).
+     */
+    function bridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+        receipt = Impl.bridge(dstEid, dstApp, payload, handleList, lzComposeGas, options, nativeFee);
+    }
+
+    /// @notice Low-level fee quote matching the explicit \`bytes32\` handle list {bridge} overload.
+    function quoteBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options) internal view returns (MessagingFee memory fee) {
+        fee = Impl.quoteBridge(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+    }
+`);
+  return res.join('');
 }
 
 function generateFHEOperators(operators: Operator[], adjustedFheTypes: AdjustedFheType[]): string {

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -64,6 +64,7 @@ export function generateSolidityFHELib({
   // $${FHEOperators}$$
   // $${ACLFunctions}$$
   // $${FHEtoBytes32}$$
+  // $${FHEBridge}$$
   const file = resolveTemplatePath('FHE.sol-template');
   const template = readFileSync(file, 'utf8');
 

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -98,8 +98,10 @@ function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
      * @notice Bridges a single encrypted \`${t}\` handle plus an app-defined \`payload\` to
      *         \`dstApp\` on the chain at \`dstEid\`, via the host \`ConfidentialBridge\`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from \`lzComposeGas\`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from \`lzComposeGas\`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t} handle, uint128 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
@@ -110,7 +112,8 @@ function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
     /**
      * @notice Bridges a homogeneous list of encrypted \`${t}\` handles in a single message.
      * @dev    The payload must reference the handles by their position in \`handles\`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. \`lzComposeGas\` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t}[] memory handles, uint128 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -97,74 +97,72 @@ function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
     /**
      * @notice Bridges a single encrypted \`${t}\` handle plus an app-defined \`payload\` to
      *         \`dstApp\` on the chain at \`dstEid\`, via the host \`ConfidentialBridge\`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from \`lzComposeGas\`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. \`lzComposeGas\` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-\`dstEid\` minimum, else the host \`send\` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
-    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t} handle, uint128 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t} handle, uint64 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = ${t}.unwrap(handle);
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "", nativeFee);
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted \`${t}\` handles in a single message.
      * @dev    The payload must reference the handles by their position in \`handles\`. The
-     *         caller must already hold ACL allowance on every handle. \`lzComposeGas\` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; \`lzComposeGas\` must meet
+     *         the bridge's per-\`dstEid\` minimum.
      */
-    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t}[] memory handles, uint128 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t}[] memory handles, uint64 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = ${t}.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "", nativeFee);
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-\`${t}\` {bridge} call.
-    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t} handle, uint128 lzComposeGas) internal view returns (MessagingFee memory fee) {
+    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t} handle, uint64 lzComposeGas) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = ${t}.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "");
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of \`${t}\` handles.
-    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t}[] memory handles, uint128 lzComposeGas) internal view returns (MessagingFee memory fee) {
+    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t}[] memory handles, uint64 lzComposeGas) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = ${t}.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, "");
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 `);
   });
 
-  // Type-agnostic low-level escape hatch: explicit `bytes32` handle list + raw LayerZero
-  // `options`, with a `bytes32` destination app (for mixed-type or non-EVM payloads).
+  // Type-agnostic low-level escape hatch: explicit `bytes32` handle list with a `bytes32`
+  // destination app, for mixed-type handle lists or non-EVM destinations.
   res.push(`
     /**
-     * @notice Low-level bridge of an explicit \`bytes32\` handle list with full control over
-     *         LayerZero \`options\` (mixed handle types or advanced payloads).
-     * @dev    When \`options\` is empty the bridge builds defaults from \`lzComposeGas\`; when
-     *         non-empty, \`lzComposeGas\` must be 0 (enforced host-side). The caller must
-     *         already hold ACL allowance on every handle.
+     * @notice Low-level bridge of an explicit \`bytes32\` handle list to a \`bytes32\` destination
+     *         app (mixed handle types, or non-EVM destinations).
+     * @dev    The caller must already hold ACL allowance on every handle; \`lzComposeGas\` must
+     *         meet the bridge's per-\`dstEid\` minimum.
      * @param dstEid        Destination LayerZero endpoint id.
      * @param dstApp        Destination app as bytes32 (EVM address left-padded, or native id).
      * @param payload       Opaque app payload.
      * @param handleList    Raw \`bytes32\` handles to bridge.
      * @param lzComposeGas  Gas budget for the destination \`onConfidentialBridgeReceived\` (lzCompose leg).
-     * @param options       LayerZero options; empty to derive defaults from \`lzComposeGas\`.
      * @param nativeFee     LayerZero native fee to forward as msg.value (query via {quoteBridge}).
      */
-    function bridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
-        receipt = Impl.bridge(dstEid, dstApp, payload, handleList, lzComposeGas, options, nativeFee);
+    function bridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint64 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+        receipt = Impl.bridge(dstEid, dstApp, payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Low-level fee quote matching the explicit \`bytes32\` handle list {bridge} overload.
-    function quoteBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options) internal view returns (MessagingFee memory fee) {
-        fee = Impl.quoteBridge(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+    function quoteBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint64 lzComposeGas) internal view returns (MessagingFee memory fee) {
+        fee = Impl.quoteBridge(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas);
     }
 `);
   return res.join('');

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -100,10 +100,9 @@ function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
      * @notice Bridges a single encrypted \`${t}\` handle plus an app-defined \`payload\` to
      *         \`dstApp\` on the chain at \`dstEid\`, via the host \`ConfidentialBridge\`.
      * @dev    Builds the one-element handle list. \`lzComposeGas\` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-\`dstEid\` minimum, else the host \`send\` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         \`send\` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t} handle, uint64 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
@@ -126,8 +125,8 @@ function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
     /**
      * @notice Low-level bridge of an explicit \`bytes32\` handle list to a \`bytes32\` destination
      *         app (mixed handle types, or non-EVM destinations).
-     * @dev    The caller must already hold ACL allowance on every handle; \`lzComposeGas\` must
-     *         meet the bridge's per-\`dstEid\` minimum.
+     * @dev    The caller must already hold ACL allowance on every handle; \`lzComposeGas\` must be
+     *         non-zero (the bridge reverts otherwise).
      * @param dstEid        Destination LayerZero endpoint id.
      * @param dstApp        Destination app as bytes32 (EVM address left-padded, or native id).
      * @param payload       Opaque app payload.

--- a/library-solidity/codegen/src/templateFHEDotSol.ts
+++ b/library-solidity/codegen/src/templateFHEDotSol.ts
@@ -86,9 +86,10 @@ export function generateSolidityFHELib({
 }
 
 /**
- * Generates per-type `bridge` / `quoteBridge` overloads: a single-handle and a
- * homogeneous-list variant for every encrypted type. The type-agnostic low-level
- * `bytes32[]` + `options` overloads live as literal text in the template.
+ * Generates per-type `bridge` / `quoteBridge` overloads: a single-handle variant for every
+ * encrypted type. Multi-handle bridging (which is realistically heterogeneous) goes through the
+ * type-agnostic low-level `bytes32[]` overloads appended below, since the encrypted type never
+ * crosses the wire (the receiver re-wraps raw `bytes32` handles).
  */
 function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
   const res: string[] = [];
@@ -110,33 +111,10 @@ function generateBridgeFunctions(fheTypes: AdjustedFheType[]): string {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted \`${t}\` handles in a single message.
-     * @dev    The payload must reference the handles by their position in \`handles\`. The
-     *         caller must already hold ACL allowance on every handle; \`lzComposeGas\` must meet
-     *         the bridge's per-\`dstEid\` minimum.
-     */
-    function bridge(uint32 dstEid, address dstApp, bytes memory payload, ${t}[] memory handles, uint64 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = ${t}.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-\`${t}\` {bridge} call.
     function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t} handle, uint64 lzComposeGas) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = ${t}.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of \`${t}\` handles.
-    function quoteBridge(uint32 dstEid, address srcApp, address dstApp, bytes memory payload, ${t}[] memory handles, uint64 lzComposeGas) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = ${t}.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 `);

--- a/library-solidity/codegen/src/templateImpDotSol.ts
+++ b/library-solidity/codegen/src/templateImpDotSol.ts
@@ -11,12 +11,14 @@ import { removeTemplateComments } from './utils';
  * @param operators - An array of Operator objects representing the supported operations.
  * @returns A string containing the Solidity implementation library code.
  */
-export function generateSolidityImplLib(operators: Operator[], fheTypeDotSol: string): string {
+export function generateSolidityImplLib(operators: Operator[], fheTypeDotSol: string, bridge: boolean): string {
   // Placeholders:
   // =============
   // $${FheTypeDotSol}$$
   // $${CoprocessorInterfaceOperators}$$
   // $${ImplOperators}$$
+  // $${ImplBridgeImports}$$
+  // $${ImplBridge}$$
   const file = resolveTemplatePath('Impl.sol-template');
   const template = readFileSync(file, 'utf8');
 
@@ -25,7 +27,71 @@ export function generateSolidityImplLib(operators: Operator[], fheTypeDotSol: st
   code = code.replace('$${FheTypeDotSol}$$', fheTypeDotSol);
   code = code.replace('$${CoprocessorInterfaceOperators}$$', generateCoprocessorInterfaceOperators(operators));
   code = code.replace('$${ImplOperators}$$', generateImplOperators(operators));
+  code = code.replace('$${ImplBridgeImports}$$', bridge ? generateImplBridgeImports() : '');
+  code = code.replace('$${ImplBridgeACLGetter}$$', bridge ? generateImplBridgeACLGetter() : '');
+  code = code.replace('$${ImplBridge}$$', bridge ? generateImplBridge() : '');
   return code;
+}
+
+/**
+ * The ACL getter the bridge resolution relies on (`IACL.getConfidentialBridgeAddress`). Only
+ * emitted when `lib.bridge` is enabled so non-bridge packages keep an unchanged `IACL`.
+ */
+function generateImplBridgeACLGetter(): string {
+  return `
+    /**
+     * @notice              Returns the per-chain \`ConfidentialBridge\` address tracked by the ACL.
+     * @return              The ConfidentialBridge contract address (address(0) if unset).
+     */
+    function getConfidentialBridgeAddress() external view returns (address);`;
+}
+
+/**
+ * The Impl.sol bridge import (LayerZero-free structs + the ConfidentialBridge interface).
+ * Only emitted when `lib.bridge` is enabled, so packages that also use LayerZero (e.g.
+ * host-contracts) do not redeclare `MessagingFee` / `MessagingReceipt` and collide.
+ */
+function generateImplBridgeImports(): string {
+  return `import {IConfidentialBridge, MessagingFee, MessagingReceipt} from "./bridge/IConfidentialBridge.sol";`;
+}
+
+/**
+ * The Impl.sol bridge helpers: resolve the ConfidentialBridge from the ACL and forward
+ * `send` / `quote`. Only emitted when `lib.bridge` is enabled.
+ */
+function generateImplBridge(): string {
+  return `
+    /// @notice Returned when the ACL reports no \`ConfidentialBridge\` for this chain.
+    error BridgeNotConfigured();
+
+    /**
+     * @dev Resolves the \`ConfidentialBridge\` from the ACL (\`getConfidentialBridgeAddress\`),
+     *      reverting if unset. No bridge address is stored in the library config: the ACL —
+     *      already known via \`CoprocessorConfig.ACLAddress\` — is the single source of truth,
+     *      so no struct change or extra setup call is needed.
+     */
+    function getConfidentialBridge() internal view returns (IConfidentialBridge) {
+        CoprocessorConfig storage $ = getCoprocessorConfig();
+        address addr = IACL($.ACLAddress).getConfidentialBridgeAddress();
+        if (addr == address(0)) revert BridgeNotConfigured();
+        return IConfidentialBridge(addr);
+    }
+
+    /**
+     * @notice Forwards a bridge send to the host \`ConfidentialBridge\`, paying \`nativeFee\`.
+     * @dev    Runs in the caller's context, so the bridge sees \`msg.sender == <app>\` and the
+     *         source ACL check resolves against the app.
+     */
+    function bridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+        receipt = getConfidentialBridge().send{value: nativeFee}(dstEid, dstApp, payload, handleList, lzComposeGas, options);
+    }
+
+    /**
+     * @notice Quotes the native fee for a bridge send.
+     */
+    function quoteBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options) internal view returns (MessagingFee memory fee) {
+        fee = getConfidentialBridge().quote(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+    }`;
 }
 
 function generateImplOperators(operators: Operator[]): string {

--- a/library-solidity/codegen/src/templateImpDotSol.ts
+++ b/library-solidity/codegen/src/templateImpDotSol.ts
@@ -18,6 +18,7 @@ export function generateSolidityImplLib(operators: Operator[], fheTypeDotSol: st
   // $${CoprocessorInterfaceOperators}$$
   // $${ImplOperators}$$
   // $${ImplBridgeImports}$$
+  // $${ImplBridgeACLGetter}$$
   // $${ImplBridge}$$
   const file = resolveTemplatePath('Impl.sol-template');
   const template = readFileSync(file, 'utf8');

--- a/library-solidity/codegen/src/templateImpDotSol.ts
+++ b/library-solidity/codegen/src/templateImpDotSol.ts
@@ -83,15 +83,15 @@ function generateImplBridge(): string {
      * @dev    Runs in the caller's context, so the bridge sees \`msg.sender == <app>\` and the
      *         source ACL check resolves against the app.
      */
-    function bridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
-        receipt = getConfidentialBridge().send{value: nativeFee}(dstEid, dstApp, payload, handleList, lzComposeGas, options);
+    function bridge(uint32 dstEid, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint64 lzComposeGas, uint256 nativeFee) internal returns (MessagingReceipt memory receipt) {
+        receipt = getConfidentialBridge().send{value: nativeFee}(dstEid, dstApp, payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Quotes the native fee for a bridge send.
      */
-    function quoteBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint128 lzComposeGas, bytes memory options) internal view returns (MessagingFee memory fee) {
-        fee = getConfidentialBridge().quote(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+    function quoteBridge(uint32 dstEid, address srcApp, bytes32 dstApp, bytes memory payload, bytes32[] memory handleList, uint64 lzComposeGas) internal view returns (MessagingFee memory fee) {
+        fee = getConfidentialBridge().quote(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas);
     }`;
 }
 

--- a/library-solidity/codegen/src/templates/ConfidentialOAppCore.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppCore.sol-template
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+/**
+ * @title   ConfidentialOAppCore
+ * @notice  Shared peer registry for a confidential omnichain app (OApp). A "peer" is the
+ *          trusted counterpart instance of this app on another chain, addressed by its
+ *          LayerZero endpoint id (`eid`). The same registry is used by both the send side
+ *          ({ConfidentialOAppSender}) and the receive side ({ConfidentialOAppReceiver}), so an
+ *          app configures each peer once and it applies in both directions.
+ * @dev     App identifiers are `bytes32` so non-EVM peers (e.g. Solana program ids) fit; EVM
+ *          peers are the address left-padded to `bytes32`. Subclasses expose {_setPeer} behind
+ *          their own access control (e.g. `onlyOwner`).
+ */
+abstract contract ConfidentialOAppCore {
+    /// @notice The trusted peer app per endpoint id (`bytes32(0)` if unset).
+    mapping(uint32 eid => bytes32 peer) public peers;
+
+    event PeerSet(uint32 indexed eid, bytes32 indexed peer);
+
+    /// @notice No peer is configured for the requested endpoint id.
+    error NoPeer(uint32 eid);
+
+    /// @dev Register (or clear, with `bytes32(0)`) the peer for `eid`.
+    function _setPeer(uint32 eid, bytes32 peer) internal virtual {
+        peers[eid] = peer;
+        emit PeerSet(eid, peer);
+    }
+
+    /**
+     * @notice Whether `peer` is the trusted counterpart on `eid`. Default: exact match against
+     *         the registered peer (an unset peer is never trusted). Override for a custom policy.
+     */
+    function isPeer(uint32 eid, bytes32 peer) public view virtual returns (bool) {
+        bytes32 registered = peers[eid];
+        return registered != bytes32(0) && registered == peer;
+    }
+
+    /// @dev Returns the peer for `eid`, reverting {NoPeer} if none is set (used on the send side).
+    function _getPeerOrRevert(uint32 eid) internal view returns (bytes32 peer) {
+        peer = peers[eid];
+        if (peer == bytes32(0)) revert NoPeer(eid);
+    }
+}

--- a/library-solidity/codegen/src/templates/ConfidentialOAppReceiver.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppReceiver.sol-template
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Impl} from "../Impl.sol";
+import {IDstApp} from "./IConfidentialBridge.sol";
+import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
+
+/**
+ * @title   ConfidentialOAppReceiver
+ * @notice  Receive side of a confidential omnichain app. Implements the bridge's
+ *          {IDstApp-onConfidentialBridgeReceived} callback and enforces the two checks every
+ *          receiver needs:
+ *            1. the caller is the trusted local `ConfidentialBridge`;
+ *            2. `(srcEid, srcApp)` is a trusted peer (see {ConfidentialOAppCore-isPeer}).
+ *          Subclasses implement {_onReceiveHandles} and receive the derived destination handles
+ *          as raw `bytes32`, wrapping each to its known encrypted type (e.g.
+ *          `euint64.wrap(handles[i])`). The host bridge has already granted transient ACL
+ *          allowance for every handle before this is invoked.
+ * @dev     The trusted bridge is resolved from the ACL — the same source the send path
+ *          (`FHE.bridge`) uses — so inbound authentication and outbound routing can never
+ *          diverge. Requires the app to have configured the ACL via `FHE.setCoprocessor(...)`.
+ */
+abstract contract ConfidentialOAppReceiver is ConfidentialOAppCore, IDstApp {
+    error OnlyConfidentialBridge(address caller);
+    error UntrustedPeer(uint32 srcEid, bytes32 srcApp);
+
+    /**
+     * @notice The trusted local ConfidentialBridge — the only authorized
+     *         `onConfidentialBridgeReceived` caller. Resolved from the ACL, the same source the
+     *         `FHE.bridge` send path uses.
+     * @dev    Reverts `Impl.BridgeNotConfigured` if the ACL reports no bridge for this chain.
+     */
+    function confidentialBridge() public view returns (address) {
+        return address(Impl.getConfidentialBridge());
+    }
+
+    /**
+     * @inheritdoc IDstApp
+     * @dev Authenticates caller + peer, then dispatches to {_onReceiveHandles}. `srcHandleList`
+     *      is intentionally not forwarded — it carries opaque source-chain handles that are not
+     *      usable locally.
+     */
+    function onConfidentialBridgeReceived(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata /* srcHandleList */,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external override {
+        if (msg.sender != confidentialBridge()) revert OnlyConfidentialBridge(msg.sender);
+        if (!isPeer(srcEid, srcApp)) revert UntrustedPeer(srcEid, srcApp);
+
+        _onReceiveHandles(srcEid, srcApp, payload, dstHandleList, guid);
+    }
+
+    /**
+     * @notice App hook: handle a bridged payload with the derived destination handles.
+     * @param srcEid    Source endpoint id.
+     * @param srcApp    Source app (bytes32; for EVM, a left-padded address).
+     * @param payload   Opaque app payload as encoded by the source app.
+     * @param handles   Derived destination handles as raw `bytes32`, aligned by index with the
+     *                  source list. Wrap each to its known type, e.g. `euint64.wrap(handles[i])`.
+     *                  Transient ACL allowance has already been granted to this contract.
+     * @param guid      LayerZero message GUID of the transfer; useful for correlation or
+     *                  idempotency. Apps that don't need it can ignore the parameter.
+     */
+    function _onReceiveHandles(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata handles,
+        bytes32 guid
+    ) internal virtual;
+}

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -10,7 +10,8 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
  *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
  *          `FHE.bridge`, so subclasses never deal with the bridge contract or peer encoding
- *          directly.
+ *          directly. A single-handle convenience and a type-agnostic multi-handle overload are
+ *          provided (a message may carry up to the bridge's `MAX_HANDLES`).
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
  *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
  */
@@ -22,17 +23,8 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
 
     /**
      * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
-     * @dev    The bridge checks `isAllowed(handle, msg.sender)`, and since `_bridge` runs in
-     *         this contract's context `msg.sender` is THIS contract — so the contract must hold
-     *         ACL allowance on `handle` (e.g. via `FHE.allowThis`), not the external caller.
-     *         {_bridge} performs no caller authorization of its own; subclasses must gate their
-     *         public entrypoint (as `ConfidentialOFTViaLib.send` does with `FHE.isSenderAllowed`).
-     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
-     * @param payload       Opaque app payload (the receiver decodes it).
-     * @param handle        The encrypted value to bridge; this contract must hold ACL allowance on it.
-     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
-     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
-     * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
+     * @dev    Convenience wrapper over the multi-handle {_bridge}; the payload must reference the
+     *         handle at index 0. See the list overload for the allowance/gas rules.
      */
     function _bridge(
         uint32 dstEid,
@@ -41,23 +33,61 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
-        if (lzComposeGas == 0) revert ZeroComposeGas();
-        bytes32 peer = _getPeerOrRevert(dstEid);
-        bytes32[] memory handleList = new bytes32[](1);
-        handleList[0] = euint64.unwrap(handle);
-        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, nativeFee);
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = euint64.unwrap(handle);
+        return _bridge(dstEid, payload, handles, lzComposeGas, nativeFee);
     }
 
-    /// @notice Quotes the native fee for the matching {_bridge} call.
+    /**
+     * @notice Bridge a list of encrypted handles to the peer on `dstEid` in a single message.
+     * @dev    Type-agnostic: pass raw `bytes32` handles (e.g. `euint64.unwrap(h)`); mixing
+     *         encrypted types within one list is fine. The destination receiver gets the derived
+     *         handles aligned one-to-one by index.
+     *
+     *         The bridge checks `isAllowed(handle, msg.sender)` for every handle, and since
+     *         `_bridge` runs in this contract's context `msg.sender` is THIS contract — so the
+     *         contract must hold ACL allowance on each handle (e.g. via `FHE.allowThis`), not the
+     *         external caller. {_bridge} performs no caller authorization of its own; subclasses
+     *         must gate their public entrypoint (as `ConfidentialOFTViaLib.send` does with
+     *         `FHE.isSenderAllowed`).
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload (the receiver decodes it); reference handles by index.
+     * @param handles       Raw `bytes32` handles to bridge; this contract must hold ACL allowance
+     *                      on each. Up to the bridge's `MAX_HANDLES`.
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
+     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
+     * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
+     */
+    function _bridge(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32[] memory handles,
+        uint64 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        if (lzComposeGas == 0) revert ZeroComposeGas();
+        return FHE.bridge(dstEid, _getPeerOrRevert(dstEid), payload, handles, lzComposeGas, nativeFee);
+    }
+
+    /// @notice Quotes the native fee for the single-handle {_bridge} call.
     function _quoteBridge(
         uint32 dstEid,
         bytes memory payload,
         euint64 handle,
         uint64 lzComposeGas
     ) internal view returns (MessagingFee memory) {
-        bytes32 peer = _getPeerOrRevert(dstEid);
-        bytes32[] memory handleList = new bytes32[](1);
-        handleList[0] = euint64.unwrap(handle);
-        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas);
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = euint64.unwrap(handle);
+        return _quoteBridge(dstEid, payload, handles, lzComposeGas);
+    }
+
+    /// @notice Quotes the native fee for the multi-handle {_bridge} call.
+    function _quoteBridge(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32[] memory handles,
+        uint64 lzComposeGas
+    ) internal view returns (MessagingFee memory) {
+        return FHE.quoteBridge(dstEid, address(this), _getPeerOrRevert(dstEid), payload, handles, lzComposeGas);
     }
 }

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -9,14 +9,15 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  * @title   ConfidentialOAppSender
  * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
  *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
- *          `FHE.bridge`, so subclasses never deal with the bridge contract, LayerZero options,
- *          or peer encoding directly.
+ *          `FHE.bridge`, so subclasses never deal with the bridge contract or peer encoding
+ *          directly.
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
  *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
  */
 abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
-    /// @notice `lzComposeGas` is 0; with the default (empty) options the destination receive
-    ///         callback would never run, so the bridged value would never be delivered.
+    /// @notice `lzComposeGas` is 0; the destination receive callback would never run, so the
+    ///         bridged value would never be delivered. (The bridge also enforces a per-`dstEid`
+    ///         minimum; this is a cheap pre-check for the clearly-invalid zero case.)
     error ZeroComposeGas();
 
     /**
@@ -25,21 +26,21 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
      * @param payload       Opaque app payload (the receiver decodes it).
      * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
      * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
-     *                      be non-zero, since {_bridge} sends with default (empty) options.
+     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
      */
     function _bridge(
         uint32 dstEid,
         bytes memory payload,
         euint64 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
         if (lzComposeGas == 0) revert ZeroComposeGas();
         bytes32 peer = _getPeerOrRevert(dstEid);
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, "", nativeFee);
+        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for the matching {_bridge} call.
@@ -47,11 +48,11 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         uint32 dstEid,
         bytes memory payload,
         euint64 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory) {
         bytes32 peer = _getPeerOrRevert(dstEid);
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas, "");
+        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas);
     }
 }

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -22,9 +22,14 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
 
     /**
      * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
+     * @dev    The bridge checks `isAllowed(handle, msg.sender)`, and since `_bridge` runs in
+     *         this contract's context `msg.sender` is THIS contract — so the contract must hold
+     *         ACL allowance on `handle` (e.g. via `FHE.allowThis`), not the external caller.
+     *         {_bridge} performs no caller authorization of its own; subclasses must gate their
+     *         public entrypoint (as `ConfidentialOFTViaLib.send` does with `FHE.isSenderAllowed`).
      * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
      * @param payload       Opaque app payload (the receiver decodes it).
-     * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
+     * @param handle        The encrypted value to bridge; this contract must hold ACL allowance on it.
      * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
      *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -15,12 +15,17 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
  */
 abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
+    /// @notice `lzComposeGas` is 0; with the default (empty) options the destination receive
+    ///         callback would never run, so the bridged value would never be delivered.
+    error ZeroComposeGas();
+
     /**
      * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
      * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
      * @param payload       Opaque app payload (the receiver decodes it).
      * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
-     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg).
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
+     *                      be non-zero, since {_bridge} sends with default (empty) options.
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
      */
     function _bridge(
@@ -30,6 +35,7 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         uint128 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
+        if (lzComposeGas == 0) revert ZeroComposeGas();
         bytes32 peer = _getPeerOrRevert(dstEid);
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.24;
 
-import {FHE, euint64} from "../FHE.sol";
+import {FHE} from "../FHE.sol";
+import {Impl} from "../Impl.sol";
 import {MessagingFee, MessagingReceipt} from "./IConfidentialBridge.sol";
 import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
 
@@ -10,55 +11,117 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
  *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
  *          `FHE.bridge`, so subclasses never deal with the bridge contract or peer encoding
- *          directly. A single-handle convenience and a type-agnostic multi-handle overload are
- *          provided (a message may carry up to the bridge's `MAX_HANDLES`).
+ *          directly (a message may carry up to the bridge's `MAX_HANDLES`).
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
- *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
+ *          Quote the fee with {_quoteBridge} and forward it as `msg.value`.
+ *
+ *          AUTHORIZATION — read before exposing a send entrypoint. The bridge checks
+ *          `isAllowed(handle, msg.sender)`, and `_bridge*` runs in THIS contract's context, so the
+ *          check is against the contract — which typically holds `allowThis` allowance on its
+ *          handles. The external caller is therefore NOT authorized by the bridge. There are two
+ *          send helpers, named so the call site declares its safety posture:
+ *          - {_bridgeFrom}: safe default. Asserts the external caller is ACL-allowed on every handle
+ *            (the raw-handle equivalent of `FHE.isSenderAllowed`) before bridging. Type-agnostic:
+ *            covers any encrypted type, single or multi, via `bytes32` handles. Use when the caller
+ *            owns the handle(s) being sent.
+ *          - {_bridgeUnchecked}: NO caller authorization. Use only for handles the caller does not
+ *            (and should not) hold allowance on — e.g. a value derived inside the app such as a
+ *            burn result — and gate the entrypoint yourself first (see `ConfidentialOFTViaLib`).
+ *            A public entrypoint that calls this without its own gate lets anyone bridge the
+ *            contract's handles to a configured peer.
  */
 abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
     /// @notice `lzComposeGas` is 0; the destination receive callback would never run, so the
-    ///         bridged value would never be delivered. (The bridge also enforces a per-`dstEid`
-    ///         minimum; this is a cheap pre-check for the clearly-invalid zero case.)
+    ///         bridged value would never be delivered (the bridge rejects a zero gas budget too).
     error ZeroComposeGas();
 
+    /// @notice {_bridgeFrom} was called with a `handle` the external `sender` is not ACL-allowed on.
+    error UnauthorizedSender(bytes32 handle, address sender);
+
     /**
-     * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
-     * @dev    Convenience wrapper over the multi-handle {_bridge}; the payload must reference the
-     *         handle at index 0. See the list overload for the allowance/gas rules.
+     * @notice Safe send: bridge a list of encrypted handles the external caller owns to the peer on
+     *         `dstEid` in a single message.
+     * @dev    Asserts the external `msg.sender` is ACL-allowed on EVERY handle (`Impl.isAllowed`, the
+     *         raw-handle check `FHE.isSenderAllowed` performs per type) before bridging, reverting
+     *         {UnauthorizedSender} with the first handle that fails. This removes the footgun of an
+     *         unguarded entrypoint. Type-agnostic: pass raw `bytes32` handles (e.g. `euint64.unwrap(h)`),
+     *         mixing types within one list is fine. For a handle the caller does not hold allowance on
+     *         (e.g. a value derived inside the app), gate the entrypoint yourself and use
+     *         {_bridgeUnchecked}. The payload references handles by their index.
      */
-    function _bridge(
+    function _bridgeFrom(
         uint32 dstEid,
         bytes memory payload,
-        euint64 handle,
+        bytes32[] memory handles,
+        uint64 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        for (uint256 i = 0; i < handles.length; i++) {
+            if (!Impl.isAllowed(handles[i], msg.sender)) revert UnauthorizedSender(handles[i], msg.sender);
+        }
+        return _bridgeUnchecked(dstEid, payload, handles, lzComposeGas, nativeFee);
+    }
+
+    /**
+     * @notice Safe send: single-handle convenience over the multi-handle {_bridgeFrom}.
+     * @dev    Type-agnostic — pass the raw `bytes32` handle (`T.unwrap(h)` for any encrypted type).
+     *         Asserts the caller owns `handle`, then bridges it; the payload must reference it at
+     *         index 0.
+     */
+    function _bridgeFrom(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32 handle,
         uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
         bytes32[] memory handles = new bytes32[](1);
-        handles[0] = euint64.unwrap(handle);
-        return _bridge(dstEid, payload, handles, lzComposeGas, nativeFee);
+        handles[0] = handle;
+        return _bridgeFrom(dstEid, payload, handles, lzComposeGas, nativeFee);
     }
 
     /**
-     * @notice Bridge a list of encrypted handles to the peer on `dstEid` in a single message.
+     * @notice Unauthorized send: single-handle convenience over the multi-handle {_bridgeUnchecked},
+     *         WITHOUT checking the external caller.
+     * @dev    Type-agnostic — pass the raw `bytes32` handle (`T.unwrap(h)` for any encrypted type).
+     *         The payload must reference it at index 0. See that overload for the authorization/gas
+     *         rules — in particular, the caller is NOT authorized here, so gate the entrypoint yourself.
+     */
+    function _bridgeUnchecked(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32 handle,
+        uint64 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = handle;
+        return _bridgeUnchecked(dstEid, payload, handles, lzComposeGas, nativeFee);
+    }
+
+    /**
+     * @notice Unauthorized send: bridge a list of encrypted handles to the peer on `dstEid` in a
+     *         single message, WITHOUT checking the external caller.
      * @dev    Type-agnostic: pass raw `bytes32` handles (e.g. `euint64.unwrap(h)`); mixing
      *         encrypted types within one list is fine. The destination receiver gets the derived
      *         handles aligned one-to-one by index.
      *
-     *         The bridge checks `isAllowed(handle, msg.sender)` for every handle, and since
-     *         `_bridge` runs in this contract's context `msg.sender` is THIS contract — so the
-     *         contract must hold ACL allowance on each handle (e.g. via `FHE.allowThis`), not the
-     *         external caller. {_bridge} performs no caller authorization of its own; subclasses
-     *         must gate their public entrypoint (as `ConfidentialOFTViaLib.send` does with
-     *         `FHE.isSenderAllowed`).
+     *         No caller authorization is performed. The bridge checks `isAllowed(handle, msg.sender)`
+     *         for every handle, and since this runs in the contract's context `msg.sender` is THIS
+     *         contract — so the contract must hold ACL allowance on each handle (e.g. via
+     *         `FHE.allowThis`), and the external caller is NOT authorized. Subclasses MUST gate their
+     *         public entrypoint (as `ConfidentialOFTViaLib.send` does with `FHE.isSenderAllowed` on
+     *         the input it then burns). For the common "caller owns the handle" case, prefer the safe
+     *         {_bridgeFrom}.
      * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
      * @param payload       Opaque app payload (the receiver decodes it); reference handles by index.
      * @param handles       Raw `bytes32` handles to bridge; this contract must hold ACL allowance
      *                      on each. Up to the bridge's `MAX_HANDLES`.
-     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
-     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must be
+     *                      non-zero (the bridge reverts otherwise).
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
      */
-    function _bridge(
+    function _bridgeUnchecked(
         uint32 dstEid,
         bytes memory payload,
         bytes32[] memory handles,
@@ -69,19 +132,19 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         return FHE.bridge(dstEid, _getPeerOrRevert(dstEid), payload, handles, lzComposeGas, nativeFee);
     }
 
-    /// @notice Quotes the native fee for the single-handle {_bridge} call.
+    /// @notice Quotes the native fee for the single-handle send (pass `T.unwrap(h)` for any type).
     function _quoteBridge(
         uint32 dstEid,
         bytes memory payload,
-        euint64 handle,
+        bytes32 handle,
         uint64 lzComposeGas
     ) internal view returns (MessagingFee memory) {
         bytes32[] memory handles = new bytes32[](1);
-        handles[0] = euint64.unwrap(handle);
+        handles[0] = handle;
         return _quoteBridge(dstEid, payload, handles, lzComposeGas);
     }
 
-    /// @notice Quotes the native fee for the multi-handle {_bridge} call.
+    /// @notice Quotes the native fee for the multi-handle send.
     function _quoteBridge(
         uint32 dstEid,
         bytes memory payload,

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHE, euint64} from "../FHE.sol";
+import {MessagingFee, MessagingReceipt} from "./IConfidentialBridge.sol";
+import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
+
+/**
+ * @title   ConfidentialOAppSender
+ * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
+ *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
+ *          `FHE.bridge`, so subclasses never deal with the bridge contract, LayerZero options,
+ *          or peer encoding directly.
+ * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
+ *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
+ */
+abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
+    /**
+     * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload (the receiver decodes it).
+     * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg).
+     * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
+     */
+    function _bridge(
+        uint32 dstEid,
+        bytes memory payload,
+        euint64 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        bytes32 peer = _getPeerOrRevert(dstEid);
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint64.unwrap(handle);
+        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, "", nativeFee);
+    }
+
+    /// @notice Quotes the native fee for the matching {_bridge} call.
+    function _quoteBridge(
+        uint32 dstEid,
+        bytes memory payload,
+        euint64 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory) {
+        bytes32 peer = _getPeerOrRevert(dstEid);
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint64.unwrap(handle);
+        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas, "");
+    }
+}

--- a/library-solidity/codegen/src/templates/FHE.sol-template
+++ b/library-solidity/codegen/src/templates/FHE.sol-template
@@ -768,4 +768,15 @@ library FHE {
     //$$ -----------------------------------------------------------------------
     $${FHEtoBytes32}$$
     //$$ -----------------------------------------------------------------------
+
+    //$$ -----------------------------------------------------------------------
+    //$$ -
+    //$$ -             🌉 FHE Bridge Template Placeholder
+    //$$ -
+    //$$ -   Per-type single-handle and homogeneous-list `bridge` / `quoteBridge`
+    //$$ -   overloads. The low-level `bytes32[]` + `options` escape hatch below is
+    //$$ -   type-agnostic and handles mixed-type or advanced payloads.
+    //$$ -----------------------------------------------------------------------
+    $${FHEBridge}$$
+    //$$ -----------------------------------------------------------------------
 }

--- a/library-solidity/codegen/src/templates/FHE.sol-template
+++ b/library-solidity/codegen/src/templates/FHE.sol-template
@@ -773,9 +773,9 @@ library FHE {
     //$$ -
     //$$ -             🌉 FHE Bridge Template Placeholder
     //$$ -
-    //$$ -   Per-type single-handle and homogeneous-list `bridge` / `quoteBridge`
-    //$$ -   overloads. The low-level `bytes32[]` + `options` escape hatch below is
-    //$$ -   type-agnostic and handles mixed-type or advanced payloads.
+    //$$ -   Per-type single-handle `bridge` / `quoteBridge` overloads. The low-level
+    //$$ -   `bytes32[]` escape hatch is type-agnostic and handles multi-handle
+    //$$ -   (realistically mixed-type) or non-EVM destination payloads.
     //$$ -----------------------------------------------------------------------
     $${FHEBridge}$$
     //$$ -----------------------------------------------------------------------

--- a/library-solidity/codegen/src/templates/IConfidentialBridge.sol-template
+++ b/library-solidity/codegen/src/templates/IConfidentialBridge.sol-template
@@ -35,8 +35,7 @@ interface IConfidentialBridge {
         bytes32 dstApp,
         bytes calldata payload,
         bytes32[] calldata handleList,
-        uint128 lzComposeGas,
-        bytes calldata options
+        uint64 lzComposeGas
     ) external payable returns (MessagingReceipt memory receipt);
 
     function quote(
@@ -45,8 +44,7 @@ interface IConfidentialBridge {
         bytes32 dstApp,
         bytes calldata payload,
         bytes32[] calldata handleList,
-        uint128 lzComposeGas,
-        bytes calldata options
+        uint64 lzComposeGas
     ) external view returns (MessagingFee memory fee);
 }
 

--- a/library-solidity/codegen/src/templates/IConfidentialBridge.sol-template
+++ b/library-solidity/codegen/src/templates/IConfidentialBridge.sol-template
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+/**
+ * @title   LayerZero messaging structs (local copies)
+ * @notice  `MessagingFee` and `MessagingReceipt` are the fee-quote and send-receipt types the
+ *          bridge returns. They originate in LayerZero's `ILayerZeroEndpointV2`, but are copied
+ *          here field-for-field so that apps using `fhevm/solidity` do not have to install the
+ *          LayerZero packages just to bridge. The layout is identical, so they are ABI-compatible
+ *          with the real bridge.
+ */
+struct MessagingFee {
+    uint256 nativeFee;
+    uint256 lzTokenFee;
+}
+
+struct MessagingReceipt {
+    bytes32 guid;
+    uint64 nonce;
+    MessagingFee fee;
+}
+
+/**
+ * @title   IConfidentialBridge
+ * @notice  Minimal view of the host `ConfidentialBridge` that the library wrapper needs.
+ *          Only `send` and `quote` are declared — the library never references the
+ *          LayerZero OApp surface.
+ * @dev     Must stay in sync with `host-contracts/contracts/bridge/HandlesSender.sol`.
+ *          The per-dstEid lzReceive gas configuration is exposed by the bridge through
+ *          separate setters/getters and does not affect this `send`/`quote` surface.
+ */
+interface IConfidentialBridge {
+    function send(
+        uint32 dstEid,
+        bytes32 dstApp,
+        bytes calldata payload,
+        bytes32[] calldata handleList,
+        uint128 lzComposeGas,
+        bytes calldata options
+    ) external payable returns (MessagingReceipt memory receipt);
+
+    function quote(
+        uint32 dstEid,
+        address srcApp,
+        bytes32 dstApp,
+        bytes calldata payload,
+        bytes32[] calldata handleList,
+        uint128 lzComposeGas,
+        bytes calldata options
+    ) external view returns (MessagingFee memory fee);
+}
+
+/**
+ * @title   IDstApp
+ * @notice  Callback a destination app implements to receive a bridged payload.
+ *          Mirrors `host-contracts/contracts/bridge/interfaces/IDstApp.sol`.
+ * @dev     The {ConfidentialBridgeReceiver} base contract implements this and exposes a
+ *          typed `_onReceiveHandles` hook so apps don't deal with raw `bytes32` handles.
+ */
+interface IDstApp {
+    function onConfidentialBridgeReceived(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata srcHandleList,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external;
+}

--- a/library-solidity/codegen/src/templates/IConfidentialBridge.sol-template
+++ b/library-solidity/codegen/src/templates/IConfidentialBridge.sol-template
@@ -54,7 +54,7 @@ interface IConfidentialBridge {
  * @title   IDstApp
  * @notice  Callback a destination app implements to receive a bridged payload.
  *          Mirrors `host-contracts/contracts/bridge/interfaces/IDstApp.sol`.
- * @dev     The {ConfidentialBridgeReceiver} base contract implements this and exposes a
+ * @dev     The {ConfidentialOAppReceiver} base contract implements this and exposes a
  *          typed `_onReceiveHandles` hook so apps don't deal with raw `bytes32` handles.
  */
 interface IDstApp {

--- a/library-solidity/codegen/src/templates/Impl.sol-template
+++ b/library-solidity/codegen/src/templates/Impl.sol-template
@@ -7,6 +7,7 @@ pragma solidity ^0.8.24;
 //$$ -
 //$$ -----------------------------------------------------------------------
 import {FheType} from "$${FheTypeDotSol}$$";
+$${ImplBridgeImports}$$
 //$$ -----------------------------------------------------------------------
 
 /**
@@ -132,6 +133,7 @@ interface IACL {
      * @return results      Return payloads for each call in `data`.
      */
     function multicall(bytes[] calldata data) external payable returns (bytes[] memory results);
+    $${ImplBridgeACLGetter}$$
 
     /**
      * @notice              Allows the use of handle by address account for this transaction.
@@ -280,6 +282,8 @@ library Impl {
         $.CoprocessorAddress = coprocessorConfig.CoprocessorAddress;
         $.KMSVerifierAddress = coprocessorConfig.KMSVerifierAddress;
     }
+
+    $${ImplBridge}$$
 
     //$$ -----------------------------------------------------------------------
     //$$ -

--- a/library-solidity/examples/bridge/BridgeLibHarness.sol
+++ b/library-solidity/examples/bridge/BridgeLibHarness.sol
@@ -105,33 +105,7 @@ contract BridgeLibHarness {
         return FHE.bridge(e, a, p, eaddress.wrap(h), g, msg.value);
     }
 
-    // ---------------- multi-handle, typed arrays (multi-handle coverage) ----------------
-
-    function bridgeArray64(
-        uint32 e,
-        address a,
-        bytes calldata p,
-        bytes32[] calldata hs,
-        uint64 g
-    ) external payable returns (MessagingReceipt memory) {
-        euint64[] memory typed = new euint64[](hs.length);
-        for (uint256 i = 0; i < hs.length; i++) typed[i] = euint64.wrap(hs[i]);
-        return FHE.bridge(e, a, p, typed, g, msg.value);
-    }
-
-    function bridgeArray256(
-        uint32 e,
-        address a,
-        bytes calldata p,
-        bytes32[] calldata hs,
-        uint64 g
-    ) external payable returns (MessagingReceipt memory) {
-        euint256[] memory typed = new euint256[](hs.length);
-        for (uint256 i = 0; i < hs.length; i++) typed[i] = euint256.wrap(hs[i]);
-        return FHE.bridge(e, a, p, typed, g, msg.value);
-    }
-
-    // ---------------- low-level escape hatches ----------------
+    // ---------------- multi-handle escape hatch (realistically heterogeneous) ----------------
 
     function bridgeList(
         uint32 e,
@@ -163,18 +137,6 @@ contract BridgeLibHarness {
         uint64 g
     ) external view returns (MessagingFee memory) {
         return FHE.quoteBridge(e, address(this), a, p, euint32.wrap(h), g);
-    }
-
-    function quoteArray64(
-        uint32 e,
-        address a,
-        bytes calldata p,
-        bytes32[] calldata hs,
-        uint64 g
-    ) external view returns (MessagingFee memory) {
-        euint64[] memory typed = new euint64[](hs.length);
-        for (uint256 i = 0; i < hs.length; i++) typed[i] = euint64.wrap(hs[i]);
-        return FHE.quoteBridge(e, address(this), a, p, typed, g);
     }
 
     function quoteList(

--- a/library-solidity/examples/bridge/BridgeLibHarness.sol
+++ b/library-solidity/examples/bridge/BridgeLibHarness.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHE, ebool, euint8, euint16, euint32, euint64, euint128, euint256, eaddress} from "../../lib/FHE.sol";
+import {CoprocessorConfig} from "../../lib/Impl.sol";
+import {MessagingFee, MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
+
+/**
+ * @title   BridgeLibHarness
+ * @notice  Minimal contract whose only job is to call the library's send-side functions
+ *          (`FHE.bridge` / `FHE.quoteBridge`) so tests can drive every typed overload. It passes
+ *          an arbitrary `bytes32` handle straight through (no encrypted math), letting a test
+ *          confirm the wrapper looks the bridge up from the ACL and forwards every argument and
+ *          `msg.value` unchanged — without needing a running coprocessor.
+ * @dev     Test-only helper; not part of the published library.
+ */
+contract BridgeLibHarness {
+    constructor(address acl) {
+        // Only ACLAddress is read by the bridge path; the coprocessor/KMS addresses are
+        // irrelevant here, so any non-zero placeholder is fine.
+        FHE.setCoprocessor(
+            CoprocessorConfig({ACLAddress: acl, CoprocessorAddress: address(1), KMSVerifierAddress: address(2)})
+        );
+    }
+
+    // ---------------- single-handle, per type (multi-type coverage) ----------------
+
+    function bridgeBool(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, ebool.wrap(h), g, msg.value);
+    }
+
+    function bridge8(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, euint8.wrap(h), g, msg.value);
+    }
+
+    function bridge16(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, euint16.wrap(h), g, msg.value);
+    }
+
+    function bridge32(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, euint32.wrap(h), g, msg.value);
+    }
+
+    function bridge64(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, euint64.wrap(h), g, msg.value);
+    }
+
+    function bridge128(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, euint128.wrap(h), g, msg.value);
+    }
+
+    function bridge256(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, euint256.wrap(h), g, msg.value);
+    }
+
+    function bridgeAddr(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, eaddress.wrap(h), g, msg.value);
+    }
+
+    // ---------------- multi-handle, typed arrays (multi-handle coverage) ----------------
+
+    function bridgeArray64(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32[] calldata hs,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        euint64[] memory typed = new euint64[](hs.length);
+        for (uint256 i = 0; i < hs.length; i++) typed[i] = euint64.wrap(hs[i]);
+        return FHE.bridge(e, a, p, typed, g, msg.value);
+    }
+
+    function bridgeArray256(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32[] calldata hs,
+        uint128 g
+    ) external payable returns (MessagingReceipt memory) {
+        euint256[] memory typed = new euint256[](hs.length);
+        for (uint256 i = 0; i < hs.length; i++) typed[i] = euint256.wrap(hs[i]);
+        return FHE.bridge(e, a, p, typed, g, msg.value);
+    }
+
+    // ---------------- low-level escape hatches ----------------
+
+    function bridgeList(
+        uint32 e,
+        bytes32 a,
+        bytes calldata p,
+        bytes32[] calldata hs,
+        uint128 g,
+        bytes calldata o
+    ) external payable returns (MessagingReceipt memory) {
+        return FHE.bridge(e, a, p, hs, g, o, msg.value);
+    }
+
+    // ---------------- quotes ----------------
+
+    function quote64(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external view returns (MessagingFee memory) {
+        return FHE.quoteBridge(e, address(this), a, p, euint64.wrap(h), g);
+    }
+
+    function quote32(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32 h,
+        uint128 g
+    ) external view returns (MessagingFee memory) {
+        return FHE.quoteBridge(e, address(this), a, p, euint32.wrap(h), g);
+    }
+
+    function quoteArray64(
+        uint32 e,
+        address a,
+        bytes calldata p,
+        bytes32[] calldata hs,
+        uint128 g
+    ) external view returns (MessagingFee memory) {
+        euint64[] memory typed = new euint64[](hs.length);
+        for (uint256 i = 0; i < hs.length; i++) typed[i] = euint64.wrap(hs[i]);
+        return FHE.quoteBridge(e, address(this), a, p, typed, g);
+    }
+
+    function quoteList(
+        uint32 e,
+        bytes32 a,
+        bytes calldata p,
+        bytes32[] calldata hs,
+        uint128 g,
+        bytes calldata o
+    ) external view returns (MessagingFee memory) {
+        return FHE.quoteBridge(e, address(this), a, p, hs, g, o);
+    }
+}

--- a/library-solidity/examples/bridge/BridgeLibHarness.sol
+++ b/library-solidity/examples/bridge/BridgeLibHarness.sol
@@ -30,7 +30,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, ebool.wrap(h), g, msg.value);
     }
@@ -40,7 +40,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, euint8.wrap(h), g, msg.value);
     }
@@ -50,7 +50,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, euint16.wrap(h), g, msg.value);
     }
@@ -60,7 +60,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, euint32.wrap(h), g, msg.value);
     }
@@ -70,7 +70,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, euint64.wrap(h), g, msg.value);
     }
@@ -80,7 +80,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, euint128.wrap(h), g, msg.value);
     }
@@ -90,7 +90,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, euint256.wrap(h), g, msg.value);
     }
@@ -100,7 +100,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         return FHE.bridge(e, a, p, eaddress.wrap(h), g, msg.value);
     }
@@ -112,7 +112,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32[] calldata hs,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         euint64[] memory typed = new euint64[](hs.length);
         for (uint256 i = 0; i < hs.length; i++) typed[i] = euint64.wrap(hs[i]);
@@ -124,7 +124,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32[] calldata hs,
-        uint128 g
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
         euint256[] memory typed = new euint256[](hs.length);
         for (uint256 i = 0; i < hs.length; i++) typed[i] = euint256.wrap(hs[i]);
@@ -138,10 +138,9 @@ contract BridgeLibHarness {
         bytes32 a,
         bytes calldata p,
         bytes32[] calldata hs,
-        uint128 g,
-        bytes calldata o
+        uint64 g
     ) external payable returns (MessagingReceipt memory) {
-        return FHE.bridge(e, a, p, hs, g, o, msg.value);
+        return FHE.bridge(e, a, p, hs, g, msg.value);
     }
 
     // ---------------- quotes ----------------
@@ -151,7 +150,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external view returns (MessagingFee memory) {
         return FHE.quoteBridge(e, address(this), a, p, euint64.wrap(h), g);
     }
@@ -161,7 +160,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32 h,
-        uint128 g
+        uint64 g
     ) external view returns (MessagingFee memory) {
         return FHE.quoteBridge(e, address(this), a, p, euint32.wrap(h), g);
     }
@@ -171,7 +170,7 @@ contract BridgeLibHarness {
         address a,
         bytes calldata p,
         bytes32[] calldata hs,
-        uint128 g
+        uint64 g
     ) external view returns (MessagingFee memory) {
         euint64[] memory typed = new euint64[](hs.length);
         for (uint256 i = 0; i < hs.length; i++) typed[i] = euint64.wrap(hs[i]);
@@ -183,9 +182,8 @@ contract BridgeLibHarness {
         bytes32 a,
         bytes calldata p,
         bytes32[] calldata hs,
-        uint128 g,
-        bytes calldata o
+        uint64 g
     ) external view returns (MessagingFee memory) {
-        return FHE.quoteBridge(e, address(this), a, p, hs, g, o);
+        return FHE.quoteBridge(e, address(this), a, p, hs, g);
     }
 }

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -15,7 +15,7 @@ import {MessagingFee, MessagingReceipt} from "../../lib/bridge/IConfidentialBrid
  *          `fhevm/solidity` library. It is a confidential omnichain app (OApp): it inherits
  *          {ConfidentialOAppSender} for the send half and {ConfidentialOAppReceiver} for the
  *          receive half, which together give it:
- *            - Sending: `_bridge(...)` burns an encrypted amount here and has it minted on the
+ *            - Sending: {send} burns an encrypted amount here and has it minted on the
  *              destination chain. The app never touches LayerZero or the bridge contract.
  *            - Receiving: one hook ({_onReceiveHandles}) mints the incoming amount; the base
  *              authenticates the bridge and the source peer first.
@@ -68,11 +68,14 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
 
         // The bridged amount is delivered out-of-band in the bridge's handle list (minted from
         // `handles[0]` on receipt), so the payload only needs to carry the recipient.
-        // `mintComposeGas` is validated (must be non-zero) by {ConfidentialOAppSender-_bridge}.
+        // `mintComposeGas` is validated (must be non-zero) by {ConfidentialOAppSender-_bridgeUnchecked}.
         bytes memory payload = abi.encode(recipient);
 
         emit Bridged(msg.sender, dstEid, recipient);
-        return _bridge(dstEid, payload, actualAmount, mintComposeGas, msg.value);
+        // `actualAmount` is a fresh burn result the caller holds no allowance on, so {_bridgeFrom}'s
+        // `isSenderAllowed` check cannot apply here; the entrypoint is instead gated above on the
+        // input `amount` (line: `isSenderAllowed(amount)`), so the unchecked send is deliberate.
+        return _bridgeUnchecked(dstEid, payload, euint64.unwrap(actualAmount), mintComposeGas, msg.value);
     }
 
     /// @notice Quote the native fee to {send} `amount` to `recipient` on `dstEid`; pass the
@@ -83,7 +86,7 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         address recipient,
         uint64 mintComposeGas
     ) external view returns (MessagingFee memory) {
-        return _quoteBridge(dstEid, abi.encode(recipient), amount, mintComposeGas);
+        return _quoteBridge(dstEid, abi.encode(recipient), euint64.unwrap(amount), mintComposeGas);
     }
 
     // ---------------------------- Receive side ----------------------------

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -30,6 +30,7 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
 
     error UnauthorizedUseOfEncryptedAmount(euint64 amount, address sender);
     error SweepFailed();
+    error RefundFailed();
 
     mapping(address holder => euint64 balance) private _balances;
 
@@ -40,7 +41,8 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         // {ConfidentialOAppReceiver}. Nothing else to wire — and the two anchors can never diverge.
     }
 
-    /// @dev Accept native-fee refunds the bridge / LayerZero endpoint may push back on `send`.
+    /// @dev Accept the native-fee change the LayerZero endpoint pushes back during {send}; {send}
+    ///      forwards it on to the caller in the same transaction.
     receive() external payable {}
 
     // ----------------------------- Send side -----------------------------
@@ -48,7 +50,8 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
     /**
      * @notice Burn `amount` locally and bridge it to `recipient` on `dstEid`.
      * @dev    Quote the LayerZero fee with {quoteSend} and forward it as `msg.value`; any excess
-     *         is refunded to this contract (see `receive()` / {sweep}).
+     *         over the actual fee is refunded to `msg.sender` in the same transaction (see the
+     *         refund at the end of this function and `receive()`).
      *         NOTE: FHE cannot revert on an encrypted comparison, so if `amount` exceeds the
      *         caller's balance the burn yields an encrypted 0 and a zero-value message is still
      *         bridged (the caller pays the fee for a no-op `_mint`). Callers should confirm a
@@ -75,7 +78,24 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         // `actualAmount` is a fresh burn result the caller holds no allowance on, so {_bridgeFrom}'s
         // `isSenderAllowed` check cannot apply here; the entrypoint is instead gated above on the
         // input `amount` (line: `isSenderAllowed(amount)`), so the unchecked send is deliberate.
-        return _bridgeUnchecked(dstEid, payload, euint64.unwrap(actualAmount), mintComposeGas, msg.value);
+        MessagingReceipt memory receipt = _bridgeUnchecked(
+            dstEid,
+            payload,
+            euint64.unwrap(actualAmount),
+            mintComposeGas,
+            msg.value
+        );
+
+        // Refund any overpaid native fee to the caller. The endpoint refunds the excess
+        // (`msg.value - receipt.fee.nativeFee`) to this contract within the same tx (accepted by
+        // `receive()`); forward it on so overpayment isn't trapped for the owner to {sweep}.
+        // Underpayment reverts upstream in the endpoint, so this cannot underflow.
+        uint256 excess = msg.value - receipt.fee.nativeFee;
+        if (excess != 0) {
+            (bool ok, ) = payable(msg.sender).call{value: excess}("");
+            if (!ok) revert RefundFailed();
+        }
+        return receipt;
     }
 
     /// @notice Quote the native fee to {send} `amount` to `recipient` on `dstEid`; pass the
@@ -124,8 +144,9 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         return _balances[holder];
     }
 
-    /// @notice Withdraw native balance accumulated from bridge fee refunds (see `receive()`),
-    ///         so overpaid fees aren't trapped in the contract.
+    /// @notice Withdraw any stray native balance (e.g. a direct transfer). Overpaid bridge fees are
+    ///         refunded to the caller inside {send}, so this is only a dust safety net, not the
+    ///         refund path.
     function sweep(address to) external onlyOwner {
         (bool ok, ) = to.call{value: address(this).balance}("");
         if (!ok) revert SweepFailed();

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -7,7 +7,7 @@ import {FHE, euint64, externalEuint64, ebool} from "../../lib/FHE.sol";
 import {ZamaConfig} from "../../config/ZamaConfig.sol";
 import {ConfidentialOAppSender} from "../../lib/bridge/ConfidentialOAppSender.sol";
 import {ConfidentialOAppReceiver} from "../../lib/bridge/ConfidentialOAppReceiver.sol";
-import {MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
+import {MessagingFee, MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
 
 /**
  * @title   ConfidentialOFTViaLib
@@ -29,6 +29,7 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
     event Received(uint32 indexed srcEid, address indexed recipient);
 
     error UnauthorizedUseOfEncryptedAmount(euint64 amount, address sender);
+    error SweepFailed();
 
     mapping(address holder => euint64 balance) private _balances;
 
@@ -46,8 +47,8 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
 
     /**
      * @notice Burn `amount` locally and bridge it to `recipient` on `dstEid`.
-     * @dev    Quote the LayerZero fee with {_quoteBridge} and forward it as `msg.value`; any
-     *         excess is refunded to this contract (see `receive()` above).
+     * @dev    Quote the LayerZero fee with {quoteSend} and forward it as `msg.value`; any excess
+     *         is refunded to this contract (see `receive()` / {sweep}).
      *         NOTE: FHE cannot revert on an encrypted comparison, so if `amount` exceeds the
      *         caller's balance the burn yields an encrypted 0 and a zero-value message is still
      *         bridged (the caller pays the fee for a no-op `_mint`). Callers should confirm a
@@ -74,6 +75,17 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         return _bridge(dstEid, payload, actualAmount, mintComposeGas, msg.value);
     }
 
+    /// @notice Quote the native fee to {send} `amount` to `recipient` on `dstEid`; pass the
+    ///         returned `nativeFee` as `msg.value` to {send}.
+    function quoteSend(
+        uint32 dstEid,
+        euint64 amount,
+        address recipient,
+        uint128 mintComposeGas
+    ) external view returns (MessagingFee memory) {
+        return _quoteBridge(dstEid, abi.encode(recipient), amount, mintComposeGas);
+    }
+
     // ---------------------------- Receive side ----------------------------
 
     /// @inheritdoc ConfidentialOAppReceiver
@@ -84,6 +96,9 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         bytes32[] calldata handles,
         bytes32 /* guid */
     ) internal override {
+        // The bridge delivers each message's compose exactly once (a retry only follows a revert),
+        // so this unconditional mint is safe. If your receive hook is NOT idempotent, track `guid`
+        // and dedupe to avoid a double-mint on retry.
         address recipient = abi.decode(payload, (address));
         _mint(recipient, euint64.wrap(handles[0]));
         emit Received(srcEid, recipient);
@@ -104,6 +119,13 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
 
     function balanceOf(address holder) external view returns (euint64) {
         return _balances[holder];
+    }
+
+    /// @notice Withdraw native balance accumulated from bridge fee refunds (see `receive()`),
+    ///         so overpaid fees aren't trapped in the contract.
+    function sweep(address to) external onlyOwner {
+        (bool ok, ) = to.call{value: address(this).balance}("");
+        if (!ok) revert SweepFailed();
     }
 
     // ------------------------------ Internals -----------------------------

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -29,6 +29,8 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
     event Received(uint32 indexed srcEid, address indexed recipient);
 
     error UnauthorizedUseOfEncryptedAmount(euint64 amount, address sender);
+    /// @notice `mintComposeGas` is 0, so the destination mint callback would never run.
+    error MintComposeGasRequired();
 
     mapping(address holder => euint64 balance) private _balances;
 
@@ -62,6 +64,9 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         uint128 mintComposeGas
     ) external payable returns (MessagingReceipt memory) {
         if (!FHE.isSenderAllowed(amount)) revert UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+        // With empty LayerZero options the bridge sizes the destination mint (lzCompose) leg
+        // from `mintComposeGas`; a value of 0 means the mint callback never runs.
+        if (mintComposeGas == 0) revert MintComposeGasRequired();
 
         euint64 actualAmount = _burn(msg.sender, amount);
 

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -60,7 +60,7 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         uint32 dstEid,
         euint64 amount,
         address recipient,
-        uint128 mintComposeGas
+        uint64 mintComposeGas
     ) external payable returns (MessagingReceipt memory) {
         if (!FHE.isSenderAllowed(amount)) revert UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
 
@@ -81,7 +81,7 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         uint32 dstEid,
         euint64 amount,
         address recipient,
-        uint128 mintComposeGas
+        uint64 mintComposeGas
     ) external view returns (MessagingFee memory) {
         return _quoteBridge(dstEid, abi.encode(recipient), amount, mintComposeGas);
     }

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -29,8 +29,6 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
     event Received(uint32 indexed srcEid, address indexed recipient);
 
     error UnauthorizedUseOfEncryptedAmount(euint64 amount, address sender);
-    /// @notice `mintComposeGas` is 0, so the destination mint callback would never run.
-    error MintComposeGasRequired();
 
     mapping(address holder => euint64 balance) private _balances;
 
@@ -64,14 +62,13 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         uint128 mintComposeGas
     ) external payable returns (MessagingReceipt memory) {
         if (!FHE.isSenderAllowed(amount)) revert UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
-        // With empty LayerZero options the bridge sizes the destination mint (lzCompose) leg
-        // from `mintComposeGas`; a value of 0 means the mint callback never runs.
-        if (mintComposeGas == 0) revert MintComposeGasRequired();
 
         euint64 actualAmount = _burn(msg.sender, amount);
 
-        // Payload references the same handle at index 0 (so the receiver mints it).
-        bytes memory payload = abi.encode(recipient, euint64.unwrap(actualAmount));
+        // The bridged amount is delivered out-of-band in the bridge's handle list (minted from
+        // `handles[0]` on receipt), so the payload only needs to carry the recipient.
+        // `mintComposeGas` is validated (must be non-zero) by {ConfidentialOAppSender-_bridge}.
+        bytes memory payload = abi.encode(recipient);
 
         emit Bridged(msg.sender, dstEid, recipient);
         return _bridge(dstEid, payload, actualAmount, mintComposeGas, msg.value);
@@ -87,7 +84,7 @@ contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, Confiden
         bytes32[] calldata handles,
         bytes32 /* guid */
     ) internal override {
-        (address recipient, ) = abi.decode(payload, (address, bytes32));
+        address recipient = abi.decode(payload, (address));
         _mint(recipient, euint64.wrap(handles[0]));
         emit Received(srcEid, recipient);
     }

--- a/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
+++ b/library-solidity/examples/bridge/ConfidentialOFTViaLib.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+import {FHE, euint64, externalEuint64, ebool} from "../../lib/FHE.sol";
+import {ZamaConfig} from "../../config/ZamaConfig.sol";
+import {ConfidentialOAppSender} from "../../lib/bridge/ConfidentialOAppSender.sol";
+import {ConfidentialOAppReceiver} from "../../lib/bridge/ConfidentialOAppReceiver.sol";
+import {MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
+
+/**
+ * @title   ConfidentialOFTViaLib
+ * @notice  Example confidential token that can be bridged across chains, built entirely on the
+ *          `fhevm/solidity` library. It is a confidential omnichain app (OApp): it inherits
+ *          {ConfidentialOAppSender} for the send half and {ConfidentialOAppReceiver} for the
+ *          receive half, which together give it:
+ *            - Sending: `_bridge(...)` burns an encrypted amount here and has it minted on the
+ *              destination chain. The app never touches LayerZero or the bridge contract.
+ *            - Receiving: one hook ({_onReceiveHandles}) mints the incoming amount; the base
+ *              authenticates the bridge and the source peer first.
+ *
+ * @dev     An instance is deployed on each supported chain and wired to its peers once via
+ *          {setPeer} (the peer applies to both directions). The app only deals with its own
+ *          burn/mint logic and a `euint64` amount.
+ */
+contract ConfidentialOFTViaLib is Ownable2Step, ConfidentialOAppSender, ConfidentialOAppReceiver {
+    event Bridged(address indexed from, uint32 indexed dstEid, address indexed recipient);
+    event Received(uint32 indexed srcEid, address indexed recipient);
+
+    error UnauthorizedUseOfEncryptedAmount(euint64 amount, address sender);
+
+    mapping(address holder => euint64 balance) private _balances;
+
+    constructor(address _owner) Ownable(_owner) {
+        FHE.setCoprocessor(ZamaConfig.getEthereumCoprocessorConfig());
+        // Both directions resolve the ConfidentialBridge from the ACL configured above:
+        // the send path through `FHE.bridge` and the receive path through
+        // {ConfidentialOAppReceiver}. Nothing else to wire — and the two anchors can never diverge.
+    }
+
+    /// @dev Accept native-fee refunds the bridge / LayerZero endpoint may push back on `send`.
+    receive() external payable {}
+
+    // ----------------------------- Send side -----------------------------
+
+    /**
+     * @notice Burn `amount` locally and bridge it to `recipient` on `dstEid`.
+     * @dev    Quote the LayerZero fee with {_quoteBridge} and forward it as `msg.value`; any
+     *         excess is refunded to this contract (see `receive()` above).
+     *         NOTE: FHE cannot revert on an encrypted comparison, so if `amount` exceeds the
+     *         caller's balance the burn yields an encrypted 0 and a zero-value message is still
+     *         bridged (the caller pays the fee for a no-op `_mint`). Callers should confirm a
+     *         sufficient balance off-chain before sending. This matches the host
+     *         `ConfidentialOFT` example's burn-and-mint semantics.
+     * @param mintComposeGas Gas budget for the destination mint (lzCompose leg).
+     */
+    function send(
+        uint32 dstEid,
+        euint64 amount,
+        address recipient,
+        uint128 mintComposeGas
+    ) external payable returns (MessagingReceipt memory) {
+        if (!FHE.isSenderAllowed(amount)) revert UnauthorizedUseOfEncryptedAmount(amount, msg.sender);
+
+        euint64 actualAmount = _burn(msg.sender, amount);
+
+        // Payload references the same handle at index 0 (so the receiver mints it).
+        bytes memory payload = abi.encode(recipient, euint64.unwrap(actualAmount));
+
+        emit Bridged(msg.sender, dstEid, recipient);
+        return _bridge(dstEid, payload, actualAmount, mintComposeGas, msg.value);
+    }
+
+    // ---------------------------- Receive side ----------------------------
+
+    /// @inheritdoc ConfidentialOAppReceiver
+    function _onReceiveHandles(
+        uint32 srcEid,
+        bytes32 /* srcApp */,
+        bytes calldata payload,
+        bytes32[] calldata handles,
+        bytes32 /* guid */
+    ) internal override {
+        (address recipient, ) = abi.decode(payload, (address, bytes32));
+        _mint(recipient, euint64.wrap(handles[0]));
+        emit Received(srcEid, recipient);
+    }
+
+    // ------------------------------- Admin --------------------------------
+
+    /// @notice Register the remote OFT peer for `eid` (applies to both send and receive).
+    ///         For an EVM peer, pass the remote address left-padded to bytes32.
+    function setPeer(uint32 eid, bytes32 peer) external onlyOwner {
+        _setPeer(eid, peer);
+    }
+
+    function mint(address to, externalEuint64 encryptedAmount, bytes calldata inputProof) external onlyOwner {
+        euint64 amount = FHE.fromExternal(encryptedAmount, inputProof);
+        _mint(to, amount);
+    }
+
+    function balanceOf(address holder) external view returns (euint64) {
+        return _balances[holder];
+    }
+
+    // ------------------------------ Internals -----------------------------
+
+    function _burn(address from, euint64 amount) internal returns (euint64 actualAmount) {
+        euint64 fromBalance = _balances[from];
+        ebool canBurn = FHE.le(amount, fromBalance);
+        actualAmount = FHE.select(canBurn, amount, FHE.asEuint64(0));
+        euint64 newBalance = FHE.sub(fromBalance, actualAmount);
+        _balances[from] = newBalance;
+        FHE.allowThis(newBalance);
+        FHE.allow(newBalance, from);
+        FHE.allowThis(actualAmount);
+    }
+
+    function _mint(address to, euint64 amount) internal {
+        euint64 newBalance = FHE.add(_balances[to], amount);
+        _balances[to] = newBalance;
+        FHE.allowThis(newBalance);
+        FHE.allow(newBalance, to);
+    }
+}

--- a/library-solidity/examples/bridge/MockACL.sol
+++ b/library-solidity/examples/bridge/MockACL.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+/**
+ * @title   MockACL
+ * @notice  Minimal stand-in for the host ACL exposing only the surface `FHE.bridge` reads:
+ *          {getConfidentialBridgeAddress}. Lets the wrapper resolve a test bridge without
+ *          spinning up the full FHEVM host stack.
+ * @dev     Test-only; not part of the published library. The real ACL returns a fixed bridge
+ *          address, but this mock makes it settable so a test can point the wrapper at a
+ *          {MockConfidentialBridge} — or at address(0) to check the "no bridge configured"
+ *          (`BridgeNotConfigured`) revert.
+ */
+contract MockACL {
+    address public confidentialBridge;
+
+    function setConfidentialBridgeAddress(address bridge) external {
+        confidentialBridge = bridge;
+    }
+
+    function getConfidentialBridgeAddress() external view returns (address) {
+        return confidentialBridge;
+    }
+}

--- a/library-solidity/examples/bridge/MockACL.sol
+++ b/library-solidity/examples/bridge/MockACL.sol
@@ -9,10 +9,13 @@ pragma solidity ^0.8.24;
  * @dev     Test-only; not part of the published library. The real ACL returns a fixed bridge
  *          address, but this mock makes it settable so a test can point the wrapper at a
  *          {MockConfidentialBridge} — or at address(0) to check the "no bridge configured"
- *          (`BridgeNotConfigured`) revert.
+ *          (`BridgeNotConfigured`) revert. It also stubs {isAllowed} (settable per handle/account)
+ *          so the safe `ConfidentialOAppSender._bridgeFrom` path (`FHE.isSenderAllowed`) is testable.
  */
 contract MockACL {
     address public confidentialBridge;
+
+    mapping(bytes32 handle => mapping(address account => bool)) private _allowed;
 
     function setConfidentialBridgeAddress(address bridge) external {
         confidentialBridge = bridge;
@@ -20,5 +23,14 @@ contract MockACL {
 
     function getConfidentialBridgeAddress() external view returns (address) {
         return confidentialBridge;
+    }
+
+    /// @notice Grant or revoke `account`'s allowance on `handle` (drives `FHE.isSenderAllowed`).
+    function setAllowed(bytes32 handle, address account, bool value) external {
+        _allowed[handle][account] = value;
+    }
+
+    function isAllowed(bytes32 handle, address account) external view returns (bool) {
+        return _allowed[handle][account];
     }
 }

--- a/library-solidity/examples/bridge/MockConfidentialBridge.sol
+++ b/library-solidity/examples/bridge/MockConfidentialBridge.sol
@@ -31,10 +31,19 @@ contract MockConfidentialBridge is IConfidentialBridge {
     /// @dev Native fee returned by {quote}; settable so tests can exercise fee plumbing.
     uint256 public quotedNativeFee;
 
+    /// @dev Fee {send} actually charges. When 0 (default) it charges the full `msg.value` (no
+    ///      excess); when set below `msg.value` it refunds the difference to the caller — mirroring
+    ///      how the LayerZero endpoint pushes back native-fee change — so refund paths are testable.
+    uint256 public chargedFee;
+
     event Sent(uint32 indexed dstEid, bytes32 indexed dstApp, address indexed caller, uint256 value);
 
     function setQuotedNativeFee(uint256 fee) external {
         quotedNativeFee = fee;
+    }
+
+    function setChargedFee(uint256 fee) external {
+        chargedFee = fee;
     }
 
     function send(
@@ -56,11 +65,19 @@ contract MockConfidentialBridge is IConfidentialBridge {
         sendCalled = true;
         emit Sent(dstEid, dstApp, msg.sender, msg.value);
 
+        // Charge `chargedFee` (or the full value when unset) and refund any excess to the caller,
+        // as the real endpoint does — so the receipt's `fee.nativeFee` can be below `msg.value`.
+        uint256 fee = chargedFee == 0 ? msg.value : chargedFee;
+        if (msg.value > fee) {
+            (bool ok, ) = payable(msg.sender).call{value: msg.value - fee}("");
+            require(ok, "mock refund failed");
+        }
+
         // Deterministic receipt so tests can assert pass-through of the return value.
         receipt = MessagingReceipt({
             guid: keccak256(abi.encode(dstEid, dstApp, payload)),
             nonce: 1,
-            fee: MessagingFee({nativeFee: msg.value, lzTokenFee: 0})
+            fee: MessagingFee({nativeFee: fee, lzTokenFee: 0})
         });
     }
 

--- a/library-solidity/examples/bridge/MockConfidentialBridge.sol
+++ b/library-solidity/examples/bridge/MockConfidentialBridge.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {IConfidentialBridge, MessagingFee, MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
+import {IDstApp} from "../../lib/bridge/IConfidentialBridge.sol";
+
+/**
+ * @title   MockConfidentialBridge
+ * @notice  Test double for the host `ConfidentialBridge`. Records the arguments and
+ *          `msg.value` of the last {send} call so tests can assert that the `FHE.bridge`
+ *          wrapper forwards everything verbatim, and lets a test drive the receive side by
+ *          replaying {IDstApp.onConfidentialBridgeReceived} on a destination app.
+ * @dev     Test-only stand-in for the real on-chain `ConfidentialBridge`; not part of the
+ *          published library. It does no real cross-chain messaging — it just records what was
+ *          sent and lets a test replay a delivery into a receiver.
+ */
+contract MockConfidentialBridge is IConfidentialBridge {
+    struct SendCall {
+        uint32 dstEid;
+        bytes32 dstApp;
+        bytes payload;
+        bytes32[] handleList;
+        uint128 lzComposeGas;
+        bytes options;
+        uint256 value;
+        address caller;
+    }
+
+    SendCall private _lastSend;
+    bool public sendCalled;
+
+    /// @dev Native fee returned by {quote}; settable so tests can exercise fee plumbing.
+    uint256 public quotedNativeFee;
+
+    event Sent(uint32 indexed dstEid, bytes32 indexed dstApp, address indexed caller, uint256 value);
+
+    function setQuotedNativeFee(uint256 fee) external {
+        quotedNativeFee = fee;
+    }
+
+    function send(
+        uint32 dstEid,
+        bytes32 dstApp,
+        bytes calldata payload,
+        bytes32[] calldata handleList,
+        uint128 lzComposeGas,
+        bytes calldata options
+    ) external payable override returns (MessagingReceipt memory receipt) {
+        _lastSend = SendCall({
+            dstEid: dstEid,
+            dstApp: dstApp,
+            payload: payload,
+            handleList: handleList,
+            lzComposeGas: lzComposeGas,
+            options: options,
+            value: msg.value,
+            caller: msg.sender
+        });
+        sendCalled = true;
+        emit Sent(dstEid, dstApp, msg.sender, msg.value);
+
+        // Deterministic receipt so tests can assert pass-through of the return value.
+        receipt = MessagingReceipt({
+            guid: keccak256(abi.encode(dstEid, dstApp, payload)),
+            nonce: 1,
+            fee: MessagingFee({nativeFee: msg.value, lzTokenFee: 0})
+        });
+    }
+
+    function quote(
+        uint32,
+        address,
+        bytes32,
+        bytes calldata,
+        bytes32[] calldata,
+        uint128,
+        bytes calldata
+    ) external view override returns (MessagingFee memory fee) {
+        fee = MessagingFee({nativeFee: quotedNativeFee, lzTokenFee: 0});
+    }
+
+    // -------- assertions surface --------
+
+    function lastSend() external view returns (SendCall memory) {
+        return _lastSend;
+    }
+
+    /// @notice Replay a derived-handle delivery onto `dstApp`, impersonating the bridge.
+    function deliver(
+        address dstApp,
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata srcHandleList,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external {
+        IDstApp(dstApp).onConfidentialBridgeReceived(srcEid, srcApp, payload, srcHandleList, dstHandleList, guid);
+    }
+}

--- a/library-solidity/examples/bridge/MockConfidentialBridge.sol
+++ b/library-solidity/examples/bridge/MockConfidentialBridge.sol
@@ -20,8 +20,7 @@ contract MockConfidentialBridge is IConfidentialBridge {
         bytes32 dstApp;
         bytes payload;
         bytes32[] handleList;
-        uint128 lzComposeGas;
-        bytes options;
+        uint64 lzComposeGas;
         uint256 value;
         address caller;
     }
@@ -43,8 +42,7 @@ contract MockConfidentialBridge is IConfidentialBridge {
         bytes32 dstApp,
         bytes calldata payload,
         bytes32[] calldata handleList,
-        uint128 lzComposeGas,
-        bytes calldata options
+        uint64 lzComposeGas
     ) external payable override returns (MessagingReceipt memory receipt) {
         _lastSend = SendCall({
             dstEid: dstEid,
@@ -52,7 +50,6 @@ contract MockConfidentialBridge is IConfidentialBridge {
             payload: payload,
             handleList: handleList,
             lzComposeGas: lzComposeGas,
-            options: options,
             value: msg.value,
             caller: msg.sender
         });
@@ -73,8 +70,7 @@ contract MockConfidentialBridge is IConfidentialBridge {
         bytes32,
         bytes calldata,
         bytes32[] calldata,
-        uint128,
-        bytes calldata
+        uint64
     ) external view override returns (MessagingFee memory fee) {
         fee = MessagingFee({nativeFee: quotedNativeFee, lzTokenFee: 0});
     }

--- a/library-solidity/examples/bridge/OAppHarness.sol
+++ b/library-solidity/examples/bridge/OAppHarness.sol
@@ -45,7 +45,7 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         uint32 dstEid,
         bytes calldata payload,
         bytes32 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) external payable returns (MessagingReceipt memory) {
         return _bridge(dstEid, payload, euint64.wrap(handle), lzComposeGas, msg.value);
     }
@@ -55,7 +55,7 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         uint32 dstEid,
         bytes calldata payload,
         bytes32 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) external view returns (MessagingFee memory) {
         return _quoteBridge(dstEid, payload, euint64.wrap(handle), lzComposeGas);
     }

--- a/library-solidity/examples/bridge/OAppHarness.sol
+++ b/library-solidity/examples/bridge/OAppHarness.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHE, euint64} from "../../lib/FHE.sol";
+import {CoprocessorConfig} from "../../lib/Impl.sol";
+import {MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
+import {ConfidentialOAppSender} from "../../lib/bridge/ConfidentialOAppSender.sol";
+import {ConfidentialOAppReceiver} from "../../lib/bridge/ConfidentialOAppReceiver.sol";
+
+/**
+ * @title   OAppHarness
+ * @notice  Minimal confidential OApp (both {ConfidentialOAppSender} and
+ *          {ConfidentialOAppReceiver}) used to exercise the abstracts: it sends through the
+ *          sender helper and records the last inbound delivery so a test can assert auth +
+ *          dispatch. The constructor wires the ACL (which resolves the trusted bridge). `setPeer`
+ *          is exposed without access control on purpose (test-only); `setTrustAllPeers` flips an
+ *          {isPeer} override to exercise the custom-trust-policy extension point.
+ * @dev     Test-only helper; not part of the published library.
+ */
+contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
+    uint32 public lastSrcEid;
+    bytes32 public lastSrcApp;
+    bytes public lastPayload;
+    bytes32[] public lastHandles;
+    bytes32 public lastGuid;
+    uint256 public receiveCount;
+    bool public trustAllPeers;
+
+    constructor(address acl) {
+        FHE.setCoprocessor(
+            CoprocessorConfig({ACLAddress: acl, CoprocessorAddress: address(1), KMSVerifierAddress: address(2)})
+        );
+    }
+
+    function setPeer(uint32 eid, bytes32 peer) external {
+        _setPeer(eid, peer);
+    }
+
+    function setTrustAllPeers(bool v) external {
+        trustAllPeers = v;
+    }
+
+    /// @dev Send a single raw handle to the peer on `dstEid` via the sender helper.
+    function bridgeToPeer(
+        uint32 dstEid,
+        bytes calldata payload,
+        bytes32 handle,
+        uint128 lzComposeGas
+    ) external payable returns (MessagingReceipt memory) {
+        return _bridge(dstEid, payload, euint64.wrap(handle), lzComposeGas, msg.value);
+    }
+
+    function lastHandlesLength() external view returns (uint256) {
+        return lastHandles.length;
+    }
+
+    /// @dev Custom trust policy: accept any peer when `trustAllPeers`, else the default registry.
+    function isPeer(uint32 eid, bytes32 peer) public view override returns (bool) {
+        if (trustAllPeers) return true;
+        return super.isPeer(eid, peer);
+    }
+
+    function _onReceiveHandles(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata handles,
+        bytes32 guid
+    ) internal override {
+        lastSrcEid = srcEid;
+        lastSrcApp = srcApp;
+        lastPayload = payload;
+        lastGuid = guid;
+        delete lastHandles;
+        for (uint256 i = 0; i < handles.length; i++) {
+            lastHandles.push(handles[i]);
+        }
+        receiveCount++;
+    }
+}

--- a/library-solidity/examples/bridge/OAppHarness.sol
+++ b/library-solidity/examples/bridge/OAppHarness.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {FHE, euint64} from "../../lib/FHE.sol";
 import {CoprocessorConfig} from "../../lib/Impl.sol";
-import {MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
+import {MessagingFee, MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
 import {ConfidentialOAppSender} from "../../lib/bridge/ConfidentialOAppSender.sol";
 import {ConfidentialOAppReceiver} from "../../lib/bridge/ConfidentialOAppReceiver.sol";
 
@@ -48,6 +48,16 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         uint128 lzComposeGas
     ) external payable returns (MessagingReceipt memory) {
         return _bridge(dstEid, payload, euint64.wrap(handle), lzComposeGas, msg.value);
+    }
+
+    /// @dev Quote the fee for a single raw handle to the peer on `dstEid` via the sender helper.
+    function quoteToPeer(
+        uint32 dstEid,
+        bytes calldata payload,
+        bytes32 handle,
+        uint128 lzComposeGas
+    ) external view returns (MessagingFee memory) {
+        return _quoteBridge(dstEid, payload, euint64.wrap(handle), lzComposeGas);
     }
 
     function lastHandlesLength() external view returns (uint256) {

--- a/library-solidity/examples/bridge/OAppHarness.sol
+++ b/library-solidity/examples/bridge/OAppHarness.sol
@@ -32,12 +32,32 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         );
     }
 
+    /// @dev Accept native-fee change refunded by the (mock) bridge so {bridgeRefundingExcess} can
+    ///      forward it on, mirroring `ConfidentialOFTViaLib`.
+    receive() external payable {}
+
     function setPeer(uint32 eid, bytes32 peer) external {
         _setPeer(eid, peer);
     }
 
     function setTrustAllPeers(bool v) external {
         trustAllPeers = v;
+    }
+
+    /// @dev Mirrors the `ConfidentialOFTViaLib` fee-refund pattern: bridge, then forward any overpaid
+    ///      native fee (`msg.value - receipt.fee.nativeFee`) back to the caller so it isn't trapped.
+    function bridgeRefundingExcess(
+        uint32 dstEid,
+        bytes calldata payload,
+        bytes32 handle,
+        uint64 lzComposeGas
+    ) external payable returns (MessagingReceipt memory receipt) {
+        receipt = _bridgeUnchecked(dstEid, payload, handle, lzComposeGas, msg.value);
+        uint256 excess = msg.value - receipt.fee.nativeFee;
+        if (excess != 0) {
+            (bool ok, ) = payable(msg.sender).call{value: excess}("");
+            require(ok, "refund failed");
+        }
     }
 
     /// @dev Send a single raw handle to the peer on `dstEid` via the unchecked sender helper.

--- a/library-solidity/examples/bridge/OAppHarness.sol
+++ b/library-solidity/examples/bridge/OAppHarness.sol
@@ -60,6 +60,16 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         return _quoteBridge(dstEid, payload, euint64.wrap(handle), lzComposeGas);
     }
 
+    /// @dev Send a list of raw handles to the peer on `dstEid` via the multi-handle sender helper.
+    function bridgeManyToPeer(
+        uint32 dstEid,
+        bytes calldata payload,
+        bytes32[] calldata handles,
+        uint64 lzComposeGas
+    ) external payable returns (MessagingReceipt memory) {
+        return _bridge(dstEid, payload, handles, lzComposeGas, msg.value);
+    }
+
     function lastHandlesLength() external view returns (uint256) {
         return lastHandles.length;
     }

--- a/library-solidity/examples/bridge/OAppHarness.sol
+++ b/library-solidity/examples/bridge/OAppHarness.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.24;
 
-import {FHE, euint64} from "../../lib/FHE.sol";
+import {FHE} from "../../lib/FHE.sol";
 import {CoprocessorConfig} from "../../lib/Impl.sol";
 import {MessagingFee, MessagingReceipt} from "../../lib/bridge/IConfidentialBridge.sol";
 import {ConfidentialOAppSender} from "../../lib/bridge/ConfidentialOAppSender.sol";
@@ -40,14 +40,36 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         trustAllPeers = v;
     }
 
-    /// @dev Send a single raw handle to the peer on `dstEid` via the sender helper.
+    /// @dev Send a single raw handle to the peer on `dstEid` via the unchecked sender helper.
     function bridgeToPeer(
         uint32 dstEid,
         bytes calldata payload,
         bytes32 handle,
         uint64 lzComposeGas
     ) external payable returns (MessagingReceipt memory) {
-        return _bridge(dstEid, payload, euint64.wrap(handle), lzComposeGas, msg.value);
+        return _bridgeUnchecked(dstEid, payload, handle, lzComposeGas, msg.value);
+    }
+
+    /// @dev Send a single handle the caller owns via the safe {_bridgeFrom} helper (asserts
+    ///      `isSenderAllowed`). Reverts `UnauthorizedSender` if the caller is not ACL-allowed.
+    function bridgeFromCaller(
+        uint32 dstEid,
+        bytes calldata payload,
+        bytes32 handle,
+        uint64 lzComposeGas
+    ) external payable returns (MessagingReceipt memory) {
+        return _bridgeFrom(dstEid, payload, handle, lzComposeGas, msg.value);
+    }
+
+    /// @dev Send a list of handles the caller owns via the type-agnostic safe {_bridgeFrom} helper;
+    ///      reverts `UnauthorizedSender` pinpointing the first handle the caller is not allowed on.
+    function bridgeManyFromCaller(
+        uint32 dstEid,
+        bytes calldata payload,
+        bytes32[] calldata handles,
+        uint64 lzComposeGas
+    ) external payable returns (MessagingReceipt memory) {
+        return _bridgeFrom(dstEid, payload, handles, lzComposeGas, msg.value);
     }
 
     /// @dev Quote the fee for a single raw handle to the peer on `dstEid` via the sender helper.
@@ -57,17 +79,17 @@ contract OAppHarness is ConfidentialOAppSender, ConfidentialOAppReceiver {
         bytes32 handle,
         uint64 lzComposeGas
     ) external view returns (MessagingFee memory) {
-        return _quoteBridge(dstEid, payload, euint64.wrap(handle), lzComposeGas);
+        return _quoteBridge(dstEid, payload, handle, lzComposeGas);
     }
 
-    /// @dev Send a list of raw handles to the peer on `dstEid` via the multi-handle sender helper.
+    /// @dev Send a list of raw handles to the peer on `dstEid` via the multi-handle unchecked helper.
     function bridgeManyToPeer(
         uint32 dstEid,
         bytes calldata payload,
         bytes32[] calldata handles,
         uint64 lzComposeGas
     ) external payable returns (MessagingReceipt memory) {
-        return _bridge(dstEid, payload, handles, lzComposeGas, msg.value);
+        return _bridgeUnchecked(dstEid, payload, handles, lzComposeGas, msg.value);
     }
 
     function lastHandlesLength() external view returns (uint256) {

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -10116,8 +10116,10 @@ library FHE {
      * @notice Bridges a single encrypted `ebool` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10143,7 +10145,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `ebool` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10218,8 +10221,10 @@ library FHE {
      * @notice Bridges a single encrypted `euint8` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10245,7 +10250,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `euint8` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10320,8 +10326,10 @@ library FHE {
      * @notice Bridges a single encrypted `euint16` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10347,7 +10355,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `euint16` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10422,8 +10431,10 @@ library FHE {
      * @notice Bridges a single encrypted `euint32` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10449,7 +10460,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `euint32` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10524,8 +10536,10 @@ library FHE {
      * @notice Bridges a single encrypted `euint64` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10551,7 +10565,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `euint64` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10626,8 +10641,10 @@ library FHE {
      * @notice Bridges a single encrypted `euint128` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10653,7 +10670,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `euint128` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10728,8 +10746,10 @@ library FHE {
      * @notice Bridges a single encrypted `eaddress` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10755,7 +10775,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `eaddress` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,
@@ -10830,8 +10851,10 @@ library FHE {
      * @notice Bridges a single encrypted `euint256` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
-     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
+     *         value of 0 means the destination receive callback never runs. The caller must
+     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
+     *         reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10857,7 +10880,8 @@ library FHE {
     /**
      * @notice Bridges a homogeneous list of encrypted `euint256` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle.
+     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
+     *         non-zero, or the destination receive callback never runs.
      */
     function bridge(
         uint32 dstEid,

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -10134,27 +10134,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `ebool` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        ebool[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = ebool.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`ebool` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10166,22 +10145,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = ebool.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `ebool` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        ebool[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = ebool.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10207,27 +10170,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `euint8` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        euint8[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint8.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`euint8` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10239,22 +10181,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint8.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `euint8` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        euint8[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint8.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10280,27 +10206,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `euint16` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        euint16[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint16.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`euint16` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10312,22 +10217,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint16.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `euint16` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        euint16[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint16.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10353,27 +10242,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `euint32` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        euint32[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint32.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`euint32` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10385,22 +10253,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint32.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `euint32` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        euint32[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint32.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10426,27 +10278,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `euint64` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        euint64[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint64.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`euint64` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10458,22 +10289,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `euint64` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        euint64[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint64.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10499,27 +10314,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `euint128` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        euint128[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint128.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`euint128` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10531,22 +10325,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint128.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `euint128` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        euint128[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint128.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10572,27 +10350,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `eaddress` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        eaddress[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = eaddress.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`eaddress` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10604,22 +10361,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = eaddress.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `eaddress` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        eaddress[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = eaddress.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
@@ -10645,27 +10386,6 @@ library FHE {
         receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
-    /**
-     * @notice Bridges a homogeneous list of encrypted `euint256` handles in a single message.
-     * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
-     *         the bridge's per-`dstEid` minimum.
-     */
-    function bridge(
-        uint32 dstEid,
-        address dstApp,
-        bytes memory payload,
-        euint256[] memory handles,
-        uint64 lzComposeGas,
-        uint256 nativeFee
-    ) internal returns (MessagingReceipt memory receipt) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint256.unwrap(handles[i]);
-        }
-        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
-    }
-
     /// @notice Quotes the native fee for a single-`euint256` {bridge} call.
     function quoteBridge(
         uint32 dstEid,
@@ -10677,22 +10397,6 @@ library FHE {
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint256.unwrap(handle);
-        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
-    }
-
-    /// @notice Quotes the native fee for bridging a list of `euint256` handles.
-    function quoteBridge(
-        uint32 dstEid,
-        address srcApp,
-        address dstApp,
-        bytes memory payload,
-        euint256[] memory handles,
-        uint64 lzComposeGas
-    ) internal view returns (MessagingFee memory fee) {
-        bytes32[] memory handleList = new bytes32[](handles.length);
-        for (uint256 i = 0; i < handles.length; i++) {
-            handleList[i] = euint256.unwrap(handles[i]);
-        }
         fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -10116,10 +10116,9 @@ library FHE {
      * @notice Bridges a single encrypted `ebool` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10152,10 +10151,9 @@ library FHE {
      * @notice Bridges a single encrypted `euint8` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10188,10 +10186,9 @@ library FHE {
      * @notice Bridges a single encrypted `euint16` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10224,10 +10221,9 @@ library FHE {
      * @notice Bridges a single encrypted `euint32` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10260,10 +10256,9 @@ library FHE {
      * @notice Bridges a single encrypted `euint64` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10296,10 +10291,9 @@ library FHE {
      * @notice Bridges a single encrypted `euint128` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10332,10 +10326,9 @@ library FHE {
      * @notice Bridges a single encrypted `eaddress` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10368,10 +10361,9 @@ library FHE {
      * @notice Bridges a single encrypted `euint256` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
      * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
-     *         destination receive callback (lzCompose leg) and must be at least the bridge's
-     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
-     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
-     *         at index 0.
+     *         destination receive callback (lzCompose leg) and must be non-zero, else the host
+     *         `send` reverts. The caller must already hold ACL allowance on the handle (e.g. via
+     *         {allowThis}); the payload must reference it at index 0.
      */
     function bridge(
         uint32 dstEid,
@@ -10403,8 +10395,8 @@ library FHE {
     /**
      * @notice Low-level bridge of an explicit `bytes32` handle list to a `bytes32` destination
      *         app (mixed handle types, or non-EVM destinations).
-     * @dev    The caller must already hold ACL allowance on every handle; `lzComposeGas` must
-     *         meet the bridge's per-`dstEid` minimum.
+     * @dev    The caller must already hold ACL allowance on every handle; `lzComposeGas` must be
+     *         non-zero (the bridge reverts otherwise).
      * @param dstEid        Destination LayerZero endpoint id.
      * @param dstApp        Destination app as bytes32 (EVM address left-padded, or native id).
      * @param payload       Opaque app payload.

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -10115,60 +10115,44 @@ library FHE {
     /**
      * @notice Bridges a single encrypted `ebool` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         ebool handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = ebool.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `ebool` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         ebool[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = ebool.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`ebool` {bridge} call.
@@ -10178,19 +10162,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         ebool handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = ebool.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `ebool` handles.
@@ -10200,80 +10176,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         ebool[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = ebool.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `euint8` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint8 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint8.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `euint8` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint8[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint8.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`euint8` {bridge} call.
@@ -10283,19 +10235,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint8 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint8.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `euint8` handles.
@@ -10305,80 +10249,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint8[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint8.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `euint16` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint16 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint16.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `euint16` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint16[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint16.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`euint16` {bridge} call.
@@ -10388,19 +10308,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint16 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint16.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `euint16` handles.
@@ -10410,80 +10322,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint16[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint16.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `euint32` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint32 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint32.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `euint32` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint32[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint32.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`euint32` {bridge} call.
@@ -10493,19 +10381,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint32 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint32.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `euint32` handles.
@@ -10515,80 +10395,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint32[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint32.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `euint64` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint64 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `euint64` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint64[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint64.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`euint64` {bridge} call.
@@ -10598,19 +10454,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint64 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `euint64` handles.
@@ -10620,80 +10468,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint64[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint64.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `euint128` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint128 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint128.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `euint128` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint128[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint128.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`euint128` {bridge} call.
@@ -10703,19 +10527,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint128 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint128.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `euint128` handles.
@@ -10725,80 +10541,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint128[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint128.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `eaddress` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         eaddress handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = eaddress.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `eaddress` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         eaddress[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = eaddress.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`eaddress` {bridge} call.
@@ -10808,19 +10600,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         eaddress handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = eaddress.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `eaddress` handles.
@@ -10830,80 +10614,56 @@ library FHE {
         address dstApp,
         bytes memory payload,
         eaddress[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = eaddress.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
      * @notice Bridges a single encrypted `euint256` handle plus an app-defined `payload` to
      *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
-     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
-     *         options from `lzComposeGas`, which MUST be non-zero — with the default options a
-     *         value of 0 means the destination receive callback never runs. The caller must
-     *         already hold ACL allowance on the handle (e.g. via {allowThis}); the payload must
-     *         reference it at index 0.
+     * @dev    Builds the one-element handle list. `lzComposeGas` is the gas budget for the
+     *         destination receive callback (lzCompose leg) and must be at least the bridge's
+     *         per-`dstEid` minimum, else the host `send` reverts. The caller must already hold
+     *         ACL allowance on the handle (e.g. via {allowThis}); the payload must reference it
+     *         at index 0.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint256 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint256.unwrap(handle);
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /**
      * @notice Bridges a homogeneous list of encrypted `euint256` handles in a single message.
      * @dev    The payload must reference the handles by their position in `handles`. The
-     *         caller must already hold ACL allowance on every handle. `lzComposeGas` MUST be
-     *         non-zero, or the destination receive callback never runs.
+     *         caller must already hold ACL allowance on every handle; `lzComposeGas` must meet
+     *         the bridge's per-`dstEid` minimum.
      */
     function bridge(
         uint32 dstEid,
         address dstApp,
         bytes memory payload,
         euint256[] memory handles,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint256.unwrap(handles[i]);
         }
-        receipt = Impl.bridge(
-            dstEid,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            "",
-            nativeFee
-        );
+        receipt = Impl.bridge(dstEid, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for a single-`euint256` {bridge} call.
@@ -10913,19 +10673,11 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint256 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint256.unwrap(handle);
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /// @notice Quotes the native fee for bridging a list of `euint256` handles.
@@ -10935,35 +10687,25 @@ library FHE {
         address dstApp,
         bytes memory payload,
         euint256[] memory handles,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
         bytes32[] memory handleList = new bytes32[](handles.length);
         for (uint256 i = 0; i < handles.length; i++) {
             handleList[i] = euint256.unwrap(handles[i]);
         }
-        fee = Impl.quoteBridge(
-            dstEid,
-            srcApp,
-            bytes32(uint256(uint160(dstApp))),
-            payload,
-            handleList,
-            lzComposeGas,
-            ""
-        );
+        fee = Impl.quoteBridge(dstEid, srcApp, bytes32(uint256(uint160(dstApp))), payload, handleList, lzComposeGas);
     }
 
     /**
-     * @notice Low-level bridge of an explicit `bytes32` handle list with full control over
-     *         LayerZero `options` (mixed handle types or advanced payloads).
-     * @dev    When `options` is empty the bridge builds defaults from `lzComposeGas`; when
-     *         non-empty, `lzComposeGas` must be 0 (enforced host-side). The caller must
-     *         already hold ACL allowance on every handle.
+     * @notice Low-level bridge of an explicit `bytes32` handle list to a `bytes32` destination
+     *         app (mixed handle types, or non-EVM destinations).
+     * @dev    The caller must already hold ACL allowance on every handle; `lzComposeGas` must
+     *         meet the bridge's per-`dstEid` minimum.
      * @param dstEid        Destination LayerZero endpoint id.
      * @param dstApp        Destination app as bytes32 (EVM address left-padded, or native id).
      * @param payload       Opaque app payload.
      * @param handleList    Raw `bytes32` handles to bridge.
      * @param lzComposeGas  Gas budget for the destination `onConfidentialBridgeReceived` (lzCompose leg).
-     * @param options       LayerZero options; empty to derive defaults from `lzComposeGas`.
      * @param nativeFee     LayerZero native fee to forward as msg.value (query via {quoteBridge}).
      */
     function bridge(
@@ -10971,11 +10713,10 @@ library FHE {
         bytes32 dstApp,
         bytes memory payload,
         bytes32[] memory handleList,
-        uint128 lzComposeGas,
-        bytes memory options,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
-        receipt = Impl.bridge(dstEid, dstApp, payload, handleList, lzComposeGas, options, nativeFee);
+        receipt = Impl.bridge(dstEid, dstApp, payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Low-level fee quote matching the explicit `bytes32` handle list {bridge} overload.
@@ -10985,9 +10726,8 @@ library FHE {
         bytes32 dstApp,
         bytes memory payload,
         bytes32[] memory handleList,
-        uint128 lzComposeGas,
-        bytes memory options
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
-        fee = Impl.quoteBridge(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+        fee = Impl.quoteBridge(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas);
     }
 }

--- a/library-solidity/lib/FHE.sol
+++ b/library-solidity/lib/FHE.sol
@@ -10111,4 +10111,859 @@ library FHE {
     function toBytes32(euint256 value) internal pure returns (bytes32 ct) {
         ct = euint256.unwrap(value);
     }
+
+    /**
+     * @notice Bridges a single encrypted `ebool` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        ebool handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = ebool.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `ebool` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        ebool[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = ebool.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`ebool` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        ebool handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = ebool.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `ebool` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        ebool[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = ebool.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `euint8` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint8 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint8.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `euint8` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint8[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint8.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`euint8` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint8 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint8.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `euint8` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint8[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint8.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `euint16` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint16 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint16.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `euint16` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint16[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint16.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`euint16` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint16 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint16.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `euint16` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint16[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint16.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `euint32` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint32 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint32.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `euint32` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint32[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint32.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`euint32` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint32 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint32.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `euint32` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint32[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint32.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `euint64` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint64 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint64.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `euint64` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint64[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint64.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`euint64` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint64 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint64.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `euint64` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint64[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint64.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `euint128` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint128 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint128.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `euint128` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint128[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint128.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`euint128` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint128 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint128.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `euint128` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint128[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint128.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `eaddress` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        eaddress handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = eaddress.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `eaddress` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        eaddress[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = eaddress.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`eaddress` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        eaddress handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = eaddress.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `eaddress` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        eaddress[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = eaddress.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Bridges a single encrypted `euint256` handle plus an app-defined `payload` to
+     *         `dstApp` on the chain at `dstEid`, via the host `ConfidentialBridge`.
+     * @dev    Builds the one-element handle list and lets the bridge derive default LayerZero
+     *         options from `lzComposeGas`. The caller must already hold ACL allowance on the
+     *         handle (e.g. via {allowThis}); the payload must reference it at index 0.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint256 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint256.unwrap(handle);
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /**
+     * @notice Bridges a homogeneous list of encrypted `euint256` handles in a single message.
+     * @dev    The payload must reference the handles by their position in `handles`. The
+     *         caller must already hold ACL allowance on every handle.
+     */
+    function bridge(
+        uint32 dstEid,
+        address dstApp,
+        bytes memory payload,
+        euint256[] memory handles,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint256.unwrap(handles[i]);
+        }
+        receipt = Impl.bridge(
+            dstEid,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            "",
+            nativeFee
+        );
+    }
+
+    /// @notice Quotes the native fee for a single-`euint256` {bridge} call.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint256 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint256.unwrap(handle);
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /// @notice Quotes the native fee for bridging a list of `euint256` handles.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        address dstApp,
+        bytes memory payload,
+        euint256[] memory handles,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory fee) {
+        bytes32[] memory handleList = new bytes32[](handles.length);
+        for (uint256 i = 0; i < handles.length; i++) {
+            handleList[i] = euint256.unwrap(handles[i]);
+        }
+        fee = Impl.quoteBridge(
+            dstEid,
+            srcApp,
+            bytes32(uint256(uint160(dstApp))),
+            payload,
+            handleList,
+            lzComposeGas,
+            ""
+        );
+    }
+
+    /**
+     * @notice Low-level bridge of an explicit `bytes32` handle list with full control over
+     *         LayerZero `options` (mixed handle types or advanced payloads).
+     * @dev    When `options` is empty the bridge builds defaults from `lzComposeGas`; when
+     *         non-empty, `lzComposeGas` must be 0 (enforced host-side). The caller must
+     *         already hold ACL allowance on every handle.
+     * @param dstEid        Destination LayerZero endpoint id.
+     * @param dstApp        Destination app as bytes32 (EVM address left-padded, or native id).
+     * @param payload       Opaque app payload.
+     * @param handleList    Raw `bytes32` handles to bridge.
+     * @param lzComposeGas  Gas budget for the destination `onConfidentialBridgeReceived` (lzCompose leg).
+     * @param options       LayerZero options; empty to derive defaults from `lzComposeGas`.
+     * @param nativeFee     LayerZero native fee to forward as msg.value (query via {quoteBridge}).
+     */
+    function bridge(
+        uint32 dstEid,
+        bytes32 dstApp,
+        bytes memory payload,
+        bytes32[] memory handleList,
+        uint128 lzComposeGas,
+        bytes memory options,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        receipt = Impl.bridge(dstEid, dstApp, payload, handleList, lzComposeGas, options, nativeFee);
+    }
+
+    /// @notice Low-level fee quote matching the explicit `bytes32` handle list {bridge} overload.
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        bytes32 dstApp,
+        bytes memory payload,
+        bytes32[] memory handleList,
+        uint128 lzComposeGas,
+        bytes memory options
+    ) internal view returns (MessagingFee memory fee) {
+        fee = Impl.quoteBridge(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+    }
 }

--- a/library-solidity/lib/Impl.sol
+++ b/library-solidity/lib/Impl.sol
@@ -499,18 +499,10 @@ library Impl {
         bytes32 dstApp,
         bytes memory payload,
         bytes32[] memory handleList,
-        uint128 lzComposeGas,
-        bytes memory options,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory receipt) {
-        receipt = getConfidentialBridge().send{value: nativeFee}(
-            dstEid,
-            dstApp,
-            payload,
-            handleList,
-            lzComposeGas,
-            options
-        );
+        receipt = getConfidentialBridge().send{value: nativeFee}(dstEid, dstApp, payload, handleList, lzComposeGas);
     }
 
     /**
@@ -522,10 +514,9 @@ library Impl {
         bytes32 dstApp,
         bytes memory payload,
         bytes32[] memory handleList,
-        uint128 lzComposeGas,
-        bytes memory options
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory fee) {
-        fee = getConfidentialBridge().quote(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
+        fee = getConfidentialBridge().quote(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas);
     }
 
     function add(bytes32 lhs, bytes32 rhs, bool scalar) internal returns (bytes32 result) {

--- a/library-solidity/lib/Impl.sol
+++ b/library-solidity/lib/Impl.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {FheType} from "./FheType.sol";
+import {IConfidentialBridge, MessagingFee, MessagingReceipt} from "./bridge/IConfidentialBridge.sol";
 
 /**
  * @title   CoprocessorConfig
@@ -319,6 +320,12 @@ interface IACL {
     function multicall(bytes[] calldata data) external payable returns (bytes[] memory results);
 
     /**
+     * @notice              Returns the per-chain `ConfidentialBridge` address tracked by the ACL.
+     * @return              The ConfidentialBridge contract address (address(0) if unset).
+     */
+    function getConfidentialBridgeAddress() external view returns (address);
+
+    /**
      * @notice              Allows the use of handle by address account for this transaction.
      * @dev                 The caller must be allowed to use handle for allowTransient() to succeed.
      *                      If not, allowTransient() reverts.
@@ -464,6 +471,61 @@ library Impl {
         $.ACLAddress = coprocessorConfig.ACLAddress;
         $.CoprocessorAddress = coprocessorConfig.CoprocessorAddress;
         $.KMSVerifierAddress = coprocessorConfig.KMSVerifierAddress;
+    }
+
+    /// @notice Returned when the ACL reports no `ConfidentialBridge` for this chain.
+    error BridgeNotConfigured();
+
+    /**
+     * @dev Resolves the `ConfidentialBridge` from the ACL (`getConfidentialBridgeAddress`),
+     *      reverting if unset. No bridge address is stored in the library config: the ACL —
+     *      already known via `CoprocessorConfig.ACLAddress` — is the single source of truth,
+     *      so no struct change or extra setup call is needed.
+     */
+    function getConfidentialBridge() internal view returns (IConfidentialBridge) {
+        CoprocessorConfig storage $ = getCoprocessorConfig();
+        address addr = IACL($.ACLAddress).getConfidentialBridgeAddress();
+        if (addr == address(0)) revert BridgeNotConfigured();
+        return IConfidentialBridge(addr);
+    }
+
+    /**
+     * @notice Forwards a bridge send to the host `ConfidentialBridge`, paying `nativeFee`.
+     * @dev    Runs in the caller's context, so the bridge sees `msg.sender == <app>` and the
+     *         source ACL check resolves against the app.
+     */
+    function bridge(
+        uint32 dstEid,
+        bytes32 dstApp,
+        bytes memory payload,
+        bytes32[] memory handleList,
+        uint128 lzComposeGas,
+        bytes memory options,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory receipt) {
+        receipt = getConfidentialBridge().send{value: nativeFee}(
+            dstEid,
+            dstApp,
+            payload,
+            handleList,
+            lzComposeGas,
+            options
+        );
+    }
+
+    /**
+     * @notice Quotes the native fee for a bridge send.
+     */
+    function quoteBridge(
+        uint32 dstEid,
+        address srcApp,
+        bytes32 dstApp,
+        bytes memory payload,
+        bytes32[] memory handleList,
+        uint128 lzComposeGas,
+        bytes memory options
+    ) internal view returns (MessagingFee memory fee) {
+        fee = getConfidentialBridge().quote(dstEid, srcApp, dstApp, payload, handleList, lzComposeGas, options);
     }
 
     function add(bytes32 lhs, bytes32 rhs, bool scalar) internal returns (bytes32 result) {

--- a/library-solidity/lib/bridge/ConfidentialOAppCore.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppCore.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+/**
+ * @title   ConfidentialOAppCore
+ * @notice  Shared peer registry for a confidential omnichain app (OApp). A "peer" is the
+ *          trusted counterpart instance of this app on another chain, addressed by its
+ *          LayerZero endpoint id (`eid`). The same registry is used by both the send side
+ *          ({ConfidentialOAppSender}) and the receive side ({ConfidentialOAppReceiver}), so an
+ *          app configures each peer once and it applies in both directions.
+ * @dev     App identifiers are `bytes32` so non-EVM peers (e.g. Solana program ids) fit; EVM
+ *          peers are the address left-padded to `bytes32`. Subclasses expose {_setPeer} behind
+ *          their own access control (e.g. `onlyOwner`).
+ */
+abstract contract ConfidentialOAppCore {
+    /// @notice The trusted peer app per endpoint id (`bytes32(0)` if unset).
+    mapping(uint32 eid => bytes32 peer) public peers;
+
+    event PeerSet(uint32 indexed eid, bytes32 indexed peer);
+
+    /// @notice No peer is configured for the requested endpoint id.
+    error NoPeer(uint32 eid);
+
+    /// @dev Register (or clear, with `bytes32(0)`) the peer for `eid`.
+    function _setPeer(uint32 eid, bytes32 peer) internal virtual {
+        peers[eid] = peer;
+        emit PeerSet(eid, peer);
+    }
+
+    /**
+     * @notice Whether `peer` is the trusted counterpart on `eid`. Default: exact match against
+     *         the registered peer (an unset peer is never trusted). Override for a custom policy.
+     */
+    function isPeer(uint32 eid, bytes32 peer) public view virtual returns (bool) {
+        bytes32 registered = peers[eid];
+        return registered != bytes32(0) && registered == peer;
+    }
+
+    /// @dev Returns the peer for `eid`, reverting {NoPeer} if none is set (used on the send side).
+    function _getPeerOrRevert(uint32 eid) internal view returns (bytes32 peer) {
+        peer = peers[eid];
+        if (peer == bytes32(0)) revert NoPeer(eid);
+    }
+}

--- a/library-solidity/lib/bridge/ConfidentialOAppReceiver.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppReceiver.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {Impl} from "../Impl.sol";
+import {IDstApp} from "./IConfidentialBridge.sol";
+import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
+
+/**
+ * @title   ConfidentialOAppReceiver
+ * @notice  Receive side of a confidential omnichain app. Implements the bridge's
+ *          {IDstApp-onConfidentialBridgeReceived} callback and enforces the two checks every
+ *          receiver needs:
+ *            1. the caller is the trusted local `ConfidentialBridge`;
+ *            2. `(srcEid, srcApp)` is a trusted peer (see {ConfidentialOAppCore-isPeer}).
+ *          Subclasses implement {_onReceiveHandles} and receive the derived destination handles
+ *          as raw `bytes32`, wrapping each to its known encrypted type (e.g.
+ *          `euint64.wrap(handles[i])`). The host bridge has already granted transient ACL
+ *          allowance for every handle before this is invoked.
+ * @dev     The trusted bridge is resolved from the ACL — the same source the send path
+ *          (`FHE.bridge`) uses — so inbound authentication and outbound routing can never
+ *          diverge. Requires the app to have configured the ACL via `FHE.setCoprocessor(...)`.
+ */
+abstract contract ConfidentialOAppReceiver is ConfidentialOAppCore, IDstApp {
+    error OnlyConfidentialBridge(address caller);
+    error UntrustedPeer(uint32 srcEid, bytes32 srcApp);
+
+    /**
+     * @notice The trusted local ConfidentialBridge — the only authorized
+     *         `onConfidentialBridgeReceived` caller. Resolved from the ACL, the same source the
+     *         `FHE.bridge` send path uses.
+     * @dev    Reverts `Impl.BridgeNotConfigured` if the ACL reports no bridge for this chain.
+     */
+    function confidentialBridge() public view returns (address) {
+        return address(Impl.getConfidentialBridge());
+    }
+
+    /**
+     * @inheritdoc IDstApp
+     * @dev Authenticates caller + peer, then dispatches to {_onReceiveHandles}. `srcHandleList`
+     *      is intentionally not forwarded — it carries opaque source-chain handles that are not
+     *      usable locally.
+     */
+    function onConfidentialBridgeReceived(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata /* srcHandleList */,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external override {
+        if (msg.sender != confidentialBridge()) revert OnlyConfidentialBridge(msg.sender);
+        if (!isPeer(srcEid, srcApp)) revert UntrustedPeer(srcEid, srcApp);
+
+        _onReceiveHandles(srcEid, srcApp, payload, dstHandleList, guid);
+    }
+
+    /**
+     * @notice App hook: handle a bridged payload with the derived destination handles.
+     * @param srcEid    Source endpoint id.
+     * @param srcApp    Source app (bytes32; for EVM, a left-padded address).
+     * @param payload   Opaque app payload as encoded by the source app.
+     * @param handles   Derived destination handles as raw `bytes32`, aligned by index with the
+     *                  source list. Wrap each to its known type, e.g. `euint64.wrap(handles[i])`.
+     *                  Transient ACL allowance has already been granted to this contract.
+     * @param guid      LayerZero message GUID of the transfer; useful for correlation or
+     *                  idempotency. Apps that don't need it can ignore the parameter.
+     */
+    function _onReceiveHandles(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata handles,
+        bytes32 guid
+    ) internal virtual;
+}

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -10,7 +10,8 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
  *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
  *          `FHE.bridge`, so subclasses never deal with the bridge contract or peer encoding
- *          directly.
+ *          directly. A single-handle convenience and a type-agnostic multi-handle overload are
+ *          provided (a message may carry up to the bridge's `MAX_HANDLES`).
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
  *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
  */
@@ -22,17 +23,8 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
 
     /**
      * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
-     * @dev    The bridge checks `isAllowed(handle, msg.sender)`, and since `_bridge` runs in
-     *         this contract's context `msg.sender` is THIS contract — so the contract must hold
-     *         ACL allowance on `handle` (e.g. via `FHE.allowThis`), not the external caller.
-     *         {_bridge} performs no caller authorization of its own; subclasses must gate their
-     *         public entrypoint (as `ConfidentialOFTViaLib.send` does with `FHE.isSenderAllowed`).
-     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
-     * @param payload       Opaque app payload (the receiver decodes it).
-     * @param handle        The encrypted value to bridge; this contract must hold ACL allowance on it.
-     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
-     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
-     * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
+     * @dev    Convenience wrapper over the multi-handle {_bridge}; the payload must reference the
+     *         handle at index 0. See the list overload for the allowance/gas rules.
      */
     function _bridge(
         uint32 dstEid,
@@ -41,23 +33,61 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
-        if (lzComposeGas == 0) revert ZeroComposeGas();
-        bytes32 peer = _getPeerOrRevert(dstEid);
-        bytes32[] memory handleList = new bytes32[](1);
-        handleList[0] = euint64.unwrap(handle);
-        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, nativeFee);
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = euint64.unwrap(handle);
+        return _bridge(dstEid, payload, handles, lzComposeGas, nativeFee);
     }
 
-    /// @notice Quotes the native fee for the matching {_bridge} call.
+    /**
+     * @notice Bridge a list of encrypted handles to the peer on `dstEid` in a single message.
+     * @dev    Type-agnostic: pass raw `bytes32` handles (e.g. `euint64.unwrap(h)`); mixing
+     *         encrypted types within one list is fine. The destination receiver gets the derived
+     *         handles aligned one-to-one by index.
+     *
+     *         The bridge checks `isAllowed(handle, msg.sender)` for every handle, and since
+     *         `_bridge` runs in this contract's context `msg.sender` is THIS contract — so the
+     *         contract must hold ACL allowance on each handle (e.g. via `FHE.allowThis`), not the
+     *         external caller. {_bridge} performs no caller authorization of its own; subclasses
+     *         must gate their public entrypoint (as `ConfidentialOFTViaLib.send` does with
+     *         `FHE.isSenderAllowed`).
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload (the receiver decodes it); reference handles by index.
+     * @param handles       Raw `bytes32` handles to bridge; this contract must hold ACL allowance
+     *                      on each. Up to the bridge's `MAX_HANDLES`.
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
+     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
+     * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
+     */
+    function _bridge(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32[] memory handles,
+        uint64 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        if (lzComposeGas == 0) revert ZeroComposeGas();
+        return FHE.bridge(dstEid, _getPeerOrRevert(dstEid), payload, handles, lzComposeGas, nativeFee);
+    }
+
+    /// @notice Quotes the native fee for the single-handle {_bridge} call.
     function _quoteBridge(
         uint32 dstEid,
         bytes memory payload,
         euint64 handle,
         uint64 lzComposeGas
     ) internal view returns (MessagingFee memory) {
-        bytes32 peer = _getPeerOrRevert(dstEid);
-        bytes32[] memory handleList = new bytes32[](1);
-        handleList[0] = euint64.unwrap(handle);
-        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas);
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = euint64.unwrap(handle);
+        return _quoteBridge(dstEid, payload, handles, lzComposeGas);
+    }
+
+    /// @notice Quotes the native fee for the multi-handle {_bridge} call.
+    function _quoteBridge(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32[] memory handles,
+        uint64 lzComposeGas
+    ) internal view returns (MessagingFee memory) {
+        return FHE.quoteBridge(dstEid, address(this), _getPeerOrRevert(dstEid), payload, handles, lzComposeGas);
     }
 }

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -9,14 +9,15 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  * @title   ConfidentialOAppSender
  * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
  *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
- *          `FHE.bridge`, so subclasses never deal with the bridge contract, LayerZero options,
- *          or peer encoding directly.
+ *          `FHE.bridge`, so subclasses never deal with the bridge contract or peer encoding
+ *          directly.
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
  *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
  */
 abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
-    /// @notice `lzComposeGas` is 0; with the default (empty) options the destination receive
-    ///         callback would never run, so the bridged value would never be delivered.
+    /// @notice `lzComposeGas` is 0; the destination receive callback would never run, so the
+    ///         bridged value would never be delivered. (The bridge also enforces a per-`dstEid`
+    ///         minimum; this is a cheap pre-check for the clearly-invalid zero case.)
     error ZeroComposeGas();
 
     /**
@@ -25,21 +26,21 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
      * @param payload       Opaque app payload (the receiver decodes it).
      * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
      * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
-     *                      be non-zero, since {_bridge} sends with default (empty) options.
+     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
      */
     function _bridge(
         uint32 dstEid,
         bytes memory payload,
         euint64 handle,
-        uint128 lzComposeGas,
+        uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
         if (lzComposeGas == 0) revert ZeroComposeGas();
         bytes32 peer = _getPeerOrRevert(dstEid);
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, "", nativeFee);
+        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, nativeFee);
     }
 
     /// @notice Quotes the native fee for the matching {_bridge} call.
@@ -47,11 +48,11 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         uint32 dstEid,
         bytes memory payload,
         euint64 handle,
-        uint128 lzComposeGas
+        uint64 lzComposeGas
     ) internal view returns (MessagingFee memory) {
         bytes32 peer = _getPeerOrRevert(dstEid);
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);
-        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas, "");
+        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas);
     }
 }

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -22,9 +22,14 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
 
     /**
      * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
+     * @dev    The bridge checks `isAllowed(handle, msg.sender)`, and since `_bridge` runs in
+     *         this contract's context `msg.sender` is THIS contract — so the contract must hold
+     *         ACL allowance on `handle` (e.g. via `FHE.allowThis`), not the external caller.
+     *         {_bridge} performs no caller authorization of its own; subclasses must gate their
+     *         public entrypoint (as `ConfidentialOFTViaLib.send` does with `FHE.isSenderAllowed`).
      * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
      * @param payload       Opaque app payload (the receiver decodes it).
-     * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
+     * @param handle        The encrypted value to bridge; this contract must hold ACL allowance on it.
      * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
      *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -15,12 +15,17 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
  */
 abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
+    /// @notice `lzComposeGas` is 0; with the default (empty) options the destination receive
+    ///         callback would never run, so the bridged value would never be delivered.
+    error ZeroComposeGas();
+
     /**
      * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
      * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
      * @param payload       Opaque app payload (the receiver decodes it).
      * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
-     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg).
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
+     *                      be non-zero, since {_bridge} sends with default (empty) options.
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
      */
     function _bridge(
@@ -30,6 +35,7 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         uint128 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
+        if (lzComposeGas == 0) revert ZeroComposeGas();
         bytes32 peer = _getPeerOrRevert(dstEid);
         bytes32[] memory handleList = new bytes32[](1);
         handleList[0] = euint64.unwrap(handle);

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause-Clear
 pragma solidity ^0.8.24;
 
-import {FHE, euint64} from "../FHE.sol";
+import {FHE} from "../FHE.sol";
+import {Impl} from "../Impl.sol";
 import {MessagingFee, MessagingReceipt} from "./IConfidentialBridge.sol";
 import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
 
@@ -10,55 +11,117 @@ import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
  * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
  *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
  *          `FHE.bridge`, so subclasses never deal with the bridge contract or peer encoding
- *          directly. A single-handle convenience and a type-agnostic multi-handle overload are
- *          provided (a message may carry up to the bridge's `MAX_HANDLES`).
+ *          directly (a message may carry up to the bridge's `MAX_HANDLES`).
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
- *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
+ *          Quote the fee with {_quoteBridge} and forward it as `msg.value`.
+ *
+ *          AUTHORIZATION — read before exposing a send entrypoint. The bridge checks
+ *          `isAllowed(handle, msg.sender)`, and `_bridge*` runs in THIS contract's context, so the
+ *          check is against the contract — which typically holds `allowThis` allowance on its
+ *          handles. The external caller is therefore NOT authorized by the bridge. There are two
+ *          send helpers, named so the call site declares its safety posture:
+ *          - {_bridgeFrom}: safe default. Asserts the external caller is ACL-allowed on every handle
+ *            (the raw-handle equivalent of `FHE.isSenderAllowed`) before bridging. Type-agnostic:
+ *            covers any encrypted type, single or multi, via `bytes32` handles. Use when the caller
+ *            owns the handle(s) being sent.
+ *          - {_bridgeUnchecked}: NO caller authorization. Use only for handles the caller does not
+ *            (and should not) hold allowance on — e.g. a value derived inside the app such as a
+ *            burn result — and gate the entrypoint yourself first (see `ConfidentialOFTViaLib`).
+ *            A public entrypoint that calls this without its own gate lets anyone bridge the
+ *            contract's handles to a configured peer.
  */
 abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
     /// @notice `lzComposeGas` is 0; the destination receive callback would never run, so the
-    ///         bridged value would never be delivered. (The bridge also enforces a per-`dstEid`
-    ///         minimum; this is a cheap pre-check for the clearly-invalid zero case.)
+    ///         bridged value would never be delivered (the bridge rejects a zero gas budget too).
     error ZeroComposeGas();
 
+    /// @notice {_bridgeFrom} was called with a `handle` the external `sender` is not ACL-allowed on.
+    error UnauthorizedSender(bytes32 handle, address sender);
+
     /**
-     * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
-     * @dev    Convenience wrapper over the multi-handle {_bridge}; the payload must reference the
-     *         handle at index 0. See the list overload for the allowance/gas rules.
+     * @notice Safe send: bridge a list of encrypted handles the external caller owns to the peer on
+     *         `dstEid` in a single message.
+     * @dev    Asserts the external `msg.sender` is ACL-allowed on EVERY handle (`Impl.isAllowed`, the
+     *         raw-handle check `FHE.isSenderAllowed` performs per type) before bridging, reverting
+     *         {UnauthorizedSender} with the first handle that fails. This removes the footgun of an
+     *         unguarded entrypoint. Type-agnostic: pass raw `bytes32` handles (e.g. `euint64.unwrap(h)`),
+     *         mixing types within one list is fine. For a handle the caller does not hold allowance on
+     *         (e.g. a value derived inside the app), gate the entrypoint yourself and use
+     *         {_bridgeUnchecked}. The payload references handles by their index.
      */
-    function _bridge(
+    function _bridgeFrom(
         uint32 dstEid,
         bytes memory payload,
-        euint64 handle,
+        bytes32[] memory handles,
+        uint64 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        for (uint256 i = 0; i < handles.length; i++) {
+            if (!Impl.isAllowed(handles[i], msg.sender)) revert UnauthorizedSender(handles[i], msg.sender);
+        }
+        return _bridgeUnchecked(dstEid, payload, handles, lzComposeGas, nativeFee);
+    }
+
+    /**
+     * @notice Safe send: single-handle convenience over the multi-handle {_bridgeFrom}.
+     * @dev    Type-agnostic — pass the raw `bytes32` handle (`T.unwrap(h)` for any encrypted type).
+     *         Asserts the caller owns `handle`, then bridges it; the payload must reference it at
+     *         index 0.
+     */
+    function _bridgeFrom(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32 handle,
         uint64 lzComposeGas,
         uint256 nativeFee
     ) internal returns (MessagingReceipt memory) {
         bytes32[] memory handles = new bytes32[](1);
-        handles[0] = euint64.unwrap(handle);
-        return _bridge(dstEid, payload, handles, lzComposeGas, nativeFee);
+        handles[0] = handle;
+        return _bridgeFrom(dstEid, payload, handles, lzComposeGas, nativeFee);
     }
 
     /**
-     * @notice Bridge a list of encrypted handles to the peer on `dstEid` in a single message.
+     * @notice Unauthorized send: single-handle convenience over the multi-handle {_bridgeUnchecked},
+     *         WITHOUT checking the external caller.
+     * @dev    Type-agnostic — pass the raw `bytes32` handle (`T.unwrap(h)` for any encrypted type).
+     *         The payload must reference it at index 0. See that overload for the authorization/gas
+     *         rules — in particular, the caller is NOT authorized here, so gate the entrypoint yourself.
+     */
+    function _bridgeUnchecked(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32 handle,
+        uint64 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = handle;
+        return _bridgeUnchecked(dstEid, payload, handles, lzComposeGas, nativeFee);
+    }
+
+    /**
+     * @notice Unauthorized send: bridge a list of encrypted handles to the peer on `dstEid` in a
+     *         single message, WITHOUT checking the external caller.
      * @dev    Type-agnostic: pass raw `bytes32` handles (e.g. `euint64.unwrap(h)`); mixing
      *         encrypted types within one list is fine. The destination receiver gets the derived
      *         handles aligned one-to-one by index.
      *
-     *         The bridge checks `isAllowed(handle, msg.sender)` for every handle, and since
-     *         `_bridge` runs in this contract's context `msg.sender` is THIS contract — so the
-     *         contract must hold ACL allowance on each handle (e.g. via `FHE.allowThis`), not the
-     *         external caller. {_bridge} performs no caller authorization of its own; subclasses
-     *         must gate their public entrypoint (as `ConfidentialOFTViaLib.send` does with
-     *         `FHE.isSenderAllowed`).
+     *         No caller authorization is performed. The bridge checks `isAllowed(handle, msg.sender)`
+     *         for every handle, and since this runs in the contract's context `msg.sender` is THIS
+     *         contract — so the contract must hold ACL allowance on each handle (e.g. via
+     *         `FHE.allowThis`), and the external caller is NOT authorized. Subclasses MUST gate their
+     *         public entrypoint (as `ConfidentialOFTViaLib.send` does with `FHE.isSenderAllowed` on
+     *         the input it then burns). For the common "caller owns the handle" case, prefer the safe
+     *         {_bridgeFrom}.
      * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
      * @param payload       Opaque app payload (the receiver decodes it); reference handles by index.
      * @param handles       Raw `bytes32` handles to bridge; this contract must hold ACL allowance
      *                      on each. Up to the bridge's `MAX_HANDLES`.
-     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must
-     *                      meet the bridge's per-`dstEid` minimum (and be non-zero).
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg); must be
+     *                      non-zero (the bridge reverts otherwise).
      * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
      */
-    function _bridge(
+    function _bridgeUnchecked(
         uint32 dstEid,
         bytes memory payload,
         bytes32[] memory handles,
@@ -69,19 +132,19 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         return FHE.bridge(dstEid, _getPeerOrRevert(dstEid), payload, handles, lzComposeGas, nativeFee);
     }
 
-    /// @notice Quotes the native fee for the single-handle {_bridge} call.
+    /// @notice Quotes the native fee for the single-handle send (pass `T.unwrap(h)` for any type).
     function _quoteBridge(
         uint32 dstEid,
         bytes memory payload,
-        euint64 handle,
+        bytes32 handle,
         uint64 lzComposeGas
     ) internal view returns (MessagingFee memory) {
         bytes32[] memory handles = new bytes32[](1);
-        handles[0] = euint64.unwrap(handle);
+        handles[0] = handle;
         return _quoteBridge(dstEid, payload, handles, lzComposeGas);
     }
 
-    /// @notice Quotes the native fee for the multi-handle {_bridge} call.
+    /// @notice Quotes the native fee for the multi-handle send.
     function _quoteBridge(
         uint32 dstEid,
         bytes memory payload,

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHE, euint64} from "../FHE.sol";
+import {MessagingFee, MessagingReceipt} from "./IConfidentialBridge.sol";
+import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
+
+/**
+ * @title   ConfidentialOAppSender
+ * @notice  Send side of a confidential omnichain app. Looks up the destination peer from the
+ *          shared {ConfidentialOAppCore} registry and bridges encrypted handles to it through
+ *          `FHE.bridge`, so subclasses never deal with the bridge contract, LayerZero options,
+ *          or peer encoding directly.
+ * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
+ *          Quote the fee with {_quoteBridge} and forward it as `msg.value` to {_bridge}.
+ */
+abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
+    /**
+     * @notice Bridge a single encrypted `euint64` handle to the peer on `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload (the receiver decodes it).
+     * @param handle        The encrypted value to bridge; the caller must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination receive callback (lzCompose leg).
+     * @param nativeFee     LayerZero native fee to forward (query via {_quoteBridge}).
+     */
+    function _bridge(
+        uint32 dstEid,
+        bytes memory payload,
+        euint64 handle,
+        uint128 lzComposeGas,
+        uint256 nativeFee
+    ) internal returns (MessagingReceipt memory) {
+        bytes32 peer = _getPeerOrRevert(dstEid);
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint64.unwrap(handle);
+        return FHE.bridge(dstEid, peer, payload, handleList, lzComposeGas, "", nativeFee);
+    }
+
+    /// @notice Quotes the native fee for the matching {_bridge} call.
+    function _quoteBridge(
+        uint32 dstEid,
+        bytes memory payload,
+        euint64 handle,
+        uint128 lzComposeGas
+    ) internal view returns (MessagingFee memory) {
+        bytes32 peer = _getPeerOrRevert(dstEid);
+        bytes32[] memory handleList = new bytes32[](1);
+        handleList[0] = euint64.unwrap(handle);
+        return FHE.quoteBridge(dstEid, address(this), peer, payload, handleList, lzComposeGas, "");
+    }
+}

--- a/library-solidity/lib/bridge/IConfidentialBridge.sol
+++ b/library-solidity/lib/bridge/IConfidentialBridge.sol
@@ -35,8 +35,7 @@ interface IConfidentialBridge {
         bytes32 dstApp,
         bytes calldata payload,
         bytes32[] calldata handleList,
-        uint128 lzComposeGas,
-        bytes calldata options
+        uint64 lzComposeGas
     ) external payable returns (MessagingReceipt memory receipt);
 
     function quote(
@@ -45,8 +44,7 @@ interface IConfidentialBridge {
         bytes32 dstApp,
         bytes calldata payload,
         bytes32[] calldata handleList,
-        uint128 lzComposeGas,
-        bytes calldata options
+        uint64 lzComposeGas
     ) external view returns (MessagingFee memory fee);
 }
 

--- a/library-solidity/lib/bridge/IConfidentialBridge.sol
+++ b/library-solidity/lib/bridge/IConfidentialBridge.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+/**
+ * @title   LayerZero messaging structs (local copies)
+ * @notice  `MessagingFee` and `MessagingReceipt` are the fee-quote and send-receipt types the
+ *          bridge returns. They originate in LayerZero's `ILayerZeroEndpointV2`, but are copied
+ *          here field-for-field so that apps using `fhevm/solidity` do not have to install the
+ *          LayerZero packages just to bridge. The layout is identical, so they are ABI-compatible
+ *          with the real bridge.
+ */
+struct MessagingFee {
+    uint256 nativeFee;
+    uint256 lzTokenFee;
+}
+
+struct MessagingReceipt {
+    bytes32 guid;
+    uint64 nonce;
+    MessagingFee fee;
+}
+
+/**
+ * @title   IConfidentialBridge
+ * @notice  Minimal view of the host `ConfidentialBridge` that the library wrapper needs.
+ *          Only `send` and `quote` are declared — the library never references the
+ *          LayerZero OApp surface.
+ * @dev     Must stay in sync with `host-contracts/contracts/bridge/HandlesSender.sol`.
+ *          The per-dstEid lzReceive gas configuration is exposed by the bridge through
+ *          separate setters/getters and does not affect this `send`/`quote` surface.
+ */
+interface IConfidentialBridge {
+    function send(
+        uint32 dstEid,
+        bytes32 dstApp,
+        bytes calldata payload,
+        bytes32[] calldata handleList,
+        uint128 lzComposeGas,
+        bytes calldata options
+    ) external payable returns (MessagingReceipt memory receipt);
+
+    function quote(
+        uint32 dstEid,
+        address srcApp,
+        bytes32 dstApp,
+        bytes calldata payload,
+        bytes32[] calldata handleList,
+        uint128 lzComposeGas,
+        bytes calldata options
+    ) external view returns (MessagingFee memory fee);
+}
+
+/**
+ * @title   IDstApp
+ * @notice  Callback a destination app implements to receive a bridged payload.
+ *          Mirrors `host-contracts/contracts/bridge/interfaces/IDstApp.sol`.
+ * @dev     The {ConfidentialBridgeReceiver} base contract implements this and exposes a
+ *          typed `_onReceiveHandles` hook so apps don't deal with raw `bytes32` handles.
+ */
+interface IDstApp {
+    function onConfidentialBridgeReceived(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata srcHandleList,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external;
+}

--- a/library-solidity/lib/bridge/IConfidentialBridge.sol
+++ b/library-solidity/lib/bridge/IConfidentialBridge.sol
@@ -54,7 +54,7 @@ interface IConfidentialBridge {
  * @title   IDstApp
  * @notice  Callback a destination app implements to receive a bridged payload.
  *          Mirrors `host-contracts/contracts/bridge/interfaces/IDstApp.sol`.
- * @dev     The {ConfidentialBridgeReceiver} base contract implements this and exposes a
+ * @dev     The {ConfidentialOAppReceiver} base contract implements this and exposes a
  *          typed `_onReceiveHandles` hook so apps don't deal with raw `bytes32` handles.
  */
 interface IDstApp {

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -308,6 +308,49 @@ describe('Confidential bridge helpers', function () {
       expect(sent.lzComposeGas).to.equal(200_000n);
     });
 
+    it('_bridgeFrom bridges when the caller is ACL-allowed on the handle', async function () {
+      const { acl, bridge, oapp } = await deployOAppFixture();
+      const peer = padded(randAddr());
+      await oapp.setPeer(DST_EID, peer);
+      const [caller] = await ethers.getSigners();
+      await acl.setAllowed(handleA, caller.address, true);
+
+      await oapp.bridgeFromCaller(DST_EID, '0x', handleA, 200_000);
+
+      const sent = await bridge.lastSend();
+      expect(sent.dstApp).to.equal(peer);
+      expect(sent.handleList).to.deep.equal([handleA]);
+    });
+
+    it('_bridgeFrom reverts UnauthorizedSender(handle, caller) when the caller is not allowed', async function () {
+      const { oapp } = await deployOAppFixture();
+      await oapp.setPeer(DST_EID, padded(randAddr()));
+      const [caller] = await ethers.getSigners();
+      // No setAllowed for handleA -> isAllowed is false.
+      await expect(oapp.bridgeFromCaller(DST_EID, '0x', handleA, 200_000))
+        .to.be.revertedWithCustomError(oapp, 'UnauthorizedSender')
+        .withArgs(handleA, caller.address);
+    });
+
+    it('_bridgeFrom (multi) bridges a list the caller owns and pinpoints the first it does not', async function () {
+      const { acl, bridge, oapp } = await deployOAppFixture();
+      const peer = padded(randAddr());
+      await oapp.setPeer(DST_EID, peer);
+      const [caller] = await ethers.getSigners();
+      // Caller owns A and C but NOT B.
+      await acl.setAllowed(handleA, caller.address, true);
+      await acl.setAllowed(handleC, caller.address, true);
+
+      // Mixed list reverts on the first disallowed handle (B).
+      await expect(oapp.bridgeManyFromCaller(DST_EID, '0x', [handleA, handleB, handleC], 200_000))
+        .to.be.revertedWithCustomError(oapp, 'UnauthorizedSender')
+        .withArgs(handleB, caller.address);
+
+      // A fully-owned list goes through.
+      await oapp.bridgeManyFromCaller(DST_EID, '0x', [handleA, handleC], 200_000);
+      expect((await bridge.lastSend()).handleList).to.deep.equal([handleA, handleC]);
+    });
+
     it('reverts NoPeer when no peer is configured for the destination eid', async function () {
       const { oapp } = await deployOAppFixture();
       await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 50_000)).to.be.revertedWithCustomError(oapp, 'NoPeer');

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -351,6 +351,22 @@ describe('Confidential bridge helpers', function () {
       expect((await bridge.lastSend()).handleList).to.deep.equal([handleA, handleC]);
     });
 
+    it('forwards overpaid native fee back to the caller (OFT refund pattern)', async function () {
+      const { bridge, oapp } = await deployOAppFixture();
+      await oapp.setPeer(DST_EID, padded(randAddr()));
+      const chargedFee = ethers.parseEther('0.01');
+      await bridge.setChargedFee(chargedFee); // bridge keeps this, refunds the rest
+
+      // Overpay 0.03; the bridge charges 0.01 and pushes back 0.02, which the app forwards on.
+      await oapp.bridgeRefundingExcess(DST_EID, '0x', handleA, 200_000, { value: ethers.parseEther('0.03') });
+
+      // Nothing is trapped in the app; the bridge kept exactly the fee (the 0.02 went to the caller).
+      expect(await ethers.provider.getBalance(await oapp.getAddress()), 'nothing trapped in app').to.equal(0n);
+      expect(await ethers.provider.getBalance(await bridge.getAddress()), 'bridge kept only the fee').to.equal(
+        chargedFee,
+      );
+    });
+
     it('reverts NoPeer when no peer is configured for the destination eid', async function () {
       const { oapp } = await deployOAppFixture();
       await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 50_000)).to.be.revertedWithCustomError(oapp, 'NoPeer');

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -65,7 +65,6 @@ describe('Confidential bridge helpers', function () {
         expect(sent.payload).to.equal(ethers.hexlify(payload));
         expect(sent.handleList).to.deep.equal([handleA]);
         expect(sent.lzComposeGas).to.equal(gas);
-        expect(sent.options).to.equal('0x'); // single-handle overloads derive defaults from gas
         expect(sent.value).to.equal(fee);
         expect(sent.caller).to.equal(await harness.getAddress());
       });
@@ -79,7 +78,7 @@ describe('Confidential bridge helpers', function () {
   });
 
   describe('send side — typed array overloads (multi-handle)', function () {
-    it('euint64[]: sends one message carrying the whole list, empty options', async function () {
+    it('euint64[]: sends one message carrying the whole list', async function () {
       const { bridge, harness } = await deploySendFixture();
       const dstApp = randAddr();
       const fee = ethers.parseEther('0.03');
@@ -89,7 +88,6 @@ describe('Confidential bridge helpers', function () {
       const sent = await bridge.lastSend();
       expect(sent.dstApp).to.equal(padded(dstApp));
       expect(sent.handleList).to.deep.equal([handleA, handleB, handleC]);
-      expect(sent.options).to.equal('0x');
       expect(sent.value).to.equal(fee);
     });
 
@@ -113,18 +111,17 @@ describe('Confidential bridge helpers', function () {
   });
 
   describe('send side — low-level bytes32[] escape hatch', function () {
-    it('forwards an explicit handle list, raw bytes32 dstApp, and custom options verbatim', async function () {
+    it('forwards an explicit handle list and raw bytes32 dstApp verbatim', async function () {
       const { bridge, harness } = await deploySendFixture();
       const dstApp = padded(randAddr());
       const payload = ethers.toUtf8Bytes('multi');
-      const options = '0xdeadbeef';
 
-      await harness.bridgeList(DST_EID, dstApp, payload, [handleA, handleB], 0, options, { value: 0 });
+      await harness.bridgeList(DST_EID, dstApp, payload, [handleA, handleB], 50_000, { value: 0 });
 
       const sent = await bridge.lastSend();
       expect(sent.dstApp).to.equal(dstApp);
       expect(sent.handleList).to.deep.equal([handleA, handleB]);
-      expect(sent.options).to.equal(options);
+      expect(sent.lzComposeGas).to.equal(50_000n);
     });
   });
 
@@ -172,7 +169,7 @@ describe('Confidential bridge helpers', function () {
     it('quotes through the low-level overload', async function () {
       const { bridge, harness } = await deploySendFixture();
       await bridge.setQuotedNativeFee(99n);
-      const fee = await harness.quoteList(DST_EID, padded(randAddr()), '0x', [handleA], 0, '0xbeef');
+      const fee = await harness.quoteList(DST_EID, padded(randAddr()), '0x', [handleA], 50_000);
       expect(fee.nativeFee).to.equal(99n);
     });
   });

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -177,7 +177,7 @@ describe('Confidential bridge helpers', function () {
     });
   });
 
-  describe('receive side — ConfidentialBridgeReceiver', function () {
+  describe('receive side — ConfidentialOAppReceiver', function () {
     const peer = h('0xabcd');
     const payload = ethers.toUtf8Bytes('mint');
     const GUID = h('0x77');
@@ -341,6 +341,16 @@ describe('Confidential bridge helpers', function () {
       const { oapp } = await deployOAppFixture();
       await oapp.setPeer(DST_EID, padded(randAddr()));
       await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 0)).to.be.revertedWithCustomError(oapp, 'ZeroComposeGas');
+    });
+
+    it('quotes the fee for the resolved peer (NoPeer if unset)', async function () {
+      const { bridge, oapp } = await deployOAppFixture();
+      await expect(oapp.quoteToPeer(DST_EID, '0x', handleA, 50_000)).to.be.revertedWithCustomError(oapp, 'NoPeer');
+
+      await oapp.setPeer(DST_EID, padded(randAddr()));
+      await bridge.setQuotedNativeFee(555n);
+      const fee = await oapp.quoteToPeer(DST_EID, '0x', handleA, 50_000);
+      expect(fee.nativeFee).to.equal(555n);
     });
   });
 

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -334,7 +334,13 @@ describe('Confidential bridge helpers', function () {
 
     it('reverts NoPeer when no peer is configured for the destination eid', async function () {
       const { oapp } = await deployOAppFixture();
-      await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 0)).to.be.revertedWithCustomError(oapp, 'NoPeer');
+      await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 50_000)).to.be.revertedWithCustomError(oapp, 'NoPeer');
+    });
+
+    it('reverts ZeroComposeGas when lzComposeGas is 0 (the receive callback would never run)', async function () {
+      const { oapp } = await deployOAppFixture();
+      await oapp.setPeer(DST_EID, padded(randAddr()));
+      await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 0)).to.be.revertedWithCustomError(oapp, 'ZeroComposeGas');
     });
   });
 

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -1,0 +1,399 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+/**
+ * Tests for the cross-chain bridging helpers in `fhevm/solidity`. They run against mock
+ * contracts (a fake ACL and a fake bridge), so no real FHEVM stack, coprocessor, or LayerZero
+ * network is needed.
+ *
+ * Covered:
+ *   - `FHE.bridge` / `FHE.quoteBridge`: look the bridge up from the ACL and forward every
+ *     argument plus `msg.value` unchanged — every encrypted type, single handles and lists, and
+ *     the low-level escape-hatch overload.
+ *   - `ConfidentialOAppSender`: resolves the destination peer from the shared registry and
+ *     bridges to it.
+ *   - `ConfidentialOAppReceiver`: only accepts calls from the trusted bridge and a trusted peer
+ *     (a check apps can override), and hands the app the raw handles.
+ *   - A full send → receive round trip across two OApp instances.
+ */
+describe('Confidential bridge helpers', function () {
+  const DST_EID = 30101;
+  const SRC_EID = 30184;
+  const h = (n: string) => ethers.zeroPadValue(n, 32);
+  const handleA = h('0x01');
+  const handleB = h('0x02');
+  const handleC = h('0x03');
+  const padded = (addr: string) => ethers.zeroPadValue(addr.toLowerCase(), 32);
+  const randAddr = () => ethers.Wallet.createRandom().address;
+
+  async function deploySendFixture() {
+    const [deployer, app, other] = await ethers.getSigners();
+    const acl = await (await ethers.getContractFactory('MockACL')).deploy();
+    const bridge = await (await ethers.getContractFactory('MockConfidentialBridge')).deploy();
+    await acl.setConfidentialBridgeAddress(await bridge.getAddress());
+    const harness = await (await ethers.getContractFactory('BridgeLibHarness')).deploy(await acl.getAddress());
+    return { deployer, app, other, acl, bridge, harness };
+  }
+
+  describe('send side — typed single-handle overloads (multi-type)', function () {
+    // One entrypoint per encrypted type; all funnel through the same bytes32 pass-through.
+    const cases: [string, string][] = [
+      ['ebool', 'bridgeBool'],
+      ['euint8', 'bridge8'],
+      ['euint16', 'bridge16'],
+      ['euint32', 'bridge32'],
+      ['euint64', 'bridge64'],
+      ['euint128', 'bridge128'],
+      ['euint256', 'bridge256'],
+      ['eaddress', 'bridgeAddr'],
+    ];
+
+    for (const [typeName, fn] of cases) {
+      it(`${typeName}: resolves the bridge from the ACL and forwards every argument + msg.value`, async function () {
+        const { bridge, harness } = await deploySendFixture();
+        const dstApp = randAddr();
+        const payload = ethers.toUtf8Bytes(`payload-${typeName}`);
+        const gas = 123_456n;
+        const fee = ethers.parseEther('0.01');
+
+        await (harness as any)[fn](DST_EID, dstApp, payload, handleA, gas, { value: fee });
+
+        expect(await bridge.sendCalled()).to.equal(true);
+        const sent = await bridge.lastSend();
+        expect(sent.dstEid).to.equal(DST_EID);
+        expect(sent.dstApp).to.equal(padded(dstApp));
+        expect(sent.payload).to.equal(ethers.hexlify(payload));
+        expect(sent.handleList).to.deep.equal([handleA]);
+        expect(sent.lzComposeGas).to.equal(gas);
+        expect(sent.options).to.equal('0x'); // single-handle overloads derive defaults from gas
+        expect(sent.value).to.equal(fee);
+        expect(sent.caller).to.equal(await harness.getAddress());
+      });
+    }
+
+    it('forwards a zero native fee unchanged', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await harness.bridge64(DST_EID, randAddr(), '0x', handleA, 0, { value: 0 });
+      expect((await bridge.lastSend()).value).to.equal(0n);
+    });
+  });
+
+  describe('send side — typed array overloads (multi-handle)', function () {
+    it('euint64[]: sends one message carrying the whole list, empty options', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      const dstApp = randAddr();
+      const fee = ethers.parseEther('0.03');
+
+      await harness.bridgeArray64(DST_EID, dstApp, '0x', [handleA, handleB, handleC], 50_000, { value: fee });
+
+      const sent = await bridge.lastSend();
+      expect(sent.dstApp).to.equal(padded(dstApp));
+      expect(sent.handleList).to.deep.equal([handleA, handleB, handleC]);
+      expect(sent.options).to.equal('0x');
+      expect(sent.value).to.equal(fee);
+    });
+
+    it('euint256[]: array generation is uniform across types', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await harness.bridgeArray256(DST_EID, randAddr(), '0x', [handleA, handleB], 1, { value: 0 });
+      expect((await bridge.lastSend()).handleList).to.deep.equal([handleA, handleB]);
+    });
+
+    it('a single-element typed array behaves like the single-handle overload', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await harness.bridgeArray64(DST_EID, randAddr(), '0x', [handleA], 1, { value: 0 });
+      expect((await bridge.lastSend()).handleList).to.deep.equal([handleA]);
+    });
+
+    it('an empty typed array forwards an empty handle list', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await harness.bridgeArray64(DST_EID, randAddr(), '0x', [], 1, { value: 0 });
+      expect((await bridge.lastSend()).handleList).to.deep.equal([]);
+    });
+  });
+
+  describe('send side — low-level bytes32[] escape hatch', function () {
+    it('forwards an explicit handle list, raw bytes32 dstApp, and custom options verbatim', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      const dstApp = padded(randAddr());
+      const payload = ethers.toUtf8Bytes('multi');
+      const options = '0xdeadbeef';
+
+      await harness.bridgeList(DST_EID, dstApp, payload, [handleA, handleB], 0, options, { value: 0 });
+
+      const sent = await bridge.lastSend();
+      expect(sent.dstApp).to.equal(dstApp);
+      expect(sent.handleList).to.deep.equal([handleA, handleB]);
+      expect(sent.options).to.equal(options);
+    });
+  });
+
+  describe('send side — receipt + failure + quotes', function () {
+    it('returns the bridge receipt to the caller', async function () {
+      const { harness } = await deploySendFixture();
+      const fee = ethers.parseEther('0.02');
+      const receipt = await harness.bridge64.staticCall(DST_EID, randAddr(), '0x', handleA, 0, { value: fee });
+      expect(receipt.fee.nativeFee).to.equal(fee);
+      expect(receipt.nonce).to.equal(1n);
+    });
+
+    it('reverts BridgeNotConfigured when the ACL reports no bridge', async function () {
+      const { acl, harness } = await deploySendFixture();
+      await acl.setConfidentialBridgeAddress(ethers.ZeroAddress);
+      await expect(harness.bridge64(DST_EID, randAddr(), '0x', handleA, 0)).to.be.revertedWithCustomError(
+        harness,
+        'BridgeNotConfigured',
+      );
+    });
+
+    it('re-resolves the bridge from the ACL on every call (no caching)', async function () {
+      const { acl, harness } = await deploySendFixture();
+      const bridge2 = await (await ethers.getContractFactory('MockConfidentialBridge')).deploy();
+      await acl.setConfidentialBridgeAddress(await bridge2.getAddress());
+      await harness.bridge64(DST_EID, randAddr(), '0x', handleA, 0);
+      expect(await bridge2.sendCalled()).to.equal(true);
+    });
+
+    it('quotes the native fee for the single-euint64 overload', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await bridge.setQuotedNativeFee(777n);
+      const fee = await harness.quote64(DST_EID, randAddr(), '0x', handleA, 0);
+      expect(fee.nativeFee).to.equal(777n);
+      expect(fee.lzTokenFee).to.equal(0n);
+    });
+
+    it('quotes a multi-type (euint32) and a typed-array (euint64[]) send', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await bridge.setQuotedNativeFee(42n);
+      expect((await harness.quote32(DST_EID, randAddr(), '0x', handleA, 0)).nativeFee).to.equal(42n);
+      expect((await harness.quoteArray64(DST_EID, randAddr(), '0x', [handleA, handleB], 0)).nativeFee).to.equal(42n);
+    });
+
+    it('quotes through the low-level overload', async function () {
+      const { bridge, harness } = await deploySendFixture();
+      await bridge.setQuotedNativeFee(99n);
+      const fee = await harness.quoteList(DST_EID, padded(randAddr()), '0x', [handleA], 0, '0xbeef');
+      expect(fee.nativeFee).to.equal(99n);
+    });
+  });
+
+  describe('receive side — ConfidentialBridgeReceiver', function () {
+    const peer = h('0xabcd');
+    const payload = ethers.toUtf8Bytes('mint');
+    const GUID = h('0x77');
+
+    async function deployReceiveFixture() {
+      const [, app] = await ethers.getSigners();
+      const acl = await (await ethers.getContractFactory('MockACL')).deploy();
+      const bridge = await (await ethers.getContractFactory('MockConfidentialBridge')).deploy();
+      await acl.setConfidentialBridgeAddress(await bridge.getAddress());
+      const receiver = await (await ethers.getContractFactory('OAppHarness')).deploy(await acl.getAddress());
+      return { app, acl, bridge, receiver };
+    }
+
+    it('resolves the trusted bridge from the ACL (same source as the send path)', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      expect(await receiver.confidentialBridge()).to.equal(await bridge.getAddress());
+    });
+
+    it('tracks an ACL bridge-address change for inbound auth', async function () {
+      const { acl, receiver } = await deployReceiveFixture();
+      const bridge2 = await (await ethers.getContractFactory('MockConfidentialBridge')).deploy();
+      await acl.setConfidentialBridgeAddress(await bridge2.getAddress());
+      expect(await receiver.confidentialBridge()).to.equal(await bridge2.getAddress());
+    });
+
+    it('rejects onConfidentialBridgeReceived from a caller that is not the bridge', async function () {
+      const { app, receiver } = await deployReceiveFixture();
+      const asApp = receiver.connect(app) as typeof receiver;
+      await expect(
+        asApp.onConfidentialBridgeReceived(SRC_EID, peer, payload, [], [handleA], GUID),
+      ).to.be.revertedWithCustomError(receiver, 'OnlyConfidentialBridge');
+    });
+
+    it('rejects an unregistered peer even when the bridge calls', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      await expect(
+        bridge.deliver(await receiver.getAddress(), SRC_EID, peer, payload, [], [handleA], GUID),
+      ).to.be.revertedWithCustomError(receiver, 'UntrustedPeer');
+    });
+
+    it('rejects a peer mismatch (registered, but different srcApp)', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      await receiver.setPeer(SRC_EID, peer);
+      await expect(
+        bridge.deliver(await receiver.getAddress(), SRC_EID, h('0x9999'), payload, [], [handleA], GUID),
+      ).to.be.revertedWithCustomError(receiver, 'UntrustedPeer');
+    });
+
+    it('registers a peer, emits PeerSet, and exposes it via peers', async function () {
+      const { receiver } = await deployReceiveFixture();
+      await expect(receiver.setPeer(SRC_EID, peer)).to.emit(receiver, 'PeerSet').withArgs(SRC_EID, peer);
+      expect(await receiver.peers(SRC_EID)).to.equal(peer);
+    });
+
+    it('dispatches typed handles to the app hook once caller + peer check out', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      await receiver.setPeer(SRC_EID, peer);
+
+      await bridge.deliver(await receiver.getAddress(), SRC_EID, peer, payload, [handleC], [handleA, handleB], GUID);
+
+      expect(await receiver.receiveCount()).to.equal(1n);
+      expect(await receiver.lastSrcEid()).to.equal(SRC_EID);
+      expect(await receiver.lastSrcApp()).to.equal(peer);
+      expect(await receiver.lastPayload()).to.equal(ethers.hexlify(payload));
+      expect(await receiver.lastGuid()).to.equal(GUID);
+      expect(await receiver.lastHandlesLength()).to.equal(2n);
+      expect(await receiver.lastHandles(0)).to.equal(handleA);
+      expect(await receiver.lastHandles(1)).to.equal(handleB);
+    });
+
+    it('dispatches a single handle', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      await receiver.setPeer(SRC_EID, peer);
+      await bridge.deliver(await receiver.getAddress(), SRC_EID, peer, payload, [], [handleA], GUID);
+      expect(await receiver.lastHandlesLength()).to.equal(1n);
+      expect(await receiver.lastHandles(0)).to.equal(handleA);
+    });
+
+    it('ignores the source-chain handle list (only dst handles are dispatched)', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      await receiver.setPeer(SRC_EID, peer);
+      // srcHandleList differs from dstHandleList; only the dst list must reach the hook.
+      await bridge.deliver(await receiver.getAddress(), SRC_EID, peer, payload, [handleC, handleC], [handleB], GUID);
+      expect(await receiver.lastHandlesLength()).to.equal(1n);
+      expect(await receiver.lastHandles(0)).to.equal(handleB);
+    });
+
+    it('counts repeated deliveries and reflects the latest one', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      await receiver.setPeer(SRC_EID, peer);
+      const addr = await receiver.getAddress();
+      await bridge.deliver(addr, SRC_EID, peer, payload, [], [handleA], GUID);
+      await bridge.deliver(addr, SRC_EID, peer, payload, [], [handleB], GUID);
+      expect(await receiver.receiveCount()).to.equal(2n);
+      expect(await receiver.lastHandles(0)).to.equal(handleB);
+    });
+
+    it('lets a peer be re-registered and rejects the old one afterwards', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      const addr = await receiver.getAddress();
+      await receiver.setPeer(SRC_EID, peer);
+      const newPeer = h('0xfeed');
+      await receiver.setPeer(SRC_EID, newPeer);
+
+      await bridge.deliver(addr, SRC_EID, newPeer, payload, [], [handleA], GUID); // new peer ok
+      expect(await receiver.receiveCount()).to.equal(1n);
+      await expect(
+        bridge.deliver(addr, SRC_EID, peer, payload, [], [handleA], GUID), // old peer rejected
+      ).to.be.revertedWithCustomError(receiver, 'UntrustedPeer');
+    });
+
+    it('honors a custom trust policy via the isPeer override', async function () {
+      const { bridge, receiver } = await deployReceiveFixture();
+      const addr = await receiver.getAddress();
+      const stranger = h('0xdead'); // no peer registered for SRC_EID
+
+      // Default policy rejects an unregistered/mismatched peer.
+      await expect(bridge.deliver(addr, SRC_EID, stranger, payload, [], [handleA], GUID)).to.be.revertedWithCustomError(
+        receiver,
+        'UntrustedPeer',
+      );
+
+      // A permissive override accepts the same delivery.
+      await receiver.setTrustAllPeers(true);
+      await bridge.deliver(addr, SRC_EID, stranger, payload, [], [handleA], GUID);
+      expect(await receiver.receiveCount()).to.equal(1n);
+      expect(await receiver.lastHandles(0)).to.equal(handleA);
+    });
+  });
+
+  describe('send side — ConfidentialOAppSender (peer-resolved)', function () {
+    async function deployOAppFixture() {
+      const acl = await (await ethers.getContractFactory('MockACL')).deploy();
+      const bridge = await (await ethers.getContractFactory('MockConfidentialBridge')).deploy();
+      await acl.setConfidentialBridgeAddress(await bridge.getAddress());
+      const oapp = await (await ethers.getContractFactory('OAppHarness')).deploy(await acl.getAddress());
+      return { acl, bridge, oapp };
+    }
+
+    it('resolves the destination peer from the registry and bridges to it', async function () {
+      const { bridge, oapp } = await deployOAppFixture();
+      const peer = padded(randAddr());
+      await oapp.setPeer(DST_EID, peer);
+      const fee = ethers.parseEther('0.01');
+
+      await oapp.bridgeToPeer(DST_EID, '0x', handleA, 200_000, { value: fee });
+
+      const sent = await bridge.lastSend();
+      expect(sent.dstApp).to.equal(peer); // the registered peer, not an arg
+      expect(sent.handleList).to.deep.equal([handleA]);
+      expect(sent.lzComposeGas).to.equal(200_000n);
+      expect(sent.value).to.equal(fee);
+    });
+
+    it('reverts NoPeer when no peer is configured for the destination eid', async function () {
+      const { oapp } = await deployOAppFixture();
+      await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 0)).to.be.revertedWithCustomError(oapp, 'NoPeer');
+    });
+  });
+
+  describe('round trip — two OApps send and receive together', function () {
+    it('a value sent by the source OApp is delivered to the destination OApp', async function () {
+      // One mock ACL + bridge ties the two sides together. In production the two OApp instances
+      // live on different chains; here a single mock bridge plays both roles so we can follow one
+      // message end to end.
+      const acl = await (await ethers.getContractFactory('MockACL')).deploy();
+      const bridge = await (await ethers.getContractFactory('MockConfidentialBridge')).deploy();
+      await acl.setConfidentialBridgeAddress(await bridge.getAddress());
+
+      // Two OApps — each is a ConfidentialOAppSender + ConfidentialOAppReceiver.
+      const srcApp = await (await ethers.getContractFactory('OAppHarness')).deploy(await acl.getAddress());
+      const dstApp = await (await ethers.getContractFactory('OAppHarness')).deploy(await acl.getAddress());
+      const srcAppAddr = await srcApp.getAddress();
+      const dstAppAddr = await dstApp.getAddress();
+
+      // Wire peers once (one entry per direction, by endpoint id).
+      await srcApp.setPeer(DST_EID, padded(dstAppAddr)); // source knows where to send
+      await dstApp.setPeer(SRC_EID, padded(srcAppAddr)); // destination trusts the source app
+
+      const payload = ethers.toUtf8Bytes('hello from the source chain');
+      const srcHandle = handleA;
+      const fee = ethers.parseEther('0.01');
+      const guid = h('0xa11ce5');
+
+      // 1) SEND — the source OApp bridges to its peer on DST_EID via the sender helper.
+      await srcApp.bridgeToPeer(DST_EID, payload, srcHandle, 100_000, { value: fee });
+
+      // The bridge captured exactly what was forwarded — to the destination app, with the fee.
+      const sent = await bridge.lastSend();
+      expect(sent.dstApp).to.equal(padded(dstAppAddr));
+      expect(sent.payload).to.equal(ethers.hexlify(payload));
+      expect(sent.handleList).to.deep.equal([srcHandle]);
+      expect(sent.value).to.equal(fee);
+
+      // 2) DELIVER — the bridge derives a *new* destination handle (handles are chain-specific)
+      //    and calls the destination OApp. We model the derived handle as `dstHandle`.
+      const dstHandle = handleB;
+      await bridge.deliver(
+        dstAppAddr,
+        SRC_EID,
+        padded(srcAppAddr),
+        sent.payload,
+        [...sent.handleList],
+        [dstHandle],
+        guid,
+      );
+
+      // 3) The destination OApp authenticated the bridge + peer and received the destination
+      //    handle, the original payload, and the message guid.
+      expect(await dstApp.receiveCount()).to.equal(1n);
+      expect(await dstApp.lastSrcEid()).to.equal(SRC_EID);
+      expect(await dstApp.lastSrcApp()).to.equal(padded(srcAppAddr));
+      expect(await dstApp.lastPayload()).to.equal(ethers.hexlify(payload));
+      expect(await dstApp.lastGuid()).to.equal(guid);
+      expect(await dstApp.lastHandlesLength()).to.equal(1n);
+      expect(await dstApp.lastHandles(0)).to.equal(dstHandle);
+    });
+  });
+});

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -329,6 +329,19 @@ describe('Confidential bridge helpers', function () {
       expect(sent.value).to.equal(fee);
     });
 
+    it('bridges a multi-handle list to the resolved peer in one message', async function () {
+      const { bridge, oapp } = await deployOAppFixture();
+      const peer = padded(randAddr());
+      await oapp.setPeer(DST_EID, peer);
+
+      await oapp.bridgeManyToPeer(DST_EID, '0x', [handleA, handleB, handleC], 200_000, { value: 0 });
+
+      const sent = await bridge.lastSend();
+      expect(sent.dstApp).to.equal(peer);
+      expect(sent.handleList).to.deep.equal([handleA, handleB, handleC]);
+      expect(sent.lzComposeGas).to.equal(200_000n);
+    });
+
     it('reverts NoPeer when no peer is configured for the destination eid', async function () {
       const { oapp } = await deployOAppFixture();
       await expect(oapp.bridgeToPeer(DST_EID, '0x', handleA, 50_000)).to.be.revertedWithCustomError(oapp, 'NoPeer');

--- a/library-solidity/test/bridge/Bridge.ts
+++ b/library-solidity/test/bridge/Bridge.ts
@@ -77,39 +77,6 @@ describe('Confidential bridge helpers', function () {
     });
   });
 
-  describe('send side — typed array overloads (multi-handle)', function () {
-    it('euint64[]: sends one message carrying the whole list', async function () {
-      const { bridge, harness } = await deploySendFixture();
-      const dstApp = randAddr();
-      const fee = ethers.parseEther('0.03');
-
-      await harness.bridgeArray64(DST_EID, dstApp, '0x', [handleA, handleB, handleC], 50_000, { value: fee });
-
-      const sent = await bridge.lastSend();
-      expect(sent.dstApp).to.equal(padded(dstApp));
-      expect(sent.handleList).to.deep.equal([handleA, handleB, handleC]);
-      expect(sent.value).to.equal(fee);
-    });
-
-    it('euint256[]: array generation is uniform across types', async function () {
-      const { bridge, harness } = await deploySendFixture();
-      await harness.bridgeArray256(DST_EID, randAddr(), '0x', [handleA, handleB], 1, { value: 0 });
-      expect((await bridge.lastSend()).handleList).to.deep.equal([handleA, handleB]);
-    });
-
-    it('a single-element typed array behaves like the single-handle overload', async function () {
-      const { bridge, harness } = await deploySendFixture();
-      await harness.bridgeArray64(DST_EID, randAddr(), '0x', [handleA], 1, { value: 0 });
-      expect((await bridge.lastSend()).handleList).to.deep.equal([handleA]);
-    });
-
-    it('an empty typed array forwards an empty handle list', async function () {
-      const { bridge, harness } = await deploySendFixture();
-      await harness.bridgeArray64(DST_EID, randAddr(), '0x', [], 1, { value: 0 });
-      expect((await bridge.lastSend()).handleList).to.deep.equal([]);
-    });
-  });
-
   describe('send side — low-level bytes32[] escape hatch', function () {
     it('forwards an explicit handle list and raw bytes32 dstApp verbatim', async function () {
       const { bridge, harness } = await deploySendFixture();
@@ -159,11 +126,10 @@ describe('Confidential bridge helpers', function () {
       expect(fee.lzTokenFee).to.equal(0n);
     });
 
-    it('quotes a multi-type (euint32) and a typed-array (euint64[]) send', async function () {
+    it('quotes a multi-type (euint32) send', async function () {
       const { bridge, harness } = await deploySendFixture();
       await bridge.setQuotedNativeFee(42n);
       expect((await harness.quote32(DST_EID, randAddr(), '0x', handleA, 0)).nativeFee).to.equal(42n);
-      expect((await harness.quoteArray64(DST_EID, randAddr(), '0x', [handleA, handleB], 0)).nativeFee).to.equal(42n);
     });
 
     it('quotes through the low-level overload', async function () {

--- a/test-suite/e2e/contracts/bridge/BridgeApp.sol
+++ b/test-suite/e2e/contracts/bridge/BridgeApp.sol
@@ -3,28 +3,30 @@ pragma solidity ^0.8.24;
 
 import "@fhevm/solidity/lib/FHE.sol";
 import {E2ECoprocessorConfig} from "../E2ECoprocessorConfigLocal.sol";
+import {ConfidentialOAppSender} from "@fhevm/solidity/lib/bridge/ConfidentialOAppSender.sol";
+import {ConfidentialOAppReceiver} from "@fhevm/solidity/lib/bridge/ConfidentialOAppReceiver.sol";
+import {MessagingReceipt} from "@fhevm/solidity/lib/bridge/IConfidentialBridge.sol";
 
-/// @notice Bridge destination callback (mirror of host-contracts' IDstApp; inlined since the
-///         bridge interfaces aren't part of the e2e contract project).
-interface IDstApp {
-    function onConfidentialBridgeReceived(
-        uint32 srcEid,
-        bytes32 srcApp,
-        bytes calldata payload,
-        bytes32[] calldata srcHandleList,
-        bytes32[] calldata dstHandleList,
-        bytes32 guid
-    ) external;
-}
-
-/// @notice Test dapp exercising the confidential bridge end-to-end (deployed on each chain).
-/// @dev Source: {makeHandle}/{makeComputedHandle} produce a handle ACL-allowed to the caller for
-///      `ConfidentialBridge.send`. Destination: {onConfidentialBridgeReceived} (called by the bridge's lzCompose, which
-///      has granted transient ACL allowance) makes each bridged handle decryptable so the test can
-///      assert it — publicly when `payload` is empty, or to a user when `payload` encodes an address.
-contract BridgeApp is E2ECoprocessorConfig, IDstApp {
+/// @notice Test dapp exercising the confidential bridge end-to-end THROUGH the `@fhevm/solidity`
+///         OApp wrappers (rather than calling the host `ConfidentialBridge` directly).
+/// @dev It sends via {ConfidentialOAppSender-_bridgeUnchecked} (peer resolved from the OApp registry)
+///      and receives via {ConfidentialOAppReceiver}, which authenticates `msg.sender == bridge` and
+///      `isPeer(srcEid, srcApp)` before dispatching to {_onReceiveHandles}. Peers are wired once with
+///      {setPeer} (one entry serves both directions). `setPeer` is intentionally unguarded (test-only).
+///
+///      Source: {makeHandle}/{makeComputedHandle}/{addToHandle} produce a handle ACL-allowed to the
+///      caller and this contract (so the bridge's `isAllowed(handle, this)` check passes on send).
+///      Destination: {_onReceiveHandles} (post-auth) makes each bridged handle decryptable so the
+///      test can assert it — publicly when `payload` is empty, or to a user when `payload` encodes
+///      an address.
+contract BridgeApp is E2ECoprocessorConfig, ConfidentialOAppSender, ConfidentialOAppReceiver {
     /// @notice Lets the test read the produced handle from the receipt.
     event HandleMinted(bytes32 handle);
+
+    /// @notice Trust the remote app as this app's peer on `eid` (serves send + receive).
+    function setPeer(uint32 eid, bytes32 peer) external {
+        _setPeer(eid, peer);
+    }
 
     /// @notice Verify an encrypted input and register it as a bridgeable handle.
     function makeHandle(externalEuint64 encryptedAmount, bytes calldata inputProof) external returns (bytes32) {
@@ -44,8 +46,8 @@ contract BridgeApp is E2ECoprocessorConfig, IDstApp {
     /// @notice Compute on an EXISTING handle (e.g. one just received via the bridge): registers a
     ///         new handle `existing + addend`, ACL-allowed to the caller, so a bridged handle can
     ///         be computed on and then re-bridged. Requires this contract to already hold ACL
-    ///         allowance on `existing` — the bridge callback grants it (`FHE.allowThis`) when a
-    ///         handle is delivered with a user payload.
+    ///         allowance on `existing` — the receive hook grants it (`FHE.allowThis`) when a handle
+    ///         is delivered with a user payload.
     function addToHandle(bytes32 existing, uint64 addend) external returns (bytes32) {
         return _register(FHE.add(euint64.wrap(existing), FHE.asEuint64(addend)));
     }
@@ -58,21 +60,35 @@ contract BridgeApp is E2ECoprocessorConfig, IDstApp {
         emit HandleMinted(handle);
     }
 
-    /// @notice Bridge callback: empty `payload` => make each handle publicly decryptable;
+    /// @notice Bridge `handles` to this app's peer on `dstEid`, via the OApp sender wrapper.
+    /// @dev Uses the multi-handle {ConfidentialOAppSender-_bridgeUnchecked}, which resolves the peer
+    ///      from the registry; this contract must already hold ACL allowance on every handle (see
+    ///      {makeHandle}). Unchecked is intentional for this test dapp: the entrypoint is open so the
+    ///      e2e can drive arbitrary handle lists.
+    function send(
+        uint32 dstEid,
+        bytes32[] calldata handles,
+        bytes calldata payload,
+        uint64 lzComposeGas
+    ) external payable returns (MessagingReceipt memory) {
+        return _bridgeUnchecked(dstEid, payload, handles, lzComposeGas, msg.value);
+    }
+
+    /// @notice Receive hook (post-auth): empty `payload` => make each handle publicly decryptable;
     ///         `payload == abi.encode(address user)` => grant persistent ACL allowance to `user`
-    ///         (and this contract) so it can be user-decrypted.
-    /// @dev The transient ACL allowance granted before this call suffices within the lzCompose tx.
-    function onConfidentialBridgeReceived(
+    ///         (and this contract) so it can be user-decrypted or computed on.
+    /// @dev Only reached after {ConfidentialOAppReceiver} has verified the caller is the bridge and
+    ///      `(srcEid, srcApp)` is a registered peer. Transient ACL allowance is already granted.
+    function _onReceiveHandles(
         uint32 /* srcEid */,
         bytes32 /* srcApp */,
         bytes calldata payload,
-        bytes32[] calldata /* srcHandleList */,
-        bytes32[] calldata dstHandleList,
+        bytes32[] calldata handles,
         bytes32 /* guid */
-    ) external override {
+    ) internal override {
         address user = payload.length == 32 ? abi.decode(payload, (address)) : address(0);
-        for (uint256 i = 0; i < dstHandleList.length; i++) {
-            euint64 handle = euint64.wrap(dstHandleList[i]);
+        for (uint256 i = 0; i < handles.length; i++) {
+            euint64 handle = euint64.wrap(handles[i]);
             if (user == address(0)) {
                 FHE.makePubliclyDecryptable(handle);
             } else {

--- a/test-suite/e2e/test/bridge/confidentialBridge.ts
+++ b/test-suite/e2e/test/bridge/confidentialBridge.ts
@@ -21,9 +21,6 @@ import {
 // Mock endpoint has no executor, so the test relays itself; with a real endpoint (BRIDGE_REAL_LZ), LZ delivers and the test only waits for the HandleBridged event.
 const USE_REAL_LZ = (process.env.BRIDGE_REAL_LZ || '').toLowerCase() === 'true';
 
-const BRIDGE_SEND_ABI = [
-  'function send(uint32 dstEid, bytes32 dstApp, bytes payload, bytes32[] handleList, uint64 lzComposeGas) payable',
-];
 const LZ_COMPOSE_GAS = 1_000_000n;
 const DECRYPT_TIMEOUT_MS = 180_000;
 
@@ -132,10 +129,11 @@ describe('Confidential Bridge', function () {
   async function bridge(src: BridgeEnd, dst: BridgeEnd, handles: string[], payload = '0x', skipCompose = false) {
     const ctx = { srcEndpoint: src.endpoint, dstEndpoint: dst.endpoint, dstBridge: dst.bridge, dstSigner: dst.alice };
     const fromBlock = await getProvider(dst.cfg).getBlockNumber();
-    const dstApp = ethers.zeroPadValue(dst.appAddr, 32);
-    const bridgeContract = new ethers.Contract(src.bridge, BRIDGE_SEND_ABI, src.alice);
+    // Send through the OApp wrapper: the app resolves the dst peer from its registry and calls
+    // FHE.bridge (which forwards to the host ConfidentialBridge). This exercises the
+    // `@fhevm/solidity` sender wrapper end-to-end rather than calling the bridge directly.
     const sendReceipt = await sendWithNonceRetry(src.alice, () =>
-      bridgeContract.send(dst.cfg.chainId, dstApp, payload, handles, LZ_COMPOSE_GAS, {
+      src.app.connect(src.alice).getFunction('send')(dst.cfg.chainId, handles, payload, LZ_COMPOSE_GAS, {
         value: 0,
         gasLimit: 5_000_000,
       }),
@@ -182,6 +180,15 @@ describe('Confidential Bridge', function () {
     };
     host = await build(0);
     chainB = await build(1);
+
+    // Wire OApp peers: each app trusts the other (one entry serves both send and receive). The
+    // authenticated receiver checks `isPeer(srcEid, srcApp)`, so both directions must be registered.
+    await sendWithNonceRetry(host.alice, () =>
+      host.app.connect(host.alice).getFunction('setPeer')(chainB.cfg.chainId, ethers.zeroPadValue(chainB.appAddr, 32)),
+    );
+    await sendWithNonceRetry(chainB.alice, () =>
+      chainB.app.connect(chainB.alice).getFunction('setPeer')(host.cfg.chainId, ethers.zeroPadValue(host.appAddr, 32)),
+    );
   });
 
   it('bridges a handle host->chain-b and publicly decrypts it on the destination', async function () {
@@ -306,6 +313,11 @@ describe('Confidential Bridge', function () {
     const fakeSrcBridge = host.bridge; // arbitrary; just must match the registered peer
     const bridgeOwner = new ethers.Contract(chainB.bridge, ['function setPeer(uint32,bytes32)'], owner);
     await (await bridgeOwner.setPeer(FAKE_EID, ethers.zeroPadValue(fakeSrcBridge, 32))).wait();
+    // The forged delivery also passes the OApp receiver's peer check: `forgeDelivery` sets the
+    // message `srcApp` to the forged source bridge, so register that as the app peer for FAKE_EID.
+    await sendWithNonceRetry(chainB.alice, () =>
+      chainB.app.connect(chainB.alice).getFunction('setPeer')(FAKE_EID, ethers.zeroPadValue(fakeSrcBridge, 32)),
+    );
 
     // Mint a real euint64 handle on host but DO NOT bridge.send it, so there is no source BridgeHandle.
     // Forging the delivery leaves the handle unassociated (no ciphertext) while onConfidentialBridgeReceived still grants


### PR DESCRIPTION
## What

Adds the `@fhevm/solidity` **confidential bridge send/receive wrappers** — the library-side (Workstream A) counterpart to the host `ConfidentialBridge` already in `main` (#2734). Apps get a typed OApp surface for bridging encrypted handles over LayerZero without touching the bridge contract or LayerZero packages.

- `FHE.bridge` / `FHE.quoteBridge` — per-type single-handle overloads + a type-agnostic `bytes32[]` escape hatch (generated).
- `lib/bridge/`: `ConfidentialOAppCore` (peer registry), `ConfidentialOAppSender`, `ConfidentialOAppReceiver`, and a LayerZero-free `IConfidentialBridge` mirror.
- Sender exposes **`_bridgeFrom`** (safe: asserts the caller is ACL-allowed on every handle) and **`_bridgeUnchecked`** (escape hatch; gate yourself) — both type-agnostic over `bytes32`/`bytes32[]`.
- Examples: `ConfidentialOFTViaLib` (confidential OFT built entirely on the library) + test harnesses/mocks.

## Notes

- **Fully codegen-driven.** Everything under `library-solidity/lib/` is regenerated from `codegen/src` (templates + generators, gated per-package by `lib.bridge`). Verified: wiping `lib/bridge`, `lib/FHE.sol`, `lib/Impl.sol` and running `npm run codegen` reproduces them with zero diff. `host-contracts` is unaffected (`bridge: false`).
- **Tests:** 37 passing in `library-solidity/test/bridge/Bridge.ts` (send/receive/round-trip against mocks).
- **e2e:** rewiring the multi-chain e2e (`test-suite/e2e`) to drive `BridgeApp` through these wrappers is a **follow-up** — `main`'s e2e bridge tests have evolved since this work began and need re-adaptation onto their current form.

Supersedes the library portion of #2871 (which was targeting the now-merged `cBridge` integration branch).
