### PR TITLE
fix(coprocessor): take shared cutover lock for GCS writers in cutover gate

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -334,19 +334,25 @@ pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 /// compatible, so this does **not** serialize BCS worker replicas against each
 /// other — only against the one-shot cutover.
 ///
-/// GCS-mode workers write to the `gcs-*` schema (never the cutover target), so
-/// the gate is a no-op for them: it returns `false` without taking the lock.
+/// GCS-mode (green) workers also take the shared lock: their writes land in the
+/// `gcs` schema, which `execute_cutover` merges into the live tables and then
+/// drops. Without the lock a green write committing between cutover's merge read
+/// and its `DROP SCHEMA gcs CASCADE` would be neither merged nor preserved (a
+/// silent-loss window); holding the shared lock makes cutover's exclusive request
+/// block until the write commits, so it is merged before the drop. They skip only
+/// the [`is_retired`] re-check: a green binary is strictly newer than the live
+/// stack, so it can never be retired (`is_retired` is always `false` for it).
 pub async fn cutover_gate(
     tx: &mut Transaction<'_, Postgres>,
     gcs_mode: bool,
 ) -> Result<bool, sqlx::Error> {
-    if gcs_mode {
-        return Ok(false);
-    }
     sqlx::query("SELECT pg_advisory_xact_lock_shared($1)")
         .bind(CUTOVER_LOCK_ID)
         .execute(&mut **tx)
         .await?;
+    if gcs_mode {
+        return Ok(false);
+    }
     is_retired(tx).await
 }
 

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -606,8 +606,9 @@ impl Database {
     /// at BEGIN (via `begin_guarded_pool`), then takes the shared cutover advisory
     /// lock and re-checks retirement. Returns `Ok(None)` if a committed cutover has
     /// retired this stack — the caller must skip the write. GCS-mode connections
-    /// (`self.gcs_mode`) skip the gate: they write the gcs schema, not the cutover
-    /// target. See `versioning::cutover_gate`.
+    /// (`self.gcs_mode`) still take the shared lock (their gcs-schema writes are
+    /// merged into the cutover target) but skip the retirement re-check, since a
+    /// green stack can never be retired. See `versioning::cutover_gate`.
     pub async fn new_transaction(
         &self,
     ) -> Result<Option<Transaction<'_>>, SqlxError> {


### PR DESCRIPTION
GCS-mode (green) writers previously short-circuited cutover_gate and skipped the shared advisory lock entirely. Their writes land in the gcs schema, which execute_cutover merges into the live tables and then drops.  

Move the shared-lock acquisition ahead of the gcs_mode check so green writers join the cutover barrier.