### PR TITLE
test(coprocessor): add real TFHE operator conformance

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/tests/real_tfhe_conformance.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/tests/real_tfhe_conformance.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::OnceLock};
+use std::{
+    path::PathBuf,
+    sync::{Mutex, MutexGuard, OnceLock},
+};
 
 use fhevm_engine_common::{
     tfhe_ops::perform_fhe_operation,
@@ -8,7 +11,7 @@ use fhevm_engine_common::{
 use tfhe::{
     prelude::{FheDecrypt, FheTryEncrypt},
     xof_key_set::CompressedXofKeySet,
-    ClientKey, FheBool, ServerKey,
+    ClientKey, FheBool, FheUint64, FheUint8, ServerKey,
 };
 
 struct TestKeys {
@@ -36,10 +39,14 @@ fn test_keys() -> &'static TestKeys {
     })
 }
 
-fn install_server_key() -> &'static TestKeys {
+fn install_server_key() -> (MutexGuard<'static, ()>, &'static TestKeys) {
+    static EXECUTION: Mutex<()> = Mutex::new(());
+    let execution = EXECUTION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let keys = test_keys();
     tfhe::set_server_key(keys.server.clone());
-    keys
+    (execution, keys)
 }
 
 fn run(
@@ -51,24 +58,265 @@ fn run(
         .unwrap_or_else(|error| panic!("{operation:?} failed: {error}"))
 }
 
-#[test]
-fn bool_xor_uses_real_tfhe() {
-    let keys = install_server_key();
-    let lhs = FheBool::try_encrypt(true, &keys.client).expect("encrypt lhs");
-    let rhs = FheBool::try_encrypt(false, &keys.client).expect("encrypt rhs");
+fn encrypted_bool(value: bool, keys: &TestKeys) -> SupportedFheCiphertexts {
+    SupportedFheCiphertexts::FheBool(
+        FheBool::try_encrypt(value, &keys.client).expect("encrypt FheBool"),
+    )
+}
 
-    let result = run(
-        SupportedFheOperations::FheBitXor,
-        &[
-            SupportedFheCiphertexts::FheBool(lhs),
-            SupportedFheCiphertexts::FheBool(rhs),
-        ],
-        0,
-    );
+fn encrypted_u8(value: u8, keys: &TestKeys) -> SupportedFheCiphertexts {
+    SupportedFheCiphertexts::FheUint8(
+        FheUint8::try_encrypt(value, &keys.client).expect("encrypt FheUint8"),
+    )
+}
 
+fn encrypted_u64(value: u64, keys: &TestKeys) -> SupportedFheCiphertexts {
+    SupportedFheCiphertexts::FheUint64(
+        FheUint64::try_encrypt(value, &keys.client).expect("encrypt FheUint64"),
+    )
+}
+
+fn scalar(value: impl Into<Vec<u8>>) -> SupportedFheCiphertexts {
+    SupportedFheCiphertexts::Scalar(value.into())
+}
+
+fn decrypt_bool(result: SupportedFheCiphertexts, keys: &TestKeys) -> bool {
     assert_eq!(result.type_num(), 0);
     let SupportedFheCiphertexts::FheBool(result) = result else {
         panic!("expected FheBool result");
     };
-    assert!(result.decrypt(&keys.client));
+    result.decrypt(&keys.client)
+}
+
+fn decrypt_u8(result: SupportedFheCiphertexts, keys: &TestKeys) -> u8 {
+    assert_eq!(result.type_num(), 2);
+    let SupportedFheCiphertexts::FheUint8(result) = result else {
+        panic!("expected FheUint8 result");
+    };
+    result.decrypt(&keys.client)
+}
+
+fn decrypt_u64(result: SupportedFheCiphertexts, keys: &TestKeys) -> u64 {
+    assert_eq!(result.type_num(), 5);
+    let SupportedFheCiphertexts::FheUint64(result) = result else {
+        panic!("expected FheUint64 result");
+    };
+    result.decrypt(&keys.client)
+}
+
+#[test]
+fn bool_xor_uses_real_tfhe() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheBitXor,
+        &[encrypted_bool(true, keys), encrypted_bool(false, keys)],
+        0,
+    );
+    assert!(decrypt_bool(result, keys));
+}
+
+#[test]
+fn bool_not_uses_real_tfhe() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheNot,
+        &[encrypted_bool(true, keys)],
+        0,
+    );
+    assert!(!decrypt_bool(result, keys));
+}
+
+#[test]
+fn uint8_encrypted_add_wraps() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheAdd,
+        &[encrypted_u8(250, keys), encrypted_u8(10, keys)],
+        2,
+    );
+    assert_eq!(decrypt_u8(result, keys), 4);
+}
+
+#[test]
+fn uint8_scalar_subtraction_wraps() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheSub,
+        &[encrypted_u8(3, keys), scalar(vec![5])],
+        2,
+    );
+    assert_eq!(decrypt_u8(result, keys), 254);
+}
+
+#[test]
+fn uint8_comparison_returns_bool() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheLt,
+        &[encrypted_u8(7, keys), encrypted_u8(9, keys)],
+        0,
+    );
+    assert!(decrypt_bool(result, keys));
+}
+
+#[test]
+fn uint8_scalar_shift_and_rotate_are_distinct() {
+    let (_execution, keys) = install_server_key();
+    let shifted = run(
+        SupportedFheOperations::FheShl,
+        &[encrypted_u8(0b1000_0001, keys), scalar(vec![1])],
+        2,
+    );
+    let rotated = run(
+        SupportedFheOperations::FheRotl,
+        &[encrypted_u8(0b1000_0001, keys), scalar(vec![1])],
+        2,
+    );
+    assert_eq!(decrypt_u8(shifted, keys), 0b0000_0010);
+    assert_eq!(decrypt_u8(rotated, keys), 0b0000_0011);
+}
+
+#[test]
+fn uint64_encrypted_multiply_uses_real_tfhe() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheMul,
+        &[encrypted_u64(7, keys), encrypted_u64(9, keys)],
+        5,
+    );
+    assert_eq!(decrypt_u64(result, keys), 63);
+}
+
+#[test]
+fn uint64_scalar_division_and_remainder_are_supported() {
+    let (_execution, keys) = install_server_key();
+    let quotient = run(
+        SupportedFheOperations::FheDiv,
+        &[
+            encrypted_u64(29, keys),
+            scalar(5_u64.to_be_bytes().to_vec()),
+        ],
+        5,
+    );
+    let remainder = run(
+        SupportedFheOperations::FheRem,
+        &[
+            encrypted_u64(29, keys),
+            scalar(5_u64.to_be_bytes().to_vec()),
+        ],
+        5,
+    );
+    assert_eq!(decrypt_u64(quotient, keys), 5);
+    assert_eq!(decrypt_u64(remainder, keys), 4);
+}
+
+#[test]
+fn uint64_unary_negation_wraps() {
+    let (_execution, keys) = install_server_key();
+    let result = run(SupportedFheOperations::FheNeg, &[encrypted_u64(1, keys)], 5);
+    assert_eq!(decrypt_u64(result, keys), u64::MAX);
+}
+
+#[test]
+fn uint8_cast_to_uint64_uses_big_endian_type_id() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheCast,
+        &[
+            encrypted_u8(200, keys),
+            scalar(5_u16.to_be_bytes().to_vec()),
+        ],
+        5,
+    );
+    assert_eq!(decrypt_u64(result, keys), 200);
+}
+
+#[test]
+fn if_then_else_selects_uint8_branch() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheIfThenElse,
+        &[
+            encrypted_bool(false, keys),
+            encrypted_u8(10, keys),
+            encrypted_u8(20, keys),
+        ],
+        2,
+    );
+    assert_eq!(decrypt_u8(result, keys), 20);
+}
+
+#[test]
+fn non_empty_uint8_sum_wraps() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheSum,
+        &[
+            encrypted_u8(250, keys),
+            encrypted_u8(10, keys),
+            encrypted_u8(1, keys),
+        ],
+        2,
+    );
+    assert_eq!(decrypt_u8(result, keys), 5);
+}
+
+#[test]
+fn non_empty_uint8_is_in_returns_bool() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheIsIn,
+        &[
+            encrypted_u8(7, keys),
+            encrypted_u8(3, keys),
+            encrypted_u8(7, keys),
+            encrypted_u8(11, keys),
+        ],
+        0,
+    );
+    assert!(decrypt_bool(result, keys));
+}
+
+#[test]
+fn uint8_mul_div_uses_fused_real_tfhe_operation() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheMulDiv,
+        &[
+            encrypted_u8(10, keys),
+            encrypted_u8(9, keys),
+            scalar(vec![6]),
+        ],
+        2,
+    );
+    assert_eq!(decrypt_u8(result, keys), 15);
+}
+
+#[test]
+fn uint8_rand_returns_typed_ciphertext() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheRand,
+        &[
+            scalar(42_u128.to_be_bytes().to_vec()),
+            scalar(2_u16.to_be_bytes().to_vec()),
+        ],
+        2,
+    );
+    let _ = decrypt_u8(result, keys);
+}
+
+#[test]
+fn uint8_rand_bounded_respects_exclusive_upper_bound() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
+        SupportedFheOperations::FheRandBounded,
+        &[
+            scalar(42_u128.to_be_bytes().to_vec()),
+            scalar(vec![10]),
+            scalar(2_u16.to_be_bytes().to_vec()),
+        ],
+        2,
+    );
+    assert!(decrypt_u8(result, keys) < 10);
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/tests/real_tfhe_conformance.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/tests/real_tfhe_conformance.rs
@@ -1,0 +1,74 @@
+use std::{path::PathBuf, sync::OnceLock};
+
+use fhevm_engine_common::{
+    tfhe_ops::perform_fhe_operation,
+    types::{SupportedFheCiphertexts, SupportedFheOperations},
+    utils::safe_deserialize_key,
+};
+use tfhe::{
+    prelude::{FheDecrypt, FheTryEncrypt},
+    xof_key_set::CompressedXofKeySet,
+    ClientKey, FheBool, ServerKey,
+};
+
+struct TestKeys {
+    client: ClientKey,
+    server: ServerKey,
+}
+
+fn test_keys() -> &'static TestKeys {
+    static KEYS: OnceLock<TestKeys> = OnceLock::new();
+    KEYS.get_or_init(|| {
+        let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../fhevm-keys");
+        let keyset: CompressedXofKeySet = safe_deserialize_key(
+            &std::fs::read(fixtures.join("xof-keyset")).expect("read xof-keyset fixture"),
+        )
+        .expect("deserialize xof-keyset fixture");
+        let (_, server) = keyset
+            .decompress()
+            .expect("decompress xof-keyset fixture")
+            .into_raw_parts();
+        let client = safe_deserialize_key(
+            &std::fs::read(fixtures.join("xof-cks")).expect("read xof-cks fixture"),
+        )
+        .expect("deserialize xof-cks fixture");
+        TestKeys { client, server }
+    })
+}
+
+fn install_server_key() -> &'static TestKeys {
+    let keys = test_keys();
+    tfhe::set_server_key(keys.server.clone());
+    keys
+}
+
+fn run(
+    operation: SupportedFheOperations,
+    inputs: &[SupportedFheCiphertexts],
+    output_type: i16,
+) -> SupportedFheCiphertexts {
+    perform_fhe_operation(operation as i16, inputs, 0, output_type)
+        .unwrap_or_else(|error| panic!("{operation:?} failed: {error}"))
+}
+
+#[test]
+fn bool_xor_uses_real_tfhe() {
+    let keys = install_server_key();
+    let lhs = FheBool::try_encrypt(true, &keys.client).expect("encrypt lhs");
+    let rhs = FheBool::try_encrypt(false, &keys.client).expect("encrypt rhs");
+
+    let result = run(
+        SupportedFheOperations::FheBitXor,
+        &[
+            SupportedFheCiphertexts::FheBool(lhs),
+            SupportedFheCiphertexts::FheBool(rhs),
+        ],
+        0,
+    );
+
+    assert_eq!(result.type_num(), 0);
+    let SupportedFheCiphertexts::FheBool(result) = result else {
+        panic!("expected FheBool result");
+    };
+    assert!(result.decrypt(&keys.client));
+}

--- a/coprocessor/fhevm-engine/fhevm-engine-common/tests/real_tfhe_conformance.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/tests/real_tfhe_conformance.rs
@@ -14,6 +14,10 @@ use tfhe::{
     ClientKey, FheBool, FheUint64, FheUint8, ServerKey,
 };
 
+const BOOL_TYPE: i16 = 0;
+const U8_TYPE: i16 = 2;
+const U64_TYPE: i16 = 5;
+
 struct TestKeys {
     client: ClientKey,
     server: ServerKey,
@@ -81,7 +85,7 @@ fn scalar(value: impl Into<Vec<u8>>) -> SupportedFheCiphertexts {
 }
 
 fn decrypt_bool(result: SupportedFheCiphertexts, keys: &TestKeys) -> bool {
-    assert_eq!(result.type_num(), 0);
+    assert_eq!(result.type_num(), BOOL_TYPE);
     let SupportedFheCiphertexts::FheBool(result) = result else {
         panic!("expected FheBool result");
     };
@@ -89,7 +93,7 @@ fn decrypt_bool(result: SupportedFheCiphertexts, keys: &TestKeys) -> bool {
 }
 
 fn decrypt_u8(result: SupportedFheCiphertexts, keys: &TestKeys) -> u8 {
-    assert_eq!(result.type_num(), 2);
+    assert_eq!(result.type_num(), U8_TYPE);
     let SupportedFheCiphertexts::FheUint8(result) = result else {
         panic!("expected FheUint8 result");
     };
@@ -97,7 +101,7 @@ fn decrypt_u8(result: SupportedFheCiphertexts, keys: &TestKeys) -> u8 {
 }
 
 fn decrypt_u64(result: SupportedFheCiphertexts, keys: &TestKeys) -> u64 {
-    assert_eq!(result.type_num(), 5);
+    assert_eq!(result.type_num(), U64_TYPE);
     let SupportedFheCiphertexts::FheUint64(result) = result else {
         panic!("expected FheUint64 result");
     };
@@ -110,7 +114,7 @@ fn bool_xor_uses_real_tfhe() {
     let result = run(
         SupportedFheOperations::FheBitXor,
         &[encrypted_bool(true, keys), encrypted_bool(false, keys)],
-        0,
+        BOOL_TYPE,
     );
     assert!(decrypt_bool(result, keys));
 }
@@ -121,7 +125,7 @@ fn bool_not_uses_real_tfhe() {
     let result = run(
         SupportedFheOperations::FheNot,
         &[encrypted_bool(true, keys)],
-        0,
+        BOOL_TYPE,
     );
     assert!(!decrypt_bool(result, keys));
 }
@@ -132,7 +136,7 @@ fn uint8_encrypted_add_wraps() {
     let result = run(
         SupportedFheOperations::FheAdd,
         &[encrypted_u8(250, keys), encrypted_u8(10, keys)],
-        2,
+        U8_TYPE,
     );
     assert_eq!(decrypt_u8(result, keys), 4);
 }
@@ -143,7 +147,7 @@ fn uint8_scalar_subtraction_wraps() {
     let result = run(
         SupportedFheOperations::FheSub,
         &[encrypted_u8(3, keys), scalar(vec![5])],
-        2,
+        U8_TYPE,
     );
     assert_eq!(decrypt_u8(result, keys), 254);
 }
@@ -154,26 +158,31 @@ fn uint8_comparison_returns_bool() {
     let result = run(
         SupportedFheOperations::FheLt,
         &[encrypted_u8(7, keys), encrypted_u8(9, keys)],
-        0,
+        BOOL_TYPE,
     );
     assert!(decrypt_bool(result, keys));
 }
 
 #[test]
-fn uint8_scalar_shift_and_rotate_are_distinct() {
+fn uint8_scalar_shift_discards_high_bit() {
     let (_execution, keys) = install_server_key();
-    let shifted = run(
+    let result = run(
         SupportedFheOperations::FheShl,
         &[encrypted_u8(0b1000_0001, keys), scalar(vec![1])],
-        2,
+        U8_TYPE,
     );
-    let rotated = run(
+    assert_eq!(decrypt_u8(result, keys), 0b0000_0010);
+}
+
+#[test]
+fn uint8_scalar_rotate_preserves_high_bit() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
         SupportedFheOperations::FheRotl,
         &[encrypted_u8(0b1000_0001, keys), scalar(vec![1])],
-        2,
+        U8_TYPE,
     );
-    assert_eq!(decrypt_u8(shifted, keys), 0b0000_0010);
-    assert_eq!(decrypt_u8(rotated, keys), 0b0000_0011);
+    assert_eq!(decrypt_u8(result, keys), 0b0000_0011);
 }
 
 #[test]
@@ -182,38 +191,47 @@ fn uint64_encrypted_multiply_uses_real_tfhe() {
     let result = run(
         SupportedFheOperations::FheMul,
         &[encrypted_u64(7, keys), encrypted_u64(9, keys)],
-        5,
+        U64_TYPE,
     );
     assert_eq!(decrypt_u64(result, keys), 63);
 }
 
 #[test]
-fn uint64_scalar_division_and_remainder_are_supported() {
+fn uint64_scalar_division_is_supported() {
     let (_execution, keys) = install_server_key();
-    let quotient = run(
+    let result = run(
         SupportedFheOperations::FheDiv,
         &[
             encrypted_u64(29, keys),
             scalar(5_u64.to_be_bytes().to_vec()),
         ],
-        5,
+        U64_TYPE,
     );
-    let remainder = run(
+    assert_eq!(decrypt_u64(result, keys), 5);
+}
+
+#[test]
+fn uint64_scalar_remainder_is_supported() {
+    let (_execution, keys) = install_server_key();
+    let result = run(
         SupportedFheOperations::FheRem,
         &[
             encrypted_u64(29, keys),
             scalar(5_u64.to_be_bytes().to_vec()),
         ],
-        5,
+        U64_TYPE,
     );
-    assert_eq!(decrypt_u64(quotient, keys), 5);
-    assert_eq!(decrypt_u64(remainder, keys), 4);
+    assert_eq!(decrypt_u64(result, keys), 4);
 }
 
 #[test]
 fn uint64_unary_negation_wraps() {
     let (_execution, keys) = install_server_key();
-    let result = run(SupportedFheOperations::FheNeg, &[encrypted_u64(1, keys)], 5);
+    let result = run(
+        SupportedFheOperations::FheNeg,
+        &[encrypted_u64(1, keys)],
+        U64_TYPE,
+    );
     assert_eq!(decrypt_u64(result, keys), u64::MAX);
 }
 
@@ -224,9 +242,9 @@ fn uint8_cast_to_uint64_uses_big_endian_type_id() {
         SupportedFheOperations::FheCast,
         &[
             encrypted_u8(200, keys),
-            scalar(5_u16.to_be_bytes().to_vec()),
+            scalar((U64_TYPE as u16).to_be_bytes().to_vec()),
         ],
-        5,
+        U64_TYPE,
     );
     assert_eq!(decrypt_u64(result, keys), 200);
 }
@@ -241,7 +259,7 @@ fn if_then_else_selects_uint8_branch() {
             encrypted_u8(10, keys),
             encrypted_u8(20, keys),
         ],
-        2,
+        U8_TYPE,
     );
     assert_eq!(decrypt_u8(result, keys), 20);
 }
@@ -256,7 +274,7 @@ fn non_empty_uint8_sum_wraps() {
             encrypted_u8(10, keys),
             encrypted_u8(1, keys),
         ],
-        2,
+        U8_TYPE,
     );
     assert_eq!(decrypt_u8(result, keys), 5);
 }
@@ -272,7 +290,7 @@ fn non_empty_uint8_is_in_returns_bool() {
             encrypted_u8(7, keys),
             encrypted_u8(11, keys),
         ],
-        0,
+        BOOL_TYPE,
     );
     assert!(decrypt_bool(result, keys));
 }
@@ -287,36 +305,7 @@ fn uint8_mul_div_uses_fused_real_tfhe_operation() {
             encrypted_u8(9, keys),
             scalar(vec![6]),
         ],
-        2,
+        U8_TYPE,
     );
     assert_eq!(decrypt_u8(result, keys), 15);
-}
-
-#[test]
-fn uint8_rand_returns_typed_ciphertext() {
-    let (_execution, keys) = install_server_key();
-    let result = run(
-        SupportedFheOperations::FheRand,
-        &[
-            scalar(42_u128.to_be_bytes().to_vec()),
-            scalar(2_u16.to_be_bytes().to_vec()),
-        ],
-        2,
-    );
-    let _ = decrypt_u8(result, keys);
-}
-
-#[test]
-fn uint8_rand_bounded_respects_exclusive_upper_bound() {
-    let (_execution, keys) = install_server_key();
-    let result = run(
-        SupportedFheOperations::FheRandBounded,
-        &[
-            scalar(42_u128.to_be_bytes().to_vec()),
-            scalar(vec![10]),
-            scalar(2_u16.to_be_bytes().to_vec()),
-        ],
-        2,
-    );
-    assert!(decrypt_u8(result, keys) < 10);
 }


### PR DESCRIPTION
## What

Add 16 individually filterable, deterministic real-TFHE conformance tests at the production `tfhe_ops::perform_fhe_operation` seam.

The representative ordinary lane covers:

- Bool XOR and Not
- Uint8 encrypted addition and scalar subtraction wrapping
- Uint8 comparison returning Bool
- distinct Uint8 scalar shift and rotate behavior
- Uint64 multiplication, scalar division, scalar remainder, and unary wrapping
- Uint8 to Uint64 Cast with a big-endian type identifier
- IfThenElse, non-empty Sum, non-empty IsIn, and MulDiv

## Why

The fast catalog validates cleartext semantics, while the Solana Mollusk layer validates instruction admission and account behavior. This layer verifies that the real TFHE implementation produces the expected typed ciphertext and decrypted result without requiring listeners, databases, validators, Docker, or Solana.

## How

- Load the checked-in KMS-shaped `xof-keyset` and matching `xof-cks` fixtures once per test process.
- Install the real server key on every executing test thread.
- Encrypt every value operand with `FheTryEncrypt` and the matching client key.
- Call `perform_fhe_operation` directly.
- Assert the returned ciphertext variant and `type_num`, then decrypt and compare with test-owned constants.
- Serialize real-TFHE execution with a standard-library mutex. An unconstrained debug run left 12 tests executing after 80 seconds; serialization avoids CPU oversubscription while retaining ordinary named Rust tests.

## Feedback loop

Run the full target with the repository's optimized local profile:

```console
NO_DNA=1 cargo test --profile local -p fhevm-engine-common --test real_tfhe_conformance
```

Measured on the implementation machine:

- cold optimized build plus full target: 2m51s wall; the 16 tests themselves took 23.08s
- warm full target: 20.31s wall; the tests took 19.85s
- warm exact Uint8 addition: 3.82s wall; the test process took 3.48s, dominated by fixture loading

The unoptimized test profile is intentionally not the feedback lane: a sampled serialized run was stopped after 240.65s while executing Uint64 multiplication.

## Residual scope

- Rand and RandBounded need an independently specified fixed-seed known-answer contract. Type-only or range-only assertions would not prove seed encoding or randomness semantics, so they are not claimed here.
- Uint128, Uint160, and Uint256 remain outside the ordinary lane. No arbitrary timing threshold or ignored benchmark is introduced by this PR.
- This PR validates the CPU/default-feature `perform_fhe_operation` path. GPU execution and GPU conformance are not claimed and remain residual work.
- Full-stack reconstruction, database/event paths, and Solana admission remain separate layers.

Tracks zama-ai/fhevm-internal#1696 Phase 3.
