### PR TITLE
chore: solana sector hygiene — doc index, module docs, feature-flag annotations (FI#1617)

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
@@ -1,3 +1,12 @@
+//! Transport-agnostic core of the Solana ingestion path: Anchor event decoding
+//! (`zama-host` + `confidential-token`) and mapping into the coprocessor
+//! database, shared by every transport ([`crate::solana_listener`] RPC polling,
+//! [`crate::solana_grpc_listener`] Yellowstone, LiteSVM in-process tests) and by
+//! the emitless reconstruction path ([`crate::solana_reconstruct`]).
+//!
+//! Design rationale lives in `solana/docs/DESIGN_DECISIONS.md` (event transport:
+//! DD-003; finalized-fetch decrypt trust model: DD-024).
+
 use std::{collections::HashSet, fmt, ops::DerefMut};
 
 use alloy_primitives::{Address, FixedBytes, Log};

--- a/coprocessor/fhevm-engine/host-listener/src/solana_finalized_account_fetcher.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_finalized_account_fetcher.rs
@@ -1,3 +1,7 @@
+//! Fetches finalized on-chain account state before enqueueing decrypts, so a
+//! decrypt is only served for data a finalized slot actually committed
+//! (finalized-fetch trust model, `solana/docs/DESIGN_DECISIONS.md` DD-024).
+
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -13,6 +13,20 @@ adopted
 product-open
   The PoC has a clear direction, but production API, governance, service integration, or encoding
   details still need a final product decision.
+
+superseded
+  A later DD or code change replaced this design; kept for history. The entry names its successor.
+```
+
+Index by subsystem (jump targets for the "read before changing X" pointer in the top README):
+
+```text
+ACL & handles            DD-001, DD-002, DD-005, DD-006, DD-008, DD-015, DD-019
+Input verification       DD-007, DD-013, DD-014, DD-026
+Decrypt / KMS / gateway  DD-012, DD-020, DD-021, DD-022, DD-024, DD-025, DD-027, DD-030
+Token & transfer         DD-009, DD-010, DD-011, DD-016, DD-018 (superseded)
+fhe_eval & events        DD-003, DD-004, DD-017, DD-023, DD-029
+Scope boundaries         DD-028
 ```
 
 ## DD-001: Store Handles In ACL Records, Not PDA Seeds

--- a/solana/docs/README.md
+++ b/solana/docs/README.md
@@ -20,5 +20,10 @@ TESTING.md
   Test layout, Mollusk runtime coverage, how to run the suites, and the build traps.
 ```
 
+Program-level docs live next to the code: [`../programs/zama-host/README.md`](../programs/zama-host/README.md)
+(state/PDA layout, roles, external-input flow) and
+[`../scripts/poc/test-keypairs/README.md`](../scripts/poc/test-keypairs/README.md) (committed PoC
+keypairs and rotation).
+
 When a change alters the intended architecture, update `DESIGN_DECISIONS.md` (or the relevant doc
 here) before treating the work as ready for handoff.

--- a/solana/programs/confidential-token/Cargo.toml
+++ b/solana/programs/confidential-token/Cargo.toml
@@ -17,6 +17,8 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build", "zama-host/idl-build"]
+# Demo-only helpers (e.g. create_random_amount) for the e2e scripts; must never
+# be enabled in a production build.
 poc = []
 
 [dependencies]

--- a/solana/programs/zama-host/Cargo.toml
+++ b/solana/programs/zama-host/Cargo.toml
@@ -17,6 +17,8 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build"]
+# Test-emit-only instructions (test_emit_*) for runtime-tests; must never be
+# enabled in a production build.
 poc = []
 # Emit on-chain events (`emit_cpi!`/`emit!`). Default-on so all existing builds
 # behave identically; disable with `--no-default-features` to let off-chain

--- a/solana/scripts/poc/adversarial-l4.sh
+++ b/solana/scripts/poc/adversarial-l4.sh
@@ -11,6 +11,7 @@
 #
 # Prereq: a running stack (solana/scripts/poc/clean-e2e.sh) — same as full-vertical.sh. Local-only,
 # MAINNET-safe (validator pinned 127.0.0.1:8899). Run AFTER (or independently of) full-vertical.sh.
+# Manual-only: not wired into solana-e2e.yml CI.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 KMS="$(cd "$ROOT/../../zama/kms" 2>/dev/null && pwd || echo /Users/work/code/zama/kms)"


### PR DESCRIPTION
Hygiene pass for [fhevm-internal#1617](https://github.com/zama-ai/fhevm-internal/issues/1617), rechecked against the current `feature/solana` tip (post `ac92f577e` docs cleanup and #2953). Comment/doc-only — zero behavior change.

Most of #1617 §1 (stale README/OZ_GUIDE/TRANSIENT_ALLOW prose) was already resolved by `ac92f577e`, and #2953 removed the naming-trap types (`EncryptedValueAcl`, receiver program). This PR lands what remains valid, plus small structural fixes surfaced by a fresh doc-footprint audit:

- **Feature-flag annotations (§4):** `poc` in `zama-host` and `confidential-token` Cargo.toml marked as test/demo-only, never for production builds. (`emit-events` already carried an adequate comment.)
- **Stray (§3):** `adversarial-l4.sh` is referenced from `solana/README.md` but not wired into CI — annotated as manual-only instead of deleted.
- **Module docs:** `solana_adapter.rs` (2.5k lines, previously zero module doc) and `solana_finalized_account_fetcher.rs` get `//!` headers stating their role among the six `solana_*` listener modules, with backlinks to `solana/docs/DESIGN_DECISIONS.md` (DD-003, DD-024) — the missing off-chain→on-chain doc backlink.
- **DESIGN_DECISIONS.md:** subsystem index (DD groups: ACL, input verification, decrypt/KMS, token, fhe_eval/events) so the top README's "read before touching X" pointer has jump targets, plus a `superseded` entry in the status legend.
- **Docs index:** `zama-host/README.md` and `test-keypairs/README.md` were unindexed; now linked from `solana/docs/README.md`.

Not done here (larger, separate work): host-listener `src/solana/` module regrouping (§2 of the issue, own mechanical PR), and missing READMEs for `confidential-token` / `confidential-deposit-app` / `crates/zama-fhe`.