### PR TITLE
fix(test-suite): sync root package-lock with @fhevm/sdk 1.1.0-alpha.8 pin on release/0.14.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,7 +1955,6 @@
       "integrity": "sha512-tNrpfDu9nhB+/onG3Qzby0PFqi21HpW9dI9oa4HulW5/VfiMQllj2gKOX+BEemokdq2JQhAHvj8dTkp0euXPPg==",
       "dev": true,
       "license": "LZBL-1.2",
-      "peer": true,
       "peerDependencies": {
         "@arbitrum/nitro-contracts": "^1.1.0",
         "@axelar-network/axelar-gmp-sdk-solidity": "^5.6.4",
@@ -1980,7 +1979,6 @@
       "integrity": "sha512-1m9uZDcROJrFjjFZ06J6kmXIqFoJ4r2VH95bL5wsKjkmffNrRYyxbTr2pael7EP8dcq55HpCKc9dg4G1SfTOVQ==",
       "dev": true,
       "license": "LZBL-1.2",
-      "peer": true,
       "peerDependencies": {
         "@openzeppelin/contracts": "^4.8.1 || ^5.0.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.1 || ^5.0.0",
@@ -1994,7 +1992,6 @@
       "integrity": "sha512-JE2Ogs7oKFihIcFhsN4MQ9Q9BSjIXzpYd1hztmeW2khKQOtKI8hqClwB6D252NGW1SB8Rr78RTVCcCSceY8ErA==",
       "dev": true,
       "license": "BUSL-1.1",
-      "peer": true,
       "peerDependencies": {
         "@openzeppelin/contracts": "3.4.2-solc-0.7 || ^3.4.2 || ^4.0.0 || ^5.0.0",
         "@openzeppelin/contracts-upgradeable": "3.4.2-solc-0.7 || ^3.4.2 || ^4.0.0 || ^5.0.0",
@@ -2007,7 +2004,6 @@
       "integrity": "sha512-eOoDepVSrUlVNIlnkH0Vd5Vt4lXBkSBh6Bb16vsLbaN9AryBjy4GDpsE7K4c8iWTFL9BiBXGsV7nJTkgqi+xRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ethers": "^5.7.2"
       },
@@ -2140,7 +2136,6 @@
       "integrity": "sha512-GjjfnUbx77TnFFKALVRXJYb1bt1jvarcyyx/AQo6sZfJng5DIqzI9wDxEGlUz03tEnsS6ZOOLBsH+e/hYsruiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@layerzerolabs/lz-evm-messagelib-v2": "^3.0.148",
         "@layerzerolabs/lz-evm-protocol-v2": "^3.0.148",
@@ -2326,7 +2321,6 @@
       "integrity": "sha512-NlUlde/ycXw2bLzA2gWjjbxQaD9xIRbAF30nsoEprAWzH8dXEI1ILZUKZMyux9n9iygEXTzN0SDVjE6zWDZi9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai-as-promised": "^7.1.3",
         "chai-as-promised": "^7.1.1",
@@ -2346,7 +2340,6 @@
       "integrity": "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "lodash.isequal": "^4.5.0"
@@ -2362,7 +2355,6 @@
       "integrity": "sha512-T0JTnuib7QcpsWkHCPLT7Z6F483EjTdcdjb1e00jqS9zTGCPqinPB66LLtR/duDLdvgoiCVS6K8WxTQkA/xR1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/ignition-core": "^0.15.15",
         "@nomicfoundation/ignition-ui": "^0.15.13",
@@ -2383,7 +2375,6 @@
       "integrity": "sha512-io6Wrp1dUsJ94xEI3pw6qkPfhc9TFA+e6/+o16yQ8pvBTFMjgK5x8wIHKrrIHr9L3bkuTMtmDjyN4doqO2IqFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.1.0",
         "@nomicfoundation/hardhat-ignition": "^0.15.16",
@@ -2396,7 +2387,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ethereumjs-util": "^7.1.4"
       },
@@ -2433,7 +2423,6 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -2455,7 +2444,6 @@
       "integrity": "sha512-JdKFxYknTfOYtFXMN6iFJ1vALJPednuB+9p9OwGIRdoI6HYSh4ZBzyRURgyXtHFyaJ/SF9lBpsYV9/1zEpcYwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "5.6.1",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",
@@ -2648,14 +2636,12 @@
     "host-contracts/node_modules/@openzeppelin/contracts": {
       "version": "5.1.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "host-contracts/node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@openzeppelin/contracts": "5.1.0"
       }
@@ -2742,7 +2728,6 @@
       "version": "1.44.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/slang": "^0.18.3",
         "bignumber.js": "^9.1.2",
@@ -3659,7 +3644,6 @@
       "version": "0.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "ts-essentials": "^7.0.1"
@@ -3674,7 +3658,6 @@
       "version": "9.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fs-extra": "^9.1.0"
       },
@@ -3710,8 +3693,7 @@
     "host-contracts/node_modules/@types/chai": {
       "version": "4.3.20",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "host-contracts/node_modules/@types/chai-as-promised": {
       "version": "7.1.8",
@@ -3754,14 +3736,12 @@
     "host-contracts/node_modules/@types/mocha": {
       "version": "10.0.10",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "host-contracts/node_modules/@types/node": {
       "version": "24.10.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3828,7 +3808,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4561,7 +4540,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5429,7 +5407,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5834,7 +5811,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -6556,7 +6532,6 @@
       "version": "2.27.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
@@ -6618,7 +6593,6 @@
       "version": "0.11.45",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -6691,7 +6665,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -6759,7 +6732,6 @@
       "version": "1.0.10",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-uniq": "1.0.3",
         "eth-gas-reporter": "^0.2.25",
@@ -9687,8 +9659,7 @@
       "resolved": "https://registry.npmjs.org/solidity-bytes-utils/-/solidity-bytes-utils-0.8.4.tgz",
       "integrity": "sha512-/bjac5YR12i0plOKvGlhE51F5IWGP6rI8DJetCQlXcnwKWz/Hgf/vr+Qlk1BWz56xVcwVhmhCaDkTMnx5xvt0g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "host-contracts/node_modules/solidity-comments": {
       "version": "0.0.2",
@@ -9912,7 +9883,6 @@
       "version": "0.8.16",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.0.9",
         "@solidity-parser/parser": "^0.20.1",
@@ -10488,7 +10458,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10588,7 +10557,6 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10690,7 +10658,6 @@
       "version": "8.3.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -10827,7 +10794,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12733,7 +12699,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai-as-promised": "^7.1.3",
         "chai-as-promised": "^7.1.1",
@@ -12751,7 +12716,6 @@
       "version": "3.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "lodash.isequal": "^4.5.0"
@@ -12765,7 +12729,6 @@
       "version": "0.15.15",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/ignition-core": "^0.15.14",
         "@nomicfoundation/ignition-ui": "^0.15.13",
@@ -12784,7 +12747,6 @@
       "version": "0.15.16",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.1.0",
         "@nomicfoundation/hardhat-ignition": "^0.15.15",
@@ -12797,7 +12759,6 @@
       "version": "1.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ethereumjs-util": "^7.1.4"
       },
@@ -12834,7 +12795,6 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -13099,8 +13059,7 @@
     "library-solidity/node_modules/@openzeppelin/contracts": {
       "version": "5.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "library-solidity/node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "5.0.2",
@@ -13583,7 +13542,6 @@
       "version": "0.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "ts-essentials": "^7.0.1"
@@ -13598,7 +13556,6 @@
       "version": "9.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fs-extra": "^9.1.0"
       },
@@ -13634,8 +13591,7 @@
     "library-solidity/node_modules/@types/chai": {
       "version": "4.3.20",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "library-solidity/node_modules/@types/chai-as-promised": {
       "version": "7.1.8",
@@ -13699,14 +13655,12 @@
     "library-solidity/node_modules/@types/mocha": {
       "version": "10.0.10",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "library-solidity/node_modules/@types/node": {
       "version": "20.19.25",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -13798,7 +13752,6 @@
       "version": "5.62.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -14000,7 +13953,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14728,7 +14680,6 @@
       "version": "4.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -15602,7 +15553,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -16018,7 +15968,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -16744,7 +16693,6 @@
       "version": "2.27.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
@@ -16878,7 +16826,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -16946,7 +16893,6 @@
       "version": "1.0.10",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-uniq": "1.0.3",
         "eth-gas-reporter": "^0.2.25",
@@ -20145,7 +20091,6 @@
       "version": "0.8.15",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.0.9",
         "@solidity-parser/parser": "^0.19.0",
@@ -20766,7 +20711,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21009,7 +20953,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21127,7 +21070,6 @@
       "version": "8.3.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -21262,7 +21204,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22064,7 +22005,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -22145,7 +22085,6 @@
         "ethers": "^6.15.0",
         "prettier": "^3.6.2",
         "size-limit": "^12.0.1",
-        "test": "vitest -c ./test/vitest.config.ts",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.2",
@@ -23654,7 +23593,6 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -23846,7 +23784,6 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -24188,7 +24125,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -24545,7 +24481,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -24774,8 +24709,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "sdk/js-sdk/node_modules/electron-to-chromium": {
       "version": "1.5.378",
@@ -24915,7 +24849,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -26227,7 +26160,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -26506,7 +26438,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26587,7 +26518,6 @@
       "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -26913,10 +26843,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "sdk/js-sdk/node_modules/test": {
-      "resolved": "sdk/js-sdk/vitest -c ./test/vitest.config.ts",
-      "link": true
-    },
     "sdk/js-sdk/node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
@@ -27068,7 +26994,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27237,7 +27162,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -27812,7 +27736,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -28078,7 +28001,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -28170,7 +28092,7 @@
     },
     "sdk/js-sdk/src": {
       "name": "@fhevm/sdk",
-      "version": "1.1.0-alpha.5",
+      "version": "1.1.0-alpha.9",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@noble/curves": "2.0.1",
@@ -28198,12 +28120,12 @@
       }
     },
     "sdk/js-sdk/vitest -c ./test/vitest.config.ts": {
-      "dev": true
+      "extraneous": true
     },
     "test-suite/e2e": {
       "name": "@fhevm/e2e-suite",
       "dependencies": {
-        "@fhevm/sdk": "*",
+        "@fhevm/sdk": "1.1.0-alpha.8",
         "@fhevm/solidity": "*",
         "@openzeppelin/contracts": "^5.3.0",
         "@zama-fhe/relayer-sdk": "^0.5.0-alpha.2",
@@ -29041,6 +28963,63 @@
         "node": ">=14"
       }
     },
+    "test-suite/e2e/node_modules/@fhevm/sdk": {
+      "version": "1.1.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@fhevm/sdk/-/sdk-1.1.0-alpha.8.tgz",
+      "integrity": "sha512-Wn6JL2iMXjg+s+JwaXIhWt9owOsWmcm9HnX9yrResoNbGYjC9nlQjhIds37naCVr/8/q1L/v9apLY13Gw4mWcw==",
+      "license": "BSD-3-Clause-Clear",
+      "dependencies": {
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "wasm-feature-detect": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=22.0"
+      },
+      "peerDependencies": {
+        "ethers": ">=6.8.0",
+        "typescript": ">=5.0.4",
+        "viem": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "test-suite/e2e/node_modules/@fhevm/sdk/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "test-suite/e2e/node_modules/@fhevm/sdk/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "test-suite/e2e/node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -29233,7 +29212,6 @@
       "integrity": "sha512-NlUlde/ycXw2bLzA2gWjjbxQaD9xIRbAF30nsoEprAWzH8dXEI1ILZUKZMyux9n9iygEXTzN0SDVjE6zWDZi9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai-as-promised": "^7.1.3",
         "chai-as-promised": "^7.1.1",
@@ -29253,7 +29231,6 @@
       "integrity": "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "lodash.isequal": "^4.5.0"
@@ -29290,7 +29267,6 @@
       "integrity": "sha512-io6Wrp1dUsJ94xEI3pw6qkPfhc9TFA+e6/+o16yQ8pvBTFMjgK5x8wIHKrrIHr9L3bkuTMtmDjyN4doqO2IqFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.1.0",
         "@nomicfoundation/hardhat-ignition": "^0.15.16",
@@ -29305,7 +29281,6 @@
       "integrity": "sha512-p7HaUVDbLj7ikFivQVNhnfMHUBgiHYMwQWvGn9AriieuopGOELIrwj2KjyM2a6z70zai5YKO264Vwz+3UFJZPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ethereumjs-util": "^7.1.4"
       },
@@ -29344,7 +29319,6 @@
       "integrity": "sha512-danbGjPp2WBhLkJdQy9/ARM3WQIK+7vwzE0urNem1qZJjh9f54Kf5f1xuQv8DvqewUAkuPxVt/7q4Grz5WjqSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -29366,6 +29340,7 @@
       "integrity": "sha512-JdKFxYknTfOYtFXMN6iFJ1vALJPednuB+9p9OwGIRdoI6HYSh4ZBzyRURgyXtHFyaJ/SF9lBpsYV9/1zEpcYwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "5.6.1",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",
@@ -29394,6 +29369,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -29408,6 +29384,7 @@
       "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nofilter": "^3.1.0"
       },
@@ -29420,7 +29397,8 @@
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-0.15.13.tgz",
       "integrity": "sha512-HbTszdN1iDHCkUS9hLeooqnLEW2U45FaqFwFEYT8nIno2prFZhG+n68JEERjmfFCB5u0WgbuJwk3CgLoqtSL7Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "test-suite/e2e/node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.1.2",
@@ -29757,7 +29735,6 @@
       "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "ts-essentials": "^7.0.1"
@@ -29774,7 +29751,6 @@
       "integrity": "sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fs-extra": "^9.1.0"
       },
@@ -29816,8 +29792,7 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "test-suite/e2e/node_modules/@types/chai-as-promised": {
       "version": "7.1.8",
@@ -29872,14 +29847,12 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
       "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "test-suite/e2e/node_modules/@types/node": {
       "version": "22.19.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -30496,7 +30469,6 @@
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -31549,7 +31521,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -31785,6 +31756,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -32166,7 +32138,6 @@
       "integrity": "sha512-zQze7qe+8ltwHvhX5NQ8sN1N37WWZGw8L63y+2XcPxGwAjc/SMF829z3NS6o1krX0sryhAsVBK/xrwUqlsot4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",
         "@ethersproject/abi": "^5.1.2",
@@ -32230,7 +32201,6 @@
       "integrity": "sha512-02N4+So/fZrzJ88ci54GqwVA3Zrf0C9duuTyGt0CFRIh/CdNwbnTgkXkRfojOMLBQ+6t+lBIkgbsOtqMvNwikA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-uniq": "1.0.3",
         "eth-gas-reporter": "^0.2.25",
@@ -32597,6 +32567,7 @@
       "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -32808,7 +32779,8 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "test-suite/e2e/node_modules/json5": {
       "version": "2.2.3",
@@ -32816,6 +32788,7 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -32875,6 +32848,7 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -33259,6 +33233,7 @@
       "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "minimist": "^1.2.5",
@@ -33610,6 +33585,7 @@
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
@@ -34313,7 +34289,8 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "test-suite/e2e/node_modules/slash": {
       "version": "3.0.0",
@@ -34385,7 +34362,6 @@
       "integrity": "sha512-5P8vnB6qVX9tt1MfuONtCTEaEGO/O4WuEidPHIAJjx4sktHHKhO3rFvnE0q8L30nWJPTrcqGQMT7jpE29B2qow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.0.9",
         "@solidity-parser/parser": "^0.20.1",
@@ -34583,6 +34559,7 @@
       "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^3.0.0"
       }
@@ -34831,6 +34808,7 @@
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "3"
       }
@@ -34870,7 +34848,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -34959,7 +34936,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -35057,7 +35033,6 @@
       "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -35211,9 +35186,8 @@
     },
     "test-suite/e2e/node_modules/typescript": {
       "version": "6.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
#3080 pinned `@fhevm/sdk@1.1.0-alpha.8` in `test-suite/e2e/package.json` without regenerating the root `package-lock.json`. Since then **every `npm ci` on `release/0.14.x` fails** with:

> `npm ci` can only install packages when your package.json and package-lock.json are in sync. Missing: @fhevm/sdk@1.1.0-alpha.8 from lock file

`host-listener/build.rs` shells out to `npm ci`, so all coprocessor cargo jobs (clippy, tests) fail branch-wide — e.g. on #3125, and `js-sdk-publish` failed on the branch push this morning.

Lockfile-only regeneration via `npm install --package-lock-only`: adds the registry entry for `@fhevm/sdk@1.1.0-alpha.8` (+ its `@noble/*` deps) and records the e2e pin. Verified with `npm ci --dry-run`.

Unblocks #3125. Note: the published `@fhevm/sdk@1.1.0-alpha.8` declares `engines.node >= 22` while coprocessor CI uses Node 20 — currently a warning only, flagging for awareness.