### PR TITLE
chore(kms-connector): docs follow-up for raw private key

### DIFF
--- a/kms-connector/crates/gw-listener/src/core/config.rs
+++ b/kms-connector/crates/gw-listener/src/core/config.rs
@@ -14,13 +14,13 @@ use connector_utils::{
     tasks::default_task_limit,
 };
 use serde::Deserialize;
-#[cfg(debug_assertions)]
+#[cfg(test)]
 use serde::Serialize;
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 /// Configuration of the `GatewayListener`.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Config {
     /// The URL of the Postgres database.
     pub database_url: String,

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -14,14 +14,14 @@ use connector_utils::{
     monitoring::{health::default_healthcheck_timeout, server::default_monitoring_endpoint},
     tasks::default_task_limit,
 };
-#[cfg(debug_assertions)]
+#[cfg(test)]
 use serde::Serialize;
 use serde::{Deserialize, Deserializer};
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 /// Configuration of the `KmsWorker`.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Config {
     /// The URL of the Postgres database.
     pub database_url: String,
@@ -106,7 +106,7 @@ pub struct Config {
 
 /// Configuration of the off-chain ciphertext-attestation verifier.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 #[serde(default)]
 pub struct CtAttestationConfig {
     /// Whether the verifier runs at all. Defaults to `true`.
@@ -140,7 +140,7 @@ impl Default for CtAttestationConfig {
 
 /// Configuration of a single Host Chain.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HostChainConfig {
     /// The Host Chain RPC endpoint.
     pub url: Url,

--- a/kms-connector/crates/tx-sender/src/core/config.rs
+++ b/kms-connector/crates/tx-sender/src/core/config.rs
@@ -1,9 +1,9 @@
 use alloy::transports::http::reqwest::Url;
-#[cfg(debug_assertions)]
+#[cfg(test)]
 use connector_utils::config::serialize_pg_interval;
 use connector_utils::{
     config::{
-        AwsKmsConfig, ContractConfig, DeserializeConfig, Error, KmsWallet, PrivateKey,
+        AwsKmsConfig, ContractConfig, DeserializeConfig, Error, KmsWallet, TestingPrivateKey,
         contract::{
             default_decryption_contract_config, default_kms_generation_contract_config,
             default_protocol_config_contract_config, deserialize_decryption_contract_config,
@@ -15,7 +15,7 @@ use connector_utils::{
     monitoring::{health::default_healthcheck_timeout, server::default_monitoring_endpoint},
     tasks::default_task_limit,
 };
-#[cfg(debug_assertions)]
+#[cfg(test)]
 use serde::Serialize;
 use serde::{Deserialize, Deserializer};
 use sqlx::postgres::types::PgInterval;
@@ -23,7 +23,7 @@ use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 /// Configuration of the `TransactionSender`.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
-#[cfg_attr(debug_assertions, derive(Serialize))]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Config {
     /// The URL of the Postgres database.
     pub database_url: String,
@@ -66,7 +66,7 @@ pub struct Config {
     ///
     /// Intended for **testing purposes only** — production deployments should configure
     /// `aws_kms_config` instead.
-    pub private_key: Option<PrivateKey>,
+    pub private_key: Option<TestingPrivateKey>,
     /// The AWS KMS configuration of the `TransactionSender`'s wallet.
     pub aws_kms_config: Option<AwsKmsConfig>,
 

--- a/kms-connector/crates/utils/src/config/mod.rs
+++ b/kms-connector/crates/utils/src/config/mod.rs
@@ -7,7 +7,7 @@ pub use contract::ContractConfig;
 pub use deserialize::DeserializeConfig;
 pub use error::{Error, Result};
 use sqlx::postgres::types::PgInterval;
-pub use wallet::{AwsKmsConfig, KmsWallet, PrivateKey};
+pub use wallet::{AwsKmsConfig, KmsWallet, TestingPrivateKey};
 
 use serde::{Deserializer, Serializer};
 use std::time::Duration;

--- a/kms-connector/crates/utils/src/config/wallet.rs
+++ b/kms-connector/crates/utils/src/config/wallet.rs
@@ -30,32 +30,32 @@ pub enum KmsWallet {
 /// Configuring a raw private key is intended for **testing purposes only**.
 /// Production deployments should use an AWS KMS signer instead (see [`AwsKmsConfig`]).
 ///
-/// The inner secret is kept private and the [`Debug`] implementation redacts it, so the key
-/// is never leaked through debug logs.
+/// The [`Debug`] implementation redacts the inner secret, so the key is not leaked through debug
+/// logs.
 #[derive(Clone, Deserialize, PartialEq)]
 #[cfg_attr(debug_assertions, derive(Serialize))]
 #[serde(transparent)]
-pub struct PrivateKey(String);
+pub struct TestingPrivateKey(String);
 
-impl PrivateKey {
+impl TestingPrivateKey {
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
-impl std::fmt::Debug for PrivateKey {
+impl std::fmt::Debug for TestingPrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("PrivateKey(<redacted>)")
     }
 }
 
-impl From<String> for PrivateKey {
+impl From<String> for TestingPrivateKey {
     fn from(value: String) -> Self {
         Self(value)
     }
 }
 
-impl From<&str> for PrivateKey {
+impl From<&str> for TestingPrivateKey {
     fn from(value: &str) -> Self {
         Self(value.to_string())
     }


### PR DESCRIPTION
Follow-up of https://github.com/zama-ai/fhevm/pull/3121

- `Serialize` impl for `Config` only when compiled for `test` (not `debug_assertions`)
- Better name for the `TestingPrivateKey` struct matching its intent