### PR TITLE
test(relayer): pin Solana proof request identity

### DIFF
--- a/relayer/src/core/user_decrypt_request.rs
+++ b/relayer/src/core/user_decrypt_request.rs
@@ -182,7 +182,8 @@ mod tests {
     use crate::core::event::{
         HandleContractPair, HandleEntry, RequestValidity, RequestValiditySeconds,
     };
-    use alloy::primitives::{Address, Bytes, U256};
+    use crate::core::job_id::JobId;
+    use alloy::primitives::{Address, Bytes, B256, U256};
 
     fn sample_legacy_direct() -> UserDecryptRequest {
         UserDecryptRequest::LegacyDirect {
@@ -240,6 +241,34 @@ mod tests {
             public_key: Bytes::from(vec![0xab, 0xcd]),
             extra_data: Bytes::from(vec![0x00]),
         }
+    }
+
+    fn sample_solana_unified(extra_data: Bytes) -> UserDecryptRequest {
+        UserDecryptRequest::SolanaUnifiedV1 {
+            handles: vec![HandleEntry {
+                ct_handle: U256::from(123),
+                contract_address: Address::from([1; 20]),
+                owner_address: Address::from([2; 20]),
+            }],
+            user_identity: B256::from([2; 32]),
+            allowed_acl_domain_keys: vec![B256::from([1; 32])],
+            request_validity: RequestValiditySeconds {
+                start_timestamp: U256::from(1000),
+                duration_seconds: U256::from(604_800),
+            },
+            nonce: B256::from([3; 32]),
+            signature: Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+            public_key: Bytes::from(vec![0xab, 0xcd]),
+            extra_data,
+        }
+    }
+
+    fn solana_proof_extra_data(proof: u8) -> Bytes {
+        let mut data = vec![0x03];
+        data.extend_from_slice(&[0; 32 + 32 + 8]);
+        data.extend_from_slice(&1u32.to_be_bytes());
+        data.push(proof);
+        data.into()
     }
 
     #[test]
@@ -333,5 +362,17 @@ mod tests {
         assert_ne!(direct, delegated);
         assert_ne!(direct, unified);
         assert_ne!(delegated, unified);
+    }
+
+    #[test]
+    fn solana_proof_data_affects_content_hash_and_job_identity() {
+        let first = sample_solana_unified(solana_proof_extra_data(0xaa));
+        let second = sample_solana_unified(solana_proof_extra_data(0xbb));
+        let first_hash = first.content_hash();
+        let second_hash = second.content_hash();
+
+        assert_ne!(first_hash, second_hash);
+        assert_ne!(JobId::from(first_hash), JobId::from(second_hash));
+        assert_ne!(first_hash, sample_eip712_unified().content_hash());
     }
 }

--- a/relayer/src/core/user_decrypt_request.rs
+++ b/relayer/src/core/user_decrypt_request.rs
@@ -365,14 +365,39 @@ mod tests {
     }
 
     #[test]
-    fn solana_proof_data_affects_content_hash_and_job_identity() {
+    fn solana_request_domain_and_proof_pin_job_identity() {
         let first = sample_solana_unified(solana_proof_extra_data(0xaa));
         let second = sample_solana_unified(solana_proof_extra_data(0xbb));
         let first_hash = first.content_hash();
         let second_hash = second.content_hash();
 
+        // This golden digest makes the Solana variant/domain separator load-bearing,
+        // rather than relying on unlike EVM and Solana payloads to hash differently.
+        assert_eq!(
+            hex::encode(first_hash),
+            "71f74ed228523685ec6de56b3b50753553a12214504d46b0f15e496e3b6f7c8c"
+        );
         assert_ne!(first_hash, second_hash);
         assert_ne!(JobId::from(first_hash), JobId::from(second_hash));
-        assert_ne!(first_hash, sample_eip712_unified().content_hash());
+    }
+
+    #[test]
+    fn solana_excluded_fields_do_not_affect_content_hash() {
+        let first = sample_solana_unified(solana_proof_extra_data(0xaa));
+        let mut second = first.clone();
+        if let UserDecryptRequest::SolanaUnifiedV1 {
+            signature,
+            request_validity,
+            ..
+        } = &mut second
+        {
+            *signature = Bytes::from(vec![0xff; 4]);
+            *request_validity = RequestValiditySeconds {
+                start_timestamp: U256::from(999_999),
+                duration_seconds: U256::from(99_999),
+            };
+        }
+
+        assert_eq!(first.content_hash(), second.content_hash());
     }
 }

--- a/relayer/src/http/endpoints/v3/handlers/user_decrypt.rs
+++ b/relayer/src/http/endpoints/v3/handlers/user_decrypt.rs
@@ -1,4 +1,4 @@
-//! v3 `/v3/user-decrypt` handler (unified EIP-712 user-decryption).
+//! v3 `/v3/user-decrypt` handler (unified user-decryption).
 //!
 //! POST validates the typed-attestation envelope, converts it to the
 //! shared `UserDecryptRequest` with `UserDecryptPayload::Unified`, runs the
@@ -164,9 +164,7 @@ impl UserDecryptHandler {
             }
         };
 
-        // `TryFrom<AttestedUserDecryptRequestJson>` only constructs
-        // `Eip712UnifiedV1`; the downstream `UserDecryptReqData::Unified`
-        // tag relies on it.
+        // The attestation type selects the EVM or Solana unified request variant.
         let user_decrypt_request: UserDecryptRequest =
             match parse_and_validate::<AttestedUserDecryptRequestJson, UserDecryptRequest>(&body) {
                 Ok(request) => request,

--- a/relayer/src/http/server.rs
+++ b/relayer/src/http/server.rs
@@ -178,9 +178,8 @@ pub async fn run_http_server(
         // Add OpenAPI documentation
         .merge(openapi_middleware());
 
-    // Solana MMR proof service: only mounted when a deployment configures it
-    // (interim internal endpoint until the Solana user-decrypt path calls it
-    // in-process; see relayer/src/solana_proof/http.rs).
+    // Solana MMR proof service: mounted only when configured. Clients use this
+    // endpoint to obtain the proof included in the signed user-decrypt request.
     if let Some(service) = solana_proof_service {
         info!("Solana MMR proof service enabled at /internal/solana/mmr-proof");
         app = app.merge(crate::solana_proof::http::router(service));

--- a/relayer/src/solana_proof/http.rs
+++ b/relayer/src/solana_proof/http.rs
@@ -1,12 +1,9 @@
 //! Internal HTTP endpoint exposing `proof::build_proof`.
 //!
-//! There is no existing Solana user-decrypt HTTP path in the relayer yet (the
-//! gateway/host modules are EVM-only today), so this stands alone as an
-//! internal route rather than plugging into an existing handler.
 //! `http/server.rs::run_http_server` mounts `router(service)` when the
-//! deployment's `solana_proof` config section is present. This is an interim
-//! internal endpoint until the Solana user-decrypt path lands and calls
-//! [`crate::solana_proof::build_proof`] in-process instead of over HTTP.
+//! deployment's `solana_proof` config section is present. A client discovers
+//! the proof through this internal route before encoding it in `extraData` and
+//! signing the Solana user-decrypt request submitted through the v3 endpoint.
 
 use std::sync::Arc;
 

--- a/relayer/src/solana_proof/mod.rs
+++ b/relayer/src/solana_proof/mod.rs
@@ -14,14 +14,8 @@
 //!   file-backed implementation.
 //! - [`ingest`]: the poll loop and targeted per-lineage catch-up.
 //! - [`proof`]: `build_proof`, the public entry point tying the above together.
-//! - [`http`]: an internal HTTP endpoint exposing `build_proof`, and the
-//!   in-process `SolanaProofService` handle used to construct it.
-//!
-//! **Integration point for the future Solana user-decrypt orchestrator**: once
-//! that path exists, call [`proof::build_proof`] directly in-process (it takes
-//! `&impl ChainFetcher, &impl LeafStore` — no HTTP round-trip needed) instead
-//! of routing through [`http::mmr_proof_handler`], which exists only so this
-//! service is independently reachable before that wiring lands.
+//! - [`http`]: an internal HTTP endpoint exposing `build_proof` so a client can
+//!   discover a proof before signing and submitting a Solana user-decrypt request.
 
 pub mod chain;
 pub mod config;


### PR DESCRIPTION
Pins the Solana user-decrypt deduplication contract: otherwise-identical requests with different proof-bearing `extraData` now have different content hashes and job identities, and remain distinct from the EVM request variant.

Removes stale guidance suggesting the relayer could inject an MMR proof after receiving a request; Solana proof discovery and encoding must happen before the Ed25519 signature is produced.

Also corrects EIP-712-only handler wording because v3 conversion selects either the EVM or Solana unified request variant.

The focused test, complete eight-test content-hash module, formatting, and warnings-denied relayer clippy pass; this corrects part of zama-ai/fhevm-internal#1636 without changing runtime behavior.
