### PR TITLE
feat(coprocessor): re-randomise input ciphertexts before expand

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/types.rs
@@ -725,67 +725,6 @@ impl SupportedFheCiphertexts {
         }
     }
 
-    pub fn add_re_randomization_metadata(&mut self, hash_data: &[u8]) {
-        match self {
-            SupportedFheCiphertexts::FheBool(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint4(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint8(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint16(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint32(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint64(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint128(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint160(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheUint256(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheBytes64(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheBytes128(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::FheBytes256(ct) => {
-                ct.re_randomization_metadata_mut().set_data(hash_data);
-            }
-            SupportedFheCiphertexts::Scalar(_) => (),
-        }
-    }
-
-    pub fn add_to_rerandomisation_context(&self, context: &mut ReRandomizationContext) {
-        match self {
-            SupportedFheCiphertexts::FheBool(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint4(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint8(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint16(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint32(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint64(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint128(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint160(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheUint256(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheBytes64(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheBytes128(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::FheBytes256(c) => context.add_ciphertext(c),
-            SupportedFheCiphertexts::Scalar(_) => {
-                // Do nothing
-            }
-        };
-    }
     pub fn re_randomise(
         &mut self,
         cpk: &CompactPublicKey,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/mod.rs
@@ -300,7 +300,7 @@ async fn test_max_input_index() {
 
 #[tokio::test]
 #[serial(db)]
-async fn test_verify_proof_rerandomises_ciphertexts_before_storage() {
+async fn test_verify_proof_rerandomises_compact_list_before_expansion() {
     let (pool_mngr, _instance, material) = utils::setup().await.expect("valid setup");
     let pool = pool_mngr.pool();
 
@@ -363,6 +363,17 @@ async fn test_verify_proof_rerandomises_ciphertexts_before_storage() {
             .zip(&baseline)
             .all(|(stored_ct, baseline_ct)| stored_ct.ciphertext != *baseline_ct),
         "stored ciphertexts should differ from the pre-rerandomization compression"
+    );
+
+    let expected = utils::compress_inputs_with_compact_list_rerandomization(&material, &zk_pok)
+        .await
+        .unwrap();
+    assert_eq!(
+        stored
+            .iter()
+            .map(|ct| ct.ciphertext.clone())
+            .collect::<Vec<_>>(),
+        expected
     );
 
     let decrypted = utils::decrypt_ciphertexts(&pool, &material, &handles)

--- a/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/tests/utils.rs
@@ -6,6 +6,8 @@ use fhevm_engine_common::pg_pool::PostgresPoolManager;
 use fhevm_engine_common::tfhe_ops::{current_ciphertext_version, extract_ct_list};
 use fhevm_engine_common::types::SupportedFheCiphertexts;
 use fhevm_engine_common::utils::{safe_deserialize_conformant, safe_serialize};
+use sha3::Digest;
+use sha3::Keccak256;
 use sqlx::Row;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
@@ -247,6 +249,53 @@ pub(crate) async fn compress_inputs_without_rerandomization(
     tokio::task::spawn_blocking(move || {
         tfhe::set_server_key(latest_key.sks);
         let expanded = verified_list.expand_without_verification()?;
+        let cts = extract_ct_list(&expanded)?;
+        cts.into_iter()
+            .map(|ct| ct.compress().map_err(anyhow::Error::from))
+            .collect()
+    })
+    .await?
+}
+
+/// Recomputes the ciphertexts the verifier is expected to store: re-randomize
+/// the verified compact list seeded from the blob hash, expand, then compress.
+/// Must stay in lockstep with `crate::verifier::verify_proof` — the test
+/// compares its output bitwise against the stored ciphertexts.
+pub(crate) async fn compress_inputs_with_compact_list_rerandomization(
+    material: &ProofMaterial,
+    raw_ct: &[u8],
+) -> anyhow::Result<Vec<Vec<u8>>> {
+    let latest_key = material.key.clone();
+    let latest_crs = material.crs.clone();
+
+    let verified_list: tfhe::ProvenCompactCiphertextList = safe_deserialize_conformant(
+        raw_ct,
+        &crate::verifier::proven_list_conformance_params(&latest_key.pks, &latest_crs),
+    )?;
+
+    if verified_list.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut hasher = Keccak256::new();
+    hasher.update(crate::verifier::RAW_CT_HASH_DOMAIN_SEPARATOR);
+    hasher.update(raw_ct);
+    let blob_hash = hasher.finalize().to_vec();
+
+    tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<Vec<u8>>> {
+        tfhe::set_server_key(latest_key.sks);
+
+        let mut re_rand_context = tfhe::ReRandomizationContext::new(
+            crate::verifier::RERANDOMISATION_DOMAIN_SEPARATOR,
+            [blob_hash.as_slice()],
+            crate::verifier::COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR,
+        );
+        re_rand_context.add_ciphertext(&verified_list);
+
+        let mut seed_gen = re_rand_context.finalize();
+        let expanded = verified_list
+            .re_randomize_and_expand_without_verification(&latest_key.pks, seed_gen.next_seed()?)?;
+
         let cts = extract_ct_list(&expanded)?;
         cts.into_iter()
             .map(|ct| ct.compress().map_err(anyhow::Error::from))

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -559,30 +559,25 @@ pub(crate) fn verify_proof(
     let verified_list = verify_proof_only(request_id, raw_ct, key, crs, aux_data)
         .inspect_err(telemetry::set_current_span_error)?;
 
-    // Step 2: Expand the verified ciphertext list
-    let mut cts = expand_verified_list(request_id, &verified_list)
-        .inspect_err(telemetry::set_current_span_error)?;
-
-    // Step 3: Compute blob hash and set re-randomization metadata on all ciphertexts
+    // Step 2: Compute blob hash used to seed the compact-list re-randomization
     let mut h = Keccak256::new();
     h.update(RAW_CT_HASH_DOMAIN_SEPARATOR);
     h.update(raw_ct);
     let blob_hash = h.finalize().to_vec();
 
-    let handles: Vec<Vec<u8>> = cts
-        .iter_mut()
-        .enumerate()
-        .map(|(idx, ct)| set_ciphertext_metadata(&blob_hash, idx, ct, aux_data))
-        .collect::<Result<Vec<_>, ExecutionError>>()
+    // Step 3: Re-randomize the verified compact list, then expand
+    let cts = rerand_and_expand_verified_list(request_id, &verified_list, &blob_hash, &key.pks)
         .inspect_err(telemetry::set_current_span_error)?;
 
-    // Step 4: Re-randomize all ciphertexts before compression
-    re_randomise_ciphertexts(&mut cts, &blob_hash, &key.pks)
+    // Step 4: Compute handle hashes
+    let handles: Vec<Vec<u8>> = (0..cts.len())
+        .map(|idx| compute_handle_hash(&blob_hash, idx, aux_data))
+        .collect::<Result<Vec<_>, ExecutionError>>()
         .inspect_err(telemetry::set_current_span_error)?;
 
     // Step 5: Compress and build final ciphertext records
     let cts = cts
-        .iter_mut()
+        .iter()
         .zip(handles)
         .enumerate()
         .map(|(idx, (ct, handle))| finalize_ciphertext(request_id, handle, idx, ct, aux_data))
@@ -671,18 +666,36 @@ fn verify_proof_only(
     Ok(the_list)
 }
 
-#[tracing::instrument(name = "expand_ciphertext_list", skip_all, fields(count = tracing::field::Empty))]
-fn expand_verified_list(
+#[tracing::instrument(name = "rerandomize_and_expand_ciphertext_list", skip_all, fields(request_id = request_id, input_count = tracing::field::Empty, count = tracing::field::Empty))]
+fn rerand_and_expand_verified_list(
     request_id: i64,
     the_list: &tfhe::ProvenCompactCiphertextList,
+    blob_hash: &[u8],
+    cpk: &tfhe::CompactPublicKey,
 ) -> Result<Vec<SupportedFheCiphertexts>, ExecutionError> {
     if the_list.is_empty() {
         return Ok(vec![]);
     }
+    tracing::Span::current().record("input_count", the_list.len());
 
+    let mut re_rand_context = ReRandomizationContext::new(
+        RERANDOMISATION_DOMAIN_SEPARATOR,
+        [blob_hash],
+        COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR,
+    );
+    re_rand_context.add_ciphertext(the_list);
+    let mut seed_gen = re_rand_context.finalize();
+    let seed = seed_gen
+        .next_seed()
+        .map_err(FhevmError::ReRandomisationError)
+        .inspect_err(telemetry::set_current_span_error)?;
+
+    // The list already passed conformance and ZK verification, so a failure
+    // here is an operator-side re-randomisation problem (e.g. server key
+    // without re-randomisation material), not an invalid user proof.
     let expanded: tfhe::CompactCiphertextListExpander = the_list
-        .expand_without_verification()
-        .map_err(|err| ExecutionError::InvalidProof(request_id, err.to_string()))
+        .re_randomize_and_expand_without_verification(cpk, seed)
+        .map_err(FhevmError::ReRandomisationError)
         .inspect_err(telemetry::set_current_span_error)?;
 
     let cts = extract_ct_list(&expanded)
@@ -692,12 +705,11 @@ fn expand_verified_list(
     Ok(cts)
 }
 
-/// Computes the handle hash and sets re-randomization metadata on a ciphertext.
+/// Computes the handle hash
 /// Returns the full 256-bit handle hash (before index/chain/type/version are patched in).
-fn set_ciphertext_metadata(
+fn compute_handle_hash(
     blob_hash: &[u8],
     ct_idx: usize,
-    the_ct: &mut SupportedFheCiphertexts,
     aux_data: &auxiliary::ZkData,
 ) -> Result<Vec<u8>, ExecutionError> {
     if ct_idx > MAX_INPUT_INDEX as usize {
@@ -719,36 +731,7 @@ fn set_ciphertext_metadata(
     let handle = handle_hash.finalize().to_vec();
     assert_eq!(handle.len(), 32);
 
-    // Add the full 256bit hash as re-randomization metadata, NOT the
-    // truncated hash of the handle
-    the_ct.add_re_randomization_metadata(&handle);
-
     Ok(handle)
-}
-
-/// Re-randomizes all ciphertexts using the compact public key.
-#[tracing::instrument(name = "rerandomise_cts", skip_all)]
-fn re_randomise_ciphertexts(
-    cts: &mut [SupportedFheCiphertexts],
-    blob_hash: &[u8],
-    cpk: &tfhe::CompactPublicKey,
-) -> Result<(), ExecutionError> {
-    let mut re_rand_context = ReRandomizationContext::new(
-        RERANDOMISATION_DOMAIN_SEPARATOR,
-        [blob_hash],
-        COMPACT_PUBLIC_ENCRYPTION_DOMAIN_SEPARATOR,
-    );
-    for ct in cts.iter() {
-        ct.add_to_re_randomization_context(&mut re_rand_context);
-    }
-    let mut seed_gen = re_rand_context.finalize();
-    for ct in cts.iter_mut() {
-        let seed = seed_gen
-            .next_seed()
-            .map_err(FhevmError::ReRandomisationError)?;
-        ct.re_randomise(cpk, seed)?;
-    }
-    Ok(())
 }
 
 /// Compresses the ciphertext and builds the final Ciphertext record with patched handle.
@@ -761,7 +744,7 @@ fn finalize_ciphertext(
     request_id: i64,
     mut handle: Vec<u8>,
     ct_idx: usize,
-    the_ct: &mut SupportedFheCiphertexts,
+    the_ct: &SupportedFheCiphertexts,
     aux_data: &auxiliary::ZkData,
 ) -> Result<Ciphertext, ExecutionError> {
     let serialized_type = the_ct.type_num();


### PR DESCRIPTION
Reintroduce the compact-list re-randomisation reverted in 537cd123c (#2759, revert of #2383): the zkproof-worker now re-randomises the verified ProvenCompactCiphertextList — seeded from the input blob hash — and expands it in a single step, instead of expanding first and re-randomising each expanded ciphertext before compression. The per-ciphertext re-randomisation metadata is no longer set at input verification, so the now-unused
SupportedFheCiphertexts::add_re_randomization_metadata is removed (the scheduler's operation-input re-randomisation helpers are unaffected).

BREAKING CHANGE: for the same input blob, stored ciphertexts are not bitwise-equal to those produced by the previous rerand-after-expand scheme, so a mixed fleet would diverge. Ship only via a synchronised (blue-green) coprocessor upgrade, never a rolling one.