### PR TITLE
refactor(coprocessor): rename ethereum chain id flag to canonical protocol config chain id

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.13.7
+version: 0.13.8
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-catchup-only-deployment.yaml
@@ -211,8 +211,8 @@ spec:
                 {{- toYaml $chain.protocolConfigContractAddressValueFrom | nindent 16 }}
               {{- end }}
             {{- end }}
-            {{- with $.Values.commonConfig.ethereumChainId }}
-            - name: ETHEREUM_CHAIN_ID
+            {{- with $.Values.commonConfig.canonicalProtocolConfigChainId }}
+            - name: CANONICAL_PROTOCOL_CONFIG_CHAIN_ID
               value: {{ . | quote }}
             {{- end }}
           {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerCatchupOnlyShared.tracing.enabled }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-consumer-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-consumer-deployment.yaml
@@ -207,8 +207,8 @@ spec:
                 {{- toYaml $chain.protocolConfigContractAddressValueFrom | nindent 16 }}
               {{- end }}
             {{- end }}
-            {{- with $.Values.commonConfig.ethereumChainId }}
-            - name: ETHEREUM_CHAIN_ID
+            {{- with $.Values.commonConfig.canonicalProtocolConfigChainId }}
+            - name: CANONICAL_PROTOCOL_CONFIG_CHAIN_ID
               value: {{ . | quote }}
             {{- end }}
           {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerConsumerShared.tracing.enabled }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-deployment.yaml
@@ -211,8 +211,8 @@ spec:
                 {{- toYaml $chain.protocolConfigContractAddressValueFrom | nindent 16 }}
               {{- end }}
             {{- end }}
-            {{- with $.Values.commonConfig.ethereumChainId }}
-            - name: ETHEREUM_CHAIN_ID
+            {{- with $.Values.commonConfig.canonicalProtocolConfigChainId }}
+            - name: CANONICAL_PROTOCOL_CONFIG_CHAIN_ID
               value: {{ . | quote }}
             {{- end }}
           {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerShared.tracing.enabled }}

--- a/charts/coprocessor/templates/coprocessor-host-listener-poller-deployment.yaml
+++ b/charts/coprocessor/templates/coprocessor-host-listener-poller-deployment.yaml
@@ -214,8 +214,8 @@ spec:
                 {{- toYaml $chain.protocolConfigContractAddressValueFrom | nindent 16 }}
               {{- end }}
             {{- end }}
-            {{- with $.Values.commonConfig.ethereumChainId }}
-            - name: ETHEREUM_CHAIN_ID
+            {{- with $.Values.commonConfig.canonicalProtocolConfigChainId }}
+            - name: CANONICAL_PROTOCOL_CONFIG_CHAIN_ID
               value: {{ . | quote }}
             {{- end }}
           {{- if default $.Values.commonConfig.tracing.enabled $.Values.hostListenerPollerShared.tracing.enabled }}

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -81,9 +81,10 @@ commonConfig:
   kmsGenerationContractAddress: {}  # optional — e.g. 0x...
   protocolConfigContractAddress: {}  # optional — e.g. 0x...
 
-  # Ethereum host chain id. Only the host-listener whose own chain id matches
-  # this value decodes ProtocolConfig.CoprocessorUpgradeProposed events.
-  ethereumChainId: ""
+  # Chain id of the canonical chain hosting the ProtocolConfig contract. Only
+  # the host-listener whose own chain id matches this value decodes
+  # ProtocolConfig.CoprocessorUpgradeProposed events.
+  canonicalProtocolConfigChainId: ""
 
   # Coprocessor stack version baked into the service images (the value printed
   # by `<binary> --stack-version`). When set, it is surfaced as the

--- a/coprocessor/fhevm-engine/host-listener/src/bin/consumer.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/consumer.rs
@@ -144,7 +144,7 @@ async fn main() -> anyhow::Result<()> {
 
     if matches!(args.protocol_config.chain_id, Some(0)) {
         return Err(anyhow::anyhow!(
-            "--ethereum-chain-id=0 is not a valid chain id; omit the flag to disable ProtocolConfig decoding"
+            "--canonical-protocol-config-chain-id=0 is not a valid chain id; omit the flag to disable ProtocolConfig decoding"
         ));
     }
     let protocol_config_address = args.protocol_config.parsed_address()?;
@@ -192,7 +192,7 @@ async fn main() -> anyhow::Result<()> {
         dependent_ops_max_per_chain: args.dependent_ops_max_per_chain,
         chain_id: args.chain_id,
         gcs_mode,
-        ethereum_chain_id: args.protocol_config.chain_id,
+        canonical_protocol_config_chain_id: args.protocol_config.chain_id,
     };
 
     run_consumer(config).await

--- a/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
@@ -175,7 +175,7 @@ async fn main() -> anyhow::Result<()> {
 
     if matches!(args.protocol_config.chain_id, Some(0)) {
         return Err(anyhow::anyhow!(
-            "--ethereum-chain-id=0 is not a valid chain id; omit the flag to disable ProtocolConfig decoding"
+            "--canonical-protocol-config-chain-id=0 is not a valid chain id; omit the flag to disable ProtocolConfig decoding"
         ));
     }
     let protocol_config_address = args.protocol_config.parsed_address()?;
@@ -225,7 +225,7 @@ async fn main() -> anyhow::Result<()> {
         dependence_cross_block: args.dependence_cross_block,
         dependent_ops_max_per_chain: args.dependent_ops_max_per_chain,
         gcs_mode,
-        ethereum_chain_id: args.protocol_config.chain_id,
+        canonical_protocol_config_chain_id: args.protocol_config.chain_id,
     };
 
     run_poller(config).await

--- a/coprocessor/fhevm-engine/host-listener/src/consumer/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/consumer/mod.rs
@@ -57,7 +57,7 @@ pub struct ConsumerConfig {
     pub dependent_ops_max_per_chain: u32,
     pub chain_id: String,
     pub gcs_mode: bool,
-    pub ethereum_chain_id: Option<u64>,
+    pub canonical_protocol_config_chain_id: Option<u64>,
 }
 
 pub fn collect_logs(payload: &BlockPayload) -> Vec<Log> {
@@ -324,7 +324,7 @@ pub async fn run_consumer(config: ConsumerConfig) -> Result<()> {
     let chain_id = ChainId::try_from(chain_id)?;
     let is_protocol_config_listener =
         crate::protocol_config::resolve_protocol_config_listener(
-            config.ethereum_chain_id,
+            config.canonical_protocol_config_chain_id,
             chain_id.as_u64(),
         )?;
 

--- a/coprocessor/fhevm-engine/host-listener/src/database/ingest.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/ingest.rs
@@ -38,7 +38,7 @@ pub struct IngestOptions {
     pub dependence_cross_block: bool,
     pub dependent_ops_max_per_chain: u32,
     /// Resolved once at startup from the listener's own `chain_id` and the
-    /// configured `--ethereum-chain-id`. When false, the listener silently
+    /// configured `--canonical-protocol-config-chain-id`. When false, the listener silently
     /// skips `ProtocolConfig.CoprocessorUpgradeProposed` events.
     pub is_protocol_config_listener: bool,
 }
@@ -240,7 +240,7 @@ pub async fn ingest_block_logs(
         .execute(&mut *tx)
         .await?;
 
-    // Only the listener watching the configured Ethereum host chain decodes
+    // Only the listener watching the configured canonical chain decodes
     // `CoprocessorUpgradeProposed`; every other listener skips the channel.
     let is_protocol_config_listener = options.is_protocol_config_listener;
 

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -97,7 +97,7 @@ pub struct PollerConfig {
     pub dependence_cross_block: bool,
     pub dependent_ops_max_per_chain: u32,
     pub gcs_mode: bool,
-    pub ethereum_chain_id: Option<u64>,
+    pub canonical_protocol_config_chain_id: Option<u64>,
 }
 
 pub async fn run_poller(config: PollerConfig) -> Result<()> {
@@ -144,7 +144,7 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
     let chain_id_str = chain_id.to_string();
     let is_protocol_config_listener =
         crate::protocol_config::resolve_protocol_config_listener(
-            config.ethereum_chain_id,
+            config.canonical_protocol_config_chain_id,
             chain_id.as_u64(),
         )?;
     blockchain_timeout_tick.update();

--- a/coprocessor/fhevm-engine/host-listener/src/protocol_config/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/protocol_config/mod.rs
@@ -23,13 +23,13 @@ pub struct ProtocolConfigArgs {
     pub address: String,
 
     #[arg(
-        id = "ethereum_chain_id",
-        long = "ethereum-chain-id",
-        value_name = "ETHEREUM_CHAIN_ID",
-        env = "ETHEREUM_CHAIN_ID",
-        help = "Ethereum host chain id. The listener decodes \
-                ProtocolConfig.CoprocessorUpgradeProposed only when its own chain id matches. \
-                Omit on listeners that don't run against the Ethereum host chain."
+        id = "canonical_protocol_config_chain_id",
+        long = "canonical-protocol-config-chain-id",
+        value_name = "CANONICAL_PROTOCOL_CONFIG_CHAIN_ID",
+        env = "CANONICAL_PROTOCOL_CONFIG_CHAIN_ID",
+        help = "Chain id of the canonical chain hosting the ProtocolConfig contract. \
+                The listener decodes ProtocolConfig.CoprocessorUpgradeProposed only when its \
+                own chain id matches. Omit on listeners that don't run against the canonical chain."
     )]
     pub chain_id: Option<u64>,
 }
@@ -48,21 +48,21 @@ impl ProtocolConfigArgs {
     }
 }
 
-/// True iff `ethereum_chain_id == Some(chain_id)`. Rejects `Some(0)`; logs the resolved role.
+/// True iff `canonical_protocol_config_chain_id == Some(chain_id)`. Rejects `Some(0)`; logs the resolved role.
 pub fn resolve_protocol_config_listener(
-    ethereum_chain_id: Option<u64>,
+    canonical_protocol_config_chain_id: Option<u64>,
     chain_id: u64,
 ) -> Result<bool> {
-    if matches!(ethereum_chain_id, Some(0)) {
+    if matches!(canonical_protocol_config_chain_id, Some(0)) {
         return Err(anyhow!(
-            "--ethereum-chain-id=0 is not a valid chain id; omit the flag to disable ProtocolConfig decoding"
+            "--canonical-protocol-config-chain-id=0 is not a valid chain id; omit the flag to disable ProtocolConfig decoding"
         ));
     }
-    let is_listener = ethereum_chain_id == Some(chain_id);
+    let is_listener = canonical_protocol_config_chain_id == Some(chain_id);
     info!(
         is_protocol_config_listener = is_listener,
         chain_id,
-        ethereum_chain_id = ?ethereum_chain_id,
+        canonical_protocol_config_chain_id = ?canonical_protocol_config_chain_id,
         "Resolved ProtocolConfig listener role",
     );
     Ok(is_listener)

--- a/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
@@ -189,7 +189,7 @@ async fn poller_catches_up_to_safe_tip(
         dependence_cross_block: false,
         dependent_ops_max_per_chain: 0,
         gcs_mode: false,
-        ethereum_chain_id: Some(chain_id.as_u64()),
+        canonical_protocol_config_chain_id: Some(chain_id.as_u64()),
     };
 
     let poller_handle = tokio::spawn(run_poller(config));


### PR DESCRIPTION
### Summary

Renames the host-listener flag `--ethereum-chain-id` to `--canonical-protocol-config-chain-id` so the name is explicit about which chain it refers to — the canonical chain hosting the `ProtocolConfig` contract, whose `CoprocessorUpgradeProposed` events the listener trusts.

- CLI flag, env var, and value_name → `canonical-protocol-config-chain-id` / `CANONICAL_PROTOCOL_CONFIG_CHAIN_ID`
- Rust config fields, resolver param, error messages, and doc comments → `canonical_protocol_config_chain_id`
- Helm: `commonConfig.canonicalProtocolConfigChainId` + `CANONICAL_PROTOCOL_CONFIG_CHAIN_ID` env across all four host-listener deployments; bump coprocessor chart `0.13.7` → `0.13.8`