### PR TITLE
refactor(host-contracts): route bridge verification through verifyContract wrapper

### DIFF
--- a/host-contracts/tasks/blockExplorerVerify.ts
+++ b/host-contracts/tasks/blockExplorerVerify.ts
@@ -10,9 +10,13 @@ import { getRequiredEnvVar, loadHostAddresses } from './utils/loadVariables';
 // When a per-contract `task:verify*` is called straight from a deploy script (the gitops sc-deploy
 // pattern), that error combines with `set -eo pipefail` to abort the whole deploy. Genuine failures
 // (bad API key, explorer down, bytecode mismatch) are rethrown unchanged.
-export async function verifyContract(run: RunTaskFunction, address: string): Promise<void> {
+export async function verifyContract(
+  run: RunTaskFunction,
+  address: string,
+  constructorArguments: unknown[] = [],
+): Promise<void> {
   try {
-    await run('verify:verify', { address, constructorArguments: [] });
+    await run('verify:verify', { address, constructorArguments });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (/already verified/i.test(message)) {
@@ -175,14 +179,8 @@ task('task:verifyBridge')
     // an immutable in its constructor (via OAppCoreUpgradeable), so the impl
     // verification needs that one constructorArg. The proxy itself is a
     // standard ERC1967Proxy with no constructor args.
-    await run('verify:verify', {
-      address: implementationConfidentialBridgeAddress,
-      constructorArguments: [lzEndpoint],
-    });
-    await run('verify:verify', {
-      address: proxyAddress,
-      constructorArguments: [],
-    });
+    await verifyContract(run, implementationConfidentialBridgeAddress, [lzEndpoint]);
+    await verifyContract(run, proxyAddress);
   });
 
 task('task:verifyAllHostContracts')


### PR DESCRIPTION
Routes `task:verifyBridge` through the `verifyContract` wrapper instead of calling `verify:verify` directly, so bridge verification gets the same "already verified" tolerance as the other host contracts. Adds an optional `constructorArguments` param to the wrapper (impl needs `[lzEndpoint]`, proxy none).