### PR TITLE
fix(sdk): fix extraData version check

### DIFF
--- a/sdk/js-sdk/src/core/_version.ts
+++ b/sdk/js-sdk/src/core/_version.ts
@@ -1,3 +1,3 @@
 // This file is auto-generated
-export const version: string = '1.1.0-alpha.8';
+export const version: string = '1.1.0-alpha.9';
 export const sdkName: string = '@fhevm/sdk';

--- a/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
@@ -308,7 +308,7 @@ export async function reconcileKmsSignersContext(
   }
 
   // Reject if extraData serialization version differs.
-  if (relayerKmsExtraData.version !== requestedKmsExtraData.version) {
+  if (relayerKmsExtraData.version !== 0 && relayerKmsExtraData.version !== requestedKmsExtraData.version) {
     throw new Error(
       `ExtraData serialization version mismatch: SDK uses v${requestedKmsExtraData.version}, ` +
         `relayer returned v${relayerKmsExtraData.version}. ` +

--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fhevm/sdk",
   "description": "TypeScript Interface for FHEVM",
-  "version": "1.1.0-alpha.8",
+  "version": "1.1.0-alpha.9",
   "type": "module",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
This occurs when contracts have been upgraded but not the KMS yet.