### PR TITLE
docs(coprocessor): document poller --seed-start-block flag

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.13.8
+version: 0.13.9
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -432,13 +432,12 @@ hostListenerPollerShared:
   #     --dependence-cross-block
   #   v0.12 only:
   #     --dependent-ops-max-per-chain=0
-  #   images with --seed-start-block (zama-ai/fhevm#3123; 0.13.x/0.14.x
-  #   backports zama-ai/fhevm#3124 / zama-ai/fhevm#3125):
-  #     --seed-start-block=-10000            # initial sync anchor when no poller state exists yet;
+  #   when the image supports it:
+  #     --seed-start-block=-10000            # starting block when no poller state exists yet;
   #                                             # >= 0 absolute height, negative = blocks behind head.
-  #                                             # Initialization-only: an existing anchor row always
+  #                                             # Used only at first startup: existing state always
   #                                             # wins, so restarts never rewind or skip. Set this when
-  #                                             # onboarding a new host chain to avoid a genesis walk.
+  #                                             # onboarding a new host chain to avoid walking from genesis.
   extraArgs: []
 
   # Service ports configuration

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -432,6 +432,13 @@ hostListenerPollerShared:
   #     --dependence-cross-block
   #   v0.12 only:
   #     --dependent-ops-max-per-chain=0
+  #   images with --seed-start-block (zama-ai/fhevm#3123; 0.13.x/0.14.x
+  #   backports zama-ai/fhevm#3124 / zama-ai/fhevm#3125):
+  #     --seed-start-block=-10000            # initial sync anchor when no poller state exists yet;
+  #                                             # >= 0 absolute height, negative = blocks behind head.
+  #                                             # Initialization-only: an existing anchor row always
+  #                                             # wins, so restarts never rewind or skip. Set this when
+  #                                             # onboarding a new host chain to avoid a genesis walk.
   extraArgs: []
 
   # Service ports configuration

--- a/coprocessor/fhevm-engine/host-listener/README.md
+++ b/coprocessor/fhevm-engine/host-listener/README.md
@@ -49,28 +49,24 @@ BROKER_URL=redis://listener-redis:6379 host_listener_consumer \
 
 Use `--url` or `--broker-url` to override `BROKER_URL` for a single process.
 
-### Poller initial sync anchor (`--seed-start-block`)
+### Poller starting block (`--seed-start-block`)
 
 `host_listener_poller` tracks its progress in
 `host_listener_poller_state.last_caught_up_block`. When that row is missing
-(fresh database, new chain onboarding, or a poller added to a running
-listener-only deployment), `--seed-start-block` is required and seeds the
-anchor: `>= 0` is an absolute block height (`0` = genesis, explicitly),
-negative means that many blocks behind the current head at first startup.
-Without the flag the poller exits with an error, so a missing value on a new
-chain surfaces at deploy time instead of silently walking the chain from
-genesis. (Older versions seeded from `max(host_chain_blocks_valid)` — the WS
-listener's table — which made the seed a startup race between the two
-services; that fallback is removed.)
+(fresh database, new chain, or a poller added to a listener-only deployment),
+`--seed-start-block` is required and sets the starting block: `>= 0` is an
+absolute block height (`0` = genesis), negative means that many blocks behind
+the current head at first startup. Without the flag the poller exits with an
+error, so a missing value on a new chain fails at deploy time instead of
+silently scanning from genesis.
 
-The flag is initialization-only, on purpose. It is **not** the listener's
-`--start-at-block` (which beats persisted state on every startup): once the
-anchor row exists the flag is inert, so leaving it in Helm values can never
-rewind the poller on restart, skip blocks past the anchor, or clobber a
-drift-revert anchor reset.
+The flag is used only the first time. It is **not** the listener's
+`--start-at-block` (which overrides saved state on every startup): once the
+poller has saved its progress, the flag is ignored. Leaving it in Helm values
+will not move the poller backward or skip ahead on restart.
 
-To fix a poller that already persisted a bad anchor (e.g. a genesis walk in
-progress), patch the database instead:
+To fix a poller that already saved a bad starting block (for example, it is
+scanning from genesis), update the database instead:
 
 ```sql
 UPDATE host_listener_poller_state

--- a/coprocessor/fhevm-engine/host-listener/README.md
+++ b/coprocessor/fhevm-engine/host-listener/README.md
@@ -49,6 +49,35 @@ BROKER_URL=redis://listener-redis:6379 host_listener_consumer \
 
 Use `--url` or `--broker-url` to override `BROKER_URL` for a single process.
 
+### Poller initial sync anchor (`--seed-start-block`)
+
+`host_listener_poller` tracks its progress in
+`host_listener_poller_state.last_caught_up_block`. When that row is missing
+(fresh database, new chain onboarding, or a poller added to a running
+listener-only deployment), `--seed-start-block` is required and seeds the
+anchor: `>= 0` is an absolute block height (`0` = genesis, explicitly),
+negative means that many blocks behind the current head at first startup.
+Without the flag the poller exits with an error, so a missing value on a new
+chain surfaces at deploy time instead of silently walking the chain from
+genesis. (Older versions seeded from `max(host_chain_blocks_valid)` — the WS
+listener's table — which made the seed a startup race between the two
+services; that fallback is removed.)
+
+The flag is initialization-only, on purpose. It is **not** the listener's
+`--start-at-block` (which beats persisted state on every startup): once the
+anchor row exists the flag is inert, so leaving it in Helm values can never
+rewind the poller on restart, skip blocks past the anchor, or clobber a
+drift-revert anchor reset.
+
+To fix a poller that already persisted a bad anchor (e.g. a genesis walk in
+progress), patch the database instead:
+
+```sql
+UPDATE host_listener_poller_state
+SET last_caught_up_block = <target_block>, updated_at = NOW()
+WHERE chain_id = <chain_id>;
+```
+
 ### Dependent ops throttling (optional)
 
 `--dependent-ops-max-per-chain` enables slow-lane assignment (`0` disables).


### PR DESCRIPTION
Companion docs for the poller `--seed-start-block` flag.

- `charts/coprocessor/values.yaml`: add `--seed-start-block` to the `hostListenerPollerShared.extraArgs` CLI inventory comment (the chart already passes it through via `extraArgs`, no template change needed).
- `host-listener/README.md`: section explaining the poller's starting block — absolute vs behind-head forms, first-startup-only behavior (unlike the listener's `--start-at-block`), and the manual `host_listener_poller_state` update for pollers that already saved a bad starting block.

Docs kept out of the code PRs so the three code commits stay identical (same patch-id) across main and the release branches.