### PR TITLE
fix(sdk): fix extraData version check

### DIFF
--- a/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
+++ b/sdk/js-sdk/src/core/host-contracts/readKmsSignersContext-p.ts
@@ -308,7 +308,7 @@ export async function reconcileKmsSignersContext(
   }
 
   // Reject if extraData serialization version differs.
-  if (relayerKmsExtraData.version !== requestedKmsExtraData.version) {
+  if (relayerKmsExtraData.version !== 0 && relayerKmsExtraData.version !== requestedKmsExtraData.version) {
     throw new Error(
       `ExtraData serialization version mismatch: SDK uses v${requestedKmsExtraData.version}, ` +
         `relayer returned v${relayerKmsExtraData.version}. ` +


### PR DESCRIPTION
This occurs when contracts have been upgraded but not the KMS yet.