### PR TITLE
chore(coprocessor): bump crossbeam-epoch for audit

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -2868,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Updates `crossbeam-epoch` from `0.9.18` to `0.9.20` in the coprocessor lockfile.

This addresses the new RustSec advisory `RUSTSEC-2026-0204`, which made `coprocessor-dependency-analysis/dependencies-check` fail when `cargo-audit audit` scans `coprocessor/fhevm-engine/Cargo.lock`.

## Validation

- `cargo update -w --locked`
- `cargo tree -i crossbeam-epoch`
- `cargo-deny deny check license --deny license-not-encountered`
- `cargo-audit audit`
