### PR TITLE
refactor(coprocessor): drop poller seed fallback on WS-listener blocks

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
@@ -52,6 +52,14 @@ struct Args {
 
     #[arg(
         long,
+        default_value = None,
+        help = "Initial sync block used only when no poller state exists yet; an existing anchor always wins (can be negative from last block)",
+        allow_hyphen_values = true
+    )]
+    initial_start_block: Option<i64>,
+
+    #[arg(
+        long,
         default_value_t = 15,
         help = "Depth behind the head considered final (in blocks)"
     )]
@@ -220,6 +228,7 @@ async fn main() -> anyhow::Result<()> {
         max_http_retries: args.max_http_retries,
         rpc_compute_units_per_second: args.rpc_compute_units_per_second,
         health_port: args.health_port,
+        initial_start_block: args.initial_start_block,
         dependence_cache_size: args.dependence_cache_size,
         dependence_by_connexity: args.dependence_by_connexity,
         dependence_cross_block: args.dependence_cross_block,

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -71,6 +71,70 @@ fn handle_rpc_failure<E: std::fmt::Display>(
     }
 }
 
+/// Sync anchor to seed `host_listener_poller_state` with when no persisted
+/// anchor exists. Unlike the listener's --start-at-block, the flag is
+/// initialization-only: an existing anchor row always wins, so restarts never
+/// rewind or skip. On a fresh database the flag beats blocks recorded by the
+/// WS listener, making the seed deterministic; >= 0 is an absolute height,
+/// negative means that many blocks behind the current head.
+#[derive(Debug, PartialEq, Eq)]
+enum StartAnchor {
+    Block(i64),
+    BehindHead(u64),
+}
+
+fn resolve_start_anchor(
+    initial_start_block: Option<i64>,
+    last_valid_block: Option<i64>,
+) -> StartAnchor {
+    match (initial_start_block, last_valid_block) {
+        (Some(block), _) if block >= 0 => StartAnchor::Block(block),
+        (Some(delta), _) => StartAnchor::BehindHead(delta.unsigned_abs()),
+        (None, Some(block)) => StartAnchor::Block(block),
+        (None, None) => StartAnchor::Block(0),
+    }
+}
+
+#[cfg(test)]
+mod start_anchor_tests {
+    use super::{resolve_start_anchor, StartAnchor};
+
+    #[test]
+    fn flag_wins_over_ws_listener_blocks() {
+        assert_eq!(
+            resolve_start_anchor(Some(7), Some(42)),
+            StartAnchor::Block(7)
+        );
+        assert_eq!(
+            resolve_start_anchor(Some(-7), Some(42)),
+            StartAnchor::BehindHead(7)
+        );
+    }
+
+    #[test]
+    fn non_negative_flag_is_absolute() {
+        assert_eq!(resolve_start_anchor(Some(7), None), StartAnchor::Block(7));
+        assert_eq!(resolve_start_anchor(Some(0), None), StartAnchor::Block(0));
+    }
+
+    #[test]
+    fn negative_flag_is_behind_head() {
+        assert_eq!(
+            resolve_start_anchor(Some(-10_000), None),
+            StartAnchor::BehindHead(10_000)
+        );
+    }
+
+    #[test]
+    fn no_flag_falls_back_to_ws_listener_blocks_then_genesis() {
+        assert_eq!(
+            resolve_start_anchor(None, Some(42)),
+            StartAnchor::Block(42)
+        );
+        assert_eq!(resolve_start_anchor(None, None), StartAnchor::Block(0));
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PollerConfig {
     pub url: String,
@@ -91,6 +155,9 @@ pub struct PollerConfig {
     /// Higher values = less throttling.
     pub rpc_compute_units_per_second: u64,
     pub health_port: u16,
+    /// Initial sync anchor when no poller state exists yet
+    /// (initialization-only; >= 0 absolute, negative from head).
+    pub initial_start_block: Option<i64>,
     // Dependence chain settings
     pub dependence_cache_size: u16,
     pub dependence_by_connexity: bool,
@@ -226,7 +293,20 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         Some(block) => u64::try_from(block)
             .context("last_caught_up_block cannot be negative")?,
         None => {
-            let initial = db.read_last_valid_block().await.unwrap_or(0);
+            let initial = match resolve_start_anchor(
+                config.initial_start_block,
+                db.read_last_valid_block().await,
+            ) {
+                StartAnchor::Block(block) => block,
+                StartAnchor::BehindHead(delta) => {
+                    let head = client.latest_block_number().await.context(
+                        "Failed to fetch head to resolve negative initial-start-block",
+                    )?;
+                    i64::try_from(head.saturating_sub(delta)).context(
+                        "start block computed from head is out of range",
+                    )?
+                }
+            };
             db.poller_set_last_caught_up_block(chain_id, initial)
                 .await?;
             db.tick.update();

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -71,27 +71,21 @@ fn handle_rpc_failure<E: std::fmt::Display>(
     }
 }
 
-/// Sync anchor to seed `host_listener_poller_state` with when no persisted
-/// anchor exists. Unlike the listener's --start-at-block, the flag is
-/// initialization-only: an existing anchor row always wins, so restarts never
-/// rewind or skip. On a fresh database the flag beats blocks recorded by the
-/// WS listener, making the seed deterministic; >= 0 is an absolute height,
-/// negative means that many blocks behind the current head.
+/// Seed for `host_listener_poller_state` when no anchor row exists yet; an
+/// existing row always wins in the caller, so restarts never rewind or skip.
+/// A non-negative value is an absolute height, a negative value means that
+/// many blocks behind the current head, unset falls back to genesis.
 #[derive(Debug, PartialEq, Eq)]
 enum StartAnchor {
     Block(i64),
     BehindHead(u64),
 }
 
-fn resolve_start_anchor(
-    initial_start_block: Option<i64>,
-    last_valid_block: Option<i64>,
-) -> StartAnchor {
-    match (initial_start_block, last_valid_block) {
-        (Some(block), _) if block >= 0 => StartAnchor::Block(block),
-        (Some(delta), _) => StartAnchor::BehindHead(delta.unsigned_abs()),
-        (None, Some(block)) => StartAnchor::Block(block),
-        (None, None) => StartAnchor::Block(0),
+fn resolve_start_anchor(initial_start_block: Option<i64>) -> StartAnchor {
+    match initial_start_block {
+        Some(block) if block >= 0 => StartAnchor::Block(block),
+        Some(delta) => StartAnchor::BehindHead(delta.unsigned_abs()),
+        None => StartAnchor::Block(0),
     }
 }
 
@@ -100,38 +94,22 @@ mod start_anchor_tests {
     use super::{resolve_start_anchor, StartAnchor};
 
     #[test]
-    fn flag_wins_over_ws_listener_blocks() {
-        assert_eq!(
-            resolve_start_anchor(Some(7), Some(42)),
-            StartAnchor::Block(7)
-        );
-        assert_eq!(
-            resolve_start_anchor(Some(-7), Some(42)),
-            StartAnchor::BehindHead(7)
-        );
-    }
-
-    #[test]
     fn non_negative_flag_is_absolute() {
-        assert_eq!(resolve_start_anchor(Some(7), None), StartAnchor::Block(7));
-        assert_eq!(resolve_start_anchor(Some(0), None), StartAnchor::Block(0));
+        assert_eq!(resolve_start_anchor(Some(7)), StartAnchor::Block(7));
+        assert_eq!(resolve_start_anchor(Some(0)), StartAnchor::Block(0));
     }
 
     #[test]
     fn negative_flag_is_behind_head() {
         assert_eq!(
-            resolve_start_anchor(Some(-10_000), None),
+            resolve_start_anchor(Some(-10_000)),
             StartAnchor::BehindHead(10_000)
         );
     }
 
     #[test]
-    fn no_flag_falls_back_to_ws_listener_blocks_then_genesis() {
-        assert_eq!(
-            resolve_start_anchor(None, Some(42)),
-            StartAnchor::Block(42)
-        );
-        assert_eq!(resolve_start_anchor(None, None), StartAnchor::Block(0));
+    fn no_flag_falls_back_to_genesis() {
+        assert_eq!(resolve_start_anchor(None), StartAnchor::Block(0));
     }
 }
 
@@ -293,10 +271,14 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
         Some(block) => u64::try_from(block)
             .context("last_caught_up_block cannot be negative")?,
         None => {
-            let initial = match resolve_start_anchor(
-                config.initial_start_block,
-                db.read_last_valid_block().await,
-            ) {
+            if config.initial_start_block.is_none() {
+                warn!(
+                    chain_id = %chain_id,
+                    "No poller state and no --initial-start-block; seeding at genesis"
+                );
+            }
+            let initial = match resolve_start_anchor(config.initial_start_block)
+            {
                 StartAnchor::Block(block) => block,
                 StartAnchor::BehindHead(delta) => {
                     let head = client.latest_block_number().await.context(

--- a/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
@@ -184,6 +184,7 @@ async fn poller_catches_up_to_safe_tip(
         max_http_retries: 0,
         rpc_compute_units_per_second: 1000,
         health_port: 18081,
+        initial_start_block: None,
         dependence_cache_size: 10_000,
         dependence_by_connexity: false,
         dependence_cross_block: false,


### PR DESCRIPTION
Stacked on #3123 — retarget to `main` once it merges. **Main only, deliberately not backported**: this is a behavior change for flagless fresh deployments and does not belong in a patch release (discussed with Rudy).

The poller's first-seed fallback on `host_chain_blocks_valid` (a table owned by the WS listener) was a bootstrap aid from when the poller was introduced into already-running systems. That migration is complete — every live deployment has its own `host_listener_poller_state` row — so the only code path still reaching the fallback is a fresh database, where the cross-service read *is* the startup race.

After this change the poller's seed sources are entirely its own:
1. persisted anchor row (always wins)
2. `--initial-start-block`
3. genesis, with a `warn!`

Consequences:
- flagless fresh deployment: guaranteed genesis walk with a warning, instead of a scheduling-dependent race (deterministic and loud beats silent and lucky)
- adding a poller to an already-running listener-only deployment now requires `--initial-start-block` explicitly
- `resolve_start_anchor` collapses to a single-argument pure function

Tested: `cargo test -p host-listener --lib start_anchor`, clippy clean.