### PR TITLE
chore(kms-connector): better docs and logs for raw private key

### DIFF
--- a/kms-connector/config/tx-sender.toml
+++ b/kms-connector/config/tx-sender.toml
@@ -42,6 +42,8 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # Private key as a hex string (optional if `aws_kms_config` is configured)
 # If provided, the connector will use this private key
 # Format: hex string with or without 0x prefix
+# WARNING: Using a raw private key is intended for TESTING PURPOSES ONLY.
+#          Production deployments MUST use `aws_kms_config` instead (see below).
 # IMPORTANT: Keep this secure and never share it!
 # ENV: KMS_CONNECTOR_PRIVATE_KEY
 private_key = "0x3f45b129a7fd099146e9fe63851a71646231f7743c712695f3b2d2bf0e41c774"

--- a/kms-connector/crates/gw-listener/src/core/config.rs
+++ b/kms-connector/crates/gw-listener/src/core/config.rs
@@ -13,7 +13,9 @@ use connector_utils::{
     monitoring::{health::default_healthcheck_timeout, server::default_monitoring_endpoint},
     tasks::default_task_limit,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+#[cfg(debug_assertions)]
+use serde::Serialize;
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 /// Configuration of the `GatewayListener`.

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -14,7 +14,9 @@ use connector_utils::{
     monitoring::{health::default_healthcheck_timeout, server::default_monitoring_endpoint},
     tasks::default_task_limit,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(debug_assertions)]
+use serde::Serialize;
+use serde::{Deserialize, Deserializer};
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 /// Configuration of the `KmsWorker`.

--- a/kms-connector/crates/tx-sender/src/core/config.rs
+++ b/kms-connector/crates/tx-sender/src/core/config.rs
@@ -1,7 +1,7 @@
 use alloy::transports::http::reqwest::Url;
 use connector_utils::{
     config::{
-        AwsKmsConfig, ContractConfig, DeserializeConfig, Error, KmsWallet,
+        AwsKmsConfig, ContractConfig, DeserializeConfig, Error, KmsWallet, PrivateKey,
         contract::{
             default_decryption_contract_config, default_kms_generation_contract_config,
             default_protocol_config_contract_config, deserialize_decryption_contract_config,
@@ -59,7 +59,10 @@ pub struct Config {
     pub protocol_config_contract: ContractConfig,
 
     /// The private key of the `TransactionSender`'s wallet.
-    pub private_key: Option<String>,
+    ///
+    /// Intended for **testing purposes only** — production deployments should configure
+    /// `aws_kms_config` instead.
+    pub private_key: Option<PrivateKey>,
     /// The AWS KMS configuration of the `TransactionSender`'s wallet.
     pub aws_kms_config: Option<AwsKmsConfig>,
 
@@ -143,7 +146,7 @@ impl Config {
     pub async fn build_wallet(&self, chain_id: u64) -> Result<KmsWallet, Error> {
         let chain_id = Some(chain_id);
         if let Some(private_key) = &self.private_key {
-            KmsWallet::from_private_key_str(private_key, chain_id)
+            KmsWallet::from_private_key_str(private_key.as_str(), chain_id)
         } else if let Some(aws_kms_config) = self.aws_kms_config.clone() {
             KmsWallet::from_aws_kms(aws_kms_config, chain_id).await
         } else {
@@ -231,7 +234,7 @@ impl Default for Config {
             protocol_config_contract: default_protocol_config_contract_config(),
             service_name: default_service_name(),
             private_key: Some(
-                "0x3f45b129a7fd099146e9fe63851a71646231f7743c712695f3b2d2bf0e41c774".to_string(),
+                "0x3f45b129a7fd099146e9fe63851a71646231f7743c712695f3b2d2bf0e41c774".into(),
             ),
             aws_kms_config: None,
             tx_retries: default_tx_retries(),

--- a/kms-connector/crates/tx-sender/src/core/config.rs
+++ b/kms-connector/crates/tx-sender/src/core/config.rs
@@ -1,4 +1,6 @@
 use alloy::transports::http::reqwest::Url;
+#[cfg(debug_assertions)]
+use connector_utils::config::serialize_pg_interval;
 use connector_utils::{
     config::{
         AwsKmsConfig, ContractConfig, DeserializeConfig, Error, KmsWallet, PrivateKey,
@@ -8,12 +10,14 @@ use connector_utils::{
             deserialize_kms_generation_contract_config,
             deserialize_protocol_config_contract_config,
         },
-        default_database_pool_size, deserialize_pg_interval, serialize_pg_interval,
+        default_database_pool_size, deserialize_pg_interval,
     },
     monitoring::{health::default_healthcheck_timeout, server::default_monitoring_endpoint},
     tasks::default_task_limit,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(debug_assertions)]
+use serde::Serialize;
+use serde::{Deserialize, Deserializer};
 use sqlx::postgres::types::PgInterval;
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 

--- a/kms-connector/crates/tx-sender/src/core/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/core/tx_sender.rs
@@ -165,6 +165,13 @@ where
 impl TransactionSender<DbKmsResponsePicker, WalletProviderFillers, RootProvider> {
     /// Creates a new `TransactionSender` instance from a valid `Config`.
     pub async fn from_config(config: Config) -> anyhow::Result<(Self, State)> {
+        if config.private_key.is_some() {
+            warn!(
+                "Signing transactions with a raw private key. This is intended for TESTING \
+                PURPOSES ONLY, production deployments should use an AWS KMS signer instead!"
+            );
+        }
+
         let db_pool = connect_to_db(&config.database_url, config.database_pool_size).await?;
         let response_picker = DbKmsResponsePicker::connect(db_pool.clone(), &config).await?;
 

--- a/kms-connector/crates/utils/src/config/mod.rs
+++ b/kms-connector/crates/utils/src/config/mod.rs
@@ -7,7 +7,7 @@ pub use contract::ContractConfig;
 pub use deserialize::DeserializeConfig;
 pub use error::{Error, Result};
 use sqlx::postgres::types::PgInterval;
-pub use wallet::{AwsKmsConfig, KmsWallet};
+pub use wallet::{AwsKmsConfig, KmsWallet, PrivateKey};
 
 use serde::{Deserializer, Serializer};
 use std::time::Duration;

--- a/kms-connector/crates/utils/src/config/wallet.rs
+++ b/kms-connector/crates/utils/src/config/wallet.rs
@@ -23,6 +23,44 @@ pub enum KmsWallet {
     AwsKms(AwsSigner),
 }
 
+/// A wallet private key, provided as a hex string (with or without `0x` prefix).
+///
+/// # Testing only
+///
+/// Configuring a raw private key is intended for **testing purposes only**.
+/// Production deployments should use an AWS KMS signer instead (see [`AwsKmsConfig`]).
+///
+/// The inner secret is kept private and the [`Debug`] implementation redacts it, so the key
+/// is never leaked through debug logs.
+#[derive(Clone, Deserialize, PartialEq)]
+#[cfg_attr(debug_assertions, derive(Serialize))]
+#[serde(transparent)]
+pub struct PrivateKey(String);
+
+impl PrivateKey {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for PrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("PrivateKey(<redacted>)")
+    }
+}
+
+impl From<String> for PrivateKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for PrivateKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
 /// Configuration for AWS KMS signer.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct AwsKmsConfig {


### PR DESCRIPTION
### Summary

The `TransactionSender` supports a raw hex private key for local/testing setups. This PR wraps it in a small `PrivateKey` newtype so it renders as `PrivateKey(<redacted>)` in debug logs instead of the raw string, and makes the "testing only, use AWS KMS in production" guidance explicit in the config docs.

###  Changes

- New `PrivateKey` newtype (`utils/config/wallet.rs`): `#[serde(transparent)]` over `String`, so the config format is unchanged; custom `Debug` redacts the value. Used for `TransactionSender`'s `private_key` field.
- Docs: field doc and `tx-sender.toml` now note that raw keys are for testing and `aws_kms_config` is the production path.
- Cleanup: gated `Serialize/serialize_pg_interval` imports behind `#[cfg(debug_assertions)]` (they're only used by the debug-only derive), removing release-build warnings in the `tx-sender`, `gw-listener`, and  `kms-worker` configs.