### PR TITLE
feat(sdk): cleartext relayer reads plaintexts from the executor (Option B)

### DIFF
--- a/sdk/js-sdk/src/core/modules/ethereum/types-ct.ts
+++ b/sdk/js-sdk/src/core/modules/ethereum/types-ct.ts
@@ -1,4 +1,4 @@
-import type { Bytes65Hex, BytesHex, ChecksummedAddress } from '../../types/primitives.js';
+import type { Bytes65Hex, BytesHex, ChecksummedAddress, Uint256 } from '../../types/primitives.js';
 import type { Prettify } from '../../types/utils.js';
 import type { EthereumModule } from './types.js';
 
@@ -72,6 +72,32 @@ export type RecoverAddressModuleFunction = {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// hashTypedData
+////////////////////////////////////////////////////////////////////////////////
+
+// Same EIP-712 inputs as `signTypedData`, minus the wallet signer: computes the
+// 32-byte typed-data digest so a raw KMS/coprocessor private key can sign it via
+// `sign({ hash, privateKey })`. Used by the cleartext relayer to synthesize
+// KMS signatures without standing up a `Cleartext*` on-chain verifier.
+export type HashTypedDataParameters = Readonly<{
+  domain: {
+    readonly chainId: Uint256;
+    readonly name: string;
+    readonly verifyingContract: ChecksummedAddress;
+    readonly version: string;
+  };
+  types: Readonly<Record<string, ReadonlyArray<{ name: string; type: string }>>>;
+  primaryType: string;
+  message: Readonly<Record<string, unknown>>;
+}>;
+
+export type HashTypedDataReturnType = BytesHex;
+
+export type HashTypedDataModuleFunction = {
+  hashTypedData(parameters: HashTypedDataParameters): HashTypedDataReturnType;
+};
+
+////////////////////////////////////////////////////////////////////////////////
 // cleartextEthereumModule
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -81,7 +107,8 @@ export type CleartextEthereumModule = EthereumModule &
       SignModuleFunction &
       GeneratePrivateKeyModuleFunction &
       GetPublicKeyModuleFunction &
-      RecoverAddressModuleFunction
+      RecoverAddressModuleFunction &
+      HashTypedDataModuleFunction
   >;
 
 export type CleartextEthereumModuleFactory = () => {

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchDelegatedUserDecrypt.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchDelegatedUserDecrypt.ts
@@ -1,4 +1,3 @@
-import type { BytesHex, ChecksummedAddress } from '../../../types/primitives.js';
 import type { FetchUserDecryptResultItem } from '../../../types/relayer.js';
 import type { CleartextEthereumModule } from '../../ethereum/types-ct.js';
 import type {
@@ -7,60 +6,16 @@ import type {
   RelayerClientWithRuntime,
 } from '../types.js';
 import { remove0x } from '../../../base/string.js';
-import { asUint32BigInt, tryParseUintBigIntString, randomUniqueUints } from '../../../base/uint.js';
+import { randomUniqueUints } from '../../../base/uint.js';
 import { getTrustedClient } from '../../../runtime/CoreFhevm-p.js';
 import { userDecryptResultToKmsSigncryptedShares } from '../utils.js';
 import { getKmsSignersPrivateKeyMap } from './signers.js';
-
-////////////////////////////////////////////////////////////////////////////////
-
-const delegatedUserDecryptAbi = [
-  {
-    type: 'function',
-    name: 'delegatedUserDecrypt',
-    inputs: [
-      {
-        name: 'pairs',
-        type: 'tuple[]',
-        internalType: 'struct HandleContractPair[]',
-        components: [
-          { name: 'handle', type: 'bytes32', internalType: 'bytes32' },
-          {
-            name: 'contractAddress',
-            type: 'address',
-            internalType: 'address',
-          },
-        ],
-      },
-      { name: 'delegator', type: 'address', internalType: 'address' },
-      { name: 'delegate', type: 'address', internalType: 'address' },
-      { name: 'publicKey', type: 'bytes', internalType: 'bytes' },
-      {
-        name: 'contractAddresses',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'startTimestamp',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'durationDays',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      { name: 'delegateSignature', type: 'bytes', internalType: 'bytes' },
-    ],
-    outputs: [
-      { name: 'payload', type: 'bytes', internalType: 'bytes' },
-      { name: 'signers', type: 'address[]', internalType: 'address[]' },
-      { name: 'threshold', type: 'uint256', internalType: 'uint256' },
-      { name: 'extraData', type: 'bytes', internalType: 'bytes' },
-    ],
-    stateMutability: 'view',
-  },
-] as const;
+import {
+  readCleartextExecutorAddress,
+  readKmsSignersAndThreshold,
+  readPlaintexts,
+  xorMaskWithPublicKey,
+} from './plaintextSource.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -73,6 +28,8 @@ export async function fetchDelegatedUserDecrypt(
   const pairs = payload.handleContractPairs;
   const contractAddresses = payload.kmsDecryptEip712Message.contractAddresses;
 
+  // Replicates CleartextKMSVerifier._requireAllPairsAuthorized: every requested
+  // pair's contract must appear in the EIP-712 authorized contractAddresses list.
   const authCount = contractAddresses.length;
   for (const { contractAddress: c } of pairs) {
     let authorized: boolean = false;
@@ -87,33 +44,30 @@ export async function fetchDelegatedUserDecrypt(
     }
   }
 
-  const { kmsDecryptEip712Message, kmsDecryptEip712Signer, kmsDecryptEip712Signature } = payload;
+  const { kmsDecryptEip712Message } = payload;
+
+  // Option B: read cleartexts from CleartextFHEVMExecutor.plaintexts and rebuild
+  // the KMS payload off-chain. The delegation (delegator/delegate) authorization
+  // is enforced by the caller (fetchKmsSigncryptedSharesV1 step 7, checkDelegation).
   const trustedClient = getTrustedClient(relayerClient);
-  const res = (await relayerClient.runtime.ethereum.readContract(trustedClient, {
-    abi: delegatedUserDecryptAbi,
-    address: relayerClient.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
-    args: [
-      pairs.map((p) => ({
-        handle: p.handle.bytes32Hex,
-        contractAddress: p.contractAddress,
-      })),
-      kmsDecryptEip712Message.delegatorAddress,
-      kmsDecryptEip712Signer,
-      kmsDecryptEip712Message.publicKey,
-      kmsDecryptEip712Message.contractAddresses,
-      _parseUintBigIntString('kmsDecryptEip712Message.startTimestamp', kmsDecryptEip712Message.startTimestamp),
-      _parseUintBigIntString('kmsDecryptEip712Message.durationDays', kmsDecryptEip712Message.durationDays),
-      kmsDecryptEip712Signature,
-    ],
-    functionName: delegatedUserDecryptAbi[0].name,
-  })) as unknown[];
+  const executorAddress = await readCleartextExecutorAddress(relayerClient, trustedClient);
+  const rawCleartexts = await readPlaintexts(
+    relayerClient,
+    trustedClient,
+    executorAddress,
+    pairs.map((p) => p.handle),
+  );
 
-  const commonKmsSigncryptedSharePayload = res[0] as BytesHex;
+  const maskedCleartexts = xorMaskWithPublicKey(kmsDecryptEip712Message.publicKey, rawCleartexts);
+  const extraData = kmsDecryptEip712Message.extraData;
+
+  const commonKmsSigncryptedSharePayload = relayerClient.runtime.ethereum.encode({
+    types: ['uint256[]', 'bytes'],
+    values: [maskedCleartexts, extraData],
+  });
   const commonKmsSigncryptedSharePayloadNo0x = remove0x(commonKmsSigncryptedSharePayload);
-  const signersAddress = res[1] as readonly ChecksummedAddress[];
-  const threshold = asUint32BigInt(res[2]);
-  const extraData = res[3] as BytesHex;
 
+  const { signers: signersAddress, threshold } = await readKmsSignersAndThreshold(relayerClient, trustedClient);
   const signers = getKmsSignersPrivateKeyMap(relayerClient);
 
   const randomSignersAddress = randomUniqueUints(signersAddress.length, Number(threshold)).map(
@@ -134,14 +88,4 @@ export async function fetchDelegatedUserDecrypt(
   }
 
   return userDecryptResultToKmsSigncryptedShares(result);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-function _parseUintBigIntString(label: string, value: string): bigint {
-  const bn = tryParseUintBigIntString(value);
-  if (bn === undefined) {
-    throw new Error(`${label} is not a valid uint string, got ${JSON.stringify(value)}`);
-  }
-  return bn;
 }

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchPublicDecrypt.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchPublicDecrypt.ts
@@ -1,30 +1,16 @@
-import type { Bytes32Hex, Bytes65Hex, BytesHex, ChecksummedAddress } from '../../../types/primitives.js';
+import type { Bytes65Hex, BytesHex } from '../../../types/primitives.js';
 import type { CleartextEthereumModule } from '../../ethereum/types-ct.js';
 import type { FetchPublicDecryptParameters, FetchPublicDecryptReturnType, RelayerClientWithRuntime } from '../types.js';
 import { getTrustedClient } from '../../../runtime/CoreFhevm-p.js';
+import { createKmsEip712Domain } from '../../../kms/createKmsEip712Domain.js';
+import { kmsPublicDecryptEip712Types } from '../../../kms/kmsPublicDecryptEip712Types.js';
 import { getKmsSignersPrivateKeyMap } from './signers.js';
-
-////////////////////////////////////////////////////////////////////////////////
-
-const publicDecryptAbi = [
-  {
-    type: 'function',
-    name: 'publicDecrypt',
-    inputs: [{ name: 'handles', type: 'bytes32[]', internalType: 'bytes32[]' }],
-    outputs: [
-      {
-        name: 'abiEncodedCleartexts',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-      { name: 'digest', type: 'bytes32', internalType: 'bytes32' },
-      { name: 'signers', type: 'address[]', internalType: 'address[]' },
-      { name: 'threshold', type: 'uint256', internalType: 'uint256' },
-      { name: 'extraData', type: 'bytes', internalType: 'bytes' },
-    ],
-    stateMutability: 'view',
-  },
-] as const;
+import {
+  encodeTypedCleartexts,
+  readCleartextExecutorAddress,
+  readKmsSignersAndThreshold,
+  readPlaintexts,
+} from './plaintextSource.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -33,26 +19,55 @@ export async function fetchPublicDecrypt(
   parameters: FetchPublicDecryptParameters,
 ): Promise<FetchPublicDecryptReturnType> {
   const cleartextEthereumModule = relayerClient.runtime.ethereum as CleartextEthereumModule;
+  const orderedHandles = parameters.payload.orderedHandles;
 
+  // Option B: read cleartexts from CleartextFHEVMExecutor.plaintexts and rebuild
+  // the public-decrypt result off-chain instead of reading the CleartextKMSVerifier
+  // view. ACL `isAllowedForDecryption` gating is enforced by the caller
+  // (publicDecrypt step 4, checkAllowedForDecryption).
   const trustedClient = getTrustedClient(relayerClient);
-  const res = (await relayerClient.runtime.ethereum.readContract(trustedClient, {
-    abi: publicDecryptAbi,
-    address: relayerClient.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
-    args: [parameters.payload.orderedHandles.map((h) => h.bytes32Hex)],
-    functionName: publicDecryptAbi[0].name,
-  })) as unknown[];
+  const executorAddress = await readCleartextExecutorAddress(relayerClient, trustedClient);
+  const cleartexts = await readPlaintexts(relayerClient, trustedClient, executorAddress, orderedHandles);
 
-  const digest = res[1] as Bytes32Hex;
-  const signersAddress = res[2] as readonly ChecksummedAddress[];
+  const orderedAbiEncodedClearValues = encodeTypedCleartexts(cleartextEthereumModule, orderedHandles, cleartexts);
+
+  // The caller passes the requested extraData (= current KmsSignersContext
+  // extraData). Reuse it verbatim so the returned extraData reconciles exactly
+  // (publicDecrypt step 6) and the signed digest matches the verifier's.
+  const extraData = parameters.payload.extraData;
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Warning!!!! Do not sign over '0x00' — only '0x' is permitted (matches
+  // verifyKmsPublicDecryptEip712 / createPublicDecryptionProof).
+  ////////////////////////////////////////////////////////////////////////////
+  const signedExtraData: BytesHex = extraData === ('0x00' as BytesHex) ? ('0x' as BytesHex) : extraData;
+
+  // A 'PublicDecryptVerification' domain uses the gateway chainId.
+  const domain = createKmsEip712Domain({
+    chainId: relayerClient.chain.fhevm.gateway.id,
+    verifyingContractAddressDecryption: relayerClient.chain.fhevm.gateway.contracts.decryption.address,
+  });
+
+  const digest = cleartextEthereumModule.hashTypedData({
+    domain,
+    types: kmsPublicDecryptEip712Types,
+    primaryType: 'PublicDecryptVerification',
+    message: {
+      ctHandles: orderedHandles.map((h) => h.bytes32Hex),
+      decryptedResult: orderedAbiEncodedClearValues,
+      extraData: signedExtraData,
+    },
+  });
+
+  const { signers: signersAddress } = await readKmsSignersAndThreshold(relayerClient, trustedClient);
   const signers = getKmsSignersPrivateKeyMap(relayerClient);
 
   const kmsPublicDecryptEip712Signatures: Bytes65Hex[] = [];
 
-  for (let i = 0; i < signersAddress.length; ++i) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const privateKey = signers.get(signersAddress[i]!);
+  for (const signerAddress of signersAddress) {
+    const privateKey = signers.get(signerAddress);
     if (privateKey === undefined) {
-      throw new Error('Unable to find kms signer');
+      throw new Error(`Unable to find KMS signer for address ${signerAddress}`);
     }
 
     const signature = await cleartextEthereumModule.sign({ hash: digest, privateKey });
@@ -60,8 +75,8 @@ export async function fetchPublicDecrypt(
   }
 
   return {
-    orderedAbiEncodedClearValues: res[0] as BytesHex,
+    orderedAbiEncodedClearValues,
     kmsPublicDecryptEip712Signatures,
-    extraData: res[4] as BytesHex,
+    extraData,
   };
 }

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchUserDecrypt.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/fetchUserDecrypt.ts
@@ -1,61 +1,17 @@
-import type { BytesHex, ChecksummedAddress } from '../../../types/primitives.js';
 import type { FetchUserDecryptResultItem } from '../../../types/relayer.js';
 import type { CleartextEthereumModule } from '../../ethereum/types-ct.js';
 import type { FetchUserDecryptParametersV1, FetchUserDecryptReturnType, RelayerClientWithRuntime } from '../types.js';
 import { remove0x } from '../../../base/string.js';
-import { asUint32BigInt, tryParseUintBigIntString, randomUniqueUints } from '../../../base/uint.js';
+import { randomUniqueUints } from '../../../base/uint.js';
 import { getTrustedClient } from '../../../runtime/CoreFhevm-p.js';
 import { userDecryptResultToKmsSigncryptedShares } from '../utils.js';
 import { getKmsSignersPrivateKeyMap } from './signers.js';
-
-////////////////////////////////////////////////////////////////////////////////
-
-const userDecryptAbi = [
-  {
-    type: 'function',
-    name: 'userDecrypt',
-    inputs: [
-      {
-        name: 'pairs',
-        type: 'tuple[]',
-        internalType: 'struct HandleContractPair[]',
-        components: [
-          { name: 'handle', type: 'bytes32', internalType: 'bytes32' },
-          {
-            name: 'contractAddress',
-            type: 'address',
-            internalType: 'address',
-          },
-        ],
-      },
-      { name: 'userAddress', type: 'address', internalType: 'address' },
-      { name: 'publicKey', type: 'bytes', internalType: 'bytes' },
-      {
-        name: 'contractAddresses',
-        type: 'address[]',
-        internalType: 'address[]',
-      },
-      {
-        name: 'startTimestamp',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: 'durationDays',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      { name: 'userSignature', type: 'bytes', internalType: 'bytes' },
-    ],
-    outputs: [
-      { name: 'payload', type: 'bytes', internalType: 'bytes' },
-      { name: 'signers', type: 'address[]', internalType: 'address[]' },
-      { name: 'threshold', type: 'uint256', internalType: 'uint256' },
-      { name: 'extraData', type: 'bytes', internalType: 'bytes' },
-    ],
-    stateMutability: 'view',
-  },
-] as const;
+import {
+  readCleartextExecutorAddress,
+  readKmsSignersAndThreshold,
+  readPlaintexts,
+  xorMaskWithPublicKey,
+} from './plaintextSource.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -68,6 +24,8 @@ export async function fetchUserDecrypt(
   const pairs = payload.handleContractPairs;
   const contractAddresses = payload.kmsDecryptEip712Message.contractAddresses;
 
+  // Replicates CleartextKMSVerifier._requireAllPairsAuthorized: every requested
+  // pair's contract must appear in the EIP-712 authorized contractAddresses list.
   const authCount = contractAddresses.length;
   for (const { contractAddress: c } of pairs) {
     let authorized: boolean = false;
@@ -82,32 +40,33 @@ export async function fetchUserDecrypt(
     }
   }
 
-  const { kmsDecryptEip712Message, kmsDecryptEip712Signer, kmsDecryptEip712Signature } = payload;
+  const { kmsDecryptEip712Message } = payload;
+
+  // Option B: read cleartexts from CleartextFHEVMExecutor.plaintexts and rebuild
+  // the KMS payload off-chain, instead of reading the CleartextKMSVerifier view.
   const trustedClient = getTrustedClient(relayerClient);
-  const res = (await relayerClient.runtime.ethereum.readContract(trustedClient, {
-    abi: userDecryptAbi,
-    address: relayerClient.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress,
-    args: [
-      pairs.map((p) => ({
-        handle: p.handle.bytes32Hex,
-        contractAddress: p.contractAddress,
-      })),
-      kmsDecryptEip712Signer,
-      kmsDecryptEip712Message.publicKey,
-      kmsDecryptEip712Message.contractAddresses,
-      _parseUintBigIntString('kmsDecryptEip712Message.startTimestamp', kmsDecryptEip712Message.startTimestamp),
-      _parseUintBigIntString('kmsDecryptEip712Message.durationDays', kmsDecryptEip712Message.durationDays),
-      kmsDecryptEip712Signature,
-    ],
-    functionName: userDecryptAbi[0].name,
-  })) as unknown[];
+  const executorAddress = await readCleartextExecutorAddress(relayerClient, trustedClient);
+  const rawCleartexts = await readPlaintexts(
+    relayerClient,
+    trustedClient,
+    executorAddress,
+    pairs.map((p) => p.handle),
+  );
 
-  const commonKmsSigncryptedSharePayload = res[0] as BytesHex;
+  const maskedCleartexts = xorMaskWithPublicKey(kmsDecryptEip712Message.publicKey, rawCleartexts);
+
+  // extraData: the permit's message.extraData is already asserted equal to the
+  // current KmsSignersContext extraData by the caller (fetchKmsSigncryptedSharesV1
+  // step 9), so reusing it keeps the shares consistent with that context.
+  const extraData = kmsDecryptEip712Message.extraData;
+
+  const commonKmsSigncryptedSharePayload = relayerClient.runtime.ethereum.encode({
+    types: ['uint256[]', 'bytes'],
+    values: [maskedCleartexts, extraData],
+  });
   const commonKmsSigncryptedSharePayloadNo0x = remove0x(commonKmsSigncryptedSharePayload);
-  const signersAddress = res[1] as readonly ChecksummedAddress[];
-  const threshold = asUint32BigInt(res[2]);
-  const extraData = res[3] as BytesHex;
 
+  const { signers: signersAddress, threshold } = await readKmsSignersAndThreshold(relayerClient, trustedClient);
   const signers = getKmsSignersPrivateKeyMap(relayerClient);
 
   const randomSignersAddress = randomUniqueUints(signersAddress.length, Number(threshold)).map(
@@ -128,14 +87,4 @@ export async function fetchUserDecrypt(
   }
 
   return userDecryptResultToKmsSigncryptedShares(result);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-function _parseUintBigIntString(label: string, value: string): bigint {
-  const bn = tryParseUintBigIntString(value);
-  if (bn === undefined) {
-    throw new Error(`${label} is not a valid uint string, got ${JSON.stringify(value)}`);
-  }
-  return bn;
 }

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/plaintextSource.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/plaintextSource.ts
@@ -1,0 +1,158 @@
+import type { Address, BytesHex, ChecksummedAddress } from '../../../types/primitives.js';
+import type { Handle } from '../../../types/encryptedTypes-p.js';
+import type { CleartextEthereumModule } from '../../ethereum/types-ct.js';
+import type { TrustedClient } from '../../ethereum/types.js';
+import type { RelayerClientWithRuntime } from '../types.js';
+import { remove0x } from '../../../base/string.js';
+import { asUint32BigInt } from '../../../base/uint.js';
+import { addressToChecksummedAddress } from '../../../base/address.js';
+import {
+  getFHEVMExecutorAddressAbi,
+  getKmsSignersAbi,
+  getThresholdAbi,
+} from '../../../host-contracts/abi-fragments/fragments.js';
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Option B — cleartext "disabled KMSVerifier" plaintext source.
+//
+// The cleartext mock relayer used to read masked cleartexts + the KMS payload
+// from the `Cleartext*KMSVerifier` view. That view required the full `Cleartext*`
+// host set, which partners deploying only forge-fhevm do not have. Instead we
+// read the raw plaintext straight from `CleartextFHEVMExecutor.plaintexts` (the
+// mapping forge-fhevm populates) and rebuild the KMS wire format off-chain,
+// reusing the already-local KMS signing. Only the *plaintext source* moves;
+// everything downstream (masking, signing, reconstruct) is unchanged.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// CleartextFHEVMExecutor.plaintexts(bytes32) — the handle→cleartext mirror.
+const plaintextsAbi = [
+  {
+    type: 'function',
+    name: 'plaintexts',
+    inputs: [{ name: 'handle', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view',
+  },
+] as const;
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Resolves the (cleartext) FHEVMExecutor address from the host ACL, so the
+ * `plaintexts` mapping can be read without hardcoding a host-address constant.
+ * forge-fhevm wires its `CleartextFHEVMExecutor` in as the ACL's executor.
+ */
+export async function readCleartextExecutorAddress(
+  relayerClient: RelayerClientWithRuntime,
+  trustedClient: TrustedClient,
+): Promise<ChecksummedAddress> {
+  const res = await relayerClient.runtime.ethereum.readContract(trustedClient, {
+    abi: getFHEVMExecutorAddressAbi,
+    address: relayerClient.chain.fhevm.contracts.acl.address as ChecksummedAddress,
+    args: [],
+    functionName: getFHEVMExecutorAddressAbi[0].name,
+  });
+  return addressToChecksummedAddress(res as Address);
+}
+
+/**
+ * Reads the cleartext uint256 recorded for each handle from
+ * `CleartextFHEVMExecutor.plaintexts`. Authorization (ACL) is enforced by the
+ * decrypt caller before the relayer is invoked, matching the on-chain view which
+ * gated reads through `CleartextACL`.
+ */
+export async function readPlaintexts(
+  relayerClient: RelayerClientWithRuntime,
+  trustedClient: TrustedClient,
+  executorAddress: ChecksummedAddress,
+  handles: readonly Handle[],
+): Promise<bigint[]> {
+  const cleartexts: bigint[] = [];
+  for (const handle of handles) {
+    const res = await relayerClient.runtime.ethereum.readContract(trustedClient, {
+      abi: plaintextsAbi,
+      address: executorAddress,
+      args: [handle.bytes32Hex],
+      functionName: plaintextsAbi[0].name,
+    });
+    cleartexts.push(res as bigint);
+  }
+  return cleartexts;
+}
+
+/**
+ * Reads the registered KMS signer set and threshold from the standard KMSVerifier
+ * (which forge-fhevm implements). These replace the `signers` / `threshold` the
+ * `Cleartext*KMSVerifier` view used to return.
+ */
+export async function readKmsSignersAndThreshold(
+  relayerClient: RelayerClientWithRuntime,
+  trustedClient: TrustedClient,
+): Promise<{ signers: readonly ChecksummedAddress[]; threshold: bigint }> {
+  const kmsVerifierAddress = relayerClient.chain.fhevm.contracts.kmsVerifier.address as ChecksummedAddress;
+
+  const signersRes = await relayerClient.runtime.ethereum.readContract(trustedClient, {
+    abi: getKmsSignersAbi,
+    address: kmsVerifierAddress,
+    args: [],
+    functionName: getKmsSignersAbi[0].name,
+  });
+
+  const thresholdRes = await relayerClient.runtime.ethereum.readContract(trustedClient, {
+    abi: getThresholdAbi,
+    address: kmsVerifierAddress,
+    args: [],
+    functionName: getThresholdAbi[0].name,
+  });
+
+  const signers = (signersRes as readonly Address[]).map(addressToChecksummedAddress);
+  return { signers, threshold: asUint32BigInt(thresholdRes) };
+}
+
+/**
+ * Reversible mask that replicates `CleartextKMSVerifier._xorMaskWithPublicKey`:
+ * XORs each cleartext with the first 32 bytes of the user's public key. The
+ * client reverses it in `decrypt/mock.ts:_xorUnmaskWithPublicKey` with the same
+ * 32 bytes. NOT real encryption — only the cleartext wire format.
+ */
+export function xorMaskWithPublicKey(publicKey: BytesHex, cleartexts: readonly bigint[]): bigint[] {
+  const hex = remove0x(publicKey);
+  if (hex.length < 64) {
+    throw new Error(`PublicKeyTooShort: publicKey has ${hex.length / 2} bytes, need >= 32`);
+  }
+  const mask = BigInt('0x' + hex.slice(0, 64));
+  return cleartexts.map((c) => c ^ mask);
+}
+
+/**
+ * Replicates `CleartextKMSVerifier._encodeTypedCleartexts`: each cleartext is cast
+ * to its FHE-natural type (bool → 0/1, address → uint160, else uint256) and packed
+ * into a 32-byte word. For these static value types `abi.encode(v0, …, vn)` is
+ * byte-identical to the packed layout, and it round-trips through the proof's
+ * `decode(handle.solidityPrimitiveTypeName[], …)`.
+ */
+export function encodeTypedCleartexts(
+  ethereumModule: CleartextEthereumModule,
+  handles: readonly Handle[],
+  cleartexts: readonly bigint[],
+): BytesHex {
+  const words = handles.map((handle, i) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const value = cleartexts[i]!;
+    switch (handle.solidityPrimitiveTypeName) {
+      case 'bool':
+        return value !== 0n ? 1n : 0n;
+      case 'address':
+        return value & ((1n << 160n) - 1n);
+      case 'uint256':
+        return value;
+    }
+  });
+
+  return ethereumModule.encode({
+    types: words.map(() => 'uint256'),
+    values: words,
+  });
+}

--- a/sdk/js-sdk/src/core/modules/relayer/cleartext/signers.ts
+++ b/sdk/js-sdk/src/core/modules/relayer/cleartext/signers.ts
@@ -8,6 +8,21 @@ const FHEVM_TEST_MNEMONIC = 'test test test test test test test future home engi
 const COPROCESSOR_PATH = "0'/2/";
 const KMS_PATH = "0'/3/";
 
+// forge-fhevm registers a single KMS signer and a single coprocessor signer from
+// these deploy-default private keys (`KMS_SIGNER_PRIVATE_KEY_0` /
+// `COPROCESSOR_SIGNER_PRIVATE_KEY_0` in `deploy-local.sh`). They are NOT derivable
+// from `FHEVM_TEST_MNEMONIC`, so a cleartext client running against a forge-fhevm
+// deployment must know them explicitly: the on-chain `getKmsSigners()` returns
+// these addresses and the cleartext relayer signs shares with `map.get(address)`.
+const FORGE_KMS_SIGNER: { readonly address: ChecksummedAddress; readonly privateKey: BytesHex } = {
+  address: '0x0971C80fF03B428fD2094dd5354600ab103201C5' as ChecksummedAddress,
+  privateKey: '0x388b7680e4e1afa06efbfd45cdd1fe39f3c6af381df6555a19661f283b97de91' as BytesHex,
+};
+const FORGE_COPROCESSOR_SIGNER: { readonly address: ChecksummedAddress; readonly privateKey: BytesHex } = {
+  address: '0xc9990FEfE0c27D31D0C2aa36196b085c0c4d456c' as ChecksummedAddress,
+  privateKey: '0x7ec8ada6642fc4ccfb7729bc29c17cf8d21b61abd5642d1db992c0b8672ab901' as BytesHex,
+};
+
 type PrivateKeyMap = Map<ChecksummedAddress, BytesHex>;
 
 const signersPrivateKeyMap: { readonly coprocessor: PrivateKeyMap; readonly kms: PrivateKeyMap } = {
@@ -20,6 +35,7 @@ const signersPrivateKeyMap: { readonly coprocessor: PrivateKeyMap; readonly kms:
 export function getCoprocessorSignersPrivateKeyMap(relayerClient: RelayerClientWithRuntime): PrivateKeyMap {
   if (signersPrivateKeyMap.coprocessor.size === 0) {
     _fillSignersPrivateKey(relayerClient, COPROCESSOR_PATH, 20, signersPrivateKeyMap.coprocessor);
+    signersPrivateKeyMap.coprocessor.set(FORGE_COPROCESSOR_SIGNER.address, FORGE_COPROCESSOR_SIGNER.privateKey);
   }
   return signersPrivateKeyMap.coprocessor;
 }
@@ -29,6 +45,7 @@ export function getCoprocessorSignersPrivateKeyMap(relayerClient: RelayerClientW
 export function getKmsSignersPrivateKeyMap(relayerClient: RelayerClientWithRuntime): PrivateKeyMap {
   if (signersPrivateKeyMap.kms.size === 0) {
     _fillSignersPrivateKey(relayerClient, KMS_PATH, 20, signersPrivateKeyMap.kms);
+    signersPrivateKeyMap.kms.set(FORGE_KMS_SIGNER.address, FORGE_KMS_SIGNER.privateKey);
   }
   return signersPrivateKeyMap.kms;
 }

--- a/sdk/js-sdk/src/ethers/internal/ethereum-ct.ts
+++ b/sdk/js-sdk/src/ethers/internal/ethereum-ct.ts
@@ -3,6 +3,8 @@ import type {
   GeneratePrivateKeyReturnType,
   GetPublicKeyParameters,
   GetPublicKeyReturnType,
+  HashTypedDataParameters,
+  HashTypedDataReturnType,
   MnemonicToAccountParameters,
   MnemonicToAccountReturnType,
   RecoverAddressParameters,
@@ -11,6 +13,7 @@ import type {
   SignReturnType,
 } from '../../core/modules/ethereum/types-ct.js';
 import type { BytesHex, ChecksummedAddress } from '../../core/types/primitives.js';
+import type { TypedDataField } from 'ethers';
 import {
   decode,
   encode,
@@ -20,7 +23,7 @@ import {
   recoverTypedDataAddress,
   signTypedData,
 } from './ethereum.js';
-import { SigningKey, HDNodeWallet, Wallet } from 'ethers';
+import { SigningKey, HDNodeWallet, TypedDataEncoder, Wallet } from 'ethers';
 import { sign, recoverAddress } from '../../core/base/sign.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -45,6 +48,18 @@ export const cleartextEthereumModule: CleartextEthereumModuleFactory = () => {
       sign: (parameters: SignParameters): Promise<SignReturnType> => {
         const signature = sign(parameters);
         return Promise.resolve(signature);
+      },
+      hashTypedData: (parameters: HashTypedDataParameters): HashTypedDataReturnType => {
+        // ethers derives the domain separator itself and rejects an EIP712Domain
+        // entry in `types`, so pass only the primary type (mirrors signTypedData).
+        const primaryTypeFields = parameters.types[parameters.primaryType];
+        if (primaryTypeFields === undefined) {
+          throw new Error(`Primary type "${parameters.primaryType}" not found in types`);
+        }
+        const typesToHash: Record<string, TypedDataField[]> = {
+          [parameters.primaryType]: [...primaryTypeFields],
+        };
+        return TypedDataEncoder.hash(parameters.domain, typesToHash, parameters.message) as BytesHex;
       },
       generatePrivateKey: (): GeneratePrivateKeyReturnType => {
         return Wallet.createRandom().privateKey as BytesHex;

--- a/sdk/js-sdk/src/viem/internal/ethereum-ct.ts
+++ b/sdk/js-sdk/src/viem/internal/ethereum-ct.ts
@@ -3,6 +3,8 @@ import type {
   GeneratePrivateKeyReturnType,
   GetPublicKeyParameters,
   GetPublicKeyReturnType,
+  HashTypedDataParameters,
+  HashTypedDataReturnType,
   MnemonicToAccountParameters,
   MnemonicToAccountReturnType,
   RecoverAddressParameters,
@@ -22,7 +24,7 @@ import {
   signTypedData,
 } from './ethereum.js';
 import { bytesToHex } from '../../core/base/bytes.js';
-import { recoverAddress } from 'viem';
+import { hashTypedData, recoverAddress } from 'viem';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -46,6 +48,14 @@ export const cleartextEthereumModule: CleartextEthereumModuleFactory = () => {
       },
       sign: (parameters: SignParameters): Promise<SignReturnType> => {
         return sign({ hash: parameters.hash, privateKey: parameters.privateKey, to: 'hex' }) as Promise<Bytes65Hex>;
+      },
+      hashTypedData: (parameters: HashTypedDataParameters): HashTypedDataReturnType => {
+        return hashTypedData({
+          domain: parameters.domain,
+          types: parameters.types as Record<string, Array<{ name: string; type: string }>>,
+          primaryType: parameters.primaryType,
+          message: parameters.message,
+        }) as BytesHex;
       },
       generatePrivateKey: (): GeneratePrivateKeyReturnType => {
         return generatePrivateKey() as BytesHex;


### PR DESCRIPTION
## Summary
Option B for the cleartext migration: the cleartext relayer now reads plaintexts from `CleartextFHEVMExecutor.plaintexts` instead of the `Cleartext*KMSVerifier` view, rebuilding the KMS wire format off-chain. Partners deploying **only forge-fhevm** (executor + standard ACL/KMS) can run the cleartext path — no full `Cleartext*` host set required.

## Changes (8 files, cleartext-only)
- **Plaintext source (4):** new `plaintextSource.ts` (`readCleartextExecutorAddress` via ACL, `readPlaintexts`, `readKmsSignersAndThreshold`, `xorMaskWithPublicKey`, `encodeTypedCleartexts`) + rewired `fetch{User,DelegatedUser,Public}Decrypt`.
- **`hashTypedData` primitive (3):** `types-ct.ts` + viem/ethers `ethereum-ct.ts`, so raw KMS keys can sign the public-decrypt EIP-712 digest locally.
- **Signer reconciliation (1):** `signers.ts` registers forge-fhevm's 2 deploy-default signer keys.

The real mainnet/testnet decrypt path is untouched — all changes live in the cleartext-only modules injected via `getCleartextViemRuntime()`.

## Testing
- `tsc -b --noEmit` clean; full unit suite (784) green.
- Live localcleartext v13 e2e: **cleartext-ethers 69/69**, **cleartext-viem 70/70**.
- Verified end-to-end through the `@zama-fhe/sdk` wrapper (public-decrypt uint64/bool/address on a live anvil, zero wrapper change).

Opening as a **draft** to run CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)