### PR TITLE
fix(test-suite): sync package-lock.json with pinned @fhevm/sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28203,7 +28203,7 @@
     "test-suite/e2e": {
       "name": "@fhevm/e2e-suite",
       "dependencies": {
-        "@fhevm/sdk": "*",
+        "@fhevm/sdk": "1.1.0-alpha.8",
         "@fhevm/solidity": "*",
         "@openzeppelin/contracts": "^5.3.0",
         "@zama-fhe/relayer-sdk": "^0.5.0-alpha.2",
@@ -29039,6 +29039,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "test-suite/e2e/node_modules/@fhevm/sdk": {
+      "version": "1.1.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@fhevm/sdk/-/sdk-1.1.0-alpha.8.tgz",
+      "integrity": "sha512-Wn6JL2iMXjg+s+JwaXIhWt9owOsWmcm9HnX9yrResoNbGYjC9nlQjhIds37naCVr/8/q1L/v9apLY13Gw4mWcw==",
+      "license": "BSD-3-Clause-Clear",
+      "dependencies": {
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "wasm-feature-detect": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=22.0"
+      },
+      "peerDependencies": {
+        "ethers": ">=6.8.0",
+        "typescript": ">=5.0.4",
+        "viem": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "test-suite/e2e/node_modules/@fhevm/sdk/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "test-suite/e2e/node_modules/@fhevm/sdk/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "test-suite/e2e/node_modules/@jridgewell/resolve-uri": {


### PR DESCRIPTION
PR #3080 pinned test-suite/e2e's @fhevm/sdk dependency to 1.1.0-alpha.8 in package.json but never regenerated the lock file, which still resolved it to the local workspace package. This broke `npm ci` (EUSAGE) for any workspace, including the js-sdk-publish job.