### PR TITLE
ci(test-suite): report Solana native unit coverage

### DIFF
--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -102,6 +102,78 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  native-coverage:
+    name: solana-tests/native-coverage
+    needs: check-changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
+    permissions:
+      contents: 'read'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: solana
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+
+      - name: Setup Rust toolchain file
+        run: cp rust-toolchain.toml ..
+
+      - uses: dsherret/rust-toolchain-file@3551321aa44dd44a0393eb3b6bdfbc5d25ecf621 # v1
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # v2.68.25
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Cache cargo
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            solana/target/llvm-cov-target
+          key: ${{ runner.os }}-cargo-solana-coverage-${{ hashFiles('solana/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-solana-coverage-
+
+      - name: Measure native unit coverage
+        run: |
+          cargo llvm-cov \
+            --workspace \
+            --exclude zama-solana-runtime-tests \
+            --json \
+            --summary-only \
+            --output-path /tmp/solana-native-coverage.json
+
+          {
+            echo '### Solana native unit coverage'
+            echo
+            echo 'Mollusk executes prebuilt SBF programs, so it validates runtime behavior but cannot attribute LLVM coverage to program instruction bodies. The runtime-test harness is excluded here to avoid inflating this native signal.'
+            echo
+            echo '| Component | Covered lines | Coverage |'
+            echo '| --- | ---: | ---: |'
+            jq -r '
+              def row($label; $path):
+                [.data[0].files[] | select(.filename | contains($path)) | .summary.lines] as $parts
+                | ($parts | map(.count) | add) as $total
+                | ($parts | map(.covered) | add) as $covered
+                | if ($total // 0) == 0 then
+                    error("no coverage entries found for \($label)")
+                  else
+                    "| \($label) | \($covered)/\($total) | \((($covered * 10000 / $total) | round) / 100)% |"
+                  end;
+              [
+                row("zama-solana-acl"; "/crates/zama-solana-acl/"),
+                row("solana-ed25519-instruction"; "/crates/solana-ed25519-instruction/"),
+                row("zama-fhe"; "/crates/zama-fhe/"),
+                row("zama-host"; "/programs/zama-host/"),
+                row("confidential-token"; "/programs/confidential-token/"),
+                row("confidential-deposit-app"; "/programs/confidential-deposit-app/")
+              ][]
+            ' /tmp/solana-native-coverage.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # The off-chain reconstruction path (host-listener, solana-reconstruct feature) is otherwise
   # only built/exercised by the full solana-e2e job. Compile it here and run its unit tests so a
   # break (e.g. the fhe_eval ACL-record account-offset) is caught in minutes, not 40+.

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -154,23 +154,35 @@ jobs:
             echo '| Component | Covered lines | Coverage |'
             echo '| --- | ---: | ---: |'
             jq -r '
-              def row($label; $path):
-                [.data[0].files[] | select(.filename | contains($path)) | .summary.lines] as $parts
+              def components: [
+                {label: "zama-solana-acl", path: "/crates/zama-solana-acl/"},
+                {label: "solana-ed25519-instruction", path: "/crates/solana-ed25519-instruction/"},
+                {label: "zama-fhe", path: "/crates/zama-fhe/"},
+                {label: "zama-host", path: "/programs/zama-host/"},
+                {label: "confidential-token", path: "/programs/confidential-token/"},
+                {label: "confidential-deposit-app", path: "/programs/confidential-deposit-app/"}
+              ];
+              def line_parts($report; $path):
+                [$report.data[0].files[] | select(.filename | contains($path)) | .summary.lines];
+              def row($report; $component):
+                line_parts($report; $component.path) as $parts
                 | ($parts | map(.count) | add) as $total
                 | ($parts | map(.covered) | add) as $covered
                 | if ($total // 0) == 0 then
-                    error("no coverage entries found for \($label)")
+                    error("no coverage entries found for \($component.label)")
                   else
-                    "| \($label) | \($covered)/\($total) | \((($covered * 10000 / $total) | round) / 100)% |"
+                    "| \($component.label) | \($covered)/\($total) | \((($covered * 10000 / $total) | round) / 100)% |"
                   end;
-              [
-                row("zama-solana-acl"; "/crates/zama-solana-acl/"),
-                row("solana-ed25519-instruction"; "/crates/solana-ed25519-instruction/"),
-                row("zama-fhe"; "/crates/zama-fhe/"),
-                row("zama-host"; "/programs/zama-host/"),
-                row("confidential-token"; "/programs/confidential-token/"),
-                row("confidential-deposit-app"; "/programs/confidential-deposit-app/")
-              ][]
+              . as $report
+              | components as $components
+              | [$components[] | line_parts($report; .path)[] | .count] as $selected_counts
+              | ($selected_counts | add) as $selected_total
+              | $report.data[0].totals.lines.count as $workspace_total
+              | if $selected_total != $workspace_total then
+                  error("component rows cover \($selected_total) of \($workspace_total) workspace lines")
+                else
+                  $components[] | row($report; .)
+                end
             ' /tmp/solana-native-coverage.json
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -149,11 +149,12 @@ jobs:
           {
             echo '### Solana native unit coverage'
             echo
-            echo 'Mollusk executes prebuilt SBF programs, so it validates runtime behavior but cannot attribute LLVM coverage to program instruction bodies. The runtime-test harness is excluded here to avoid inflating this native signal.'
+            echo 'Mollusk executes prebuilt SBF programs, so it validates runtime behavior but cannot attribute LLVM coverage to program instruction bodies. The runtime-test harness is excluded here to avoid inflating this native signal. Inline #[cfg(test)] modules remain instrumented, so percentages are gap-finding signals rather than product-code coverage.'
             echo
             echo '| Component | Covered lines | Coverage |'
             echo '| --- | ---: | ---: |'
             jq -r '
+              # Keep this list aligned with non-excluded solana/Cargo.toml workspace members.
               def components: [
                 {label: "zama-solana-acl", path: "/crates/zama-solana-acl/"},
                 {label: "solana-ed25519-instruction", path: "/crates/solana-ed25519-instruction/"},

--- a/solana/docs/TESTING.md
+++ b/solana/docs/TESTING.md
@@ -74,6 +74,10 @@ instead count the Rust test harness and make the total look healthier without me
 on-chain code. Use the component table to find native unit-test gaps, and use the Mollusk suites to
 validate account, CPI, PDA, ACL, event, and persistence behavior.
 
+The report includes inline `#[cfg(test)]` modules that live in instrumented source files. Their
+lines can raise a component percentage, so the table is a gap-finding signal rather than a measure
+of product-code coverage.
+
 The host-listener and relayer live in separate workspaces and are not folded into this number. Their
 Solana modules need separately scoped reports in their own workflows; combining their package-wide
 coverage with this workspace would not produce a meaningful floor.

--- a/solana/docs/TESTING.md
+++ b/solana/docs/TESTING.md
@@ -54,6 +54,30 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
+### Native unit coverage
+
+CI publishes component-level native Rust line coverage. Run the same measurement locally with:
+
+```bash
+cargo llvm-cov \
+  --workspace \
+  --exclude zama-solana-runtime-tests \
+  --json \
+  --summary-only \
+  --output-path /tmp/solana-native-coverage.json
+```
+
+This is intentionally an informational signal without a coverage floor. Mollusk executes the
+programs from prebuilt SBF artifacts, not the instrumented native libraries, so it cannot attribute
+runtime execution to the program instruction source. Including `zama-solana-runtime-tests` would
+instead count the Rust test harness and make the total look healthier without measuring more
+on-chain code. Use the component table to find native unit-test gaps, and use the Mollusk suites to
+validate account, CPI, PDA, ACL, event, and persistence behavior.
+
+The host-listener and relayer live in separate workspaces and are not folded into this number. Their
+Solana modules need separately scoped reports in their own workflows; combining their package-wide
+coverage with this workspace would not produce a meaningful floor.
+
 The adapters live in sibling workspaces and need offline SQLx metadata (no live DB):
 
 ```bash


### PR DESCRIPTION
## What

Publish component-level native Rust line coverage for the Solana workspace in the Actions job summary and document the equivalent local command.

## Why

A single floor would be misleading: Mollusk executes prebuilt SBF artifacts that LLVM cannot instrument, while current native coverage ranges from 98.38% for `zama-solana-acl` to 6.05% for `confidential-token`.

## Validation

`cargo llvm-cov --workspace --exclude zama-solana-runtime-tests --json --summary-only --output-path /tmp/solana-native-coverage-final.json` passed in 6.00s warm and measured 5,031/11,381 lines (44.21%); the component-table `jq` parser and workflow YAML were validated locally.

## Boundary

This first signal is informational, excludes the runtime-test harness to avoid inflated attribution, and leaves host-listener and relayer for separate workspace-specific measurement lanes.

## Tracking

Tracks [zama-ai/fhevm-internal#1657](https://github.com/zama-ai/fhevm-internal/issues/1657).
