### PR TITLE
refactor(library-solidity): generate lib/bridge OApp abstracts via codegen

### DIFF
--- a/library-solidity/codegen.config.json
+++ b/library-solidity/codegen.config.json
@@ -4,7 +4,8 @@
   "noHostContracts": true,
   "lib": {
     "outDir": "./lib",
-    "fheTypeDir": "./lib"
+    "fheTypeDir": "./lib",
+    "bridge": true
   },
   "tests": {
     "numberOfTestSplits": 12,

--- a/library-solidity/codegen/src/config.ts
+++ b/library-solidity/codegen/src/config.ts
@@ -55,6 +55,10 @@ export type HostContractsUserConfig = {
 export type LibUserConfig = {
   outDir?: string;
   fheTypeDir?: string;
+  // whether to generate the confidential-bridge OApp abstracts under `lib/bridge/`
+  // (ConfidentialOAppCore/Sender/Receiver/ConfidentialOApp + IDstApp). Library-only;
+  // host-contracts leaves this off so it does not emit the OApp abstracts.
+  bridge?: boolean;
 };
 
 export type TestsUserConfig = {
@@ -76,6 +80,8 @@ export type LibConfig = {
   outDir: string;
   // directory where the FheType.sol file is located
   fheTypeDir: string;
+  // whether to generate the confidential-bridge OApp abstracts under `lib/bridge/`
+  bridge: boolean;
 };
 
 export type TestsConfig = {
@@ -212,6 +218,7 @@ function resolveLibConfig(userLibConfig: LibUserConfig | undefined): LibConfig {
   const p: LibConfig = {
     fheTypeDir: userLibConfig?.fheTypeDir ?? outDir,
     outDir,
+    bridge: userLibConfig?.bridge ?? false,
   };
   assertRelative(p.fheTypeDir);
   assertRelative(p.outDir);
@@ -273,6 +280,7 @@ function toAbsoluteLibConfig(resolved: LibConfig, baseDir: string): LibConfig {
   return {
     outDir: toAbsoluteDirectory(resolved.outDir, baseDir),
     fheTypeDir: toAbsoluteDirectory(resolved.fheTypeDir, baseDir),
+    bridge: resolved.bridge,
   };
 }
 

--- a/library-solidity/codegen/src/main.ts
+++ b/library-solidity/codegen/src/main.ts
@@ -23,6 +23,13 @@ import { generateSolidityHCULimit } from './hcuLimitGenerator';
 import { ALL_OPERATORS } from './operators';
 import { ALL_OPERATORS_PRICES } from './operatorsPrices';
 import { fromDirToFile, fromFileToFile, isDirectory } from './paths';
+import {
+  generateConfidentialOAppCoreLib,
+  generateConfidentialOAppLib,
+  generateConfidentialOAppReceiverLib,
+  generateConfidentialOAppSenderLib,
+  generateIDstAppLib,
+} from './templateBridge';
 import { generateFhevmECDSALib, generateSolidityFHELib } from './templateFHEDotSol';
 import { generateSolidityFheType } from './templateFheTypeDotSol';
 import { generateSolidityImplLib } from './templateImpDotSol';
@@ -151,6 +158,13 @@ export async function commandGenerateAllFiles(options: any) {
   const fheDotSol = `${path.join(absConfig.lib.outDir, 'FHE.sol')}`;
   const hcuLimitDotSol = `${path.join(absConfig.hostContracts.outDir, 'HCULimit.sol')}`;
 
+  // Confidential-bridge OApp abstracts (`lib/bridge/`); only emitted when `lib.bridge` is enabled.
+  const iDstAppDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'IDstApp.sol')}`;
+  const oAppCoreDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOAppCore.sol')}`;
+  const oAppSenderDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOAppSender.sol')}`;
+  const oAppReceiverDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOAppReceiver.sol')}`;
+  const oAppDotSol = `${path.join(absConfig.lib.outDir, 'bridge', 'ConfidentialOApp.sol')}`;
+
   const defaultOverloadsJsonFile = absConfig.tests.overloads;
   const resolvedOverloadsJsonFile = userOverloadsJson
     ? toAbsoluteFileWithExtension(userOverloadsJson, '.json', process.cwd())
@@ -219,6 +233,16 @@ export async function commandGenerateAllFiles(options: any) {
     await formatAndWriteFile(`${implDotSol}`, implCode);
     await formatAndWriteFile(`${ecdsaDotSol}`, ecdsaCode);
     await formatAndWriteFile(`${fheDotSol}`, fheCode);
+
+    // Generate the confidential-bridge OApp abstracts under `lib/bridge/` (library-only).
+    if (absConfig.lib.bridge) {
+      mkDir(path.dirname(iDstAppDotSol));
+      await formatAndWriteFile(`${iDstAppDotSol}`, generateIDstAppLib());
+      await formatAndWriteFile(`${oAppCoreDotSol}`, generateConfidentialOAppCoreLib());
+      await formatAndWriteFile(`${oAppSenderDotSol}`, generateConfidentialOAppSenderLib());
+      await formatAndWriteFile(`${oAppReceiverDotSol}`, generateConfidentialOAppReceiverLib());
+      await formatAndWriteFile(`${oAppDotSol}`, generateConfidentialOAppLib());
+    }
   } else {
     debugLog(`Skipping lib generation.`);
   }

--- a/library-solidity/codegen/src/templateBridge.ts
+++ b/library-solidity/codegen/src/templateBridge.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'fs';
+
+import { resolveTemplatePath } from './paths';
+import { removeTemplateComments } from './utils';
+
+/**
+ * Confidential-bridge OApp abstracts (`lib/bridge/`).
+ *
+ * All of these are generated from templates under `codegen/src/templates/`, so `lib/bridge/` is
+ * fully reproducible from `codegen/src` (`rm -rf lib/bridge && npm run codegen`). The static
+ * abstracts are emitted verbatim from their templates; the Sender's per-encrypted-type
+ * single-handle overloads are generated in a loop (see {generateConfidentialOAppSenderLib}) so the
+ * repetition lives in one place.
+ */
+
+/** Encrypted handle types that get a type-safe single-handle send overload, in declaration order. */
+const BRIDGE_HANDLE_TYPES = ['ebool', 'euint8', 'euint16', 'euint32', 'euint64', 'euint128', 'euint256', 'eaddress'];
+
+function readBridgeTemplate(templateFilename: string): string {
+  return removeTemplateComments(readFileSync(resolveTemplatePath(templateFilename), 'utf8'));
+}
+
+export function generateIDstAppLib(): string {
+  return readBridgeTemplate('IDstApp.sol-template');
+}
+
+export function generateConfidentialOAppCoreLib(): string {
+  return readBridgeTemplate('ConfidentialOAppCore.sol-template');
+}
+
+export function generateConfidentialOAppReceiverLib(): string {
+  return readBridgeTemplate('ConfidentialOAppReceiver.sol-template');
+}
+
+export function generateConfidentialOAppLib(): string {
+  return readBridgeTemplate('ConfidentialOApp.sol-template');
+}
+
+/**
+ * The Sender abstract: a `private` `bytes32` core, one type-safe overload per encrypted type
+ * (generated below), the multi-handle list send, and the two quote helpers. The per-type
+ * overloads all delegate to the `bytes32` core via `FHE.toBytes32`.
+ */
+export function generateConfidentialOAppSenderLib(): string {
+  const typedOverloads = BRIDGE_HANDLE_TYPES.map(
+    (t) => `
+    /**
+     * @notice Type-safe {${t}} overload: bridges a single encrypted \`${t}\` handle to the peer cOApp
+     *         configured for \`dstEid\`.
+     * @dev    Unwraps \`handle\` to \`bytes32\` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards \`msg.value\` as the
+     *         LayerZero native fee, so the calling entrypoint must be \`payable\` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for \`dstEid\`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted \`${t}\` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback \`onConfidentialBridgeReceived\` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their \`onConfidentialBridgeReceived\` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
+    function _sendHandleToPeer(
+        uint32 dstEid,
+        bytes memory payload,
+        ${t} handle,
+        uint64 lzComposeGas
+    ) internal returns (bytes32 guid, uint64 nonce) {
+        (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
+    }
+`,
+  ).join('');
+
+  return readBridgeTemplate('ConfidentialOAppSender.sol-template').replace(
+    '$${SendHandleTypedOverloads}$$',
+    typedOverloads,
+  );
+}

--- a/library-solidity/codegen/src/templates/ConfidentialOApp.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOApp.sol-template
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {ConfidentialOAppSender} from "./ConfidentialOAppSender.sol";
+import {ConfidentialOAppReceiver} from "./ConfidentialOAppReceiver.sol";
+
+/**
+ * @title ConfidentialOApp
+ * @dev Abstract contract serving as the base for ConfidentialOApp implementation, combining ConfidentialOAppSender and ConfidentialOAppReceiver functionality.
+ */
+abstract contract ConfidentialOApp is ConfidentialOAppSender, ConfidentialOAppReceiver {}

--- a/library-solidity/codegen/src/templates/ConfidentialOAppCore.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppCore.sol-template
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {IConfidentialBridge} from "../Impl.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {FHE} from "../FHE.sol";
+
+interface IConfidentialOAppCore {
+    /// @notice No peer is configured for the requested endpoint id.
+    error NoPeer(uint32 eid);
+
+    /// @notice The LayerZero ConfidentialBridge does not support the requested endpoint id (not routable).
+    error UnsupportedEid(uint32 eid);
+
+    /// @notice Event emitted when a peer ConfidentialOApp (cOApp) is set for a corresponding LayerZero endpoint
+    event PeerSet(uint32 eid, bytes32 peer);
+
+    /**
+     * @notice Retrieves the LayerZero ConfidentialBridge address associated with the cOApp.
+     * @return cBridge The ConfidentialBridge address.
+     */
+    function LZConfidentialBridgeAddress() external view returns (address cBridge);
+
+    /**
+     * @notice Retrieves the peer (cOApp) associated with a corresponding LayerZero endpoint.
+     * @param eid The LayerZero endpoint ID.
+     * @return peer The peer address (cOApp instance) associated with the corresponding endpoint.
+     */
+    function peers(uint32 eid) external view returns (bytes32 peer);
+
+    /**
+     * @notice Sets the peer address (cOApp instance) for a corresponding endpoint.
+     * @param eid The endpoint ID.
+     * @param peer The address of the peer to be associated with the corresponding endpoint.
+     */
+    function setPeer(uint32 eid, bytes32 peer) external;
+}
+
+/**
+ * @title   ConfidentialOAppCore
+ * @notice  Shared peer registry for a confidential omnichain app (cOApp) relying on a LayerZero-enabled ConfidentialBridge.
+ *          A "peer" is the trusted counterpart instance of this cOApp on another chain, addressed by its LayerZero endpoint id (`eid`).
+ *          The same registry is used by both the send side ({ConfidentialOAppSender}) and the receive side ({ConfidentialOAppReceiver}), so an
+ *          app configures each peer once and it applies in both directions.
+ * @dev     App identifiers are `bytes32` so non-EVM peers (e.g. Solana program ids) fit; EVM
+ *          peers are the address left-padded to `bytes32`.
+ * @dev     The trusted bridge is resolved from the ACL, so the app must have configured the ACL via `FHE.setCoprocessor(...)`.
+ */
+abstract contract ConfidentialOAppCore is IConfidentialOAppCore, Ownable {
+    /// @notice The trusted peer app per endpoint id (`bytes32(0)` if unset).
+    mapping(uint32 eid => bytes32 peer) public peers;
+
+    /**
+     * @notice Retrieves the LayerZero ConfidentialBridge address associated with the cOApp.
+     * @return cBridge The ConfidentialBridge address.
+     * @dev Resolves the ConfidentialBridge from the ACL via {FHE-getLZConfidentialBridgeAddress},
+     *      which reverts if the bridge is not deployed on the current chain.
+     */
+    function LZConfidentialBridgeAddress() public view virtual override returns (address cBridge) {
+        cBridge = FHE.getLZConfidentialBridgeAddress();
+    }
+
+    /**
+     * @notice Configure the canonical peer cOApp on the chain at `eid`. Must be set before
+     *         this contract can send to that eid or receive a message from it via the bridge.
+     *         Pass bytes32(0) to clear a peer.
+     * @param eid LayerZero endpoint id of the remote chain.
+     * @param peer Peer app on the remote chain as bytes32. EVM peers: pass
+     *              `bytes32(uint256(uint160(remoteAddress)))`.
+     *
+     * @dev Only the owner/admin of the cOApp can call this function.
+     * @dev Indicates that the peer is trusted to send LayerZero messages to this cOApp.
+     * @dev Set this to bytes32(0) to remove the peer address.
+     * @dev Peer is a bytes32 to accommodate non-evm chains.
+     * @dev When setting a non-zero `peer`, this reverts if the ConfidentialBridge is not deployed on the
+     *      current chain (`ConfidentialBridgeNotDeployed`), or if it is deployed but not wired to the
+     *      destination chain identified by `eid` (`UnsupportedEid`). Clearing a peer (bytes32(0)) skips these checks.
+     */
+    function setPeer(uint32 eid, bytes32 peer) public virtual onlyOwner {
+        _setPeer(eid, peer);
+    }
+
+    /**
+     * @notice Sets the peer address (cOApp instance) for a corresponding endpoint.
+     * @param _eid The endpoint ID.
+     * @param _peer The address of the peer to be associated with the corresponding endpoint.
+     *
+     * @dev Indicates that the peer is trusted to send LayerZero messages to this cOApp.
+     * @dev Set this to bytes32(0) to remove the peer address.
+     * @dev Peer is a bytes32 to accommodate non-evm chains.
+     */
+    function _setPeer(uint32 _eid, bytes32 _peer) internal virtual {
+        // When configuring a (non-zero) peer, ensure the ConfidentialBridge can route to `_eid`;
+        // a zero destination chain id means the eid is unsupported. Clearing a peer (bytes32(0)) is always allowed.
+        if (_peer != bytes32(0) && IConfidentialBridge(LZConfidentialBridgeAddress()).getDstChainId(_eid) == 0) {
+            revert UnsupportedEid(_eid);
+        }
+        peers[_eid] = _peer;
+        emit PeerSet(_eid, _peer);
+    }
+
+    /**
+     * @notice Returns the configured peer for `eid`, reverting {NoPeer} if none is set (used on the send side).
+     * @param eid The LayerZero endpoint id of the remote chain.
+     * @return peer The trusted peer app on the remote chain as bytes32.
+     */
+    function _getPeerOrRevert(uint32 eid) internal view returns (bytes32 peer) {
+        peer = peers[eid];
+        if (peer == bytes32(0)) revert NoPeer(eid);
+    }
+}

--- a/library-solidity/codegen/src/templates/ConfidentialOAppReceiver.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppReceiver.sol-template
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {IDstApp} from "./IDstApp.sol";
+import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
+
+/**
+ * @title   ConfidentialOAppReceiver
+ * @notice  Receive side of a confidential omnichain app. Implements the destination app's
+ *          {IDstApp-onConfidentialBridgeReceived} callback and enforces the two checks every
+ *          receiver needs for security:
+ *            1. the caller is the trusted local `ConfidentialBridge`.
+ *            2. `(srcEid, srcApp)` is a trusted peer.
+ *          Subclasses implement {_onReceiveHandles} and receive the derived destination handles
+ *          as raw `bytes32`, wrapping each to its known encrypted type (e.g.
+ *          `euint64.wrap(dstHandleList[i])`). The local bridge has already granted transient ACL
+ *          allowance for every `dstHandleList[i]` before this callback is invoked.
+ */
+abstract contract ConfidentialOAppReceiver is ConfidentialOAppCore, IDstApp {
+    /// @notice The callback was not invoked by the trusted local `ConfidentialBridge`.
+    /// @param caller The unauthorized `msg.sender` that attempted the call.
+    error OnlyConfidentialBridge(address caller);
+
+    /// @notice The `srcApp` does not match the peer configured for `srcEid`, so the message is not trusted.
+    /// @param srcEid The LayerZero endpoint id of the source chain.
+    /// @param srcApp The source app that sent the message (bytes32; for EVM, a left-padded address).
+    error OnlyPeer(uint32 srcEid, bytes32 srcApp);
+
+    /**
+     * @inheritdoc IDstApp
+     */
+    function onConfidentialBridgeReceived(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata srcHandleList,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external virtual {
+        // Ensure that the caller is the trusted local `ConfidentialBridge`.
+        if (msg.sender != LZConfidentialBridgeAddress()) revert OnlyConfidentialBridge(msg.sender);
+
+        // Ensure that the sender matches the expected peer for the source endpoint.
+        if (_getPeerOrRevert(srcEid) != srcApp) revert OnlyPeer(srcEid, srcApp);
+
+        // Dispatch to the app hook to handle the bridged payload with the derived destination handles.
+        _onReceiveHandles(srcEid, srcApp, payload, srcHandleList, dstHandleList, guid);
+    }
+
+    /**
+     * @notice App hook: handle a bridged payload with the derived destination handles. Called by
+     *         {onConfidentialBridgeReceived} only after the caller and peer have been authenticated.
+     * @dev    Must be implemented by inheriting contracts.
+     * @param srcEid        Source LayerZero endpoint id.
+     * @param srcApp        Source app (bytes32; for EVM, a left-padded address).
+     * @param payload       Opaque app payload as encoded by the source app.
+     * @param srcHandleList Source-chain handles as raw `bytes32`, in the order the source app sent them.
+     *                      Treat as opaque: they are not usable on this chain.
+     * @param dstHandleList Derived destination handles as raw `bytes32`, aligned by index with
+     *                      `srcHandleList`. Wrap each to its known type, e.g. `euint64.wrap(dstHandleList[i])`.
+     *                      Transient ACL allowance has already been granted to this contract for each `dstHandleList[i]`.
+     * @param guid          LayerZero message GUID of the transfer; useful for correlation or
+     *                      analytics. Apps that don't need it can ignore the parameter.
+     */
+    function _onReceiveHandles(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata srcHandleList,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) internal virtual;
+}

--- a/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
+++ b/library-solidity/codegen/src/templates/ConfidentialOAppSender.sol-template
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import {FHE} from "../FHE.sol";
+import {Impl} from "../Impl.sol";
+import {ConfidentialOAppCore} from "./ConfidentialOAppCore.sol";
+import "encrypted-types/EncryptedTypes.sol";
+
+/**
+ * @title   ConfidentialOAppSender
+ * @notice  Send side of a confidential omnichain app (cOApp) relying on a LayerZero-enabled ConfidentialBridge.
+ *          Looks up the destination peer from the shared {ConfidentialOAppCore} registry and bridges encrypted
+ *          handles to it through `FHE.sendLZConfidentialBridge`.
+ * @dev     A message may carry up to 32 handles.
+ * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
+ * @dev     Quote the fee with {_quoteSendHandleToPeer/_quoteSendHandlesToPeer} and forward it as `msg.value`
+ *          when sending, i.e before calling any of {_sendHandleToPeer/_sendHandlesToPeer}.
+ */
+abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
+    /**
+     * @notice Bridges a single raw `bytes32` handle to the peer cOApp configured for `dstEid`.
+     * @dev    *Private* core behind the per-type {_sendHandleToPeer} overloads. Wraps `handle` in a
+     *         one-element list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Raw `bytes32` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
+    function _sendHandleToPeer(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32 handle,
+        uint64 lzComposeGas
+    ) private returns (bytes32 guid, uint64 nonce) {
+        bytes32[] memory handles = new bytes32[](1);
+        handles[0] = handle;
+        (guid, nonce) = FHE.sendLZConfidentialBridge(
+            dstEid,
+            _getPeerOrRevert(dstEid),
+            payload,
+            handles,
+            lzComposeGas,
+            msg.value
+        );
+    }
+
+    $${SendHandleTypedOverloads}$$
+
+    /**
+     * @notice Bridges a list of encrypted handles to the peer cOApp configured for `dstEid` in a single message.
+     * @dev    Forwards `msg.value` as the LayerZero native fee, so the calling entrypoint must be `payable` and
+     *         funded with the amount returned by {_quoteSendHandlesToPeer}. The destination receiver gets the
+     *         derived handles aligned one-to-one by index. Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver.
+     * @param handles       Raw `bytes32` handles to bridge (mixing encrypted types is fine); this contract must hold
+     *                      ACL allowance on each. Should be non-empty and contain a maximum of 32 handles.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
+    function _sendHandlesToPeer(
+        uint32 dstEid,
+        bytes memory payload,
+        bytes32[] memory handles,
+        uint64 lzComposeGas
+    ) internal returns (bytes32 guid, uint64 nonce) {
+        (guid, nonce) = FHE.sendLZConfidentialBridge(
+            dstEid,
+            _getPeerOrRevert(dstEid),
+            payload,
+            handles,
+            lzComposeGas,
+            msg.value
+        );
+    }
+
+    /**
+     * @notice Quotes the LayerZero native fee to bridge a single handle to the peer configured for `dstEid`.
+     * @dev    Call this function before calling {_sendHandleToPeer} and forward the result as `msg.value`.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @dev    See {FHE-quoteLZConfidentialBridge} for the race-condition caveat.
+     * @param  dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param  payload       Opaque app payload matching the intended send (only its length affects the fee).
+     * @param  lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                       app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return nativeFee     The native fee to forward as `msg.value` to {_sendHandleToPeer}.
+     */
+    function _quoteSendHandleToPeer(
+        uint32 dstEid,
+        bytes memory payload,
+        uint64 lzComposeGas
+    ) internal view returns (uint256 nativeFee) {
+        bytes32[] memory handles = new bytes32[](1); // null handle works for the quote
+        nativeFee = FHE.quoteLZConfidentialBridge(
+            dstEid,
+            address(this),
+            _getPeerOrRevert(dstEid),
+            payload,
+            handles,
+            lzComposeGas
+        );
+    }
+
+    /**
+     * @notice Quotes the LayerZero native fee for a multi-handle send to the peer configured for `dstEid`.
+     * @dev    Call before {_sendHandlesToPeer} and forward the result as `msg.value`. Null handles are used for
+     *         the quote (the fee depends only on the number of handles, not their values), so pass `numHandles`
+     *         equal to the size of the list you intend to send. Reverts {NoPeer} if no peer is configured for
+     *         `dstEid`. See {FHE-quoteLZConfidentialBridge} for the race-condition caveat.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload matching the intended send (only its length affects the fee).
+     * @param numHandles    Number of handles the intended send will carry (must match for a correct estimate).
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return nativeFee    The native fee to forward as `msg.value` to {_sendHandlesToPeer}.
+     */
+    function _quoteSendHandlesToPeer(
+        uint32 dstEid,
+        bytes memory payload,
+        uint256 numHandles,
+        uint64 lzComposeGas
+    ) internal view returns (uint256 nativeFee) {
+        bytes32[] memory handles = new bytes32[](numHandles); // null handles work for the quote
+        nativeFee = FHE.quoteLZConfidentialBridge(
+            dstEid,
+            address(this),
+            _getPeerOrRevert(dstEid),
+            payload,
+            handles,
+            lzComposeGas
+        );
+    }
+}

--- a/library-solidity/codegen/src/templates/IDstApp.sol-template
+++ b/library-solidity/codegen/src/templates/IDstApp.sol-template
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+/**
+ * @title   IDstApp
+ * @notice Interface implemented by confidential destination apps to receive bridged payloads.
+ * @dev `onConfidentialBridgeReceived` is invoked from `ConfidentialBridge.lzCompose` inside a dedicated
+ *      `lzCompose` transaction, after transient ACL allowance has been granted to the
+ *      destination app for every derived handle in `dstHandleList`. Apps should treat
+ *      `srcHandleList` entries as opaque bytes blobs (they are source-chain handles,
+ *      not usable on this chain) and operate on `dstHandleList` entries by index.
+ * @dev     The {ConfidentialOAppReceiver} base contract implements this interface.
+ */
+interface IDstApp {
+    /**
+     * @notice Receive a bridged payload from a source chain.
+     * @dev **SECURITY WARNING**: When `onConfidentialBridgeReceived` is called, the implementing app MUST verify that:
+     *      (1) `msg.sender` is the `ConfidentialBridge`, and
+     *      (2) `srcApp` on the `srcEid` source chain has been registered as a trusted peer by the app.
+     *      Failing to enforce both checks is a security vulnerability: any caller could otherwise invoke
+     *      this callback, or a malicious/unauthorized source app could deliver forged payloads and handles,
+     *      leading to spoofed cross-chain messages and app-level state corruption.
+     * @param srcEid          The LayerZero endpoint id of the source chain.
+     * @param srcApp          The source app that initiated the bridge on the source chain,
+     *                        as bytes32. For EVM source chains this is a left-zero-padded
+     *                        20-byte address (`address(uint160(uint256(srcApp)))` to
+     *                        convert). For non-EVM source chains (e.g. Solana) this carries
+     *                        the full 32-byte native program/account identifier.
+     * @param payload         The opaque app-level payload (as encoded by the source app).
+     * @param srcHandleList   The list of source-chain handles, in the order the source app
+     *                        passed them to `ConfidentialBridge.send`. Treat as opaque bytes32.
+     * @param dstHandleList   The list of destination-chain handles derived from
+     *                        `srcHandleList`, one-to-one by index. The ConfidentialBridge has
+     *                        already granted transient ACL allowance to this app for each.
+     * @param guid            The LayerZero message GUID of the cross-chain transfer. Lets
+     *                        apps correlate this delivery with the source-side send (which
+     *                        emits the same GUID via `ConfidentialBridge`'s `BridgeHandle`).
+     *
+     * @dev Reverting from `onConfidentialBridgeReceived` reverts only the lzCompose transaction. Bridge state
+     *      from the lzReceive step (derivations + `HandleBridged` events) is already
+     *      committed on-chain and the coprocessor's association is unaffected.
+     *      Note that `lzCompose` can be retried. If the app determines the source app is
+     *      untrusted, it should revert here to prevent app-level state changes.
+     */
+    function onConfidentialBridgeReceived(
+        uint32 srcEid,
+        bytes32 srcApp,
+        bytes calldata payload,
+        bytes32[] calldata srcHandleList,
+        bytes32[] calldata dstHandleList,
+        bytes32 guid
+    ) external;
+}

--- a/library-solidity/examples/bridge/ConfidentialMultiChainToken.sol
+++ b/library-solidity/examples/bridge/ConfidentialMultiChainToken.sol
@@ -84,7 +84,7 @@ contract ConfidentialMultiChainToken is ConfidentialOApp {
     /**
      * @notice Quote the LayerZero native fee for a {send} call, without sending.
      * @dev    Mirrors {send}'s wire shape so the returned fee matches what {send} would
-     *         charge: the payload is an abi-encoded `(address, bytes32)` pair and a single
+     *         charge: the payload is an abi-encoded `address` (the recipient) and a single
      *         handle is bridged. The fee is a function only of that message shape and the
      *         execution options (derived from `mintComposeGas`), not of the
      *         `amount`/`recipient` values — so this view takes no amount and quotes with a

--- a/library-solidity/lib/bridge/ConfidentialOAppSender.sol
+++ b/library-solidity/lib/bridge/ConfidentialOAppSender.sol
@@ -11,7 +11,7 @@ import "encrypted-types/EncryptedTypes.sol";
  * @notice  Send side of a confidential omnichain app (cOApp) relying on a LayerZero-enabled ConfidentialBridge.
  *          Looks up the destination peer from the shared {ConfidentialOAppCore} registry and bridges encrypted
  *          handles to it through `FHE.sendLZConfidentialBridge`.
- * @dev     A message may carry up to 32 handes.
+ * @dev     A message may carry up to 32 handles.
  * @dev     The destination is taken from {peers} (a `bytes32`, so non-EVM peers work too).
  * @dev     Quote the fee with {_quoteSendHandleToPeer/_quoteSendHandlesToPeer} and forward it as `msg.value`
  *          when sending, i.e before calling any of {_sendHandleToPeer/_sendHandlesToPeer}.
@@ -50,7 +50,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         );
     }
 
-    /// @notice Type-safe {ebool} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {ebool} overload: bridges a single encrypted `ebool` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `ebool` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -60,7 +75,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {euint8} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {euint8} overload: bridges a single encrypted `euint8` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `euint8` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -70,7 +100,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {euint16} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {euint16} overload: bridges a single encrypted `euint16` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `euint16` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -80,7 +125,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {euint32} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {euint32} overload: bridges a single encrypted `euint32` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `euint32` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -90,7 +150,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {euint64} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {euint64} overload: bridges a single encrypted `euint64` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `euint64` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -100,7 +175,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {euint128} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {euint128} overload: bridges a single encrypted `euint128` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `euint128` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -110,7 +200,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {euint256} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {euint256} overload: bridges a single encrypted `euint256` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `euint256` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,
@@ -120,7 +225,22 @@ abstract contract ConfidentialOAppSender is ConfidentialOAppCore {
         (guid, nonce) = _sendHandleToPeer(dstEid, payload, FHE.toBytes32(handle), lzComposeGas);
     }
 
-    /// @notice Type-safe {eaddress} overload of the single-handle send; unwraps `handle` and bridges it to the peer on `dstEid`.. See the private {_sendHandleToPeer} core for the full semantics.
+    /**
+     * @notice Type-safe {eaddress} overload: bridges a single encrypted `eaddress` handle to the peer cOApp
+     *         configured for `dstEid`.
+     * @dev    Unwraps `handle` to `bytes32` and forwards to the private core. Wraps it in a one-element
+     *         list; the destination receiver references it at index 0. Forwards `msg.value` as the
+     *         LayerZero native fee, so the calling entrypoint must be `payable` and funded with
+     *         the amount returned by {_quoteSendHandleToPeer}.
+     * @dev    Reverts {NoPeer} if no peer is configured for `dstEid`.
+     * @param dstEid        Destination LayerZero endpoint id (must have a configured peer).
+     * @param payload       Opaque app payload; decoded by the destination receiver, which references the handle by index.
+     * @param handle        Encrypted `eaddress` handle to bridge; this contract must hold ACL allowance on it.
+     * @param lzComposeGas  Gas budget for the destination app callback `onConfidentialBridgeReceived` (lzCompose leg). The amount needed is
+     *                      app-specific, apps should size it for their `onConfidentialBridgeReceived` workload.
+     * @return guid         The LayerZero message guid.
+     * @return nonce        The LayerZero message nonce.
+     */
     function _sendHandleToPeer(
         uint32 dstEid,
         bytes memory payload,


### PR DESCRIPTION
## What

Makes the confidential-bridge **OApp abstracts under `lib/bridge/`** generated from `codegen/src`, so the whole `lib/` directory stays reproducible (`rm -rf lib/bridge && npm run codegen`) — they were hand-written before.

- New `codegen/src/templateBridge.ts` + templates for `ConfidentialOAppCore`, `ConfidentialOAppSender`, `ConfidentialOAppReceiver`, `ConfidentialOApp`, and `IDstApp`.
- The Sender's **per-encrypted-type single-handle overloads are now loop-generated** (one place) instead of hand-repeated 8×.
- Wired in `main.ts`, gated behind a new `lib.bridge` flag (`config.ts` + `codegen.config.json`) so it's **library-only** — host-contracts leaves it off and never emits the OApp abstracts.

## Notes

- **Verified reproducible & near-identical:** after wiping and regenerating, the four static abstracts (`Core`/`Receiver`/`ConfidentialOApp`/`IDstApp`) come out **byte-identical** to the current contracts; the only content deltas are two Sender doc typos the template corrects (`"32 handes"` → `"32 handles"`, and a stray double-period on the `eaddress` overload) plus the `ConfidentialMultiChainToken.quoteSend` payload natspec (`(address, bytes32)` → `address`).
- `hardhat compile` passes.
- Stacked on the method-name rename (`89d101c8b`); no naming changes here.
