### PR TITLE
perf(coprocessor): compile docker images through sccache backed by the CI S3 cache

### DIFF
--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -19,6 +19,10 @@ ARG CARGO_PROFILE=release
 
 USER root
 
+# sccache, pinned for reproducibility; this layer only rebuilds when the base
+# image changes.
+RUN cargo install sccache --locked --version 0.8.2
+
 WORKDIR /app
 
 COPY listener ./listener
@@ -37,11 +41,32 @@ WORKDIR /app/coprocessor/fhevm-engine
 # NOTE: We use a cache mount for the target directory to enable incremental compilation.
 # Because cache mounts are NOT committed to the image layer, we must copy the binary
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
+#
+# The cache mounts only help local builds: CI gets a fresh buildkit instance every
+# run, so they start empty there. When CI provides S3 credentials (buildkit secrets
+# SCCACHE_AWS_ACCESS_KEY_ID / SCCACHE_AWS_SECRET_ACCESS_KEY), compilation goes
+# through sccache backed by the runners' S3 cache bucket instead: compiled
+# dependency artifacts (tfhe & friends) are then shared across all coprocessor
+# images, platforms, and runs. Without the secrets (local builds, or a CI that
+# doesn't pass them) this is a plain cargo build. CARGO_INCREMENTAL=0 because
+# sccache cannot cache incremental compilation.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=SCCACHE_AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=SCCACHE_AWS_SECRET_ACCESS_KEY \
+    if [ -s /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID ]; then \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID)" \
+             AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/SCCACHE_AWS_SECRET_ACCESS_KEY)" \
+             RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
+             SCCACHE_BUCKET=gh-actions-cache-eu-west-3 \
+             SCCACHE_REGION=eu-west-3 \
+             SCCACHE_S3_KEY_PREFIX=sccache/fhevm-coprocessor \
+             CARGO_INCREMENTAL=0; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener && \
-    cp target/${CARGO_PROFILE}/gw_listener /tmp/gw_listener
+    cp target/${CARGO_PROFILE}/gw_listener /tmp/gw_listener && \
+    if [ -n "${RUSTC_WRAPPER:-}" ]; then sccache --show-stats; fi
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -24,6 +24,10 @@ ARG CARGO_PROFILE=release
 
 USER root
 
+# sccache, pinned for reproducibility; this layer only rebuilds when the base
+# image changes.
+RUN cargo install sccache --locked --version 0.8.2
+
 WORKDIR /app
 
 COPY listener ./listener
@@ -41,13 +45,34 @@ WORKDIR /app/coprocessor/fhevm-engine
 # NOTE: We use a cache mount for the target directory to enable incremental compilation.
 # Because cache mounts are NOT committed to the image layer, we must copy the binary
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
+#
+# The cache mounts only help local builds: CI gets a fresh buildkit instance every
+# run, so they start empty there. When CI provides S3 credentials (buildkit secrets
+# SCCACHE_AWS_ACCESS_KEY_ID / SCCACHE_AWS_SECRET_ACCESS_KEY), compilation goes
+# through sccache backed by the runners' S3 cache bucket instead: compiled
+# dependency artifacts (tfhe & friends) are then shared across all coprocessor
+# images, platforms, and runs. Without the secrets (local builds, or a CI that
+# doesn't pass them) this is a plain cargo build. CARGO_INCREMENTAL=0 because
+# sccache cannot cache incremental compilation.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=SCCACHE_AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=SCCACHE_AWS_SECRET_ACCESS_KEY \
+    if [ -s /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID ]; then \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID)" \
+             AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/SCCACHE_AWS_SECRET_ACCESS_KEY)" \
+             RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
+             SCCACHE_BUCKET=gh-actions-cache-eu-west-3 \
+             SCCACHE_REGION=eu-west-3 \
+             SCCACHE_S3_KEY_PREFIX=sccache/fhevm-coprocessor \
+             CARGO_INCREMENTAL=0; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener && \
     cp target/${CARGO_PROFILE}/host_listener /tmp/host_listener && \
     cp target/${CARGO_PROFILE}/host_listener_poller /tmp/host_listener_poller && \
-    cp target/${CARGO_PROFILE}/host_listener_consumer /tmp/host_listener_consumer
+    cp target/${CARGO_PROFILE}/host_listener_consumer /tmp/host_listener_consumer && \
+    if [ -n "${RUSTC_WRAPPER:-}" ]; then sccache --show-stats; fi
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod

--- a/coprocessor/fhevm-engine/sns-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-worker/Dockerfile
@@ -5,6 +5,10 @@ ARG CARGO_PROFILE=release
 
 USER root
 
+# sccache, pinned for reproducibility; this layer only rebuilds when the base
+# image changes.
+RUN cargo install sccache --locked --version 0.8.2
+
 WORKDIR /app
 
 COPY listener ./listener
@@ -15,15 +19,36 @@ COPY shared/ciphertext-attestation ./shared/ciphertext-attestation
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build sns_executor binary
+# Build sns_worker binary
 # NOTE: We use a cache mount for the target directory to enable incremental compilation.
 # Because cache mounts are NOT committed to the image layer, we must copy the binary
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
+#
+# The cache mounts only help local builds: CI gets a fresh buildkit instance every
+# run, so they start empty there. When CI provides S3 credentials (buildkit secrets
+# SCCACHE_AWS_ACCESS_KEY_ID / SCCACHE_AWS_SECRET_ACCESS_KEY), compilation goes
+# through sccache backed by the runners' S3 cache bucket instead: compiled
+# dependency artifacts (tfhe & friends) are then shared across all coprocessor
+# images, platforms, and runs. Without the secrets (local builds, or a CI that
+# doesn't pass them) this is a plain cargo build. CARGO_INCREMENTAL=0 because
+# sccache cannot cache incremental compilation.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=SCCACHE_AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=SCCACHE_AWS_SECRET_ACCESS_KEY \
+    if [ -s /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID ]; then \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID)" \
+             AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/SCCACHE_AWS_SECRET_ACCESS_KEY)" \
+             RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
+             SCCACHE_BUCKET=gh-actions-cache-eu-west-3 \
+             SCCACHE_REGION=eu-west-3 \
+             SCCACHE_S3_KEY_PREFIX=sccache/fhevm-coprocessor \
+             CARGO_INCREMENTAL=0; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker && \
-    cp target/${CARGO_PROFILE}/sns_worker /tmp/sns_worker
+    cp target/${CARGO_PROFILE}/sns_worker /tmp/sns_worker && \
+    if [ -n "${RUSTC_WRAPPER:-}" ]; then sccache --show-stats; fi
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod

--- a/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
@@ -5,6 +5,10 @@ ARG CARGO_PROFILE=release
 
 USER root
 
+# sccache, pinned for reproducibility; this layer only rebuilds when the base
+# image changes.
+RUN cargo install sccache --locked --version 0.8.2
+
 WORKDIR /app
 
 COPY listener ./listener
@@ -19,11 +23,32 @@ WORKDIR /app/coprocessor/fhevm-engine
 # NOTE: We use a cache mount for the target directory to enable incremental compilation.
 # Because cache mounts are NOT committed to the image layer, we must copy the binary
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
+#
+# The cache mounts only help local builds: CI gets a fresh buildkit instance every
+# run, so they start empty there. When CI provides S3 credentials (buildkit secrets
+# SCCACHE_AWS_ACCESS_KEY_ID / SCCACHE_AWS_SECRET_ACCESS_KEY), compilation goes
+# through sccache backed by the runners' S3 cache bucket instead: compiled
+# dependency artifacts (tfhe & friends) are then shared across all coprocessor
+# images, platforms, and runs. Without the secrets (local builds, or a CI that
+# doesn't pass them) this is a plain cargo build. CARGO_INCREMENTAL=0 because
+# sccache cannot cache incremental compilation.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=SCCACHE_AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=SCCACHE_AWS_SECRET_ACCESS_KEY \
+    if [ -s /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID ]; then \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID)" \
+             AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/SCCACHE_AWS_SECRET_ACCESS_KEY)" \
+             RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
+             SCCACHE_BUCKET=gh-actions-cache-eu-west-3 \
+             SCCACHE_REGION=eu-west-3 \
+             SCCACHE_S3_KEY_PREFIX=sccache/fhevm-coprocessor \
+             CARGO_INCREMENTAL=0; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker && \
-    cp target/${CARGO_PROFILE}/tfhe_worker /tmp/tfhe_worker
+    cp target/${CARGO_PROFILE}/tfhe_worker /tmp/tfhe_worker && \
+    if [ -n "${RUSTC_WRAPPER:-}" ]; then sccache --show-stats; fi
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -5,6 +5,10 @@ ARG CARGO_PROFILE=release
 
 USER root
 
+# sccache, pinned for reproducibility; this layer only rebuilds when the base
+# image changes.
+RUN cargo install sccache --locked --version 0.8.2
+
 WORKDIR /app
 
 COPY listener ./listener
@@ -19,11 +23,32 @@ WORKDIR /app/coprocessor/fhevm-engine
 # NOTE: We use a cache mount for the target directory to enable incremental compilation.
 # Because cache mounts are NOT committed to the image layer, we must copy the binary
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
+#
+# The cache mounts only help local builds: CI gets a fresh buildkit instance every
+# run, so they start empty there. When CI provides S3 credentials (buildkit secrets
+# SCCACHE_AWS_ACCESS_KEY_ID / SCCACHE_AWS_SECRET_ACCESS_KEY), compilation goes
+# through sccache backed by the runners' S3 cache bucket instead: compiled
+# dependency artifacts (tfhe & friends) are then shared across all coprocessor
+# images, platforms, and runs. Without the secrets (local builds, or a CI that
+# doesn't pass them) this is a plain cargo build. CARGO_INCREMENTAL=0 because
+# sccache cannot cache incremental compilation.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=SCCACHE_AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=SCCACHE_AWS_SECRET_ACCESS_KEY \
+    if [ -s /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID ]; then \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID)" \
+             AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/SCCACHE_AWS_SECRET_ACCESS_KEY)" \
+             RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
+             SCCACHE_BUCKET=gh-actions-cache-eu-west-3 \
+             SCCACHE_REGION=eu-west-3 \
+             SCCACHE_S3_KEY_PREFIX=sccache/fhevm-coprocessor \
+             CARGO_INCREMENTAL=0; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender && \
-    cp target/${CARGO_PROFILE}/transaction_sender /tmp/transaction_sender
+    cp target/${CARGO_PROFILE}/transaction_sender /tmp/transaction_sender && \
+    if [ -n "${RUSTC_WRAPPER:-}" ]; then sccache --show-stats; fi
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -1,9 +1,13 @@
-# Stage 1: Build ZK Proof Worker
+# Stage 1: Build ZKProof Worker
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
 ARG CARGO_PROFILE=release
 
 USER root
+
+# sccache, pinned for reproducibility; this layer only rebuilds when the base
+# image changes.
+RUN cargo install sccache --locked --version 0.8.2
 
 WORKDIR /app
 
@@ -19,11 +23,32 @@ WORKDIR /app/coprocessor/fhevm-engine
 # NOTE: We use a cache mount for the target directory to enable incremental compilation.
 # Because cache mounts are NOT committed to the image layer, we must copy the binary
 # to a non-mounted path (/tmp) during the same RUN instruction for COPY --from to work.
+#
+# The cache mounts only help local builds: CI gets a fresh buildkit instance every
+# run, so they start empty there. When CI provides S3 credentials (buildkit secrets
+# SCCACHE_AWS_ACCESS_KEY_ID / SCCACHE_AWS_SECRET_ACCESS_KEY), compilation goes
+# through sccache backed by the runners' S3 cache bucket instead: compiled
+# dependency artifacts (tfhe & friends) are then shared across all coprocessor
+# images, platforms, and runs. Without the secrets (local builds, or a CI that
+# doesn't pass them) this is a plain cargo build. CARGO_INCREMENTAL=0 because
+# sccache cannot cache incremental compilation.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=SCCACHE_AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=SCCACHE_AWS_SECRET_ACCESS_KEY \
+    if [ -s /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID ]; then \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/SCCACHE_AWS_ACCESS_KEY_ID)" \
+             AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/SCCACHE_AWS_SECRET_ACCESS_KEY)" \
+             RUSTC_WRAPPER=/usr/local/cargo/bin/sccache \
+             SCCACHE_BUCKET=gh-actions-cache-eu-west-3 \
+             SCCACHE_REGION=eu-west-3 \
+             SCCACHE_S3_KEY_PREFIX=sccache/fhevm-coprocessor \
+             CARGO_INCREMENTAL=0; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker && \
-    cp target/${CARGO_PROFILE}/zkproof_worker /tmp/zkproof_worker
+    cp target/${CARGO_PROFILE}/zkproof_worker /tmp/zkproof_worker && \
+    if [ -n "${RUSTC_WRAPPER:-}" ]; then sccache --show-stats; fi
 
 # Stage 2: Runtime image
 FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS prod


### PR DESCRIPTION
## What

Compile the 6 heavy coprocessor docker images (host-listener, gw-listener, tfhe-worker, sns-worker, zkproof-worker, transaction-sender) through **sccache** backed by the CI S3 cache bucket, so compiled dependency artifacts (tfhe & friends) are shared **across images, platforms, and runs**.

## Why

Today any source change recompiles the entire tfhe-heavy workspace from scratch in each image, per platform, per prod/dev variant (measured: host-listener 10.7 min amd64 / 16.3 min arm64 per merge-queue run with coprocessor changes):

- The Dockerfiles' buildkit cache mounts (`target/`, cargo registry) never survive CI — each run gets a fresh buildkit instance.
- The S3 layer cache only stores whole layers, and the single cargo-build layer is invalidated by any source edit.

A cargo-chef split was attempted first (see earlier commits' CI runs) but fought this workspace twice — out-of-workspace path deps, then dev-dependencies requiring a newer rustc at `cook` time. sccache caches at the rustc-invocation level and is indifferent to workspace shape.

## How

- Pinned `sccache 0.8.2` installed in the builder stage (layer rebuilds only on base-image change).
- The build routes through sccache **only when CI provides S3 credentials** as buildkit secrets (`SCCACHE_AWS_ACCESS_KEY_ID` / `SCCACHE_AWS_SECRET_ACCESS_KEY`); without them it is a plain cargo build — local builds and current CI behave exactly as on main.
- Shared cache prefix `sccache/fhevm-coprocessor` in the existing `gh-actions-cache-eu-west-3` bucket; sccache keys include compiler/target/flags so amd64/arm64 coexist safely.
- `sccache --show-stats` prints hit rates at the end of each build for verification.

## Activation requires a 2-line ci-templates change

`common-docker.yml`'s build-push-action step must pass the two secrets (reusing the same AWS secrets it already uses for the buildx layer cache), then the pinned ci-templates SHA gets bumped in the fhevm caller workflows:

```yaml
          secrets: |
            BLOCKCHAIN_ACTIONS_TOKEN=${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
            SCCACHE_AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_S3_USER }}
            SCCACHE_AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_KEY_S3_USER }}
```

Until that lands this PR is a no-op in CI (safe to merge in either order).

## Expected effect (once activated)

- First run populates the cache (the six images miss in parallel — limited benefit).
- From the second run on, dependency compiles are cache hits; only workspace crates + linking remain. Rough expectation: host-listener amd64 toward ~4–6 min.
- Known ceiling: sccache cannot cache **linking**, and `lto = "fat"` in the release profile makes the link the dominant leftover — switching to thin LTO (needs a runtime benchmark, separate decision) is the next lever.

## Validation

Label the PR `e2e orchestrate test` to trigger the image builds. Before ci-templates passes the secrets, expect timings identical to main and no `sccache` output in build logs; after activation, check the `sccache --show-stats` block (second run should show a high hit rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
