### PR TITLE
perf(coprocessor): cut tfhe-worker cargo-test time via optimized deps and full FHE parallelism

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -130,3 +130,11 @@ opt-level = 1
 lto = false
 debug = 1
 codegen-units = 16
+
+# Dependencies at full optimization even under coverage. Coverage is only
+# reported for workspace crates, and the CI test runtime is dominated by FHE
+# compute inside tfhe & friends — at opt-level 1 that made the tfhe-worker
+# test job exceed 2 hours. Workspace crates stay at opt-level 1 for fast
+# compiles; dependency builds are cached by Cargo.lock in CI.
+[profile.coverage.package."*"]
+opt-level = 3

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/utils.rs
@@ -80,7 +80,12 @@ async fn start_coprocessor(rx: Receiver<bool>, db_url: &str) -> u16 {
         work_items_batch_size: 40,
         dependence_chains_per_batch: 10,
         key_cache_size: 4,
-        coprocessor_fhe_threads: 4,
+        // Tests are #[serial(db)] so a single app instance owns the machine:
+        // give the FHE blocking pool every core. At 4 threads the operator
+        // matrix tests left 3/4 of the 16-core CI runner idle.
+        coprocessor_fhe_threads: std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(4),
         tokio_threads: 2,
         pg_pool_max_connections: 2,
         metrics_addr: None,


### PR DESCRIPTION
The merge-queue tfhe-worker coverage job takes ~2h20 (139 min in `cargo llvm-cov test`). Log analysis of run 28791824015: compile is only 5 min (cache works); 134 min is test runtime, of which two tests account for 100 min - test_fhe_binary_operands_events (82.4 min) and test_fhe_cast_events (18 min). Two compounding causes:

- The `coverage` profile compiles everything at opt-level 1, including tfhe & friends where all the FHE compute happens. Coverage is only reported for workspace crates, so deps paid a several-fold runtime penalty for nothing. Add [profile.coverage.package."*"] opt-level = 3: workspace crates keep opt-level 1 (fast compile, accurate instrumentation), dependencies run at full speed. One-time slower dep compile is absorbed by the Cargo.lock-keyed CI cache.

- The test harness pinned coprocessor_fhe_threads: 4 on a 16-core runner. The scheduler dispatches each op via spawn_blocking, capped by max_blocking_threads = coprocessor_fhe_threads, so 3/4 of the machine idled through the operator matrix. Tests are #[serial(db)] - one app owns the machine - so size the pool to available_parallelism().

Expected: the two matrix tests drop from ~100 min to the 10-20 min range; job total from ~2h20 toward ~40 min. Validate on a merge-queue run (full type matrix) - PR CI uses the reduced `local` matrix.