### PR TITLE
feat(relayer): validate produced-public output batches

### DIFF
--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -190,6 +190,8 @@ struct CompiledIx {
     program_id_index: usize,
     accounts: Vec<usize>,
     data: String,
+    #[serde(rename = "stackHeight", default)]
+    stack_height: Option<u32>,
 }
 
 #[derive(Deserialize)]
@@ -235,9 +237,56 @@ struct GetTransactionResult {
     meta: Option<Meta>,
 }
 
+fn decode_transaction_result(
+    signature: &str,
+    parsed: GetTransactionResult,
+) -> Result<ChainTransaction, ChainError> {
+    if parsed.meta.as_ref().and_then(|m| m.err.as_ref()).is_some() {
+        // This guard deliberately precedes account-key and instruction decoding:
+        // failed transactions committed no state and must contribute no leaves.
+        return Ok(ChainTransaction {
+            signature: signature.to_string(),
+            slot: parsed.slot,
+            instructions: Vec::new(),
+        });
+    }
+    let mut account_keys: Vec<[u8; 32]> = parsed
+        .transaction
+        .message
+        .account_keys
+        .iter()
+        .map(|s| base58_to_32(s))
+        .collect::<Result<_, _>>()?;
+    if let Some(loaded) = parsed
+        .meta
+        .as_ref()
+        .and_then(|m| m.loaded_addresses.as_ref())
+    {
+        for addr in loaded.writable.iter().chain(loaded.readonly.iter()) {
+            account_keys.push(base58_to_32(addr)?);
+        }
+    }
+    let instructions = flatten_execution_order(
+        &parsed.transaction.message.instructions,
+        parsed
+            .meta
+            .as_ref()
+            .map(|m| m.inner_instructions.as_slice())
+            .unwrap_or(&[]),
+        &account_keys,
+    )?;
+    Ok(ChainTransaction {
+        signature: signature.to_string(),
+        slot: parsed.slot,
+        instructions,
+    })
+}
+
 fn compiled_to_raw(
     ix: &CompiledIx,
     account_keys: &[[u8; 32]],
+    top_level_index: usize,
+    is_inner: bool,
 ) -> Result<RawInstruction, ChainError> {
     let program_id = *account_keys
         .get(ix.program_id_index)
@@ -257,6 +306,11 @@ fn compiled_to_raw(
         program_id,
         accounts,
         data,
+        top_level_index,
+        // RPC omits stackHeight on message instructions; their height is known.
+        // Inner instructions retain the RPC field so missing nesting metadata
+        // can be rejected by the lifecycle decoder.
+        stack_height: if is_inner { ix.stack_height } else { Some(1) },
     })
 }
 
@@ -320,46 +374,7 @@ impl ChainFetcher for RpcChainFetcher {
         }
         let parsed: GetTransactionResult =
             serde_json::from_value(result).map_err(|e| ChainError::Rpc(e.to_string()))?;
-        if parsed.meta.as_ref().and_then(|m| m.err.clone()).is_some() {
-            // A failed transaction never persisted its instructions' effects on-chain.
-            return Ok(Some(ChainTransaction {
-                signature: signature.to_string(),
-                slot: parsed.slot,
-                instructions: Vec::new(),
-            }));
-        }
-        let mut account_keys: Vec<[u8; 32]> = parsed
-            .transaction
-            .message
-            .account_keys
-            .iter()
-            .map(|s| base58_to_32(s))
-            .collect::<Result<_, _>>()?;
-        if let Some(loaded) = parsed
-            .meta
-            .as_ref()
-            .and_then(|m| m.loaded_addresses.as_ref())
-        {
-            for addr in loaded.writable.iter().chain(loaded.readonly.iter()) {
-                account_keys.push(base58_to_32(addr)?);
-            }
-        }
-
-        let instructions = flatten_execution_order(
-            &parsed.transaction.message.instructions,
-            parsed
-                .meta
-                .as_ref()
-                .map(|m| m.inner_instructions.as_slice())
-                .unwrap_or(&[]),
-            &account_keys,
-        )?;
-
-        Ok(Some(ChainTransaction {
-            signature: signature.to_string(),
-            slot: parsed.slot,
-            instructions,
-        }))
+        Ok(Some(decode_transaction_result(signature, parsed)?))
     }
 
     async fn get_lineage_state(
@@ -396,14 +411,44 @@ fn flatten_execution_order(
     let mut by_index: std::collections::HashMap<usize, &Vec<CompiledIx>> =
         std::collections::HashMap::new();
     for group in inner_groups {
-        by_index.insert(group.index, &group.instructions);
+        if group.index >= top_level.len() {
+            return Err(ChainError::Rpc(format!(
+                "inner-instruction group index {} is out of range",
+                group.index
+            )));
+        }
+        if by_index.insert(group.index, &group.instructions).is_some() {
+            return Err(ChainError::Rpc(format!(
+                "duplicate inner-instruction group index {}",
+                group.index
+            )));
+        }
+        let mut previous_height = 1u32;
+        for (position, instruction) in group.instructions.iter().enumerate() {
+            let height = instruction.stack_height.ok_or_else(|| {
+                ChainError::Rpc(format!(
+                    "inner instruction {position} in group {} has no stackHeight",
+                    group.index
+                ))
+            })?;
+            if height < 2
+                || (position == 0 && height != 2)
+                || height > previous_height.saturating_add(1)
+            {
+                return Err(ChainError::Rpc(format!(
+                    "impossible stackHeight {height} at inner instruction {position} in group {}",
+                    group.index
+                )));
+            }
+            previous_height = height;
+        }
     }
     let mut out = Vec::new();
     for (i, ix) in top_level.iter().enumerate() {
-        out.push(compiled_to_raw(ix, account_keys)?);
+        out.push(compiled_to_raw(ix, account_keys, i, false)?);
         if let Some(inner) = by_index.get(&i) {
             for inner_ix in inner.iter() {
-                out.push(compiled_to_raw(inner_ix, account_keys)?);
+                out.push(compiled_to_raw(inner_ix, account_keys, i, true)?);
             }
         }
     }
@@ -455,11 +500,13 @@ mod tests {
                 program_id_index: 0,
                 accounts: vec![],
                 data: "".to_string(),
+                stack_height: None,
             },
             CompiledIx {
                 program_id_index: 1,
                 accounts: vec![],
                 data: "".to_string(),
+                stack_height: None,
             },
         ];
         let inner_groups = vec![InnerIxGroup {
@@ -468,13 +515,107 @@ mod tests {
                 program_id_index: 2,
                 accounts: vec![],
                 data: "".to_string(),
+                stack_height: Some(2),
             }],
         }];
         let out = flatten_execution_order(&top_level, &inner_groups, &account_keys).unwrap();
         assert_eq!(out.len(), 3);
         assert_eq!(out[0].program_id, [1u8; 32]);
+        assert_eq!(out[0].stack_height, Some(1));
         assert_eq!(out[1].program_id, [3u8; 32]); // inner CPI spawned by top-level 0
+        assert_eq!(out[1].stack_height, Some(2));
+        assert_eq!(out[1].top_level_index, 0);
         assert_eq!(out[2].program_id, [2u8; 32]);
+    }
+
+    #[test]
+    fn flatten_rejects_duplicate_and_orphan_inner_groups() {
+        let account_keys = vec![[1u8; 32]];
+        let top_level = vec![CompiledIx {
+            program_id_index: 0,
+            accounts: vec![],
+            data: "".to_string(),
+            stack_height: None,
+        }];
+        let duplicate = vec![
+            InnerIxGroup {
+                index: 0,
+                instructions: vec![],
+            },
+            InnerIxGroup {
+                index: 0,
+                instructions: vec![],
+            },
+        ];
+        assert!(matches!(
+            flatten_execution_order(&top_level, &duplicate, &account_keys),
+            Err(ChainError::Rpc(message)) if message.contains("duplicate")
+        ));
+
+        let orphan = vec![InnerIxGroup {
+            index: 1,
+            instructions: vec![],
+        }];
+        assert!(matches!(
+            flatten_execution_order(&top_level, &orphan, &account_keys),
+            Err(ChainError::Rpc(message)) if message.contains("out of range")
+        ));
+    }
+
+    #[test]
+    fn flatten_rejects_impossible_inner_stack_traces() {
+        let account_keys = vec![[1u8; 32]];
+        let top_level = vec![CompiledIx {
+            program_id_index: 0,
+            accounts: vec![],
+            data: "".to_string(),
+            stack_height: None,
+        }];
+        for heights in [vec![3], vec![2, 4], vec![2, 1], vec![2, 2, 4]] {
+            let group = vec![InnerIxGroup {
+                index: 0,
+                instructions: heights
+                    .into_iter()
+                    .map(|height| CompiledIx {
+                        program_id_index: 0,
+                        accounts: vec![],
+                        data: "".to_string(),
+                        stack_height: Some(height),
+                    })
+                    .collect(),
+            }];
+            assert!(matches!(
+                flatten_execution_order(&top_level, &group, &account_keys),
+                Err(ChainError::Rpc(message)) if message.contains("impossible")
+            ));
+        }
+        let missing = vec![InnerIxGroup {
+            index: 0,
+            instructions: vec![CompiledIx {
+                program_id_index: 0,
+                accounts: vec![],
+                data: "".to_string(),
+                stack_height: None,
+            }],
+        }];
+        assert!(matches!(
+            flatten_execution_order(&top_level, &missing, &account_keys),
+            Err(ChainError::Rpc(message)) if message.contains("no stackHeight")
+        ));
+
+        let valid = vec![InnerIxGroup {
+            index: 0,
+            instructions: [2, 3, 3, 2]
+                .into_iter()
+                .map(|height| CompiledIx {
+                    program_id_index: 0,
+                    accounts: vec![],
+                    data: "".to_string(),
+                    stack_height: Some(height),
+                })
+                .collect(),
+        }];
+        assert!(flatten_execution_order(&top_level, &valid, &account_keys).is_ok());
     }
 
     #[test]
@@ -508,5 +649,31 @@ mod tests {
         let account = account_info_params(&address);
         assert_eq!(account[1]["commitment"], "confirmed");
         assert_eq!(account[1]["encoding"], "base64");
+    }
+
+    #[test]
+    fn failed_transaction_is_rejected_before_instruction_decoding() {
+        let parsed: GetTransactionResult = serde_json::from_value(json!({
+            "slot": 42,
+            "transaction": { "message": {
+                // Deliberately malformed: decoding this key would fail.
+                "accountKeys": ["not-base58!"],
+                "instructions": [{
+                    "programIdIndex": 99,
+                    "accounts": [],
+                    "data": ""
+                }]
+            }},
+            "meta": {
+                "err": { "InstructionError": [0, "Custom"] },
+                "innerInstructions": []
+            }
+        }))
+        .unwrap();
+
+        let transaction = decode_transaction_result("failed", parsed).unwrap();
+
+        assert!(transaction.instructions.is_empty());
+        assert_eq!(transaction.slot, 42);
     }
 }

--- a/relayer/src/solana_proof/decode.rs
+++ b/relayer/src/solana_proof/decode.rs
@@ -5,11 +5,15 @@
 //! One exception needs sibling context: a born-public (`make_public=true`)
 //! `fhe_eval` durable output commits a public-decrypt leaf to the eval OUTPUT
 //! handle, which is derived on-chain from slot entropy and appears in no
-//! instruction arg. That handle is recovered from the per-step op event the
-//! host emits via `emit_cpi!` (an inner instruction of the same `fhe_eval`), so
-//! [`decode_program_instructions`] correlates each `fhe_eval` with the op events
-//! that immediately follow it. The resolved handle is untrusted and guarded by
-//! the on-chain peak cross-check at proof time (DD-035).
+//! instruction arg. The host therefore emits one narrow lifecycle batch from a
+//! self-CPI. [`decode_program_instructions`] accepts it only when it exactly
+//! matches the enclosing successful `fhe_eval`; the confirmed MMR peak check
+//! remains the defense-in-depth authority at proof time (DD-035).
+//!
+//! Relayers must support a lifecycle version before that producer version is
+//! deployed; an unknown version intentionally halts ingestion. RPC responses
+//! must also include `stackHeight` for every inner instruction so the batch can
+//! be bound to its immediate enclosing frame.
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use sha2::{Digest, Sha256};
@@ -23,6 +27,8 @@ pub struct RawInstruction {
     pub program_id: [u8; 32],
     pub accounts: Vec<[u8; 32]>,
     pub data: Vec<u8>,
+    pub top_level_index: usize,
+    pub stack_height: Option<u32>,
 }
 
 /// One subject grant as carried in `create_encrypted_value`/`allow_subjects` args.
@@ -62,7 +68,7 @@ pub enum DecodedInstruction {
         subjects: Vec<SubjectGrant>,
         /// `Some(output_handle)` when the durable output was born public
         /// (`make_public=true`) AND its output handle was resolved from the
-        /// op event this transaction emitted. `None` otherwise — the output
+        /// lifecycle batch this transaction emitted. `None` otherwise — the output
         /// handle is derived on-chain from slot entropy and appears in no
         /// instruction arg, so without the event it stays unresolved and any
         /// born-public leaf fails closed at proof time rather than serving a wrong result.
@@ -131,43 +137,11 @@ fn event_discriminator(name: &str) -> [u8; 8] {
 /// host-listener's `ANCHOR_EVENT_IX_TAG_LE`.
 const ANCHOR_EVENT_IX_TAG_LE: [u8; 8] = 0x1d9acb512ea545e4_u64.to_le_bytes();
 
-/// The `fhe_eval` op events, one emitted per plan step in step order. Every
-/// one carries its verified output handle as the final `result: [u8; 32]` field
-/// (see `zama_host::events`), so the handle is the last 32 bytes of the payload.
-const OP_EVENT_NAMES: [&str; 9] = [
-    "FheBinaryOpEvent",
-    "FheTernaryOpEvent",
-    "TrivialEncryptEvent",
-    "FheRandEvent",
-    "FheRandBoundedEvent",
-    "FheUnaryOpEvent",
-    "FheSumEvent",
-    "FheIsInEvent",
-    "FheMulDivEvent",
-];
-
-/// Extracts the verified output handle (`result`) from an `emit_cpi!` op-event
-/// inner instruction (self-CPI to the host program). Returns `None` for any
-/// instruction that is not a recognized op-event CPI. The handle is UNTRUSTED:
-/// callers rely on the on-chain peak cross-check (DD-035) to fail closed if a
-/// resolved handle is wrong — it is never trusted to authorize on its own.
-pub fn op_event_result(ix: &RawInstruction, program_id: [u8; 32]) -> Option<[u8; 32]> {
-    if ix.program_id != program_id {
-        return None;
-    }
-    let after_tag = ix.data.strip_prefix(&ANCHOR_EVENT_IX_TAG_LE)?;
-    if after_tag.len() < 8 + 32 {
-        return None;
-    }
-    let disc: [u8; 8] = after_tag[..8].try_into().ok()?;
-    if !OP_EVENT_NAMES
-        .iter()
-        .any(|name| event_discriminator(name) == disc)
-    {
-        return None;
-    }
-    // `result` is the last field of every op event; borsh has no trailing bytes.
-    after_tag[after_tag.len() - 32..].try_into().ok()
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BornPublicOutput {
+    step_index: u16,
+    encrypted_value: [u8; 32],
+    output_handle: [u8; 32],
 }
 
 const ENCRYPTED_VALUE_ACCOUNT_INDEX: usize = 2;
@@ -195,6 +169,24 @@ pub enum DecodeError {
     },
     #[error("fhe_eval durable output has mismatched previous_handle/previous_subjects options")]
     InvalidFheEvalPreviousState,
+    #[error("missing or invalid Solana instruction stack metadata")]
+    InvalidStackMetadata,
+    #[error("born-public lifecycle event is missing for fhe_eval")]
+    MissingBornPublicEvent,
+    #[error("unexpected or unconsumed born-public lifecycle event")]
+    UnexpectedBornPublicEvent,
+    #[error("unexpected zama-host descendant inside fhe_eval execution frame")]
+    UnexpectedHostDescendant,
+    #[error("born-public lifecycle event has an invalid host self-CPI envelope")]
+    InvalidBornPublicEnvelope,
+    #[error("born-public lifecycle event has unsupported version {0}")]
+    UnsupportedBornPublicVersion(u8),
+    #[error("born-public lifecycle event is malformed: {0}")]
+    MalformedBornPublicEvent(String),
+    #[error("born-public lifecycle event does not exactly match fhe_eval outputs")]
+    BornPublicMismatch,
+    #[error("born-public lifecycle event contains duplicate accounts or handles")]
+    DuplicateBornPublicOutput,
     #[error("borsh decode failed: {0}")]
     Borsh(String),
 }
@@ -252,7 +244,7 @@ pub fn decode_instructions(ix: &RawInstruction) -> Result<Vec<DecodedInstruction
             handle,
         }])
     } else if disc == discriminator("fhe_eval") {
-        // Without the op events (single-instruction decode), no born-public
+        // Without the lifecycle batch (single-instruction decode), no born-public
         // output handle can be resolved; those leaves fail closed at proof time.
         decode_fhe_eval_instruction(ix, &[])
     } else {
@@ -260,22 +252,19 @@ pub fn decode_instructions(ix: &RawInstruction) -> Result<Vec<DecodedInstruction
     }
 }
 
-/// Decodes one `fhe_eval` instruction's durable outputs, resolving each
-/// born-public output's handle from `op_event_results` (the transaction's
-/// op events, in step/emission order). Pass an empty slice when the events are
-/// unavailable.
 fn decode_fhe_eval_instruction(
     ix: &RawInstruction,
-    op_event_results: &[[u8; 32]],
+    born_public_handles: &[Option<[u8; 32]>],
 ) -> Result<Vec<DecodedInstruction>, DecodeError> {
     let (disc, mut body) = ix.data.split_at(8);
     debug_assert_eq!(disc, discriminator("fhe_eval"));
     let plan = FheEvalArgs::deserialize(&mut body).map_err(borsh_err)?;
-    decode_fhe_eval_durable_outputs(ix, &plan, op_event_results)
+    decode_fhe_eval_durable_outputs(ix, &plan, born_public_handles)
 }
 
 /// Back-compat helper for tests and single-output callers. Transaction replay
-/// uses [`decode_instructions`] so multi-output `fhe_eval` frames are preserved.
+/// uses [`decode_program_instructions`] so multi-output `fhe_eval` frames and
+/// their lifecycle batches are validated together.
 pub fn decode_instruction(ix: &RawInstruction) -> Result<Option<DecodedInstruction>, DecodeError> {
     Ok(decode_instructions(ix)?.into_iter().next())
 }
@@ -313,17 +302,8 @@ fn fhe_eval_durable_output_account(
 fn decode_fhe_eval_durable_outputs(
     ix: &RawInstruction,
     plan: &FheEvalArgs,
-    op_event_results: &[[u8; 32]],
+    born_public_handles: &[Option<[u8; 32]>],
 ) -> Result<Vec<DecodedInstruction>, DecodeError> {
-    // Correlation contract: the host emits exactly one op event per plan step,
-    // in step order (see `fhe_eval/walk.rs`), so the durable output produced by
-    // step `i` binds `op_event_results[i]`. Only trust the events when their
-    // count matches the plan exactly; a mismatch means the events for this
-    // instruction were not captured whole (e.g. log-transported large frames we
-    // do not yet read), so resolve no handles and let born-public leaves fail
-    // closed rather than risk a wrong correlation. A wrong-but-well-formed handle
-    // is still caught by the on-chain peak cross-check at proof time (DD-035).
-    let output_handles = (op_event_results.len() == plan.steps.len()).then_some(op_event_results);
     let mut out = Vec::new();
     for (step_index, step) in plan.steps.iter().enumerate() {
         let FheEvalOutput::AllowedDurable {
@@ -339,7 +319,7 @@ fn decode_fhe_eval_durable_outputs(
         };
         let encrypted_value = fhe_eval_durable_output_account(ix, *output_encrypted_value_index)?;
         let make_public_handle = if *make_public {
-            output_handles.map(|handles| handles[step_index])
+            born_public_handles.get(step_index).copied().flatten()
         } else {
             None
         };
@@ -389,6 +369,131 @@ fn fhe_eval_step_output(step: &FheEvalStep) -> &FheEvalOutput {
     }
 }
 
+fn is_born_public_event(ix: &RawInstruction, program_id: [u8; 32]) -> bool {
+    ix.program_id == program_id
+        && ix.data.starts_with(&ANCHOR_EVENT_IX_TAG_LE)
+        && ix.data.get(8..16) == Some(event_discriminator("PublicOutputsProducedEvent").as_slice())
+}
+
+fn decode_born_public_event(
+    ix: &RawInstruction,
+    program_id: [u8; 32],
+) -> Result<Vec<BornPublicOutput>, DecodeError> {
+    if ix.program_id != program_id
+        || ix.accounts.as_slice() != [zama_host::EVENT_AUTHORITY_AND_BUMP.0.to_bytes()]
+    {
+        return Err(DecodeError::InvalidBornPublicEnvelope);
+    }
+    // RPC compiled inner instructions do not expose CPI AccountMeta flags.
+    // Because failed transactions are discarded in `chain`, successful Anchor
+    // dispatch with this exact PDA proves the host supplied its signer seeds;
+    // #3136 separately pins the on-chain meta as signed and readonly.
+    let mut body = ix
+        .data
+        .strip_prefix(&ANCHOR_EVENT_IX_TAG_LE)
+        .and_then(|data| data.strip_prefix(&event_discriminator("PublicOutputsProducedEvent")))
+        .ok_or(DecodeError::InvalidBornPublicEnvelope)?;
+    let version = u8::deserialize(&mut body)
+        .map_err(|e| DecodeError::MalformedBornPublicEvent(e.to_string()))?;
+    if version != zama_host::PUBLIC_OUTPUTS_PRODUCED_EVENT_VERSION {
+        return Err(DecodeError::UnsupportedBornPublicVersion(version));
+    }
+    const RECORD_BYTES: usize = 66;
+    let count_bytes: [u8; 4] = body
+        .get(..4)
+        .ok_or_else(|| DecodeError::MalformedBornPublicEvent("missing record count".to_string()))?
+        .try_into()
+        .expect("record count slice has fixed length");
+    let count = u32::from_le_bytes(count_bytes) as usize;
+    let expected_len = count
+        .checked_mul(RECORD_BYTES)
+        .and_then(|records| records.checked_add(4))
+        .ok_or_else(|| {
+            DecodeError::MalformedBornPublicEvent(
+                "record count overflows encoded length".to_string(),
+            )
+        })?;
+    // The producer emits no event for an empty batch, so an encoded batch must
+    // contain at least one record.
+    if !(1..=zama_host::MAX_FHE_EVAL_OPS).contains(&count) || body.len() != expected_len {
+        return Err(DecodeError::MalformedBornPublicEvent(format!(
+            "invalid record count or encoded length: count={count}, bytes={}",
+            body.len()
+        )));
+    }
+    let outputs = <Vec<zama_host::events::ProducedPublicOutput>>::deserialize(&mut body)
+        .map_err(|e| DecodeError::MalformedBornPublicEvent(e.to_string()))?;
+    if !body.is_empty() {
+        return Err(DecodeError::MalformedBornPublicEvent(
+            "trailing-byte payload".to_string(),
+        ));
+    }
+    Ok(outputs
+        .into_iter()
+        .map(|output| BornPublicOutput {
+            step_index: output.step_index,
+            encrypted_value: output.encrypted_value.to_bytes(),
+            output_handle: output.output_handle,
+        })
+        .collect())
+}
+
+fn expected_born_public_outputs(
+    ix: &RawInstruction,
+    plan: &FheEvalArgs,
+) -> Result<Vec<(u16, [u8; 32])>, DecodeError> {
+    plan.steps
+        .iter()
+        .enumerate()
+        .filter_map(|(step_index, step)| {
+            let FheEvalOutput::AllowedDurable {
+                output_encrypted_value_index,
+                make_public: true,
+                ..
+            } = fhe_eval_step_output(step)
+            else {
+                return None;
+            };
+            Some(
+                fhe_eval_durable_output_account(ix, *output_encrypted_value_index)
+                    .map(|account| (step_index as u16, account)),
+            )
+        })
+        .collect()
+}
+
+fn validate_born_public_event(
+    expected: &[(u16, [u8; 32])],
+    actual: Vec<BornPublicOutput>,
+    step_count: usize,
+) -> Result<Vec<Option<[u8; 32]>>, DecodeError> {
+    let mut accounts = std::collections::HashSet::with_capacity(actual.len());
+    let mut handles = std::collections::HashSet::with_capacity(actual.len());
+    if actual.iter().any(|record| {
+        !accounts.insert(record.encrypted_value) || !handles.insert(record.output_handle)
+    }) {
+        return Err(DecodeError::DuplicateBornPublicOutput);
+    }
+    if actual.len() != expected.len()
+        || actual
+            .iter()
+            .zip(expected)
+            .any(|(record, (step_index, account))| {
+                record.step_index != *step_index || record.encrypted_value != *account
+            })
+    {
+        return Err(DecodeError::BornPublicMismatch);
+    }
+    let mut handles_by_step = vec![None; step_count];
+    for record in actual {
+        let slot = handles_by_step
+            .get_mut(usize::from(record.step_index))
+            .ok_or(DecodeError::BornPublicMismatch)?;
+        *slot = Some(record.output_handle);
+    }
+    Ok(handles_by_step)
+}
+
 /// Decodes every instruction in a transaction targeting `program_id`, in the
 /// order supplied (caller is responsible for top-level/inner interleaving —
 /// see `chain::flatten_execution_order`). Ignores instructions for other programs.
@@ -396,30 +501,65 @@ pub fn decode_program_instructions(
     program_id: [u8; 32],
     instructions: &[RawInstruction],
 ) -> Result<Vec<DecodedInstruction>, DecodeError> {
+    if instructions
+        .iter()
+        .any(|ix| matches!(ix.stack_height, None | Some(0)))
+    {
+        return Err(DecodeError::InvalidStackMetadata);
+    }
     let mut out = Vec::new();
     let mut index = 0;
     while index < instructions.len() {
         let ix = &instructions[index];
+        if is_born_public_event(ix, program_id) {
+            return Err(DecodeError::UnexpectedBornPublicEvent);
+        }
         if ix.program_id != program_id {
             index += 1;
             continue;
         }
         if is_fhe_eval(ix) {
-            // `fhe_eval`'s `emit_cpi!` op events are its own inner instructions,
-            // which `chain::flatten_execution_order` places immediately after it
-            // in execution order. Collect that contiguous run to resolve
-            // born-public output handles for this frame.
-            let mut op_event_results = Vec::new();
-            let mut next = index + 1;
-            while let Some(result) = instructions
-                .get(next)
-                .and_then(|ev| op_event_result(ev, program_id))
-            {
-                op_event_results.push(result);
-                next += 1;
+            let mut body = &ix.data[8..];
+            let plan = FheEvalArgs::deserialize(&mut body).map_err(borsh_err)?;
+            let expected = expected_born_public_outputs(ix, &plan)?;
+            let eval_height = ix.stack_height.ok_or(DecodeError::InvalidStackMetadata)?;
+            let event_height = eval_height
+                .checked_add(1)
+                .ok_or(DecodeError::InvalidStackMetadata)?;
+            let mut frame_end = index + 1;
+            while let Some(child) = instructions.get(frame_end) {
+                let child_height = child
+                    .stack_height
+                    .ok_or(DecodeError::InvalidStackMetadata)?;
+                if child.top_level_index != ix.top_level_index || child_height <= eval_height {
+                    break;
+                }
+                frame_end += 1;
             }
-            out.extend(decode_fhe_eval_instruction(ix, &op_event_results)?);
-            index = next;
+            let event_indexes = (index + 1..frame_end)
+                .filter(|&child| is_born_public_event(&instructions[child], program_id))
+                .collect::<Vec<_>>();
+            if instructions[index + 1..frame_end].iter().any(|child| {
+                child.program_id == program_id && !is_born_public_event(child, program_id)
+            }) {
+                return Err(DecodeError::UnexpectedHostDescendant);
+            }
+            let handles = match (expected.is_empty(), event_indexes.as_slice()) {
+                (true, []) => vec![None; plan.steps.len()],
+                (true, _) => return Err(DecodeError::UnexpectedBornPublicEvent),
+                (false, []) => return Err(DecodeError::MissingBornPublicEvent),
+                (false, [event_index]) => {
+                    let event_ix = &instructions[*event_index];
+                    if event_ix.stack_height != Some(event_height) {
+                        return Err(DecodeError::InvalidBornPublicEnvelope);
+                    }
+                    let actual = decode_born_public_event(event_ix, program_id)?;
+                    validate_born_public_event(&expected, actual, plan.steps.len())?
+                }
+                (false, _) => return Err(DecodeError::UnexpectedBornPublicEvent),
+            };
+            out.extend(decode_fhe_eval_durable_outputs(ix, &plan, &handles)?);
+            index = frame_end;
         } else {
             out.extend(decode_instructions(ix)?);
             index += 1;
@@ -438,7 +578,7 @@ mod tests {
     use anchor_lang::prelude::Pubkey;
     use anchor_lang::AnchorSerialize;
     use borsh::BorshSerialize;
-    use zama_host::state::{AclSubjectEntry, FheEvalOperand, FheEvalOutput, FheEvalStep};
+    use zama_host::state::{AclSubjectEntry, FheEvalOutput, FheEvalStep};
 
     fn program_id() -> [u8; 32] {
         [7u8; 32]
@@ -455,6 +595,8 @@ mod tests {
             program_id: program_id(),
             accounts,
             data,
+            top_level_index: 0,
+            stack_height: Some(1),
         }
     }
 
@@ -469,6 +611,8 @@ mod tests {
             program_id: program_id(),
             accounts,
             data,
+            top_level_index: 0,
+            stack_height: Some(1),
         }
     }
 
@@ -545,117 +689,27 @@ mod tests {
         output
     }
 
-    /// Builds the `emit_cpi!` op-event inner instruction the host emits per step,
-    /// carrying the verified output `result` handle (here a `TrivialEncryptEvent`).
-    fn op_event_ix(result: [u8; 32]) -> RawInstruction {
-        op_event_ix_named("TrivialEncryptEvent", result)
-    }
-
-    fn op_event_ix_named(event_name: &str, result: [u8; 32]) -> RawInstruction {
-        use zama_host::events::{
-            FheBinaryOpEvent, FheIsInEvent, FheMulDivEvent, FheRandBoundedEvent, FheRandEvent,
-            FheSumEvent, FheTernaryOpEvent, FheUnaryOpEvent, TrivialEncryptEvent,
-        };
-        use zama_host::state::{FheBinaryOpCode, FheTernaryOpCode, FheUnaryOpCode};
-
+    fn born_public_event_ix(records: &[(u16, [u8; 32], [u8; 32])]) -> RawInstruction {
         let mut data = ANCHOR_EVENT_IX_TAG_LE.to_vec();
-        data.extend_from_slice(&event_discriminator(event_name));
-        match event_name {
-            "FheBinaryOpEvent" => FheBinaryOpEvent {
-                version: 1,
-                op: FheBinaryOpCode::Add,
-                subject: pk(0x30),
-                lhs: pk(0x10),
-                rhs: pk(0x11),
-                scalar: false,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheTernaryOpEvent" => FheTernaryOpEvent {
-                version: 1,
-                op: FheTernaryOpCode::IfThenElse,
-                subject: pk(0x30),
-                control: pk(0x10),
-                if_true: pk(0x11),
-                if_false: pk(0x12),
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "TrivialEncryptEvent" => TrivialEncryptEvent {
-                version: 1,
-                subject: pk(0x30),
-                plaintext: pk(0x02),
-                fhe_type: 5,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheRandEvent" => FheRandEvent {
-                version: 1,
-                subject: pk(0x30),
-                seed: [0x44; 16],
-                fhe_type: 5,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheRandBoundedEvent" => FheRandBoundedEvent {
-                version: 1,
-                subject: pk(0x30),
-                upper_bound: pk(0x13),
-                seed: [0x44; 16],
-                fhe_type: 5,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheUnaryOpEvent" => FheUnaryOpEvent {
-                version: 1,
-                op: FheUnaryOpCode::Neg,
-                subject: pk(0x30),
-                operand: pk(0x10),
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheSumEvent" => FheSumEvent {
-                version: 1,
-                subject: pk(0x30),
-                operands: vec![pk(0x10), pk(0x11)],
-                fhe_type: 5,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheIsInEvent" => FheIsInEvent {
-                version: 1,
-                subject: pk(0x30),
-                value: pk(0x10),
-                set: vec![pk(0x11), pk(0x12)],
-                fhe_type: 5,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            "FheMulDivEvent" => FheMulDivEvent {
-                version: 1,
-                subject: pk(0x30),
-                factor1: pk(0x10),
-                factor2: pk(0x11),
-                divisor: pk(0x12),
-                scalar: true,
-                result,
-            }
-            .serialize(&mut data)
-            .unwrap(),
-            other => panic!("unhandled test event type: {other}"),
-        };
+        data.extend_from_slice(&event_discriminator("PublicOutputsProducedEvent"));
+        data.push(zama_host::PUBLIC_OUTPUTS_PRODUCED_EVENT_VERSION);
+        let records = records
+            .iter()
+            .map(|(step_index, encrypted_value, output_handle)| {
+                zama_host::events::ProducedPublicOutput {
+                    step_index: *step_index,
+                    encrypted_value: Pubkey::new_from_array(*encrypted_value),
+                    output_handle: *output_handle,
+                }
+            })
+            .collect::<Vec<_>>();
+        AnchorSerialize::serialize(&records, &mut data).unwrap();
         RawInstruction {
             program_id: program_id(),
-            accounts: vec![pk(0xEE), program_id()],
+            accounts: vec![zama_host::EVENT_AUTHORITY_AND_BUMP.0.to_bytes()],
             data,
+            top_level_index: 0,
+            stack_height: Some(2),
         }
     }
 
@@ -795,6 +849,8 @@ mod tests {
             program_id: program_id(),
             accounts: vec![pk(0), pk(0), pk(0)],
             data,
+            top_level_index: 0,
+            stack_height: Some(1),
         };
         assert_eq!(decode_instruction(&ix).unwrap(), None);
     }
@@ -815,235 +871,227 @@ mod tests {
             program_id: program_id(),
             accounts: vec![],
             data: vec![1, 2, 3],
+            top_level_index: 0,
+            stack_height: Some(1),
         };
         assert_eq!(decode_instruction(&ix), Err(DecodeError::DataTooShort));
     }
 
-    #[test]
-    fn op_event_result_extracts_handle_from_emit_cpi_event() {
-        let ix = op_event_ix(pk(0x21));
-        assert_eq!(op_event_result(&ix, program_id()), Some(pk(0x21)));
-    }
-
-    #[test]
-    fn op_event_result_accepts_all_fhe_eval_event_kinds() {
-        for event_name in OP_EVENT_NAMES {
-            let ix = op_event_ix_named(event_name, pk(0x21));
-            assert_eq!(
-                op_event_result(&ix, program_id()),
-                Some(pk(0x21)),
-                "{event_name} should carry a decodable result handle"
-            );
-        }
-    }
-
-    #[test]
-    fn op_event_result_ignores_non_event_and_foreign_program_instructions() {
-        // A zama-host instruction that is not an emit_cpi event.
-        let not_event = ix_with_data(vec![], "make_handle_public", pk(0x20));
-        assert_eq!(op_event_result(&not_event, program_id()), None);
-        // The right bytes but a different program id (not a self-CPI).
-        let mut foreign = op_event_ix(pk(0x21));
-        foreign.program_id = pk(0xFF);
-        assert_eq!(op_event_result(&foreign, program_id()), None);
-    }
-
-    #[test]
-    fn born_public_output_handle_is_resolved_from_the_following_op_event() {
-        let ev = pk(0xE0);
-        let burn_handle = pk(0x21);
-        let plan = FheEvalArgs {
-            context_id: pk(0x01),
-            steps: vec![FheEvalStep::TrivialEncrypt {
-                plaintext: pk(0x02),
-                fhe_type: 5,
-                output: make_public_durable_output(0, &[0x30], Some(pk(0x20)), Some(&[0x30])),
-            }],
-        };
-        let eval_ix = ix_with_anchor_data(fhe_eval_accounts(&[ev]), "fhe_eval", plan);
-        let decoded =
-            decode_program_instructions(program_id(), &[eval_ix, op_event_ix(burn_handle)])
-                .unwrap();
-        assert_eq!(
-            decoded,
-            vec![DecodedInstruction::FheEvalUpdateEncryptedValue {
-                encrypted_value: ev,
-                previous_handle: pk(0x20),
-                previous_subjects: vec![pk(0x30)],
-                output_subjects: vec![pk(0x30)],
-                make_public_handle: Some(burn_handle),
-            }]
-        );
-    }
-
-    #[test]
-    fn born_public_output_stays_unresolved_when_event_count_mismatches_plan() {
-        // One durable step but no op event captured: the correlation count check
-        // fails, so no handle is resolved and the born-public leaf fails closed.
-        let ev = pk(0xE0);
-        let plan = FheEvalArgs {
-            context_id: pk(0x01),
-            steps: vec![FheEvalStep::TrivialEncrypt {
-                plaintext: pk(0x02),
-                fhe_type: 5,
-                output: make_public_durable_output(0, &[0x30], Some(pk(0x20)), Some(&[0x30])),
-            }],
-        };
-        let eval_ix = ix_with_anchor_data(fhe_eval_accounts(&[ev]), "fhe_eval", plan);
-        let decoded = decode_program_instructions(program_id(), &[eval_ix]).unwrap();
-        assert_eq!(
-            decoded,
-            vec![DecodedInstruction::FheEvalUpdateEncryptedValue {
-                encrypted_value: ev,
-                previous_handle: pk(0x20),
-                previous_subjects: vec![pk(0x30)],
-                output_subjects: vec![pk(0x30)],
-                make_public_handle: None,
-            }]
-        );
-    }
-
-    #[test]
-    fn multi_step_born_public_binds_each_output_to_its_own_step_event() {
-        // Two durable outputs; the born-public one is the SECOND step, so it must
-        // bind the SECOND event's handle, proving per-step (not positional-in-
-        // durable-subset) correlation.
+    fn two_born_public_outputs() -> (RawInstruction, RawInstruction) {
         let ev0 = pk(0xE0);
         let ev1 = pk(0xE1);
-        let first_handle = pk(0x50);
-        let second_handle = pk(0x51);
         let plan = FheEvalArgs {
             context_id: pk(0x01),
             steps: vec![
                 FheEvalStep::TrivialEncrypt {
                     plaintext: pk(0x02),
                     fhe_type: 5,
-                    output: durable_output(0, &[0x30], None, None),
+                    output: make_public_durable_output(0, &[0x30], None, None),
                 },
                 FheEvalStep::TrivialEncrypt {
                     plaintext: pk(0x03),
                     fhe_type: 5,
-                    output: make_public_durable_output(1, &[0x30], Some(pk(0x20)), Some(&[0x30])),
+                    output: make_public_durable_output(1, &[0x31], Some(pk(0x20)), Some(&[0x31])),
                 },
             ],
         };
-        let eval_ix = ix_with_anchor_data(fhe_eval_accounts(&[ev0, ev1]), "fhe_eval", plan);
-        let decoded = decode_program_instructions(
-            program_id(),
-            &[
-                eval_ix,
-                op_event_ix(first_handle),
-                op_event_ix(second_handle),
-            ],
-        )
-        .unwrap();
+        let eval = ix_with_anchor_data(fhe_eval_accounts(&[ev0, ev1]), "fhe_eval", plan);
+        let event = born_public_event_ix(&[(0, ev0, pk(0x50)), (1, ev1, pk(0x51))]);
+        (eval, event)
+    }
+
+    #[test]
+    fn exact_born_public_batch_resolves_each_durable_output() {
+        let (eval, event) = two_born_public_outputs();
+        let decoded = decode_program_instructions(program_id(), &[eval, event]).unwrap();
         assert_eq!(
             decoded,
             vec![
                 DecodedInstruction::FheEvalCreateEncryptedValue {
-                    encrypted_value: ev0,
+                    encrypted_value: pk(0xE0),
                     subjects: vec![SubjectGrant { subject: pk(0x30) }],
-                    make_public_handle: None,
+                    make_public_handle: Some(pk(0x50)),
                 },
                 DecodedInstruction::FheEvalUpdateEncryptedValue {
-                    encrypted_value: ev1,
+                    encrypted_value: pk(0xE1),
                     previous_handle: pk(0x20),
-                    previous_subjects: vec![pk(0x30)],
-                    output_subjects: vec![pk(0x30)],
-                    make_public_handle: Some(second_handle),
+                    previous_subjects: vec![pk(0x31)],
+                    output_subjects: vec![pk(0x31)],
+                    make_public_handle: Some(pk(0x51)),
                 },
             ]
         );
     }
 
     #[test]
-    fn born_public_output_handle_is_resolved_for_new_operator_variants() {
-        let ev = pk(0xE0);
-        let burn_handle = pk(0x21);
-        let operators = [
-            (
-                "unary",
-                FheEvalStep::Unary {
-                    op: zama_host::state::FheUnaryOpCode::Neg,
-                    operand: FheEvalOperand::AllowedDurable {
-                        handle: pk(0x10),
-                        encrypted_value_index: 1,
-                    },
-                    output_fhe_type: 5,
-                    output: make_public_durable_output(0, &[0x30], Some(pk(0x20)), Some(&[0x30])),
-                },
-                "FheUnaryOpEvent",
-            ),
-            (
-                "sum",
-                FheEvalStep::Sum {
-                    operands: vec![FheEvalOperand::AllowedDurable {
-                        handle: pk(0x10),
-                        encrypted_value_index: 1,
-                    }],
-                    fhe_type: 5,
-                    output: make_public_durable_output(0, &[0x30], Some(pk(0x20)), Some(&[0x30])),
-                },
-                "FheSumEvent",
-            ),
-            (
-                "is_in",
-                FheEvalStep::IsIn {
-                    value: FheEvalOperand::AllowedDurable {
-                        handle: pk(0x10),
-                        encrypted_value_index: 1,
-                    },
-                    set: vec![FheEvalOperand::AllowedDurable {
-                        handle: pk(0x11),
-                        encrypted_value_index: 2,
-                    }],
-                    fhe_type: 5,
-                    output: make_public_durable_output(0, &[0x30], Some(pk(0x20)), Some(&[0x30])),
-                },
-                "FheIsInEvent",
-            ),
-            (
-                "mul_div",
-                FheEvalStep::MulDiv {
-                    factor1: FheEvalOperand::AllowedDurable {
-                        handle: pk(0x10),
-                        encrypted_value_index: 1,
-                    },
-                    factor2: FheEvalOperand::Scalar(pk(0x11)),
-                    divisor: pk(0x12),
-                    output_fhe_type: 5,
-                    output: make_public_durable_output(0, &[0x30], Some(pk(0x20)), Some(&[0x30])),
-                },
-                "FheMulDivEvent",
-            ),
-        ];
+    fn batches_are_associated_with_their_enclosing_fhe_eval() {
+        let (mut first_eval, mut first_event) = two_born_public_outputs();
+        first_eval.stack_height = Some(2);
+        first_event.stack_height = Some(3);
+        let (mut second_eval, mut second_event) = two_born_public_outputs();
+        second_eval.stack_height = Some(2);
+        second_event.stack_height = Some(3);
+        second_event.data =
+            born_public_event_ix(&[(0, pk(0xE0), pk(0x60)), (1, pk(0xE1), pk(0x61))]).data;
 
-        for (name, step, event_name) in operators {
-            let plan = FheEvalArgs {
-                context_id: pk(0x01),
-                steps: vec![step],
-            };
-            let eval_ix = ix_with_anchor_data(
-                fhe_eval_accounts(&[ev, pk(0xD1), pk(0xD2)]),
-                "fhe_eval",
-                plan,
-            );
-            let decoded = decode_program_instructions(
-                program_id(),
-                &[eval_ix, op_event_ix_named(event_name, burn_handle)],
-            )
-            .unwrap();
-            assert_eq!(
-                decoded,
-                vec![DecodedInstruction::FheEvalUpdateEncryptedValue {
-                    encrypted_value: ev,
-                    previous_handle: pk(0x20),
-                    previous_subjects: vec![pk(0x30)],
-                    output_subjects: vec![pk(0x30)],
-                    make_public_handle: Some(burn_handle),
-                }],
-                "{name} born-public output should resolve from its op event"
-            );
-        }
+        let decoded = decode_program_instructions(
+            program_id(),
+            &[first_eval, first_event, second_eval, second_event],
+        )
+        .unwrap();
+
+        assert_eq!(decoded.len(), 4);
+        assert!(matches!(
+            &decoded[2],
+            DecodedInstruction::FheEvalCreateEncryptedValue {
+                make_public_handle: Some(handle),
+                ..
+            } if *handle == pk(0x60)
+        ));
+    }
+
+    #[test]
+    fn missing_born_public_batch_fails_closed() {
+        let (eval, _) = two_born_public_outputs();
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval]),
+            Err(DecodeError::MissingBornPublicEvent)
+        );
+    }
+
+    #[test]
+    fn extra_batch_for_non_public_frame_fails_closed() {
+        let plan = FheEvalArgs {
+            context_id: pk(0x01),
+            steps: vec![FheEvalStep::TrivialEncrypt {
+                plaintext: pk(0x02),
+                fhe_type: 5,
+                output: durable_output(0, &[0x30], None, None),
+            }],
+        };
+        let eval = ix_with_anchor_data(fhe_eval_accounts(&[pk(0xE0)]), "fhe_eval", plan);
+        let event = born_public_event_ix(&[(0, pk(0xE0), pk(0x50))]);
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, event]),
+            Err(DecodeError::UnexpectedBornPublicEvent)
+        );
+    }
+
+    #[test]
+    fn reordered_or_mismatched_born_public_batch_fails_closed() {
+        let (eval, _) = two_born_public_outputs();
+        let reordered = born_public_event_ix(&[(1, pk(0xE1), pk(0x51)), (0, pk(0xE0), pk(0x50))]);
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, reordered]),
+            Err(DecodeError::BornPublicMismatch)
+        );
+    }
+
+    #[test]
+    fn duplicate_accounts_and_handles_fail_closed() {
+        let (eval, _) = two_born_public_outputs();
+        let duplicate_account =
+            born_public_event_ix(&[(0, pk(0xE0), pk(0x50)), (1, pk(0xE0), pk(0x51))]);
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval.clone(), duplicate_account],),
+            Err(DecodeError::DuplicateBornPublicOutput)
+        );
+        let duplicate_handle =
+            born_public_event_ix(&[(0, pk(0xE0), pk(0x50)), (1, pk(0xE1), pk(0x50))]);
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, duplicate_handle]),
+            Err(DecodeError::DuplicateBornPublicOutput)
+        );
+    }
+
+    #[test]
+    fn malformed_unknown_version_and_wrong_envelope_fail_closed() {
+        let (eval, mut malformed) = two_born_public_outputs();
+        malformed.data.push(0);
+        assert!(matches!(
+            decode_program_instructions(program_id(), &[eval.clone(), malformed]),
+            Err(DecodeError::MalformedBornPublicEvent(_))
+        ));
+
+        let (_, mut unknown_version) = two_born_public_outputs();
+        unknown_version.data[16] = 99;
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval.clone(), unknown_version],),
+            Err(DecodeError::UnsupportedBornPublicVersion(99))
+        );
+
+        let (_, mut wrong_envelope) = two_born_public_outputs();
+        wrong_envelope.accounts = vec![pk(0xEE)];
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, wrong_envelope]),
+            Err(DecodeError::InvalidBornPublicEnvelope)
+        );
+    }
+
+    #[test]
+    fn huge_declared_record_count_fails_before_record_decode() {
+        let (eval, mut event) = two_born_public_outputs();
+        event.data.truncate(21);
+        event.data[17..21].copy_from_slice(&u32::MAX.to_le_bytes());
+
+        assert!(matches!(
+            decode_program_instructions(program_id(), &[eval, event]),
+            Err(DecodeError::MalformedBornPublicEvent(_))
+        ));
+    }
+
+    #[test]
+    fn oversized_batch_fails_closed() {
+        let (eval, _) = two_born_public_outputs();
+        let records = (0..=zama_host::MAX_FHE_EVAL_OPS)
+            .map(|index| (index as u16, [index as u8; 32], [(index + 1) as u8; 32]))
+            .collect::<Vec<_>>();
+        let oversized = born_public_event_ix(&records);
+        assert!(matches!(
+            decode_program_instructions(program_id(), &[eval, oversized]),
+            Err(DecodeError::MalformedBornPublicEvent(_))
+        ));
+    }
+
+    #[test]
+    fn extra_unconsumed_and_wrongly_nested_batches_fail_closed() {
+        let (eval, event) = two_born_public_outputs();
+        assert_eq!(
+            decode_program_instructions(program_id(), &[event.clone(), eval.clone()]),
+            Err(DecodeError::UnexpectedBornPublicEvent)
+        );
+
+        let mut wrong_nesting = event;
+        wrong_nesting.stack_height = Some(3);
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, wrong_nesting]),
+            Err(DecodeError::InvalidBornPublicEnvelope)
+        );
+    }
+
+    #[test]
+    fn unexpected_host_descendant_inside_eval_frame_fails_closed() {
+        let (eval, event) = two_born_public_outputs();
+        let mut nested_host_instruction = ix_with_data(
+            vec![pk(0xA), pk(0xB), pk(0xE0)],
+            "make_handle_public",
+            pk(0x50),
+        );
+        nested_host_instruction.stack_height = Some(2);
+
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, nested_host_instruction, event],),
+            Err(DecodeError::UnexpectedHostDescendant)
+        );
+    }
+
+    #[test]
+    fn missing_stack_metadata_fails_closed() {
+        let (eval, mut event) = two_born_public_outputs();
+        event.stack_height = None;
+        assert_eq!(
+            decode_program_instructions(program_id(), &[eval, event]),
+            Err(DecodeError::InvalidStackMetadata)
+        );
     }
 }

--- a/relayer/src/solana_proof/ingest.rs
+++ b/relayer/src/solana_proof/ingest.rs
@@ -404,6 +404,8 @@ mod tests {
             program_id,
             accounts,
             data,
+            top_level_index: 0,
+            stack_height: Some(1),
         }
     }
 
@@ -599,6 +601,34 @@ mod tests {
         let cursor = store.get_cursor().await.unwrap().unwrap();
         assert_eq!(cursor.last_signature, Some("sig3".to_string()));
         assert_eq!(cursor.last_slot, 3);
+    }
+
+    #[tokio::test]
+    async fn decode_failure_does_not_advance_cursor_or_store_state() {
+        let program_id = pk(0x99);
+        let chain = FakeChain::new(program_id);
+        chain.push_tx(
+            "malformed",
+            1,
+            &[],
+            vec![RawInstruction {
+                program_id,
+                accounts: vec![],
+                data: vec![1, 2, 3],
+                top_level_index: 0,
+                stack_height: Some(1),
+            }],
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileLeafStore::open(dir.path().join("leaves.json"))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            poll_once(&chain, &store, program_id, 100, 100).await,
+            Err(IngestError::Decode(_))
+        ));
+        assert_eq!(store.get_cursor().await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/relayer/src/solana_proof/proof.rs
+++ b/relayer/src/solana_proof/proof.rs
@@ -173,6 +173,8 @@ mod tests {
             program_id,
             accounts,
             data,
+            top_level_index: 0,
+            stack_height: Some(1),
         }
     }
 
@@ -187,26 +189,31 @@ mod tests {
         out
     }
 
-    /// Builds the inner instruction the host emits for a `TrivialEncrypt` op via
-    /// `emit_cpi!`: a self-CPI whose data is the Anchor event sentinel + event
-    /// discriminator + borsh event, carrying the verified output `result` handle.
-    fn trivial_encrypt_event_ix(program_id: [u8; 32], result: [u8; 32]) -> RawInstruction {
+    fn born_public_event_ix(
+        program_id: [u8; 32],
+        lineage: [u8; 32],
+        result: [u8; 32],
+    ) -> RawInstruction {
         use anchor_lang::AnchorSerialize;
-        use zama_host::events::TrivialEncryptEvent;
-        let event = TrivialEncryptEvent {
-            version: 1,
-            subject: pk(0x30),
-            plaintext: pk(0x02),
-            fhe_type: 5,
-            result,
-        };
+        use zama_host::events::ProducedPublicOutput;
         let mut data = ANCHOR_EVENT_IX_TAG_LE.to_vec();
-        data.extend_from_slice(&event_discriminator("TrivialEncryptEvent"));
-        event.serialize(&mut data).unwrap();
+        data.extend_from_slice(&event_discriminator("PublicOutputsProducedEvent"));
+        data.push(zama_host::PUBLIC_OUTPUTS_PRODUCED_EVENT_VERSION);
+        AnchorSerialize::serialize(
+            &vec![ProducedPublicOutput {
+                step_index: 0,
+                encrypted_value: Pubkey::new_from_array(lineage),
+                output_handle: result,
+            }],
+            &mut data,
+        )
+        .unwrap();
         RawInstruction {
             program_id,
-            accounts: vec![pk(0xEE), program_id],
+            accounts: vec![zama_host::EVENT_AUTHORITY_AND_BUMP.0.to_bytes()],
             data,
+            top_level_index: 0,
+            stack_height: Some(2),
         }
     }
 
@@ -772,7 +779,7 @@ mod tests {
     /// `public(new_burn_handle)`. The output handle behind the public leaf is
     /// derived on-chain from slot entropy and carried in NO instruction arg, so
     /// the relayer cannot recompute it from thin JSON-RPC. It is instead resolved
-    /// from the `TrivialEncryptEvent` the burn emits via `emit_cpi!` (an inner
+    /// from the born-public lifecycle batch the burn emits as an inner
     /// instruction of the `fhe_eval`, already flattened into the tx by
     /// `chain::flatten_execution_order`). With that handle the relayer now
     /// reconstructs all three leaves and serves a verified public-decrypt proof.
@@ -783,7 +790,7 @@ mod tests {
         let owner = pk(0x30);
         let compute = pk(0x31);
         let old_handle = pk(0x20);
-        // Derived on-chain from previous_bank_hash; recovered from the op event.
+        // Derived on-chain from previous_bank_hash; recovered from the lifecycle batch.
         let burn_handle = pk(0x21);
         let chain = FakeChain::new(program_id);
 
@@ -826,14 +833,14 @@ mod tests {
         );
 
         // The burn: an fhe_eval durable supersede output, born public inline,
-        // followed by its `emit_cpi!` op event carrying the output handle.
+        // followed by its narrow lifecycle batch carrying the output handle.
         chain.push_tx(
             "sig2",
             2,
             &[lineage],
             vec![
                 born_public_burn_ix(program_id, lineage, old_handle, owner, compute),
-                trivial_encrypt_event_ix(program_id, burn_handle),
+                born_public_event_ix(program_id, lineage, burn_handle),
             ],
         );
 
@@ -927,7 +934,7 @@ mod tests {
             &[lineage],
             vec![
                 born_public_burn_ix(program_id, lineage, old_handle, owner, compute),
-                trivial_encrypt_event_ix(program_id, forged_handle),
+                born_public_event_ix(program_id, lineage, forged_handle),
             ],
         );
 


### PR DESCRIPTION
Part of zama-ai/fhevm-internal#1675.

## Summary

- Replace legacy per-operation event correlation with exact `PublicOutputsProducedEvent` validation.
- Preserve top-level instruction indexes and RPC `stackHeight` so each lifecycle batch is bound to its immediate enclosing `fhe_eval`.
- Require the configured host program, canonical event-authority PDA, supported lifecycle version, bounded exact Borsh payload, and ordered one-to-one step/account records.
- Reject failed transactions before instruction decoding and fail closed on malformed execution topology or lifecycle data.
- Preserve the existing atomic replay/store boundary and confirmed MMR peak verification.

## Validation contract

For each successful `fhe_eval`, the relayer derives the expected produced-public `(step_index, encrypted_value)` records from the instruction plan. A frame with no produced public output must have no lifecycle batch; a nonempty frame must have exactly one immediate-child batch. Missing, extra, reordered, duplicate, malformed, oversized, unknown-version, wrongly nested, or unconsumed batches reject the entire transaction decode before store or cursor mutation.

RPC inner instructions do not expose CPI signer/readonly flags. Authentication therefore uses a confirmed successful transaction, the exact host event-dispatch instruction, and the exact seed-derived event-authority PDA. PR #3136 separately proves that the on-chain producer requests one signed readonly account meta.

## Operational contract

- Deploy relayer support before deploying a producer with a new lifecycle version; unknown versions intentionally halt ingestion.
- `stackHeight` is required for every inner instruction and is the RPC compatibility floor for this path.
- The producer emits no event for an empty batch; an encoded batch must contain `1..=MAX_FHE_EVAL_OPS` records.

## Evidence

- 65 Solana-proof subsystem tests passed after restack.
- Relayer formatting passed.
- Failed-transaction decoding and confirmed-RPC parameter tests are both retained.
- The atomic regression still proves lifecycle decode failure leaves the file-store cursor unset.
- The confirmed-peak mismatch regression still rejects a forged event handle.

## Boundaries

This PR consumes the protocol boundary introduced by #3136. It does not change the producer, replay/store architecture, Docker stack, or terminal full-vertical flow. General operation events remain non-authoritative and are not reintroduced.

## Stack

- Base: #3136.
- Next: terminal relayer-only two-leaf proof flow.
