### PR TITLE
fix(relayer): serve keyurl dataId as hex

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -1994,9 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/relayer/openapi.yml
+++ b/relayer/openapi.yml
@@ -1569,8 +1569,8 @@ components:
       properties:
         dataId:
           type: string
-          description: On-chain key/CRS identifier, as a decimal string.
-          example: '3'
+          description: On-chain key/CRS identifier, as a `0x`-prefixed 32-byte big-endian hex string.
+          example: '0x0400000000000000000000000000000000000000000000000000000000000003'
         urls:
           type: array
           items:

--- a/relayer/src/host/keyurl_poller.rs
+++ b/relayer/src/host/keyurl_poller.rs
@@ -42,6 +42,12 @@ struct KmsStorageNode {
     storage_prefix: String,
 }
 
+/// The canonical 32-byte big-endian hex encoding of an on-chain key/CRS id, lowercase, no `0x`
+/// prefix. Used both as the URL path segment and, `0x`-prefixed, as the served `dataId`.
+fn id_hex(id: U256) -> String {
+    hex::encode(id.to_be_bytes::<32>())
+}
+
 /// Build the full object URL the KMS Core writes to:
 /// `{storage_url}/{storage_prefix}/{segment}/{id_hex}` (`segment` = `PublicKey`|`CRS`, `id_hex` =
 /// 32-byte big-endian id, lowercase, no `0x`). The getters return only `storage_url`.
@@ -50,13 +56,12 @@ struct KmsStorageNode {
 /// equivalent; the served response carries a single URL (the SDK requires exactly one), built
 /// from the first context node.
 fn build_object_url(node: &KmsStorageNode, segment: &str, id: U256) -> String {
-    let id_hex = hex::encode(id.to_be_bytes::<32>());
     format!(
         "{}/{}/{}/{}",
         node.storage_url.trim_end_matches('/'),
         node.storage_prefix,
         segment,
-        id_hex
+        id_hex(id)
     )
 }
 
@@ -211,11 +216,11 @@ impl KeyUrlPoller {
 
         Ok(KeyUrlResponseJson::new(
             KeyData {
-                data_id: ids.key_id.to_string(),
+                data_id: format!("0x{}", id_hex(ids.key_id)),
                 urls: vec![build_object_url(node, "PublicKey", ids.key_id)],
             },
             KeyData {
-                data_id: ids.crs_id.to_string(),
+                data_id: format!("0x{}", id_hex(ids.crs_id)),
                 urls: vec![build_object_url(node, "CRS", ids.crs_id)],
             },
         ))

--- a/relayer/tests/common/utils.rs
+++ b/relayer/tests/common/utils.rs
@@ -1013,15 +1013,15 @@ pub const TEST_KEYURL_STORAGE_PREFIX: &str = "PUB-p1";
 /// The full object URL the poller reconstructs for a given `segment` (`PublicKey` / `CRS`) and id:
 /// `{storage_url}/{storage_prefix}/{segment}/{id_hex}` (id as 32-byte big-endian, lowercase hex).
 #[allow(dead_code)]
-pub fn test_keyurl_expected_url(segment: &str, id: u64) -> String {
-    let id_hex = hex::encode(U256::from(id).to_be_bytes::<32>());
+pub fn test_keyurl_expected_url(segment: &str, id: U256) -> String {
+    let id_hex = hex::encode(id.to_be_bytes::<32>());
     format!("{TEST_KEYURL_STORAGE_URL}/{TEST_KEYURL_STORAGE_PREFIX}/{segment}/{id_hex}")
 }
 
 /// The served `dataId` for a given on-chain id: `0x`-prefixed 32-byte big-endian, lowercase hex.
 #[allow(dead_code)]
-pub fn test_keyurl_expected_data_id(id: u64) -> String {
-    format!("0x{}", hex::encode(U256::from(id).to_be_bytes::<32>()))
+pub fn test_keyurl_expected_data_id(id: U256) -> String {
+    format!("0x{}", hex::encode(id.to_be_bytes::<32>()))
 }
 
 /// Register a single `eth_call` response keyed by destination address and 4-byte selector.

--- a/relayer/tests/common/utils.rs
+++ b/relayer/tests/common/utils.rs
@@ -1018,6 +1018,12 @@ pub fn test_keyurl_expected_url(segment: &str, id: u64) -> String {
     format!("{TEST_KEYURL_STORAGE_URL}/{TEST_KEYURL_STORAGE_PREFIX}/{segment}/{id_hex}")
 }
 
+/// The served `dataId` for a given on-chain id: `0x`-prefixed 32-byte big-endian, lowercase hex.
+#[allow(dead_code)]
+pub fn test_keyurl_expected_data_id(id: u64) -> String {
+    format!("0x{}", hex::encode(U256::from(id).to_be_bytes::<32>()))
+}
+
 /// Register a single `eth_call` response keyed by destination address and 4-byte selector.
 fn register_call_response(
     host_server: &MockServer,

--- a/relayer/tests/keyurl_poller_test.rs
+++ b/relayer/tests/keyurl_poller_test.rs
@@ -199,12 +199,15 @@ async fn initialize_maps_chain_state_to_response() {
         .await
         .expect("initialize should succeed");
 
-    // dataId carries the real on-chain getActiveKeyId / getActiveCrsId (decimal string).
+    // dataId carries the real on-chain getActiveKeyId / getActiveCrsId, as 0x-prefixed hex.
     assert_eq!(
         response.response.fhe_key_info[0].fhe_public_key.data_id,
-        "3"
+        format!("0x{}", hex::encode(U256::from(3u64).to_be_bytes::<32>()))
     );
-    assert_eq!(response.response.crs["2048"].data_id, "4");
+    assert_eq!(
+        response.response.crs["2048"].data_id,
+        format!("0x{}", hex::encode(U256::from(4u64).to_be_bytes::<32>()))
+    );
     // urls are reconstructed as {storageUrl}/{storagePrefix}/{PublicKey|CRS}/{id_hex} from the
     // NewKmsContext node config and the hex-encoded id.
     assert_eq!(
@@ -251,7 +254,10 @@ async fn run_pushes_updated_value_on_id_change() {
         .initialize()
         .await
         .expect("initialize should succeed");
-    assert_eq!(initial.response.fhe_key_info[0].fhe_public_key.data_id, "3");
+    assert_eq!(
+        initial.response.fhe_key_info[0].fhe_public_key.data_id,
+        format!("0x{}", hex::encode(U256::from(3u64).to_be_bytes::<32>()))
+    );
 
     let (tx, mut rx) = watch::channel(initial);
     let run_handle = tokio::spawn(async move { poller.run(tx).await });
@@ -266,7 +272,7 @@ async fn run_pushes_updated_value_on_id_change() {
 
     assert_eq!(
         rx.borrow().response.fhe_key_info[0].fhe_public_key.data_id,
-        "7"
+        format!("0x{}", hex::encode(U256::from(7u64).to_be_bytes::<32>()))
     );
 
     run_handle.abort();

--- a/relayer/tests/keyurl_test.rs
+++ b/relayer/tests/keyurl_test.rs
@@ -9,6 +9,7 @@ use crate::common::utils::{
     test_keyurl_expected_data_id, test_keyurl_expected_url, TestSetup, TEST_KEYURL_CRS_ID,
     TEST_KEYURL_KEY_ID,
 };
+use alloy::primitives::U256;
 use rstest::rstest;
 use serde_json::Value;
 
@@ -113,12 +114,12 @@ mod helpers {
         // dataId carries the real on-chain getActiveKeyId / getActiveCrsId, as 0x-prefixed hex.
         assert_eq!(
             fhe_public_key["dataId"].as_str().unwrap(),
-            test_keyurl_expected_data_id(TEST_KEYURL_KEY_ID),
+            test_keyurl_expected_data_id(U256::from(TEST_KEYURL_KEY_ID)),
             "fhePublicKey.dataId should equal on-chain getActiveKeyId"
         );
         assert_eq!(
             crs_2048["dataId"].as_str().unwrap(),
-            test_keyurl_expected_data_id(TEST_KEYURL_CRS_ID),
+            test_keyurl_expected_data_id(U256::from(TEST_KEYURL_CRS_ID)),
             "crs.2048.dataId should equal on-chain getActiveCrsId"
         );
 
@@ -126,12 +127,12 @@ mod helpers {
         // hex-encoded id: {storageUrl}/{storagePrefix}/{PublicKey|CRS}/{id_hex}.
         assert_eq!(
             fhe_public_key["urls"][0].as_str().unwrap(),
-            test_keyurl_expected_url("PublicKey", TEST_KEYURL_KEY_ID),
+            test_keyurl_expected_url("PublicKey", U256::from(TEST_KEYURL_KEY_ID)),
             "fhePublicKey.urls[0] should be the reconstructed object URL"
         );
         assert_eq!(
             crs_2048["urls"][0].as_str().unwrap(),
-            test_keyurl_expected_url("CRS", TEST_KEYURL_CRS_ID),
+            test_keyurl_expected_url("CRS", U256::from(TEST_KEYURL_CRS_ID)),
             "crs.2048.urls[0] should be the reconstructed object URL"
         );
 

--- a/relayer/tests/keyurl_test.rs
+++ b/relayer/tests/keyurl_test.rs
@@ -6,7 +6,8 @@
 mod common;
 
 use crate::common::utils::{
-    test_keyurl_expected_url, TestSetup, TEST_KEYURL_CRS_ID, TEST_KEYURL_KEY_ID,
+    test_keyurl_expected_data_id, test_keyurl_expected_url, TestSetup, TEST_KEYURL_CRS_ID,
+    TEST_KEYURL_KEY_ID,
 };
 use rstest::rstest;
 use serde_json::Value;
@@ -109,15 +110,15 @@ mod helpers {
 
         // --- Chain-sourced values (served from the host-chain poller) ---
 
-        // dataId carries the real on-chain getActiveKeyId / getActiveCrsId (decimal string).
+        // dataId carries the real on-chain getActiveKeyId / getActiveCrsId, as 0x-prefixed hex.
         assert_eq!(
             fhe_public_key["dataId"].as_str().unwrap(),
-            TEST_KEYURL_KEY_ID.to_string(),
+            test_keyurl_expected_data_id(TEST_KEYURL_KEY_ID),
             "fhePublicKey.dataId should equal on-chain getActiveKeyId"
         );
         assert_eq!(
             crs_2048["dataId"].as_str().unwrap(),
-            TEST_KEYURL_CRS_ID.to_string(),
+            test_keyurl_expected_data_id(TEST_KEYURL_CRS_ID),
             "crs.2048.dataId should equal on-chain getActiveCrsId"
         );
 


### PR DESCRIPTION
Fixes [zama-ai/fhevm-internal#1663](https://github.com/zama-ai/fhevm-internal/issues/1663).

`dataId` now uses the same `0x`-prefixed 32-byte big-endian hex
encoding already used for the `urls` path segment, instead of a
decimal string. relayer-v2 got the equivalent fix in
[zama-ai/relayer#79](https://github.com/zama-ai/relayer/pull/79).

- [x] `cargo test --features integration-tests --test keyurl_poller_test --test keyurl_test` (locally: 6/6 pass)
