### PR TITLE
chore(test-suite): remove bridge e2e test warnings

### DIFF
--- a/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/host-sc-docker-compose.yml
@@ -64,7 +64,7 @@ services:
     env_file:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/env/host-sc.env
     command:
-      - npx hardhat compile:specific --contract examples/bridge/mocks && npx hardhat compile:specific --contract contracts && if [ -z "${LZ_ENDPOINT_ADDRESS}" ]; then npx hardhat task:deployLocalLzEndpoint --eid ${BRIDGE_EID} --remote-eid ${BRIDGE_REMOTE_EID} && export $(grep -E '^LZ_ENDPOINT_ADDRESS=' addresses/.env.host | xargs); else export LZ_ENDPOINT_ADDRESS=${LZ_ENDPOINT_ADDRESS} && echo "LZ_ENDPOINT_ADDRESS=${LZ_ENDPOINT_ADDRESS}" >> addresses/.env.host; fi && npx hardhat task:deployBridge
+      - npx hardhat compile:specific --contract examples/bridge/mocks && npx hardhat compile:specific --contract contracts && if [ -z "${LZ_ENDPOINT_ADDRESS:-}" ]; then npx hardhat task:deployLocalLzEndpoint --eid ${BRIDGE_EID:-} --remote-eid ${BRIDGE_REMOTE_EID:-} && export $(grep -E '^LZ_ENDPOINT_ADDRESS=' addresses/.env.host | xargs); else export LZ_ENDPOINT_ADDRESS=${LZ_ENDPOINT_ADDRESS:-} && echo "LZ_ENDPOINT_ADDRESS=${LZ_ENDPOINT_ADDRESS:-}" >> addresses/.env.host; fi && npx hardhat task:deployBridge
     depends_on:
       host-sc-deploy:
         condition: service_completed_successfully
@@ -77,7 +77,7 @@ services:
     env_file:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/env/host-sc.env
     command:
-      - npx hardhat compile:specific --contract contracts && npx hardhat task:setBridgePeer --bridge-address ${BRIDGE_LOCAL_ADDRESS} --remote-eid ${BRIDGE_REMOTE_EID} --remote-bridge ${BRIDGE_REMOTE_ADDRESS} && npx hardhat task:setDstChainId --bridge-address ${BRIDGE_LOCAL_ADDRESS} --remote-eid ${BRIDGE_REMOTE_EID} --remote-chain-id ${BRIDGE_REMOTE_CHAIN_ID}
+      - npx hardhat compile:specific --contract contracts && npx hardhat task:setBridgePeer --bridge-address ${BRIDGE_LOCAL_ADDRESS:-} --remote-eid ${BRIDGE_REMOTE_EID:-} --remote-bridge ${BRIDGE_REMOTE_ADDRESS:-} && npx hardhat task:setDstChainId --bridge-address ${BRIDGE_LOCAL_ADDRESS:-} --remote-eid ${BRIDGE_REMOTE_EID:-} --remote-chain-id ${BRIDGE_REMOTE_CHAIN_ID:-}
     depends_on:
       host-sc-deploy-bridge:
         condition: service_completed_successfully


### PR DESCRIPTION
Suppresses warnings for unset env variables on confidential bridge e2e testing.

```
time="2026-07-12T23:18:39Z" level=warning msg="The \"LZ_ENDPOINT_ADDRESS\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_EID\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_REMOTE_EID\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"LZ_ENDPOINT_ADDRESS\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"LZ_ENDPOINT_ADDRESS\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_LOCAL_ADDRESS\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_REMOTE_EID\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_REMOTE_ADDRESS\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_LOCAL_ADDRESS\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_REMOTE_EID\" variable is not set. Defaulting to a blank string."
time="2026-07-12T23:18:39Z" level=warning msg="The \"BRIDGE_REMOTE_CHAIN_ID\" variable is not set. Defaulting to a blank string."
```