### PR TITLE
docs: solana EVM_PARITY.md rewrite per sub-feature for readability

### DIFF
--- a/solana/docs/EVM_PARITY.md
+++ b/solana/docs/EVM_PARITY.md
@@ -1,198 +1,367 @@
-# EVM → Solana Parity Note
+# EVM → Solana Parity Map
 
-This note maps each EVM-side capability of the Zama confidential-token + FHEVM host design to
-its Solana equivalent in this PoC, or records a justified divergence. It is grounded in direct
-code review of `ERC7984.sol`, `host-contracts/`, `gateway-contracts/`, and the Solana programs +
-adapters (`fhevm/solana/programs/{zama-host,confidential-token,confidential-deposit-app}`,
-`fhevm/coprocessor/.../host-listener`, `fhevm/kms-connector`).
+What this document is: a per-sub-feature map of every EVM-side capability of the Zama
+confidential-token + FHEVM host design onto its Solana equivalent in this PoC — or a justified
+divergence. Every claim is grounded in code review of `ERC7984.sol`, `host-contracts/`,
+`gateway-contracts/`, and the Solana programs + adapters
+(`solana/programs/{zama-host,confidential-token,confidential-deposit-app}`,
+`coprocessor/.../host-listener`, `kms-connector`).
 
-Legend:
+Who it is for:
+
+- **Zama engineers** extending the port — each section names the code entry points.
+- **OpenZeppelin reviewers** — each section separates faithful parity from PoC shortcuts, and the
+  [fragility list](#fragile--attention-for-a-security-pass) is the security-pass worklist.
+- **Integrators porting from ERC7984** — read [Do not assume](#porting-from-erc7984-do-not-assume)
+  first; it lists the EVM guarantees that do *not* hold here.
+
+Design rationale for every divergence is recorded in
+[`DESIGN_DECISIONS.md`](./DESIGN_DECISIONS.md) (DD-001..DD-030) and RFC 024. Unsettled questions
+live in the [open decisions ledger](#open-decisions-ledger) at the end, with owners.
+
+## Legend
 
 - **MET** — Solana faithfully implements the EVM semantics (sometimes stricter).
-- **DIVERGENCE** — re-expressed differently because of a Solana platform constraint (account model,
-  no `msg.sender`, no transient storage, no `ecrecover`/EIP-712, shallow CPI stack, compute-budget
-  vs gas/HCU). The intent is preserved.
-- **SCOPE** — deliberately not implemented in this PoC; not Solana-constrained, mechanically
-  extensible; not required by the confidential token.
-- **PRODUCT-OPEN** — belongs to an off-chain service or a future program by design (KMS Core,
-  Gateway registry, keygen, payment, live transport).
+- **DIVERGENCE** — re-expressed differently because of a Solana platform constraint; intent preserved.
+- **PARTIAL** — the common path is ported, a named edge is not.
+- **INTENTIONAL GAP** — deliberately not ported; the section says what replaces it.
+- **SCOPE** — deliberately not in this PoC; not Solana-constrained; mechanically extensible.
+- **PRODUCT-OPEN** — belongs to an off-chain service or a future program by design.
 
-Design rationale for the divergences below is recorded in
-[`DESIGN_DECISIONS.md`](./DESIGN_DECISIONS.md) (DD-001..DD-030) and RFC 024.
+## The five constraints behind every divergence
 
----
+Every DIVERGENCE row below traces back to one of these Solana platform facts. Internalize them
+once and the rest of the document reads as consequences:
 
-## 1. ERC7984 confidential token → `confidential-token`
+1. **No `msg.sender`.** There is no implicit caller identity; compute identity is an explicit
+   signer account, and "the app" is an explicit app-context pubkey, not a program id (program ids
+   are reusable library code).
+2. **No transient storage.** EVM's `allowTransient`/tstore has no primitive; transaction-local
+   permission is modeled as instruction-local evidence plus CPI signer propagation (DD-008).
+3. **Accounts must be pre-declared, but computed handles are unpredictable.** Handles carry
+   protocol-injected entropy, so an account keyed on a handle cannot be named before the compute
+   runs. This single fact forced the nonce-key ACL design (DD-001).
+4. **Shallow CPI stack (~4 levels) and 64-account transaction cap.** Deep call-chains and
+   per-permission accounts do not scale; designs flatten instead of nest.
+5. **Storage (rent) is the dominant cost, not compute.** Account creation is expensive and
+   permanent; the design minimizes accounts born per operation.
 
-| ERC7984 capability | Semantics | Solana equivalent | Status |
-|---|---|---|---|
-| `confidentialTransfer(to, euint64)` | holder transfers an already-allowed handle; `require isAllowed(amount, sender)` | `confidential_transfer(amount_handle)` — owner-signed; owner-scoped amount ACL; rotates sender/recipient balance handles + births output ACL records | **MET** |
-| `confidentialTransfer(to, externalEuint64, inputProof)` | transfer a freshly verified external input | `confidential_transfer(amount_attestation)` — the attestation is consumed inline as the `fhe_eval` `FheEvalOperand::VerifiedInput` operand (the Solana `FHE.fromExternal` analog): verified in-frame, transient-allowed, no persistent input ACL | **MET** (DD-007: verify ≠ allow; caller-is-contract enforced via `attestation.contract_address == compute_subject`) |
-| `confidentialTransferFrom(from,to,euint64)` | operator transfer; `require isOperator` + `isAllowed`; `allowTransient(transferred, sender)` | no Solana production equivalent | **INTENTIONAL GAP** — operator/delegated transfer APIs were removed to simplify authority and reduce attack surface |
-| `confidentialTransferFrom(from,to,externalEuint64,proof)` | operator transfer of external input | no Solana production equivalent | **INTENTIONAL GAP** — the owner-authorized `confidential_transfer(amount_attestation)` fromExternal path is the supported route |
-| `confidentialTransferAndCall(...)` ×4 | transfer then call `onConfidentialTransferReceived`; refund `select(success,0,sent)`; `transferred = sent - refund`; transient-allow to sender | not ported; a receiving app exposes its own instruction that CPIs `confidential_transfer` with the user as sole signer (see `confidential-deposit-app`) | **INTENTIONAL GAP** (DD-011) — the callback is an EVM workaround for contracts not observing incoming transfers; Solana propagates signer authority through CPI. Token-2022 transfer hooks are rejected as a substitute (veto-only, not receiver callbacks) |
-| `setOperator(operator, until)` | time-bounded operator approval (`uint48` deadline); `OperatorSet` event | no Solana production equivalent | **INTENTIONAL GAP** — no operator rows or operator events |
-| `isOperator(holder, spender)` | `holder==spender \|\| now <= until` | no Solana production equivalent | **INTENTIONAL GAP** — holder self-authority is handled by owner-signed paths |
-| `requestDiscloseEncryptedAmount(euint64)` | `makePubliclyDecryptable` + event; `require isAllowed(amount, sender)` | `request_disclose_balance` / `request_disclose_amount` → host `allow_for_decryption`; emits `*DisclosureRequestedEvent` | **MET** (DD-010: label-scoped — balance vs amount paths distinct) |
-| `discloseEncryptedAmount(euint64, cleartext, proof)` | `FHE.checkSignatures` + `AmountDisclosed` event | `disclose_balance_secp` / `disclose_amount_secp(cleartext)` — verify ACL + material commitment + `public_decrypt` + on-chain secp256k1 KMS-cert verification against the witness-pinned `kms_context` (consume-once) | **MET** (DD-021/DD-022: mirrors EVM `KMSVerifier` — same threshold cert verifies on both sides) |
-| `confidentialTotalSupply()` view | encrypted total supply handle | `Mint` state total-supply handle (born in `initialize_mint`; rotated by `confidential_burn`) — read off-chain | **MET** (DIVERGENCE: account read, not a view call) |
-| `confidentialBalanceOf(account)` view | encrypted balance handle | `ConfidentialTokenAccount.balance_handle` (+ `balance_acl_record`, `next_balance_nonce_sequence`; RFC 024 token shape) — read off-chain | **MET** (DIVERGENCE: account read) |
-| `name/symbol/decimals(=6)/contractURI` views | metadata | mint/app config; `wrap_usdc` ties decimals to the underlying SPL mint | **DIVERGENCE** (app config / off-chain reads) |
-| `_mint(to, amount)` | increase total supply + credit | `initialize_mint` (total-supply ACL birth) + `wrap_usdc` (escrow SPL USDC → trivial-encrypt → add to balance) + `initialize_token_account` (zero-balance birth) | **DIVERGENCE** — minting modeled as SPL wrapping (RFC 024 wrap flow; real SPL-token boundary) |
-| `_burn(from, amount)` | decrease balance + total supply | `confidential_burn` (rotate balance + total supply) + `redeem_burned_amount` (release underlying from vault — KMS-cert gated, public-decrypt gated) | **MET** + Solana-only redeem leg (no ERC7984 analogue; wrapper needs underlying release) |
-| `_update` safe-math (`tryIncrease`/`tryDecrease`, `select`, allow/allowThis) | overflow/underflow-safe FHE balance update, conditional transfer of `select(success, amount, 0)` | `confidential-token/src/fhe.rs` + host `fhe_binary_op*`/`fhe_ternary_op_*` (add/sub/ge/select) + producer ACL birth | **PARTIAL** — `tryDecrease` reproduced (transfer/burn debit: `ge` → `sub` → `select(success, candidate, balance)`); `tryIncrease` NOT reproduced — the wrap/mint total-supply increase and the recipient credit use a plain `add`. Total-supply overflow is instead bounded by the 1:1 SPL backing (a real `u64` mint), per the `_mint` DIVERGENCE above. Output ACL via authorized producer paths |
-| `FHE.allow / allowThis` | durable ACL grant to user / contract | output `*_and_bind` producer paths (births canonical `AclRecord` with subjects) + `allow_acl_subjects` (append) | **MET** |
-| `FHE.allowTransient(transferred, sender)` | transaction-local grant | instruction-local `AllowedLocal` value within one `fhe_eval`, plus CPI signer propagation within one instruction | **DIVERGENCE** (no tstore; DD-008) |
-| `ConfidentialTransfer` / `OperatorSet` / `AmountDisclose(d/Requested)` events | indexing | token-local + host events (`AclAllowedEvent`, transfer/disclosure events); no operator events | **PARTIAL** (DD-003: events are indexing hints, not authorization) |
-| self-transfer | (EVM updates regardless) | `confidential_transfer` no-op when from==to (no handle rotation, no output ACL) | **MET** (RFC 024 explicit; avoids useless historical handles) |
+## Porting from ERC7984: do not assume
 
-ERC7984's FHE op footprint is exactly **add / sub / compare(ge) / select / trivial-encrypt / rand /
-fromExternal** — all implemented. The confidential token is therefore **op-complete**.
+The EVM standard makes guarantees this port deliberately does not. Integrators arriving from
+Solidity should check each of these against their assumptions:
 
----
-
-## 2. FHEVM host (`host-contracts/`) → `zama-host`
-
-| EVM unit | Capability | Solana equivalent | Status |
-|---|---|---|---|
-| `ACL.allow(handle, account)` | persistent grant; caller must be allowed | `allow_acl_subjects` — authority `Signer` + `ACL_ROLE_GRANT` on record + canonical PDA + deny-list + pause; append-only | **MET** (stricter: explicit grant role) |
-| `ACL.allowForDecryption(handles[])` | mark publicly decryptable | `allow_for_decryption` — dedicated `ACL_ROLE_PUBLIC_DECRYPT`, never set at birth, idempotent | **MET** (DIVERGENCE: per-handle; DD-005) |
-| `ACL.allowTransient(handle, account)` | tx-local grant | no durable analog; instruction-local `AllowedLocal` within one `fhe_eval`, plus CPI signer propagation within one instruction | **DIVERGENCE** (no tstore; DD-008) |
-| `ACL.isAllowed(handle, account)` | transient OR persistent | `assert_acl_record` / `assert_record_subject_role(ACL_ROLE_USE)` | **MET** |
-| `ACL.isAllowedForDecryption(handle)` | public-decrypt flag | `AclRecord.public_decrypt` | **MET** |
-| `ACL.persistAllowed` / `allowedTransient` | read pair | inline subject lookup + `AclPermission` overflow PDA; transient = instruction-local `AllowedLocal` | **MET** / **DIVERGENCE** |
-| `ACL.cleanTransientStorage()` | wipe tx transient (AA bundling) | nothing to reclaim — `AllowedLocal` values are instruction-scoped and never persisted (the one-shot `TransientSession` account tier was removed, DD-008) | **DIVERGENCE** (no durable transient state) |
-| `ACL.delegate/revokeForUserDecryption` | user-decrypt delegation lifecycle | `delegate_for_user_decryption` / `revoke_...` — PDA per `(delegator,delegate,app)`, slot-based expiry, same-slot double-update guard, wildcard-delegate rejected | **MET** |
-| `ACL` deny list (`blockAccount`/`isAccountDenied`) | owner deny list | `set_deny_subject` + `DenySubjectRecord`, gated into grant paths | **MET** |
-| `ACL` pause/owner/UUPS | pauser role, 2-step ownership, upgrade | single `admin` (`set_host_pause` etc.) | **DIVERGENCE** (admin signer) + **PRODUCT-OPEN** (BPF upgrade authority handles program upgrade) |
-| `FHEVMExecutor.fheAdd/fheSub` | binary add/sub | `fhe_binary_op{,_and_bind_output}` op=Add/Sub | **MET** |
-| `FHEVMExecutor.fheGe` | ≥ comparison → ebool | op=Ge | **MET** |
-| `FHEVMExecutor.fheIfThenElse(select)` | ternary; ebool control, branch type-checked | `fhe_ternary_op_and_bind_output` op=IfThenElse | **MET** |
-| `FHEVMExecutor.fheRand/fheRandBounded` | random / bounded random | `fhe_rand_and_bind` / `fhe_rand_bounded_and_bind` (pow2+≤max bound check) | **MET** (DIVERGENCE: slot/bankhash+nonce seed vs counterRand+blockhash) |
-| `FHEVMExecutor.trivialEncrypt` | plaintext → ct handle | `trivial_encrypt_and_bind` | **MET** |
-| `FHEVMExecutor.verifyCiphertext` (input) | verify signed/proved input, allowTransient | `fhe_eval` `FheEvalOperand::VerifiedInput` operand — in-frame secp256k1 recover + threshold-check of the coprocessor EIP-712 `CiphertextVerification` attestation, asserts `contract_chain_id == host chain id`; transient-allowed, no persistent ACL | **MET** (DD-007: verify ≠ allow; same coprocessor EIP-712 trust root as EVM) |
-| `FHEVMExecutor` batched/expression compute | — | `fhe_eval` (bounded mixed-step eval; `MAX_FHE_EVAL_OPS=16`) | **MET** (Solana-native batching to limit CPI depth; DD-008; mixed binary/ternary/trivial-encrypt/rand steps with `AllowedLocal` transients, and `VerifiedInput` operands) |
-| operand ACL + scalar rule | encrypted operand needs ACL; scalar exempt | `assert_record_subject_role(ACL_ROLE_USE)` per operand; scalar RHS rejects a permission witness | **MET** (RFC 024 scalar rule; DD-006) |
-| handle byte-layout (ver/type/chainid/computed-marker) + entropy-seeded derivation | symbolic-exec handle | identical layout; `sha256(domain, op, operands, programID, chainid, prev_bank_hash, ts)` + nonce-bound variant for durable outputs | **MET** (DIVERGENCE: sha256 vs keccak, bankhash vs blockhash → handles not cross-chain-interoperable) |
-| compute identity = `msg.sender` | implicit caller | explicit `compute_subject: Signer` checked `is_signer && is_allowed` | **DIVERGENCE** (no `msg.sender`; RFC 024 compute-signer) |
-| `FHEVMExecutor` op breadth: Mul/Div/Rem/BitAnd/Or/Xor/Shl/Shr/Rotl/Rotr/Eq/Ne/Gt/Lt/Le/Min/Max, Neg/Not, cast, Sum/IsIn | full opcode catalog | only Add/Sub/Ge/IfThenElse shipped | **SCOPE** — not Solana-constrained; mechanically extensible (enum + per-op type-gate table + handle hash already op-parametrized + coprocessor map arm + tests); **not used by ERC7984** |
-| `HCULimit` (per-op/tx/block/depth homomorphic-compute caps) | gas-like metering | `HostConfig::max_hcu_per_tx` / `max_hcu_depth_per_tx` summed over an `fhe_eval` plan (`0` = off), plus Solana compute-budget + op-count/collection caps | **DIVERGENCE** (per-plan cap + compute-budget vs per-block metering) — see fragility #3 |
-| `KMSVerifier` (on-chain decrypt-sig threshold verify) | verify KMS sigs on-chain | on-chain secp256k1: `eip712::verify_kms_public_decrypt` recovers EVM KMS signers and threshold-checks them against the witness-pinned `KmsContext` (rejects high-s) | **MET** (DD-021: mirrors EVM `KMSVerifier`) |
-| `ProtocolConfig` / `KMSGeneration` / `PauserSet` (role set) | KMS node/threshold registry, keygen, pauser role set | none (subset in `HostConfig`: authorities/chain_id/flags) | **PRODUCT-OPEN** |
-| `FheType` (86 variants) | type enum | supported set Bool/Uint8..Uint256 (covers token + shipped ops) | **MET (partial)** / **SCOPE** (signed/large/string types) |
+- **No operator / approve / `transferFrom`.** All production transfer paths are owner-signed.
+  A program that needs to move a user's funds composes via CPI with the user's signature
+  propagating through (see [§6](#6-cpi-composition--confidential-deposit-app)). Delegation
+  semantics for multi-transfer flows (swaps, subscriptions) are an open product question tracked
+  in the ledger.
+- **No `confidentialTransferAndCall` / receiver callback.** The EVM callback exists because
+  contracts cannot observe incoming transfers; Solana apps drive the transfer themselves inside
+  their own instruction, atomically (DD-011).
+- **Multi-leg flows that EVM does in one transaction may be multiple transactions here** (e.g.
+  burn → redeem is two legs, the second gated on a KMS certificate). Refund-on-reject is
+  best-effort across legs, not atomic.
+- **`tryIncrease` safe-math is not reproduced on credit paths.** The debit path reproduces EVM's
+  `ge → sub → select` underflow guard; the recipient-credit and total-supply increase use a plain
+  FHE `add`, bounded instead by the 1:1 SPL backing of the wrap model (a real `u64` mint). Fine
+  for 6-decimal wrapped USDC; re-evaluate before any high-supply/18-decimal token.
+- **Views are account reads.** `confidentialBalanceOf`-style calls become reads of
+  `ConfidentialTokenAccount` / mint state, off-chain.
+- **Events are indexing hints, never authorization** (DD-003). Nothing security-relevant may be
+  derived from an event alone.
 
 ---
 
-## 3. Gateway / KMS (`gateway-contracts/`) → `zama-host` + `kms-connector` + token disclose
+## 1. ACL & handles
 
-| EVM gateway capability | Semantics | Solana equivalent | Status |
-|---|---|---|---|
-| `Decryption.publicDecryptionRequest/Response` | request + threshold-consensus public decrypt | token `request_disclose_*` (sets `public_decrypt`, creates a `DisclosureRequest` witness PDA); on-chain `disclose_*_secp` consumes a secp256k1 KMS cert verified against the witness-pinned `KmsContext` | **MET** (DD-012/DD-021/DD-022: same EVM KMS trust model, verified on-chain) |
-| `Decryption.userDecryptionRequest` + EIP-712 | user-signed, contract-scoped, validity window | routed through the unified Gateway V2 path via the typed `userDecryptionRequestSolana(HandleEntry[], UserDecryptionRequestSolanaPayload)` entrypoint; chain-aware validator branches on `contracts_chain_id` | **MET** (DD-012/DD-026/DD-027: reuses the Gateway/EVM stack, typed Solana fields) |
-| `Decryption.delegatedUserDecryptionRequest` + RFC-017 wildcard | delegate-signed; wildcard contract scope | `UserDecryptionDelegation` PDA per `(delegator,delegate,app)`, slot expiry, wildcard = `[0xff;32]` app-context sentinel; carried in the same Gateway V2 Solana user-decrypt payload | **MET** (semantics) / **DIVERGENCE** (PDA mechanism) |
-| `Decryption.userDecryptionResponse` (per-share sigs → threshold) | threshold response | Gateway V2 response path; connector verifies the KMS threshold response | **MET** (DD-012) |
-| `checkDecryptionReady` (material added) | all handles have ciphertext material | `verify_material_commitment` (state==COMMITTED + canonical PDA) / on-chain `assert_material_commitment` | **MET** |
-| `CiphertextCommits.addCiphertextMaterial` | multi-coprocessor consensus adds (keyId, ctDigest, snsDigest) | `commit_handle_material` — single `material_authority` writes one-shot `HandleMaterialCommitment`, seals ACL record | **DIVERGENCE** (consensus → single authority; consensus is off-chain) |
-| `checkCiphertextMaterial` | material-present check | `commitment.state==COMMITTED` + hash binding | **MET** |
-| `InputVerification.verifyProofRequest/Response` (ZKPoK consensus) + `FHEVMExecutor.verifyInput` (tx-scoped transient allow, no persistent ACL) | coprocessor ZK-proof verify + consensus + EIP-712; verifyInput grants only a transient allow | `FheEvalOperand::VerifiedInput` (the `FHE.fromExternal` analog) — consuming it in `fhe_eval` does on-chain secp256k1 recover + threshold-check of the coprocessor EIP-712 `CiphertextVerification` attestation and asserts `contract_chain_id == host chain id`; transient-allows the input for that eval, creates **no persistent ACL** (DD-007) | **MET** (parity with `verifyInput`: verify ≠ allow; Solana has no transient store so durable perms are a separate explicit grant) + partial **SCOPE/PRODUCT-OPEN** (external proof/transciphering service, no `rejectProofResponse`) |
-| `HandleOps`/`FHETypeBitSizes` | parse chainId/fheType; bit-size table | mirrored exactly in connector (`solana_native_handle_chain_id`, `*_fhe_type_encrypted_bits`) | **MET** |
-| `MAX_DECRYPTION_REQUEST_BITS=2048` | per-request cleartext cap | `SOLANA_NATIVE_MAX_ENCRYPTED_BITS_PER_REQUEST=2048` enforced | **MET** |
-| `Structs` (Sns material, delegation, pairs) | cross-contract DTOs | witness structs + on-chain `AclRecord`/`UserDecryptionDelegation`/`HandleMaterialCommitment` | **MET** (re-modeled) |
-| unified decrypt routing | (Solana as a Gateway host chain) | Solana is registered as a host chain (bytes32 ACL = the `zama_host` program id, high-bit chain id); decrypt reuses the Gateway V2 path rather than a parallel native stack. Residual `native-v0` connector library/store code exists but is not the chosen path (DD-012) | **MET** (unified) / superseded native-v0 subsystem |
-| `GatewayConfig` (KMS/coprocessor/host-chain/threshold registry) | on-chain registry | connector reads registry off-chain (`Config`); `HostConfig` holds authorities/flags, the single coprocessor input signer, and the current `KmsContext` pointer | **PRODUCT-OPEN** |
-| `KMSGeneration` (keygen/crsgen ceremony) | key/CRS lifecycle | none (referenced only by `key_id`) | **PRODUCT-OPEN** |
-| `ProtocolPayment` ($ZAMA fees) | per-request fee | none (rent/tx fees only) | **PRODUCT-OPEN** |
+**EVM:** `ACL.sol` — persistent `allow(handle, account)` mapping slots, deny list, transient
+allow, `msg.sender`-implicit granting.
+**Solana:** handles cannot key accounts (constraint 3), so ACL records are PDAs derived from
+app-controlled nonce metadata, and the handle is stored *inside* the record, bound at compute time
+(DD-001). Grants are append-only with an explicit grant role — stricter than EVM's implicit model.
+
+| EVM capability | Solana equivalent | Status |
+|---|---|---|
+| `ACL.allow(handle, account)` | `allow_acl_subjects` — authority `Signer` + `ACL_ROLE_GRANT` + canonical PDA + deny-list + pause; append-only | **MET** (stricter) |
+| `ACL.allowForDecryption(handles[])` | `allow_for_decryption` — dedicated `ACL_ROLE_PUBLIC_DECRYPT`, never set at birth (DD-005) | **MET** (per-handle) |
+| `ACL.isAllowed` / `isAllowedForDecryption` | `assert_acl_record` / role checks / `AclRecord.public_decrypt` | **MET** |
+| inline subjects overflow | `AclPermission` canonical overflow PDA (`MAX_ACL_SUBJECTS=8` inline) | **MET** (DD-004: layout is ABI) |
+| deny list (`blockAccount`) | `set_deny_subject` + `DenySubjectRecord`, gated into grant paths | **MET** |
+| pause / 2-step owner / UUPS | single `admin` signer; BPF loader owns upgrades | **DIVERGENCE** + **PRODUCT-OPEN** (see [§9](#9-admin-config--governance)) |
+| `delegate/revokeForUserDecryption` | PDA per `(delegator, delegate, app)`, slot expiry, same-slot guard, wildcard-delegate rejected | **MET** |
+
+State types, one line each (the names are close; the purposes are not):
+`AclRecord` — the canonical per-handle authorization record (subjects, roles, public-decrypt flag);
+`AclPermission` — overflow witness PDA for subjects beyond the inline 8;
+`HandleMaterialCommitment` — ciphertext-material availability, separate from authorization (DD-006).
+
+Handle derivation preserves the EVM byte layout (version/type/chain-id/computed-marker) but hashes
+with sha256 over bank-hash entropy instead of keccak over blockhash — handles are therefore **not
+cross-chain interoperable** (accepted divergence). Fail-closed when the prior bank hash is
+unavailable; the zero-entropy fallback is compile- and chain-id-confined to the local PoC chain
+(DD-014, DD-015).
+
+Code: `zama-host/src/state/{acl_record,acl_permission,deny_subject_record}.rs`,
+`instructions/{allow_acl_subjects,assert_acl_record,allow_for_decryption,set_deny_subject}.rs`,
+`instructions/fhe_eval/handles.rs`. Tests: `runtime-tests/tests/host_mollusk.rs`.
+
+> **Known cost problem.** This model creates ACL accounts per transfer; at Solana rent prices that
+> is on the order of $1–2 per confidential transfer — explicitly rejected as a production cost
+> (guild decision, June 2026). The successor design (mutable encrypted-value "current" pointer +
+> Merkle Mountain Range for historical proofs) is specified in fhevm-internal#1569 and is **not**
+> in this code yet. This document describes what is built, not that plan.
+
+## 2. Transient allow
+
+**EVM:** `allowTransient` writes tstore, wiped at transaction end; `transferAndCall` leans on it.
+**Solana:** no transient storage (constraint 2). Transaction-local permission is
+instruction-local: an `AllowedLocal` value alive within one `fhe_eval`, plus signer authority
+propagating through CPI within one instruction. Nothing durable is written, so there is nothing
+to clean (`cleanTransientStorage` has no analog; the earlier one-shot `TransientSession` account
+tier was removed — DD-008). Cross-CPI transient allowance ("oneshot accounts") was deliberately
+deferred until a real DeFi flow proves the need.
+
+## 3. Input verification
+
+**EVM:** `InputVerification.verifyProofRequest/Response` (ZKPoK consensus) +
+`FHEVMExecutor.verifyInput` — verified inputs get a *transient* allow only; persisting is the
+app's explicit job.
+**Solana:** identical semantics, one mechanism: the `FheEvalOperand::VerifiedInput` operand
+consumed inside `fhe_eval` (the `FHE.fromExternal` analog). It re-verifies the coprocessor's
+EIP-712 `CiphertextVerification` attestation in-frame via `secp256k1_recover` + threshold check,
+asserts `contract_chain_id == host chain id`, and transient-allows the input for that eval only —
+no persistent ACL is created (DD-007: verify ≠ allow).
+
+Two deliberate choices worth knowing the why of:
+
+- **Coprocessors keep their EVM secp256k1/EIP-712 keys** — verifying EIP-712 on Solana is cheap,
+  and issuing coprocessors Solana-native keys would double key-management for an input path that
+  the transciphering RFC (tech-spec#457) is expected to replace. Decision June 2026.
+- **The standalone `verify_coprocessor_input` instruction and `InputVerifiedEvent` were removed**
+  — verification is inline-only, matching EVM's "verifyInput grants transient only" shape. A
+  regression test pins this (`plan_contracts.rs`).
+
+Status: **MET**, with **SCOPE/PRODUCT-OPEN** residue (the external proof service behind the
+attestation, `rejectProofResponse`) and one production blocker: the signer set is a single
+hardcoded signer at threshold 1 (fragility #1, fhevm-internal#1608).
+
+Code: `zama-host/src/instructions/input_verification.rs`, `eip712.rs`;
+SDK `sdk/js-sdk/src/core/coprocessor/SolanaZkProof-p.ts`.
+
+## 4. `fhe_eval` & FHE ops (+ HCU)
+
+**EVM:** `FHEVMExecutor` — one op per external call, gas + `HCULimit` for per-op/tx/block metering.
+**Solana:** `fhe_eval` is a bounded batched evaluator (`MAX_FHE_EVAL_OPS=16`, mixed
+binary/ternary/trivial-encrypt/rand steps + `VerifiedInput` operands + `AllowedLocal` transients)
+— Solana-native batching that respects the CPI depth budget (constraint 4). Compute identity is an
+explicit `compute_subject: Signer` (constraint 1). Per-op standalone instructions
+(`fhe_binary_op*`, `fhe_rand*`, `trivial_encrypt_and_bind`) exist alongside.
+
+| Capability | Status |
+|---|---|
+| Add / Sub / Ge / IfThenElse(select) / Rand / RandBounded / trivialEncrypt / fromExternal | **MET** — exactly ERC7984's op footprint; the token is **op-complete** |
+| Remaining opcode catalog (Mul, Div, bitwise, shifts, Eq/Ne/Gt/…, casts, Sum/IsIn) | **SCOPE** — mechanically extensible: enum + per-op type-gate row + handle hash (already op-parametrized) + coprocessor map arm + tests |
+| operand ACL + scalar rule | **MET** — `ACL_ROLE_USE` per encrypted operand; scalar RHS rejects a permission witness |
+| `FheType` breadth (86 variants) | **MET (partial)** — Bool/Uint8..Uint256; signed/large/string types are SCOPE |
+| `HCULimit` per-op/tx/block/depth metering | **DIVERGENCE** — per-plan caps (`HostConfig::max_hcu_per_tx`, `max_hcu_depth_per_tx`, 0 = off) + Solana compute budget; **no per-block plane** (fragility #3) |
+
+HCU framing from the guild (June 2026): HCU is fundamentally *metering* for future
+pay-per-computation; the limit is a DoS stopgap. Per-instruction limits were chosen over
+per-transaction; a per-block budget is under design — a naive global counter would serialize the
+chain to ~85 TPS through one hot account, so the direction is per-app budgets (ledger item).
+
+Code: `zama-host/src/instructions/fhe_eval.rs` + `fhe_eval/{admission,event_budget,event_transport,handles,hcu,preflight,walk}.rs`.
+Tests: `host_mollusk.rs`, `plan_contracts.rs`.
+
+## 5. Confidential token (ERC7984 → `confidential-token`)
+
+A standalone program (not a Token-2022 extension — the ZK confidential-transfer extension is
+unadopted and cryptographically incompatible; guild decision June 2026), modeled as a wrap of a
+real SPL mint. Minting is SPL escrow + trivial-encrypt; burning releases the underlying via a
+KMS-cert-gated redeem leg.
+
+| ERC7984 capability | Solana equivalent | Status |
+|---|---|---|
+| `confidentialTransfer(to, euint64)` | `confidential_transfer(amount_handle)` — owner-signed; rotates both balance handles + births output ACL records | **MET** |
+| `confidentialTransfer(to, external, proof)` | `confidential_transfer(amount_attestation)` — attestation consumed inline as `VerifiedInput` | **MET** (DD-007) |
+| `confidentialTransferFrom` (×2, operator) | — | **INTENTIONAL GAP** — owner-signed paths only; see [Do not assume](#porting-from-erc7984-do-not-assume) |
+| `confidentialTransferAndCall` (×4) | app-driven CPI composition ([§6](#6-cpi-composition--confidential-deposit-app)) | **INTENTIONAL GAP** (DD-011) |
+| `setOperator` / `isOperator` | — | **INTENTIONAL GAP** — delegation semantics = open ledger item |
+| `requestDiscloseEncryptedAmount` | `request_disclose_{balance,amount}` → `allow_for_decryption`; label-scoped (DD-010) | **MET** |
+| `discloseEncryptedAmount(cleartext, proof)` | `disclose_{balance,amount}_secp` — ACL + material + `public_decrypt` + on-chain secp256k1 KMS cert against witness-pinned `kms_context`, consume-once | **MET** (DD-021/DD-022) |
+| `confidentialTotalSupply` / `confidentialBalanceOf` / metadata views | account reads (`Mint` supply handle, `ConfidentialTokenAccount.balance_handle`) | **DIVERGENCE** (account reads) |
+| `_mint` | `initialize_mint` + `wrap_usdc` (SPL escrow → trivial-encrypt → add) | **DIVERGENCE** (wrap model) |
+| `_burn` | `confidential_burn` + `redeem_burned_amount_secp` (KMS-cert-gated underlying release) | **MET** + Solana-only redeem leg |
+| `_update` safe-math | debit path `ge → sub → select` reproduced; credit/supply-increase plain `add` | **PARTIAL** — see [Do not assume](#porting-from-erc7984-do-not-assume) |
+| `FHE.allow / allowThis` | `*_and_bind` producer paths + `allow_acl_subjects` | **MET** |
+| self-transfer no-op | no handle rotation when from==to (RFC 024) | **MET** |
+| token events | token-local + host events; no operator events | **PARTIAL** (DD-003) |
+
+Persistence discipline: a transfer persists only the final balance handles and the
+transferred-amount ACL record — intermediates stay transient (DD-019).
+
+Code: `programs/confidential-token/src/instructions/`, `src/fhe.rs`, `src/state/`.
+Tests: `runtime-tests/tests/token_mollusk.rs`.
+
+## 6. CPI composition (→ `confidential-deposit-app`)
+
+The replacement for `confidentialTransferAndCall`, shown as a working reference: a vault-style
+`deposit` instruction that CPIs `confidential_token::confidential_transfer` with the depositor's
+one signature propagating through — the transfer and the app's own bookkeeping are atomic in one
+transaction, and the receiver *is* the caller, so the EVM callback's success-bit provenance
+problem cannot arise (that provenance gap was OZ's headline finding on the earlier ported callback
+flow, fhevm-internal#1591; the flow was removed by #2953).
+
+Code: `programs/confidential-deposit-app/src/lib.rs`. Status: **DD-011 realized**; exercised by
+the e2e vertical, no dedicated Mollusk suite yet.
+
+## 7. Decrypt paths
+
+**User decrypt — MET, via the real Gateway.** Solana is a registered Gateway host chain (bytes32
+ACL id, high-bit chain id). User decrypts route through the unified Gateway V2 path with a typed
+`userDecryptionRequestSolana` entrypoint (DD-012 — a reversal: an earlier native-v0 Solana-only
+stack was built, then abandoned for Gateway reuse; its residual connector code is dead scaffolding
+to retire). The user-facing signature is **native ed25519** (a Solana wallet signature, not
+EIP-712) — re-verified per-party by the kms-connector; the KMS *return* path stays
+EIP-712/secp256k1 so KMS nodes need no EdDSA support. Delegation is a PDA per
+`(delegator, delegate, app)` with slot expiry; wildcard = sentinel app-context (RFC-017 parity).
+
+**Public decrypt — MET, verified on-chain.** `request_disclose_*` creates a `DisclosureRequest`
+witness PDA; `disclose_*_secp` consumes a KMS `PublicDecryptVerification` cert with full on-chain
+secp256k1 threshold verification against the witness-pinned `KmsContext` singleton (DD-020/DD-021/
+DD-022 — witness created before the consume; consume-once; context rotation rejects stale certs).
+Same KMS trust root as EVM's `KMSVerifier`, verified with the same rigor.
+
+Code: `zama-host/src/instructions/{allow_for_decryption,define_kms_context,delegate_for_user_decryption}.rs`,
+`eip712.rs::verify_kms_public_decrypt`; SDK `sdk/js-sdk/src/solana/actions/userDecrypt.ts`,
+`core/coprocessor/SolanaUserDecrypt-p.ts`; connector
+`kms-worker/src/core/{event_processor/solana_user_decrypt.rs,solana_v2_fetcher.rs,solana_acl.rs}`.
+Adversarial live checks: `scripts/poc/adversarial-l4.sh` (signature-substitution and
+context-rotation rejection).
+
+## 8. Event transport, listener & finality
+
+**EVM:** logs are a trusted, durable part of execution; the listener just subscribes.
+**Solana:** log delivery is provider-dependent and `emit!` is droppable, so **events are indexing
+hints, never authorization** (DD-003), and the listener can rebuild every compute/ACL event from
+instruction data alone:
+
+- `solana_listener.rs` — RPC-polling transport; `solana_grpc_listener.rs` — Yellowstone gRPC
+  transport (the production direction; guild decision June 2026, validated by a PoC that tracked
+  CPI + PDA creation with zero emitted events); both feed the shared decoder in
+  `solana_adapter.rs`.
+- `solana_reconstruct.rs` — the emitless path: rebuilds events from decoded instructions + block
+  context (`solana_slot_hashes.rs` streams the SlotHashes sysvar for off-chain handle
+  recomputation). The e2e suite runs one leg with an EMITLESS build of `zama-host` to prove
+  reconstruction is a complete event source.
+- Audience split (decided, details open): Zama's own ingestion uses Yellowstone; a lean
+  `emit_cpi` surface stays for third-party indexers who won't run Geyser. Which events are
+  public-facing is an open ledger item.
+
+**Finality:** decrypts must only be served for state a finalized slot committed.
+`solana_finalized_account_fetcher.rs` re-fetches account state at `finalized` before enqueueing
+decrypts (DD-024). The big open question — *where the finality gate sits* and wiring the Solana
+poller into the EVM reorg substrate — is DD-025 / fragility #5. `drift_revert` is poller drift,
+not an on-chain reorg (DD-029).
+
+Status: **DIVERGENCE** by design (DD-003) + **PRODUCT-OPEN** (production Geyser provider, reorg
+wiring).
+
+## 9. Admin, config & governance
+
+`HostConfig` singleton: authorities, chain id, pause, HCU caps, feature flags
+(`initialize_host_config`, `set_host_pause`, `set_max_hcu_*`). Divergences from EVM:
+single admin signer (no 2-step ownership), no UUPS — Solana programs upgrade natively through the
+BPF loader, so no proxy pattern exists or is needed. Production governance (a Squads multisig vs.
+the single Ethereum DAO used for EVM chains; whether Squads supports a Safe-style admin-module
+override) is a dedicated RFC in progress — ledger item. `ProtocolConfig` / `KMSGeneration` /
+`PauserSet` registry equivalents: **PRODUCT-OPEN** (no KMS keygen is needed on Solana; keys are
+referenced by `key_id` only).
+
+## 10. Gateway registry & payment
+
+`GatewayConfig` (registry) is read off-chain by the connector; `HostConfig` carries the
+Solana-side subset (authorities, coprocessor input signer, current `KmsContext`).
+`ProtocolPayment` ($ZAMA fees): none — rent and tx fees only. Both **PRODUCT-OPEN**.
+Kept name: the gateway entrypoint stays `verifyProofRequestSolana` (DD-030, decided after debate).
+
+## 11. Cross-repo ABI pinning (load-bearing, easy to miss)
+
+Connector account decoders and the coprocessor's vendored IDL are **hand-mirrored against
+`zama-host/src/state/` with no compile-time link**. Guards: `scripts/check_solana_abi.py` (ABI
+golden manifest), `check-zama-host-idl.sh` (IDL drift), `EVENT_VERSION` pins, and DD-004's
+negative-test discipline. A same-length field reorder would still not be caught at build time —
+treat any state-layout change as a cross-repo ABI break: update program checks, connector
+decoders, listener constants, IDL/golden files, and docs together (see `TESTING.md` traps).
+
+## 12. Testing & e2e surface
+
+Automated: Mollusk suites `runtime-tests/tests/{host_mollusk,token_mollusk,plan_contracts}.rs`
+(the negative-test suite is the enforcement arm of DD-004). Live vertical: `scripts/poc/`
+(`clean-e2e.sh`, `full-vertical.sh` — CI-wired via `solana-e2e.yml`, including the EMITLESS
+reconstruction leg; `adversarial-l4.sh` — manual-only). Details: [`TESTING.md`](./TESTING.md).
 
 ---
 
-## 4. Coprocessor / KMS adapter integration
+## Critical assessment
 
-- **Coprocessor host-listener** (`coprocessor/.../host-listener/src/solana_adapter.rs`): decodes
-  zama-host Anchor CPI events (codegen from vendored IDL `idl/zama_host.json`) into TFHE/ACL DB
-  rows. `cargo check -p host-listener` → exit 0. **Library-only**: no live Geyser/Yellowstone
-  subscriber is wired (PRODUCT-OPEN, DD-003). Only Add/Sub/Ge / IfThenElse mapped (tracks §2 SCOPE).
-- **KMS connector** (`kms-connector/crates/kms-worker/src/core/solana_*.rs` and
-  `kms-connector/crates/tx-sender/src/core/solana_native.rs`): witness decoders +
-  `SolanaAclVerifier` (canonical-PDA, owner, hash-domain, role checks). Decrypt reuses the unified
-  Gateway V2 path with a typed Solana user-decrypt entrypoint and on-chain secp256k1 cert verification
-  (DD-012/DD-021/DD-026); the older `native-v0` request/response subsystem remains as library/store
-  code but is not the chosen path and is not wired into the worker/tx-sender binaries. Account layouts
-  are hand-mirrored 1:1 against
-  `zama-host/src/state/` (verified) but **version-pinned / no compile-time link** — a
-  layout/seed/hash-domain/EVENT_VERSION change in zama-host requires editing the connector decoder,
-  bumping listener event constants, and regenerating the coprocessor IDLs/ABI golden manifest.
+### Solid (faithful, often stricter than EVM)
 
-**Adapters are present and integrated at the PoC boundary.** Live transport (production Geyser
-provider, full KMS-connector wiring beyond the harness, and wiring the Solana poller into the EVM
-reorg substrate) is PRODUCT-OPEN by design (DD-024/DD-025/DD-028).
+The ACL core (explicit grant role, append-only, canonical PDAs), public-decrypt as a post-birth
+release, delegation lifecycle, preserved handle byte-layout, operand-ACL discipline + scalar rule,
+ABI/account-meta exactness with extensive negative tests, the owner-authorized token flows with
+label-scoped disclosure, on-chain secp256k1 verification of both coprocessor attestations and KMS
+certs (same trust roots as EVM), and the connector's canonical-PDA + material-binding checks.
 
----
+### Fragile — attention for a security pass
 
-## 5. Critical assessment — solid vs fragile
+PoC shortcuts, not correctness bugs; each maps to a PRODUCT-OPEN item or tracked issue.
 
-**Solid (faithful, often stricter than EVM):** the ACL core (`allow`/`isAllowed`/grant authority/
-append-only/no-generic-bind per RFC 024), public-decrypt release gated on a dedicated role and never
-at birth, delegation lifecycle (slot expiry, same-slot guard, wildcard-delegate rejection), one-shot
-transient capabilities with same-tx creation proof, preserved handle byte-layout,
-operand-ACL discipline + scalar-RHS rule, ABI/account-meta exactness (DD-004, extensive negative
-tests), the confidential-token flows (owner-authorized transfer/transfer-and-call split/wrap/burn/redeem/
-disclose) with separate payer semantics and label-scoped disclosure (DD-010), and the
-connector's canonical-PDA + material-binding verification.
+1. **Single coprocessor input signer at threshold 1** (`HostConfig::coprocessor_signer`); the
+   threshold machinery exists but is unused for inputs. → registered n-of-m set,
+   fhevm-internal#1608.
+2. **`poc`-gated test shims** are compiled out of production; the zero-birth-entropy fallback is
+   additionally chain-id-confined (DD-014). Residual risk is build discipline only.
+3. **No per-block HCU plane** — per-plan caps + compute budget only; per-app block budget under
+   design (ledger).
+4. **Disclosure/redemption off-chain wiring** — on-chain verification is complete; a deployed
+   finalized-fetcher and KMS cert publication path still need production wiring.
+5. **Solana poller not wired into the EVM reorg substrate** (DD-025) — polls at `confirmed`,
+   inserts directly. Reorg correctness is the biggest open architectural gap; native-v0 residue to
+   retire with it.
+6. **Hand-mirrored cross-repo ABI** ([§11](#11-cross-repo-abi-pinning-load-bearing-easy-to-miss)).
+7. **Material commitment is one-shot with single-authority blast radius** — a wrong seal
+   permanently bricks a handle's decryptability (EVM has consensus in front of the same
+   irreversibility).
+8. **ACL storage cost** (~$1–2/transfer) is production-rejected — successor design tracked, not
+   yet built (see [§1](#1-acl--handles)).
 
-**Fragile / attention for a security pass (PoC shortcuts, not correctness bugs):**
+## Open decisions ledger
 
-1. **Input verification trusts a single coprocessor signer at threshold 1** (`HostConfig::coprocessor_signer`),
-   not yet a registered n-of-m set — the threshold machinery (`eip712::verify_threshold`) exists but
-   input verification uses the single-signer path. Remaining work is the registered signer set
-   (FUTURE_DESIGN §1) and the real proof/transciphering service behind the attestation.
-2. **Test/mock bypass gates** (`set_test_shims_enabled`, `test_emit_*`) are `#[cfg(feature = "poc")]`
-   — compiled out of default/production builds. The surviving state relaxation, the zero birth-entropy
-   fallback, is additionally confined to `SOLANA_POC_CHAIN_ID` via `HostConfig::zero_birth_entropy_allowed`,
-   so it cannot weaken birth entropy on a deployed chain regardless of flags (DD-014). The former
-   `mock_input_verified_and_bind` input short-circuit was removed entirely.
-3. **No per-block HCU / complexity metering.** The host caps total and critical-path HCU per
-   `fhe_eval` plan (`HostConfig::max_hcu_per_tx` / `max_hcu_depth_per_tx`, `0` = off) plus the Solana
-   compute budget, but there is no EVM-style per-block `HCULimit` plane. Relevant to DoS/cost-bounding.
-4. **On-chain disclosure/redemption uses secp256k1 KMS-cert verification + request witnesses.**
-   The listener persists finalized account fetch intents and exposes claim/store/complete helpers. The
-   residual risk is off-chain integration: a deployed fetcher and KMS certificate publication path
-   still need to be wired before the flow is end-to-end production ready.
-5. **The Solana poller is not wired into the EVM reorg substrate** (DD-025/DD-028): it polls at
-   `confirmed` and inserts directly, bypassing the block-status machine. Reorg correctness is an open
-   gap and the residual `native-v0` connector code is dead scaffolding to retire.
-6. **Hand-mirrored, version-pinned ABI across repos with no compile-time link** (connector decoders +
-   vendored coprocessor IDL). Lengths are checked, but a same-length field reorder in `AclRecord`
-   would not be caught at build time. Event versions are now pinned by
-   `solana/scripts/check_solana_abi.py` and `check-zama-host-idl.sh`; `MAX_ACL_SUBJECTS=8` remains a
-   PoC capacity limit mirrored by off-chain decoders.
-7. **`previous_bank_hash` is fail-closed on real chains.** When the prior bank hash is unavailable,
-   handle birth returns `PreviousBankHashUnavailable` rather than substituting a zero hash. The
-   zero-hash fallback (intended only for local Mollusk bootstrap) is confined to `SOLANA_POC_CHAIN_ID` via
-   `HostConfig::zero_birth_entropy_allowed`, so it cannot weaken birth entropy on a deployed chain
-   (DD-014). Bank-hash + timestamp entropy is the resolved policy (keep per-block entropy, DD-015).
-8. **Material commitment is one-shot/irreversible** with single-authority blast radius — a wrong seal
-   permanently bricks a handle's decryptability (matches EVM "no delete" but without consensus).
+Questions this document deliberately does not answer, with owners (as of July 2026):
 
-None of the fragilities are correctness defects in the implemented paths (the negative-test suite is
-extensive); they are the expected boundary between a PoC and a production deployment, and every one
-maps to an item tracked as PRODUCT-OPEN in `DESIGN_DECISIONS.md` / `FUTURE_DESIGN.md`.
+| Question | Direction so far | Owner / tracker |
+|---|---|---|
+| ACL storage successor (encrypted-value "current" + MMR history) | specified, PoC pending | Elias — fhevm-internal#1569, RFC-024 |
+| Operator/approve/delegation semantics for multi-transfer flows | OZ retiring `setOperator` toward "confidential approve" on EVM; Solana analog to be co-designed | joint Zama/OZ session; Roman, Joseph-André |
+| Historical-access semantics (does "current" grant history? revocable?) | punted to product | Arik |
+| User-decrypt signing UX (raw sign vs SIWS envelope) | SIWS most promising, undecided | product + SDK |
+| App-context identity (which pubkey stands in for `msg.sender` per app) | mint/market/vault PDA per app, opaque to KMS | design thread, tech-spec#448 |
+| Per-app HCU block budget | avoids the hot-account TPS ceiling of a global counter | NikitaK, PR pending |
+| Which events are public (`emit_cpi`) vs internal (Yellowstone) | keep both, split by audience | guild |
+| Governance (Squads vs cross-chain DAO, admin-module override) | dedicated RFC | Joseph-André |
+| Finality-gate placement / reorg substrate wiring | DD-025 (BIG OPEN) | host-listener owners |
+| Transciphering input flow (replaces ZKPoK + attestations) | tech-spec#457 — track, don't wait | Panos; Nico reviewing |
 
----
+## Net verdict
 
-## 6. Net parity verdict
-
-- **Confidential token (ERC7984):** intentionally **not fully ported**. The owner-authorized
-  transfer, wrap/burn/redeem, disclosure, and encrypted-balance flows cover the Solana PoC surface;
-  ERC7984 operator/delegated-transfer APIs are deliberate gaps, transfer-and-call is replaced by
-  app-driven CPI composition (DD-011), and Solidity view-style calls are account-read equivalents.
 - **FHEVM host authorization model** (ACL, executor authorization, input verification, transient,
-  decrypt release, delegation, material commitment): faithfully ported, frequently stricter.
-- **Constraint-driven divergences** are all intentional and documented (no tstore, no `msg.sender`,
-  shallow CPI, per-plan HCU cap vs per-block metering, account-witnesses vs storage reads). Input and
-  KMS-cert verification use on-chain secp256k1 recovery — the same EIP-712 trust roots as EVM.
-- **SCOPE** items (executor opcode breadth, full FheType set) are not Solana-limited and not needed
-  by the token; mechanically extensible.
-- **PRODUCT-OPEN** items (`ProtocolConfig`/`KMSGeneration`/`GatewayConfig`/payment, registered
-  coprocessor signer set, production Geyser provider + reorg wiring, full KMS-connector wiring,
-  external input proof service) are off-chain services or future work by design (DD-012, DD-003,
-  DD-007, DD-025).
+  decrypt release, delegation, material commitment): **faithfully ported, frequently stricter**.
+- **Confidential token:** intentionally **not fully ported** — owner-signed transfer, wrap/burn/
+  redeem, and disclosure cover the PoC surface; operator APIs and transfer-and-call are deliberate
+  gaps replaced by Solana-idiomatic composition.
+- **Every divergence is constraint-driven and documented**; nothing diverges silently.
+- **SCOPE** items (opcode breadth, full type set) are mechanical extensions, not Solana limits.
+- **PRODUCT-OPEN** items are the PoC→production boundary: registries, payment, signer sets,
+  production event transport, reorg wiring — each tracked above.

--- a/solana/docs/EVM_PARITY.md
+++ b/solana/docs/EVM_PARITY.md
@@ -161,7 +161,7 @@ explicit `compute_subject: Signer` (constraint 1). Per-op standalone instruction
 | Capability | Status |
 |---|---|
 | Add / Sub / Ge / IfThenElse(select) / Rand / RandBounded / trivialEncrypt / fromExternal | **MET** — exactly ERC7984's op footprint; the token is **op-complete** |
-| Remaining opcode catalog (Mul, Div, bitwise, shifts, Eq/Ne/Gt/…, casts, Sum/IsIn) | **SCOPE, closing** — being added by fhevm#2975 (fheSum/fheIsIn/fheMulDiv, unary + missing binary ops); the extension recipe is mechanical: enum + per-op type-gate row + handle hash (already op-parametrized) + coprocessor map arm + tests |
+| Remaining opcode catalog (Mul, Div, bitwise, shifts, Eq/Ne/Gt/…, casts, Sum/IsIn) | **SCOPE** — mechanically extensible: enum + per-op type-gate row + handle hash (already op-parametrized) + coprocessor map arm + tests |
 | operand ACL + scalar rule | **MET** — `ACL_ROLE_USE` per encrypted operand; scalar RHS rejects a permission witness |
 | `FheType` breadth (86 variants) | **MET (partial)** — Bool/Uint8..Uint256; signed/large/string types are SCOPE |
 | `HCULimit` per-op/tx/block/depth metering | **DIVERGENCE** — per-plan caps (`HostConfig::max_hcu_per_tx`, `max_hcu_depth_per_tx`, 0 = off) + Solana compute budget; **no per-block plane** (fragility #3) |

--- a/solana/docs/EVM_PARITY.md
+++ b/solana/docs/EVM_PARITY.md
@@ -96,11 +96,11 @@ State types, one line each (the names are close; the purposes are not):
 `AclPermission` — overflow witness PDA for subjects beyond the inline 8;
 `HandleMaterialCommitment` — ciphertext-material availability, separate from authorization (DD-006).
 
-Handle derivation preserves the EVM byte layout (version/type/chain-id/computed-marker) but hashes
-with sha256 over bank-hash entropy instead of keccak over blockhash — handles are therefore **not
-cross-chain interoperable** (accepted divergence). Fail-closed when the prior bank hash is
-unavailable; the zero-entropy fallback is compile- and chain-id-confined to the local PoC chain
-(DD-014, DD-015).
+Handle derivation preserves the EVM byte layout (version/type/chain-id/computed-marker) **and the
+keccak256 hash**; what differs is the entropy source (previous bank hash + timestamp vs blockhash)
+and the embedded chain id, which keep handles chain-scoped by construction. (sha256 appears only in
+the ACL nonce-key domain hash, DD-001.) Fail-closed when the prior bank hash is unavailable; the
+zero-entropy fallback is compile- and chain-id-confined to the local PoC chain (DD-014, DD-015).
 
 Code: `zama-host/src/state/{acl_record,acl_permission,deny_subject_record}.rs`,
 `instructions/{allow_acl_subjects,assert_acl_record,allow_for_decryption,set_deny_subject}.rs`,
@@ -161,7 +161,7 @@ explicit `compute_subject: Signer` (constraint 1). Per-op standalone instruction
 | Capability | Status |
 |---|---|
 | Add / Sub / Ge / IfThenElse(select) / Rand / RandBounded / trivialEncrypt / fromExternal | **MET** — exactly ERC7984's op footprint; the token is **op-complete** |
-| Remaining opcode catalog (Mul, Div, bitwise, shifts, Eq/Ne/Gt/…, casts, Sum/IsIn) | **SCOPE** — mechanically extensible: enum + per-op type-gate row + handle hash (already op-parametrized) + coprocessor map arm + tests |
+| Remaining opcode catalog (Mul, Div, bitwise, shifts, Eq/Ne/Gt/…, casts, Sum/IsIn) | **SCOPE, closing** — being added by fhevm#2975 (fheSum/fheIsIn/fheMulDiv, unary + missing binary ops); the extension recipe is mechanical: enum + per-op type-gate row + handle hash (already op-parametrized) + coprocessor map arm + tests |
 | operand ACL + scalar rule | **MET** — `ACL_ROLE_USE` per encrypted operand; scalar RHS rejects a permission witness |
 | `FheType` breadth (86 variants) | **MET (partial)** — Bool/Uint8..Uint256; signed/large/string types are SCOPE |
 | `HCULimit` per-op/tx/block/depth metering | **DIVERGENCE** — per-plan caps (`HostConfig::max_hcu_per_tx`, `max_hcu_depth_per_tx`, 0 = off) + Solana compute budget; **no per-block plane** (fragility #3) |


### PR DESCRIPTION
Rewrites `solana/docs/EVM_PARITY.md` — same verified facts as before (every parity row re-checked against the current tip), restructured to be readable and breathable for its three real audiences:

- **Zama engineers**: one section per sub-feature (ACL & handles, transient allow, input verification, fhe_eval+HCU, confidential token, CPI composition, decrypt paths, event transport & finality, admin/governance, gateway registry, ABI pinning, testing), each with a short prose *why*, a trimmed table, and exact code pointers.
- **OpenZeppelin reviewers**: the fragility list is kept intact as the security-pass worklist, and PoC shortcuts are explicitly separated from production requirements throughout.
- **ERC7984 integrators**: a new top-level **"porting from ERC7984: do not assume"** section — non-atomicity of multi-leg flows, no operator/approve, partial safe-math, account-read views, events-are-hints — the exact traps raised in the OZ review of the PoC.

Structural additions:
- **The five platform constraints** (no `msg.sender`, no transient storage, pre-declared accounts vs unpredictable handles, shallow CPI/64-account cap, rent-dominated cost) stated once up front, so every DIVERGENCE row reads as a consequence rather than an arbitrary choice.
- **Open decisions ledger** with owners and trackers: ACL storage successor (FI#1569), operator/approve semantics (joint OZ session), historical-access policy (product), user-decrypt signing UX, per-app HCU block budget, public-vs-internal event split, governance RFC, finality gate (DD-025), transciphering (tech-spec#457).
- The ACL **cost problem** (~$1–2/transfer, production-rejected) stated explicitly instead of implied.

Content sources: code review at the current `feature/solana` tip, `DESIGN_DECISIONS.md` DD-001..030, guild weekly decisions (Apr–Jul 2026), and the OZ-track review findings (FI#1591/#1593 context). No code changes.