### PR TITLE
feat(coprocessor): add --seed-start-block flag to host-listener poller

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
@@ -52,6 +52,14 @@ struct Args {
 
     #[arg(
         long,
+        default_value = None,
+        help = "Initial sync block used only when no poller state exists yet; an existing anchor always wins (can be negative from last block)",
+        allow_hyphen_values = true
+    )]
+    seed_start_block: Option<i64>,
+
+    #[arg(
+        long,
         default_value_t = 15,
         help = "Depth behind the head considered final (in blocks)"
     )]
@@ -220,6 +228,7 @@ async fn main() -> anyhow::Result<()> {
         max_http_retries: args.max_http_retries,
         rpc_compute_units_per_second: args.rpc_compute_units_per_second,
         health_port: args.health_port,
+        seed_start_block: args.seed_start_block,
         dependence_cache_size: args.dependence_cache_size,
         dependence_by_connexity: args.dependence_by_connexity,
         dependence_cross_block: args.dependence_cross_block,

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -71,6 +71,58 @@ fn handle_rpc_failure<E: std::fmt::Display>(
     }
 }
 
+/// Seed for `host_listener_poller_state` when no anchor row exists yet; an
+/// existing row always wins in the caller, so restarts never rewind or skip.
+/// A non-negative value is an absolute height (0 = genesis, explicitly), a
+/// negative value means that many blocks behind the current head. Unset is an
+/// error: the first start for a chain must state where to begin.
+#[derive(Debug, PartialEq, Eq)]
+enum StartAnchor {
+    Block(i64),
+    BehindHead(u64),
+}
+
+fn resolve_start_anchor(seed_start_block: Option<i64>) -> Result<StartAnchor> {
+    match seed_start_block {
+        Some(block) if block >= 0 => Ok(StartAnchor::Block(block)),
+        Some(delta) => Ok(StartAnchor::BehindHead(delta.unsigned_abs())),
+        None => Err(anyhow!(
+            "no poller state for this chain and no --seed-start-block; \
+             set it explicitly (0 for genesis)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod start_anchor_tests {
+    use super::{resolve_start_anchor, StartAnchor};
+
+    #[test]
+    fn non_negative_flag_is_absolute() {
+        assert_eq!(
+            resolve_start_anchor(Some(7)).unwrap(),
+            StartAnchor::Block(7)
+        );
+        assert_eq!(
+            resolve_start_anchor(Some(0)).unwrap(),
+            StartAnchor::Block(0)
+        );
+    }
+
+    #[test]
+    fn negative_flag_is_behind_head() {
+        assert_eq!(
+            resolve_start_anchor(Some(-10_000)).unwrap(),
+            StartAnchor::BehindHead(10_000)
+        );
+    }
+
+    #[test]
+    fn no_flag_is_an_error() {
+        assert!(resolve_start_anchor(None).is_err());
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PollerConfig {
     pub url: String,
@@ -91,6 +143,9 @@ pub struct PollerConfig {
     /// Higher values = less throttling.
     pub rpc_compute_units_per_second: u64,
     pub health_port: u16,
+    /// Initial sync anchor when no poller state exists yet
+    /// (initialization-only; >= 0 absolute, negative from head).
+    pub seed_start_block: Option<i64>,
     // Dependence chain settings
     pub dependence_cache_size: u16,
     pub dependence_by_connexity: bool,
@@ -226,7 +281,17 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         Some(block) => u64::try_from(block)
             .context("last_caught_up_block cannot be negative")?,
         None => {
-            let initial = db.read_last_valid_block().await.unwrap_or(0);
+            let initial = match resolve_start_anchor(config.seed_start_block)? {
+                StartAnchor::Block(block) => block,
+                StartAnchor::BehindHead(delta) => {
+                    let head = client.latest_block_number().await.context(
+                        "Failed to fetch head to resolve negative seed-start-block",
+                    )?;
+                    i64::try_from(head.saturating_sub(delta)).context(
+                        "start block computed from head is out of range",
+                    )?
+                }
+            };
             db.poller_set_last_caught_up_block(chain_id, initial)
                 .await?;
             db.tick.update();

--- a/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
@@ -184,6 +184,7 @@ async fn poller_catches_up_to_safe_tip(
         max_http_retries: 0,
         rpc_compute_units_per_second: 1000,
         health_port: 18081,
+        seed_start_block: Some(0),
         dependence_cache_size: 10_000,
         dependence_by_connexity: false,
         dependence_cross_block: false,

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -57,6 +57,7 @@ services:
     command:
       - host_listener_poller
       - --database-url=${DATABASE_URL}
+      - --seed-start-block=0
       - --acl-contract-address=${ACL_CONTRACT_ADDRESS}
       - --tfhe-contract-address=${FHEVM_EXECUTOR_CONTRACT_ADDRESS}
       - --kms-generation-address=${KMS_GENERATION_ADDRESS}

--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -484,9 +484,35 @@ describe("compat", () => {
     expect(policy.coprocessorDropFlags["host-listener-poller"]?.sort()).toEqual([
       "--confidential-bridge-address",
       "--protocol-config-address",
+      "--seed-start-block",
     ]);
     expect(policy.composeEnv.HOST_ADD_PAUSERS_INTERNAL_FLAG).toBe("--use-internal-proxy-address");
     expect(policy.composeEnv.GATEWAY_ADD_PAUSERS_INTERNAL_FLAG).toBe("--use-internal-proxy-address");
+  });
+
+  test("drops --seed-start-block only for host-listener bundles that predate the 0.13.2 backport", () => {
+    const stateFor = (version: string) => ({
+      versions: {
+        target: "mainnet" as const,
+        lockName: "compat.json",
+        env: { COPROCESSOR_HOST_LISTENER_VERSION: version } as Record<string, string>,
+        sources: [],
+      },
+      overrides: [],
+      scenario: testDefaultScenario(),
+    });
+    const dropsSeedStartBlock = (version: string) =>
+      (compatPolicyForState(stateFor(version)).coprocessorDropFlags["host-listener-poller"] ?? []).includes(
+        "--seed-start-block",
+      );
+
+    expect(dropsSeedStartBlock("v0.11.0")).toBe(true);
+    expect(dropsSeedStartBlock("v0.13.0-2")).toBe(true);
+    expect(dropsSeedStartBlock("v0.13.1")).toBe(true);
+    expect(dropsSeedStartBlock("v0.13.2-0")).toBe(false);
+    expect(dropsSeedStartBlock("v0.13.3")).toBe(false);
+    expect(dropsSeedStartBlock("v0.14.0-4")).toBe(false);
+    expect(dropsSeedStartBlock("13a37bc")).toBe(false);
   });
 
   test("requires modern host addresses when host-contracts is locally overridden", () => {

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -66,6 +66,12 @@ export const COMPAT_MATRIX = {
     },
     {
       key: "COPROCESSOR_HOST_LISTENER_VERSION",
+      below: [0, 13, 2] as CompatSemver,
+      profile: "legacy-host-listener-poller-no-seed-start-block",
+      unparsed: "modern" as const,
+    },
+    {
+      key: "COPROCESSOR_HOST_LISTENER_VERSION",
       below: [0, 12, 0] as CompatSemver,
       profile: "legacy-coprocessor-api-keys",
       unparsed: "modern" as const,
@@ -147,6 +153,18 @@ const SHIM_PROFILES = {
       "host-listener": ["--confidential-bridge-address"],
       "host-listener-poller": ["--confidential-bridge-address"],
       "host-listener-consumer": ["--confidential-bridge-address"],
+    },
+    connectorEnv: {},
+    composeEnv: {},
+  },
+  // --seed-start-block landed on main and was backported to release/0.13.x
+  // (first shipped in v0.13.2-0) and release/0.14.x (first shipped in
+  // v0.14.0-4). Build suffixes within a release family are not comparable, so
+  // the floor is the 0.13.2 family; 0.14.x builds all resolve as supported.
+  "legacy-host-listener-poller-no-seed-start-block": {
+    coprocessorArgs: {},
+    coprocessorDropFlags: {
+      "host-listener-poller": ["--seed-start-block"],
     },
     connectorEnv: {},
     composeEnv: {},


### PR DESCRIPTION
## Problem

When the poller starts against a fresh database (new chain onboarding), it has no persisted anchor and falls back to `max(host_chain_blocks_valid)` — a table owned by the WS listener. This cross-service read is a startup race: if the poller initializes before the WS listener has written anything, it anchors at `0` and walks the chain from genesis. Observed on Amoy pollers on devnet (3 of 5 stacks ~2-3 months behind head) and on testnet (Zama + partners).

Context: [Slack thread](https://zama-ai.slack.com/archives/C065F16D5U3/p1783081767401399)

## Fix

Drop the cross-service read entirely and add an `--seed-start-block` flag. The poller's seed sources are now its own, in one linear precedence:

1. **Persisted anchor row** (`host_listener_poller_state`) — always wins; the flag is inert once it exists
2. **`--seed-start-block`** — `>= 0`: absolute height; negative: that many blocks behind head at first startup
3. **Neither → explicit error** — a missing flag on a new chain surfaces as a crash-loop at deploy time instead of a silent weeks-long genesis walk; `--seed-start-block=0` opts into genesis deliberately

### Deliberately NOT the listener's `--start-at-block` semantics

The listener's flag beats persisted state on every startup. Transplanting that onto the poller would mean: every pod restart rewinds the anchor and re-walks; a flag above the anchor silently skips blocks; and it would clobber drift-revert's anchor reset. Hence a distinct name and initialization-only semantics — safe to leave in Helm values permanently.

## Behavior changes when the flag is unset

- Flagless fresh deployment: explicit startup error, instead of a scheduling-dependent race. The e2e compose poller passes `--seed-start-block=0` (fresh local chain: genesis is the honest value).
- Adding a poller to an already-running listener-only deployment now requires `--seed-start-block` explicitly (the removed fallback previously covered that case).
- Existing deployments with an anchor row: untouched.

## Notes for operators

- Already-lagging pollers keep their persisted anchor and still need the manual patch:
  ```sql
  UPDATE host_listener_poller_state SET last_caught_up_block = <target>, updated_at = NOW() WHERE chain_id = 80002;
  ```
- Wiring the flag into helm values (`coprocessor-operator`) is a separate change.

## Testing

- Anchor seeding extracted into a pure `resolve_start_anchor` helper with unit tests (`cargo test -p host-listener --lib start_anchor`).

## Backports

Same commit cherry-picked to `release/0.13.x` (#3124) and `release/0.14.x` (#3125), identical patch-id `e8d7dea5d57db1272a619d5bb1e1863b111cf234`.