### PR TITLE
test(test-suite): source Solana e2e proofs from relayer

### DIFF
--- a/solana/scripts/poc/full-vertical.sh
+++ b/solana/scripts/poc/full-vertical.sh
@@ -549,7 +549,7 @@ echo "$relout" | grep -q 'OK request_disclose_amount' || fail "request_disclose_
 echo "    disclosure request witness created (KMS context pinned); handle released for public decrypt"
 
 # Public-decrypt the burned handle -> cleartext + KMS PublicDecryptVerification cert. This lineage
-# must contain the born-public lifecycle leaf followed by the explicit make_handle_public leaf; a
+# must contain the produced-public lifecycle leaf followed by the explicit make_handle_public leaf; a
 # proof for a one-leaf lineage would not exercise lifecycle-batch ingestion.
 run_public_decrypt_with_proof "burned" "$BURNED_HANDLE" "$BURNED_ACL" "" 2 1
 cr="$PUBLIC_DECRYPT_JSON"

--- a/solana/scripts/poc/full-vertical.sh
+++ b/solana/scripts/poc/full-vertical.sh
@@ -44,15 +44,14 @@ run_public_decrypt_with_proof() {
   local handle="$2"
   local acl="$3"
   local expected="${4:-}"
-  # Proof source (5th arg, default relayer): the e2e sources the MMR proof from the running relayer
-  # proof service. `local` is reserved for the born-public burned leg until the relayer consumes
-  # the host's lifecycle batch, and drives the in-process PoC builder instead. The client retries
-  # a transient `503 lagging` internally (re-invoking here would be unsafe for stateful steps).
-  local proof_source="${5:-relayer}"
+  local expected_leaf_count="${5:-}"
+  local expected_leaf_index="${6:-}"
+  # The e2e sources MMR proofs from the running relayer proof service. The client retries a transient
+  # `503 lagging` internally (re-invoking here would be unsafe for stateful steps).
   local proof
   proof="$(cd "$ROOT/solana/scripts/poc/live-client" && \
     PUBLIC_DECRYPT_PROOF=1 PUB_HANDLE="$handle" PUB_ACL="$acl" \
-    PROOF_SOURCE="$proof_source" RELAYER_URL=http://127.0.0.1:3000 \
+    RELAYER_URL=http://127.0.0.1:3000 \
     ./target/debug/poc-live-client 2>&1)" \
     || fail "$label public proof: $proof"
   echo "$proof" | grep -E 'PUB H|PUB mmrProofBytes' >/dev/null || fail "$label public proof missing fields: $proof"
@@ -74,6 +73,14 @@ run_public_decrypt_with_proof() {
     [ -n "${!required}" ] || fail "$label public proof missing $required: $proof"
   done
   [ "$pub_h" = "$handle" ] || fail "$label public proof handle $pub_h != $handle"
+  if [ -n "$expected_leaf_count" ]; then
+    [ "$pub_leaf_count" = "$expected_leaf_count" ] \
+      || fail "$label public proof leaf_count $pub_leaf_count != $expected_leaf_count"
+  fi
+  if [ -n "$expected_leaf_index" ]; then
+    [ "$pub_leaf_index" = "$expected_leaf_index" ] \
+      || fail "$label public proof leaf_index $pub_leaf_index != $expected_leaf_index"
+  fi
   PUBLIC_DECRYPT_INCLUSION_PROOF_BYTES="$pub_mmr_inclusion_proof_bytes"
 
   local result
@@ -216,7 +223,7 @@ done
 # here; the client retries a transient `503 lagging` internally, so this is not re-invoked on lag.
 hist_proof="$(cd "$ROOT/solana/scripts/poc/live-client" && \
   HISTORICAL_STEP=supersede TE_VALUE="$VALUE" \
-  PROOF_SOURCE=relayer RELAYER_URL=http://127.0.0.1:3000 \
+  RELAYER_URL=http://127.0.0.1:3000 \
   ./target/debug/poc-live-client 2>&1)" || fail "historical supersede/proof command failed: $hist_proof"
 echo "$hist_proof" | grep -E 'HIST H_new|HIST mmrProofBytes' || fail "historical supersede/proof: $hist_proof"
 HIST_H_OLD2="$(hist_field "$hist_proof" H_old)"
@@ -541,12 +548,10 @@ relout="$(lc CONSUME_SEAL=1 TS_ACL="$BURNED_ACL" TS_HANDLE="$BURNED_HANDLE" \
 echo "$relout" | grep -q 'OK request_disclose_amount' || fail "request_disclose_amount witness: $(echo "$relout" | tail -3)"
 echo "    disclosure request witness created (KMS context pinned); handle released for public decrypt"
 
-# Public-decrypt the burned handle -> cleartext + KMS PublicDecryptVerification cert.
-# PROOF_SOURCE=local: unlike the compute/input-flow/historical legs (relayer-sourced), the
-# born-public burned handle is derived on-chain from slot entropy and is not carried in instruction
-# data. The host now emits it in a narrow lifecycle batch, but this leg stays on the in-process PoC
-# builder until the immediately stacked relayer slice validates and consumes that batch.
-run_public_decrypt_with_proof "burned" "$BURNED_HANDLE" "$BURNED_ACL" "" local
+# Public-decrypt the burned handle -> cleartext + KMS PublicDecryptVerification cert. This lineage
+# must contain the born-public lifecycle leaf followed by the explicit make_handle_public leaf; a
+# proof for a one-leaf lineage would not exercise lifecycle-batch ingestion.
+run_public_decrypt_with_proof "burned" "$BURNED_HANDLE" "$BURNED_ACL" "" 2 1
 cr="$PUBLIC_DECRYPT_JSON"
 # The burned handle's public-decrypt MMR proof (DD-036): both the redeem and disclose consume
 # steps authorize by verifying it against the lineage's on-chain peaks. request_burn_redemption

--- a/solana/scripts/poc/live-client/Cargo.lock
+++ b/solana/scripts/poc/live-client/Cargo.lock
@@ -1707,6 +1707,7 @@ dependencies = [
  "borsh",
  "confidential-token",
  "serde",
+ "serde_json",
  "solana-keypair",
  "ureq",
  "zama-host",

--- a/solana/scripts/poc/live-client/Cargo.toml
+++ b/solana/scripts/poc/live-client/Cargo.toml
@@ -20,6 +20,7 @@ solana-keypair = "3.1.2"
 # Blocking HTTP client for the relayer MMR-proof endpoint.
 ureq = { version = "2", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 zama-host = { path = "../../../programs/zama-host", features = ["no-entrypoint"] }
 zama-solana-acl = { path = "../../../crates/zama-solana-acl" }
 confidential-token = { path = "../../../programs/confidential-token", features = ["no-entrypoint", "poc"] }

--- a/solana/scripts/poc/live-client/Cargo.toml
+++ b/solana/scripts/poc/live-client/Cargo.toml
@@ -17,7 +17,7 @@ anchor-lang = "1.0.2"
 anchor-client = "1.0.2"
 borsh = "1"
 solana-keypair = "3.1.2"
-# Blocking HTTP client for the relayer MMR-proof endpoint (PROOF_SOURCE=relayer).
+# Blocking HTTP client for the relayer MMR-proof endpoint.
 ureq = { version = "2", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 zama-host = { path = "../../../programs/zama-host", features = ["no-entrypoint"] }

--- a/solana/scripts/poc/live-client/main.rs
+++ b/solana/scripts/poc/live-client/main.rs
@@ -613,38 +613,6 @@ fn trivial_encrypt_eval(
     Ok(())
 }
 
-fn build_historical_access_proof(
-    encrypted_value_account: [u8; 32],
-    peaks: &[[u8; 32]],
-    leaf_count: u64,
-    old_handle: [u8; 32],
-    subject: [u8; 32],
-) -> Result<(zama_solana_acl::MmrProof, Vec<u8>), Box<dyn std::error::Error>> {
-    let leaf = zama_solana_acl::historical_access_leaf_commitment(
-        encrypted_value_account,
-        0,
-        old_handle,
-        subject,
-    );
-    let leaves = [leaf];
-    let proof = zama_solana_acl::mmr_build_proof(&leaves, 0).ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "failed to build historical MMR proof for leaf 0",
-        )
-    })?;
-    if !zama_solana_acl::mmr_verify(peaks, leaf_count, leaf, &proof) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("historical MMR proof did not verify against live leaf_count={leaf_count}"),
-        )
-        .into());
-    }
-
-    let proof_bytes = proof_blob(MMR_MODE_HISTORICAL, &proof)?;
-    Ok((proof, proof_bytes))
-}
-
 fn proof_blob(
     mode: u8,
     proof: &zama_solana_acl::MmrProof,
@@ -652,95 +620,6 @@ fn proof_blob(
     let mut proof_bytes = vec![mode];
     proof_bytes.extend_from_slice(&borsh::to_vec(proof)?);
     Ok(proof_bytes)
-}
-
-fn locate_public_decrypt_leaf_index(
-    encrypted_value_account: [u8; 32],
-    leaves: &[[u8; 32]],
-    handle: [u8; 32],
-) -> Option<u64> {
-    leaves.iter().enumerate().find_map(|(index, leaf)| {
-        let index = index as u64;
-        let public_leaf =
-            zama_solana_acl::public_decrypt_leaf_commitment(encrypted_value_account, index, handle);
-        (*leaf == public_leaf).then_some(index)
-    })
-}
-
-fn build_public_decrypt_proof(
-    encrypted_value_account: [u8; 32],
-    value_account: &zama_host::EncryptedValue,
-    handle: [u8; 32],
-) -> Result<(zama_solana_acl::MmrProof, Vec<u8>), Box<dyn std::error::Error>> {
-    // The burned/disclosed lineage can hold MORE than one public-decrypt leaf for the
-    // SAME handle: a born-public burn (DD-036) seals one, and a later explicit
-    // `make_handle_public` seal appends another — the host has no live "already public"
-    // flag by design (lib.rs authorize_public docs), so it never dedups. Reconstruct one
-    // `MarkedPublic` per on-chain leaf so the reconstructed peaks/leaf_count match the
-    // live account. NOTE (PoC shortcut): this assumes the lineage is entirely
-    // same-handle public leaves, which holds for full-vertical's single-burn flow; a
-    // lineage that also carries supersede (historical) leaves cannot be rebuilt from the
-    // handle alone — route through the relayer proof service (`solana_proof::build_proof`)
-    // for that (tracked follow-up).
-    let events: Vec<zama_solana_acl::LineageEvent> =
-        std::iter::repeat(zama_solana_acl::LineageEvent::MarkedPublic { handle })
-            .take(value_account.leaf_count as usize)
-            .collect();
-    let reconstructed =
-        zama_solana_acl::reconstruct(encrypted_value_account, &events).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to reconstruct public-decrypt lineage: {e:?}"),
-            )
-        })?;
-    let leaf_index =
-        locate_public_decrypt_leaf_index(encrypted_value_account, &reconstructed.leaves, handle)
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "failed to locate PublicDecryptLeaf in reconstructed lineage",
-                )
-            })?;
-    let proof = reconstructed
-        .build_verified_proof(&value_account.peaks, value_account.leaf_count, leaf_index)
-        .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("public-decrypt lineage reconstruction diverged from live account: {e:?}"),
-            )
-        })?;
-    let shared = value_account.to_shared();
-    zama_solana_acl::authorize_public(encrypted_value_account, &shared, handle, &proof).map_err(
-        |e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("public-decrypt MMR proof did not verify against live lineage: {e:?}"),
-            )
-        },
-    )?;
-    let proof_bytes = proof_blob(MMR_MODE_PUBLIC, &proof)?;
-    Ok((proof, proof_bytes))
-}
-
-/// Proof source for the public + historical MMR proofs.
-/// - `Relayer` (default): fetch the inclusion proof from the running relayer proof service
-///   (`GET /internal/solana/mmr-proof`). This is what the e2e uses — the relayer, not the PoC,
-///   produces the accepted proof.
-/// - `Local`: synthesize the proof in-process by reconstructing the lineage from thin chain facts.
-///   Reserved for the born-public burned leg until the relayer consumes the host lifecycle batch,
-///   and for unit tests. Selected explicitly via `PROOF_SOURCE=local`.
-enum ProofSource {
-    Relayer,
-    Local,
-}
-
-fn proof_source() -> ProofSource {
-    match std::env::var("PROOF_SOURCE").ok().as_deref() {
-        Some("local") => ProofSource::Local,
-        // Anything else (unset or "relayer") is the relayer path: the e2e sources proofs from the
-        // relayer by construction, so the synthetic path is never reached without opting in.
-        _ => ProofSource::Relayer,
-    }
 }
 
 fn relayer_url() -> String {
@@ -766,9 +645,9 @@ struct RelayerMmrProofDto {
 
 /// Fetches a verified MMR inclusion proof from the relayer proof service, retrying a bounded number
 /// of times while the service's ingestion is still catching up to chain (`503 lagging`). REQUIRES
-/// `verified == true`; any other non-verified response fails loudly at once. Retrying HERE (not by
-/// re-invoking the client) keeps the caller idempotent — the historical `supersede` step appends
-/// on-chain leaves, so re-running it would corrupt the lineage.
+/// `verified == true`; every other response, including `500 corrupt_cache`, fails loudly at once.
+/// Retrying HERE (not by re-invoking the client) keeps the caller idempotent — the historical
+/// `supersede` step appends on-chain leaves, so re-running it would corrupt the lineage.
 fn fetch_relayer_mmr_proof(
     encrypted_value: &Pubkey,
     leaf_index: u64,
@@ -777,7 +656,10 @@ fn fetch_relayer_mmr_proof(
     for attempt in 1..=MAX_ATTEMPTS {
         match fetch_relayer_mmr_proof_once(encrypted_value, leaf_index) {
             Ok(proof) => return Ok(proof),
-            Err(e) if e.to_string().contains("lagging") && attempt < MAX_ATTEMPTS => {
+            Err(e)
+                if e.to_string().starts_with("relayer proof lagging:")
+                    && attempt < MAX_ATTEMPTS =>
+            {
                 eprintln!(
                     "relayer proof lagging (attempt {attempt}/{MAX_ATTEMPTS}); retrying in 2s"
                 );
@@ -803,8 +685,21 @@ fn fetch_relayer_mmr_proof_once(
     let body: RelayerMmrProofResponse = match ureq::get(&url).call() {
         Ok(resp) => resp.into_json()?,
         Err(ureq::Error::Status(code, resp)) => {
-            let status = resp.into_string().unwrap_or_default();
-            return Err(format!("relayer proof HTTP {code}: {status}").into());
+            let error_body: RelayerMmrProofResponse = resp.into_json().map_err(|e| {
+                format!("relayer proof HTTP {code} returned an invalid error body: {e}")
+            })?;
+            if code == 503 && error_body.status == "lagging" {
+                return Err(format!(
+                    "relayer proof lagging: HTTP {code}, leaf_count={}",
+                    error_body.leaf_count
+                )
+                .into());
+            }
+            return Err(format!(
+                "relayer proof HTTP {code}: status={}, leaf_count={}",
+                error_body.status, error_body.leaf_count
+            )
+            .into());
         }
         Err(e) => return Err(format!("relayer proof request to {url} failed: {e}").into()),
     };
@@ -816,6 +711,13 @@ fn fetch_relayer_mmr_proof_once(
         .into());
     }
     let dto = body.mmr_proof.expect("checked is_some above");
+    if dto.leaf_index != leaf_index {
+        return Err(format!(
+            "relayer proof leaf_index {} does not match requested {leaf_index}",
+            dto.leaf_index
+        )
+        .into());
+    }
     let siblings = dto
         .siblings
         .iter()
@@ -838,31 +740,23 @@ fn public_decrypt_proof_step(
     let encrypted_value = public_proof_encrypted_value_from_env()?;
     let value_account = fetch_encrypted_value(host, encrypted_value)?;
     let value_key = value_account.value_key();
-    let (proof, proof_bytes) = match proof_source() {
-        ProofSource::Local => {
-            build_public_decrypt_proof(encrypted_value.to_bytes(), &value_account, handle)?
-        }
-        ProofSource::Relayer => {
-            // Chain facts (peaks/leaf_count/current handle) come from the live account; the proof
-            // itself comes from the relayer. The public-decrypt leaf is the lineage's last leaf.
-            let leaf_index = value_account
-                .leaf_count
-                .checked_sub(1)
-                .ok_or("public-decrypt lineage has no leaves")?;
-            let proof = fetch_relayer_mmr_proof(&encrypted_value, leaf_index)?;
-            // Fail-fast: the relayer proof must authorize this handle against the live lineage
-            // before it is handed to the KMS / on-chain consume steps.
-            let shared = value_account.to_shared();
-            zama_solana_acl::authorize_public(encrypted_value.to_bytes(), &shared, handle, &proof)
-                .map_err(|e| {
-                    Box::<dyn std::error::Error>::from(format!(
-                        "relayer public-decrypt proof did not verify against live lineage: {e:?}"
-                    ))
-                })?;
-            let proof_bytes = proof_blob(MMR_MODE_PUBLIC, &proof)?;
-            (proof, proof_bytes)
-        }
-    };
+    // Chain facts (peaks/leaf_count/current handle) come from the live account; the proof itself
+    // comes from the relayer. The public-decrypt leaf is the lineage's last leaf.
+    let leaf_index = value_account
+        .leaf_count
+        .checked_sub(1)
+        .ok_or("public-decrypt lineage has no leaves")?;
+    let proof = fetch_relayer_mmr_proof(&encrypted_value, leaf_index)?;
+    // Fail-fast: the relayer proof must authorize this handle against the live lineage before it is
+    // handed to the KMS / on-chain consume steps.
+    let shared = value_account.to_shared();
+    zama_solana_acl::authorize_public(encrypted_value.to_bytes(), &shared, handle, &proof)
+        .map_err(|e| {
+            Box::<dyn std::error::Error>::from(format!(
+                "relayer public-decrypt proof did not verify against live lineage: {e:?}"
+            ))
+        })?;
+    let proof_bytes = proof_blob(MMR_MODE_PUBLIC, &proof)?;
 
     println!("PUB H 0x{}", hex(&handle));
     println!("PUB encryptedValueAccount {encrypted_value}");
@@ -936,41 +830,29 @@ fn historical_supersede_step(
             )?;
             let value_account = fetch_encrypted_value(host, target.encrypted_value)?;
             let subject = payer.pubkey().to_bytes();
-            let (proof, proof_bytes) = match proof_source() {
-                ProofSource::Local => build_historical_access_proof(
-                    target.encrypted_value.to_bytes(),
-                    &value_account.peaks,
-                    value_account.leaf_count,
-                    old_handle,
-                    subject,
-                )?,
-                ProofSource::Relayer => {
-                    // The e2e historical lineage has exactly one historical leaf, at index 0.
-                    let proof = fetch_relayer_mmr_proof(&target.encrypted_value, 0)?;
-                    // Fail-fast: the relayer proof must verify against the live peaks for the
-                    // historical-access leaf (old handle bound to this subject).
-                    let leaf = zama_solana_acl::historical_access_leaf_commitment(
-                        target.encrypted_value.to_bytes(),
-                        0,
-                        old_handle,
-                        subject,
-                    );
-                    if !zama_solana_acl::mmr_verify(
-                        &value_account.peaks,
-                        value_account.leaf_count,
-                        leaf,
-                        &proof,
-                    ) {
-                        return Err(format!(
-                            "relayer historical proof did not verify against live leaf_count={}",
-                            value_account.leaf_count
-                        )
-                        .into());
-                    }
-                    let proof_bytes = proof_blob(MMR_MODE_HISTORICAL, &proof)?;
-                    (proof, proof_bytes)
-                }
-            };
+            // The e2e historical lineage has exactly one historical leaf, at index 0.
+            let proof = fetch_relayer_mmr_proof(&target.encrypted_value, 0)?;
+            // Fail-fast: the relayer proof must verify against the live peaks for the
+            // historical-access leaf (old handle bound to this subject).
+            let leaf = zama_solana_acl::historical_access_leaf_commitment(
+                target.encrypted_value.to_bytes(),
+                0,
+                old_handle,
+                subject,
+            );
+            if !zama_solana_acl::mmr_verify(
+                &value_account.peaks,
+                value_account.leaf_count,
+                leaf,
+                &proof,
+            ) {
+                return Err(format!(
+                    "relayer historical proof did not verify against live leaf_count={}",
+                    value_account.leaf_count
+                )
+                .into());
+            }
+            let proof_bytes = proof_blob(MMR_MODE_HISTORICAL, &proof)?;
 
             println!("HIST H_old 0x{}", hex(&old_handle));
             println!("HIST H_new 0x{}", hex(&result.handle));
@@ -2887,162 +2769,4 @@ fn initialize_mint(
         acl.data.len()
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn historical_proof_for_first_supersession_verifies() {
-        let encrypted_value_account = [0xAC; 32];
-        let old_handle = [0x10; 32];
-        let subject = [0x01; 32];
-        let leaf = zama_solana_acl::historical_access_leaf_commitment(
-            encrypted_value_account,
-            0,
-            old_handle,
-            subject,
-        );
-        let mut peaks = Vec::new();
-        let mut leaf_count = 0;
-        zama_solana_acl::mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
-
-        let (proof, proof_bytes) = build_historical_access_proof(
-            encrypted_value_account,
-            &peaks,
-            leaf_count,
-            old_handle,
-            subject,
-        )
-        .unwrap();
-
-        assert_eq!(proof.leaf_index, 0);
-        assert!(proof.siblings.is_empty());
-        assert_eq!(proof_bytes[0], MMR_MODE_HISTORICAL);
-        assert!(zama_solana_acl::mmr_verify(
-            &peaks, leaf_count, leaf, &proof
-        ));
-    }
-
-    #[test]
-    fn public_decrypt_proof_for_made_public_handle_verifies() {
-        let encrypted_value_account = [0xAC; 32];
-        let handle = [0x20; 32];
-        let events = [zama_solana_acl::LineageEvent::MarkedPublic { handle }];
-        let reconstructed = zama_solana_acl::reconstruct(encrypted_value_account, &events).unwrap();
-        let proof = reconstructed.build_proof(0).unwrap();
-        let mut value = zama_solana_acl::EncryptedValue {
-            current_handle: handle,
-            leaf_count: reconstructed.leaf_count,
-            peaks: reconstructed.peaks.clone(),
-            ..Default::default()
-        };
-        value.subjects = vec![[0x01; 32]];
-        let host_value = zama_host::EncryptedValue {
-            acl_domain_key: Pubkey::new_from_array(value.acl_domain_key),
-            app_account: Pubkey::new_from_array(value.app_account),
-            encrypted_value_label: value.encrypted_value_label,
-            current_handle: value.current_handle,
-            subjects: value
-                .subjects
-                .iter()
-                .copied()
-                .map(Pubkey::new_from_array)
-                .collect(),
-            leaf_count: value.leaf_count,
-            peaks: value.peaks.clone(),
-            bump: value.bump,
-        };
-
-        let (built, proof_bytes) =
-            build_public_decrypt_proof(encrypted_value_account, &host_value, handle).unwrap();
-        assert_eq!(built, proof);
-        assert_eq!(proof_bytes[0], MMR_MODE_PUBLIC);
-        assert!(
-            zama_solana_acl::authorize_public(encrypted_value_account, &value, handle, &built)
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn public_decrypt_proof_for_twice_public_handle_verifies() {
-        // Regression for the full-vertical born-public burned handle: it is made public
-        // TWICE (born-public burn per DD-036, then an explicit make_handle_public seal),
-        // so the on-chain lineage has leaf_count == 2 for the SAME handle. A single-event
-        // reconstruction yields leaf_count == 1 and diverges (PeaksDiverged); the proof
-        // builder must reconstruct one MarkedPublic per on-chain leaf.
-        let encrypted_value_account = [0xAC; 32];
-        let handle = [0x21; 32];
-        let events = [
-            zama_solana_acl::LineageEvent::MarkedPublic { handle },
-            zama_solana_acl::LineageEvent::MarkedPublic { handle },
-        ];
-        let reconstructed = zama_solana_acl::reconstruct(encrypted_value_account, &events).unwrap();
-        assert_eq!(reconstructed.leaf_count, 2);
-        let mut value = zama_solana_acl::EncryptedValue {
-            current_handle: handle,
-            leaf_count: reconstructed.leaf_count,
-            peaks: reconstructed.peaks.clone(),
-            ..Default::default()
-        };
-        value.subjects = vec![[0x01; 32]];
-        let host_value = zama_host::EncryptedValue {
-            acl_domain_key: Pubkey::new_from_array(value.acl_domain_key),
-            app_account: Pubkey::new_from_array(value.app_account),
-            encrypted_value_label: value.encrypted_value_label,
-            current_handle: value.current_handle,
-            subjects: value
-                .subjects
-                .iter()
-                .copied()
-                .map(Pubkey::new_from_array)
-                .collect(),
-            leaf_count: value.leaf_count,
-            peaks: value.peaks.clone(),
-            bump: value.bump,
-        };
-
-        // Regressed as PeaksDiverged before the leaf_count-aware reconstruction fix.
-        let (built, proof_bytes) =
-            build_public_decrypt_proof(encrypted_value_account, &host_value, handle).unwrap();
-        assert_eq!(proof_bytes[0], MMR_MODE_PUBLIC);
-        assert!(
-            zama_solana_acl::authorize_public(encrypted_value_account, &value, handle, &built)
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn historical_leaf_is_rejected_by_public_verify() {
-        let encrypted_value_account = [0xAC; 32];
-        let old_handle = [0x10; 32];
-        let subject = [0x01; 32];
-        let historical_leaf = zama_solana_acl::historical_access_leaf_commitment(
-            encrypted_value_account,
-            0,
-            old_handle,
-            subject,
-        );
-        let mut peaks = Vec::new();
-        let mut leaf_count = 0;
-        zama_solana_acl::mmr_append(&mut peaks, &mut leaf_count, historical_leaf).unwrap();
-        let proof = zama_solana_acl::mmr_build_proof(&[historical_leaf], 0).unwrap();
-        let proof_bytes = proof_blob(MMR_MODE_HISTORICAL, &proof).unwrap();
-        let value = zama_solana_acl::EncryptedValue {
-            current_handle: [0x11; 32],
-            leaf_count,
-            peaks,
-            ..Default::default()
-        };
-
-        assert_eq!(proof_bytes[0], MMR_MODE_HISTORICAL);
-        assert!(zama_solana_acl::authorize_public(
-            encrypted_value_account,
-            &value,
-            old_handle,
-            &proof
-        )
-        .is_err());
-    }
 }

--- a/solana/scripts/poc/live-client/main.rs
+++ b/solana/scripts/poc/live-client/main.rs
@@ -22,6 +22,7 @@ use solana_keypair::{read_keypair_file, Keypair};
 
 const EVENT_AUTHORITY_SEED: &[u8] = b"__event_authority";
 const HISTORICAL_LABEL_MARKER: u8 = 3;
+const RELAYER_LAGGING_PREFIX: &str = "relayer proof lagging:";
 const MMR_MODE_HISTORICAL: u8 = 0x01;
 const MMR_MODE_PUBLIC: u8 = 0x02;
 
@@ -654,13 +655,10 @@ fn fetch_relayer_mmr_proof(
     leaf_index: u64,
 ) -> Result<zama_solana_acl::MmrProof, Box<dyn std::error::Error>> {
     const MAX_ATTEMPTS: u32 = 15;
-    for attempt in 1..=MAX_ATTEMPTS {
+    for attempt in 1..MAX_ATTEMPTS {
         match fetch_relayer_mmr_proof_once(encrypted_value, leaf_index) {
             Ok(proof) => return Ok(proof),
-            Err(e)
-                if e.to_string().starts_with("relayer proof lagging:")
-                    && attempt < MAX_ATTEMPTS =>
-            {
+            Err(e) if is_relayer_lagging(&e.to_string()) => {
                 eprintln!(
                     "relayer proof lagging (attempt {attempt}/{MAX_ATTEMPTS}); retrying in 2s"
                 );
@@ -669,7 +667,11 @@ fn fetch_relayer_mmr_proof(
             Err(e) => return Err(e),
         }
     }
-    Err("relayer proof still lagging after retries".into())
+    fetch_relayer_mmr_proof_once(encrypted_value, leaf_index)
+}
+
+fn is_relayer_lagging(message: &str) -> bool {
+    message.starts_with(RELAYER_LAGGING_PREFIX)
 }
 
 fn fetch_relayer_mmr_proof_once(
@@ -726,7 +728,7 @@ fn relayer_http_error(code: u16, raw_body: &[u8]) -> String {
     if let Ok(error_body) = serde_json::from_slice::<RelayerMmrProofResponse>(raw_body) {
         if code == 503 && error_body.status == "lagging" {
             return format!(
-                "relayer proof lagging: HTTP {code}, leaf_count={}",
+                "{RELAYER_LAGGING_PREFIX} HTTP {code}, leaf_count={}",
                 error_body.leaf_count
             );
         }
@@ -2785,21 +2787,25 @@ fn initialize_mint(
 
 #[cfg(test)]
 mod tests {
-    use super::relayer_http_error;
+    use super::{is_relayer_lagging, relayer_http_error};
 
     #[test]
     fn retries_only_structured_lagging_response() {
         let lagging = br#"{"mmr_proof":null,"leaf_count":7,"proof_slot":42,"verified":false,"status":"lagging"}"#;
+        let lagging_error = relayer_http_error(503, lagging);
         assert_eq!(
-            relayer_http_error(503, lagging),
+            lagging_error,
             "relayer proof lagging: HTTP 503, leaf_count=7"
         );
+        assert!(is_relayer_lagging(&lagging_error));
 
         let wrong_status = br#"{"mmr_proof":null,"leaf_count":7,"proof_slot":42,"verified":false,"status":"corrupt_cache"}"#;
+        let fatal_error = relayer_http_error(503, wrong_status);
         assert_eq!(
-            relayer_http_error(503, wrong_status),
+            fatal_error,
             "relayer proof HTTP 503: status=corrupt_cache, leaf_count=7"
         );
+        assert!(!is_relayer_lagging(&fatal_error));
     }
 
     #[test]

--- a/solana/scripts/poc/live-client/main.rs
+++ b/solana/scripts/poc/live-client/main.rs
@@ -10,6 +10,7 @@
 //! Underlying SPL mint is passed via $UNDERLYING_MINT (create it with `spl-token
 //! create-token`). RPC is pinned to the local validator — never mainnet.
 
+use std::io::Read;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -685,21 +686,9 @@ fn fetch_relayer_mmr_proof_once(
     let body: RelayerMmrProofResponse = match ureq::get(&url).call() {
         Ok(resp) => resp.into_json()?,
         Err(ureq::Error::Status(code, resp)) => {
-            let error_body: RelayerMmrProofResponse = resp.into_json().map_err(|e| {
-                format!("relayer proof HTTP {code} returned an invalid error body: {e}")
-            })?;
-            if code == 503 && error_body.status == "lagging" {
-                return Err(format!(
-                    "relayer proof lagging: HTTP {code}, leaf_count={}",
-                    error_body.leaf_count
-                )
-                .into());
-            }
-            return Err(format!(
-                "relayer proof HTTP {code}: status={}, leaf_count={}",
-                error_body.status, error_body.leaf_count
-            )
-            .into());
+            let mut raw_body = Vec::new();
+            resp.into_reader().read_to_end(&mut raw_body)?;
+            return Err(relayer_http_error(code, &raw_body).into());
         }
         Err(e) => return Err(format!("relayer proof request to {url} failed: {e}").into()),
     };
@@ -731,6 +720,29 @@ fn fetch_relayer_mmr_proof_once(
         leaf_index: dto.leaf_index,
         siblings,
     })
+}
+
+fn relayer_http_error(code: u16, raw_body: &[u8]) -> String {
+    if let Ok(error_body) = serde_json::from_slice::<RelayerMmrProofResponse>(raw_body) {
+        if code == 503 && error_body.status == "lagging" {
+            return format!(
+                "relayer proof lagging: HTTP {code}, leaf_count={}",
+                error_body.leaf_count
+            );
+        }
+        return format!(
+            "relayer proof HTTP {code}: status={}, leaf_count={}",
+            error_body.status, error_body.leaf_count
+        );
+    }
+
+    let body = String::from_utf8_lossy(raw_body);
+    let body = if body.is_empty() {
+        "<empty response body>"
+    } else {
+        body.as_ref()
+    };
+    format!("relayer proof HTTP {code}: {body}")
 }
 
 fn public_decrypt_proof_step(
@@ -2769,4 +2781,40 @@ fn initialize_mint(
         acl.data.len()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::relayer_http_error;
+
+    #[test]
+    fn retries_only_structured_lagging_response() {
+        let lagging = br#"{"mmr_proof":null,"leaf_count":7,"proof_slot":42,"verified":false,"status":"lagging"}"#;
+        assert_eq!(
+            relayer_http_error(503, lagging),
+            "relayer proof lagging: HTTP 503, leaf_count=7"
+        );
+
+        let wrong_status = br#"{"mmr_proof":null,"leaf_count":7,"proof_slot":42,"verified":false,"status":"corrupt_cache"}"#;
+        assert_eq!(
+            relayer_http_error(503, wrong_status),
+            "relayer proof HTTP 503: status=corrupt_cache, leaf_count=7"
+        );
+    }
+
+    #[test]
+    fn preserves_non_json_error_body_for_diagnostics() {
+        assert_eq!(
+            relayer_http_error(502, b"upstream unavailable"),
+            "relayer proof HTTP 502: upstream unavailable"
+        );
+        assert_eq!(
+            relayer_http_error(500, &[b'b', 0xff]),
+            "relayer proof HTTP 500: b\u{fffd}"
+        );
+        assert_eq!(
+            relayer_http_error(500, b""),
+            "relayer proof HTTP 500: <empty response body>"
+        );
+    }
 }


### PR DESCRIPTION
Terminal acceptance slice for zama-ai/fhevm-internal#1675. This PR also partially addresses fhevm-internal#1658.

## Outcome

Make the Solana full-vertical e2e source every historical and public MMR proof from the running relayer. Delete local proof builders, proof-source switches, and builder-only tests while preserving client-side verification, wire encoding, and proof reuse.

## Decisive invariant

The burned lineage must contain exactly two public leaves:

1. leaf 0: the entropy-derived `make_public=true` output recovered from the host lifecycle batch introduced by merged #3136 and validated by merged #3138
2. leaf 1: the later explicit `make_handle_public` performed by `request_disclose_amount`

The client requests `leaf_count - 1` and the terminal flow requires `leaf_count == 2`, requested/returned `leaf_index == 1`, and a proof that authorizes the burned handle against the live account. This prevents the flow from passing if lifecycle-batch ingestion omitted the first leaf.

The mode-free inclusion-proof bytes are captured once and reused unchanged by both redeem and disclose.

## Retry and failure behavior

- retry only HTTP `503` with a structured JSON `status=lagging`
- bound retries to 15 attempts with a 2-second delay inside the proof fetch
- fail immediately on `corrupt_cache`, other HTTP statuses, malformed bodies, transport errors, unverified responses, or response-index mismatch
- preserve non-JSON and invalid-UTF-8 HTTP error bodies as lossy raw diagnostics
- never rerun a stateful live-client operation to hide relayer lag

## Evidence before full vertical

- live-client formatting and tests, including structured-lagging and raw-error-body regressions
- `bash -n` for `full-vertical.sh`
- all 65 focused relayer Solana-proof tests passed on merged #3138
- forbidden local-builder/source-selection symbols absent
- independent adversarial reviews of #3136 and #3138 found no merge-blocking issue

## Merge gate

- base: `feature/solana`, including merged producer #3136 and relayer consumer #3138
- terminal gate: `solana-e2e/full-vertical-reconstruct` on this exact head with a fresh validator and fresh relayer store

This PR remains draft until that run proves both public leaves are served exclusively by the relayer and the same fetched proof succeeds in both on-chain consume paths.
