### PR TITLE
fix(sdk): harden Solana config and proof hex

### DIFF
--- a/sdk/js-sdk/src/solana/internal/config.test.ts
+++ b/sdk/js-sdk/src/solana/internal/config.test.ts
@@ -1,0 +1,60 @@
+import type { FhevmRuntimeConfig } from '../../core/types/coreFhevmRuntime.js';
+import { describe, expect, it, vi } from 'vitest';
+
+type ConfigModule = typeof import('./config.js');
+
+async function loadConfigModule(): Promise<ConfigModule> {
+  vi.resetModules();
+  return import('./config.js');
+}
+
+describe('Solana runtime config', () => {
+  it('allows an identical normalized config with the same logger callbacks', async () => {
+    const { setFhevmRuntimeConfig } = await loadConfigModule();
+    const debug = vi.fn();
+    const warn = vi.fn();
+    const error = vi.fn();
+    const locateFile = (file: string): URL => new URL(file, 'https://example.test/');
+    const config: FhevmRuntimeConfig = {
+      locateFile,
+      wasmAssetLoadMode: 'verified-blob',
+      moduleVersions: { tfhe: '1.6.1', kms: '0.13.20-0', checkCompatibility: 'warn' },
+      logger: { debug, warn, error },
+      singleThread: false,
+      numberOfThreads: 4,
+      auth: { type: 'ApiKeyHeader', header: 'x-api-key', value: 'secret' },
+    };
+
+    setFhevmRuntimeConfig(config);
+
+    expect(() =>
+      setFhevmRuntimeConfig({
+        ...config,
+        logger: { debug, warn, error },
+        moduleVersions: { tfhe: '1.6.1', kms: '0.13.20-0', checkCompatibility: 'warn' },
+        auth: { type: 'ApiKeyHeader', header: 'x-api-key', value: 'secret' },
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects a changed logger callback', async () => {
+    const { setFhevmRuntimeConfig } = await loadConfigModule();
+    const logger = { debug: vi.fn(), error: vi.fn() };
+
+    setFhevmRuntimeConfig({ logger });
+
+    expect(() => setFhevmRuntimeConfig({ logger: { ...logger, debug: vi.fn() } })).toThrow(
+      'FhevmRuntime config has already been set and cannot be changed.',
+    );
+  });
+
+  it('rejects changed nested configuration', async () => {
+    const { setFhevmRuntimeConfig } = await loadConfigModule();
+
+    setFhevmRuntimeConfig({ auth: { type: 'ApiKeyHeader', value: 'first' } });
+
+    expect(() => setFhevmRuntimeConfig({ auth: { type: 'ApiKeyHeader', value: 'second' } })).toThrow(
+      'FhevmRuntime config has already been set and cannot be changed.',
+    );
+  });
+});

--- a/sdk/js-sdk/src/solana/internal/config.ts
+++ b/sdk/js-sdk/src/solana/internal/config.ts
@@ -1,6 +1,46 @@
 import type { FhevmRuntimeConfig } from '../../core/types/coreFhevmRuntime.js';
+import { cloneModuleVersions, moduleVersionsAreEqual } from '../../core/runtimeConfig-p.js';
 
 let solanaFhevmRuntimeConfig: FhevmRuntimeConfig | undefined;
+
+////////////////////////////////////////////////////////////////////////////////
+
+function loggersAreEqual(a: FhevmRuntimeConfig['logger'], b: FhevmRuntimeConfig['logger']): boolean {
+  return a === b || (a?.debug === b?.debug && a?.warn === b?.warn && a?.error === b?.error);
+}
+
+function authConfigsAreEqual(a: FhevmRuntimeConfig['auth'], b: FhevmRuntimeConfig['auth']): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a?.type !== b?.type) {
+    return false;
+  }
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+
+  switch (a.type) {
+    case 'BearerToken':
+      return b.type === 'BearerToken' && a.token === b.token;
+    case 'ApiKeyHeader':
+      return b.type === 'ApiKeyHeader' && a.header === b.header && a.value === b.value;
+    case 'ApiKeyCookie':
+      return b.type === 'ApiKeyCookie' && a.cookie === b.cookie && a.value === b.value;
+  }
+}
+
+function runtimeConfigsAreEqual(a: FhevmRuntimeConfig, b: FhevmRuntimeConfig): boolean {
+  return (
+    loggersAreEqual(a.logger, b.logger) &&
+    a.locateFile === b.locateFile &&
+    a.wasmAssetLoadMode === b.wasmAssetLoadMode &&
+    moduleVersionsAreEqual(a.moduleVersions, b.moduleVersions) &&
+    a.singleThread === b.singleThread &&
+    a.numberOfThreads === b.numberOfThreads &&
+    authConfigsAreEqual(a.auth, b.auth)
+  );
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -16,19 +56,16 @@ let solanaFhevmRuntimeConfig: FhevmRuntimeConfig | undefined;
  */
 export function setFhevmRuntimeConfig(config: FhevmRuntimeConfig): void {
   if (solanaFhevmRuntimeConfig === undefined) {
-    solanaFhevmRuntimeConfig = Object.freeze({
+    solanaFhevmRuntimeConfig = Object.freeze<FhevmRuntimeConfig>({
       ...config,
       logger: config.logger ? Object.freeze({ ...config.logger }) : undefined,
+      moduleVersions: cloneModuleVersions(config.moduleVersions),
+      auth: config.auth ? Object.freeze({ ...config.auth }) : undefined,
     });
     return;
   }
 
-  if (
-    solanaFhevmRuntimeConfig.logger !== config.logger ||
-    solanaFhevmRuntimeConfig.locateFile !== config.locateFile ||
-    solanaFhevmRuntimeConfig.singleThread !== config.singleThread ||
-    solanaFhevmRuntimeConfig.numberOfThreads !== config.numberOfThreads
-  ) {
+  if (!runtimeConfigsAreEqual(solanaFhevmRuntimeConfig, config)) {
     throw new Error(
       'FhevmRuntime config has already been set and cannot be changed. ' +
         'Ensure setFhevmRuntimeConfig is called only once, or with identical parameters.',

--- a/sdk/js-sdk/src/solana/proof.test.ts
+++ b/sdk/js-sdk/src/solana/proof.test.ts
@@ -56,6 +56,28 @@ function proofBlob(mode: number, leafIndex: bigint, siblings: readonly Uint8Arra
   return concatBytes(new Uint8Array([mode]), u64LE(leafIndex), u32LE(siblings.length), ...siblings);
 }
 
+describe('hexToBytes', () => {
+  it('accepts unprefixed, 0x-prefixed, and 0X-prefixed hex', () => {
+    expect(hexToBytes('00aF')).toEqual(new Uint8Array([0x00, 0xaf]));
+    expect(hexToBytes('0x00aF')).toEqual(new Uint8Array([0x00, 0xaf]));
+    expect(hexToBytes('0X00aF')).toEqual(new Uint8Array([0x00, 0xaf]));
+  });
+
+  it('round-trips bytes through the exported hex helpers', () => {
+    const bytes = new Uint8Array([0x00, 0x12, 0xab, 0xff]);
+    expect(hexToBytes(bytesToHex(bytes))).toEqual(bytes);
+  });
+
+  it('rejects malformed characters instead of coercing them to zero', () => {
+    expect(() => hexToBytes('0xzz')).toThrow('hexToBytes: invalid hex string: 0xzz');
+    expect(() => hexToBytes('0y00')).toThrow('hexToBytes: invalid hex string: 0y00');
+  });
+
+  it('rejects odd-length hex', () => {
+    expect(() => hexToBytes('0x123')).toThrow('hexToBytes: odd-length hex string: 0x123');
+  });
+});
+
 describe('decodeMmrProofTransportBlob', () => {
   const sibling = new Uint8Array(32).fill(0x42);
 

--- a/sdk/js-sdk/src/solana/proof.ts
+++ b/sdk/js-sdk/src/solana/proof.ts
@@ -71,6 +71,9 @@ export function hexToBytes(hex: string): Uint8Array {
   if (clean.length % 2 !== 0) {
     throw new Error(`hexToBytes: odd-length hex string: ${hex}`);
   }
+  if (!/^[0-9a-fA-F]*$/.test(clean)) {
+    throw new Error(`hexToBytes: invalid hex string: ${hex}`);
+  }
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < out.length; i++) {
     out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);


### PR DESCRIPTION
Solana runtime configuration is now compared across every public field after cloning nested logger, module-version, and auth values. Repeating an equivalent configuration with the same logger callbacks remains idempotent, while changed nested values are rejected. The exported Solana proof-hex parser now rejects non-hex characters instead of allowing `NaN` to become zero bytes, while preserving prefixed and unprefixed inputs. Focused Vitest coverage exercises both contracts, including valid round trips, malformed characters, prefixes, and odd lengths.

Related to zama-ai/fhevm-internal#1709.
