### PR TITLE
feat(sdk): accept ebool/euintN type aliases in encrypt values

### DIFF
--- a/sdk/js-sdk/src/core/actions/encrypt/encryptValue.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/encryptValue.ts
@@ -8,6 +8,7 @@ import { addressToChecksummedAddress, assertIsAddress } from '../../base/address
 import { toArray } from '../../base/object.js';
 import { createTypedValue } from '../../base/typedValue.js';
 import { encrypt as encrypt_ } from '../../coprocessor/encrypt.js';
+import { resolveRawValueTypeName } from '../../handle/FheType.js';
 import { asFhevmWithTfheVersion } from '../../runtime/CoreFhevm-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,7 +34,9 @@ export async function encryptValue(
   const { contractAddress, userAddress, options } = parameters;
 
   // Validates `value`
-  const values = toArray(parameters.value).map(createTypedValue);
+  const values = toArray(parameters.value).map((v) =>
+    createTypedValue({ type: resolveRawValueTypeName(v.type), value: v.value }),
+  );
 
   assertIsAddress(contractAddress, {});
   assertIsAddress(userAddress, {});

--- a/sdk/js-sdk/src/core/actions/encrypt/encryptValues.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/encryptValues.ts
@@ -7,6 +7,7 @@ import type { EncryptedValue } from '../../types/encryptedTypes.js';
 import { addressToChecksummedAddress, assertIsAddress } from '../../base/address.js';
 import { createTypedValue } from '../../base/typedValue.js';
 import { encrypt as encrypt_ } from '../../coprocessor/encrypt.js';
+import { resolveRawValueTypeName } from '../../handle/FheType.js';
 import { asFhevmWithTfheVersion } from '../../runtime/CoreFhevm-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -30,8 +31,11 @@ export async function encryptValues(
   parameters: EncryptValuesParameters,
 ): Promise<EncryptValuesReturnType> {
   const { contractAddress, userAddress, options } = parameters;
+
   // Validates `values`
-  const values = parameters.values.map(createTypedValue);
+  const values = parameters.values.map((v) =>
+    createTypedValue({ type: resolveRawValueTypeName(v.type), value: v.value }),
+  );
 
   assertIsAddress(contractAddress, {});
   assertIsAddress(userAddress, {});

--- a/sdk/js-sdk/src/core/actions/encrypt/generateZkProof.ts
+++ b/sdk/js-sdk/src/core/actions/encrypt/generateZkProof.ts
@@ -5,6 +5,7 @@ import type { ZkProof } from '../../types/zkProof-p.js';
 import type { BytesHex } from '../../types/primitives.js';
 import { createTypedValue } from '../../base/typedValue.js';
 import { createZkProofBuilder } from '../../coprocessor/ZkProofBuilder-p.js';
+import { resolveRawValueTypeName } from '../../handle/FheType.js';
 import { asFhevmWithTfheVersion } from '../../runtime/CoreFhevm-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -28,7 +29,7 @@ export async function generateZkProof(
 
   const builder = createZkProofBuilder();
   for (const value of values) {
-    builder.addTypedValue(createTypedValue(value));
+    builder.addTypedValue(createTypedValue({ type: resolveRawValueTypeName(value.type), value: value.value }));
   }
 
   const f = asFhevmWithTfheVersion(fhevm);

--- a/sdk/js-sdk/src/core/handle/FheType.test.ts
+++ b/sdk/js-sdk/src/core/handle/FheType.test.ts
@@ -20,6 +20,7 @@ import {
   toClearValueType,
   fheTypeNameFromTypeName,
   typeNameFromFheTypeName,
+  resolveRawValueTypeName,
 } from './FheType.js';
 import { InvalidTypeError } from '../base/errors/InvalidTypeError.js';
 
@@ -420,6 +421,31 @@ describe('FheType', () => {
       expect(typeNameFromFheTypeName('euint128')).toBe('uint128');
       expect(typeNameFromFheTypeName('euint256')).toBe('uint256');
       expect(typeNameFromFheTypeName('eaddress')).toBe('address');
+    });
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // resolveRawValueTypeName
+  //////////////////////////////////////////////////////////////////////////////
+
+  describe('resolveRawValueTypeName', () => {
+    it('resolves FHE type aliases to their clear ValueTypeName', () => {
+      expect(resolveRawValueTypeName('ebool')).toBe('bool');
+      expect(resolveRawValueTypeName('euint8')).toBe('uint8');
+      expect(resolveRawValueTypeName('euint16')).toBe('uint16');
+      expect(resolveRawValueTypeName('euint32')).toBe('uint32');
+      expect(resolveRawValueTypeName('euint64')).toBe('uint64');
+      expect(resolveRawValueTypeName('euint128')).toBe('uint128');
+      expect(resolveRawValueTypeName('euint256')).toBe('uint256');
+      expect(resolveRawValueTypeName('eaddress')).toBe('address');
+    });
+
+    it('returns non-FHE type names unchanged', () => {
+      expect(resolveRawValueTypeName('bool')).toBe('bool');
+      expect(resolveRawValueTypeName('uint8')).toBe('uint8');
+      expect(resolveRawValueTypeName('address')).toBe('address');
+      expect(resolveRawValueTypeName('uint160')).toBe('uint160');
+      expect(resolveRawValueTypeName('not-a-type')).toBe('not-a-type');
     });
   });
 

--- a/sdk/js-sdk/src/core/handle/FheType.ts
+++ b/sdk/js-sdk/src/core/handle/FheType.ts
@@ -354,6 +354,17 @@ export function typeNameFromFheTypeName(fheType: FheType): ValueTypeName {
   return fheType.substring(1) as ValueTypeName;
 }
 
+/**
+ * Resolves a raw type name to its clear `ValueTypeName`, accepting FHE type
+ * aliases ("ebool", "euint8", ...) in addition to clear-value names
+ * ("bool", "uint8", ...). Non-FHE type names are returned unchanged.
+ * @example resolveRawValueTypeName('euint8') // 'uint8'
+ * @example resolveRawValueTypeName('uint8') // 'uint8' (unchanged)
+ */
+export function resolveRawValueTypeName(type: string): string {
+  return isFheType(type) ? typeNameFromFheTypeName(type) : type;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Solidity primitive type names
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Solidity developers think in terms of ebool/euint8/.../eaddress, not the
SDK's internal clear-value type names (bool/uint8/.../address). Add
resolveRawValueTypeName() to FheType.ts, which maps FHE type aliases to
their clear ValueTypeName counterpart (passing other type names through
unchanged), and call it from encryptValue(), encryptValues(), and
generateZkProof() before building each TypedValue — so callers can pass
either naming convention in `type`.
