### PR TITLE
feat(host-contracts): add ConfidentialBridge deploy and prepareUpgrade tasks for existing chains

### DIFF
--- a/.github/workflows/host-contracts-upgrade-tests.yml
+++ b/.github/workflows/host-contracts-upgrade-tests.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Bootstrap host contracts missing from UPGRADE_FROM_TAG
         working-directory: current-fhevm/host-contracts
-        run: npx hardhat task:deployEmptyProxiesProtocolConfigKMSGeneration
+        run: npx hardhat task:deployEmptyProxyForConfidentialBridge
 
       - name: Run prepare-only upgrades
         working-directory: current-fhevm/host-contracts

--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -56,20 +56,6 @@ The values to feed into those setter tasks should come from the currently deploy
 environment you are upgrading. A practical source of truth is the verified source bundle of
 the implementation currently behind the proxy, specifically `addresses/FHEVMHostAddresses.sol`.
 
-If the upgrade baseline predates `ProtocolConfig` and `KMSGeneration` (for example
-`UPGRADE_FROM_TAG=v0.11.1` in CI), run:
-
-```bash
-npx hardhat task:deployEmptyProxiesProtocolConfigKMSGeneration
-```
-
-This compatibility task deploys only the empty UUPS proxies for missing address keys and appends
-the missing generated constants so prepare-upgrade tasks can compile against the current
-source tree. Keep it as a forward-compat safeguard if a manifest contract starts importing
-those generated addresses before the baseline tag catches up. `DEPLOYER_PRIVATE_KEY` is only
-required when the task actually needs to bootstrap missing proxies. Once the baseline tag
-includes those contracts, the task becomes a no-op and the bootstrap step can be removed.
-
 Then run:
 
 ```bash

--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -294,36 +294,22 @@ task('task:deployEmptyUUPSProxies')
     }
   });
 
-task('task:deployEmptyProxiesProtocolConfigKMSGeneration').setAction(async function (_, { ethers, upgrades, run }) {
+task('task:deployEmptyProxyForConfidentialBridge').setAction(async function (_, { ethers, upgrades, run }) {
   ensureAddressesDirectoryExists();
 
-  const existingEnv = readExistingHostEnv();
-
-  const targets = [
-    { envKey: 'PROTOCOL_CONFIG_CONTRACT_ADDRESS', setterTask: 'task:setProtocolConfigAddress' },
-    { envKey: 'KMS_GENERATION_CONTRACT_ADDRESS', setterTask: 'task:setKMSGenerationAddress' },
-    { envKey: 'CONFIDENTIAL_BRIDGE_CONTRACT_ADDRESS', setterTask: 'task:setBridgeAddress' },
-  ] as const;
-
-  const missingTargets = targets.filter(({ envKey }) => !existingEnv[envKey]);
-
-  if (missingTargets.length === 0) {
+  if (readExistingHostEnv().CONFIDENTIAL_BRIDGE_CONTRACT_ADDRESS) {
     console.warn(
-      'Empty-proxy bootstrap is a no-op; addresses/.env.host already contains ProtocolConfig, KMSGeneration and ConfidentialBridge.',
+      'Empty-proxy bootstrap is a no-op; addresses/.env.host already contains CONFIDENTIAL_BRIDGE_CONTRACT_ADDRESS.',
     );
     return;
   }
 
-  const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
-  const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
-
+  const deployer = new ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(ethers.provider);
   await run('compile:specific', { contract: 'contracts/emptyProxy' });
 
-  for (const { envKey, setterTask } of missingTargets) {
-    const proxyAddress = await deployEmptyUUPS(ethers, upgrades, deployer);
-    await run(setterTask, { address: proxyAddress });
-    process.env[envKey] = proxyAddress;
-  }
+  const proxyAddress = await deployEmptyUUPS(ethers, upgrades, deployer);
+  await run('task:setBridgeAddress', { address: proxyAddress });
+  process.env.CONFIDENTIAL_BRIDGE_CONTRACT_ADDRESS = proxyAddress;
 });
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -42,6 +42,19 @@ function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
+// Parses a comma-separated integer list task arg (e.g. --dst-eids "30101,30109") into its entries.
+// Empty/undefined yields an empty array; values stay as strings so ethers coerces them to the
+// solidity integer type at encode time.
+function parseCsvIntegers(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
 async function upgradeCurrentToNew(
   proxyAddress: string,
   currentImplementation: string,
@@ -353,6 +366,18 @@ task('task:prepareUpgradeConfidentialBridge')
     types.boolean,
   )
   .addOptionalParam(
+    'dstEids',
+    'Comma-separated LayerZero endpoint ids to seed the dstEid → dstChainId map (paired index-by-index with --dst-chain-ids). Empty by default; pairs can also be wired later via task:setDstChainId.',
+    '',
+    types.string,
+  )
+  .addOptionalParam(
+    'dstChainIds',
+    'Comma-separated destination chain ids paired index-by-index with --dst-eids.',
+    '',
+    types.string,
+  )
+  .addOptionalParam(
     'verifyContract',
     'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
     true,
@@ -366,6 +391,14 @@ task('task:prepareUpgradeConfidentialBridge')
     const lzEndpoint = getRequiredEnvVar('LZ_ENDPOINT_ADDRESS');
     if (!hre.ethers.isAddress(lzEndpoint)) {
       throw new Error(`LZ_ENDPOINT_ADDRESS is not a valid address: ${lzEndpoint}`);
+    }
+
+    const dstEids = parseCsvIntegers(taskArgs.dstEids);
+    const dstChainIds = parseCsvIntegers(taskArgs.dstChainIds);
+    if (dstEids.length !== dstChainIds.length) {
+      throw new Error(
+        `--dst-eids and --dst-chain-ids must have the same length: got ${dstEids.length} eid(s) and ${dstChainIds.length} chain id(s). initializeFromEmptyProxy would revert with DstChainIdArrayLengthMismatch.`,
+      );
     }
 
     await hre.run('compile:specific', { contract: 'contracts' });
@@ -387,7 +420,7 @@ task('task:prepareUpgradeConfidentialBridge')
     console.log('New implementation deployed at:', implementationAddress);
 
     const initSignature = 'initializeFromEmptyProxy(uint32[],uint64[])';
-    const initArgs: unknown[] = [[], []];
+    const initArgs: unknown[] = [dstEids, dstChainIds];
     const initCalldata = bridgeFactory.interface.encodeFunctionData('initializeFromEmptyProxy', initArgs);
     const outerCalldata = new Interface([
       'function upgradeToAndCall(address newImplementation, bytes data) payable',

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -4,6 +4,7 @@ import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types';
 
 import { buildProtocolConfigReinitializeArgs } from './taskDeploy';
 import { getRequiredEnvVar, loadHostAddresses } from './utils/loadVariables';
+import { buildUpgradeProposal, printUpgradeProposal, verifyProposalImplementation } from './utils/upgradeProposal';
 
 const REINITIALIZE_FUNCTION_PREFIX = 'reinitializeV'; // Prefix for reinitialize functions
 
@@ -404,49 +405,24 @@ task('task:prepareUpgradeConfidentialBridge')
 
     await hre.run('compile:specific', { contract: 'contracts' });
 
-    const deployer = new Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(hre.ethers.provider);
+    const preparedUpgrade = await buildUpgradeProposal(hre, {
+      proxyAddress,
+      contractName: 'ConfidentialBridge',
+      innerFunctionName: 'initializeFromEmptyProxy',
+      decodedArgs: [dstEids, dstChainIds],
+      constructorArgs: [lzEndpoint],
+      unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
+    });
 
-    const emptyProxyFactory = await hre.ethers.getContractFactory('EmptyUUPSProxy', deployer);
-    await hre.upgrades.forceImport(proxyAddress, emptyProxyFactory);
-
-    const bridgeFactory = await hre.ethers.getContractFactory('ConfidentialBridge', deployer);
-    console.log(`Deploying "ConfidentialBridge" for prepared upgrade on proxy ${proxyAddress}...`);
-    const implementationAddress = String(
-      await hre.upgrades.prepareUpgrade(proxyAddress, bridgeFactory, {
-        kind: 'uups',
-        constructorArgs: [lzEndpoint],
-        unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
-      }),
-    );
-    console.log('New implementation deployed at:', implementationAddress);
-
-    const initSignature = 'initializeFromEmptyProxy(uint32[],uint64[])';
-    const initArgs: unknown[] = [dstEids, dstChainIds];
-    const initCalldata = bridgeFactory.interface.encodeFunctionData('initializeFromEmptyProxy', initArgs);
-    const outerCalldata = new Interface([
-      'function upgradeToAndCall(address newImplementation, bytes data) payable',
-    ]).encodeFunctionData('upgradeToAndCall', [implementationAddress, initCalldata]);
-
-    console.log('proxyAddress:', proxyAddress);
-    console.log('newImplementationAddress:', implementationAddress);
-    console.log('innerFunctionSignature:', initSignature);
-    console.log('initializeFromEmptyProxy calldata:', initCalldata);
-    console.log('upgradeToAndCall(address,bytes) calldata:', outerCalldata);
-    console.log(
-      `To double check, run: cast calldata ${shellQuote(initSignature)} ${initArgs
-        .map((arg) => shellQuote(formatCastArg(arg)))
-        .join(' ')}`.trim(),
-    );
-
+    printUpgradeProposal(preparedUpgrade);
     if (taskArgs.verifyContract) {
-      console.log('Waiting 2 minutes before contract verification... Please wait...');
-      await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
-      await hre.run('verify:verify', {
-        address: implementationAddress,
-        contract: 'contracts/bridge/ConfidentialBridge.sol:ConfidentialBridge',
-        constructorArguments: [lzEndpoint],
-      });
+      await verifyProposalImplementation(
+        hre,
+        preparedUpgrade,
+        'contracts/bridge/ConfidentialBridge.sol:ConfidentialBridge',
+      );
     }
+    return preparedUpgrade;
   });
 
 task('task:upgradeKMSVerifier')

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -345,6 +345,76 @@ task('task:prepareUpgradeACL')
     await prepareUpgradeContract('ACL', 'ACL_CONTRACT_ADDRESS', taskArgs, hre);
   });
 
+task('task:prepareUpgradeConfidentialBridge')
+  .addOptionalParam(
+    'useInternalProxyAddress',
+    'If proxy address from the /addresses directory should be used',
+    false,
+    types.boolean,
+  )
+  .addOptionalParam(
+    'verifyContract',
+    'Verify new implementation on Etherscan (for eg if deploying on Sepolia or Mainnet)',
+    true,
+    types.boolean,
+  )
+  .setAction(async function (taskArgs: TaskArguments, hre) {
+    if (taskArgs.useInternalProxyAddress) {
+      loadHostAddresses();
+    }
+    const proxyAddress = getRequiredEnvVar('CONFIDENTIAL_BRIDGE_CONTRACT_ADDRESS');
+    const lzEndpoint = getRequiredEnvVar('LZ_ENDPOINT_ADDRESS');
+    if (!hre.ethers.isAddress(lzEndpoint)) {
+      throw new Error(`LZ_ENDPOINT_ADDRESS is not a valid address: ${lzEndpoint}`);
+    }
+
+    await hre.run('compile:specific', { contract: 'contracts' });
+
+    const deployer = new Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(hre.ethers.provider);
+
+    const emptyProxyFactory = await hre.ethers.getContractFactory('EmptyUUPSProxy', deployer);
+    await hre.upgrades.forceImport(proxyAddress, emptyProxyFactory);
+
+    const bridgeFactory = await hre.ethers.getContractFactory('ConfidentialBridge', deployer);
+    console.log(`Deploying "ConfidentialBridge" for prepared upgrade on proxy ${proxyAddress}...`);
+    const implementationAddress = String(
+      await hre.upgrades.prepareUpgrade(proxyAddress, bridgeFactory, {
+        kind: 'uups',
+        constructorArgs: [lzEndpoint],
+        unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
+      }),
+    );
+    console.log('New implementation deployed at:', implementationAddress);
+
+    const initSignature = 'initializeFromEmptyProxy(uint32[],uint64[])';
+    const initArgs: unknown[] = [[], []];
+    const initCalldata = bridgeFactory.interface.encodeFunctionData('initializeFromEmptyProxy', initArgs);
+    const outerCalldata = new Interface([
+      'function upgradeToAndCall(address newImplementation, bytes data) payable',
+    ]).encodeFunctionData('upgradeToAndCall', [implementationAddress, initCalldata]);
+
+    console.log('proxyAddress:', proxyAddress);
+    console.log('newImplementationAddress:', implementationAddress);
+    console.log('innerFunctionSignature:', initSignature);
+    console.log('initializeFromEmptyProxy calldata:', initCalldata);
+    console.log('upgradeToAndCall(address,bytes) calldata:', outerCalldata);
+    console.log(
+      `To double check, run: cast calldata ${shellQuote(initSignature)} ${initArgs
+        .map((arg) => shellQuote(formatCastArg(arg)))
+        .join(' ')}`.trim(),
+    );
+
+    if (taskArgs.verifyContract) {
+      console.log('Waiting 2 minutes before contract verification... Please wait...');
+      await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+      await hre.run('verify:verify', {
+        address: implementationAddress,
+        contract: 'contracts/bridge/ConfidentialBridge.sol:ConfidentialBridge',
+        constructorArguments: [lzEndpoint],
+      });
+    }
+  });
+
 task('task:upgradeKMSVerifier')
   .addParam(
     'currentImplementation',

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -357,7 +357,7 @@ task('task:prepareUpgradeACL')
   });
 
 // Governance prepare for the first bridge upgrade: EmptyUUPSProxy -> ConfidentialBridge via
-// initializeFromEmptyProxy. New chains get the bridge from task:deployAllHostContracts. 
+// initializeFromEmptyProxy. New chains get the bridge from task:deployAllHostContracts.
 // Any subsequent ConfidentialBridge-to-ConfidentialBridge upgrade should go through prepareUpgradeContract, not this task.
 task('task:prepareUpgradeConfidentialBridge')
   .addOptionalParam(

--- a/host-contracts/tasks/upgradeContracts.ts
+++ b/host-contracts/tasks/upgradeContracts.ts
@@ -43,8 +43,6 @@ function shellQuote(arg: string): string {
 }
 
 // Parses a comma-separated integer list task arg (e.g. --dst-eids "30101,30109") into its entries.
-// Empty/undefined yields an empty array; values stay as strings so ethers coerces them to the
-// solidity integer type at encode time.
 function parseCsvIntegers(raw: string | undefined): string[] {
   if (!raw) {
     return [];
@@ -358,6 +356,9 @@ task('task:prepareUpgradeACL')
     await prepareUpgradeContract('ACL', 'ACL_CONTRACT_ADDRESS', taskArgs, hre);
   });
 
+// Governance prepare for the first bridge upgrade: EmptyUUPSProxy -> ConfidentialBridge via
+// initializeFromEmptyProxy. New chains get the bridge from task:deployAllHostContracts. 
+// Any subsequent ConfidentialBridge-to-ConfidentialBridge upgrade should go through prepareUpgradeContract, not this task.
 task('task:prepareUpgradeConfidentialBridge')
   .addOptionalParam(
     'useInternalProxyAddress',

--- a/host-contracts/tasks/utils/upgradeProposal.ts
+++ b/host-contracts/tasks/utils/upgradeProposal.ts
@@ -47,14 +47,13 @@ export async function buildUpgradeProposal(
   const { ethers, upgrades } = hre;
   const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
   const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
-  const constructorArgs = params.constructorArgs ?? [];
   const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
   const newImplementation = await ethers.getContractFactory(params.contractName, deployer);
   await upgrades.forceImport(params.proxyAddress, currentImplementation);
   const newImplementationAddress = String(
     await upgrades.prepareUpgrade(params.proxyAddress, newImplementation, {
       kind: 'uups',
-      constructorArgs,
+      constructorArgs: params.constructorArgs,
       unsafeAllow: params.unsafeAllow,
     }),
   );
@@ -74,7 +73,7 @@ export async function buildUpgradeProposal(
     decodedArgs: params.decodedArgs,
     innerCalldata,
     outerCalldata,
-    constructorArgs,
+    constructorArgs: params.constructorArgs ?? [],
   };
 }
 

--- a/host-contracts/tasks/utils/upgradeProposal.ts
+++ b/host-contracts/tasks/utils/upgradeProposal.ts
@@ -1,3 +1,4 @@
+import type { UpgradeOptions } from '@openzeppelin/hardhat-upgrades';
 import { Interface } from 'ethers';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
@@ -29,6 +30,7 @@ export type UpgradeProposal = {
   decodedArgs: unknown[];
   innerCalldata: string;
   outerCalldata: string;
+  constructorArgs: unknown[];
 };
 
 export async function buildUpgradeProposal(
@@ -38,17 +40,22 @@ export async function buildUpgradeProposal(
     contractName: string;
     innerFunctionName: string;
     decodedArgs: unknown[];
+    constructorArgs?: UpgradeOptions['constructorArgs'];
+    unsafeAllow?: UpgradeOptions['unsafeAllow'];
   },
 ): Promise<UpgradeProposal> {
   const { ethers, upgrades } = hre;
   const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
   const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
+  const constructorArgs = params.constructorArgs ?? [];
   const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
   const newImplementation = await ethers.getContractFactory(params.contractName, deployer);
   await upgrades.forceImport(params.proxyAddress, currentImplementation);
   const newImplementationAddress = String(
     await upgrades.prepareUpgrade(params.proxyAddress, newImplementation, {
       kind: 'uups',
+      constructorArgs,
+      unsafeAllow: params.unsafeAllow,
     }),
   );
   // The factory's interface already knows the new implementation's ABI, so encode by function name
@@ -67,6 +74,7 @@ export async function buildUpgradeProposal(
     decodedArgs: params.decodedArgs,
     innerCalldata,
     outerCalldata,
+    constructorArgs,
   };
 }
 
@@ -92,7 +100,7 @@ export async function verifyProposalImplementation(
   await hre.run('verify:verify', {
     address: data.newImplementationAddress,
     contract,
-    constructorArguments: [],
+    constructorArguments: data.constructorArgs,
   });
 }
 


### PR DESCRIPTION
### Summary

Adds the standalone tasks needed to bring the ConfidentialBridge onto an already-deployed host chain (the fresh-chain path is already covered by task:deployAllHostContracts):

- task:deployEmptyProxyForConfidentialBridge: deploys only the bridge empty UUPS proxy and pins its address (deployEmptyUUPS + setBridgeAddress).
- task:prepareUpgradeConfidentialBridge: deploys the ConfidentialBridge implementation (with the immutable LayerZero endpoint constructor arg) and prints the governance upgradeToAndCall calldata.
- removes legacy deployEmptyProxiesProtocolConfigKMSGeneration task