### PR TITLE
ci(test-suite): add Solana LiteSVM coprocessor gate

### DIFF
--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -172,6 +172,7 @@ jobs:
     permissions:
       contents: 'read'
     runs-on: large_ubuntu_16
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -253,4 +254,4 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
           SQLX_OFFLINE: 'true'
-        run: cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1
+        run: cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1 --nocapture

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -93,6 +93,7 @@ jobs:
             retry curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install" -o /tmp/anza-install.sh
             sh /tmp/anza-install.sh
           fi
+          mkdir -p "$HOME/.cache/solana"
           echo "$SOLANA_BIN" >> "$GITHUB_PATH"
 
       - name: Install Anchor CLI
@@ -202,6 +203,7 @@ jobs:
             retry curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install" -o /tmp/anza-install.sh
             sh /tmp/anza-install.sh
           fi
+          mkdir -p "$HOME/.cache/solana"
           echo "$SOLANA_BIN" >> "$GITHUB_PATH"
 
       - name: Install Anchor CLI

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changes-solana: ${{ steps.filter.outputs.solana }}
+      changes-litesvm-gate: ${{ steps.filter.outputs.litesvm-gate }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -40,6 +41,18 @@ jobs:
               - coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
               - coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
               - coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+            litesvm-gate:
+              - .github/workflows/solana-tests.yml
+              - solana/**
+              - coprocessor/fhevm-engine/Cargo.lock
+              - coprocessor/fhevm-engine/Cargo.toml
+              - coprocessor/fhevm-engine/fhevm-engine-common/**
+              - coprocessor/fhevm-engine/fhevm-keys/**
+              - coprocessor/fhevm-engine/host-listener/**
+              - coprocessor/fhevm-engine/scheduler/**
+              - coprocessor/fhevm-engine/test-harness/**
+              - coprocessor/fhevm-engine/tfhe-worker/**
+              - coprocessor/proto/**
 
   build-and-test:
     name: solana-tests/build-and-test
@@ -140,3 +153,86 @@ jobs:
         env:
           SQLX_OFFLINE: 'true'
         run: cargo test -p host-listener --features solana-grpc,solana-reconstruct fhe_eval_acl
+
+  litesvm-coprocessor-gate:
+    name: solana-tests/litesvm-coprocessor-gate
+    needs: check-changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-litesvm-gate == 'true' }}
+    permissions:
+      contents: 'read'
+    runs-on: large_ubuntu_16
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+
+      - name: Checkout required LFS key fixtures
+        run: |
+          git lfs pull \
+            --include="coprocessor/fhevm-engine/fhevm-keys/xof-keyset,coprocessor/fhevm-engine/fhevm-keys/xof-cks,coprocessor/fhevm-engine/fhevm-keys/pp" \
+            --exclude=""
+
+      - name: Setup Rust toolchain file
+        run: cp coprocessor/fhevm-engine/rust-toolchain.toml .
+
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
+
+      - name: Cache Solana CLI and AVM
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.avm
+            ~/.local/share/solana
+          key: solana-toolchain-${{ runner.os }}-anchor-${{ env.ANCHOR_VERSION }}-solana-${{ env.SOLANA_VERSION }}
+
+      - name: Install Solana CLI
+        run: |
+          if ! command -v solana >/dev/null; then
+            sh -c "$(curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install")"
+          fi
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      - name: Install Anchor CLI via AVM
+        run: |
+          cargo install --git https://github.com/solana-foundation/anchor avm --locked --force
+          avm install "${ANCHOR_VERSION}"
+          avm use "${ANCHOR_VERSION}"
+          echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
+
+      - name: Verify toolchain versions
+        working-directory: solana
+        run: |
+          solana --version
+          anchor --version
+          test "$(anchor --version)" = "anchor-cli ${ANCHOR_VERSION}"
+          test "$(awk -F'"' '/^anchor_version/ { print $2 }' Anchor.toml)" = "${ANCHOR_VERSION}"
+
+      - name: Install cargo dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler mold clang
+
+      - name: Cache cargo
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            coprocessor/fhevm-engine/target
+          key: ${{ runner.os }}-cargo-litesvm-coprocessor-${{ hashFiles('coprocessor/fhevm-engine/Cargo.lock', 'solana/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-litesvm-coprocessor-
+
+      - name: Verify Docker is available for testcontainers
+        run: docker info
+
+      - name: Build Solana PoC SBF programs
+        working-directory: solana
+        run: bash scripts/check-zama-host-idl.sh
+
+      - name: Run ignored LiteSVM coprocessor integration tests
+        working-directory: coprocessor/fhevm-engine
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
+          RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+          SQLX_OFFLINE: 'true'
+        run: cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -248,7 +248,7 @@ jobs:
         working-directory: solana
         run: bash scripts/check-zama-host-idl.sh
 
-      - name: Run focused LiteSVM coprocessor smoke tests
+      - name: Run LiteSVM coprocessor tests
         working-directory: coprocessor/fhevm-engine
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
@@ -257,10 +257,12 @@ jobs:
         run: |
           set -euo pipefail
           tests=(
+            solana_confidential_transfer_with_real_ciphertexts_computes_and_decrypts
             solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata
             solana_fhe_rand_creates_ciphertext_and_decrypts
+            solana_trivial_encrypt_then_confidential_transfer_computes_and_decrypts
             solana_user_decrypt_acl_invariants_match_evm_semantics
           )
           for test in "${tests[@]}"; do
-            cargo test -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
+            cargo test --profile local -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
           done

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -248,10 +248,19 @@ jobs:
         working-directory: solana
         run: bash scripts/check-zama-host-idl.sh
 
-      - name: Run ignored LiteSVM coprocessor integration tests
+      - name: Run focused LiteSVM coprocessor smoke tests
         working-directory: coprocessor/fhevm-engine
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
           SQLX_OFFLINE: 'true'
-        run: cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1 --nocapture
+        run: |
+          set -euo pipefail
+          tests=(
+            solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata
+            solana_fhe_rand_creates_ciphertext_and_decrypts
+            solana_user_decrypt_acl_invariants_match_evm_semantics
+          )
+          for test in "${tests[@]}"; do
+            cargo test -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
+          done

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -244,25 +244,5 @@ jobs:
       - name: Verify Docker is available for testcontainers
         run: docker info
 
-      - name: Build Solana PoC SBF programs
-        working-directory: solana
-        run: bash scripts/check-zama-host-idl.sh
-
-      - name: Run LiteSVM coprocessor tests
-        working-directory: coprocessor/fhevm-engine
-        env:
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
-          RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-          SQLX_OFFLINE: 'true'
-        run: |
-          set -euo pipefail
-          tests=(
-            solana_confidential_transfer_with_real_ciphertexts_computes_and_decrypts
-            solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata
-            solana_fhe_rand_creates_ciphertext_and_decrypts
-            solana_trivial_encrypt_then_confidential_transfer_computes_and_decrypts
-            solana_user_decrypt_acl_invariants_match_evm_semantics
-          )
-          for test in "${tests[@]}"; do
-            cargo test --profile local -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
-          done
+      - name: Run LiteSVM coprocessor gate
+        run: bash solana/scripts/test-litesvm-coprocessor-gate.sh

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -12,7 +12,8 @@ concurrency:
 
 env:
   ANCHOR_VERSION: "1.0.2"
-  SOLANA_VERSION: "2.1.0"
+  SOLANA_VERSION: "2.1.21"
+  NO_DNA: "1"
 
 jobs:
   check-changes:
@@ -46,6 +47,9 @@ jobs:
               - solana/**
               - coprocessor/fhevm-engine/Cargo.lock
               - coprocessor/fhevm-engine/Cargo.toml
+              - coprocessor/fhevm-engine/rust-toolchain.toml
+              - coprocessor/fhevm-engine/.sqlx/**
+              - coprocessor/fhevm-engine/db-migration/**
               - coprocessor/fhevm-engine/fhevm-engine-common/**
               - coprocessor/fhevm-engine/fhevm-keys/**
               - coprocessor/fhevm-engine/host-listener/**
@@ -74,27 +78,33 @@ jobs:
 
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
-      - name: Cache Solana CLI and AVM
+      - name: Cache Solana CLI
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
-          path: |
-            ~/.avm
-            ~/.local/share/solana
-          key: solana-toolchain-${{ runner.os }}-anchor-${{ env.ANCHOR_VERSION }}-solana-${{ env.SOLANA_VERSION }}
+          path: ~/.local/share/solana
+          key: solana-cli-${{ runner.os }}-${{ env.SOLANA_VERSION }}
 
       - name: Install Solana CLI
         run: |
-          if ! command -v solana >/dev/null; then
-            sh -c "$(curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install")"
+          set -euo pipefail
+          retry() { local n; for n in 1 2 3; do "$@" && return 0; echo "attempt $n failed; retrying in 5s" >&2; sleep 5; done; return 1; }
+          SOLANA_BIN="$HOME/.local/share/solana/install/active_release/bin"
+          if [ ! -x "$SOLANA_BIN/solana" ]; then
+            retry curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install" -o /tmp/anza-install.sh
+            sh /tmp/anza-install.sh
           fi
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+          echo "$SOLANA_BIN" >> "$GITHUB_PATH"
 
-      - name: Install Anchor CLI via AVM
+      - name: Install Anchor CLI
         run: |
-          cargo install --git https://github.com/solana-foundation/anchor avm --locked --force
-          avm install "${ANCHOR_VERSION}"
-          avm use "${ANCHOR_VERSION}"
-          echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          retry() { local n; for n in 1 2 3; do "$@" && return 0; echo "attempt $n failed; retrying in 5s" >&2; sleep 5; done; return 1; }
+          mkdir -p "$HOME/.cargo/bin"
+          if [ ! -x "$HOME/.cargo/bin/anchor" ] || [ "$("$HOME/.cargo/bin/anchor" --version)" != "anchor-cli ${ANCHOR_VERSION}" ]; then
+            retry curl -sSfL "https://github.com/coral-xyz/anchor/releases/download/v${ANCHOR_VERSION}/anchor-${ANCHOR_VERSION}-x86_64-unknown-linux-gnu" -o "$HOME/.cargo/bin/anchor"
+            chmod +x "$HOME/.cargo/bin/anchor"
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Verify toolchain versions
         run: |
@@ -177,27 +187,33 @@ jobs:
 
       - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
 
-      - name: Cache Solana CLI and AVM
+      - name: Cache Solana CLI
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
-          path: |
-            ~/.avm
-            ~/.local/share/solana
-          key: solana-toolchain-${{ runner.os }}-anchor-${{ env.ANCHOR_VERSION }}-solana-${{ env.SOLANA_VERSION }}
+          path: ~/.local/share/solana
+          key: solana-cli-${{ runner.os }}-${{ env.SOLANA_VERSION }}
 
       - name: Install Solana CLI
         run: |
-          if ! command -v solana >/dev/null; then
-            sh -c "$(curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install")"
+          set -euo pipefail
+          retry() { local n; for n in 1 2 3; do "$@" && return 0; echo "attempt $n failed; retrying in 5s" >&2; sleep 5; done; return 1; }
+          SOLANA_BIN="$HOME/.local/share/solana/install/active_release/bin"
+          if [ ! -x "$SOLANA_BIN/solana" ]; then
+            retry curl -sSfL "https://release.anza.xyz/v${SOLANA_VERSION}/install" -o /tmp/anza-install.sh
+            sh /tmp/anza-install.sh
           fi
-          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+          echo "$SOLANA_BIN" >> "$GITHUB_PATH"
 
-      - name: Install Anchor CLI via AVM
+      - name: Install Anchor CLI
         run: |
-          cargo install --git https://github.com/solana-foundation/anchor avm --locked --force
-          avm install "${ANCHOR_VERSION}"
-          avm use "${ANCHOR_VERSION}"
-          echo "$HOME/.avm/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          retry() { local n; for n in 1 2 3; do "$@" && return 0; echo "attempt $n failed; retrying in 5s" >&2; sleep 5; done; return 1; }
+          mkdir -p "$HOME/.cargo/bin"
+          if [ ! -x "$HOME/.cargo/bin/anchor" ] || [ "$("$HOME/.cargo/bin/anchor" --version)" != "anchor-cli ${ANCHOR_VERSION}" ]; then
+            retry curl -sSfL "https://github.com/coral-xyz/anchor/releases/download/v${ANCHOR_VERSION}/anchor-${ANCHOR_VERSION}-x86_64-unknown-linux-gnu" -o "$HOME/.cargo/bin/anchor"
+            chmod +x "$HOME/.cargo/bin/anchor"
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Verify toolchain versions
         working-directory: solana

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
@@ -21,8 +21,7 @@ use host_listener::{
     solana_adapter::{
         decode_anchor_cpi_events, decode_anchor_log_events, decode_solana_transaction_events,
         insert_solana_events, normalize_solana_events_for_db, solana_transaction_id,
-        SolanaAclAllowedEvent, SolanaBlockMeta, SolanaFinalizedAccountFetch,
-        SolanaFinalizedAccountFetchKind, SolanaHostEvent,
+        SolanaAclAllowedEvent, SolanaBlockMeta, SolanaFinalizedAccountFetchKind, SolanaHostEvent,
     },
 };
 use litesvm::{types::TransactionMetadata, LiteSVM};
@@ -512,15 +511,18 @@ async fn solana_trivial_encrypt_then_confidential_transfer_computes_and_decrypts
     ];
     let (meta, account_keys, signature) =
         send_many_with_meta(&mut fixture.svm, &fixture.alice, initial_ixs);
-    let mut initial_events = host_events(&meta, &account_keys, fixture.host_program_id);
+    let initial_events = host_events(&meta, &account_keys, fixture.host_program_id);
     assert_eq!(count_tfhe_events(&initial_events), 3);
     assert_eq!(count_acl_events(&initial_events), 3);
-    add_allow_fetches(
-        &mut initial_events,
-        &[fixture.alice_initial, fixture.bob_initial, amount_handle],
-    );
 
-    insert_host_events(&harness.listener_db, initial_events, signature, 1).await?;
+    insert_host_events_and_mark_allowed(
+        &harness.listener_db,
+        initial_events,
+        signature,
+        1,
+        &[fixture.alice_initial, fixture.bob_initial, amount_handle],
+    )
+    .await?;
     wait_until_computed(&harness.app).await?;
 
     let output = transfer_output_accounts(&fixture, 1);
@@ -603,12 +605,12 @@ async fn solana_fhe_rand_creates_ciphertext_and_decrypts() -> Result<(), Box<dyn
     ];
     let (meta, account_keys, signature) =
         send_many_with_meta(&mut fixture.svm, &fixture.payer, ixs);
-    let mut events = host_events(&meta, &account_keys, fixture.host_program_id);
+    let events = host_events(&meta, &account_keys, fixture.host_program_id);
     assert_eq!(count_tfhe_events(&events), 1);
     assert_eq!(count_acl_events(&events), 1);
-    add_allow_fetches(&mut events, &[rand_handle]);
 
-    insert_host_events(&harness.listener_db, events, signature, 1).await?;
+    insert_host_events_and_mark_allowed(&harness.listener_db, events, signature, 1, &[rand_handle])
+        .await?;
     wait_until_computed(&harness.app).await?;
 
     let decrypted = decrypt_handles(&harness.pool, &[Handle::from(rand_handle)]).await?;
@@ -1280,6 +1282,17 @@ async fn insert_host_events(
     signature: Signature,
     block_number: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    insert_host_events_and_mark_allowed(listener_db, host_events, signature, block_number, &[])
+        .await
+}
+
+async fn insert_host_events_and_mark_allowed(
+    listener_db: &host_listener::database::tfhe_event_propagate::Database,
+    host_events: Vec<SolanaHostEvent>,
+    signature: Signature,
+    block_number: u64,
+    allowed_handles: &[[u8; 32]],
+) -> Result<(), Box<dyn std::error::Error>> {
     let transaction_id = solana_transaction_id(signature.as_ref());
     let block = SolanaBlockMeta {
         block_number,
@@ -1290,6 +1303,11 @@ async fn insert_host_events(
     };
     let mut db_tx = listener_db.new_transaction().await?;
     insert_solana_events(listener_db, &mut db_tx, host_events, transaction_id, block).await?;
+    for handle in allowed_handles {
+        listener_db
+            .mark_solana_computation_allowed(&mut db_tx, handle.as_slice())
+            .await?;
+    }
     db_tx.commit().await?;
     Ok(())
 }
@@ -1368,19 +1386,6 @@ fn count_acl_events(events: &[SolanaHostEvent]) -> usize {
         .iter()
         .filter(|event| matches!(event, SolanaHostEvent::AclAllowed(_)))
         .count()
-}
-
-fn add_allow_fetches(events: &mut Vec<SolanaHostEvent>, handles: &[[u8; 32]]) {
-    events.extend(handles.iter().copied().map(|handle| {
-        SolanaHostEvent::FinalizedAccountFetch(SolanaFinalizedAccountFetch {
-            account_key: handle,
-            kind: SolanaFinalizedAccountFetchKind::AclRecord,
-            reason: "acl_record_bound",
-            handle: Some(Handle::from(handle)),
-            related_account: None,
-            subject: None,
-        })
-    }));
 }
 
 fn signed_user_decrypt_request(

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
@@ -21,7 +21,8 @@ use host_listener::{
     solana_adapter::{
         decode_anchor_cpi_events, decode_anchor_log_events, decode_solana_transaction_events,
         insert_solana_events, normalize_solana_events_for_db, solana_transaction_id,
-        SolanaAclAllowedEvent, SolanaBlockMeta, SolanaFinalizedAccountFetchKind, SolanaHostEvent,
+        SolanaAclAllowedEvent, SolanaBlockMeta, SolanaFinalizedAccountFetch,
+        SolanaFinalizedAccountFetchKind, SolanaHostEvent,
     },
 };
 use litesvm::{types::TransactionMetadata, LiteSVM};
@@ -116,7 +117,7 @@ async fn solana_confidential_transfer_with_real_ciphertexts_computes_and_decrypt
     db_tx.commit().await?;
 
     assert_eq!(stats.tfhe_events, 5);
-    assert_eq!(stats.acl_events, 7);
+    assert_eq!(stats.acl_events, 3);
 
     wait_until_computed(&harness.app).await?;
     assert!(kms_like_user_decrypt_check(
@@ -306,7 +307,7 @@ fn solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata() {
         account_fetches[0].handle,
         tfhe_result_handle(&tfhe_logs[0].event.data)
     );
-    assert!(!tfhe_logs[0].is_allowed);
+    assert!(tfhe_logs[0].is_allowed);
 }
 
 #[test]
@@ -511,9 +512,13 @@ async fn solana_trivial_encrypt_then_confidential_transfer_computes_and_decrypts
     ];
     let (meta, account_keys, signature) =
         send_many_with_meta(&mut fixture.svm, &fixture.alice, initial_ixs);
-    let initial_events = host_events(&meta, &account_keys, fixture.host_program_id);
+    let mut initial_events = host_events(&meta, &account_keys, fixture.host_program_id);
     assert_eq!(count_tfhe_events(&initial_events), 3);
     assert_eq!(count_acl_events(&initial_events), 3);
+    add_allow_fetches(
+        &mut initial_events,
+        &[fixture.alice_initial, fixture.bob_initial, amount_handle],
+    );
 
     insert_host_events(&harness.listener_db, initial_events, signature, 1).await?;
     wait_until_computed(&harness.app).await?;
@@ -598,9 +603,10 @@ async fn solana_fhe_rand_creates_ciphertext_and_decrypts() -> Result<(), Box<dyn
     ];
     let (meta, account_keys, signature) =
         send_many_with_meta(&mut fixture.svm, &fixture.payer, ixs);
-    let events = host_events(&meta, &account_keys, fixture.host_program_id);
+    let mut events = host_events(&meta, &account_keys, fixture.host_program_id);
     assert_eq!(count_tfhe_events(&events), 1);
     assert_eq!(count_acl_events(&events), 1);
+    add_allow_fetches(&mut events, &[rand_handle]);
 
     insert_host_events(&harness.listener_db, events, signature, 1).await?;
     wait_until_computed(&harness.app).await?;
@@ -1364,6 +1370,19 @@ fn count_acl_events(events: &[SolanaHostEvent]) -> usize {
         .count()
 }
 
+fn add_allow_fetches(events: &mut Vec<SolanaHostEvent>, handles: &[[u8; 32]]) {
+    events.extend(handles.iter().copied().map(|handle| {
+        SolanaHostEvent::FinalizedAccountFetch(SolanaFinalizedAccountFetch {
+            account_key: handle,
+            kind: SolanaFinalizedAccountFetchKind::AclRecord,
+            reason: "acl_record_bound",
+            handle: Some(Handle::from(handle)),
+            related_account: None,
+            subject: None,
+        })
+    }));
+}
+
 fn signed_user_decrypt_request(
     signer: &Keypair,
     allowed_acl_domain_keys: Vec<Pubkey>,
@@ -1621,9 +1640,9 @@ fn send_with_meta(
     payer: &Keypair,
     ix: Instruction,
 ) -> (TransactionMetadata, Vec<Pubkey>, Signature) {
-    // Confidential transfer's real euint64 FHE ops exceed the default 200k CU limit
-    // (mollusk measures ~258k); raise it like a real client would.
-    let ixs = [set_compute_unit_limit_ix(400_000), ix];
+    // Confidential transfer's real euint64 FHE ops exceed the default 200k CU limit;
+    // use the same client-side budget as the PoC live client.
+    let ixs = [set_compute_unit_limit_ix(1_400_000), ix];
     let message = Message::new_with_blockhash(&ixs, Some(&payer.pubkey()), &svm.latest_blockhash());
     let account_keys = message.account_keys.clone();
     let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(message), &[payer]).unwrap();
@@ -1637,7 +1656,7 @@ fn send_many_with_meta(
     ixs: Vec<Instruction>,
 ) -> (TransactionMetadata, Vec<Pubkey>, Signature) {
     let mut ixs = ixs;
-    ixs.insert(0, set_compute_unit_limit_ix(400_000));
+    ixs.insert(0, set_compute_unit_limit_ix(1_400_000));
     let message = Message::new_with_blockhash(&ixs, Some(&payer.pubkey()), &svm.latest_blockhash());
     let account_keys = message.account_keys.clone();
     let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(message), &[payer]).unwrap();

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
@@ -188,6 +188,8 @@ pub async fn errors_on_allowed_handles(
 pub async fn wait_until_all_allowed_handles_computed(
     test_instance: &TestInstance,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let started_at = std::time::Instant::now();
+    let timeout = Duration::from_secs(300);
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(2)
         .connect(test_instance.db_url())
@@ -203,6 +205,16 @@ pub async fn wait_until_all_allowed_handles_computed(
         if current_count == 0 {
             println!("All computations completed");
             break;
+        } else if started_at.elapsed() >= timeout {
+            let errors = errors_on_allowed_handles(test_instance).await?;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!(
+                    "timed out after {:?} waiting for {current_count} allowed computations; errors: {errors:?}",
+                    timeout
+                ),
+            )
+            .into());
         } else {
             println!("{current_count} computations remaining, waiting...");
         }

--- a/solana/docs/TESTING.md
+++ b/solana/docs/TESTING.md
@@ -62,10 +62,10 @@ cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo check -p host-listener
 cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test -p host-listener solana_adapter::tests::
 ```
 
-The LiteSVM coprocessor gate runs a focused set of ignored Solana PoC smoke tests, including one
-real-TFHE worker round trip. It needs Docker running locally because the worker test harness starts
-a disposable Postgres container with testcontainers; no manual database setup is needed. From the
-repository root:
+The LiteSVM coprocessor gate runs the ignored Solana PoC tests against the real TFHE worker under
+the repo's optimized `local` cargo profile. It needs Docker running locally because the worker test
+harness starts a disposable Postgres container with testcontainers; no manual database setup is
+needed. From the repository root:
 
 ```bash
 bash solana/scripts/test-litesvm-coprocessor-gate.sh

--- a/solana/docs/TESTING.md
+++ b/solana/docs/TESTING.md
@@ -62,9 +62,10 @@ cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo check -p host-listener
 cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test -p host-listener solana_adapter::tests::
 ```
 
-The LiteSVM coprocessor gate runs the ignored real-TFHE worker integration tests. It needs Docker
-running locally because the test harness starts a disposable Postgres container with testcontainers;
-no manual database setup is needed. From the repository root:
+The LiteSVM coprocessor gate runs a focused set of ignored Solana PoC smoke tests, including one
+real-TFHE worker round trip. It needs Docker running locally because the worker test harness starts
+a disposable Postgres container with testcontainers; no manual database setup is needed. From the
+repository root:
 
 ```bash
 bash solana/scripts/test-litesvm-coprocessor-gate.sh

--- a/solana/docs/TESTING.md
+++ b/solana/docs/TESTING.md
@@ -62,6 +62,14 @@ cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo check -p host-listener
 cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test -p host-listener solana_adapter::tests::
 ```
 
+The LiteSVM coprocessor gate runs the ignored real-TFHE worker integration tests. It needs Docker
+running locally because the test harness starts a disposable Postgres container with testcontainers;
+no manual database setup is needed. From the repository root:
+
+```bash
+bash solana/scripts/test-litesvm-coprocessor-gate.sh
+```
+
 > Note on a green test run: the suites print many `Program ... failed: custom program error: 0x...`
 > lines. Those are **negative tests** asserting expected reverts, not test failures. The
 > authoritative signal is the `test result: ok` summary lines and the process exit code.

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -12,4 +12,12 @@ cd "$ROOT/solana"
 NO_DNA=1 bash scripts/check-zama-host-idl.sh
 
 cd "$ROOT/coprocessor/fhevm-engine"
-NO_DNA=1 SQLX_OFFLINE=true cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1 --nocapture
+tests=(
+  solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata
+  solana_fhe_rand_creates_ciphertext_and_decrypts
+  solana_user_decrypt_acl_invariants_match_evm_semantics
+)
+
+for test in "${tests[@]}"; do
+  NO_DNA=1 SQLX_OFFLINE=true cargo test -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
+done

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -12,4 +12,4 @@ cd "$ROOT/solana"
 NO_DNA=1 bash scripts/check-zama-host-idl.sh
 
 cd "$ROOT/coprocessor/fhevm-engine"
-NO_DNA=1 SQLX_OFFLINE=true cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1
+NO_DNA=1 SQLX_OFFLINE=true cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1 --nocapture

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -4,11 +4,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 export NO_DNA="${NO_DNA:-1}"
-export SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
-if command -v mold >/dev/null 2>&1; then
-  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER:-clang}"
-  export RUSTFLAGS="${RUSTFLAGS:--C link-arg=-fuse-ld=mold}"
-fi
 
 if ! docker info >/dev/null 2>&1; then
   echo "Docker must be running; the tfhe-worker test harness starts Postgres with testcontainers." >&2
@@ -19,6 +14,12 @@ cd "$ROOT/solana"
 bash scripts/check-zama-host-idl.sh
 
 cd "$ROOT/coprocessor/fhevm-engine"
+export SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+if command -v mold >/dev/null 2>&1; then
+  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER:-clang}"
+  export RUSTFLAGS="${RUSTFLAGS:--C link-arg=-fuse-ld=mold}"
+fi
+
 tests=(
   solana_confidential_transfer_with_real_ciphertexts_computes_and_decrypts
   solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -13,11 +13,13 @@ NO_DNA=1 bash scripts/check-zama-host-idl.sh
 
 cd "$ROOT/coprocessor/fhevm-engine"
 tests=(
+  solana_confidential_transfer_with_real_ciphertexts_computes_and_decrypts
   solana_fhe_eval_replays_threshold_logs_from_litesvm_metadata
   solana_fhe_rand_creates_ciphertext_and_decrypts
+  solana_trivial_encrypt_then_confidential_transfer_computes_and_decrypts
   solana_user_decrypt_acl_invariants_match_evm_semantics
 )
 
 for test in "${tests[@]}"; do
-  NO_DNA=1 SQLX_OFFLINE=true cargo test -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
+  NO_DNA=1 SQLX_OFFLINE=true cargo test --profile local -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
 done

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -9,7 +9,7 @@ if ! docker info >/dev/null 2>&1; then
 fi
 
 cd "$ROOT/solana"
-bash scripts/check-zama-host-idl.sh
+NO_DNA=1 bash scripts/check-zama-host-idl.sh
 
 cd "$ROOT/coprocessor/fhevm-engine"
-SQLX_OFFLINE=true cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1
+NO_DNA=1 SQLX_OFFLINE=true cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -3,13 +3,20 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+export NO_DNA="${NO_DNA:-1}"
+export SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+if command -v mold >/dev/null 2>&1; then
+  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER:-clang}"
+  export RUSTFLAGS="${RUSTFLAGS:--C link-arg=-fuse-ld=mold}"
+fi
+
 if ! docker info >/dev/null 2>&1; then
   echo "Docker must be running; the tfhe-worker test harness starts Postgres with testcontainers." >&2
   exit 1
 fi
 
 cd "$ROOT/solana"
-NO_DNA=1 bash scripts/check-zama-host-idl.sh
+bash scripts/check-zama-host-idl.sh
 
 cd "$ROOT/coprocessor/fhevm-engine"
 tests=(
@@ -21,5 +28,5 @@ tests=(
 )
 
 for test in "${tests[@]}"; do
-  NO_DNA=1 SQLX_OFFLINE=true cargo test --profile local -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
+  cargo test --profile local -p tfhe-worker "$test" -- --ignored --test-threads=1 --nocapture
 done

--- a/solana/scripts/test-litesvm-coprocessor-gate.sh
+++ b/solana/scripts/test-litesvm-coprocessor-gate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker must be running; the tfhe-worker test harness starts Postgres with testcontainers." >&2
+  exit 1
+fi
+
+cd "$ROOT/solana"
+bash scripts/check-zama-host-idl.sh
+
+cd "$ROOT/coprocessor/fhevm-engine"
+SQLX_OFFLINE=true cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1


### PR DESCRIPTION
## What
Adds a CI job `solana-tests/litesvm-coprocessor-gate` that runs the existing but `#[ignore]`d litesvm integration tests in `tfhe-worker/src/tests/solana_poc.rs` — real on-chain programs (litesvm, in-process) → host-listener adapter → real tfhe-worker → decrypt, asserting cleartext.

## Why
These tests are the mid-tier integration signal (ingest→compute→decrypt→ACL) that today only exists at the 40–70 min docker e2e. They're `#[ignore]`d only because CI provided neither Docker (for the testcontainers Postgres the harness self-provisions) nor built SBF programs — not because they're broken. Promoting them to a gate collapses that signal from ~40–70 min to a compile-bound job whose exec is seconds.

## How
- New job in `solana-tests.yml`, path-filtered on `solana/**` + the coprocessor test deps, so a Solana-only change triggers it.
- Installs Solana CLI + Anchor (cached), builds both PoC SBF programs (`check-zama-host-idl.sh` → `zama_host.so` + `confidential_token.so`), LFS-pulls the key fixtures, verifies Docker (`docker info`), then `cargo test -p tfhe-worker solana_poc -- --ignored --test-threads=1`.
- The tests stay `#[ignore]`d in source; the `--ignored` flag runs them only in this dedicated job, so the default `cargo test` stays DB/Docker-free. **No Postgres service container / external DATABASE_URL** — the harness spins its own Postgres via `testcontainers` (`test-harness/src/instance.rs`). Cargo caching so the heavy `tfhe` build is amortized.
- Local runner: `solana/scripts/test-litesvm-coprocessor-gate.sh` + `TESTING.md` (Docker + `anchor build` + the test command).

## Scope
Gate + local runner only. **Not** coverage expansion (new MMR-ACL test cases) — that depends on the rewrite PR #3002 and is a separate follow-up under the epic.

## Issues
Closes zama-ai/fhevm-internal#1655 — litesvm CI integration gate.
Part of zama-ai/fhevm-internal#1659 — Solana testing-strategy & feedback-loop epic.

## Validation
YAML valid; `bash -n` on the runner script passes; `zizmor` clean. Full compile/runtime path (anchor build + tfhe build + testcontainers) is confirmed by this PR's own CI (the new job's path filter includes `solana-tests.yml` + the coprocessor, so it runs here) — not run locally (heavy build / disk).
