### PR TITLE
fix(common): enforce high-bit Solana chain-id invariant

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -1991,6 +1991,11 @@
       "code": 6068,
       "name": "DivisionByZero",
       "msg": "fheDiv/fheRem divisor must be non-zero"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidChainTypeBit",
+      "msg": "host chain id must set the Solana chain-type high bit and the gateway chain id must not"
     }
   ],
   "types": [

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -994,7 +994,7 @@ mod fhe_eval_acl_tests {
             x_token: None,
             rpc_fallback_url: "http://127.0.0.1:1".to_owned(),
             program_id: ZAMA_HOST.to_owned(),
-            chain_id: 12345,
+            chain_id: zama_host::SOLANA_POC_CHAIN_ID,
         }
     }
 
@@ -1067,8 +1067,8 @@ mod fhe_eval_acl_tests {
     /// The durable `Add` output handle the fhe_eval fixtures produce, derived
     /// exactly as the program does: the base handle, no per-output binding
     /// (durable == instruction-local, matching EVM). Matches `config()`
-    /// (chain_id 12345, `PREVIOUS_BANK_HASH`), slot 42's clock ts, op_index 0,
-    /// scalar rhs.
+    /// (the Solana PoC host chain id, `PREVIOUS_BANK_HASH`), slot 42's clock ts,
+    /// op_index 0, scalar rhs.
     fn derived_add_output_handle() -> [u8; 32] {
         zama_host::state::computed_eval_handle(
             PgmBinaryOpCode::Add,
@@ -1076,7 +1076,7 @@ mod fhe_eval_acl_tests {
             [1; 32],
             true,
             5,
-            12345,
+            zama_host::SOLANA_POC_CHAIN_ID,
             PREVIOUS_BANK_HASH,
             1_700_000_000,
             [1; 32],

--- a/coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
@@ -999,7 +999,7 @@ mod tests {
 
     fn ctx() -> ReconstructContext {
         ReconstructContext {
-            chain_id: 12345,
+            chain_id: zama_host::SOLANA_POC_CHAIN_ID,
             previous_bank_hash: [3u8; 32],
             unix_timestamp: 1_700_000_000,
         }

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
@@ -474,7 +474,7 @@ fn amount_attestation_for(
 ) -> host::CoprocessorInputAttestation {
     let key = coprocessor_signing_key();
     let ct_handles = vec![amount_handle];
-    let contract_chain_id = 12345u64;
+    let contract_chain_id = host::SOLANA_POC_CHAIN_ID;
     let extra_data = vec![0x00u8];
     let digest = host::eip712::typed_data_digest(
         &host::eip712::domain_separator(

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -138,6 +138,12 @@ impl Default for CtAttestationConfig {
     }
 }
 
+/// RFC-021 reserves the high bit (bit 63) of the u64 chain id as the host
+/// `chain_type` marker: when set, the host chain is Solana rather than an EVM
+/// chain. EVM chain ids keep this bit clear. Mirrors `SOLANA_CHAIN_TYPE_BIT` in
+/// the coprocessor (`fhevm-engine-common`) and the relayer.
+pub const SOLANA_CHAIN_TYPE_BIT: u64 = 1 << 63;
+
 /// Supported host-chain ACL backends.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -508,7 +514,7 @@ mod tests {
                     [
                         {
                             "url": "http://localhost:9545",
-                            "chainId": 31888,
+                            "chainId": 9223372036854807696,
                             "chainKind": "solana",
                             "aclAddress": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
                             "solanaHostProgramId": "11111111111111111111111111111111"
@@ -526,7 +532,8 @@ mod tests {
             config.host_chains,
             vec![HostChainConfig {
                 url: Url::from_str("http://localhost:9545").unwrap(),
-                chain_id: 31888,
+                // RFC-021 Solana host id: chain-type high bit | 31888.
+                chain_id: SOLANA_CHAIN_TYPE_BIT | 31888,
                 chain_kind: HostChainKind::Solana,
                 acl_address: Some(
                     Address::from_str("0x5fbdb2315678afecb367f032d93f642f64180aa3").unwrap(),

--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -470,7 +470,8 @@ mod tests {
         public_decrypt_leaf_commitment,
     };
 
-    const CHAIN_ID: u64 = 7777;
+    // A Solana host chain id carries the RFC-021 chain-type high bit (bit 63).
+    const CHAIN_ID: u64 = crate::core::config::SOLANA_CHAIN_TYPE_BIT | 7777;
     const HOST: SolanaPubkeyBytes = [42u8; 32];
     const DOMAIN: SolanaPubkeyBytes = [1u8; 32];
     const APP: SolanaPubkeyBytes = [2u8; 32];

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{
         KmsResponsePublisher,
-        config::{Config, HostChainConfig, HostChainKind},
+        config::{Config, HostChainConfig, HostChainKind, SOLANA_CHAIN_TYPE_BIT},
         event_picker::{DbEventPicker, EventPicker},
         event_processor::{
             CiphertextManager, DbContextManager, DbEventProcessor, DecryptionProcessor,
@@ -231,8 +231,15 @@ fn validate_host_chain_configs(host_chains: &[HostChainConfig]) -> anyhow::Resul
             ));
         }
 
+        let has_chain_type_bit = host_chain.chain_id & SOLANA_CHAIN_TYPE_BIT != 0;
         match host_chain.chain_kind {
             HostChainKind::Evm => {
+                if has_chain_type_bit {
+                    return Err(anyhow!(
+                        "EVM host chain {} must not set the RFC-021 Solana chain-type high bit (bit 63)",
+                        host_chain.chain_id
+                    ));
+                }
                 if host_chain.acl_address.is_none() {
                     return Err(anyhow!(
                         "EVM host chain {} requires acl_address (the ACL contract to gate decryptions)",
@@ -247,6 +254,12 @@ fn validate_host_chain_configs(host_chains: &[HostChainConfig]) -> anyhow::Resul
                 }
             }
             HostChainKind::Solana => {
+                if !has_chain_type_bit {
+                    return Err(anyhow!(
+                        "Solana host chain {} must set the RFC-021 Solana chain-type high bit (bit 63)",
+                        host_chain.chain_id
+                    ));
+                }
                 if host_chain.solana_host_program_id.is_none() {
                     return Err(anyhow!(
                         "Solana host chain {} requires solana_host_program_id",
@@ -270,15 +283,19 @@ mod tests {
     use super::*;
     use alloy::primitives::Address;
 
+    /// Builds a host-chain config for the given logical id and kind, applying the
+    /// RFC-021 chain-type high bit to Solana ids so the fixture satisfies the
+    /// invariant enforced by `validate_host_chain_configs`.
     fn host_chain(chain_id: u64, chain_kind: HostChainKind) -> HostChainConfig {
         let mut host_chain = Config::default().host_chains.remove(0);
-        host_chain.chain_id = chain_id;
         host_chain.chain_kind = chain_kind;
         match chain_kind {
             HostChainKind::Evm => {
+                host_chain.chain_id = chain_id;
                 host_chain.solana_host_program_id = None;
             }
             HostChainKind::Solana => {
+                host_chain.chain_id = SOLANA_CHAIN_TYPE_BIT | chain_id;
                 host_chain.acl_address = None;
                 host_chain.solana_host_program_id = Some([7; 32]);
             }
@@ -305,22 +322,50 @@ mod tests {
             backends.get(&1),
             Some(HostChainAclBackend::Evm(_))
         ));
-        match backends.get(&2) {
+        match backends.get(&(SOLANA_CHAIN_TYPE_BIT | 2)) {
             Some(HostChainAclBackend::Solana(host)) => assert_eq!(host.program_id, [7; 32]),
-            _ => panic!("chain 2 should use the Solana backend"),
+            _ => panic!("the Solana host chain should use the Solana backend"),
         }
     }
 
     #[test]
-    fn rejects_duplicate_chain_ids_across_all_backend_pairs() {
-        for (first, second) in [
-            (HostChainKind::Evm, HostChainKind::Evm),
-            (HostChainKind::Evm, HostChainKind::Solana),
-            (HostChainKind::Solana, HostChainKind::Evm),
-            (HostChainKind::Solana, HostChainKind::Solana),
-        ] {
-            let error = validation_error(&[host_chain(7, first), host_chain(7, second)]);
-            assert!(error.contains("Duplicate host chain in config for chain ID 7"));
+    fn rejects_duplicate_chain_ids() {
+        // Under the RFC-021 invariant an EVM id and a Solana id can never collide
+        // (different high bit), so duplicates are only possible within one kind.
+        for kind in [HostChainKind::Evm, HostChainKind::Solana] {
+            let duplicate_id = host_chain(7, kind).chain_id;
+            let error = validation_error(&[host_chain(7, kind), host_chain(7, kind)]);
+            assert!(
+                error.contains(&format!(
+                    "Duplicate host chain in config for chain ID {duplicate_id}"
+                )),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_chain_id_inconsistent_with_chain_kind() {
+        // A Solana host chain that leaves the high bit clear.
+        let mut solana_without_bit = host_chain(9, HostChainKind::Solana);
+        solana_without_bit.chain_id = 9;
+        // An EVM host chain that sets the high bit.
+        let mut evm_with_bit = host_chain(9, HostChainKind::Evm);
+        evm_with_bit.chain_id = SOLANA_CHAIN_TYPE_BIT | 9;
+
+        let cases = [
+            (
+                solana_without_bit,
+                "must set the RFC-021 Solana chain-type high bit",
+            ),
+            (
+                evm_with_bit,
+                "must not set the RFC-021 Solana chain-type high bit",
+            ),
+        ];
+        for (host_chain, expected) in cases {
+            let error = validation_error(&[host_chain]);
+            assert!(error.contains(expected), "unexpected error: {error}");
         }
     }
 

--- a/relayer/src/config/settings.rs
+++ b/relayer/src/config/settings.rs
@@ -794,15 +794,17 @@ impl Settings {
                     i, hc.url
                 )));
             }
-            // RFC-021 host chains: an acl_address is canonical either as an EVM
-            // 0x-hex address or, on a Solana host, as a base58 Ed25519 pubkey.
-            let is_evm_address = Address::from_str(&hc.acl_address).is_ok();
-            let is_solana_address =
-                crate::http::utils::solana_address::is_solana_address(&hc.acl_address);
-            if !is_evm_address && !is_solana_address {
+            // The chain-id discriminator and ACL address encoding must agree so
+            // downstream components cannot classify the same host differently.
+            let valid_acl_address = if crate::core::event::is_solana_host_chain_id(hc.chain_id) {
+                crate::http::utils::solana_address::is_solana_address(&hc.acl_address)
+            } else {
+                Address::from_str(&hc.acl_address).is_ok()
+            };
+            if !valid_acl_address {
                 return Err(AppConfigError::InvalidAddress(format!(
-                    "host_chains[{}].acl_address is invalid: {}",
-                    i, hc.acl_address
+                    "host_chains[{}].acl_address does not match chain_id {}: {}",
+                    i, hc.chain_id, hc.acl_address
                 )));
             }
         }
@@ -1434,9 +1436,8 @@ mod tests {
         );
     }
 
-    /// RFC-021: a host chain may carry a Solana base58 acl_address (a 32-byte
-    /// Ed25519 pubkey) instead of an EVM 0x-hex address, and `validate_host_chains`
-    /// must accept it. Also confirms a malformed base58 acl_address is rejected.
+    /// RFC-021: a high-bit host chain carries a Solana base58 acl_address, while
+    /// a clear-bit host chain carries an EVM address.
     #[test]
     fn test_host_chains_accepts_solana_address_base58_acl() {
         let config_path = ConfigBuilder::from_example()
@@ -1451,21 +1452,30 @@ mod tests {
 
         let mut settings: Settings = config.try_deserialize().expect("Failed to deserialize");
         // SPL Token program id — a canonical 32-byte Solana base58 pubkey.
+        settings.host_chains[0].chain_id = (1u64 << 63) | 8009;
         settings.host_chains[0].acl_address =
             "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string();
         settings
             .validate_host_chains()
             .expect("Solana base58 acl_address must be accepted");
 
-        // A string that is neither valid EVM hex nor valid Solana base58 is rejected.
-        settings.host_chains[0].acl_address = "not-a-valid-address".to_string();
+        settings.host_chains[0].acl_address =
+            "0x339EBB773A9bC1deCFfD5ef4BC7c907e26C1f836".to_string();
         let err = settings
             .validate_host_chains()
-            .expect_err("invalid acl_address must be rejected");
+            .expect_err("Solana chain id with EVM acl_address must be rejected");
         assert!(
-            err.to_string().contains("acl_address is invalid"),
-            "Error should mention invalid acl_address, got: {err}"
+            err.to_string().contains("does not match chain_id"),
+            "Error should mention the chain/address mismatch, got: {err}"
         );
+
+        settings.host_chains[0].chain_id = 8009;
+        settings.host_chains[0].acl_address =
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string();
+        let err = settings
+            .validate_host_chains()
+            .expect_err("EVM chain id with Solana acl_address must be rejected");
+        assert!(err.to_string().contains("does not match chain_id"));
     }
 
     #[test]
@@ -1511,10 +1521,15 @@ mod tests {
                                                            // Settings::new path; this regresses the untagged-enum crash the Visitor fix removed.
         let base = std::fs::read_to_string("tests/relayer-test-config.yaml")
             .expect("read tests/relayer-test-config.yaml");
-        let solana_cfg = base.replace(
-            "  - chain_id: 8009",
-            &format!("  - chain_id: \"{SOLANA_CHAIN_ID}\""),
-        );
+        let solana_cfg = base
+            .replace(
+                "  - chain_id: 8009",
+                &format!("  - chain_id: \"{SOLANA_CHAIN_ID}\""),
+            )
+            .replace(
+                "    acl_address: \"0x339EBB773A9bC1deCFfD5ef4BC7c907e26C1f836\"",
+                "    acl_address: \"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA\"",
+            );
         assert!(
             solana_cfg.contains(&format!("\"{SOLANA_CHAIN_ID}\"")),
             "test fixture must contain the quoted Solana chain id"

--- a/relayer/src/host/acl_checker.rs
+++ b/relayer/src/host/acl_checker.rs
@@ -96,9 +96,17 @@ impl HostAclChecker {
         let mut solana_chains = std::collections::HashSet::new();
 
         for hc in host_chains {
-            // RFC-021 Solana host: base58 `acl_address` (zama-host program). No EVM ACL
-            // contract exists, so record the chain and skip building an eth_call client.
-            if crate::http::utils::solana_address::is_solana_address(&hc.acl_address) {
+            // The chain id is the sole chain-kind discriminator. Settings validation
+            // enforces the matching address encoding; keep this constructor fail-closed
+            // for direct callers too.
+            if crate::core::event::is_solana_host_chain_id(hc.chain_id) {
+                if !crate::http::utils::solana_address::is_solana_address(&hc.acl_address) {
+                    anyhow::bail!(
+                        "Invalid Solana ACL address for chain {}: {}",
+                        hc.chain_id,
+                        hc.acl_address
+                    );
+                }
                 solana_chains.insert(hc.chain_id);
                 continue;
             }
@@ -679,5 +687,31 @@ mod tests {
             .check_public_decrypt(&job_id, &[handle])
             .await
             .is_ok());
+    }
+
+    #[test]
+    fn chain_id_discriminator_rejects_mismatched_acl_address_formats() {
+        use crate::config::settings::{HostChainConfig, RetrySettings};
+
+        let retry = RetrySettings {
+            max_attempts: 1,
+            retry_interval_ms: 1,
+        };
+        let evm_address = "0x339EBB773A9bC1deCFfD5ef4BC7c907e26C1f836";
+        let solana_address = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+        for (chain_id, acl_address) in
+            [((1u64 << 63) | 12345, evm_address), (12345, solana_address)]
+        {
+            let result = HostAclChecker::new(
+                &[HostChainConfig {
+                    chain_id,
+                    url: "http://127.0.0.1:8899".to_string(),
+                    acl_address: acl_address.to_string(),
+                }],
+                retry.clone(),
+            );
+            assert!(result.is_err(), "chain/address mismatch must be rejected");
+        }
     }
 }

--- a/sdk/js-sdk/src/core/chains/utilsSolana.test.ts
+++ b/sdk/js-sdk/src/core/chains/utilsSolana.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { asBytes32Hex } from '../base/bytes.js';
+import type { FhevmSolanaChain } from '../types/fhevmSolanaChain.js';
+import { defineFhevmSolanaChain } from './utilsSolana.js';
+
+const chain = {
+  id: 9223372036854788153n,
+  fhevm: {
+    relayerUrl: 'http://localhost:3000',
+    acl: { domainKeys: [asBytes32Hex('0x1111111111111111111111111111111111111111111111111111111111111111')] },
+  },
+} as const satisfies FhevmSolanaChain;
+
+describe('defineFhevmSolanaChain', () => {
+  it('preserves an exact high-bit bigint chain id', () => {
+    expect(defineFhevmSolanaChain(chain).id).toBe(9223372036854788153n);
+  });
+
+  it.each([0n, 12345n, 1n << 64n])('rejects invalid Solana chain id %s', (id) => {
+    expect(() => defineFhevmSolanaChain({ ...chain, id })).toThrow(
+      'Solana chain id must be a u64 bigint with bit 63 set',
+    );
+  });
+});

--- a/sdk/js-sdk/src/core/chains/utilsSolana.ts
+++ b/sdk/js-sdk/src/core/chains/utilsSolana.ts
@@ -1,6 +1,16 @@
 import type { FhevmSolanaChain } from '../types/fhevmSolanaChain.js';
 import { simpleDeepFreeze } from '../base/object.js';
 
+const SOLANA_CHAIN_TYPE_BIT = 1n << 63n;
+const U64_MAX = (1n << 64n) - 1n;
+
+export function assertValidSolanaChainId(chainId: bigint): void {
+  if (typeof chainId !== 'bigint' || chainId < SOLANA_CHAIN_TYPE_BIT || chainId > U64_MAX) {
+    throw new Error('Solana chain id must be a u64 bigint with bit 63 set');
+  }
+}
+
 export function defineFhevmSolanaChain<const chain extends FhevmSolanaChain>(fhevmSolanaChain: chain): chain {
+  assertValidSolanaChainId(fhevmSolanaChain.id);
   return simpleDeepFreeze(fhevmSolanaChain);
 }

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.test.ts
@@ -24,4 +24,10 @@ describe('createFhevmBaseClient', () => {
     expect(client.solanaChain.id).toBe(9223372036854788153n);
     await expect(client.ready).resolves.toBeUndefined();
   });
+
+  it.each([0n, 12345n, 1n << 64n])('rejects invalid Solana chain id %s', (id) => {
+    expect(() => createFhevmBaseClient({ chain: { ...chain, id } })).toThrow(
+      'Solana chain id must be a u64 bigint with bit 63 set',
+    );
+  });
 });

--- a/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmBaseClient.ts
@@ -5,6 +5,7 @@ import type { Fhevm } from '../../core/types/coreFhevmClient.js';
 import { PRIVATE_SOLANA_TOKEN } from '../internal/solana-p.js';
 import { createCoreFhevm } from '../../core/runtime/CoreFhevm-p.js';
 import { getSolanaRuntime } from '../internal/runtime.js';
+import { assertValidSolanaChainId } from '../../core/chains/utilsSolana.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -20,6 +21,7 @@ export function createFhevmBaseClient<chain extends FhevmSolanaChain>(parameters
   readonly chain: chain;
   readonly options?: FhevmOptions | undefined;
 }): Fhevm<undefined, FhevmRuntime, undefined> & { readonly solanaChain: chain } {
+  assertValidSolanaChainId(parameters.chain.id);
   // The core client is chain-agnostic at runtime (it just freezes and exposes `chain`); the
   // Solana chain shape differs from `FhevmChain`, so it is carried as `solanaChain` instead and
   // the core `chain` is left undefined (no EVM semantics apply).

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1373,8 +1373,11 @@ in [`FUTURE_DESIGN.md`](./FUTURE_DESIGN.md); this list is the short index.
 - Handle birth entropy/idempotency policy is RESOLVED (keep per-block entropy, DD-015); reorg-unstable
   handles are accepted on every chain.
 - Whether confidential balances move to the staged inbound-credit profile (DD-016).
-- Replacing the PoC sentinel `chain_id` (`SOLANA_POC_CHAIN_ID = 12345`) with the repository-wide
-  high-bit Solana chain-id convention.
+- The PoC sentinel `chain_id` is RESOLVED (zama-ai/fhevm-internal#1635): `SOLANA_POC_CHAIN_ID` now
+  carries the RFC-021 chain-type high bit (`SOLANA_CHAIN_TYPE_BIT | 12345`), and `initialize_host_config`
+  rejects a host `chain_id` without bit 63 set (and a `gateway_chain_id` with it set). The
+  low-63-bit allocation for canonical MAINNET/DEVNET Solana host chain ids remains a deployment-config
+  decision, tracked separately.
 - Rent/archival policy for the `EncryptedValue` MMR itself (DD-032): the account no longer needs
   per-supersession PDA closes (one stable PDA is reused for a lineage's whole life), but growth of
   `peaks`/`subjects` over a long-lived lineage's history still needs a compaction story if rent becomes

--- a/solana/docs/FUTURE_DESIGN.md
+++ b/solana/docs/FUTURE_DESIGN.md
@@ -64,8 +64,6 @@ the listener into the EVM block-status substrate (`host_chain_blocks_valid` +
 
 Carried from `DESIGN_DECISIONS.md` "Open Product Decisions":
 
-- Replace the PoC sentinel `chain_id` (`SOLANA_POC_CHAIN_ID`) with the repository-wide high-bit
-  Solana chain-id convention.
 - Durable archival / compaction policy for ACL, material, delegation, and replay evidence (no
   `close_acl_record` today).
 - Confidential-balance profile: keep the immediate available-balance profile or move to staged

--- a/solana/programs/zama-host/src/constants.rs
+++ b/solana/programs/zama-host/src/constants.rs
@@ -7,8 +7,15 @@ pub const PUBLIC_OUTPUTS_PRODUCED_EVENT_VERSION: u8 = 1;
 /// Maximum durable subjects on an `EncryptedValue` lineage (mirrors
 /// `zama_solana_acl::MAX_ENCRYPTED_VALUE_SUBJECTS`).
 pub const MAX_ACL_SUBJECTS: usize = zama_solana_acl::MAX_ENCRYPTED_VALUE_SUBJECTS;
-/// PoC chain id used by tests and helpers that do not receive host config.
-pub const SOLANA_POC_CHAIN_ID: u64 = 12345;
+/// RFC-021 reserves the high bit (bit 63) of the u64 chain id as the host
+/// `chain_type` marker: when set, the host chain is Solana rather than an EVM
+/// chain. EVM chain ids keep this bit clear. The remaining 63 bits carry the
+/// logical chain id.
+pub const SOLANA_CHAIN_TYPE_BIT: u64 = 1 << 63;
+/// PoC Solana host chain id used by tests and helpers that do not receive host
+/// config. Carries the RFC-021 chain-type high bit so it satisfies the
+/// repository-wide invariant that every Solana host chain id sets bit 63.
+pub const SOLANA_POC_CHAIN_ID: u64 = SOLANA_CHAIN_TYPE_BIT | 12345;
 /// Seed for the singleton host config PDA.
 pub const HOST_CONFIG_SEED: &[u8] = b"host-config";
 /// Seed prefix for KMS context PDAs (one per `kmsContextId`, mirroring ProtocolConfig).

--- a/solana/programs/zama-host/src/eip712.rs
+++ b/solana/programs/zama-host/src/eip712.rs
@@ -402,7 +402,7 @@ mod tests {
             &[[3u8; 32]],
             &[4u8; 32],
             &[5u8; 32],
-            12345,
+            crate::SOLANA_POC_CHAIN_ID,
             &[0x00],
         );
         let digest = typed_data_digest(&ds, &sh);
@@ -458,7 +458,13 @@ mod tests {
         let ds = domain_separator(b"InputVerification", b"1", 31337, &[0xCDu8; 20]);
         let digest = typed_data_digest(
             &ds,
-            &ciphertext_verification_struct_hash(&handles, &user, &contract, 12345, &[0x00]),
+            &ciphertext_verification_struct_hash(
+                &handles,
+                &user,
+                &contract,
+                crate::SOLANA_POC_CHAIN_ID,
+                &[0x00],
+            ),
         );
         let sig = sign(&key, &digest);
         assert!(verify_coprocessor_input(
@@ -466,7 +472,7 @@ mod tests {
             &handles,
             &user,
             &contract,
-            12345,
+            crate::SOLANA_POC_CHAIN_ID,
             &[0x00],
             &[sig]
         ));

--- a/solana/programs/zama-host/src/errors.rs
+++ b/solana/programs/zama-host/src/errors.rs
@@ -224,4 +224,13 @@ pub enum ZamaHostError {
     /// `fheDiv`/`fheRem` divisor is zero once truncated to the operand type (EVM `DivisionByZero`).
     #[msg("fheDiv/fheRem divisor must be non-zero")]
     DivisionByZero,
+
+    /// The host `chain_id` does not carry the RFC-021 Solana chain-type high bit,
+    /// or the EVM `gateway_chain_id` carries it. The ZamaHost is always a Solana
+    /// host chain, so its chain id must set bit 63 while the gateway id (an EVM
+    /// chain) must leave it clear.
+    #[msg(
+        "host chain id must set the Solana chain-type high bit and the gateway chain id must not"
+    )]
+    InvalidChainTypeBit,
 }

--- a/solana/programs/zama-host/src/instructions/initialize_host_config.rs
+++ b/solana/programs/zama-host/src/instructions/initialize_host_config.rs
@@ -67,7 +67,14 @@ pub fn initialize_host_config(
 }
 
 fn assert_valid_host_config_args(args: &InitializeHostConfigArgs) -> Result<()> {
-    require!(args.chain_id != 0, ZamaHostError::InvalidHostConfig);
+    // RFC-021 invariant: the ZamaHost is always a Solana host chain, so its
+    // `chain_id` must set the chain-type high bit, while the EVM `gateway_chain_id`
+    // must leave it clear. Setting the bit also guarantees `chain_id != 0`.
+    require!(
+        args.chain_id & SOLANA_CHAIN_TYPE_BIT != 0
+            && args.gateway_chain_id & SOLANA_CHAIN_TYPE_BIT == 0,
+        ZamaHostError::InvalidChainTypeBit
+    );
     Ok(())
 }
 
@@ -77,7 +84,9 @@ mod tests {
 
     fn valid_args() -> InitializeHostConfigArgs {
         InitializeHostConfigArgs {
-            chain_id: 42,
+            // The ZamaHost is a Solana host chain, so its chain id sets the
+            // RFC-021 chain-type high bit.
+            chain_id: SOLANA_CHAIN_TYPE_BIT | 42,
             gateway_chain_id: 0,
             input_verification_contract: [0u8; 20],
             coprocessor_signer: [0u8; 20],
@@ -96,5 +105,32 @@ mod tests {
         let mut args = valid_args();
         args.chain_id = SOLANA_POC_CHAIN_ID;
         assert!(assert_valid_host_config_args(&args).is_ok());
+    }
+
+    #[test]
+    fn rejects_solana_chain_id_without_chain_type_bit() {
+        // A Solana host id that leaves the high bit clear (e.g. a bare EVM-style
+        // value) violates the RFC-021 invariant and must be rejected.
+        let mut args = valid_args();
+        args.chain_id = 12345;
+        let err = assert_valid_host_config_args(&args).unwrap_err();
+        assert_eq!(err, error!(ZamaHostError::InvalidChainTypeBit));
+    }
+
+    #[test]
+    fn rejects_zero_chain_id() {
+        let mut args = valid_args();
+        args.chain_id = 0;
+        let err = assert_valid_host_config_args(&args).unwrap_err();
+        assert_eq!(err, error!(ZamaHostError::InvalidChainTypeBit));
+    }
+
+    #[test]
+    fn rejects_gateway_chain_id_with_chain_type_bit() {
+        // The gateway is an EVM chain; its chain id must leave the high bit clear.
+        let mut args = valid_args();
+        args.gateway_chain_id = SOLANA_CHAIN_TYPE_BIT | 1;
+        let err = assert_valid_host_config_args(&args).unwrap_err();
+        assert_eq!(err, error!(ZamaHostError::InvalidChainTypeBit));
     }
 }

--- a/solana/programs/zama-host/src/state/tests.rs
+++ b/solana/programs/zama-host/src/state/tests.rs
@@ -19,10 +19,6 @@ fn latest_prior_bank_hash_tolerates_skipped_slots() {
     assert_eq!(latest_prior_bank_hash_from_entries(3, entries), None);
 }
 
-/// Bit 63 of the uint64 chain id is the reserved Solana `chain_type` marker
-/// (RFC-021 / #1494). It is derived from the chain id, never a schema column.
-const SOLANA_CHAIN_TYPE_BIT: u64 = 1 << 63;
-
 fn keccak(parts: &[&[u8]]) -> [u8; 32] {
     keccak_hashv(parts).to_bytes()
 }
@@ -47,8 +43,9 @@ fn assert_canonical_metadata(handle: [u8; 32], fhe_type: u8, chain_id: u64) {
 #[test]
 fn eval_handle_derivation_preserves_solana_chain_type_high_bit() {
     // A Solana host chain id sets the reserved high bit; the derived handle
-    // must round-trip it verbatim through bytes 22..30.
-    let chain_id = SOLANA_CHAIN_TYPE_BIT | SOLANA_POC_CHAIN_ID;
+    // must round-trip it verbatim through bytes 22..30. `SOLANA_POC_CHAIN_ID`
+    // already carries the chain-type high bit (RFC-021 / #1494).
+    let chain_id = SOLANA_POC_CHAIN_ID;
     let handle = computed_eval_handle(
         FheBinaryOpCode::Sub,
         [1; 32],

--- a/test-suite/fhevm/src/scenario.test.ts
+++ b/test-suite/fhevm/src/scenario.test.ts
@@ -112,6 +112,59 @@ topology:
     ).toThrow('duplicate hostChains chainId "12345"');
   });
 
+  test.each([
+    ["solana", "solana", "12345"],
+    ["evm", "evm", "9223372036854788153"],
+    ["default EVM", undefined, "9223372036854788153"],
+  ] as const)("rejects %s host chain with mismatched chain id", (_label, type, chainId) => {
+    expect(() =>
+      parseCoprocessorScenario(`
+version: 1
+kind: coprocessor-consensus
+hostChains:
+  - key: host
+${type === undefined ? "" : `    type: ${type}\n`}    chainId: "${chainId}"
+    rpcPort: 8545
+topology:
+  count: 1
+  threshold: 1
+`),
+    ).toThrow("does not match host chain type");
+  });
+
+  test("rejects host chain ids outside u64", () => {
+    expect(() =>
+      parseCoprocessorScenario(`
+version: 1
+kind: coprocessor-consensus
+hostChains:
+  - key: host
+    type: solana
+    chainId: "18446744073709551616"
+    rpcPort: 8545
+topology:
+  count: 1
+  threshold: 1
+`),
+    ).toThrow("must fit in u64");
+  });
+
+  test("preserves an exact high-bit Solana chain id", () => {
+    const scenario = parseCoprocessorScenario(`
+version: 1
+kind: coprocessor-consensus
+hostChains:
+  - key: host
+    type: solana
+    chainId: "9223372036854788153"
+    rpcPort: 8545
+topology:
+  count: 1
+  threshold: 1
+`);
+    expect(scenario.hostChains?.[0]?.chainId).toBe("9223372036854788153");
+  });
+
   test("synthesizes a local coprocessor scenario from override shorthand", () => {
     const scenario = synthesizeOverrideScenario([
       { group: "coprocessor", services: ["coprocessor-host-listener"] },

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -42,6 +42,8 @@ export const DEFAULT_KMS_TOPOLOGY: ResolvedKmsTopology = {
 };
 
 const MAX_KMS_PARTIES = 7;
+const SOLANA_CHAIN_TYPE_BIT = 1n << 63n;
+const U64_MAX = (1n << 64n) - 1n;
 
 /**
  * Parses + validates the optional `kms` block from a scenario.
@@ -204,9 +206,31 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
         throw new Error(`${sourceLabel}: duplicate hostChains key "${key}"`);
       }
       seen.add(key);
-      const chainId = normalizeScalar(chain.chainId, `${sourceLabel}: hostChains[${index}].chainId`);
-      if (!/^\d+$/.test(chainId)) {
-        throw new Error(`${sourceLabel}: hostChains[${index}].chainId "${chainId}" must be a numeric string`);
+      const chainIdLabel = `${sourceLabel}: hostChains[${index}].chainId`;
+      if (typeof chain.chainId === "number" && !Number.isSafeInteger(chain.chainId)) {
+        throw new Error(`${chainIdLabel} must be quoted when it exceeds the safe integer range`);
+      }
+      const rawChainId = normalizeScalar(chain.chainId, chainIdLabel);
+      if (!/^\d+$/.test(rawChainId)) {
+        throw new Error(`${chainIdLabel} "${rawChainId}" must be a numeric string`);
+      }
+      const parsedChainId = BigInt(rawChainId);
+      if (parsedChainId > U64_MAX) {
+        throw new Error(`${chainIdLabel} "${rawChainId}" must fit in u64`);
+      }
+      const chainId = parsedChainId.toString();
+      const type =
+        chain.type === undefined
+          ? undefined
+          : normalizeScalar(chain.type, `${sourceLabel}: hostChains[${index}].type`);
+      if (type !== undefined && !HOST_CHAIN_TYPES.includes(type as HostChainType)) {
+        throw new Error(
+          `${sourceLabel}: hostChains[${index}].type "${type}" must be one of: ${HOST_CHAIN_TYPES.join(", ")}`,
+        );
+      }
+      const hasSolanaChainTypeBit = (parsedChainId & SOLANA_CHAIN_TYPE_BIT) !== 0n;
+      if (type === "solana" ? !hasSolanaChainTypeBit : hasSolanaChainTypeBit) {
+        throw new Error(`${chainIdLabel} "${rawChainId}" does not match host chain type "${type ?? "evm"}"`);
       }
       if (seenChainIds.has(chainId)) {
         throw new Error(`${sourceLabel}: duplicate hostChains chainId "${chainId}"`);
@@ -220,15 +244,6 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
         throw new Error(`${sourceLabel}: duplicate hostChains rpcPort "${rpcPort}"`);
       }
       seenPorts.add(rpcPort);
-      const type =
-        chain.type === undefined
-          ? undefined
-          : normalizeScalar(chain.type, `${sourceLabel}: hostChains[${index}].type`);
-      if (type !== undefined && !HOST_CHAIN_TYPES.includes(type as HostChainType)) {
-        throw new Error(
-          `${sourceLabel}: hostChains[${index}].type "${type}" must be one of: ${HOST_CHAIN_TYPES.join(", ")}`,
-        );
-      }
       const nodeProvisioning =
         chain.nodeProvisioning === undefined
           ? undefined


### PR DESCRIPTION
## Intended outcome

Enforce the RFC-021 convention as a repository-wide invariant: a Solana host chain ID is a `u64` with bit 63 set; EVM chain IDs leave it clear. Reject disagreement at public configuration boundaries while preserving exact `u64`/`bigint` values end to end.

Refs zama-ai/fhevm-internal#1635 (chain-ID stream). Confidential-bridge feasibility remains out of scope.

## Chosen test ID

`SOLANA_POC_CHAIN_ID = (1 << 63) | 12345 = 9223372036854788153` (database `i64` representation `-9223372036854763463`). This matches the existing bring-up and test-suite Solana host configuration.

## Layers enforced

- **zama-host:** `initialize_host_config` rejects a host chain ID without bit 63 and a gateway chain ID with bit 63. The PoC/test constant and fixtures now conform.
- **KMS connector:** host-chain configuration rejects `solana` + clear bit and `evm` + set bit.
- **Relayer:** configuration correlates the chain-ID bit with canonical ACL address encoding; ACL backend classification follows the validated chain ID.
- **JS SDK:** one shared runtime assertion enforces an exact `u64` high-bit `bigint` at public Solana chain/client construction boundaries.
- **Test-suite:** scenario resolution parses chain IDs as `BigInt`, enforces `u64` bounds, requires the bit for `solana`, and requires it clear for `evm` or omitted type.
- **Coprocessor/listener fixtures:** Solana IDs use the high-bit PoC value.
- **Scripts/deployment:** existing exact high-bit values remain unchanged.
- **IDL/docs:** the vendored host IDL contains only the appended chain-type error; the design decision is recorded as resolved.

## Negative evidence

- Host initialization rejects zero/low-bit Solana IDs and high-bit gateway IDs.
- KMS rejects both chain-kind/bit mismatches.
- Relayer rejects both chain-bit/address-format mismatches and preserves valid Solana configuration.
- SDK rejects low-bit and out-of-`u64` values while preserving exact high-bit bigints.
- Scenario resolution rejects unsafe numeric YAML, out-of-`u64`, Solana-low-bit, and EVM/default-high-bit IDs.

## Non-goals

- No handle version/layout change.
- No account, event, type, or persisted-state layout change.
- No confidential-bridge implementation.
- No invented mainnet/devnet low-63-bit allocation.

## Validation

- Relayer: 295/295 tests.
- KMS worker: 100/100 tests.
- zama-host: 80/80 tests.
- SDK focused tests: 8/8; focused typecheck, Prettier, and source ESLint pass.
- Scenario resolver: 16/16 tests and full local typecheck.
- Pinned Anchor IDL regeneration and CI-aligned IDL/schema/ABI/event-version checks pass.
- Independent adversarial re-review at `04ff924b32204a7a69d75fb058169a94874464d1`: no actionable findings.
