### PR TITLE
fix(coprocessor): bump crossbeam-epoch to 0.9.20 on release/0.13.x (RUSTSEC-2026-0204)

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`coprocessor-dependency-analysis/dependencies-check` fails on every PR targeting `release/0.13.x` since RUSTSEC-2026-0204 was published against `crossbeam-epoch 0.9.18` (invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`; fixed in >= 0.9.20). `main` already resolves to 0.9.20, which is why the same check passes there (e.g. #3123 vs #3124).

Lockfile-only patch bump via `cargo update -p crossbeam-epoch` (0.9.18 -> 0.9.20). Verified locally: `cargo audit` on this branch now reports 0 vulnerabilities (6 pre-existing allowed warnings remain).

Unblocks #3124.