### PR TITLE
fix(kms-connector): use confirmed Solana decrypt state

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -139,6 +139,8 @@ where
 
             match self.host_chain_backend(ct_chain_id)? {
                 HostChainAclBackend::Solana(host) => {
+                    // Public access is proven by a PublicDecryptLeaf MMR proof and verified
+                    // against the live confirmed lineage account.
                     check_solana_handles_public_decrypt(host, &[ct.ctHandle.0], extra_data)
                         .await
                         .map_err(|e| {
@@ -491,7 +493,7 @@ where
     /// 2. ed25519 signature over the canonical preimage — binds `publicKey`, handles, identity,
     ///    nonce, allowed domains, and validity window to the claimed Solana identity (closes the
     ///    publicKey-substitution / relayer-bypass bug),
-    /// 3. per-handle ACL read at `finalized` commitment with owner + canonical-PDA checks and the
+    /// 3. per-handle ACL read at `confirmed` commitment with owner + canonical-PDA checks and the
     ///    domain-scoped verifier (identity as subject).
     #[tracing::instrument(skip_all)]
     pub async fn check_user_decryption_request_solana(
@@ -541,7 +543,7 @@ where
         let auth = verify_solana_user_decrypt_signature(request, chain_id)
             .map_err(|e| RequestCheckError::from_processing(RequestCheckKind::Signature, e))?;
 
-        // ACL phase: read each handle's record at finalized commitment and run the domain-scoped
+        // ACL phase: read each handle's record at confirmed commitment and run the domain-scoped
         // verifier with the identity as subject.
         let handles: Vec<HandleBytes> = request.handles.iter().map(|e| e.handle.0).collect();
         check_solana_handles_acl(host, &handles, &auth)

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -36,11 +36,11 @@
 //! authorizes exactly one handle, so multi-handle Solana requests are out of scope for this
 //! rewrite):
 //!
-//! - **current-handle** (`mmr_proof_bytes` empty): the lineage account, fetched at `finalized`
+//! - **current-handle** (`mmr_proof_bytes` empty): the lineage account, fetched at `confirmed`
 //!   commitment, is checked for canonical PDA derivation + program ownership + `current_handle ==
 //!   handle` + `subject ∈ subjects` ([`dispatch_solana_current`]).
 //! - **historical / public** (`mmr_proof_bytes` non-empty): the request carries an MMR inclusion
-//!   proof, verified against the LIVE finalized peaks (the account is always freshly fetched, never
+//!   proof, verified against the live confirmed peaks (the account is always freshly fetched, never
 //!   a cached/proof-time snapshot) via the shared crate's `authorize_historical` /
 //!   `authorize_public` ([`dispatch_solana_mmr_proof`]). There is no live "is public" flag any
 //!   more — public-ness is only provable via a `PublicDecryptLeaf` MMR leaf.
@@ -50,12 +50,12 @@
 //! [`dispatch_solana_mmr_proof`] verifies the proof against the live peaks FIRST. Only after a
 //! inclusion-proof failure does the proof's leaf count classify the result:
 //! - **proof count < live count**: terminal; the immutable queued proof is stale.
-//! - **proof count == live count**: terminal; the proof is invalid for the live state.
-//! - **proof count > live count**: recoverable through the ordinary bounded attempt budget; the
-//!   KMS finalized view is behind the proof service, so the same proof may verify after catch-up.
+//! - **proof count >= live count**: recoverable through the ordinary bounded attempt budget; the
+//!   proof service and KMS may be observing different confirmed forks or the KMS may be behind, so
+//!   the same proof may verify after catch-up.
 //!
 //! Domain, owner, canonical-account, bump, and inconsistent-MMR failures remain terminal regardless
-//! of the two counts because finalized-view catch-up cannot repair them.
+//! of the two counts because confirmed-view catch-up cannot repair them.
 //!
 //! A proof that still verifies against the live peaks despite `proof_leaf_count != leaf_count` (count
 //! drifted but the relevant mountain never merged) is accepted — verify-first, never rebuilt from
@@ -107,7 +107,7 @@ pub struct VerifiedSolanaAuth {
 }
 
 /// Per-chain Solana host configuration needed to authorize a user-decrypt request: the expected
-/// ZamaHost program id and a `finalized`-commitment account fetcher.
+/// ZamaHost program id and a `confirmed`-commitment account fetcher.
 #[derive(Clone, Debug)]
 pub struct SolanaHost {
     pub program_id: SolanaPubkeyBytes,
@@ -182,7 +182,7 @@ pub fn require_single_handle(handles: &[HandleBytes]) -> Result<HandleBytes, Pro
     }
 }
 
-/// Fetches the `EncryptedValue` lineage for `value_key` at `finalized` commitment and decodes it.
+/// Fetches the `EncryptedValue` lineage for `value_key` at `confirmed` commitment and decodes it.
 /// Never a snapshot: every call re-reads the live account, which is what lets
 /// [`dispatch_solana_mmr_proof`] verify against the LIVE peaks.
 async fn fetch_encrypted_value_acl(
@@ -198,7 +198,7 @@ async fn fetch_encrypted_value_acl(
         .map_err(ProcessingError::Recoverable)?
         .ok_or_else(|| {
             ProcessingError::Recoverable(anyhow!(
-                "Solana EncryptedValue lineage account {} not found at finalized commitment",
+                "Solana EncryptedValue lineage account {} not found at confirmed commitment",
                 Pubkey::new_from_array(account_key),
             ))
         })?;
@@ -335,9 +335,9 @@ fn dispatch_solana_public_mmr_proof(
         .map_err(|e| classify_mmr_verification_failure(e, proof_leaf_count, acl.leaf_count))
 }
 
-/// Verify-first failure classification. Only an inclusion-proof mismatch ahead of the KMS finalized
-/// view can heal through catch-up, so it gets an ordinary bounded retry. All other verifier errors,
-/// and proof mismatches at or behind the live count, are terminal.
+/// Verify-first failure classification. An inclusion-proof mismatch at or ahead of the KMS
+/// confirmed view can heal through catch-up or a confirmed-fork change, so it gets an ordinary
+/// bounded retry. All other verifier errors, and proof mismatches behind the live count, are terminal.
 fn classify_mmr_verification_failure(
     error: crate::core::solana_acl::SolanaAclVerificationError,
     proof_leaf_count: u64,
@@ -348,31 +348,27 @@ fn classify_mmr_verification_failure(
         crate::core::solana_acl::SolanaAclVerificationError::HistoricalAccessProofInvalid
             | crate::core::solana_acl::SolanaAclVerificationError::PublicDecryptProofInvalid
     );
-    if proof_invalid && proof_leaf_count > live_leaf_count {
+    if proof_invalid && proof_leaf_count >= live_leaf_count {
         ProcessingError::Recoverable(anyhow!(
-            "Solana MMR proof is ahead of the KMS finalized view: proof leaf_count={proof_leaf_count}, \
-             live finalized leaf_count={live_leaf_count}; retrying within the normal attempt budget \
-             while finalized state catches up ({error})"
+            "Solana MMR proof does not verify against the KMS confirmed view: proof leaf_count={proof_leaf_count}, \
+             live confirmed leaf_count={live_leaf_count}; retrying within the normal attempt budget \
+             while confirmed views converge ({error})"
         ))
     } else if proof_invalid && proof_leaf_count < live_leaf_count {
         ProcessingError::Irrecoverable(anyhow!(
             "Solana MMR proof is stale and immutable: proof leaf_count={proof_leaf_count}, live \
-             finalized leaf_count={live_leaf_count} ({error})"
-        ))
-    } else if proof_invalid {
-        ProcessingError::Irrecoverable(anyhow!(
-            "Solana MMR proof is invalid at live finalized leaf_count={live_leaf_count} ({error})"
+             confirmed leaf_count={live_leaf_count} ({error})"
         ))
     } else {
         ProcessingError::Irrecoverable(anyhow!(
             "Solana MMR authorization failed irrecoverably: proof leaf_count={proof_leaf_count}, \
-             live finalized leaf_count={live_leaf_count} ({error})"
+             live confirmed leaf_count={live_leaf_count} ({error})"
         ))
     }
 }
 
 /// Full Solana user-decryption ACL check for one request: fetches the named `EncryptedValue`
-/// lineage at `finalized` commitment and dispatches to the current or MMR-proof path.
+/// lineage at `confirmed` commitment and dispatches to the current or MMR-proof path.
 pub async fn check_solana_handles_acl(
     host: &SolanaHost,
     handles: &[HandleBytes],
@@ -835,7 +831,7 @@ mod tests {
             &public_blob,
         )
         .expect_err("a PublicDecryptLeaf for the old handle must not authorize the rotated handle");
-        assert!(matches!(err, ProcessingError::Irrecoverable(_)));
+        assert!(matches!(err, ProcessingError::Recoverable(_)));
 
         let mut non_public_lineage = lineage(h(30), &[owner]);
         non_public_lineage.rotate(h(31));
@@ -850,7 +846,7 @@ mod tests {
             &historical_leaf_blob,
         )
         .expect_err("a historical-access leaf must not authorize public decrypt");
-        assert!(matches!(err, ProcessingError::Irrecoverable(_)));
+        assert!(matches!(err, ProcessingError::Recoverable(_)));
     }
 
     // (3) STALE TERMINAL
@@ -888,7 +884,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_proof_at_live_leaf_count_is_terminal() {
+    fn invalid_proof_at_live_leaf_count_uses_normal_recoverable_budget() {
         let err = classify_mmr_verification_failure(
             crate::core::solana_acl::SolanaAclVerificationError::HistoricalAccessProofInvalid,
             4,
@@ -896,14 +892,15 @@ mod tests {
         );
 
         match err {
-            ProcessingError::Irrecoverable(e) => {
+            ProcessingError::Recoverable(e) => {
                 let msg = e.to_string();
-                assert!(
-                    msg.contains("invalid at live finalized leaf_count=4"),
-                    "got: {msg}"
-                );
+                assert!(msg.contains("proof leaf_count=4"), "got: {msg}");
+                assert!(msg.contains("live confirmed leaf_count=4"), "got: {msg}");
+                assert!(msg.contains("normal attempt budget"), "got: {msg}");
             }
-            other => panic!("an invalid proof at the live count must be terminal, got {other:?}"),
+            other => panic!(
+                "equal-count confirmed fork disagreement must be retryable, got {other:?}"
+            ),
         }
     }
 
@@ -919,10 +916,10 @@ mod tests {
             ProcessingError::Recoverable(e) => {
                 let msg = e.to_string();
                 assert!(msg.contains("proof leaf_count=2"), "got: {msg}");
-                assert!(msg.contains("live finalized leaf_count=1"), "got: {msg}");
+                assert!(msg.contains("live confirmed leaf_count=1"), "got: {msg}");
                 assert!(msg.contains("normal attempt budget"), "got: {msg}");
             }
-            other => panic!("a proof ahead of finalized state must be recoverable, got {other:?}"),
+            other => panic!("a proof ahead of confirmed state must be recoverable, got {other:?}"),
         }
     }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -898,9 +898,9 @@ mod tests {
                 assert!(msg.contains("live confirmed leaf_count=4"), "got: {msg}");
                 assert!(msg.contains("normal attempt budget"), "got: {msg}");
             }
-            other => panic!(
-                "equal-count confirmed fork disagreement must be retryable, got {other:?}"
-            ),
+            other => {
+                panic!("equal-count confirmed fork disagreement must be retryable, got {other:?}")
+            }
         }
     }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -348,11 +348,19 @@ fn classify_mmr_verification_failure(
         crate::core::solana_acl::SolanaAclVerificationError::HistoricalAccessProofInvalid
             | crate::core::solana_acl::SolanaAclVerificationError::PublicDecryptProofInvalid
     );
-    if proof_invalid && proof_leaf_count >= live_leaf_count {
+    if proof_invalid && proof_leaf_count == live_leaf_count {
         ProcessingError::Recoverable(anyhow!(
-            "Solana MMR proof does not verify against the KMS confirmed view: proof leaf_count={proof_leaf_count}, \
-             live confirmed leaf_count={live_leaf_count}; retrying within the normal attempt budget \
-             while confirmed views converge ({error})"
+            "Solana MMR proof does not verify against an equal-count KMS confirmed view \
+             (classification=confirmed_equal_count): proof leaf_count={proof_leaf_count}, live \
+             confirmed leaf_count={live_leaf_count}; retrying within the configured decryption \
+             attempt budget while confirmed views converge ({error})"
+        ))
+    } else if proof_invalid && proof_leaf_count > live_leaf_count {
+        ProcessingError::Recoverable(anyhow!(
+            "Solana MMR proof is ahead of the KMS confirmed view \
+             (classification=confirmed_proof_ahead): proof leaf_count={proof_leaf_count}, live \
+             confirmed leaf_count={live_leaf_count}; retrying within the configured decryption \
+             attempt budget while the KMS view catches up ({error})"
         ))
     } else if proof_invalid && proof_leaf_count < live_leaf_count {
         ProcessingError::Irrecoverable(anyhow!(
@@ -896,7 +904,10 @@ mod tests {
                 let msg = e.to_string();
                 assert!(msg.contains("proof leaf_count=4"), "got: {msg}");
                 assert!(msg.contains("live confirmed leaf_count=4"), "got: {msg}");
-                assert!(msg.contains("normal attempt budget"), "got: {msg}");
+                assert!(
+                    msg.contains("classification=confirmed_equal_count"),
+                    "got: {msg}"
+                );
             }
             other => {
                 panic!("equal-count confirmed fork disagreement must be retryable, got {other:?}")
@@ -917,7 +928,10 @@ mod tests {
                 let msg = e.to_string();
                 assert!(msg.contains("proof leaf_count=2"), "got: {msg}");
                 assert!(msg.contains("live confirmed leaf_count=1"), "got: {msg}");
-                assert!(msg.contains("normal attempt budget"), "got: {msg}");
+                assert!(
+                    msg.contains("classification=confirmed_proof_ahead"),
+                    "got: {msg}"
+                );
             }
             other => panic!("a proof ahead of confirmed state must be recoverable, got {other:?}"),
         }

--- a/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
+++ b/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
@@ -101,7 +101,7 @@ impl SolanaAclVerifier {
     }
 
     /// Current decrypt: live handle + membership, within the request's domain scope. Reads the
-    /// account fetched at `finalized` commitment — never a snapshot.
+    /// account fetched at `confirmed` commitment — never a snapshot.
     pub fn verify_current_user_decrypt(
         &self,
         account_key: SolanaPubkeyBytes,
@@ -120,7 +120,7 @@ impl SolanaAclVerifier {
         Ok(())
     }
 
-    /// Historical decrypt: a valid historical-access MMR proof against the LIVE finalized peaks
+    /// Historical decrypt: a valid historical-access MMR proof against the live confirmed peaks
     /// (the account passed in, read fresh — not a cached/snapshotted proof-time state).
     pub fn verify_historical_user_decrypt(
         &self,
@@ -144,7 +144,7 @@ impl SolanaAclVerifier {
     }
 
     /// Exact public decrypt: a valid public-decrypt MMR proof for the exact handle, against the
-    /// LIVE finalized peaks. There is no live "is_public" flag — public-ness is only provable via
+    /// live confirmed peaks. There is no live "is_public" flag — public-ness is only provable via
     /// a `PublicDecryptLeaf` MMR leaf.
     pub fn verify_public_decrypt_exact(
         &self,

--- a/kms-connector/crates/kms-worker/src/core/solana_v2_fetcher.rs
+++ b/kms-connector/crates/kms-worker/src/core/solana_v2_fetcher.rs
@@ -12,8 +12,8 @@
 //!   PDA before trusting the bytes (see [`crate::core::event_processor::decryption`]).
 
 use crate::core::solana_acl::SolanaPubkeyBytes;
-use anyhow::{anyhow, bail, Context};
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use anyhow::{Context, anyhow, bail};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use serde_json::Value;
 use solana_pubkey::Pubkey;
 use url::Url;

--- a/kms-connector/crates/kms-worker/src/core/solana_v2_fetcher.rs
+++ b/kms-connector/crates/kms-worker/src/core/solana_v2_fetcher.rs
@@ -1,26 +1,25 @@
 //! Minimal Solana account fetcher for the V2 user-decryption ACL check.
 //!
 //! Reads a single ZamaHost `EncryptedValue` account from the configured Solana host-chain RPC at
-//! **`finalized`** commitment, via the JSON-RPC `getAccountInfo` method. It is intentionally tiny:
+//! **`confirmed`** commitment, via the JSON-RPC `getAccountInfo` method. It is intentionally tiny:
 //! the connector only needs to read account bytes + owner; it does not need the full Solana SDK
 //! RPC client, which is not in the connector's dependency set.
 //!
 //! Security-relevant choices:
-//! - commitment is pinned to `finalized` so the connector never authorizes against a slot that can
-//!   still be rolled back;
+//! - commitment is pinned to `confirmed`: a valid grant observed on a supermajority-confirmed fork
+//!   is sufficient authorization even if that fork is exceptionally rolled back later;
 //! - the caller verifies `owner == ZamaHost program id` and re-derives the canonical EncryptedValue
 //!   PDA before trusting the bytes (see [`crate::core::event_processor::decryption`]).
 
 use crate::core::solana_acl::SolanaPubkeyBytes;
-use anyhow::{Context, anyhow, bail};
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use anyhow::{anyhow, bail, Context};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use serde_json::Value;
 use solana_pubkey::Pubkey;
 use url::Url;
 
-/// The Solana commitment level used for every ACL read. Authorizing decryption against anything
-/// weaker than `finalized` would let a rolled-back slot grant access.
-pub const SOLANA_COMMITMENT_FINALIZED: &str = "finalized";
+/// The Solana commitment level used for every ACL read.
+pub const SOLANA_COMMITMENT_CONFIRMED: &str = "confirmed";
 
 /// A fetched Solana account: its owner program and raw data bytes.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -29,7 +28,7 @@ pub struct SolanaAccount {
     pub data: Vec<u8>,
 }
 
-/// Fetches account data via Solana JSON-RPC `getAccountInfo` at `finalized` commitment.
+/// Fetches account data via Solana JSON-RPC `getAccountInfo` at `confirmed` commitment.
 #[derive(Clone, Debug)]
 pub struct SolanaV2Fetcher {
     url: Url,
@@ -41,7 +40,7 @@ impl SolanaV2Fetcher {
         Self { url, client }
     }
 
-    /// Builds the JSON-RPC `getAccountInfo` request body for `account`, pinned to `finalized`
+    /// Builds the JSON-RPC `getAccountInfo` request body for `account`, pinned to `confirmed`
     /// commitment and base64 encoding. Split out so it can be asserted in unit tests without a
     /// live RPC.
     pub fn account_info_request_body(account: &SolanaPubkeyBytes) -> Value {
@@ -53,13 +52,13 @@ impl SolanaV2Fetcher {
                 Pubkey::new_from_array(*account).to_string(),
                 {
                     "encoding": "base64",
-                    "commitment": SOLANA_COMMITMENT_FINALIZED,
+                    "commitment": SOLANA_COMMITMENT_CONFIRMED,
                 }
             ],
         })
     }
 
-    /// Fetches `account` at `finalized` commitment. Returns `Ok(None)` when the account does not
+    /// Fetches `account` at `confirmed` commitment. Returns `Ok(None)` when the account does not
     /// exist, `Err` on transport / decoding failures.
     pub async fn get_account(
         &self,
@@ -145,7 +144,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn request_pins_finalized_commitment() {
+    fn request_pins_confirmed_commitment() {
         let account = [3u8; 32];
         let body = SolanaV2Fetcher::account_info_request_body(&account);
 
@@ -155,8 +154,8 @@ mod tests {
             params[0].as_str().unwrap(),
             Pubkey::new_from_array(account).to_string()
         );
-        assert_eq!(params[1]["commitment"], SOLANA_COMMITMENT_FINALIZED);
-        assert_eq!(params[1]["commitment"], "finalized");
+        assert_eq!(params[1]["commitment"], SOLANA_COMMITMENT_CONFIRMED);
+        assert_eq!(params[1]["commitment"], "confirmed");
         assert_eq!(params[1]["encoding"], "base64");
     }
 

--- a/relayer/src/readiness/checker.rs
+++ b/relayer/src/readiness/checker.rs
@@ -131,7 +131,7 @@ impl ReadinessChecker {
                     .await
             }
             // RFC-021 Solana: the host-chain ACL is enforced off-gateway by the KMS Connector
-            // (`solana_acl` reads the on-chain Solana ACL at finalized commitment), so the relayer
+            // (`solana_acl` reads the on-chain Solana ACL at confirmed commitment), so the relayer
             // performs no EVM-style host ACL check here.
             UserDecryptRequest::SolanaUnifiedV1 { .. } => Ok(()),
         };

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -16,6 +16,8 @@ use serde_json::json;
 
 use crate::solana_proof::decode::RawInstruction;
 
+const SOLANA_PROOF_COMMITMENT: &str = "confirmed";
+
 #[derive(thiserror::Error, Debug)]
 pub enum ChainError {
     #[error("RPC transport error: {0}")]
@@ -61,7 +63,7 @@ pub trait ChainFetcher: Send + Sync {
         signature: &str,
     ) -> Result<Option<ChainTransaction>, ChainError>;
 
-    /// Fetches and decodes the live `EncryptedValue` account at finalized commitment.
+    /// Fetches and decodes the live `EncryptedValue` account at confirmed commitment.
     async fn get_lineage_state(
         &self,
         address: [u8; 32],
@@ -139,6 +141,42 @@ fn base58_encode(bytes: &[u8; 32]) -> String {
     let mut out: Vec<u8> = std::iter::repeat_n(ALPHABET[0], leading_zeros).collect();
     out.extend(digits.iter().rev().map(|&d| ALPHABET[d as usize]));
     String::from_utf8(out).unwrap()
+}
+
+fn signatures_params(
+    address: &[u8; 32],
+    before: Option<&str>,
+    until: Option<&str>,
+    limit: usize,
+) -> serde_json::Value {
+    let mut opts = serde_json::Map::new();
+    opts.insert("commitment".to_string(), json!(SOLANA_PROOF_COMMITMENT));
+    opts.insert("limit".to_string(), json!(limit));
+    if let Some(before) = before {
+        opts.insert("before".to_string(), json!(before));
+    }
+    if let Some(until) = until {
+        opts.insert("until".to_string(), json!(until));
+    }
+    json!([base58_encode(address), opts])
+}
+
+fn transaction_params(signature: &str) -> serde_json::Value {
+    json!([
+        signature,
+        {
+            "encoding": "json",
+            "maxSupportedTransactionVersion": 0,
+            "commitment": SOLANA_PROOF_COMMITMENT,
+        }
+    ])
+}
+
+fn account_info_params(address: &[u8; 32]) -> serde_json::Value {
+    json!([
+        base58_encode(address),
+        {"encoding": "base64", "commitment": SOLANA_PROOF_COMMITMENT}
+    ])
 }
 
 #[derive(Deserialize)]
@@ -259,18 +297,10 @@ impl ChainFetcher for RpcChainFetcher {
         until: Option<&str>,
         limit: usize,
     ) -> Result<Vec<String>, ChainError> {
-        let mut opts = serde_json::Map::new();
-        opts.insert("limit".to_string(), json!(limit));
-        if let Some(before) = before {
-            opts.insert("before".to_string(), json!(before));
-        }
-        if let Some(until) = until {
-            opts.insert("until".to_string(), json!(until));
-        }
         let result = self
             .call(
                 "getSignaturesForAddress",
-                json!([base58_encode(&address), opts]),
+                signatures_params(&address, before, until, limit),
             )
             .await?;
         let entries: Vec<SignatureEntry> =
@@ -283,13 +313,7 @@ impl ChainFetcher for RpcChainFetcher {
         signature: &str,
     ) -> Result<Option<ChainTransaction>, ChainError> {
         let result = self
-            .call(
-                "getTransaction",
-                json!([
-                    signature,
-                    {"encoding": "json", "maxSupportedTransactionVersion": 0, "commitment": "finalized"}
-                ]),
-            )
+            .call("getTransaction", transaction_params(signature))
             .await?;
         if result.is_null() {
             return Ok(None);
@@ -343,10 +367,7 @@ impl ChainFetcher for RpcChainFetcher {
         address: [u8; 32],
     ) -> Result<Option<OnChainLineageState>, ChainError> {
         let result = self
-            .call(
-                "getAccountInfo",
-                json!([base58_encode(&address), {"encoding": "base64", "commitment": "finalized"}]),
-            )
+            .call("getAccountInfo", account_info_params(&address))
             .await?;
         if result.is_null() || result.get("value").map(|v| v.is_null()).unwrap_or(true) {
             return Ok(None);
@@ -468,5 +489,24 @@ mod tests {
     fn base64_decode_matches_known_vector() {
         // "hello" base64-encoded.
         assert_eq!(base64_decode("aGVsbG8=").unwrap(), b"hello".to_vec());
+    }
+
+    #[test]
+    fn proof_rpc_params_pin_confirmed_commitment() {
+        let address = [42u8; 32];
+
+        let signatures = signatures_params(&address, Some("before"), Some("until"), 25);
+        assert_eq!(signatures[1]["commitment"], "confirmed");
+        assert_eq!(signatures[1]["limit"], 25);
+        assert_eq!(signatures[1]["before"], "before");
+        assert_eq!(signatures[1]["until"], "until");
+
+        let transaction = transaction_params("signature");
+        assert_eq!(transaction[1]["commitment"], "confirmed");
+        assert_eq!(transaction[1]["encoding"], "json");
+
+        let account = account_info_params(&address);
+        assert_eq!(account[1]["commitment"], "confirmed");
+        assert_eq!(account[1]["encoding"], "base64");
     }
 }

--- a/relayer/src/solana_proof/proof.rs
+++ b/relayer/src/solana_proof/proof.rs
@@ -58,7 +58,7 @@ pub async fn build_proof<C: ChainFetcher, S: LeafStore>(
     };
 
     // The caller can request a historical leaf immediately after submitting its
-    // superseding transaction. Until that transaction is finalized, the live
+    // superseding transaction. Until that transaction is confirmed, the live
     // lineage has not yet advanced to the requested index.
     if leaf_index >= on_chain.leaf_count {
         return Err(lagging());
@@ -721,7 +721,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn returns_lagging_until_requested_leaf_is_finalized() {
+    async fn returns_lagging_until_requested_leaf_is_confirmed() {
         let program_id = pk(0x99);
         let lineage = pk(0x04);
         let chain = FakeChain::new(program_id);

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -916,6 +916,11 @@ back later. The KMS ACL read and all three relayer proof RPC reads (`getSignatur
 end-to-end release path `confirmed`: the separate finalized-account fetcher described in DD-024 still
 gates coprocessor material availability until its stacked cleanup lands.
 
+Decision provenance: accepted by the Solana feature owner during the review of
+[`zama-ai/fhevm#3122`](https://github.com/zama-ai/fhevm/pull/3122) on 2026-07-13. The accepted trade-off
+is irreversible plaintext release after a valid authorization observed on an exceptionally rolled-back
+confirmed fork; subsequent on-chain actions still follow the surviving fork.
+
 Why this is open:
 
 The dormant/activate model and transient eval intermediates were designed separately and don't compose;

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -881,11 +881,11 @@ lags ~32 slots. Worked once the consumer was actually wired (it had been scaffol
 
 Open for debate:
 
-The RELEASE commitment level (finalized ~13s vs confirmed) — see DD-025.
+Removing or relocating this separate coprocessor gate — see DD-025.
 
-## DD-025: WHERE The Finality Gate Sits (BIG OPEN debate item)
+## DD-025: Where The Release Gate Sits
 
-Status: OPEN — recommended direction recorded, not yet implemented.
+Status: partially resolved — KMS/proof reads use `confirmed`; the coprocessor gate remains finalized.
 
 Context:
 
@@ -909,8 +909,12 @@ Options considered:
 - (C) Slot-level finality gate.
 - (D) Ingest only at finalized (+~13s latency).
 
-Also OPEN — the RELEASE commitment level: `finalized` (~13s, safe) vs `confirmed` (~1–2s, but a
-confirmed-then-reorged release is an irreversible decrypt). Most Solana dapps run at `confirmed`.
+The accepted authorization policy for KMS ACL/proof verification is `confirmed`: a grant legitimately
+observed on a supermajority-confirmed fork is sufficient even if that fork is exceptionally rolled
+back later. The KMS ACL read and all three relayer proof RPC reads (`getSignaturesForAddress`,
+`getTransaction`, and `getAccountInfo`) use that explicit commitment. This does not yet make the
+end-to-end release path `confirmed`: the separate finalized-account fetcher described in DD-024 still
+gates coprocessor material availability until its stacked cleanup lands.
 
 Why this is open:
 
@@ -919,7 +923,7 @@ the EVM substrate that would fix it (A) exists but isn't wired to Solana.
 
 Open for debate:
 
-Pick A/B/C/D and the release commitment level. (A) is recommended because the substrate is reusable.
+Pick A/B/C/D. (A) is recommended because the substrate is reusable.
 
 ## DD-026: Input / Identity Encoding (bytes32 non-EVM) and the Move To Typed User-Decrypt — RESOLVED
 
@@ -1262,9 +1266,9 @@ Solana user-decrypt path lands and can call `build_proof` in-process instead.
 
 Rationale (verbatim from the commit message): this service is in the same trust class as the relayer
 already occupies — availability-critical, but never an authorization anchor. The KMS connector
-re-verifies every proof against live finalized on-chain peaks (DD-032), so a bad or compromised proof
+re-verifies every proof against live confirmed on-chain peaks (DD-032), so a bad or compromised proof
 service can only cause a decrypt to fail, never to wrongly authorize one. Proof building cross-checks
-its reconstructed peaks against the live finalized account and triggers targeted catch-up ingestion on
+its reconstructed peaks against the live confirmed account and triggers targeted catch-up ingestion on
 divergence before refusing a proof, rather than trusting its own replay blindly.
 
 Consequences:

--- a/solana/docs/EVM_PARITY.md
+++ b/solana/docs/EVM_PARITY.md
@@ -58,7 +58,7 @@ fromExternal** — all implemented. The confidential token is therefore **op-com
 | `ACL.allow(handle, account)` | persistent grant; caller must be allowed | `allow_subjects` — authority `Signer` must already be in the `EncryptedValue.subjects` allowed set + canonical PDA + deny-list + pause; append-only and idempotent, capped at `MAX_ENCRYPTED_VALUE_SUBJECTS=8` (DD-032) | **MET** |
 | `ACL.allowForDecryption(handles[])` | mark publicly decryptable | `make_handle_public` — any allowed subject can seal an exact-handle `PublicDecryptLeaf` into the MMR; that handle's publicness is then **permanent** and survives a later durable-output supersession (append-only leaf, the KMS honors historical public leaves), while staying exact-handle scoped so a superseding handle is not itself public (DD-005's live flag superseded, DD-032) | **MET** (DIVERGENCE: per-handle) |
 | `ACL.allowTransient(handle, account)` | tx-local grant | no durable analog; instruction-local `AllowedLocal` within one `fhe_eval`, plus CPI signer propagation within one instruction | **DIVERGENCE** (no tstore; DD-008) |
-| `ACL.isAllowed(handle, account)` | transient OR persistent | live path: canonical `EncryptedValue` PDA + `current_handle` match + subject membership; historical path: MMR `HistoricalAccessLeaf` inclusion proof against live finalized peaks (DD-032) | **MET** |
+| `ACL.isAllowed(handle, account)` | transient OR persistent | live path: canonical `EncryptedValue` PDA + `current_handle` match + subject membership; historical path: MMR `HistoricalAccessLeaf` inclusion proof against live confirmed peaks (DD-032) | **MET** |
 | `ACL.isAllowedForDecryption(handle)` | public-decrypt flag | exact-handle `PublicDecryptLeaf` MMR inclusion proof (no live flag — DD-032) | **MET** (DIVERGENCE: proof, not a stored flag) |
 | `ACL.persistAllowed` / `allowedTransient` | read pair | inline subject lookup on `EncryptedValue.subjects`; transient = instruction-local `AllowedLocal` | **MET** / **DIVERGENCE** |
 | `ACL.cleanTransientStorage()` | wipe tx transient (AA bundling) | nothing to reclaim — `AllowedLocal` values are instruction-scoped and never persisted (the one-shot `TransientSession` account tier was removed, DD-008) | **DIVERGENCE** (no durable transient state) |
@@ -122,8 +122,8 @@ fromExternal** — all implemented. The confidential token is therefore **op-com
   does not yet call it in-process.
 - **KMS connector** (`kms-connector/crates/kms-worker/src/core/solana_*.rs` and
   `kms-connector/crates/tx-sender/src/core/solana_native.rs`): witness decoders +
-  `SolanaAclVerifier`, now dual-path against `EncryptedValue` (live finalized-account read, or an MMR
-  inclusion proof re-verified against live finalized peaks via the shared `zama_solana_acl` crate,
+  `SolanaAclVerifier`, now dual-path against `EncryptedValue` (live confirmed-account read, or an MMR
+  inclusion proof re-verified against live confirmed peaks via the shared `zama_solana_acl` crate,
   DD-032). Decrypt reuses the unified Gateway V2 path with a typed Solana user-decrypt entrypoint and
   on-chain secp256k1 cert verification (DD-012/DD-021/DD-026); the older `native-v0` request/response
   subsystem remains as library/store code but is not the chosen path and is not wired into the

--- a/solana/docs/MMR_ACL_MVP.md
+++ b/solana/docs/MMR_ACL_MVP.md
@@ -49,7 +49,7 @@ this note records the operational model in one place.
 
 - Historical authorization is handle-scoped and permanent. When a handle is superseded, the program
   seals one `HistoricalAccessLeaf` per then-allowed subject into the value's MMR. Historical reads roll
-  forward by proving inclusion against finalized on-chain peaks.
+  forward by proving inclusion against confirmed on-chain peaks.
 - Public decrypt is exact-handle. `make_handle_public` seals a `PublicDecryptLeaf` for the current
   handle only; a later handle update does not inherit public decryptability. An `fhe_eval` durable
   output may instead be *born* public by setting `make_public` on the output: after the new handle is
@@ -65,13 +65,14 @@ this note records the operational model in one place.
   caller/authority for grant and eval flows; it blocks new action and is not an erasure mechanism for
   already sealed history.
 - Solana programs enforce authorization. The relayer, proof builder, host-listener ingestion, and
-  coprocessor scheduling are untrusted for authorization. KMS release must verify finalized on-chain
-  facts, including live `EncryptedValue` state or MMR proof validity, before releasing plaintext.
+  coprocessor scheduling are untrusted for authorization. KMS ACL/proof verification reads confirmed
+  on-chain facts, including live `EncryptedValue` state or MMR proof validity, before releasing
+  plaintext. A separate coprocessor finalized-account gate still exists pending its own cleanup.
 - Materiality is not Solana host state. DD-031 moved ciphertext material commitments to the gateway
   `CiphertextCommits`; Solana ACL state answers only who may use or decrypt a handle.
 - The relayer-colocated MMR proof service is an untrusted helper (DD-035). The end-to-end decrypt flow
   fetches historical and public MMR proofs from this service (`GET /internal/solana/mmr-proof`); the
-  KMS re-verifies each proof against finalized on-chain peaks before releasing plaintext. One case is
+  KMS re-verifies each proof against confirmed on-chain peaks before releasing plaintext. One case is
   still built by the test client rather than the service: the amount burned during an unwrap, whose
   handle comes from block randomness and appears only in an event, so the events-off build has nothing
   for the service to read (tracked in fhevm-internal#1675).
@@ -112,7 +113,7 @@ flowchart LR
         H0["HistoricalAccessLeaf<br/>handle=H1, subject=A"] --> H1["HistoricalAccessLeaf<br/>handle=H1, subject=B"] --> P0["PublicDecryptLeaf<br/>handle=H2 (born public)"]
     end
     append --> peaks["on-chain: peaks[] (≤64) + leaf_count"]
-    peaks --> verify["off-chain: reconstruct leaves → build MMR proof<br/>→ KMS verifies inclusion vs finalized peaks"]
+    peaks --> verify["off-chain: reconstruct leaves → build MMR proof<br/>→ KMS verifies inclusion vs confirmed peaks"]
 ```
 
 ### Handle derivation (no per-output binding — DD-015)
@@ -130,9 +131,9 @@ flowchart TD
 flowchart TD
     req["decrypt request (handle, subject)"] --> kind{authorization kind}
     kind -->|"current"| ac["authorize_current:<br/>handle == current_handle<br/>AND subject ∈ subjects<br/>(no proof)"]
-    kind -->|"historical"| ah["authorize_historical:<br/>MMR proof of HistoricalAccessLeaf(handle, subject)<br/>vs finalized peaks — survives supersession/removal"]
-    kind -->|"public"| ap["authorize_public:<br/>MMR proof of PublicDecryptLeaf(handle)<br/>vs finalized peaks — exact handle, no live flag"]
-    ac & ah & ap --> kms["KMS re-verifies against finalized on-chain state before releasing plaintext"]
+    kind -->|"historical"| ah["authorize_historical:<br/>MMR proof of HistoricalAccessLeaf(handle, subject)<br/>vs confirmed peaks — survives supersession/removal"]
+    kind -->|"public"| ap["authorize_public:<br/>MMR proof of PublicDecryptLeaf(handle)<br/>vs confirmed peaks — exact handle, no live flag"]
+    ac & ah & ap --> kms["KMS re-verifies against confirmed on-chain state before releasing plaintext"]
 ```
 
 ### Burn → Redeem (Vector-2 closed, DD-036)
@@ -164,7 +165,7 @@ sequenceDiagram
 flowchart TD
     prog["zama-host fhe_eval"] -->|"emit_cpi! (≤8-event frames only;<br/>no emit! log fallback)"| ev["op-event (self-CPI inner ix):<br/>carries the block-entropy output handle"]
     prog -->|"instruction data (args)"| ix["fhe_eval durable-output / make_public args"]
-    ev --> relayer["relayer proof service (RPC polling today):<br/>resolves born-public handle from op-event,<br/>reconstructs MMR, cross-checks vs finalized peaks"]
+    ev --> relayer["relayer proof service (RPC polling today):<br/>resolves born-public handle from op-event,<br/>reconstructs MMR, cross-checks vs confirmed peaks"]
     ix --> listener["host-listener indexer:<br/>Yellowstone gRPC reconstruction-only<br/>(SlotHashes+Clock sysvar streams → block entropy;<br/>never reads events)"]
     relayer -.->|"migrate to Carbon/Geyser,<br/>then drop op-event ABI"| followup["fhevm-internal#1665"]
 ```
@@ -204,7 +205,7 @@ to a follow-up.
 - DD-032: introduced stable `EncryptedValue` lineages, single allowed-subject ACL, and MMR leaves.
 - DD-033: lifecycle instructions emit no events; indexers replay instruction data.
 - DD-034: Solana compute is scheduled eagerly (`is_allowed` is a scheduling gate, not decrypt auth).
-- DD-035: proof building is relayer-colocated and untrusted; KMS re-verifies proofs against finalized
+- DD-035: proof building is relayer-colocated and untrusted; KMS re-verifies proofs against confirmed
   chain state.
 - DD-036: burn-redemption consume authorizes by MMR public-decrypt proof (born-public delta), not the
   live handle — closes the Vector-2 fund-stranding window.

--- a/solana/docs/TESTING_STRATEGY.md
+++ b/solana/docs/TESTING_STRATEGY.md
@@ -36,7 +36,7 @@ all fail closed (see the `*_rejects_*` mollusk tests).
    handles directly; fails closed on incomplete plans.
 5. **Off-chain proof service — relayer** (`relayer/src/solana_proof`): ingest (atomic, gap-free,
    fail-closed), decode (incl. `emit_cpi!` op-event resolution for born-public handles), replay, and
-   `build_verified_proof` cross-check against finalized peaks (a wrong record surfaces as
+   `build_verified_proof` cross-check against confirmed peaks (a wrong record surfaces as
    `PeaksDiverged`/`CorruptCache`, never a bad proof).
 6. **ABI / IDL golden** (`scripts/check-zama-host-idl.sh`, `plan_contracts.rs`): vendored IDLs and the
    Borsh golden manifest must match the freshly-built Anchor IDLs; EVENT_VERSION consistency across
@@ -57,7 +57,7 @@ all fail closed (see the `*_rejects_*` mollusk tests).
 The rewrite's central correctness bet is that off-chain consumers reproduce on-chain MMR state exactly.
 The e2e `reconstruct=true` arm exercises host-listener reconstruction against the full stack, while
 `build_verified_proof` cross-checks reconstructed peaks against final chain state. A divergence fails
-closed rather than yielding a wrong proof, which the KMS then re-verifies against finalized peaks anyway
+closed rather than yielding a wrong proof, which the KMS then re-verifies against confirmed peaks anyway
 (DD-035).
 
 ## Deliberately deferred (filed as follow-ups, not gaps in the merge)

--- a/solana/docs/TESTING_STRATEGY.md
+++ b/solana/docs/TESTING_STRATEGY.md
@@ -60,6 +60,23 @@ The e2e `reconstruct=true` arm exercises host-listener reconstruction against th
 closed rather than yielding a wrong proof, which the KMS then re-verifies against confirmed peaks anyway
 (DD-035).
 
+## Confirmed-view operations
+
+An equal-leaf-count proof mismatch is retried as
+`classification=confirmed_equal_count`; a proof ahead of the KMS view is retried as
+`classification=confirmed_proof_ahead`. Both use the ordinary configured decryption budget
+(`max_decryption_attempts`, default 20) and fast event polling interval (default 3 seconds). Actual
+wall-clock exhaustion also depends on batch load and processing time; there is no separate hidden
+fork-retry loop. Deterministic mismatches remain fail-closed, but the classification distinguishes
+them from ordinary proof-ahead catch-up in logs.
+
+A persistent relayer `corrupt_cache` response means the file-backed proof cache disagrees with the
+confirmed on-chain peaks after targeted catch-up. Recovery is operational, not an authorization
+fallback: stop the relayer, remove the JSON file configured by `solana_proof.leaf_store_path`, and
+restart it so the cache is replayed from the configured `start_signature` (or from the oldest retained
+program signature when absent). Until replay catches up, proof requests fail closed; the KMS never
+trusts the cache without re-verifying the proof against live chain state.
+
 ## Deliberately deferred (filed as follow-ups, not gaps in the merge)
 
 - **Explicit Mollusk CU-trace assertions.** CU fit is currently implicit (Mollusk enforces the budget,


### PR DESCRIPTION
Switches Solana KMS ACL reads and relayer proof RPC reads from finalized to explicit confirmed commitment, matching the accepted optimistic authorization semantics and existing EVM-style behavior. Preserves signature, owner, canonical PDA, domain, subject, and MMR verification while treating equal-count confirmed-view proof disagreement as a bounded recoverable failure. Persistent proof-cache divergence remains fail-closed with the existing HTTP 500 contract and requires cache rebuild. This is the preparatory base for a stacked coprocessor cleanup; end-to-end material availability remains finalized until that follow-up removes the separate finalized-account gate.
