### PR TITLE
chore(kms-connector): increase default gauge update interval

### DIFF
--- a/kms-connector/crates/tx-sender/src/core/config.rs
+++ b/kms-connector/crates/tx-sender/src/core/config.rs
@@ -183,7 +183,7 @@ fn default_gas_multiplier_percent() -> usize {
 }
 
 fn default_gauge_update_interval() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_secs(30)
 }
 
 fn default_operation_recovery_run_interval() -> Duration {


### PR DESCRIPTION
Increase default `gauge_update_interval` from `10s` to `30s` as it seems to be more aligned with default Prometheus scrapping time (avoid wasted work, especially now that we are running many queries in the gauge update routine).