### PR TITLE
fix(kms-connector): bound Solana decryption retries

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/solana_finalized_account_fetcher.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_finalized_account_fetcher.rs
@@ -30,6 +30,13 @@ use crate::solana_adapter::{
 /// dropped/reorged transaction) so the queue cannot hot-loop forever.
 const MAX_FINALIZATION_ATTEMPTS: i32 = 60;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FinalizedAccountFetchAction {
+    Process,
+    Retry,
+    Fail,
+}
+
 #[derive(Clone, Debug)]
 pub struct SolanaFinalizedAccountFetcherConfig {
     pub rpc_url: String,
@@ -632,10 +639,12 @@ where
     // the RPC against not-yet-finalized accounts.
     let mut terminal = 0usize;
     for (job, account) in jobs.iter().zip(accounts) {
-        match account {
-            Some(account)
-                if !finalized_slot_covers_job(job, account.observed_slot) =>
-            {
+        let action = finalized_account_fetch_action(
+            job,
+            account.as_ref().map(|account| account.observed_slot),
+        );
+        match (account, action) {
+            (Some(account), FinalizedAccountFetchAction::Retry) => {
                 retry_finalized_account_fetch(
                     &mut tx,
                     job,
@@ -646,7 +655,19 @@ where
                 )
                 .await?;
             }
-            Some(account) => {
+            (Some(account), FinalizedAccountFetchAction::Fail) => {
+                fail_finalized_account_fetch(
+                    &mut tx,
+                    job,
+                    &format!(
+                        "finalized account context slot {} still predates job block {} after max attempts",
+                        account.observed_slot, job.block_number
+                    ),
+                )
+                .await?;
+                terminal += 1;
+            }
+            (Some(account), FinalizedAccountFetchAction::Process) => {
                 let witness = SolanaFinalizedAccountWitness {
                     account_key: job.account_key,
                     owner: account.owner,
@@ -698,25 +719,27 @@ where
                 }
                 terminal += 1;
             }
-            None => {
+            (None, FinalizedAccountFetchAction::Retry) => {
                 // The allow may simply not have finalized yet: retry until the
                 // attempt budget is spent, then fail hard.
-                if job.attempts < MAX_FINALIZATION_ATTEMPTS {
-                    retry_finalized_account_fetch(
-                        &mut tx,
-                        job,
-                        "account not yet found at finalized commitment; awaiting finalization",
-                    )
-                    .await?;
-                } else {
-                    fail_finalized_account_fetch(
-                        &mut tx,
-                        job,
-                        "account not found at finalized commitment after max attempts",
-                    )
-                    .await?;
-                    terminal += 1;
-                }
+                retry_finalized_account_fetch(
+                    &mut tx,
+                    job,
+                    "account not yet found at finalized commitment; awaiting finalization",
+                )
+                .await?;
+            }
+            (None, FinalizedAccountFetchAction::Fail) => {
+                fail_finalized_account_fetch(
+                    &mut tx,
+                    job,
+                    "account not found at finalized commitment after max attempts",
+                )
+                .await?;
+                terminal += 1;
+            }
+            (None, FinalizedAccountFetchAction::Process) => {
+                unreachable!("a missing account cannot be ready for processing")
             }
         }
     }
@@ -730,6 +753,19 @@ fn finalized_slot_covers_job(
     observed_slot: u64,
 ) -> bool {
     observed_slot >= job.block_number
+}
+
+fn finalized_account_fetch_action(
+    job: &SolanaFinalizedAccountFetchJob,
+    observed_slot: Option<u64>,
+) -> FinalizedAccountFetchAction {
+    if observed_slot.is_some_and(|slot| finalized_slot_covers_job(job, slot)) {
+        FinalizedAccountFetchAction::Process
+    } else if job.attempts < MAX_FINALIZATION_ATTEMPTS {
+        FinalizedAccountFetchAction::Retry
+    } else {
+        FinalizedAccountFetchAction::Fail
+    }
 }
 
 async fn retry_jobs(
@@ -916,6 +952,41 @@ mod tests {
         assert!(!finalized_slot_covers_job(&job, account.observed_slot));
         job.block_number = account.observed_slot;
         assert!(finalized_slot_covers_job(&job, account.observed_slot));
+    }
+
+    #[test]
+    fn finalized_account_fetch_transition_is_bounded_and_fail_closed() {
+        let mut job = acl_record_job(
+            "encrypted_value_created",
+            Some(Handle::from([6; 32])),
+        );
+        job.block_number = 43;
+        job.attempts = MAX_FINALIZATION_ATTEMPTS - 1;
+        assert_eq!(
+            finalized_account_fetch_action(&job, Some(42)),
+            FinalizedAccountFetchAction::Retry
+        );
+        assert_eq!(
+            finalized_account_fetch_action(&job, None),
+            FinalizedAccountFetchAction::Retry
+        );
+
+        job.attempts = MAX_FINALIZATION_ATTEMPTS;
+        assert_eq!(
+            finalized_account_fetch_action(&job, Some(42)),
+            FinalizedAccountFetchAction::Fail
+        );
+        assert_eq!(
+            finalized_account_fetch_action(&job, None),
+            FinalizedAccountFetchAction::Fail
+        );
+
+        // The witness/material path is reached only once the finalized RPC
+        // context covers the queued event, even after the retry budget expires.
+        assert_eq!(
+            finalized_account_fetch_action(&job, Some(43)),
+            FinalizedAccountFetchAction::Process
+        );
     }
 
     #[test]

--- a/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
@@ -10,12 +10,6 @@ pub enum ProcessingError {
     Irrecoverable(anyhow::Error),
     #[error("Processing failed: {0}")]
     Recoverable(anyhow::Error),
-    /// Recoverable, but exempt from the attempt budget: the failure is provably a stale-proof
-    /// retry (e.g. a Solana MMR proof built against a chain tip the lineage has since advanced
-    /// past) rather than a bad request, so retrying it must not count against
-    /// `max_decryption_attempts`. See `solana_user_decrypt`'s freshness contract.
-    #[error("Processing failed (budget-exempt retry): {0}")]
-    RecoverableBudgetExempt(anyhow::Error),
 }
 
 impl ProcessingError {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -66,14 +66,6 @@ where
                 event.mark_as_failed(&self.db_pool).await;
                 None
             }
-            // Budget-exempt recoverable errors (e.g. a stale Solana MMR proof) always get
-            // retried, regardless of the attempt counter: the counter isn't even incremented for
-            // them (see `inner_process`), so this arm must never apply the attempt-budget cutoff.
-            (Err(ProcessingError::RecoverableBudgetExempt(e)), _) => {
-                error!("{}", ProcessingError::RecoverableBudgetExempt(e));
-                event.mark_as_pending(&self.db_pool).await;
-                None
-            }
             // For now, we only check the error counter for public and user decryptions as they are
             // the most frequent operations, and we want to avoid infinite retry loop for them.
             // For key management operations, as they are not frequent at all, we currently rely on
@@ -249,11 +241,8 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
         &mut self,
         event: &mut ProtocolEvent,
     ) -> Result<Option<KmsResponseKind>, ProcessingError> {
-        let request = self.prepare_request(event).await.inspect_err(|e| {
-            // Budget-exempt errors (stale proof, legitimate retry) must not consume attempts.
-            if !matches!(e, ProcessingError::RecoverableBudgetExempt(_)) {
-                event.error_counter += 1;
-            }
+        let request = self.prepare_request(event).await.inspect_err(|_| {
+            event.error_counter += 1;
         })?;
 
         if !event.already_sent {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -45,15 +45,14 @@
 //!   `authorize_public` ([`dispatch_solana_mmr_proof`]). There is no live "is public" flag any
 //!   more — public-ness is only provable via a `PublicDecryptLeaf` MMR leaf.
 //!
-//! ## Freshness contract: Recoverable (budget-exempt) vs Irrecoverable
+//! ## Freshness contract
 //!
 //! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. Only on
 //! verification failure does it compare the proof leaf count (the leaf_count the proof was built
 //! against, carried in the legacy `proof_slot` wire field) to the account's live `leaf_count`:
-//! - **mismatch** → `ProcessingError::RecoverableBudgetExempt`: the lineage advanced since the
-//!   proof was built and the proof's mountain may have merged, so the client can rebuild and
-//!   resubmit a fresh proof. This budget-exempt path is only for MMR proof verification failures;
-//!   domain/owner/canonical-account failures are request errors even if the count changed.
+//! - **mismatch** → `ProcessingError::Irrecoverable`: the lineage advanced since the proof was
+//!   built and the proof's mountain may have merged. The queued request is immutable, so retrying
+//!   it cannot refresh the proof; the client must rebuild and submit a new request.
 //! - **match** (proof leaf count == live leaf_count but still fails to verify) → `Irrecoverable`: the
 //!   proof is simply wrong for the account's actual state, not stale.
 //!
@@ -337,8 +336,9 @@ fn dispatch_solana_public_mmr_proof(
 
 /// Verify-FIRST staleness classification: only reached after `verify_*` has already rejected the
 /// proof. A proof-leaf-count/live-`leaf_count` mismatch at that point means the lineage moved since
-/// the proof was built (its mountain may have merged) — Recoverable, budget-exempt (see module
-/// doc). Equal counts with a still-failing proof means the proof is simply wrong — Irrecoverable.
+/// the proof was built (its mountain may have merged). The request is terminal because its proof
+/// bytes cannot change; the client must submit a new request. Equal counts with a still-failing
+/// proof also mean the request is terminal because the proof is simply wrong.
 fn classify_mmr_verification_failure(
     error: crate::core::solana_acl::SolanaAclVerificationError,
     proof_leaf_count: u64,
@@ -350,7 +350,7 @@ fn classify_mmr_verification_failure(
             | crate::core::solana_acl::SolanaAclVerificationError::PublicDecryptProofInvalid
     );
     if is_freshness_shaped && proof_leaf_count != live_leaf_count {
-        ProcessingError::RecoverableBudgetExempt(anyhow!(
+        ProcessingError::Irrecoverable(anyhow!(
             "Solana MMR proof stale: built at leaf_count={proof_leaf_count}, live leaf_count={live_leaf_count} ({error})"
         ))
     } else {
@@ -842,9 +842,9 @@ mod tests {
         assert!(matches!(err, ProcessingError::Irrecoverable(_)));
     }
 
-    // (3) STALE RETRYABLE
+    // (3) STALE TERMINAL
     #[test]
-    fn stale_merged_proof_is_recoverable() {
+    fn stale_merged_proof_is_terminal() {
         let kp = identity_kp(11);
         let owner: SolanaPubkeyBytes = kp.public_key().as_ref().try_into().unwrap();
         let mut l = lineage(h(10), &[owner]);
@@ -864,13 +864,13 @@ mod tests {
         let err = dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(12), &auth)
             .expect_err("a stale (merged) proof must be rejected");
         match err {
-            ProcessingError::RecoverableBudgetExempt(e) => {
+            ProcessingError::Irrecoverable(e) => {
                 let msg = e.to_string();
                 assert!(msg.contains("leaf_count=3"), "got: {msg}");
                 assert!(msg.contains("leaf_count=4"), "got: {msg}");
             }
             other => {
-                panic!("a stale (merged) proof must be RecoverableBudgetExempt, got {other:?}")
+                panic!("a stale (merged) proof must be terminal, got {other:?}")
             }
         }
     }
@@ -899,8 +899,8 @@ mod tests {
             dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(82), &stale_auth)
                 .expect_err("a proof built against an older leaf_count must be rejected");
         assert!(
-            matches!(stale_err, ProcessingError::RecoverableBudgetExempt(_)),
-            "stale invalid proof must be budget-exempt recoverable, got {stale_err:?}"
+            matches!(stale_err, ProcessingError::Irrecoverable(_)),
+            "stale invalid proof must be terminal, got {stale_err:?}"
         );
 
         let mut live_proof = l.proof(2);
@@ -957,7 +957,7 @@ mod tests {
 
         let verifier = SolanaAclVerifier::new(HOST);
         let err = dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(70), &auth)
-            .expect_err("domain failures must not get budget-exempt stale retries");
+            .expect_err("domain failures must not be classified as stale proofs");
         assert!(matches!(err, ProcessingError::Irrecoverable(_)));
     }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -47,10 +47,12 @@
 //!
 //! ## Freshness contract
 //!
-//! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. A failed proof is
-//! terminal because the queued request cannot change its proof bytes; the client must rebuild and
-//! submit a new request. The error retains the proof and live leaf counts to diagnose likely
-//! staleness without giving it a different retry classification.
+//! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. Only after a
+//! verification failure does the proof's leaf count classify the result:
+//! - **proof count < live count**: terminal; the immutable queued proof is stale.
+//! - **proof count == live count**: terminal; the proof is invalid for the live state.
+//! - **proof count > live count**: recoverable through the ordinary bounded attempt budget; the
+//!   KMS finalized view is behind the proof service, so the same proof may verify after catch-up.
 //!
 //! A proof that still verifies against the live peaks despite `proof_leaf_count != leaf_count` (count
 //! drifted but the relevant mountain never merged) is accepted — verify-first, never rebuilt from
@@ -330,16 +332,30 @@ fn dispatch_solana_public_mmr_proof(
         .map_err(|e| classify_mmr_verification_failure(e, proof_leaf_count, acl.leaf_count))
 }
 
-/// Terminal mapping reached only after `verify_*` rejects the proof against live finalized peaks.
-/// Both counts are retained for diagnostics; the queued proof bytes cannot be refreshed in place.
+/// Verify-first failure classification. An ahead-of-live proof can become valid when the KMS
+/// finalized view catches up, so it gets an ordinary bounded retry. A proof at or behind the live
+/// count cannot be repaired in place and is terminal.
 fn classify_mmr_verification_failure(
     error: crate::core::solana_acl::SolanaAclVerificationError,
     proof_leaf_count: u64,
     live_leaf_count: u64,
 ) -> ProcessingError {
-    ProcessingError::Irrecoverable(anyhow!(
-        "Solana MMR proof invalid: built at leaf_count={proof_leaf_count}, live leaf_count={live_leaf_count} ({error})"
-    ))
+    if proof_leaf_count > live_leaf_count {
+        ProcessingError::Recoverable(anyhow!(
+            "Solana MMR proof is ahead of the KMS finalized view: proof leaf_count={proof_leaf_count}, \
+             live finalized leaf_count={live_leaf_count}; retrying within the normal attempt budget \
+             while finalized state catches up ({error})"
+        ))
+    } else if proof_leaf_count < live_leaf_count {
+        ProcessingError::Irrecoverable(anyhow!(
+            "Solana MMR proof is stale and immutable: proof leaf_count={proof_leaf_count}, live \
+             finalized leaf_count={live_leaf_count} ({error})"
+        ))
+    } else {
+        ProcessingError::Irrecoverable(anyhow!(
+            "Solana MMR proof is invalid at live finalized leaf_count={live_leaf_count} ({error})"
+        ))
+    }
 }
 
 /// Full Solana user-decryption ACL check for one request: fetches the named `EncryptedValue`
@@ -848,12 +864,52 @@ mod tests {
         match err {
             ProcessingError::Irrecoverable(e) => {
                 let msg = e.to_string();
+                assert!(msg.contains("stale and immutable"), "got: {msg}");
                 assert!(msg.contains("leaf_count=3"), "got: {msg}");
                 assert!(msg.contains("leaf_count=4"), "got: {msg}");
             }
             other => {
                 panic!("a stale (merged) proof must be terminal, got {other:?}")
             }
+        }
+    }
+
+    #[test]
+    fn invalid_proof_at_live_leaf_count_is_terminal() {
+        let err = classify_mmr_verification_failure(
+            crate::core::solana_acl::SolanaAclVerificationError::HistoricalAccessProofInvalid,
+            4,
+            4,
+        );
+
+        match err {
+            ProcessingError::Irrecoverable(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("invalid at live finalized leaf_count=4"),
+                    "got: {msg}"
+                );
+            }
+            other => panic!("an invalid proof at the live count must be terminal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proof_ahead_of_live_state_uses_normal_recoverable_budget() {
+        let err = classify_mmr_verification_failure(
+            crate::core::solana_acl::SolanaAclVerificationError::PublicDecryptProofInvalid,
+            2,
+            1,
+        );
+
+        match err {
+            ProcessingError::Recoverable(e) => {
+                let msg = e.to_string();
+                assert!(msg.contains("proof leaf_count=2"), "got: {msg}");
+                assert!(msg.contains("live finalized leaf_count=1"), "got: {msg}");
+                assert!(msg.contains("normal attempt budget"), "got: {msg}");
+            }
+            other => panic!("a proof ahead of finalized state must be recoverable, got {other:?}"),
         }
     }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -47,14 +47,10 @@
 //!
 //! ## Freshness contract
 //!
-//! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. Only on
-//! verification failure does it compare the proof leaf count (the leaf_count the proof was built
-//! against, carried in the legacy `proof_slot` wire field) to the account's live `leaf_count`:
-//! - **mismatch** → `ProcessingError::Irrecoverable`: the lineage advanced since the proof was
-//!   built and the proof's mountain may have merged. The queued request is immutable, so retrying
-//!   it cannot refresh the proof; the client must rebuild and submit a new request.
-//! - **match** (proof leaf count == live leaf_count but still fails to verify) → `Irrecoverable`: the
-//!   proof is simply wrong for the account's actual state, not stale.
+//! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. A failed proof is
+//! terminal because the queued request cannot change its proof bytes; the client must rebuild and
+//! submit a new request. The error retains the proof and live leaf counts to diagnose likely
+//! staleness without giving it a different retry classification.
 //!
 //! A proof that still verifies against the live peaks despite `proof_leaf_count != leaf_count` (count
 //! drifted but the relevant mountain never merged) is accepted — verify-first, never rebuilt from
@@ -334,30 +330,16 @@ fn dispatch_solana_public_mmr_proof(
         .map_err(|e| classify_mmr_verification_failure(e, proof_leaf_count, acl.leaf_count))
 }
 
-/// Verify-FIRST staleness classification: only reached after `verify_*` has already rejected the
-/// proof. A proof-leaf-count/live-`leaf_count` mismatch at that point means the lineage moved since
-/// the proof was built (its mountain may have merged). The request is terminal because its proof
-/// bytes cannot change; the client must submit a new request. Equal counts with a still-failing
-/// proof also mean the request is terminal because the proof is simply wrong.
+/// Terminal mapping reached only after `verify_*` rejects the proof against live finalized peaks.
+/// Both counts are retained for diagnostics; the queued proof bytes cannot be refreshed in place.
 fn classify_mmr_verification_failure(
     error: crate::core::solana_acl::SolanaAclVerificationError,
     proof_leaf_count: u64,
     live_leaf_count: u64,
 ) -> ProcessingError {
-    let is_freshness_shaped = matches!(
-        error,
-        crate::core::solana_acl::SolanaAclVerificationError::HistoricalAccessProofInvalid
-            | crate::core::solana_acl::SolanaAclVerificationError::PublicDecryptProofInvalid
-    );
-    if is_freshness_shaped && proof_leaf_count != live_leaf_count {
-        ProcessingError::Irrecoverable(anyhow!(
-            "Solana MMR proof stale: built at leaf_count={proof_leaf_count}, live leaf_count={live_leaf_count} ({error})"
-        ))
-    } else {
-        ProcessingError::Irrecoverable(anyhow!(
-            "Solana MMR proof invalid or non-freshness failure at live leaf_count={live_leaf_count}: {error}"
-        ))
-    }
+    ProcessingError::Irrecoverable(anyhow!(
+        "Solana MMR proof invalid: built at leaf_count={proof_leaf_count}, live leaf_count={live_leaf_count} ({error})"
+    ))
 }
 
 /// Full Solana user-decryption ACL check for one request: fetches the named `EncryptedValue`
@@ -875,49 +857,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn invalid_mmr_proof_classification_uses_leaf_count() {
-        let kp = identity_kp(15);
-        let owner: SolanaPubkeyBytes = kp.public_key().as_ref().try_into().unwrap();
-        let mut l = lineage(h(80), &[owner]);
-        l.rotate(h(81));
-        l.rotate(h(82));
-        l.rotate(h(83));
-
-        let stale_leaf_count = l.acl.leaf_count;
-        assert_eq!(stale_leaf_count, 3);
-        let stale_blob = proof_blob(MMR_MODE_HISTORICAL, &l.proof(2));
-        l.rotate(h(84));
-        let live_leaf_count = l.acl.leaf_count;
-        assert_eq!(live_leaf_count, 4);
-
-        let verifier = SolanaAclVerifier::new(HOST);
-        let stale_request =
-            signed_mmr_request(&kp, h(82), l.value_key(), stale_blob, stale_leaf_count);
-        let stale_auth = verify_solana_user_decrypt_signature(&stale_request, CHAIN_ID).unwrap();
-        let stale_err =
-            dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(82), &stale_auth)
-                .expect_err("a proof built against an older leaf_count must be rejected");
-        assert!(
-            matches!(stale_err, ProcessingError::Irrecoverable(_)),
-            "stale invalid proof must be terminal, got {stale_err:?}"
-        );
-
-        let mut live_proof = l.proof(2);
-        live_proof.siblings[0][0] ^= 0xff;
-        let live_blob = proof_blob(MMR_MODE_HISTORICAL, &live_proof);
-        let live_request =
-            signed_mmr_request(&kp, h(82), l.value_key(), live_blob, live_leaf_count);
-        let live_auth = verify_solana_user_decrypt_signature(&live_request, CHAIN_ID).unwrap();
-        let live_err =
-            dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(82), &live_auth)
-                .expect_err("an invalid proof carrying the live leaf_count must be rejected");
-        assert!(
-            matches!(live_err, ProcessingError::Irrecoverable(_)),
-            "invalid proof at live leaf_count must be irrecoverable, got {live_err:?}"
-        );
-    }
-
     // (3b) VERIFY-FIRST ACCEPTS COUNT DRIFT WITHOUT A MERGE
     #[test]
     fn valid_proof_survives_count_drift_without_merge() {
@@ -941,7 +880,7 @@ mod tests {
     }
 
     #[test]
-    fn domain_not_allowed_with_stale_slot_is_not_budget_exempt() {
+    fn domain_failure_remains_terminal_when_leaf_count_differs() {
         let kp = identity_kp(14);
         let owner: SolanaPubkeyBytes = kp.public_key().as_ref().try_into().unwrap();
         let mut l = lineage(h(70), &[owner]);
@@ -957,7 +896,7 @@ mod tests {
 
         let verifier = SolanaAclVerifier::new(HOST);
         let err = dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(70), &auth)
-            .expect_err("domain failures must not be classified as stale proofs");
+            .expect_err("domain failures must remain terminal");
         assert!(matches!(err, ProcessingError::Irrecoverable(_)));
     }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -48,11 +48,14 @@
 //! ## Freshness contract
 //!
 //! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. Only after a
-//! verification failure does the proof's leaf count classify the result:
+//! inclusion-proof failure does the proof's leaf count classify the result:
 //! - **proof count < live count**: terminal; the immutable queued proof is stale.
 //! - **proof count == live count**: terminal; the proof is invalid for the live state.
 //! - **proof count > live count**: recoverable through the ordinary bounded attempt budget; the
 //!   KMS finalized view is behind the proof service, so the same proof may verify after catch-up.
+//!
+//! Domain, owner, canonical-account, bump, and inconsistent-MMR failures remain terminal regardless
+//! of the two counts because finalized-view catch-up cannot repair them.
 //!
 //! A proof that still verifies against the live peaks despite `proof_leaf_count != leaf_count` (count
 //! drifted but the relevant mountain never merged) is accepted — verify-first, never rebuilt from
@@ -332,28 +335,38 @@ fn dispatch_solana_public_mmr_proof(
         .map_err(|e| classify_mmr_verification_failure(e, proof_leaf_count, acl.leaf_count))
 }
 
-/// Verify-first failure classification. An ahead-of-live proof can become valid when the KMS
-/// finalized view catches up, so it gets an ordinary bounded retry. A proof at or behind the live
-/// count cannot be repaired in place and is terminal.
+/// Verify-first failure classification. Only an inclusion-proof mismatch ahead of the KMS finalized
+/// view can heal through catch-up, so it gets an ordinary bounded retry. All other verifier errors,
+/// and proof mismatches at or behind the live count, are terminal.
 fn classify_mmr_verification_failure(
     error: crate::core::solana_acl::SolanaAclVerificationError,
     proof_leaf_count: u64,
     live_leaf_count: u64,
 ) -> ProcessingError {
-    if proof_leaf_count > live_leaf_count {
+    let proof_invalid = matches!(
+        error,
+        crate::core::solana_acl::SolanaAclVerificationError::HistoricalAccessProofInvalid
+            | crate::core::solana_acl::SolanaAclVerificationError::PublicDecryptProofInvalid
+    );
+    if proof_invalid && proof_leaf_count > live_leaf_count {
         ProcessingError::Recoverable(anyhow!(
             "Solana MMR proof is ahead of the KMS finalized view: proof leaf_count={proof_leaf_count}, \
              live finalized leaf_count={live_leaf_count}; retrying within the normal attempt budget \
              while finalized state catches up ({error})"
         ))
-    } else if proof_leaf_count < live_leaf_count {
+    } else if proof_invalid && proof_leaf_count < live_leaf_count {
         ProcessingError::Irrecoverable(anyhow!(
             "Solana MMR proof is stale and immutable: proof leaf_count={proof_leaf_count}, live \
              finalized leaf_count={live_leaf_count} ({error})"
         ))
-    } else {
+    } else if proof_invalid {
         ProcessingError::Irrecoverable(anyhow!(
             "Solana MMR proof is invalid at live finalized leaf_count={live_leaf_count} ({error})"
+        ))
+    } else {
+        ProcessingError::Irrecoverable(anyhow!(
+            "Solana MMR authorization failed irrecoverably: proof leaf_count={proof_leaf_count}, \
+             live finalized leaf_count={live_leaf_count} ({error})"
         ))
     }
 }
@@ -936,15 +949,14 @@ mod tests {
     }
 
     #[test]
-    fn domain_failure_remains_terminal_when_leaf_count_differs() {
+    fn ahead_count_domain_and_canonical_failures_remain_terminal() {
         let kp = identity_kp(14);
         let owner: SolanaPubkeyBytes = kp.public_key().as_ref().try_into().unwrap();
         let mut l = lineage(h(70), &[owner]);
         l.rotate(h(71));
-        let proof_slot = l.acl.leaf_count;
+        let proof_slot = l.acl.leaf_count + 1;
         let blob = proof_blob(MMR_MODE_HISTORICAL, &l.proof(0));
-        l.rotate(h(72));
-        assert_ne!(proof_slot, l.acl.leaf_count);
+        assert!(proof_slot > l.acl.leaf_count);
 
         let request = signed_mmr_request(&kp, h(70), l.value_key(), blob, proof_slot);
         let mut auth = verify_solana_user_decrypt_signature(&request, CHAIN_ID).unwrap();
@@ -952,8 +964,18 @@ mod tests {
 
         let verifier = SolanaAclVerifier::new(HOST);
         let err = dispatch_solana_mmr_proof(&verifier, l.account, HOST, &l.acl, h(70), &auth)
-            .expect_err("domain failures must remain terminal");
+            .expect_err("an ahead count must not make a domain failure retryable");
         assert!(matches!(err, ProcessingError::Irrecoverable(_)));
+
+        let canonical_err = classify_mmr_verification_failure(
+            crate::core::solana_acl::SolanaAclVerificationError::NonCanonicalEncryptedValueAcl,
+            2,
+            1,
+        );
+        assert!(
+            matches!(canonical_err, ProcessingError::Irrecoverable(_)),
+            "an ahead count must not make a canonical-account failure retryable"
+        );
     }
 
     // (3c) CURRENT ACCEPT


### PR DESCRIPTION
## What

- preserve verify-first acceptance for Solana MMR proofs, even when proof and live leaf counts differ;
- classify failed inclusion proofs directionally: proof count below or equal to live state is terminal, while an inclusion-proof mismatch ahead of the KMS finalized view gets an ordinary bounded retry;
- apply the existing 60-claim finalization bound to account observations whose finalized context slot still predates the queued event;
- keep witness storage and decrypt-material release behind `observed_slot >= block_number`.

An ahead-of-live inclusion-proof mismatch uses the existing `ProcessingError::Recoverable` path and therefore consumes the normal `max_decryption_attempts` budget. There is no budget-exempt retry path. Domain, owner, canonical-account, bump, and inconsistent-MMR failures remain terminal regardless of leaf counts.

## Validation

- `SQLX_OFFLINE=true cargo test -p kms-worker core::event_processor::solana_user_decrypt::tests` (24 passed)
- `SQLX_OFFLINE=true cargo test -p host-listener solana_finalized_account_fetcher::tests` (22 passed)
- `SQLX_OFFLINE=true cargo clippy -p kms-worker --all-targets -- -D warnings`
- `SQLX_OFFLINE=true cargo clippy -p host-listener --all-targets -- -D warnings`
- `cargo fmt -p kms-worker -- --check`
- `git diff --check`

The local `attempt_limit` integration suite requires its containerized Postgres fixture; all eight cases stopped at container creation in the restricted environment before exercising code.

Tracks [zama-ai/fhevm-internal#1687](https://github.com/zama-ai/fhevm-internal/issues/1687) and only the stale-finalized-witness overlap with [zama-ai/fhevm-internal#1682](https://github.com/zama-ai/fhevm-internal/issues/1682).

