### PR TITLE
test(test-suite): add representative operator smoke

### DIFF
--- a/test-suite/e2e/contracts/smoke/OperatorSmoke.sol
+++ b/test-suite/e2e/contracts/smoke/OperatorSmoke.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+pragma solidity ^0.8.24;
+
+import "@fhevm/solidity/lib/FHE.sol";
+import {E2ECoprocessorConfig} from "../E2ECoprocessorConfigLocal.sol";
+
+contract OperatorSmoke is E2ECoprocessorConfig {
+    ebool public boolResult;
+    euint32 public uint32Result;
+    euint64 public uint64Result;
+
+    function add(
+        externalEuint64 lhs,
+        externalEuint64 rhs,
+        bytes calldata inputProof
+    ) external {
+        uint64Result = FHE.add(FHE.fromExternal(lhs, inputProof), FHE.fromExternal(rhs, inputProof));
+        FHE.makePubliclyDecryptable(uint64Result);
+    }
+
+    function div(externalEuint64 lhs, uint64 rhs, bytes calldata inputProof) external {
+        uint64Result = FHE.div(FHE.fromExternal(lhs, inputProof), rhs);
+        FHE.makePubliclyDecryptable(uint64Result);
+    }
+
+    function lt(
+        externalEuint64 lhs,
+        externalEuint64 rhs,
+        bytes calldata inputProof
+    ) external {
+        boolResult = FHE.lt(FHE.fromExternal(lhs, inputProof), FHE.fromExternal(rhs, inputProof));
+        FHE.makePubliclyDecryptable(boolResult);
+    }
+
+    function neg(externalEuint32 value, bytes calldata inputProof) external {
+        uint32Result = FHE.neg(FHE.fromExternal(value, inputProof));
+        FHE.makePubliclyDecryptable(uint32Result);
+    }
+}

--- a/test-suite/e2e/test/operatorSmoke/operatorSmoke.ts
+++ b/test-suite/e2e/test/operatorSmoke/operatorSmoke.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { createInstance } from '../instance';
+import { getSigner } from '../signers';
+
+describe('Operator smoke', function () {
+  before(async function () {
+    this.signer = await getSigner(1);
+    this.instance = await createInstance();
+
+    const factory = await ethers.getContractFactory('OperatorSmoke');
+    this.contract = await factory.connect(this.signer).deploy();
+    await this.contract.waitForDeployment();
+    this.contractAddress = await this.contract.getAddress();
+  });
+
+  it('representative operator smoke: encrypted/encrypted add computes 17 + 25 = 42', async function () {
+    const input = await this.instance.encryptTypedValues({
+      values: [
+        { type: 'uint64', value: 17n },
+        { type: 'uint64', value: 25n },
+      ],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+
+    const tx = await this.contract.add(input.handles[0], input.handles[1], input.inputProof);
+    expect((await tx.wait()).status).to.equal(1);
+
+    const handle = await this.contract.uint64Result();
+    const decrypted = await this.instance.publicDecrypt([handle]);
+    expect(decrypted.clearValues[handle]).to.equal(42n);
+  });
+
+  it('representative operator smoke: encrypted/scalar div computes 84 / 2 = 42', async function () {
+    const input = await this.instance.encryptTypedValues({
+      values: [{ type: 'uint64', value: 84n }],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+
+    const tx = await this.contract.div(input.handles[0], 2n, input.inputProof);
+    expect((await tx.wait()).status).to.equal(1);
+
+    const handle = await this.contract.uint64Result();
+    const decrypted = await this.instance.publicDecrypt([handle]);
+    expect(decrypted.clearValues[handle]).to.equal(42n);
+  });
+
+  it('representative operator smoke: encrypted comparison computes 17 < 25 = true', async function () {
+    const input = await this.instance.encryptTypedValues({
+      values: [
+        { type: 'uint64', value: 17n },
+        { type: 'uint64', value: 25n },
+      ],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+
+    const tx = await this.contract.lt(input.handles[0], input.handles[1], input.inputProof);
+    expect((await tx.wait()).status).to.equal(1);
+
+    const handle = await this.contract.boolResult();
+    const decrypted = await this.instance.publicDecrypt([handle]);
+    expect(decrypted.clearValues[handle]).to.equal(true);
+  });
+
+  it('representative operator smoke: unary negation computes -42 modulo 2^32', async function () {
+    const input = await this.instance.encryptTypedValues({
+      values: [{ type: 'uint32', value: 42n }],
+      contractAddress: this.contractAddress,
+      userAddress: this.signer.address,
+    });
+
+    const tx = await this.contract.neg(input.handles[0], input.inputProof);
+    expect((await tx.wait()).status).to.equal(1);
+
+    const handle = await this.contract.uint32Result();
+    const decrypted = await this.instance.publicDecrypt([handle]);
+    expect(decrypted.clearValues[handle]).to.equal(2n ** 32n - 42n);
+  });
+});

--- a/test-suite/fhevm/README.md
+++ b/test-suite/fhevm/README.md
@@ -341,6 +341,7 @@ When changing runtime flags, env contracts, target semantics, or external compan
 ./fhevm-cli logs relayer
 ./fhevm-cli logs --no-follow relayer
 ./fhevm-cli test input-proof
+./fhevm-cli test operator-smoke
 ./fhevm-cli test erc20
 ./fhevm-cli test light
 ./fhevm-cli test standard
@@ -386,6 +387,31 @@ Supported groups:
 
 For `coprocessor`, this is also the shorthand local-dev scenario: one coprocessor instance, threshold `1`, source mode `local`.
 For `test-suite`, this is the explicit path that makes local e2e test edits take effect at runtime.
+
+### Representative operator feedback loop
+
+`operator-smoke` runs four serial-by-default, test-owned encrypted workflows: encrypted/encrypted addition,
+encrypted/scalar division, comparison, and unary negation. Each case creates an external input proof,
+executes the operator through the coprocessor, makes the result publicly decryptable, and asserts the
+decrypted value. It complements the generated operator catalog; it does not replace exhaustive operator
+coverage.
+
+For a cold run after changing the contract or test, rebuild the local test-suite image so the running
+container has the current checkout:
+
+```sh
+./fhevm-cli up --target latest-main --override test-suite
+./fhevm-cli test operator-smoke
+```
+
+For a warm run against that already-bootstrapped stack, reuse its compiled artifacts:
+
+```sh
+./fhevm-cli test operator-smoke --no-hardhat-compile
+```
+
+Use `time` with either command when measuring locally. No runtime target is claimed because cold image
+builds and warm coprocessor execution measure different work and vary with the active stack.
 
 ### Build the local workspace
 

--- a/test-suite/fhevm/src/cli.test.ts
+++ b/test-suite/fhevm/src/cli.test.ts
@@ -16,9 +16,13 @@ import { resumeOptionConflicts, shouldShowResumeHint } from "./flow/up-flow";
 import {
   DEFAULT_GATEWAY_RPC_PORT,
   DEFAULT_HOST_RPC_PORT,
+  HEAVY_TEST_PROFILES,
+  LIGHT_TEST_PROFILES,
   MINIO_PORT,
   ROLLOUT_STANDARD_TEST_PROFILES,
   STANDARD_TEST_PROFILES,
+  TEST_GREP,
+  TEST_PARALLEL,
   TEST_SUITE_CONTAINER,
 } from "./layout";
 import { testDefaultScenario } from "./test-fixtures";
@@ -147,6 +151,7 @@ describe("cli", () => {
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("standard");
     expect(result.stdout).toContain("rollout-standard");
+    expect(result.stdout).toContain("operator-smoke - standard");
     expect(result.stdout).toContain("multi-chain-isolation");
     expect(result.stdout).toContain("ciphertext-drift - 2+ coprocessors");
     expect(result.stdout).toContain("ciphertext-drift-auto-recovery - standard");
@@ -154,6 +159,16 @@ describe("cli", () => {
 
   test("standard suite includes multi-chain isolation coverage", () => {
     expect(STANDARD_TEST_PROFILES).toContain("multi-chain-isolation");
+  });
+
+  test("operator smoke is an exact serial-by-default standard-only profile", () => {
+    expect(TEST_GREP["operator-smoke"]).toBe("representative operator smoke");
+    expect("representative operator smoke".match(new RegExp(TEST_GREP.operators))).toBeNull();
+    expect(TEST_PARALLEL["operator-smoke"]).toBeUndefined();
+    expect(STANDARD_TEST_PROFILES).toContain("operator-smoke");
+    expect(LIGHT_TEST_PROFILES).not.toContain("operator-smoke");
+    expect(ROLLOUT_STANDARD_TEST_PROFILES).not.toContain("operator-smoke");
+    expect(HEAVY_TEST_PROFILES).not.toContain("operator-smoke");
   });
 
   test("rollout-standard keeps write coverage but excludes disruptive profiles", () => {

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -95,6 +95,7 @@ const TEST_PROFILE_DESCRIPTIONS: Partial<Record<(typeof TEST_PROFILE_NAMES)[numb
   "paused-gateway-contracts": "Run pause-mode checks with gateway contracts paused.",
   "input-proof": "Run basic user input proof coverage.",
   "input-proof-compute-decrypt": "Run compute-and-decrypt input proof coverage.",
+  "operator-smoke": "Run four representative encrypted operator workflows.",
   "priority-coprocessor": "Run input proof coverage with gateway priority-coprocessor mode enabled.",
   "user-decryption": "Run user decryption coverage.",
   "delegated-user-decryption": "Run delegated user decryption coverage.",

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -292,6 +292,7 @@ export const TEST_GREP: Record<string, string> = {
   "random-subset":
     "64 bits generate and decrypt|generating rand in reverting sub-call|64 bits generate with upper bound and decrypt",
   "operators": "test operator|FHEVM manual operations",
+  "operator-smoke": "representative operator smoke",
   "hcu-block-cap": "block cap scenarios",
   "erc20": "should transfer tokens between two users.",
   "negative-acl": "negative-acl",
@@ -324,6 +325,7 @@ export const STANDARD_TEST_PROFILES = [
   "coprocessor-db-state-revert",
   "input-proof",
   "input-proof-compute-decrypt",
+  "operator-smoke",
   "user-decryption",
   "delegated-user-decryption",
   "erc20",


### PR DESCRIPTION
Adds a serial-by-default standard profile with four explicit encrypted operator flows: encrypted addition, scalar division, comparison, and modular unary negation.

Each case creates an external input proof, executes through the coprocessor, makes the result publicly decryptable, and asserts the readable result; a distinct grep namespace keeps the tests out of the generated heavy operator lane.

The exhaustive 105-file stress catalog remains unchanged, and documentation distinguishes warm-stack feedback from cold build/bootstrap cost and records provenance-correct commands without claiming an unmeasured SLO.

Hardhat compilation, CLI typechecking, and 226 CLI tests pass; the standard full-stack lane is the decisive runtime gate and this partially addresses zama-ai/fhevm-internal#1295.
