### PR TITLE
chore(relayer): bump version to 0.14.0

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "fhevm-relayer"
-version = "0.9.0-rc.3"
+version = "0.14.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fhevm-relayer"
-version = "0.9.0-rc.3"
+version = "0.14.0"
 license = "BSD-3-Clause-Clear"
 edition = "2021"
 

--- a/relayer/openapi.yml
+++ b/relayer/openapi.yml
@@ -115,7 +115,7 @@ info:
   license:
     name: BSD-3-Clause-Clear
     url: https://opensource.org/licenses/BSD-3-Clause-Clear
-  version: 0.9.0-rc.3
+  version: 0.14.0
 servers:
 - url: /
   description: Current server
@@ -1968,7 +1968,7 @@ components:
           example: fhevm-relayer
         version:
           type: string
-          example: 0.9.0
+          example: 0.14.0
   securitySchemes:
     ApiKeyAuth:
       type: apiKey

--- a/relayer/relayer-migrate/Cargo.lock
+++ b/relayer/relayer-migrate/Cargo.lock
@@ -969,7 +969,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "relayer-migrate"
-version = "0.9.0-rc.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "dotenvy",

--- a/relayer/relayer-migrate/Cargo.toml
+++ b/relayer/relayer-migrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-migrate"
-version = "0.9.0-rc.3"
+version = "0.14.0"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
## Summary

- Bumps the relayer version from `0.9.0-rc.3` to `0.14.0`.

## Changes

- `relayer/Cargo.toml` — `fhevm-relayer` crate version
- `relayer/relayer-migrate/Cargo.toml` — `relayer-migrate` helper crate (kept in lockstep)
- `relayer/Cargo.lock` / `relayer/relayer-migrate/Cargo.lock` — lockfile entries
- `relayer/openapi.yml` — spec `version` field and the response example

🤖 Generated with [Claude Code](https://claude.com/claude-code)