### PR TITLE
test(test-suite): snapshot frame-cap fhe_eval profile for marginal op cost

### DIFF
--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -1,4 +1,9 @@
 {
+  "fhe_eval/sixteen_op_frame": {
+    "compute_units": 151083,
+    "unique_accounts": 9,
+    "instruction_data_bytes": 921
+  },
   "fhe_eval/three_op_frame": {
     "compute_units": 61398,
     "unique_accounts": 9,

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -2,11 +2,15 @@
   "fhe_eval/sixteen_op_frame": {
     "compute_units": 151083,
     "unique_accounts": 9,
-    "instruction_data_bytes": 921
+    "instruction_data_bytes": 921,
+    "cpi_instructions": 3,
+    "cpi_instruction_data_bytes": 60
   },
   "fhe_eval/three_op_frame": {
     "compute_units": 61398,
     "unique_accounts": 9,
-    "instruction_data_bytes": 375
+    "instruction_data_bytes": 375,
+    "cpi_instructions": 3,
+    "cpi_instruction_data_bytes": 60
   }
 }

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -1,16 +1,16 @@
 {
-  "fhe_eval/sixteen_op_frame": {
+  "fhe_eval/max_op_frame": {
     "compute_units": 151083,
     "unique_accounts": 9,
     "instruction_data_bytes": 921,
     "cpi_instructions": 3,
-    "cpi_instruction_data_bytes": 60
+    "total_cpi_instruction_data_bytes": 60
   },
   "fhe_eval/three_op_frame": {
     "compute_units": 61398,
     "unique_accounts": 9,
     "instruction_data_bytes": 375,
     "cpi_instructions": 3,
-    "cpi_instruction_data_bytes": 60
+    "total_cpi_instruction_data_bytes": 60
   }
 }

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -4,13 +4,15 @@
     "unique_accounts": 9,
     "instruction_data_bytes": 921,
     "cpi_instructions": 3,
-    "total_cpi_instruction_data_bytes": 60
+    "total_cpi_instruction_data_bytes": 60,
+    "max_cpi_instruction_data_bytes": 36
   },
   "fhe_eval/three_op_frame": {
     "compute_units": 61398,
     "unique_accounts": 9,
     "instruction_data_bytes": 375,
     "cpi_instructions": 3,
-    "total_cpi_instruction_data_bytes": 60
+    "total_cpi_instruction_data_bytes": 60,
+    "max_cpi_instruction_data_bytes": 36
   }
 }

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -2,16 +2,22 @@
   "confidential_transfer/direct": {
     "compute_units": 332592,
     "unique_accounts": 15,
-    "instruction_data_bytes": 223
+    "instruction_data_bytes": 223,
+    "cpi_instructions": 7,
+    "cpi_instruction_data_bytes": 2212
   },
   "confidential_transfer/steady_state": {
     "compute_units": 350061,
     "unique_accounts": 15,
-    "instruction_data_bytes": 223
+    "instruction_data_bytes": 223,
+    "cpi_instructions": 5,
+    "cpi_instruction_data_bytes": 2296
   },
   "initialize_token_account": {
     "compute_units": 65180,
     "unique_accounts": 12,
-    "instruction_data_bytes": 16
+    "instruction_data_bytes": 16,
+    "cpi_instructions": 6,
+    "cpi_instruction_data_bytes": 603
   }
 }

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -4,20 +4,23 @@
     "unique_accounts": 15,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
-    "total_cpi_instruction_data_bytes": 2212
+    "total_cpi_instruction_data_bytes": 2212,
+    "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
     "compute_units": 350061,
     "unique_accounts": 15,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
-    "total_cpi_instruction_data_bytes": 2296
+    "total_cpi_instruction_data_bytes": 2296,
+    "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
     "compute_units": 65180,
     "unique_accounts": 12,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,
-    "total_cpi_instruction_data_bytes": 603
+    "total_cpi_instruction_data_bytes": 603,
+    "max_cpi_instruction_data_bytes": 249
   }
 }

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -4,20 +4,20 @@
     "unique_accounts": 15,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
-    "cpi_instruction_data_bytes": 2212
+    "total_cpi_instruction_data_bytes": 2212
   },
   "confidential_transfer/steady_state": {
     "compute_units": 350061,
     "unique_accounts": 15,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
-    "cpi_instruction_data_bytes": 2296
+    "total_cpi_instruction_data_bytes": 2296
   },
   "initialize_token_account": {
     "compute_units": 65180,
     "unique_accounts": 12,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,
-    "cpi_instruction_data_bytes": 603
+    "total_cpi_instruction_data_bytes": 603
   }
 }

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -3284,10 +3284,10 @@ impl EvalFixture {
         ix
     }
 
-    /// A frame at `MAX_FHE_EVAL_OPS`: `Ge` control + 14 alternating `Sub`/`Add` transient
-    /// steps + the durable `IfThenElse` output. Same accounts and output shape as
-    /// `block_cap_instruction`, so against the three-op profile the compute-unit delta
-    /// divided by 13 is the marginal cost of one FHE eval step.
+    /// A frame at `MAX_FHE_EVAL_OPS`: `Ge` control, alternating `Sub`/`Add` transient
+    /// steps, and the durable `IfThenElse` output. Same accounts and output shape as
+    /// `block_cap_instruction`, so the compute-unit delta against the three-op profile
+    /// isolates the additional host-side FHE eval steps.
     fn max_ops_instruction(&self) -> Instruction {
         let mut steps = vec![FheEvalStep::Binary {
             op: FheBinaryOpCode::Ge,
@@ -3296,7 +3296,9 @@ impl EvalFixture {
             output_fhe_type: 0,
             output: FheEvalOutput::AllowedLocal,
         }];
-        for index in 1..=14u16 {
+        let last_transient_index = u16::try_from(host::MAX_FHE_EVAL_OPS - 2)
+            .expect("MAX_FHE_EVAL_OPS must fit producer indices");
+        for index in 1..=last_transient_index {
             let op = if index % 2 == 1 {
                 FheBinaryOpCode::Sub
             } else {
@@ -3323,7 +3325,9 @@ impl EvalFixture {
         steps.push(FheEvalStep::Ternary {
             op: FheTernaryOpCode::IfThenElse,
             control: FheEvalOperand::AllowedLocal { producer_index: 0 },
-            if_true: FheEvalOperand::AllowedLocal { producer_index: 14 },
+            if_true: FheEvalOperand::AllowedLocal {
+                producer_index: last_transient_index,
+            },
             if_false: self.balance_operand(),
             output_fhe_type: 5,
             output: FheEvalOutput::AllowedDurable {
@@ -4021,12 +4025,11 @@ fn cost_snapshot_fhe_eval_three_op_frame() {
 }
 
 #[test]
-fn cost_snapshot_fhe_eval_sixteen_op_frame() {
+fn cost_snapshot_fhe_eval_max_op_frame() {
     // A frame at MAX_FHE_EVAL_OPS with the same fixture keys, accounts, and
-    // durable-output shape as the three-op profile: the compute-unit delta
-    // between the two profiles divided by 13 is the marginal cost of one FHE
-    // eval step, which prices designs that add steps to an existing plan
-    // (e.g. a spendable-balance check on transfers).
+    // durable-output shape as the three-op profile. The compute-unit delta
+    // isolates the extra direct host-side FHE eval steps; it does not include
+    // work performed by an application before invoking the host program.
     let fixture = EvalFixture::with_block_cap_keys(
         u64::MAX,
         Pubkey::new_from_array([0x21; 32]),
@@ -4038,5 +4041,5 @@ fn cost_snapshot_fhe_eval_sixteen_op_frame() {
         .context
         .process_and_validate_instruction(&ix, &[Check::success()]);
 
-    cost_snapshot::assert_cost_snapshot("host_mollusk", "fhe_eval/sixteen_op_frame", &ix, &result);
+    cost_snapshot::assert_cost_snapshot("host_mollusk", "fhe_eval/max_op_frame", &ix, &result);
 }

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -3284,6 +3284,89 @@ impl EvalFixture {
         ix
     }
 
+    /// A frame at `MAX_FHE_EVAL_OPS`: `Ge` control + 14 alternating `Sub`/`Add` transient
+    /// steps + the durable `IfThenElse` output. Same accounts and output shape as
+    /// `block_cap_instruction`, so against the three-op profile the compute-unit delta
+    /// divided by 13 is the marginal cost of one FHE eval step.
+    fn max_ops_instruction(&self) -> Instruction {
+        let mut steps = vec![FheEvalStep::Binary {
+            op: FheBinaryOpCode::Ge,
+            lhs: self.balance_operand(),
+            rhs: self.amount_operand(),
+            output_fhe_type: 0,
+            output: FheEvalOutput::AllowedLocal,
+        }];
+        for index in 1..=14u16 {
+            let op = if index % 2 == 1 {
+                FheBinaryOpCode::Sub
+            } else {
+                FheBinaryOpCode::Add
+            };
+            // The first arithmetic step starts from the euint64 balance; later
+            // ones chain the previous arithmetic output (step 0 is the ebool
+            // control and cannot feed an arithmetic operand).
+            let lhs = if index == 1 {
+                self.balance_operand()
+            } else {
+                FheEvalOperand::AllowedLocal {
+                    producer_index: index - 1,
+                }
+            };
+            steps.push(FheEvalStep::Binary {
+                op,
+                lhs,
+                rhs: self.amount_operand(),
+                output_fhe_type: 5,
+                output: FheEvalOutput::AllowedLocal,
+            });
+        }
+        steps.push(FheEvalStep::Ternary {
+            op: FheTernaryOpCode::IfThenElse,
+            control: FheEvalOperand::AllowedLocal { producer_index: 0 },
+            if_true: FheEvalOperand::AllowedLocal { producer_index: 14 },
+            if_false: self.balance_operand(),
+            output_fhe_type: 5,
+            output: FheEvalOutput::AllowedDurable {
+                output_encrypted_value_index: 2,
+                output_app_account_authority_index: None,
+                output_acl_domain_key: self.authority,
+                output_app_account: self.app_account,
+                output_encrypted_value_label: self.output_label,
+                output_subjects: vec![host::AclSubjectEntry {
+                    pubkey: self.authority,
+                }],
+                previous_handle: None,
+                previous_subjects: None,
+                make_public: false,
+            },
+        });
+        let mut ix = anchor_ix(
+            self.program_id,
+            host::accounts::FheEval {
+                payer: self.authority,
+                compute_subject: self.authority,
+                app_account_authority: self.app_account,
+                host_config: self.host_config,
+                system_program: system_program::ID,
+                hcu_authority: self.hcu_authority,
+                hcu_block_meter: None,
+                hcu_trusted_app_record: None,
+                event_authority: event_authority(self.program_id),
+                program: self.program_id,
+            },
+            host::instruction::FheEval {
+                args: FheEvalArgs {
+                    context_id: label("max-ops-frame"),
+                    steps,
+                },
+            },
+        );
+        ix.accounts.push(writable(self.balance_value));
+        ix.accounts.push(writable(self.amount_value));
+        ix.accounts.push(writable(self.output_value));
+        ix
+    }
+
     /// A transient-only frame (single step, `AllowedLocal` output) — produces no durable
     /// output; the block-cap identity comes solely from the `hcu_authority` signer.
     fn transient_only_instruction(
@@ -3935,4 +4018,25 @@ fn cost_snapshot_fhe_eval_three_op_frame() {
         .process_and_validate_instruction(&ix, &[Check::success()]);
 
     cost_snapshot::assert_cost_snapshot("host_mollusk", "fhe_eval/three_op_frame", &ix, &result);
+}
+
+#[test]
+fn cost_snapshot_fhe_eval_sixteen_op_frame() {
+    // A frame at MAX_FHE_EVAL_OPS with the same fixture keys, accounts, and
+    // durable-output shape as the three-op profile: the compute-unit delta
+    // between the two profiles divided by 13 is the marginal cost of one FHE
+    // eval step, which prices designs that add steps to an existing plan
+    // (e.g. a spendable-balance check on transfers).
+    let fixture = EvalFixture::with_block_cap_keys(
+        u64::MAX,
+        Pubkey::new_from_array([0x21; 32]),
+        Pubkey::new_from_array([0x22; 32]),
+    );
+    let ix = fixture.max_ops_instruction();
+
+    let result = fixture
+        .context
+        .process_and_validate_instruction(&ix, &[Check::success()]);
+
+    cost_snapshot::assert_cost_snapshot("host_mollusk", "fhe_eval/sixteen_op_frame", &ix, &result);
 }

--- a/solana/runtime-tests/tests/support/cost_snapshot.rs
+++ b/solana/runtime-tests/tests/support/cost_snapshot.rs
@@ -133,6 +133,12 @@ pub fn assert_cost_snapshot(
             expected.total_cpi_instruction_data_bytes, measured.total_cpi_instruction_data_bytes
         ));
     }
+    if measured.max_cpi_instruction_data_bytes != expected.max_cpi_instruction_data_bytes {
+        failures.push(format!(
+            "maximum CPI instruction data bytes changed: {} -> {}",
+            expected.max_cpi_instruction_data_bytes, measured.max_cpi_instruction_data_bytes
+        ));
+    }
     if measured.compute_units != expected.compute_units {
         let direction = if measured.compute_units > expected.compute_units {
             "regression"
@@ -159,10 +165,9 @@ pub fn assert_cost_snapshot(
 /// account-meta pubkeys plus the program id), not a count of accounts loaded
 /// at runtime.
 ///
-/// `cpi_instructions` / `total_cpi_instruction_data_bytes` cover every inner
-/// instruction at any stack depth, so nested CPIs (token -> host -> event
-/// batch) are all included. The total therefore covers both application-to-host
-/// calls and any CPIs issued by the host.
+/// The CPI metrics cover every inner instruction at any stack depth, including
+/// application-to-host and host-issued nested calls. The total captures the
+/// aggregate payload while the maximum tracks the per-instruction runtime limit.
 #[derive(Clone, Copy, Deserialize, Serialize)]
 struct Cost {
     compute_units: u64,
@@ -170,6 +175,7 @@ struct Cost {
     instruction_data_bytes: usize,
     cpi_instructions: usize,
     total_cpi_instruction_data_bytes: usize,
+    max_cpi_instruction_data_bytes: usize,
 }
 
 fn measure(instruction: &Instruction, result: &InstructionResult) -> Cost {
@@ -189,6 +195,12 @@ fn measure(instruction: &Instruction, result: &InstructionResult) -> Cost {
             .iter()
             .map(|inner| inner.instruction.data.len())
             .sum(),
+        max_cpi_instruction_data_bytes: result
+            .inner_instructions
+            .iter()
+            .map(|inner| inner.instruction.data.len())
+            .max()
+            .unwrap_or(0),
     }
 }
 

--- a/solana/runtime-tests/tests/support/cost_snapshot.rs
+++ b/solana/runtime-tests/tests/support/cost_snapshot.rs
@@ -1,8 +1,9 @@
 //! Rolling cost snapshot over Mollusk fixtures.
 //!
 //! Records the Solana runtime cost of representative instruction profiles —
-//! compute units, unique account count, and instruction-data size — and
-//! compares them against the committed snapshot under `cost-snapshots/`.
+//! compute units, unique account count, instruction-data size, and the count
+//! and total data size of the CPIs the instruction issues — and compares them
+//! against the committed snapshot under `cost-snapshots/`.
 //! Drift in either direction fails the dedicated `cost_snapshot_*` tests:
 //! costlier is a regression, cheaper invalidates design assumptions derived
 //! from the old number (transaction packing, per-leg budgets), and both
@@ -120,6 +121,18 @@ pub fn assert_cost_snapshot(
             expected.instruction_data_bytes, measured.instruction_data_bytes
         ));
     }
+    if measured.cpi_instructions != expected.cpi_instructions {
+        failures.push(format!(
+            "CPI instruction count changed: {} -> {}",
+            expected.cpi_instructions, measured.cpi_instructions
+        ));
+    }
+    if measured.cpi_instruction_data_bytes != expected.cpi_instruction_data_bytes {
+        failures.push(format!(
+            "CPI instruction data bytes changed: {} -> {}",
+            expected.cpi_instruction_data_bytes, measured.cpi_instruction_data_bytes
+        ));
+    }
     if measured.compute_units != expected.compute_units {
         let direction = if measured.compute_units > expected.compute_units {
             "regression"
@@ -145,11 +158,18 @@ pub fn assert_cost_snapshot(
 /// `unique_accounts` is a static property of the instruction shape (unique
 /// account-meta pubkeys plus the program id), not a count of accounts loaded
 /// at runtime.
+///
+/// `cpi_instructions` / `cpi_instruction_data_bytes` cover every inner
+/// instruction at any stack depth, so nested CPIs (token -> host -> event
+/// batch) are all included. The dominant contributor today is the batched
+/// event CPI that carries the FHE operation records to the coprocessor.
 #[derive(Clone, Copy, Deserialize, Serialize)]
 struct Cost {
     compute_units: u64,
     unique_accounts: usize,
     instruction_data_bytes: usize,
+    cpi_instructions: usize,
+    cpi_instruction_data_bytes: usize,
 }
 
 fn measure(instruction: &Instruction, result: &InstructionResult) -> Cost {
@@ -163,6 +183,12 @@ fn measure(instruction: &Instruction, result: &InstructionResult) -> Cost {
         compute_units: result.compute_units_consumed,
         unique_accounts: accounts.len(),
         instruction_data_bytes: instruction.data.len(),
+        cpi_instructions: result.inner_instructions.len(),
+        cpi_instruction_data_bytes: result
+            .inner_instructions
+            .iter()
+            .map(|inner| inner.instruction.data.len())
+            .sum(),
     }
 }
 

--- a/solana/runtime-tests/tests/support/cost_snapshot.rs
+++ b/solana/runtime-tests/tests/support/cost_snapshot.rs
@@ -127,10 +127,10 @@ pub fn assert_cost_snapshot(
             expected.cpi_instructions, measured.cpi_instructions
         ));
     }
-    if measured.cpi_instruction_data_bytes != expected.cpi_instruction_data_bytes {
+    if measured.total_cpi_instruction_data_bytes != expected.total_cpi_instruction_data_bytes {
         failures.push(format!(
-            "CPI instruction data bytes changed: {} -> {}",
-            expected.cpi_instruction_data_bytes, measured.cpi_instruction_data_bytes
+            "total CPI instruction data bytes changed: {} -> {}",
+            expected.total_cpi_instruction_data_bytes, measured.total_cpi_instruction_data_bytes
         ));
     }
     if measured.compute_units != expected.compute_units {
@@ -159,17 +159,17 @@ pub fn assert_cost_snapshot(
 /// account-meta pubkeys plus the program id), not a count of accounts loaded
 /// at runtime.
 ///
-/// `cpi_instructions` / `cpi_instruction_data_bytes` cover every inner
+/// `cpi_instructions` / `total_cpi_instruction_data_bytes` cover every inner
 /// instruction at any stack depth, so nested CPIs (token -> host -> event
-/// batch) are all included. The dominant contributor today is the batched
-/// event CPI that carries the FHE operation records to the coprocessor.
+/// batch) are all included. The total therefore covers both application-to-host
+/// calls and any CPIs issued by the host.
 #[derive(Clone, Copy, Deserialize, Serialize)]
 struct Cost {
     compute_units: u64,
     unique_accounts: usize,
     instruction_data_bytes: usize,
     cpi_instructions: usize,
-    cpi_instruction_data_bytes: usize,
+    total_cpi_instruction_data_bytes: usize,
 }
 
 fn measure(instruction: &Instruction, result: &InstructionResult) -> Cost {
@@ -184,7 +184,7 @@ fn measure(instruction: &Instruction, result: &InstructionResult) -> Cost {
         unique_accounts: accounts.len(),
         instruction_data_bytes: instruction.data.len(),
         cpi_instructions: result.inner_instructions.len(),
-        cpi_instruction_data_bytes: result
+        total_cpi_instruction_data_bytes: result
             .inner_instructions
             .iter()
             .map(|inner| inner.instruction.data.len())


### PR DESCRIPTION
## What

- Adds a `fhe_eval/max_op_frame` Mollusk cost profile whose step count is derived from `MAX_FHE_EVAL_OPS` (currently 16).
- Uses the same fixed fixture keys, accounts, and durable-output shape as `fhe_eval/three_op_frame`.
- Snapshots exact compute units, unique accounts, top-level instruction-data bytes, flattened CPI count, total CPI instruction-data bytes, and the maximum individual CPI payload relevant to Solana's per-instruction limit.

## Why

The two host profiles isolate the cost of additional direct `fhe_eval` steps while holding the surrounding host instruction shape constant:

- `three_op_frame`: 61,398 CU
- `max_op_frame`: 151,083 CU
- current host-side marginal delta: (151,083 − 61,398) / 13 ≈ 6.9k CU per additional step

This is a host-program measurement, not an end-to-end confidential-transfer estimate. Application-side plan construction, account resolution, serialization, and the caller's CPI overhead are outside this comparison. The profile can inform designs such as zama-ai/fhevm-internal#1710, but any complete transfer percentage requires a representative confidential-token measurement.

## Reproducibility

After rebasing onto current `feature/solana`, all snapshots were regenerated with:

```text
PATH="$HOME/.local/share/solana/install/releases/2.1.0/solana-release/bin:$PATH" \
  bash scripts/update-cost-snapshots.sh
```

The repository script verified Solana CLI 2.1.0 and Anchor CLI 1.0.2, ran `cargo clean`, rebuilt the SBF programs, checked IDL/schema/event synchronization, cleared orphaned snapshot entries, and regenerated every live profile. The CU, account, top-level data, and aggregate CPI values were unchanged by the rebase. The regenerated snapshots additionally record the maximum per-CPI payload for every profile.

Strict compare-mode validation then passed all four snapshot tests:

- `fhe_eval/three_op_frame`
- `fhe_eval/max_op_frame`
- `confidential_transfer/direct` and its steady-state profile
- `initialize_token_account`

Rust formatting and `git diff --check` also pass.
