### PR TITLE
fix(sdk): fix localstack setup below v0.14 and add js-sdk tests

### DIFF
--- a/sdk/js-sdk/src/core/base/errors/utils.test.ts
+++ b/sdk/js-sdk/src/core/base/errors/utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { InternalError } from './InternalError.js';
+import { ensureError, assertNever, getErrorMessage } from './utils.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/base/errors/utils.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+describe('errors/utils', () => {
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('ensureError returns the same instance when given an Error', () => {
+    const error = new Error('boom');
+    expect(ensureError(error)).toBe(error);
+
+    const internalError = new InternalError({ message: 'internal boom' });
+    expect(ensureError(internalError)).toBe(internalError);
+  });
+
+  it('ensureError wraps an error-shaped object, preserving message/name/cause', () => {
+    const shaped = { message: 'shaped message', name: 'ShapedError', cause: 'root cause' };
+    const err = ensureError(shaped);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('shaped message');
+    expect(err.name).toBe('ShapedError');
+    expect(err.cause).toBe('root cause');
+  });
+
+  it('ensureError falls back to defaults for missing message/name', () => {
+    const err = ensureError({});
+
+    expect(err.message).toBe('Non-Error value caught in exception handler');
+    expect(err.name).toBe('ErrorWrapper');
+    expect(err.cause).toEqual({});
+  });
+
+  it('ensureError uses the caught value itself as cause when no cause is provided', () => {
+    const shaped = { message: 'no cause here' };
+    const err = ensureError(shaped);
+
+    expect(err.cause).toBe(shaped);
+  });
+
+  it('ensureError wraps primitive non-Error values', () => {
+    const err = ensureError('plain string');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('Non-Error value caught in exception handler');
+    expect(err.name).toBe('ErrorWrapper');
+    expect(err.cause).toBe('plain string');
+  });
+
+  // NOTE: ensureError reads `e.message`/`e.name`/`e.cause` without a null-check, so it
+  // throws a TypeError instead of returning a wrapped Error for null/undefined input.
+  it('ensureError throws when given null or undefined', () => {
+    expect(() => ensureError(null)).toThrow(TypeError);
+    expect(() => ensureError(undefined)).toThrow(TypeError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('assertNever throws an InternalError with the given message', () => {
+    expect(() => assertNever('unreachable' as never, 'unexpected value')).toThrow(
+      new InternalError({ message: 'unexpected value' }),
+    );
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('getErrorMessage extracts the message from strings, Errors, and other values', () => {
+    expect(getErrorMessage('plain string')).toBe('plain string');
+    expect(getErrorMessage(new Error('error message'))).toBe('error message');
+    expect(getErrorMessage(new InternalError({ message: 'internal message' }))).toBe('internal message');
+    expect(getErrorMessage(123)).toBe('123');
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('getErrorMessage strips leading and trailing quotes', () => {
+    expect(getErrorMessage('"quoted"')).toBe('quoted');
+    expect(getErrorMessage("'quoted'")).toBe('quoted');
+    expect(getErrorMessage(`"'mixed'"`)).toBe('mixed');
+    expect(getErrorMessage('unquoted')).toBe('unquoted');
+    expect(getErrorMessage('""')).toBe('');
+    expect(getErrorMessage(new Error('"error message"'))).toBe('error message');
+  });
+
+  it('getErrorMessage only strips quotes at the boundaries, not inside the message', () => {
+    expect(getErrorMessage('say "hello" to me')).toBe('say "hello" to me');
+    expect(getErrorMessage('"say "hello" to me"')).toBe('say "hello" to me');
+  });
+});

--- a/sdk/js-sdk/src/core/base/object.test.ts
+++ b/sdk/js-sdk/src/core/base/object.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { toArray, simpleDeepFreeze, isDeepEqual, addInternalFunction } from './object.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/base/object.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+describe('object', () => {
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('toArray', () => {
+    // Non-array values are wrapped in an array
+    expect(toArray('foo')).toEqual(['foo']);
+    expect(toArray(123)).toEqual([123]);
+    expect(toArray(null)).toEqual([null]);
+    expect(toArray(undefined)).toEqual([undefined]);
+    expect(toArray({ foo: 'bar' })).toEqual([{ foo: 'bar' }]);
+
+    // Arrays are returned as-is
+    const arr = [1, 2, 3];
+    expect(toArray(arr)).toBe(arr);
+    expect(toArray([])).toEqual([]);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('simpleDeepFreeze', () => {
+    const obj = { foo: 'bar', nested: { baz: 'qux' }, arr: [1, 2, 3] };
+    const frozen = simpleDeepFreeze(obj);
+
+    expect(frozen).toBe(obj);
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.isFrozen(frozen.nested)).toBe(true);
+
+    // Arrays are not recursed into
+    expect(Object.isFrozen(frozen.arr)).toBe(false);
+
+    // Frozen object cannot be mutated
+    expect(() => {
+      'use strict';
+      // @ts-expect-error - testing runtime immutability
+      frozen.foo = 'changed';
+    }).toThrow();
+  });
+
+  it('simpleDeepFreeze does not recurse into null values', () => {
+    const obj = { foo: null };
+    expect(() => simpleDeepFreeze(obj)).not.toThrow();
+    expect(Object.isFrozen(obj)).toBe(true);
+  });
+
+  it('simpleDeepFreeze skips already-frozen nested objects', () => {
+    const nested = Object.freeze({ baz: 'qux' });
+    const obj = { nested };
+    simpleDeepFreeze(obj);
+    expect(Object.isFrozen(obj.nested)).toBe(true);
+    expect(obj.nested).toBe(nested);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('isDeepEqual with primitives', () => {
+    // True
+    expect(isDeepEqual('foo', 'foo')).toBe(true);
+    expect(isDeepEqual(123, 123)).toBe(true);
+    expect(isDeepEqual(true, true)).toBe(true);
+    expect(isDeepEqual(null, null)).toBe(true);
+    expect(isDeepEqual(undefined, undefined)).toBe(true);
+    expect(isDeepEqual(NaN, NaN)).toBe(false); // uses === , not Object.is
+
+    // False
+    expect(isDeepEqual('foo', 'bar')).toBe(false);
+    expect(isDeepEqual(123, 456)).toBe(false);
+    expect(isDeepEqual(null, undefined)).toBe(false);
+    expect(isDeepEqual(0, false)).toBe(false);
+    expect(isDeepEqual('123', 123)).toBe(false);
+  });
+
+  it('isDeepEqual with arrays', () => {
+    // True
+    expect(isDeepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(isDeepEqual([], [])).toBe(true);
+    expect(isDeepEqual([{ foo: 'bar' }], [{ foo: 'bar' }])).toBe(true);
+    expect(isDeepEqual([[1, 2], [3]], [[1, 2], [3]])).toBe(true);
+
+    // False - order sensitive
+    expect(isDeepEqual([1, 2, 3], [3, 2, 1])).toBe(false);
+
+    // False - length mismatch
+    expect(isDeepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(isDeepEqual([1, 2, 3], [1, 2])).toBe(false);
+
+    // False - not an array
+    expect(isDeepEqual({ length: 0 }, [])).toBe(false);
+    expect(isDeepEqual('123', [1, 2, 3])).toBe(false);
+    expect(isDeepEqual(null, [])).toBe(false);
+  });
+
+  it('isDeepEqual with objects', () => {
+    // True
+    expect(isDeepEqual({ foo: 'bar' }, { foo: 'bar' })).toBe(true);
+    expect(isDeepEqual({}, {})).toBe(true);
+    expect(isDeepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true); // key order doesn't matter
+    expect(isDeepEqual({ a: { b: { c: 1 } } }, { a: { b: { c: 1 } } })).toBe(true);
+    expect(isDeepEqual({ a: [1, 2], b: 'x' }, { a: [1, 2], b: 'x' })).toBe(true);
+
+    // False - different values
+    expect(isDeepEqual({ foo: 'bar' }, { foo: 'baz' })).toBe(false);
+
+    // False - different keys
+    expect(isDeepEqual({ foo: 'bar' }, { baz: 'bar' })).toBe(false);
+
+    // False - different number of keys
+    expect(isDeepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(isDeepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+
+    // False - not an object
+    expect(isDeepEqual(null, { foo: 'bar' })).toBe(false);
+    expect(isDeepEqual([1, 2], { 0: 1, 1: 2 })).toBe(false);
+    expect(isDeepEqual('foo', { foo: 'bar' })).toBe(false);
+
+    // False - own property required, inherited properties don't count
+    const withInherited = Object.create({ foo: 'bar' });
+    withInherited.baz = 'qux';
+    expect(isDeepEqual(withInherited, { foo: 'bar' })).toBe(false);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('addInternalFunction', () => {
+    const target = { foo: 'bar' };
+    const fn = () => 'result';
+
+    const result = addInternalFunction(target, 'myFn', fn);
+
+    expect(result).toBe(target);
+    expect(result.myFn).toBe(fn);
+    expect(result.myFn()).toBe('result');
+
+    // Non-enumerable: hidden from Object.keys()/entries()
+    expect(Object.keys(result)).toEqual(['foo']);
+    expect(Object.keys(result)).not.toContain('myFn');
+
+    // Non-writable
+    expect(() => {
+      'use strict';
+      // @ts-expect-error - testing runtime immutability
+      result.myFn = () => 'other';
+    }).toThrow();
+
+    // Non-configurable
+    expect(() => {
+      Object.defineProperty(result, 'myFn', { value: () => 'other' });
+    }).toThrow();
+    expect(() => delete (result as Record<string, unknown>).myFn).toThrow();
+  });
+});

--- a/sdk/js-sdk/src/core/base/trustedValue.test.ts
+++ b/sdk/js-sdk/src/core/base/trustedValue.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { createTrustedValue, verifyTrustedValue } from './trustedValue.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/base/trustedValue.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+describe('trustedValue', () => {
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('createTrustedValue + verifyTrustedValue roundtrips the value with the same token', () => {
+    const token = Symbol('token');
+
+    expect(verifyTrustedValue(createTrustedValue('secret', token), token)).toBe('secret');
+    expect(verifyTrustedValue(createTrustedValue(123, token), token)).toBe(123);
+    expect(verifyTrustedValue(createTrustedValue(null, token), token)).toBe(null);
+    expect(verifyTrustedValue(createTrustedValue(undefined, token), token)).toBe(undefined);
+
+    const obj = { foo: 'bar' };
+    expect(verifyTrustedValue(createTrustedValue(obj, token), token)).toBe(obj);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('verifyTrustedValue throws on token mismatch', () => {
+    const token = Symbol('token');
+    const otherToken = Symbol('other-token');
+    const trusted = createTrustedValue('secret', token);
+
+    expect(() => verifyTrustedValue(trusted, otherToken)).toThrow('Token mismatch');
+  });
+
+  it('verifyTrustedValue distinguishes tokens with the same description', () => {
+    const token = Symbol('token');
+    const lookalikeToken = Symbol('token');
+    const trusted = createTrustedValue('secret', token);
+
+    expect(() => verifyTrustedValue(trusted, lookalikeToken)).toThrow('Token mismatch');
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('verifyTrustedValue throws on a forged / non-genuine value', () => {
+    const token = Symbol('token');
+
+    // Plain object shaped like a TrustedValue, but not a real instance
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const forged = { toString: () => 'TrustedValue' } as any;
+
+    expect(() => verifyTrustedValue(forged, token)).toThrow('Invalid TrustedValue');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => verifyTrustedValue(null as any, token)).toThrow('Invalid TrustedValue');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => verifyTrustedValue(undefined as any, token)).toThrow('Invalid TrustedValue');
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('createTrustedValue returns a frozen, opaque instance', () => {
+    const token = Symbol('token');
+    const trusted = createTrustedValue('secret', token);
+
+    expect(Object.isFrozen(trusted)).toBe(true);
+
+    // Does not leak the inner value through string/JSON conversion
+    expect(String(trusted)).toBe('TrustedValue');
+    expect(JSON.stringify(trusted)).toBe('"TrustedValue"');
+    expect(JSON.stringify({ trusted })).toBe('{"trusted":"TrustedValue"}');
+
+    // Cannot be mutated
+    expect(() => {
+      'use strict';
+      // @ts-expect-error - testing runtime immutability
+      trusted.injected = 'evil';
+    }).toThrow();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('each trusted value is independently verifiable', () => {
+    const token = Symbol('token');
+    const a = createTrustedValue('a', token);
+    const b = createTrustedValue('b', token);
+
+    expect(verifyTrustedValue(a, token)).toBe('a');
+    expect(verifyTrustedValue(b, token)).toBe('b');
+  });
+});

--- a/sdk/js-sdk/src/core/handle/ClearValue.test.ts
+++ b/sdk/js-sdk/src/core/handle/ClearValue.test.ts
@@ -1,0 +1,273 @@
+import type { FhevmRuntime } from '../types/coreFhevmRuntime.js';
+import type { ClearValue, Handle } from '../types/encryptedTypes-p.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isClearValue,
+  assertIsClearValue,
+  isClearValueArray,
+  assertIsClearValueArray,
+  createClearValue,
+  createClearValueArray,
+  clearValueToTypedValue,
+  abiEncodeClearValues,
+} from './ClearValue.js';
+import { buildHandle } from './FhevmHandle.js';
+import { asUint8Number, asUint64BigInt } from '../base/uint.js';
+import { asAddress } from '../base/address.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/handle/ClearValue.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+const HASH21 = `0x${'ab'.repeat(21)}`;
+const CHAIN_ID = 12345n;
+const ADDRESS = asAddress(`0x${'ab'.repeat(20)}`);
+
+const EUINT8_HANDLE: Handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: 2 });
+const EUINT64_HANDLE: Handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: 5, index: 0 });
+const EBOOL_HANDLE: Handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: 0, index: 1 });
+const EADDRESS_HANDLE: Handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: 7, index: 2 });
+
+describe('ClearValue', () => {
+  //////////////////////////////////////////////////////////////////////////////
+  // createClearValue
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('createClearValue builds a ClearValue exposing value/type/handle', () => {
+    const token = Symbol('token');
+    const clearValue = createClearValue({ value: asUint8Number(42), handle: EUINT8_HANDLE, originToken: token });
+
+    expect(clearValue.value).toBe(42);
+    expect(clearValue.type).toBe('uint8');
+    expect(clearValue.handle).toBe(EUINT8_HANDLE);
+  });
+
+  it('createClearValue supports ebool, euint64, and eaddress', () => {
+    const token = Symbol('token');
+
+    const boolValue = createClearValue({ value: true, handle: EBOOL_HANDLE, originToken: token });
+    expect(boolValue.type).toBe('bool');
+    expect(boolValue.value).toBe(true);
+
+    const bigIntValue = createClearValue({ value: asUint64BigInt(123n), handle: EUINT64_HANDLE, originToken: token });
+    expect(bigIntValue.type).toBe('uint64');
+    expect(bigIntValue.value).toBe(123n);
+
+    const addressValue = createClearValue({ value: ADDRESS, handle: EADDRESS_HANDLE, originToken: token });
+    expect(addressValue.type).toBe('address');
+    expect(addressValue.value).toBe(ADDRESS);
+  });
+
+  it('createClearValue throws when the value has the wrong JS type for the handle fheType', () => {
+    const token = Symbol('token');
+
+    expect(() =>
+      createClearValue({
+        // A string is not a valid euint8 value
+        value: 'not-a-number' as never,
+        handle: EUINT8_HANDLE,
+        originToken: token,
+      }),
+    ).toThrow();
+  });
+
+  it('createClearValue enforces the euint8/euint64 upper bound', () => {
+    const token = Symbol('token');
+
+    expect(() =>
+      createClearValue({
+        value: 999999 as never, // exceeds MAX_UINT8 (255)
+        handle: EUINT8_HANDLE,
+        originToken: token,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      createClearValue({
+        value: (2n ** 64n) as never, // exceeds MAX_UINT64
+        handle: EUINT64_HANDLE,
+        originToken: token,
+      }),
+    ).toThrow();
+  });
+
+  it('createClearValue returns a frozen instance', () => {
+    const token = Symbol('token');
+    const clearValue = createClearValue({ value: asUint8Number(1), handle: EUINT8_HANDLE, originToken: token });
+
+    expect(Object.isFrozen(clearValue)).toBe(true);
+    expect(() => {
+      'use strict';
+      // @ts-expect-error - testing runtime immutability
+      clearValue.injected = 'evil';
+    }).toThrow();
+  });
+
+  it('createClearValue toString/toJSON do not leak the value', () => {
+    const token = Symbol('token');
+    const clearValue = createClearValue({ value: asUint8Number(42), handle: EUINT8_HANDLE, originToken: token });
+
+    expect(String(clearValue)).toBe('ClearValue<euint8>');
+    expect(String(clearValue)).not.toContain('42');
+    expect(clearValue.toString()).not.toContain('42');
+    expect(JSON.stringify(clearValue)).toBe(JSON.stringify({ handle: EUINT8_HANDLE.bytes32Hex, fheType: 'euint8' }));
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // isClearValue / assertIsClearValue
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('isClearValue / assertIsClearValue only pass for the matching origin token', () => {
+    const token = Symbol('token');
+    const otherToken = Symbol('other-token');
+    const clearValue = createClearValue({ value: asUint8Number(1), handle: EUINT8_HANDLE, originToken: token });
+
+    expect(isClearValue(clearValue, token)).toBe(true);
+    expect(() => assertIsClearValue(clearValue, { originToken: token })).not.toThrow();
+
+    expect(isClearValue(clearValue, otherToken)).toBe(false);
+    expect(() => assertIsClearValue(clearValue, { originToken: otherToken })).toThrow();
+  });
+
+  it('isClearValue / assertIsClearValue reject non-ClearValue values', () => {
+    const token = Symbol('token');
+
+    expect(isClearValue({ value: 1 }, token)).toBe(false);
+    expect(isClearValue(null, token)).toBe(false);
+    expect(isClearValue(42, token)).toBe(false);
+    expect(() => assertIsClearValue('not-a-clear-value', { originToken: token })).toThrow();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // isClearValueArray / assertIsClearValueArray
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('isClearValueArray / assertIsClearValueArray validate every element', () => {
+    const token = Symbol('token');
+    const a = createClearValue({ value: asUint8Number(1), handle: EUINT8_HANDLE, originToken: token });
+    const b = createClearValue({ value: true, handle: EBOOL_HANDLE, originToken: token });
+
+    expect(isClearValueArray([a, b], token)).toBe(true);
+    expect(() => assertIsClearValueArray([a, b], { originToken: token })).not.toThrow();
+
+    expect(isClearValueArray([a, 'not-a-clear-value'], token)).toBe(false);
+    expect(() => assertIsClearValueArray([a, 'not-a-clear-value'], { originToken: token })).toThrow();
+  });
+
+  it('assertIsClearValueArray rejects a non-array value', () => {
+    const token = Symbol('token');
+    expect(() => assertIsClearValueArray('not-an-array', { originToken: token })).toThrow();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // clearValueToTypedValue
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('clearValueToTypedValue converts a ClearValue to a TypedValue', () => {
+    const token = Symbol('token');
+    const clearValue = createClearValue({ value: asUint8Number(7), handle: EUINT8_HANDLE, originToken: token });
+
+    const typedValue = clearValueToTypedValue(clearValue, token);
+    expect(typedValue.type).toBe('uint8');
+    expect(typedValue.value).toBe(7);
+  });
+
+  it('clearValueToTypedValue throws for a non-ClearValue or a mismatched token', () => {
+    const token = Symbol('token');
+    const otherToken = Symbol('other-token');
+    const clearValue = createClearValue({ value: asUint8Number(7), handle: EUINT8_HANDLE, originToken: token });
+
+    expect(() => clearValueToTypedValue(clearValue, otherToken)).toThrow();
+    expect(() => clearValueToTypedValue('not-a-clear-value', token)).toThrow();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // createClearValueArray
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('createClearValueArray builds a frozen array of ClearValues in order', () => {
+    const token = Symbol('token');
+    const result = createClearValueArray({
+      orderedValues: [asUint8Number(1), true],
+      orderedHandles: [EUINT8_HANDLE, EBOOL_HANDLE],
+      originToken: token,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.value).toBe(1);
+    expect(result[0]?.handle).toBe(EUINT8_HANDLE);
+    expect(result[1]?.value).toBe(true);
+    expect(result[1]?.handle).toBe(EBOOL_HANDLE);
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it('createClearValueArray throws when array lengths do not match', () => {
+    const token = Symbol('token');
+
+    expect(() =>
+      createClearValueArray({
+        orderedValues: [asUint8Number(1)],
+        orderedHandles: [EUINT8_HANDLE, EBOOL_HANDLE],
+        originToken: token,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      createClearValueArray({
+        orderedValues: [asUint8Number(1), true],
+        orderedHandles: [EUINT8_HANDLE],
+        originToken: token,
+      }),
+    ).toThrow();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // abiEncodeClearValues
+  //////////////////////////////////////////////////////////////////////////////
+
+  function makeRuntimeStub() {
+    const encode = vi.fn(() => '0xencoded');
+    const runtime = { ethereum: { encode } } as unknown as FhevmRuntime;
+    return { runtime, encode };
+  }
+
+  it('abiEncodeClearValues encodes ebool/euint/eaddress values as uint256', () => {
+    const token = Symbol('token');
+    const { runtime, encode } = makeRuntimeStub();
+
+    const orderedClearValues = [
+      createClearValue({ value: true, handle: EBOOL_HANDLE, originToken: token }),
+      createClearValue({ value: false, handle: EBOOL_HANDLE, originToken: token }),
+      createClearValue({ value: asUint8Number(5), handle: EUINT8_HANDLE, originToken: token }),
+      createClearValue({ value: asUint64BigInt(123n), handle: EUINT64_HANDLE, originToken: token }),
+      createClearValue({ value: ADDRESS, handle: EADDRESS_HANDLE, originToken: token }),
+    ];
+
+    const result = abiEncodeClearValues({ runtime }, { orderedClearValues });
+
+    expect(result.abiTypes).toEqual(['uint256', 'uint256', 'uint256', 'uint256', 'uint256']);
+    expect(result.abiValues).toEqual([1n, 0n, 5n, 123n, ADDRESS]);
+    expect(result.abiEncodedClearValues).toBe('0xencoded');
+    expect(encode).toHaveBeenCalledWith({ types: result.abiTypes, values: result.abiValues });
+  });
+
+  it('abiEncodeClearValues throws for an invalid ebool clear value', () => {
+    const { runtime } = makeRuntimeStub();
+
+    const forgedClearValue = { handle: { fheTypeId: 0 }, value: 2 } as unknown as ClearValue;
+
+    expect(() => abiEncodeClearValues({ runtime }, { orderedClearValues: [forgedClearValue] })).toThrow(
+      /Invalid ebool clear text value/,
+    );
+  });
+
+  it('abiEncodeClearValues throws for an unsupported fheTypeId', () => {
+    const { runtime } = makeRuntimeStub();
+
+    const forgedClearValue = { handle: { fheTypeId: 99 }, value: 1 } as unknown as ClearValue;
+
+    expect(() => abiEncodeClearValues({ runtime }, { orderedClearValues: [forgedClearValue] })).toThrow(
+      /Unsupported Fhevm primitive type id: 99/,
+    );
+  });
+});

--- a/sdk/js-sdk/src/core/handle/FheType.ts
+++ b/sdk/js-sdk/src/core/handle/FheType.ts
@@ -478,7 +478,7 @@ export function asClearValueType<etype extends FheType>(
     case 'euint32': {
       assertIsUintNumber(value, {
         ...options,
-        max: MAX_UINT_FOR_TYPE[fheTypeName],
+        max: MAX_UINT_FOR_TYPE[typeNameFromFheTypeName(fheTypeName)],
       });
       return value as ClearValueType<etype>;
     }
@@ -487,7 +487,7 @@ export function asClearValueType<etype extends FheType>(
     case 'euint256': {
       assertIsUintBigInt(value, {
         ...options,
-        max: MAX_UINT_FOR_TYPE[fheTypeName],
+        max: MAX_UINT_FOR_TYPE[typeNameFromFheTypeName(fheTypeName)],
       });
       return value as ClearValueType<etype>;
     }

--- a/sdk/js-sdk/src/core/handle/FhevmHandle.test.ts
+++ b/sdk/js-sdk/src/core/handle/FhevmHandle.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assertIsHandleBytes32Hex,
+  assertIsInputHandleBytes32Hex,
+  assertIsHandleBytes32,
+  assertIsInputHandleBytes32,
+  assertIsHandle,
+  assertIsInputHandle,
+  assertIsEncryptedValueLike,
+  isHandleBytes32,
+  isHandleBytes32Hex,
+  isHandle,
+  isInputHandle,
+  asHandle,
+  asHandleBytes32,
+  asHandleBytes32Hex,
+  handleBytes32HexToHandle,
+  bytes32HexToHandle,
+  bytes32HexToInputHandle,
+  bytes32ToHandle,
+  toFhevmHandle,
+  toInputHandle,
+  handleEquals,
+  assertHandleArrayEquals,
+  buildHandle,
+  assertHandlesBelongToSameChainId,
+  FHEVM_HANDLE_CURRENT_CIPHERTEXT_VERSION,
+} from './FhevmHandle.js';
+import { FhevmHandleError } from '../errors/FhevmHandleError.js';
+import { asBytes32Hex, asBytes32 } from '../base/bytes.js';
+import { asUint64BigInt } from '../base/uint.js';
+
+////////////////////////////////////////////////////////////////////////////////
+// npx vitest run --config src/vitest.config.ts src/core/handle/FhevmHandle.test.ts
+////////////////////////////////////////////////////////////////////////////////
+
+const HASH21 = `0x${'ab'.repeat(21)}`;
+const CHAIN_ID = 12345n;
+const EUINT8 = 2;
+const EADDRESS = 7;
+
+describe('FhevmHandle', () => {
+  //////////////////////////////////////////////////////////////////////////////
+  // buildHandle / instance getters
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('buildHandle builds a computed handle by default (no index)', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    expect(handle.hash21.toLowerCase()).toBe(HASH21);
+    expect(handle.chainId).toBe(CHAIN_ID);
+    expect(handle.fheTypeId).toBe(EUINT8);
+    expect(handle.fheType).toBe('euint8');
+    expect(handle.clearType).toBe('uint8');
+    expect(handle.version).toBe(FHEVM_HANDLE_CURRENT_CIPHERTEXT_VERSION);
+    expect(handle.index).toBe(255);
+    expect(handle.isComputed).toBe(true);
+    expect(handle.isExternal).toBe(false);
+    expect(handle.encryptionBits).toBe(8);
+    expect(handle.solidityPrimitiveTypeName).toBe('uint256');
+    expect(handle.bytes32Hex).toBe(handle.toString());
+    expect(JSON.stringify(handle)).toBe(JSON.stringify(handle.bytes32Hex));
+    expect(handle.bytes32HexNo0x).toBe(handle.bytes32Hex.slice(2));
+    expect(handle.bytes32).toBeInstanceOf(Uint8Array);
+    expect(handle.bytes32.length).toBe(32);
+  });
+
+  it('buildHandle builds an external/input handle when index is provided', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EADDRESS, index: 3 });
+
+    expect(handle.index).toBe(3);
+    expect(handle.isComputed).toBe(false);
+    expect(handle.isExternal).toBe(true);
+    expect(handle.fheType).toBe('eaddress');
+    expect(isInputHandle(handle)).toBe(true);
+  });
+
+  it('buildHandle.bytes32 returns a defensive copy each time', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    const a = handle.bytes32;
+    const b = handle.bytes32;
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // isHandleBytes32Hex / assertIsHandleBytes32Hex
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('isHandleBytes32Hex / assertIsHandleBytes32Hex accept a valid handle hex', () => {
+    const validHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32Hex;
+
+    expect(isHandleBytes32Hex(validHex)).toBe(true);
+    expect(() => assertIsHandleBytes32Hex(validHex)).not.toThrow();
+  });
+
+  it('isHandleBytes32Hex / assertIsHandleBytes32Hex reject a non bytes32-hex value', () => {
+    expect(isHandleBytes32Hex('not-a-hex')).toBe(false);
+    expect(() => assertIsHandleBytes32Hex('not-a-hex')).toThrow(FhevmHandleError);
+    expect(() => assertIsHandleBytes32Hex(123)).toThrow(FhevmHandleError);
+    expect(() => assertIsHandleBytes32Hex(null)).toThrow(FhevmHandleError);
+  });
+
+  it('isHandleBytes32Hex / assertIsHandleBytes32Hex reject an unknown fheTypeId', () => {
+    // byte 30 (fheTypeId) = 0x63 (99), which is not a known FheTypeId
+    const invalidFheTypeHex = `0x${'00'.repeat(30)}6300`;
+
+    expect(isHandleBytes32Hex(invalidFheTypeHex)).toBe(false);
+    expect(() => assertIsHandleBytes32Hex(invalidFheTypeHex)).toThrow(FhevmHandleError);
+  });
+
+  it('isHandleBytes32Hex / assertIsHandleBytes32Hex reject an unknown version', () => {
+    // byte 30 = 0x02 (euint8), byte 31 (version) = 0x01, only version 0 is supported
+    const invalidVersionHex = `0x${'00'.repeat(30)}0201`;
+
+    expect(isHandleBytes32Hex(invalidVersionHex)).toBe(false);
+    expect(() => assertIsHandleBytes32Hex(invalidVersionHex)).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // assertIsInputHandleBytes32Hex
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('assertIsInputHandleBytes32Hex accepts an external handle and rejects a computed one', () => {
+    const externalHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 }).bytes32Hex;
+    const computedHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32Hex;
+
+    expect(() => assertIsInputHandleBytes32Hex(externalHex)).not.toThrow();
+    expect(() => assertIsInputHandleBytes32Hex(computedHex)).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // isHandleBytes32 / assertIsHandleBytes32 / assertIsInputHandleBytes32
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('isHandleBytes32 / assertIsHandleBytes32 accept a valid handle bytes32', () => {
+    const validBytes = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32;
+
+    expect(isHandleBytes32(validBytes)).toBe(true);
+    expect(() => assertIsHandleBytes32(validBytes)).not.toThrow();
+  });
+
+  it('isHandleBytes32 / assertIsHandleBytes32 reject invalid values', () => {
+    expect(isHandleBytes32(new Uint8Array(31))).toBe(false);
+    expect(() => assertIsHandleBytes32(new Uint8Array(31))).toThrow(FhevmHandleError);
+    expect(() => assertIsHandleBytes32('not-bytes')).toThrow(FhevmHandleError);
+  });
+
+  it('assertIsInputHandleBytes32 accepts an external handle and rejects a computed one', () => {
+    const externalBytes = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 }).bytes32;
+    const computedBytes = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32;
+
+    expect(() => assertIsInputHandleBytes32(externalBytes)).not.toThrow();
+    expect(() => assertIsInputHandleBytes32(computedBytes)).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // isHandle / assertIsHandle / isInputHandle / assertIsInputHandle
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('isHandle / assertIsHandle only accept genuine Handle instances', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    expect(isHandle(handle)).toBe(true);
+    expect(() => assertIsHandle(handle)).not.toThrow();
+
+    expect(isHandle({ bytes32Hex: handle.bytes32Hex })).toBe(false);
+    expect(isHandle(handle.bytes32Hex)).toBe(false);
+    expect(() => assertIsHandle({ bytes32Hex: handle.bytes32Hex })).toThrow(FhevmHandleError);
+  });
+
+  it('isInputHandle / assertIsInputHandle distinguish external from computed handles', () => {
+    const external = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 5 });
+    const computed = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    expect(isInputHandle(external)).toBe(true);
+    expect(() => assertIsInputHandle(external)).not.toThrow();
+
+    expect(isInputHandle(computed)).toBe(false);
+    expect(() => assertIsInputHandle(computed)).toThrow(FhevmHandleError);
+
+    expect(isInputHandle('not-a-handle')).toBe(false);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // assertIsEncryptedValueLike
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('assertIsEncryptedValueLike accepts a Handle, a bytes32Hex string, a {bytes32Hex} object, and Bytes32', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    expect(() => assertIsEncryptedValueLike(handle)).not.toThrow();
+    expect(() => assertIsEncryptedValueLike(handle.bytes32Hex)).not.toThrow();
+    expect(() => assertIsEncryptedValueLike({ bytes32Hex: handle.bytes32Hex })).not.toThrow();
+    expect(() => assertIsEncryptedValueLike(handle.bytes32)).not.toThrow();
+  });
+
+  it('assertIsEncryptedValueLike rejects null, undefined, and malformed values', () => {
+    expect(() => assertIsEncryptedValueLike(null)).toThrow(FhevmHandleError);
+    expect(() => assertIsEncryptedValueLike(undefined)).toThrow(FhevmHandleError);
+    expect(() => assertIsEncryptedValueLike('not-a-hex')).toThrow();
+    expect(() => assertIsEncryptedValueLike({ bytes32Hex: 'not-a-hex' })).toThrow();
+    expect(() => assertIsEncryptedValueLike(123)).toThrow();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // asHandle / asHandleBytes32 / asHandleBytes32Hex
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('asHandle / asHandleBytes32 / asHandleBytes32Hex return the value when valid', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+    const bytes32 = handle.bytes32;
+    const bytes32Hex = handle.bytes32Hex;
+
+    expect(asHandle(handle)).toBe(handle);
+    expect(asHandleBytes32(bytes32)).toBe(bytes32);
+    expect(asHandleBytes32Hex(bytes32Hex)).toBe(bytes32Hex);
+  });
+
+  it('asHandle / asHandleBytes32 / asHandleBytes32Hex throw on invalid values', () => {
+    expect(() => asHandle('not-a-handle')).toThrow(FhevmHandleError);
+    expect(() => asHandleBytes32('not-bytes')).toThrow(FhevmHandleError);
+    expect(() => asHandleBytes32Hex('not-a-hex')).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // handleBytes32HexToHandle / bytes32HexToHandle / bytes32HexToInputHandle / bytes32ToHandle
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('handleBytes32HexToHandle wraps a hex string without validation (trusted)', () => {
+    const validHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32Hex;
+    const handle = handleBytes32HexToHandle(validHex);
+
+    expect(isHandle(handle)).toBe(true);
+    expect(handle.bytes32Hex).toBe(validHex);
+  });
+
+  it('bytes32HexToHandle validates fheTypeId/version and builds a Handle', () => {
+    const validHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32Hex;
+    const handle = bytes32HexToHandle(validHex);
+
+    expect(isHandle(handle)).toBe(true);
+    expect(handle.fheType).toBe('euint8');
+
+    const invalidFheTypeHex = asBytes32Hex(`0x${'00'.repeat(30)}6300`);
+    expect(() => bytes32HexToHandle(invalidFheTypeHex)).toThrow(FhevmHandleError);
+  });
+
+  it('bytes32HexToInputHandle validates the index and rejects computed handles', () => {
+    const externalHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 }).bytes32Hex;
+    const computedHex = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32Hex;
+
+    const inputHandle = bytes32HexToInputHandle(externalHex);
+    expect(isInputHandle(inputHandle)).toBe(true);
+
+    expect(() => bytes32HexToInputHandle(computedHex)).toThrow(FhevmHandleError);
+  });
+
+  it('bytes32ToHandle validates fheTypeId/version and builds a Handle from raw bytes', () => {
+    const validBytes = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 }).bytes32;
+    const handle = bytes32ToHandle(validBytes);
+
+    expect(isHandle(handle)).toBe(true);
+    expect(handle.bytes32Hex.toLowerCase()).toBe(
+      `0x${Array.from(validBytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')}`,
+    );
+
+    const invalidBytesRaw = new Uint8Array(32);
+    invalidBytesRaw[30] = 99; // unknown fheTypeId
+    const invalidBytes = asBytes32(invalidBytesRaw);
+    expect(() => bytes32ToHandle(invalidBytes)).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // toFhevmHandle / toInputHandle
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('toFhevmHandle accepts a Handle instance, a {bytes32Hex} object, a hex string, and Bytes32', () => {
+    const handle = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    expect(toFhevmHandle(handle)).toBe(handle);
+    expect(handleEquals(toFhevmHandle({ bytes32Hex: handle.bytes32Hex }), handle)).toBe(true);
+    expect(handleEquals(toFhevmHandle(handle.bytes32Hex), handle)).toBe(true);
+    expect(handleEquals(toFhevmHandle(handle.bytes32), handle)).toBe(true);
+  });
+
+  it('toFhevmHandle throws on invalid input', () => {
+    expect(() => toFhevmHandle('not-a-hex')).toThrow();
+    expect(() => toFhevmHandle({ bytes32Hex: 'not-a-hex' })).toThrow();
+    expect(() => toFhevmHandle(123)).toThrow();
+    expect(() => toFhevmHandle(null)).toThrow();
+  });
+
+  it('toInputHandle returns an input handle and rejects computed handles', () => {
+    const external = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+    const computed = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8 });
+
+    expect(handleEquals(toInputHandle(external.bytes32Hex), external)).toBe(true);
+    expect(() => toInputHandle(computed.bytes32Hex)).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // handleEquals
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('handleEquals compares handles by bytes32Hex', () => {
+    const a = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+    const b = bytes32HexToHandle(a.bytes32Hex);
+    const c = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 1 });
+
+    expect(handleEquals(a, b)).toBe(true);
+    expect(handleEquals(a, c)).toBe(false);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // assertHandleArrayEquals
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('assertHandleArrayEquals passes for matching arrays', () => {
+    const a = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+    const b = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 1 });
+
+    expect(() => assertHandleArrayEquals([a, b], [a, b])).not.toThrow();
+    // `expected` items are converted via toFhevmHandle, so raw hex strings work too
+    expect(() => assertHandleArrayEquals([a, b], [a.bytes32Hex, b.bytes32Hex] as never)).not.toThrow();
+  });
+
+  it('assertHandleArrayEquals throws on length mismatch', () => {
+    const a = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+
+    expect(() => assertHandleArrayEquals([a], [])).toThrow(FhevmHandleError);
+    expect(() => assertHandleArrayEquals([], [a])).toThrow(FhevmHandleError);
+  });
+
+  it('assertHandleArrayEquals throws on content mismatch', () => {
+    const a = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+    const b = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 1 });
+
+    expect(() => assertHandleArrayEquals([a], [b])).toThrow(FhevmHandleError);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // assertHandlesBelongToSameChainId
+  //////////////////////////////////////////////////////////////////////////////
+
+  it('assertHandlesBelongToSameChainId passes for an empty array', () => {
+    expect(() => assertHandlesBelongToSameChainId([])).not.toThrow();
+  });
+
+  it('assertHandlesBelongToSameChainId passes when all handles share a chainId', () => {
+    const a = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+    const b = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 1 });
+
+    expect(() => assertHandlesBelongToSameChainId([a, b])).not.toThrow();
+    expect(() => assertHandlesBelongToSameChainId([a, b], asUint64BigInt(CHAIN_ID))).not.toThrow();
+  });
+
+  it('assertHandlesBelongToSameChainId throws when a handle has a different chainId', () => {
+    const a = buildHandle({ chainId: CHAIN_ID, hash21: HASH21, fheTypeId: EUINT8, index: 0 });
+    const otherChainId = CHAIN_ID + 1n;
+    const b = buildHandle({ chainId: otherChainId, hash21: HASH21, fheTypeId: EUINT8, index: 1 });
+
+    expect(() => assertHandlesBelongToSameChainId([a, b])).toThrow(FhevmHandleError);
+    expect(() => assertHandlesBelongToSameChainId([a], asUint64BigInt(otherChainId))).toThrow(FhevmHandleError);
+  });
+});

--- a/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.decrypt.tests.ts
+++ b/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.decrypt.tests.ts
@@ -2,6 +2,7 @@ import type { ethers } from 'ethers';
 import type { EncryptedValue, TypedValue } from '@fhevm/sdk/types';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/ethers';
+import { canDecryptValue, canDecryptValues, canDecryptValuesFromPairs } from '@fhevm/sdk/actions/decrypt';
 import {
   decryptTestCases,
   fheTypeIdFromName,
@@ -226,6 +227,171 @@ export function defineClientDecryptDecryptTests(parameters: {
         } else {
           expect(BigInt(decrypted.value as number | bigint)).toBe(expectedRaw);
         }
+      }
+    });
+
+    // ┌─────────────────────────────────────────────────────────────────────┐
+    // │  Pairs decrypt test                                                 │
+    // │  Read all handles, decrypt via decryptValuesFromPairs, compare each │
+    // └─────────────────────────────────────────────────────────────────────┘
+
+    it('should decrypt all types via decryptValuesFromPairs', async () => {
+      const fheTest = config.fheTestContract.connect(config.signer) as ethers.Contract;
+
+      // Read all handles and their expected clear values from FHETest
+      const entries: {
+        fheType: string;
+        encryptedValue: EncryptedValue;
+        expectedRaw: bigint;
+      }[] = [];
+
+      for (const fheType of decryptTestCases) {
+        const fheTypeId = fheTypeIdFromName(fheType);
+
+        const encryptedValue: EncryptedValue = asEncryptedValue(
+          await fheTest.getHandleOf!(config.wallet.address, fheTypeId),
+        );
+        expect(encryptedValue).not.toBe('0x0000000000000000000000000000000000000000000000000000000000000000');
+
+        const expectedRaw: bigint = await fheTest.getClearText!(encryptedValue);
+        entries.push({ fheType, encryptedValue, expectedRaw });
+        console.log(`  ${fheType}: handle=${encryptedValue.slice(0, 20)}... expected=${expectedRaw}`);
+      }
+
+      // Decrypt all via decryptValuesFromPairs, each pair carrying its own contract address
+      const client = parameters.createFhevmDecryptClient({
+        chain: config.fhevmChain,
+        provider: config.provider,
+      });
+      await client.ready;
+
+      const transportKeyPair = await client.generateTransportKeyPair();
+      const signedPermit = await client.signDecryptionPermit({
+        transportKeyPair: transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.wallet.address,
+        signer: config.signer,
+      });
+
+      const pairs = entries.map((e) => ({
+        encryptedValue: asEncryptedValue(e.encryptedValue),
+        contractAddress: config.fheTestAddress,
+      }));
+
+      const typedValues: readonly TypedValue[] = await client.decryptValuesFromPairs({
+        pairs,
+        signedPermit,
+        transportKeyPair: transportKeyPair,
+      });
+
+      expect(typedValues).toHaveLength(entries.length);
+
+      // Compare each result
+      for (let i = 0; i < entries.length; i++) {
+        const { fheType, expectedRaw } = entries[i]!;
+        const decrypted = typedValues[i]!;
+        console.log(`  ${fheType}: decrypted=${decrypted.value} expected=${expectedRaw}`);
+
+        if (fheType === 'ebool') {
+          expect(decrypted.value).toBe(expectedRaw !== 0n);
+        } else if (fheType === 'eaddress') {
+          const expectedAddr = '0x' + expectedRaw.toString(16).padStart(40, '0');
+          expect(String(decrypted.value).toLowerCase()).toBe(expectedAddr.toLowerCase());
+        } else {
+          expect(BigInt(decrypted.value as number | bigint)).toBe(expectedRaw);
+        }
+      }
+    });
+
+    // ┌─────────────────────────────────────────────────────────────────────┐
+    // │  canDecryptValue / canDecryptValues / canDecryptValuesFromPairs     │
+    // │  ACL preflight checks — no actual decryption is performed           │
+    // └─────────────────────────────────────────────────────────────────────┘
+
+    it('should report canDecryptValue, canDecryptValues and canDecryptValuesFromPairs as allowed', async () => {
+      const fheTest = config.fheTestContract.connect(config.signer) as ethers.Contract;
+
+      // Read all handles from FHETest
+      const encryptedValues: EncryptedValue[] = [];
+
+      for (const fheType of decryptTestCases) {
+        const fheTypeId = fheTypeIdFromName(fheType);
+        const encryptedValue: EncryptedValue = asEncryptedValue(
+          await fheTest.getHandleOf!(config.wallet.address, fheTypeId),
+        );
+        expect(encryptedValue).not.toBe('0x0000000000000000000000000000000000000000000000000000000000000000');
+        encryptedValues.push(encryptedValue);
+      }
+
+      const client = parameters.createFhevmDecryptClient({
+        chain: config.fhevmChain,
+        provider: config.provider,
+      });
+      await client.ready;
+
+      const transportKeyPair = await client.generateTransportKeyPair();
+      const signedPermit = await client.signDecryptionPermit({
+        transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.wallet.address,
+        signer: config.signer,
+      });
+
+      // canDecryptValue — identifying the target user by a plain address
+      const singleByUserAddress = await canDecryptValue(client, {
+        encryptedValue: encryptedValues[0]!,
+        contractAddress: config.fheTestAddress,
+        userAddress: config.wallet.address,
+      });
+      expect(singleByUserAddress.allowed).toBe(true);
+      expect(singleByUserAddress.details.contractAllowed).toBe(true);
+      expect(singleByUserAddress.details.userAllowed).toBe(true);
+
+      // canDecryptValue — identifying the target user by a signed decryption permit
+      const singleByPermit = await canDecryptValue(client, {
+        encryptedValue: encryptedValues[0]!,
+        contractAddress: config.fheTestAddress,
+        signedPermit,
+        transportKeyPair,
+      });
+      expect(singleByPermit.allowed).toBe(true);
+      expect(singleByPermit.details.contractAllowed).toBe(true);
+      expect(singleByPermit.details.userAllowed).toBe(true);
+
+      // canDecryptValues — batch of handles on a single contract
+      const batchResult = await canDecryptValues(client, {
+        encryptedValues,
+        contractAddress: config.fheTestAddress,
+        signedPermit,
+        transportKeyPair,
+      });
+      expect(batchResult.allowed).toBe(true);
+      expect(batchResult.details).toHaveLength(encryptedValues.length);
+      for (const detail of batchResult.details) {
+        expect(detail.contractAllowed).toBe(true);
+        expect(detail.userAllowed).toBe(true);
+      }
+
+      // canDecryptValuesFromPairs — same batch, expressed as handle/contract-address pairs
+      const pairs = encryptedValues.map((encryptedValue) => ({
+        encryptedValue,
+        contractAddress: config.fheTestAddress,
+      }));
+
+      const pairsResult = await canDecryptValuesFromPairs(client, {
+        pairs,
+        signedPermit,
+        transportKeyPair,
+      });
+      expect(pairsResult.allowed).toBe(true);
+      expect(pairsResult.details).toHaveLength(pairs.length);
+      for (const detail of pairsResult.details) {
+        expect(detail.contractAllowed).toBe(true);
+        expect(detail.userAllowed).toBe(true);
       }
     });
   });

--- a/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.decrypt.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.decrypt.tests.ts
@@ -1,6 +1,7 @@
 import type { Hex } from 'viem';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { setFhevmRuntimeConfig } from '@fhevm/sdk/viem';
+import { canDecryptValue, canDecryptValues, canDecryptValuesFromPairs } from '@fhevm/sdk/actions/decrypt';
 import { getViemTestConfig, type CreateViemDecryptClientFn, type FheTestViemConfig } from '../setup-viem.js';
 import { FHETestABI } from '../FheTest-abi-v2.js';
 import { decryptTestCases, fheTypeIdFromName, clearTypeFromHandle, createLogger } from '../setupCommon.js';
@@ -234,6 +235,181 @@ export function defineClientDecryptDecryptTests(parameters: {
         } else {
           expect(BigInt(decrypted.value as number | bigint)).toBe(expectedRaw);
         }
+      }
+    });
+
+    // ┌─────────────────────────────────────────────────────────────────────┐
+    // │  Pairs decrypt test                                                 │
+    // │  Read all handles, decrypt via decryptValuesFromPairs, compare each │
+    // └─────────────────────────────────────────────────────────────────────┘
+
+    it('should decrypt all types via decryptValuesFromPairs', async () => {
+      // Read all handles and their expected clear values from FHETest
+      const entries: {
+        fheType: string;
+        handle: EncryptedValue;
+        expectedRaw: bigint;
+      }[] = [];
+
+      for (const fheType of decryptTestCases) {
+        const fheTypeId = fheTypeIdFromName(fheType);
+        const encryptedValue: EncryptedValue = asEncryptedValue(
+          await config.publicClient.readContract({
+            address: config.fheTestAddress as Hex,
+            abi: FHETestABI,
+            functionName: 'getHandleOf',
+            args: [config.account.address, fheTypeId],
+          }),
+        );
+        expect(encryptedValue).not.toBe('0x0000000000000000000000000000000000000000000000000000000000000000');
+
+        const expectedRaw = await config.publicClient.readContract({
+          address: config.fheTestAddress as Hex,
+          abi: FHETestABI,
+          functionName: 'getClearText',
+          args: [encryptedValue],
+        });
+        entries.push({ fheType, handle: encryptedValue, expectedRaw });
+        console.log(`  ${fheType}: handle=${encryptedValue.slice(0, 20)}... expected=${expectedRaw}`);
+      }
+
+      // Decrypt all via decryptValuesFromPairs, each pair carrying its own contract address
+      const client = parameters.createFhevmDecryptClient({
+        chain: config.fhevmChain,
+        publicClient: config.publicClient,
+      });
+      await client.ready;
+
+      const transportKeyPair = await client.generateTransportKeyPair();
+      const signedPermit = await client.signDecryptionPermit({
+        transportKeyPair: transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.account.address,
+        signer: config.account,
+      });
+
+      const pairs = entries.map((e) => ({
+        encryptedValue: asEncryptedValue(e.handle),
+        contractAddress: config.fheTestAddress,
+      }));
+
+      const typedValues: readonly TypedValue[] = await client.decryptValuesFromPairs({
+        pairs,
+        signedPermit,
+        transportKeyPair: transportKeyPair,
+      });
+
+      expect(typedValues).toHaveLength(entries.length);
+
+      // Compare each result
+      for (let i = 0; i < entries.length; i++) {
+        const { fheType, expectedRaw } = entries[i]!;
+        const decrypted = typedValues[i]!;
+        console.log(`  ${fheType}: decrypted=${decrypted.value} expected=${expectedRaw}`);
+
+        if (fheType === 'ebool') {
+          expect(decrypted.value).toBe(expectedRaw !== 0n);
+        } else if (fheType === 'eaddress') {
+          const expectedAddr = '0x' + expectedRaw.toString(16).padStart(40, '0');
+          expect(String(decrypted.value).toLowerCase()).toBe(expectedAddr.toLowerCase());
+        } else {
+          expect(BigInt(decrypted.value as number | bigint)).toBe(expectedRaw);
+        }
+      }
+    });
+
+    // ┌─────────────────────────────────────────────────────────────────────┐
+    // │  canDecryptValue / canDecryptValues / canDecryptValuesFromPairs     │
+    // │  ACL preflight checks — no actual decryption is performed           │
+    // └─────────────────────────────────────────────────────────────────────┘
+
+    it('should report canDecryptValue, canDecryptValues and canDecryptValuesFromPairs as allowed', async () => {
+      // Read all handles from FHETest
+      const encryptedValues: EncryptedValue[] = [];
+
+      for (const fheType of decryptTestCases) {
+        const fheTypeId = fheTypeIdFromName(fheType);
+        const encryptedValue: EncryptedValue = asEncryptedValue(
+          await config.publicClient.readContract({
+            address: config.fheTestAddress as Hex,
+            abi: FHETestABI,
+            functionName: 'getHandleOf',
+            args: [config.account.address, fheTypeId],
+          }),
+        );
+        expect(encryptedValue).not.toBe('0x0000000000000000000000000000000000000000000000000000000000000000');
+        encryptedValues.push(encryptedValue);
+      }
+
+      const client = parameters.createFhevmDecryptClient({
+        chain: config.fhevmChain,
+        publicClient: config.publicClient,
+      });
+      await client.ready;
+
+      const transportKeyPair = await client.generateTransportKeyPair();
+      const signedPermit = await client.signDecryptionPermit({
+        transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.account.address,
+        signer: config.account,
+      });
+
+      // canDecryptValue — identifying the target user by a plain address
+      const singleByUserAddress = await canDecryptValue(client, {
+        encryptedValue: encryptedValues[0]!,
+        contractAddress: config.fheTestAddress,
+        userAddress: config.account.address,
+      });
+      expect(singleByUserAddress.allowed).toBe(true);
+      expect(singleByUserAddress.details.contractAllowed).toBe(true);
+      expect(singleByUserAddress.details.userAllowed).toBe(true);
+
+      // canDecryptValue — identifying the target user by a signed decryption permit
+      const singleByPermit = await canDecryptValue(client, {
+        encryptedValue: encryptedValues[0]!,
+        contractAddress: config.fheTestAddress,
+        signedPermit,
+        transportKeyPair,
+      });
+      expect(singleByPermit.allowed).toBe(true);
+      expect(singleByPermit.details.contractAllowed).toBe(true);
+      expect(singleByPermit.details.userAllowed).toBe(true);
+
+      // canDecryptValues — batch of handles on a single contract
+      const batchResult = await canDecryptValues(client, {
+        encryptedValues,
+        contractAddress: config.fheTestAddress,
+        signedPermit,
+        transportKeyPair,
+      });
+      expect(batchResult.allowed).toBe(true);
+      expect(batchResult.details).toHaveLength(encryptedValues.length);
+      for (const detail of batchResult.details) {
+        expect(detail.contractAllowed).toBe(true);
+        expect(detail.userAllowed).toBe(true);
+      }
+
+      // canDecryptValuesFromPairs — same batch, expressed as handle/contract-address pairs
+      const pairs = encryptedValues.map((encryptedValue) => ({
+        encryptedValue,
+        contractAddress: config.fheTestAddress,
+      }));
+
+      const pairsResult = await canDecryptValuesFromPairs(client, {
+        pairs,
+        signedPermit,
+        transportKeyPair,
+      });
+      expect(pairsResult.allowed).toBe(true);
+      expect(pairsResult.details).toHaveLength(pairs.length);
+      for (const detail of pairsResult.details) {
+        expect(detail.contractAllowed).toBe(true);
+        expect(detail.userAllowed).toBe(true);
       }
     });
   });

--- a/sdk/js-sdk/test/scripts/localstack-restart.sh
+++ b/sdk/js-sdk/test/scripts/localstack-restart.sh
@@ -33,6 +33,8 @@ Options:
   --chain, -c <name>    Chain to pass to fhetest-deploy.sh. One of:
                         ${VALID_CHAINS[*]}.
                         Default: ${CHAIN}.
+  --fhevm-dir <path>    Directory containing the fhevm-cli / test-suite/fhevm
+                        checkout to use. Default: ${FHEVM_DIR}.
   --force, -f           Force a full down/up restart and redeploy FHETest.
   --dry-run, -n         Print the resolved configuration and the commands that
                         would be executed, then exit without doing anything.
@@ -79,6 +81,15 @@ while [[ $# -gt 0 ]]; do
             CHAIN="$2"
             shift 2
             ;;
+        --fhevm-dir)
+            require_arg_value "$1" "${2:-}"
+            FHEVM_DIR="$2"
+            shift 2
+            ;;
+        --fhevm-dir=*)
+            FHEVM_DIR="${1#--fhevm-dir=}"
+            shift
+            ;;
         --force|-f)
             FORCE=true
             shift
@@ -102,6 +113,13 @@ if ! is_valid_chain "$CHAIN"; then
     echo "Error: invalid --chain '$CHAIN'. Expected one of: ${VALID_CHAINS[*]}." >&2
     exit 1
 fi
+
+if [[ ! -d "$FHEVM_DIR" ]]; then
+    echo "Error: --fhevm-dir '$FHEVM_DIR' is not a directory." >&2
+    exit 1
+fi
+FHEVM_DIR="$(cd "$FHEVM_DIR" && pwd)"
+PROFILES_DIR="$FHEVM_DIR/profiles"
 
 if [[ -n "$PROFILE" ]]; then
     PROFILE_PATH="$PROFILES_DIR/$PROFILE"

--- a/sdk/js-sdk/test/scripts/localstack-run-tests.sh
+++ b/sdk/js-sdk/test/scripts/localstack-run-tests.sh
@@ -11,6 +11,21 @@ PROFILE=""
 CHAIN="localstack"
 VALID_CHAINS=(localstack localstack_v11 localstack_v12 localstack_v13 localstack_v14)
 
+# Chains that must run against this pinned fhevm commit rather than the
+# current checkout of test-suite/fhevm (which may no longer support the
+# fhevm-cli profiles / deploy behavior these older chains rely on).
+PINNED_FHEVM_CHAINS=(localstack_v11 localstack_v12 localstack_v13)
+# July 3 2026 : "chore(sdk): v1.1.0-alpha.7"
+PINNED_FHEVM_COMMIT="86a1821bd76dd429d53894918cc37293df2ae1a7"
+
+FHEVM_CHECKOUT_DIR=""
+cleanup_fhevm_checkout() {
+    if [[ -n "$FHEVM_CHECKOUT_DIR" ]]; then
+        rm -rf "$FHEVM_CHECKOUT_DIR"
+    fi
+}
+trap cleanup_fhevm_checkout EXIT
+
 usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
@@ -45,10 +60,32 @@ is_valid_chain() {
     return 1
 }
 
+needs_pinned_fhevm() {
+    local candidate="$1"
+    local c
+    for c in "${PINNED_FHEVM_CHAINS[@]}"; do
+        if [[ "$c" == "$candidate" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 require_arg_value() {
     if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == -* ]]; then
         echo "Error: ${1} requires a value." >&2
         exit 1
+    fi
+}
+
+format_duration() {
+    local total="$1"
+    local m=$(( total / 60 ))
+    local s=$(( total % 60 ))
+    if [[ "$m" -gt 0 ]]; then
+        printf '%dm%02ds' "$m" "$s"
+    else
+        printf '%ds' "$s"
     fi
 }
 
@@ -116,16 +153,41 @@ esac
 
 cd "$ROOT_DIR"
 
+SETUP_DURATION=0
+TESTS_DURATION=0
+STOP_DURATION=0
+
+SETUP_START=$SECONDS
 if [ "$SKIP_START" = false ]; then
   RESTART_ARGS=(--chain "$CHAIN")
   if [[ -n "$PROFILE" ]]; then
     RESTART_ARGS+=(--fhevm-cli-profile "$PROFILE")
   fi
   RESTART_ARGS+=(--force)
+
+  if needs_pinned_fhevm "$CHAIN"; then
+    REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+    FHEVM_CHECKOUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fhevm-pinned.XXXXXX")"
+    echo "Chain '$CHAIN' requires pinned fhevm commit $PINNED_FHEVM_COMMIT; checking out into $FHEVM_CHECKOUT_DIR..."
+    # Skip smudging on clone: it would otherwise try to check out $REPO_ROOT's own
+    # HEAD, which may only have LFS pointer files (actions/checkout defaults to
+    # lfs: false), causing a spurious "remote missing object" failure against the
+    # local clone's LFS remote before we ever reach the pinned commit below.
+    GIT_LFS_SKIP_SMUDGE=1 git clone --quiet "$REPO_ROOT" "$FHEVM_CHECKOUT_DIR"
+    # Point LFS at the real origin so the pinned commit's LFS objects are fetched
+    # from there instead of the local (LFS-content-less) clone source.
+    git -C "$FHEVM_CHECKOUT_DIR" config remote.origin.url "$(git -C "$REPO_ROOT" config remote.origin.url)"
+    git -C "$FHEVM_CHECKOUT_DIR" checkout --quiet "$PINNED_FHEVM_COMMIT"
+    RESTART_ARGS+=(--fhevm-dir "$FHEVM_CHECKOUT_DIR/test-suite/fhevm")
+  fi
+
   "$SCRIPT_DIR/localstack-restart.sh" "${RESTART_ARGS[@]}"
 fi
+SETUP_DURATION=$(( SECONDS - SETUP_START ))
 
 export CHAIN
+
+TESTS_START=$SECONDS
 
 # First check configuration
 if ! npx vitest run --config test/fheTest/vitest.config.ts test/fheTest/viem/clientBase.chain.test.ts; then
@@ -138,8 +200,24 @@ fi
 [[ "$RUN_VIEM"   -eq 1 ]] && npx vitest run --config test/fheTest/vitest.config.ts test/fheTest/viem
 [[ "$RUN_ETHERS" -eq 1 ]] && npx vitest run --config test/fheTest/vitest.config.ts test/fheTest/ethers
 
+TESTS_DURATION=$(( SECONDS - TESTS_START ))
+
+STOP_START=$SECONDS
 if [ "$SKIP_START" = false ]; then
-  if ! "$SCRIPT_DIR/localstack-stop.sh"; then
+  STOP_RESULT=0
+  if [[ -n "$FHEVM_CHECKOUT_DIR" ]]; then
+    "$SCRIPT_DIR/localstack-stop.sh" --fhevm-dir "$FHEVM_CHECKOUT_DIR/test-suite/fhevm" || STOP_RESULT=$?
+  else
+    "$SCRIPT_DIR/localstack-stop.sh" || STOP_RESULT=$?
+  fi
+  if [[ "$STOP_RESULT" -ne 0 ]]; then
     echo "Warning: localstack-stop.sh failed; ignoring teardown error because tests already completed." >&2
   fi
 fi
+STOP_DURATION=$(( SECONDS - STOP_START ))
+
+echo ""
+echo "Timing summary:"
+printf '  %-24s %s\n' "Setup ${CHAIN}:" "$(format_duration "$SETUP_DURATION")"
+printf '  %-24s %s\n' "Run tests:" "$(format_duration "$TESTS_DURATION")"
+printf '  %-24s %s\n' "Stop ${CHAIN}:" "$(format_duration "$STOP_DURATION")"

--- a/sdk/js-sdk/test/scripts/localstack-stop.sh
+++ b/sdk/js-sdk/test/scripts/localstack-stop.sh
@@ -4,5 +4,53 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FHEVM_DIR="$(cd "$SCRIPT_DIR/../../../../test-suite/fhevm" && pwd)"
 
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Shut down the local FHEVM stack.
+
+Options:
+  --fhevm-dir <path>    Directory containing the fhevm-cli / test-suite/fhevm
+                        checkout to use. Default: ${FHEVM_DIR}.
+  --help, -h            Print this help message and exit.
+EOF
+}
+
+require_arg_value() {
+    if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == -* ]]; then
+        echo "Error: ${1} requires a value." >&2
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fhevm-dir)
+            require_arg_value "$1" "${2:-}"
+            FHEVM_DIR="$2"
+            shift 2
+            ;;
+        --fhevm-dir=*)
+            FHEVM_DIR="${1#--fhevm-dir=}"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option '$1'. Use --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -d "$FHEVM_DIR" ]]; then
+    echo "Error: --fhevm-dir '$FHEVM_DIR' is not a directory." >&2
+    exit 1
+fi
+FHEVM_DIR="$(cd "$FHEVM_DIR" && pwd)"
+
 # Shutdown fhevm
-${FHEVM_DIR}/fhevm-cli down
+"${FHEVM_DIR}/fhevm-cli" down


### PR DESCRIPTION
## Summary
- Pin the fhevm repo version used by the localstack test scripts so tests keep passing against fhevm versions below v0.14
- Add localstack fheTests covering `decryptValuesFromPairs` and `canDecryptValue(s)`/`canDecryptValuesFromPairs` for both ethers and viem
- Add unit tests for `core/base/errors/utils`, `core/base/object`, `core/base/trustedValue`, `core/handle/ClearValue`, and `core/handle/FhevmHandle`
- Fix `MAX_UINT_FOR_TYPE` lookup in `asClearValueType` for `euint32`/`euint256`, which was indexing by the raw FHE type name instead of the clear type name and could return `undefined` for the max bound
