### PR TITLE
refactor(sdk): remove fake Solana client inputs

### DIFF
--- a/sdk/js-sdk/src/core/actions/decrypt/generateTransportKeyPair.ts
+++ b/sdk/js-sdk/src/core/actions/decrypt/generateTransportKeyPair.ts
@@ -15,7 +15,7 @@ export async function generateTransportKeyPair(
   fhevm: Fhevm<FhevmChain, WithDecrypt>,
 ): Promise<GenerateTransportKeyPairReturnType> {
   const f = asFhevmWithTkmsVersion(fhevm);
-  return await generateTransportKeyPair_(f);
+  return await generateTransportKeyPair_({ runtime: f.runtime, tkmsVersion: f.tkmsVersion });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sdk/js-sdk/src/core/kms/TransportKeyPair-p.test.ts
+++ b/sdk/js-sdk/src/core/kms/TransportKeyPair-p.test.ts
@@ -1,0 +1,28 @@
+import type { WithDecrypt } from '../types/coreFhevmRuntime.js';
+import type { TkmsPrivateKey } from '../types/tkms-p.js';
+import { describe, expect, it, vi } from 'vitest';
+import { generateTransportKeyPair } from './TransportKeyPair-p.js';
+
+describe('generateTransportKeyPair', () => {
+  it('generates a key pair from only the decrypt runtime and TKMS version', async () => {
+    const tkmsPrivateKey = {} as TkmsPrivateKey;
+    const generateTkmsPrivateKey = vi.fn().mockResolvedValue(tkmsPrivateKey);
+    const serializeTkmsPrivateKey = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const getTkmsPublicKeyHex = vi.fn().mockResolvedValue('0x010203');
+    const runtime = {
+      decrypt: {
+        generateTkmsPrivateKey,
+        serializeTkmsPrivateKey,
+        getTkmsPublicKeyHex,
+      },
+    } as unknown as WithDecrypt;
+
+    const keyPair = await generateTransportKeyPair({ runtime, tkmsVersion: '0.13.20-0' });
+
+    expect(keyPair.publicKey).toBe('0x010203');
+    expect(keyPair.tkmsVersion).toBe('0.13.20-0');
+    expect(generateTkmsPrivateKey).toHaveBeenCalledWith({ tkmsVersion: '0.13.20-0' });
+    expect(serializeTkmsPrivateKey).toHaveBeenCalledWith({ tkmsPrivateKey, tkmsVersion: '0.13.20-0' });
+    expect(getTkmsPublicKeyHex).toHaveBeenCalledWith({ tkmsPrivateKey, tkmsVersion: '0.13.20-0' });
+  });
+});

--- a/sdk/js-sdk/src/core/kms/TransportKeyPair-p.ts
+++ b/sdk/js-sdk/src/core/kms/TransportKeyPair-p.ts
@@ -3,7 +3,7 @@ import type { FhevmRuntime, WithDecrypt } from '../types/coreFhevmRuntime.js';
 import type { Bytes, BytesHex } from '../types/primitives.js';
 import type { TkmsPrivateKey } from '../types/tkms-p.js';
 import type { TkmsVersion } from '../../wasm/tkms/KmsLibApi.js';
-import type { NativeClient, OptionalNativeClient } from '../types/coreFhevmClient.js';
+import type { OptionalNativeClient } from '../types/coreFhevmClient.js';
 import type { FhevmChain } from '../types/fhevmChain.js';
 import { assertIsBytesOrBytesHex, bytesToHexLarge, hexToBytesFaster } from '../base/bytes.js';
 import { InvalidTypeError } from '../base/errors/InvalidTypeError.js';
@@ -183,8 +183,6 @@ export function assertIsTransportKeyPair(
 /** Generates a fresh {@link TransportKeyPair}. */
 export async function generateTransportKeyPair(context: {
   readonly runtime: WithDecrypt;
-  readonly chain: FhevmChain;
-  readonly client: NativeClient;
   readonly tkmsVersion: TkmsVersion;
 }): Promise<TransportKeyPair> {
   const tkmsVersion = context.tkmsVersion;

--- a/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
+++ b/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
@@ -526,6 +526,21 @@ export type CreateCoreFhevmParameters<
   readonly options?: FhevmOptions | undefined;
 };
 
+export function createCoreFhevm<runtime extends FhevmRuntime>(
+  ownerToken: symbol,
+  parameters: {
+    readonly chain?: undefined;
+    readonly client?: undefined;
+    readonly runtime: runtime;
+    readonly options?: FhevmOptions | undefined;
+  },
+): Fhevm<undefined, runtime, undefined>;
+
+export function createCoreFhevm<chain extends FhevmChain, runtime extends FhevmRuntime, client extends NativeClient>(
+  ownerToken: symbol,
+  parameters: CreateCoreFhevmParameters<chain, runtime, client>,
+): Fhevm<chain, runtime, client>;
+
 export function createCoreFhevm<chain extends FhevmChain, runtime extends FhevmRuntime, client extends NativeClient>(
   ownerToken: symbol,
   parameters: CreateCoreFhevmParameters<chain, runtime, client>,
@@ -604,12 +619,18 @@ export function setResolvedProtocolVersion(fhevm: FhevmBase, protocolVersion: Pr
   f[SET_PROTOCOL_VERSION](protocolVersion);
 }
 
-export function setResolvedTfheVersion(fhevm: FhevmBase, tfheVersion: TfheVersion): void {
+export function setResolvedTfheVersion(
+  fhevm: FhevmBase<FhevmChain | undefined, FhevmRuntime, OptionalNativeClient>,
+  tfheVersion: TfheVersion,
+): void {
   const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [SET_TFHE_VERSION]: SetTfheVersionFn };
   f[SET_TFHE_VERSION](tfheVersion);
 }
 
-export function setResolvedTkmsVersion(fhevm: FhevmBase, tkmsVersion: TkmsVersion): void {
+export function setResolvedTkmsVersion(
+  fhevm: FhevmBase<FhevmChain | undefined, FhevmRuntime, OptionalNativeClient>,
+  tkmsVersion: TkmsVersion,
+): void {
   const f = asCoreFhevm(fhevm) as CoreFhevm & { readonly [SET_TKMS_VERSION]: SetTkmsVersionFn };
   f[SET_TKMS_VERSION](tkmsVersion);
 }

--- a/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
+++ b/sdk/js-sdk/src/core/runtime/CoreFhevm-p.ts
@@ -538,13 +538,16 @@ export function createCoreFhevm<runtime extends FhevmRuntime>(
 
 export function createCoreFhevm<chain extends FhevmChain, runtime extends FhevmRuntime, client extends NativeClient>(
   ownerToken: symbol,
-  parameters: CreateCoreFhevmParameters<chain, runtime, client>,
+  parameters: CreateCoreFhevmParameters<chain, runtime, client> & {
+    readonly chain: chain;
+    readonly client: client;
+  },
 ): Fhevm<chain, runtime, client>;
 
 export function createCoreFhevm<chain extends FhevmChain, runtime extends FhevmRuntime, client extends NativeClient>(
   ownerToken: symbol,
   parameters: CreateCoreFhevmParameters<chain, runtime, client>,
-): Fhevm<chain, runtime, client> {
+): Fhevm<chain, runtime, client> | Fhevm<undefined, runtime, undefined> {
   // Pre-populate the global FheEncryptionKey cache if the caller provided one.
   // Avoids a 50MB fetch later when encrypt is first called.
   // No-op if an entry already exists for this relayerUrl (first write wins).

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test-d.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test-d.ts
@@ -1,0 +1,25 @@
+import type { NativeClient } from '../../core/types/coreFhevmClient.js';
+import type { FhevmChain } from '../../core/types/fhevmChain.js';
+import type { FhevmRuntime } from '../../core/types/coreFhevmRuntime.js';
+import type { FhevmSolanaChain } from '../../core/types/fhevmSolanaChain.js';
+import { expectTypeOf } from 'vitest';
+import { asBytes32Hex } from '../../core/base/bytes.js';
+import { createCoreFhevm } from '../../core/runtime/CoreFhevm-p.js';
+import { createFhevmBaseClient } from './createFhevmBaseClient.js';
+
+const chain = {
+  id: 9223372036854788153n,
+  fhevm: {
+    relayerUrl: 'http://localhost:3000',
+    acl: { domainKeys: [asBytes32Hex('0x1111111111111111111111111111111111111111111111111111111111111111')] },
+  },
+} as const satisfies FhevmSolanaChain;
+
+const client = createFhevmBaseClient({ chain });
+
+expectTypeOf(client.chain).toEqualTypeOf<undefined>();
+expectTypeOf(client.client).toEqualTypeOf<undefined>();
+expectTypeOf(client.solanaChain).toEqualTypeOf<typeof chain>();
+
+// @ts-expect-error Hosted core construction cannot omit its declared chain and client.
+createCoreFhevm<FhevmChain, FhevmRuntime, NativeClient>(Symbol(), { runtime: {} as FhevmRuntime });

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
@@ -1,6 +1,10 @@
 import type { FhevmSolanaChain } from '../../core/types/fhevmSolanaChain.js';
+import type { FhevmRuntime } from '../../core/types/coreFhevmRuntime.js';
+import type { FhevmChain } from '../../core/types/fhevmChain.js';
+import type { NativeClient } from '../../core/types/coreFhevmClient.js';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { asBytes32Hex } from '../../core/base/bytes.js';
+import { createCoreFhevm } from '../../core/runtime/CoreFhevm-p.js';
 import { setFhevmRuntimeConfig } from '../internal/config.js';
 import { createFhevmBaseClient } from './createFhevmBaseClient.js';
 
@@ -13,6 +17,13 @@ const chain = {
 } as const satisfies FhevmSolanaChain;
 
 describe('createFhevmBaseClient', () => {
+  it('requires chain and client for explicit hosted core types', () => {
+    if (false) {
+      // @ts-expect-error Hosted core construction cannot omit its declared chain and client.
+      createCoreFhevm<FhevmChain, FhevmRuntime, NativeClient>(Symbol(), { runtime: {} as FhevmRuntime });
+    }
+  });
+
   it('keeps the exact Solana chain while leaving EVM chain and native client absent', async () => {
     setFhevmRuntimeConfig({});
 

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
@@ -1,0 +1,30 @@
+import type { FhevmSolanaChain } from '../../core/types/fhevmSolanaChain.js';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { asBytes32Hex } from '../../core/base/bytes.js';
+import { setFhevmRuntimeConfig } from '../internal/config.js';
+import { createFhevmBaseClient } from './createFhevmBaseClient.js';
+
+const chain = {
+  id: 9223372036854788153n,
+  fhevm: {
+    relayerUrl: 'http://localhost:3000',
+    acl: { domainKeys: [asBytes32Hex('0x1111111111111111111111111111111111111111111111111111111111111111')] },
+  },
+} as const satisfies FhevmSolanaChain;
+
+describe('createFhevmBaseClient', () => {
+  it('keeps the exact Solana chain while leaving EVM chain and native client absent', async () => {
+    setFhevmRuntimeConfig({});
+
+    const client = createFhevmBaseClient({ chain });
+
+    expectTypeOf(client.chain).toEqualTypeOf<undefined>();
+    expectTypeOf(client.client).toEqualTypeOf<undefined>();
+    const inferredChain: typeof chain = client.solanaChain;
+    expect(client.chain).toBeUndefined();
+    expect(client.client).toBeUndefined();
+    expect(client.solanaChain).toBe(chain);
+    expect(inferredChain.id).toBe(9223372036854788153n);
+    await expect(client.ready).resolves.toBeUndefined();
+  });
+});

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
@@ -1,10 +1,6 @@
 import type { FhevmSolanaChain } from '../../core/types/fhevmSolanaChain.js';
-import type { FhevmRuntime } from '../../core/types/coreFhevmRuntime.js';
-import type { FhevmChain } from '../../core/types/fhevmChain.js';
-import type { NativeClient } from '../../core/types/coreFhevmClient.js';
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { asBytes32Hex } from '../../core/base/bytes.js';
-import { createCoreFhevm } from '../../core/runtime/CoreFhevm-p.js';
 import { setFhevmRuntimeConfig } from '../internal/config.js';
 import { createFhevmBaseClient } from './createFhevmBaseClient.js';
 
@@ -17,25 +13,15 @@ const chain = {
 } as const satisfies FhevmSolanaChain;
 
 describe('createFhevmBaseClient', () => {
-  it('requires chain and client for explicit hosted core types', () => {
-    if (false) {
-      // @ts-expect-error Hosted core construction cannot omit its declared chain and client.
-      createCoreFhevm<FhevmChain, FhevmRuntime, NativeClient>(Symbol(), { runtime: {} as FhevmRuntime });
-    }
-  });
-
   it('keeps the exact Solana chain while leaving EVM chain and native client absent', async () => {
     setFhevmRuntimeConfig({});
 
     const client = createFhevmBaseClient({ chain });
 
-    expectTypeOf(client.chain).toEqualTypeOf<undefined>();
-    expectTypeOf(client.client).toEqualTypeOf<undefined>();
-    const inferredChain: typeof chain = client.solanaChain;
     expect(client.chain).toBeUndefined();
     expect(client.client).toBeUndefined();
     expect(client.solanaChain).toBe(chain);
-    expect(inferredChain.id).toBe(9223372036854788153n);
+    expect(client.solanaChain.id).toBe(9223372036854788153n);
     await expect(client.ready).resolves.toBeUndefined();
   });
 });

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.ts
@@ -26,7 +26,7 @@ export function createFhevmBaseClient<chain extends FhevmSolanaChain>(parameters
   const c = createCoreFhevm(PRIVATE_SOLANA_TOKEN, {
     runtime: getSolanaRuntime(),
     options: parameters.options,
-  }) as unknown as Fhevm<undefined, FhevmRuntime, undefined>;
+  });
 
   Object.defineProperty(c, 'solanaChain', {
     value: parameters.chain,

--- a/sdk/js-sdk/src/solana/clients/decorators/decrypt.ts
+++ b/sdk/js-sdk/src/solana/clients/decorators/decrypt.ts
@@ -5,11 +5,8 @@ import type { FhevmProtocolContext } from '../../../core/types/coreFhevmClient.j
 import type { FhevmRuntime, WithDecrypt } from '../../../core/types/coreFhevmRuntime.js';
 import type { SolanaUserDecryptParameters, SolanaUserDecryptResult } from '../../actions/userDecrypt.js';
 import type { GenerateTransportKeyPairReturnType } from '../../../core/actions/decrypt/generateTransportKeyPair.js';
-import type { WithTkmsVersion } from '../../../core/types/coreFhevmClient.js';
-import { asFhevmWith, setResolvedTkmsVersion } from '../../../core/runtime/CoreFhevm-p.js';
-import {
-  generateTransportKeyPair as generateTransportKeyPair_,
-} from '../../../core/kms/TransportKeyPair-p.js';
+import { asFhevmWith, getResolvedTkmsVersion, setResolvedTkmsVersion } from '../../../core/runtime/CoreFhevm-p.js';
+import { generateTransportKeyPair as generateTransportKeyPair_ } from '../../../core/kms/TransportKeyPair-p.js';
 import { decryptModule } from '../../../core/modules/decrypt/module/index.js';
 import { hyperWasmResolveTkmsModuleVersion } from '../../../core/runtime/HyperWasmSolver-p.js';
 import { userDecrypt } from '../../actions/userDecrypt.js';
@@ -53,10 +50,7 @@ async function _initDecrypt(fhevm: FhevmBase<undefined, FhevmRuntime, OptionalNa
 
   await f.runtime.decrypt.initTkmsModule({ tkmsVersion });
 
-  // `fhevm` is the same CoreFhevmImpl instance `_initDecrypt` was called with.
-  // Cast satisfies the FhevmBase<FhevmChain, ..., NativeClient> signature; instanceof check
-  // inside setResolvedTkmsVersion validates identity at runtime.
-  setResolvedTkmsVersion(fhevm as unknown as FhevmBase, tkmsVersion);
+  setResolvedTkmsVersion(fhevm, tkmsVersion);
 }
 
 /**
@@ -86,11 +80,11 @@ export function solanaDecryptActions(
         generateTransportKeyPair: async () => {
           // Auto-init: await fhevm.ready so tkmsVersion is stored and TKMS WASM is loaded.
           await (fhevm as Fhevm<undefined, FhevmRuntime, undefined>).ready;
-          // Solana has no EVM FhevmChain/NativeClient. generateTransportKeyPair's body uses only
-          // `runtime` + `tkmsVersion` (chain/client are unused required params), so pass them as
-          // never. Read tkmsVersion directly from fhevm after ready has resolved it.
-          const tkmsVersion = (fhevm as unknown as WithTkmsVersion).tkmsVersion;
-          return generateTransportKeyPair_({ runtime, chain: {} as never, client: {} as never, tkmsVersion });
+          const tkmsVersion = getResolvedTkmsVersion(fhevm);
+          if (tkmsVersion === undefined) {
+            throw new Error('TKMS version is unresolved after client initialization');
+          }
+          return generateTransportKeyPair_({ runtime, tkmsVersion });
         },
       },
       runtime,

--- a/sdk/js-sdk/src/solana/clients/decorators/encrypt.ts
+++ b/sdk/js-sdk/src/solana/clients/decorators/encrypt.ts
@@ -1,7 +1,13 @@
 import type { Bytes32Hex } from '../../../core/types/primitives.js';
 import type { FhevmSolanaChain } from '../../../core/types/fhevmSolanaChain.js';
 import type { FhevmChain } from '../../../core/types/fhevmChain.js';
-import type { Fhevm, FhevmBase, FhevmExtension, OptionalNativeClient, WithTfheVersion } from '../../../core/types/coreFhevmClient.js';
+import type {
+  Fhevm,
+  FhevmBase,
+  FhevmExtension,
+  OptionalNativeClient,
+  WithTfheVersion,
+} from '../../../core/types/coreFhevmClient.js';
 import type { FhevmRuntime, WithEncrypt } from '../../../core/types/coreFhevmRuntime.js';
 import type { SolanaEncryptInputParameters, SolanaEncryptInputResult } from '../../actions/encryptInput.js';
 import { asFhevmWith, setResolvedTfheVersion } from '../../../core/runtime/CoreFhevm-p.js';
@@ -31,10 +37,7 @@ async function _initEncrypt(fhevm: FhevmBase<undefined, FhevmRuntime, OptionalNa
 
   await f.runtime.encrypt.initTfheModule({ tfheVersion });
 
-  // `f` is the same CoreFhevmImpl instance as `fhevm` (asFhevmWith narrows, not wraps).
-  // The cast satisfies the FhevmBase<FhevmChain, ..., NativeClient> signature; the runtime
-  // instanceof check inside setResolvedTfheVersion validates identity at runtime.
-  setResolvedTfheVersion(fhevm as unknown as FhevmBase, tfheVersion);
+  setResolvedTfheVersion(fhevm, tfheVersion);
 }
 
 /**

--- a/sdk/js-sdk/src/vitest.config.ts
+++ b/sdk/js-sdk/src/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     exclude: ['src/index.hello.test.ts', 'src/wasm/**/type-check.test.ts'],
     reporters: ['verbose'],
     passWithNoTests: false,
-    typecheck: { enabled: true },
+    typecheck: { enabled: true, tsconfig: 'tsconfig.type-tests.json' },
     coverage: {
       provider: 'v8',
       reporter: ['text'],

--- a/sdk/js-sdk/tsconfig.type-tests.json
+++ b/sdk/js-sdk/tsconfig.type-tests.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["src/**/*.test-d.ts"],
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "ESNext.Disposable"]
+  }
+}


### PR DESCRIPTION
## Purpose

Partially address [zama-ai/fhevm-internal#1592](https://github.com/zama-ai/fhevm-internal/issues/1592) by removing the Solana SDK type fabrications that can be corrected without changing public host-chain metadata or extension APIs.

## Changes

- type the core client’s existing chainless construction path explicitly
- remove unused EVM chain/client parameters from transport-key generation
- pass only the decrypt runtime and resolved TKMS version from both EVM and Solana callers
- allow private TFHE/TKMS version setters to accept the existing hostless core client
- remove the Solana base-client, version-setter, and transport-key double casts / `never` placeholders
- add focused transport-key and hostless Solana-client tests

## Intentionally quarantined

This does not claim to complete [fhevm-internal#1592](https://github.com/zama-ai/fhevm-internal/issues/1592).

- The Solana proof builder still uses an EVM-shaped ACL adapter. Removing it honestly reaches `FheEncryptionKeyMetadata.chainId: number`, while Solana’s RFC-021 host ID is an exact `bigint`. Widening that externally visible metadata family or converting the ID lossily is outside this PR.
- The remaining `.ready` and `init` casts come from the public `FhevmExtension` callback being typed as `FhevmBase`. Changing that public extension contract is outside this PR.

No proof bytes, proof metadata, chain IDs, ACL behavior, public EVM action signatures, or initialization behavior are changed.

## Validation

Passed:

- focused Vitest run: 2 files, 2 tests
- focused Vitest typecheck: no errors
- full unit suite: 791 of 792 tests pass; the only failure is an existing untouched `ZkProofBuilder.test.ts` message mismatch
- `npm run prettier:ext`
- `git diff --check`

Existing branch/environment failures observed:

- full TypeScript build has two errors in untouched files: the TFHE `WasmAssetLoadMode` export and stale `transportPublicKey` Solana test input
- `npm run build:prod` stops on formatting in untouched `src/solana/index.ts`
- ESLint reports three existing errors in untouched Solana files
- cleartext v13 reached Anvil outside the sandbox, then stopped because Solidity dependencies were absent; `forge soldeer install` crashes in the installed Foundry build before installing them


