### PR TITLE
ci(sdk): add fhevm-sdk-version override for e2e image builds

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -77,6 +77,10 @@ on:
         description: "Test suite version"
         default: ""
         type: string
+      fhevm-sdk-version:
+        description: "Published @fhevm/sdk version to build the e2e image against (requires build: true)"
+        default: ""
+        type: string
       relayer-migrate-version:
         description: "Relayer migrate version"
         default: ""
@@ -160,6 +164,7 @@ jobs:
       CONNECTOR_KMS_WORKER_VERSION: ${{ inputs.connector-kms-worker-version }}
       CONNECTOR_TX_SENDER_VERSION: ${{ inputs.connector-tx-sender-version }}
       TEST_SUITE_VERSION: ${{ inputs.test-suite-version }}
+      FHEVM_SDK_VERSION: ${{ inputs.fhevm-sdk-version }}
       RELAYER_MIGRATE_VERSION: ${{ inputs.relayer-migrate-version }}
       RELAYER_VERSION: ${{ inputs.relayer-version }}
       CORE_VERSION: ${{ inputs.kms-core-version }}

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -1,9 +1,11 @@
 ARG NODE_VERSION=22.22.2-alpine3.22
 ARG RELAYER_SDK_VERSION=""
+ARG FHEVM_SDK_VERSION=""
 
 # --- Builder Stage ---
 FROM node:${NODE_VERSION} AS builder
 ARG RELAYER_SDK_VERSION=""
+ARG FHEVM_SDK_VERSION=""
 
 WORKDIR /app
 
@@ -35,14 +37,27 @@ COPY sdk/js-sdk ./sdk/js-sdk
 # Install dependencies. Normal builds stay locked; rollout hotswap builds first
 # update the e2e workspace manifest in the image, then let npm resolve one
 # coherent dependency graph for that requested SDK version.
-RUN if [ -n "$RELAYER_SDK_VERSION" ]; then \
-      npm pkg set -w test-suite/e2e "dependencies.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}" && \
+#
+# @fhevm/sdk is also a local workspace (sdk/js-sdk/src): npm always links a
+# same-named workspace package over the registry regardless of the version
+# range requested, so pinning FHEVM_SDK_VERSION alone would silently keep
+# resolving to local source. Dropping "sdk/js-sdk/src" from the root
+# workspaces list is what actually makes npm fetch the published version.
+RUN if [ -n "$RELAYER_SDK_VERSION" ] || [ -n "$FHEVM_SDK_VERSION" ]; then \
+      if [ -n "$RELAYER_SDK_VERSION" ]; then \
+        npm pkg set -w test-suite/e2e "dependencies.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}"; \
+      fi && \
+      if [ -n "$FHEVM_SDK_VERSION" ]; then \
+        npm pkg set -w test-suite/e2e "dependencies.@fhevm/sdk=${FHEVM_SDK_VERSION}" && \
+        node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.workspaces=p.workspaces.filter(w=>w!=='sdk/js-sdk/src');fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"; \
+      fi && \
       npm install && \
       npm prune; \
     else \
       npm ci && \
       npm prune; \
-    fi
+    fi && \
+    node -e "const p=require.resolve('@fhevm/sdk/package.json',{paths:['test-suite/e2e']});console.log('Resolved @fhevm/sdk -> '+p);console.log('@fhevm/sdk version: '+require(p).version)"
 
 # Compile js-sdk
 WORKDIR /app/sdk/js-sdk

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -158,7 +158,7 @@ const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknow
   },
   "test-suite": {
     "test-suite-e2e-debug": buildSpec("../../..", "test-suite/e2e/Dockerfile", {
-      args: { RELAYER_SDK_VERSION: "${RELAYER_SDK_VERSION}" },
+      args: { RELAYER_SDK_VERSION: "${RELAYER_SDK_VERSION}", FHEVM_SDK_VERSION: "${FHEVM_SDK_VERSION}" },
     }),
   },
 };


### PR DESCRIPTION
Let the e2e Docker image be built against the officially published
`@fhevm/sdk` npm package instead of always using the local workspace
source, mirroring the existing `RELAYER_SDK_VERSION` hotswap pattern.

- **Dockerfile**: add a `FHEVM_SDK_VERSION` build ARG. When set, it pins
  `@fhevm/sdk` in `test-suite/e2e/package.json` and drops
  `sdk/js-sdk/src` from the root `workspaces` list before `npm install`.
  npm always links a same-named local workspace package over the
  registry regardless of the requested version range, so pinning the
  version alone would silently keep resolving to local source — the
  workspace list has to be trimmed too.
- Add a resolution check after install that prints the resolved
  `@fhevm/sdk` path and version, since npm may hoist the package to the
  repo root or nest it under `test-suite/e2e/node_modules` depending on
  the rest of the dependency graph.
- **compose.ts**: forward `${FHEVM_SDK_VERSION}` as a build arg for the
  `test-suite-e2e-debug` service, alongside the existing
  `RELAYER_SDK_VERSION` arg.
- **test-suite-e2e-tests.yml**: expose a `fhevm-sdk-version`
  `workflow_dispatch`/`workflow_call` input and map it to
  `FHEVM_SDK_VERSION` in the job env, so CI can opt into building
  against a specific published SDK version.

Default behavior (no `FHEVM_SDK_VERSION`) is unchanged: e2e keeps
testing the local, potentially unreleased `@fhevm/sdk` source.
