### PR TITLE
fix(kms-connector): preserve empty Solana ACL domain semantics

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
+++ b/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
@@ -100,8 +100,9 @@ impl SolanaAclVerifier {
         Ok(())
     }
 
-    /// Current decrypt: live handle + membership, within the request's domain scope. Reads the
-    /// account fetched at `confirmed` commitment — never a snapshot.
+    /// Current decrypt: live handle + membership, within the request's domain scope. An empty
+    /// domain scope is permissive. Reads the account fetched at `confirmed` commitment — never a
+    /// snapshot.
     pub fn verify_current_user_decrypt(
         &self,
         account_key: SolanaPubkeyBytes,
@@ -113,7 +114,9 @@ impl SolanaAclVerifier {
     ) -> Result<(), SolanaAclVerificationError> {
         let acl = &decoded.acl;
         self.verify_canonical(account_key, owner, acl)?;
-        if !allowed_acl_domain_keys.contains(&acl.acl_domain_key) {
+        if !allowed_acl_domain_keys.is_empty()
+            && !allowed_acl_domain_keys.contains(&acl.acl_domain_key)
+        {
             return Err(SolanaAclVerificationError::DomainNotAllowed);
         }
         authorize_current(acl, handle, subject).map_err(map_acl_error)?;
@@ -121,7 +124,8 @@ impl SolanaAclVerifier {
     }
 
     /// Historical decrypt: a valid historical-access MMR proof against the live confirmed peaks
-    /// (the account passed in, read fresh — not a cached/snapshotted proof-time state).
+    /// (the account passed in, read fresh — not a cached/snapshotted proof-time state). An empty
+    /// domain scope is permissive.
     pub fn verify_historical_user_decrypt(
         &self,
         target: EncryptedValueTarget<'_>,
@@ -130,7 +134,9 @@ impl SolanaAclVerifier {
         proof: &MmrProof,
     ) -> Result<(), SolanaAclVerificationError> {
         self.verify_canonical(target.account_key, target.owner, target.acl)?;
-        if !allowed_acl_domain_keys.contains(&target.acl.acl_domain_key) {
+        if !allowed_acl_domain_keys.is_empty()
+            && !allowed_acl_domain_keys.contains(&target.acl.acl_domain_key)
+        {
             return Err(SolanaAclVerificationError::DomainNotAllowed);
         }
         authorize_historical(
@@ -262,6 +268,10 @@ mod tests {
             v.verify_current_user_decrypt(l.account, HOST, &decoded, h(10), OWNER, &[DOMAIN])
                 .is_ok()
         );
+        assert!(
+            v.verify_current_user_decrypt(l.account, HOST, &decoded, h(10), OWNER, &[])
+                .is_ok()
+        );
         assert_eq!(
             v.verify_current_user_decrypt(l.account, HOST, &decoded, h(10), STRANGER, &[DOMAIN])
                 .unwrap_err(),
@@ -378,6 +388,15 @@ mod tests {
         assert!(
             v.verify_historical_user_decrypt(target(h(10)), OWNER, &[DOMAIN], &proof)
                 .is_ok()
+        );
+        assert!(
+            v.verify_historical_user_decrypt(target(h(10)), OWNER, &[], &proof)
+                .is_ok()
+        );
+        assert_eq!(
+            v.verify_historical_user_decrypt(target(h(10)), OWNER, &[[9; 32]], &proof)
+                .unwrap_err(),
+            SolanaAclVerificationError::DomainNotAllowed
         );
         assert!(
             v.verify_historical_user_decrypt(target(h(10)), STRANGER, &[DOMAIN], &proof)

--- a/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
+++ b/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
@@ -403,9 +403,10 @@ mod tests {
                 .unwrap_err(),
             SolanaAclVerificationError::HistoricalAccessProofInvalid
         );
-        assert!(
-            v.verify_historical_user_decrypt(target(h(99)), OWNER, &[DOMAIN], &proof)
-                .is_err()
+        assert_eq!(
+            v.verify_historical_user_decrypt(target(h(99)), OWNER, &[], &proof)
+                .unwrap_err(),
+            SolanaAclVerificationError::HistoricalAccessProofInvalid
         );
     }
 

--- a/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
+++ b/kms-connector/crates/kms-worker/src/core/solana_encrypted_value_acl.rs
@@ -273,7 +273,7 @@ mod tests {
                 .is_ok()
         );
         assert_eq!(
-            v.verify_current_user_decrypt(l.account, HOST, &decoded, h(10), STRANGER, &[DOMAIN])
+            v.verify_current_user_decrypt(l.account, HOST, &decoded, h(10), STRANGER, &[])
                 .unwrap_err(),
             SolanaAclVerificationError::EncryptedValueSubjectMissing
         );
@@ -322,7 +322,7 @@ mod tests {
         assert_ne!(wrong_account, l.account);
         assert_eq!(
             verifier()
-                .verify_current_user_decrypt(wrong_account, HOST, &decoded, h(10), OWNER, &[DOMAIN])
+                .verify_current_user_decrypt(wrong_account, HOST, &decoded, h(10), OWNER, &[])
                 .unwrap_err(),
             SolanaAclVerificationError::NonCanonicalEncryptedValueAcl
         );
@@ -398,9 +398,10 @@ mod tests {
                 .unwrap_err(),
             SolanaAclVerificationError::DomainNotAllowed
         );
-        assert!(
-            v.verify_historical_user_decrypt(target(h(10)), STRANGER, &[DOMAIN], &proof)
-                .is_err()
+        assert_eq!(
+            v.verify_historical_user_decrypt(target(h(10)), STRANGER, &[], &proof)
+                .unwrap_err(),
+            SolanaAclVerificationError::HistoricalAccessProofInvalid
         );
         assert!(
             v.verify_historical_user_decrypt(target(h(99)), OWNER, &[DOMAIN], &proof)

--- a/sdk/js-sdk/src/core/types/fhevmSolanaChain.ts
+++ b/sdk/js-sdk/src/core/types/fhevmSolanaChain.ts
@@ -23,6 +23,6 @@ export type FhevmSolanaChain = {
 };
 
 export type FhevmSolanaAcl = {
-  /** The authorized ACL domain keys (each a bytes32 0x-hex), the signed `allowedContracts` scope. */
+  /** The signed ACL-domain scope (each key is bytes32 0x-hex). Empty selects permissive mode. */
   readonly domainKeys: readonly Bytes32Hex[];
 };

--- a/sdk/js-sdk/src/core/types/fhevmSolanaChain.ts
+++ b/sdk/js-sdk/src/core/types/fhevmSolanaChain.ts
@@ -23,6 +23,6 @@ export type FhevmSolanaChain = {
 };
 
 export type FhevmSolanaAcl = {
-  /** The signed ACL-domain scope (each key is bytes32 0x-hex). Empty selects permissive mode. */
+  /** The signed ACL-domain scope. Empty accepts any ACL domain; subject and handle authorization still apply. */
   readonly domainKeys: readonly Bytes32Hex[];
 };


### PR DESCRIPTION
## Summary

- preserve Gateway/EVM permissive semantics when the signed Solana ACL-domain list is empty
- keep non-empty domain membership enforcement unchanged for current and historical authorization
- document the empty-list behavior in the connector and SDK chain configuration

## Validation

- `cargo test -p kms-worker solana_encrypted_value_acl::tests` (9 passed)
- `cargo clippy -p kms-worker --lib --tests -- -D warnings`
- `cargo fmt -p kms-worker --check`
- `git diff --check`

Refs zama-ai/fhevm-internal#1707.
