### PR TITLE
feat(test-suite): make e2e SDK selection explicit

### DIFF
--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -1,9 +1,15 @@
 ARG NODE_VERSION=22.22.2-alpine3.22
 ARG RELAYER_SDK_VERSION=""
+ARG E2E_SDK_FAMILY=""
+ARG E2E_SDK_SOURCE=""
+ARG E2E_SDK_VERSION=""
 
 # --- Builder Stage ---
 FROM node:${NODE_VERSION} AS builder
 ARG RELAYER_SDK_VERSION=""
+ARG E2E_SDK_FAMILY
+ARG E2E_SDK_SOURCE
+ARG E2E_SDK_VERSION
 
 WORKDIR /app
 
@@ -32,38 +38,50 @@ COPY library-solidity ./library-solidity
 COPY test-suite/e2e ./test-suite/e2e
 COPY sdk/js-sdk ./sdk/js-sdk
 
-# Install dependencies. Normal builds stay locked; rollout hotswap builds first
-# update the e2e workspace manifest in the image, then let npm resolve one
-# coherent dependency graph for that requested SDK version.
-RUN if [ -n "$RELAYER_SDK_VERSION" ]; then \
-      npm pkg set -w test-suite/e2e "dependencies.@zama-fhe/relayer-sdk=${RELAYER_SDK_VERSION}" && \
+# Install the repository graph from its lockfile. Published SDK cases pin the
+# selected top-level package while retaining the other workspace dependencies.
+RUN npm ci && npm prune && \
+    sdk_family="$E2E_SDK_FAMILY" && sdk_source="$E2E_SDK_SOURCE" && sdk_version="$E2E_SDK_VERSION" && \
+    if [ -z "$sdk_family$sdk_source$sdk_version" ] && [ -n "$RELAYER_SDK_VERSION" ]; then \
+      sdk_family="relayer-sdk"; sdk_source="npm"; sdk_version="$RELAYER_SDK_VERSION"; \
+    elif [ -z "$sdk_family$sdk_source$sdk_version" ]; then \
+      sdk_family="fhevm-sdk"; sdk_source="workspace"; sdk_version="workspace"; \
+    fi && \
+    if [ "$sdk_source" = "npm" ]; then \
+      if [ "$sdk_family" = "fhevm-sdk" ]; then package="@fhevm/sdk"; \
+      elif [ "$sdk_family" = "relayer-sdk" ]; then package="@zama-fhe/relayer-sdk"; \
+      else echo "Unsupported E2E_SDK_FAMILY: $sdk_family" >&2; exit 1; fi; \
+      npm pkg set -w test-suite/e2e "dependencies.${package}=${sdk_version}" && \
       npm install && \
       npm prune; \
-    else \
-      npm ci && \
-      npm prune; \
+    elif [ "$sdk_family" != "fhevm-sdk" ] || [ "$sdk_version" != "workspace" ]; then \
+      echo "workspace selection requires fhevm-sdk@workspace" >&2; exit 1; \
     fi
 
 # Compile js-sdk
 WORKDIR /app/sdk/js-sdk
 
-RUN npm install
 RUN npm run build
 
 # Compile test-suite
 WORKDIR /app/test-suite/e2e
 
+RUN npm run tsc:sdk-selection
 RUN npx hardhat compile
 
 # --- Runtime Stage ---
 FROM node:${NODE_VERSION} AS prod
 ARG RELAYER_SDK_VERSION=""
+ARG E2E_SDK_FAMILY
+ARG E2E_SDK_SOURCE
+ARG E2E_SDK_VERSION
 
-# Propagate the build ARG into the container's runtime env. instance.ts gates
-# on this:
-#   process.env.RELAYER_SDK_VERSION === ""   → use @fhevm/sdk (default)
-#   process.env.RELAYER_SDK_VERSION === "x"  → use @zama-fhe/relayer-sdk@x
+# RELAYER_SDK_VERSION remains available only for images built through the
+# legacy interface. New callers select family, source, and version explicitly.
 ENV RELAYER_SDK_VERSION=${RELAYER_SDK_VERSION}
+ENV E2E_SDK_FAMILY=${E2E_SDK_FAMILY}
+ENV E2E_SDK_SOURCE=${E2E_SDK_SOURCE}
+ENV E2E_SDK_VERSION=${E2E_SDK_VERSION}
 
 COPY --from=builder /lib/ /lib/
 COPY --from=builder /bin/ /bin/

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -41,13 +41,10 @@ COPY sdk/js-sdk ./sdk/js-sdk
 # Install the repository graph from its lockfile. Published SDK cases pin the
 # selected top-level package while retaining the other workspace dependencies.
 RUN npm ci && npm prune && \
-    npm run -w test-suite/e2e validate:sdk-selection && \
-    sdk_family="$E2E_SDK_FAMILY" && sdk_source="$E2E_SDK_SOURCE" && sdk_version="$E2E_SDK_VERSION" && \
-    if [ -z "$sdk_family$sdk_source$sdk_version" ] && [ -n "$RELAYER_SDK_VERSION" ]; then \
-      sdk_family="relayer-sdk"; sdk_source="npm"; sdk_version="$RELAYER_SDK_VERSION"; \
-    elif [ -z "$sdk_family$sdk_source$sdk_version" ]; then \
-      sdk_family="fhevm-sdk"; sdk_source="workspace"; sdk_version="workspace"; \
-    fi && \
+    selection="$(npm run --silent -w test-suite/e2e resolve:sdk-selection)" && \
+    sdk_family="$(printf '%s' "$selection" | jq -r .family)" && \
+    sdk_source="$(printf '%s' "$selection" | jq -r .source)" && \
+    sdk_version="$(printf '%s' "$selection" | jq -r .requestedVersion)" && \
     if [ "$sdk_source" = "npm" ]; then \
       if [ "$sdk_family" = "fhevm-sdk" ]; then package="@fhevm/sdk"; \
       elif [ "$sdk_family" = "relayer-sdk" ]; then package="@zama-fhe/relayer-sdk"; \
@@ -67,8 +64,8 @@ RUN npm run build
 # Compile test-suite
 WORKDIR /app/test-suite/e2e
 
-RUN npm run test:sdk-selection && npm run tsc:sdk-selection
 RUN npx hardhat compile
+RUN npm run test:sdk-selection && npm run tsc:sdk-selection
 
 # --- Runtime Stage ---
 FROM node:${NODE_VERSION} AS prod
@@ -77,8 +74,8 @@ ARG E2E_SDK_FAMILY
 ARG E2E_SDK_SOURCE
 ARG E2E_SDK_VERSION
 
-# RELAYER_SDK_VERSION remains available only for images built through the
-# legacy interface. New callers select family, source, and version explicitly.
+# RELAYER_SDK_VERSION remains available for existing image builders. New
+# callers select family, source, and version explicitly.
 ENV RELAYER_SDK_VERSION=${RELAYER_SDK_VERSION}
 ENV E2E_SDK_FAMILY=${E2E_SDK_FAMILY}
 ENV E2E_SDK_SOURCE=${E2E_SDK_SOURCE}

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -41,6 +41,7 @@ COPY sdk/js-sdk ./sdk/js-sdk
 # Install the repository graph from its lockfile. Published SDK cases pin the
 # selected top-level package while retaining the other workspace dependencies.
 RUN npm ci && npm prune && \
+    npm run -w test-suite/e2e validate:sdk-selection && \
     sdk_family="$E2E_SDK_FAMILY" && sdk_source="$E2E_SDK_SOURCE" && sdk_version="$E2E_SDK_VERSION" && \
     if [ -z "$sdk_family$sdk_source$sdk_version" ] && [ -n "$RELAYER_SDK_VERSION" ]; then \
       sdk_family="relayer-sdk"; sdk_source="npm"; sdk_version="$RELAYER_SDK_VERSION"; \
@@ -66,7 +67,7 @@ RUN npm run build
 # Compile test-suite
 WORKDIR /app/test-suite/e2e
 
-RUN npm run tsc:sdk-selection
+RUN npm run test:sdk-selection && npm run tsc:sdk-selection
 RUN npx hardhat compile
 
 # --- Runtime Stage ---

--- a/test-suite/e2e/package.json
+++ b/test-suite/e2e/package.json
@@ -28,6 +28,8 @@
     "codegen": "../../library-solidity/codegen/codegen.mjs lib --config ./codegen.config.json --verbose",
     "codegen:overloads": "../../library-solidity/codegen/codegen.mjs overloads --config ./codegen.config.json --verbose --force",
     "prettier": "prettier --write \"**/*.{js,json,md,sol,ts,yml}\"",
+    "test:sdk-selection": "node --test -r ts-node/register test/sdk/selection.test.ts",
+    "tsc:sdk-selection": "tsc --noEmit -p tsconfig.sdk-selection.json",
     "tsc": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/test-suite/e2e/package.json
+++ b/test-suite/e2e/package.json
@@ -30,6 +30,7 @@
     "prettier": "prettier --write \"**/*.{js,json,md,sol,ts,yml}\"",
     "test:sdk-selection": "node --test -r ts-node/register test/sdk/selection.test.ts",
     "tsc:sdk-selection": "tsc --noEmit -p tsconfig.sdk-selection.json",
+    "validate:sdk-selection": "node -r ts-node/register -e \"require('./test/sdk/selection').selectSdk(process.env)\"",
     "tsc": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/test-suite/e2e/package.json
+++ b/test-suite/e2e/package.json
@@ -28,9 +28,9 @@
     "codegen": "../../library-solidity/codegen/codegen.mjs lib --config ./codegen.config.json --verbose",
     "codegen:overloads": "../../library-solidity/codegen/codegen.mjs overloads --config ./codegen.config.json --verbose --force",
     "prettier": "prettier --write \"**/*.{js,json,md,sol,ts,yml}\"",
-    "test:sdk-selection": "node --test -r ts-node/register test/sdk/selection.test.ts",
+    "test:sdk-selection": "TS_NODE_PROJECT=tsconfig.sdk-selection.json node --test -r ts-node/register test/sdk/selection.test.ts",
     "tsc:sdk-selection": "tsc --noEmit -p tsconfig.sdk-selection.json",
-    "validate:sdk-selection": "node -r ts-node/register -e \"require('./test/sdk/selection').selectSdk(process.env)\"",
+    "resolve:sdk-selection": "node -r ts-node/register -e \"process.stdout.write(JSON.stringify(require('./test/sdk/selection').selectSdk(process.env)))\"",
     "tsc": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/test-suite/e2e/test/instance.ts
+++ b/test-suite/e2e/test/instance.ts
@@ -1,32 +1,14 @@
-import { MainnetConfig, SepoliaConfig } from '@zama-fhe/relayer-sdk/node';
 import { network } from 'hardhat';
 import { vars } from 'hardhat/config';
 
-import { FhevmSdk } from './sdk/fhevm-sdk/sdk';
-import { RelayerSdk } from './sdk/relayer-sdk/sdk';
+import { createSdkInstance, sdkNetworkDefaults } from './sdk/factory';
 import type { Signers } from './signers';
 import { FhevmInstances } from './types';
 
-console.log(`=========================================================`);
-console.log(`process.env.RELAYER_SDK_VERSION=${process.env.RELAYER_SDK_VERSION}`);
-
-let useFhevmSdk = false;
-if (!(typeof process.env.RELAYER_SDK_VERSION === 'string' && process.env.RELAYER_SDK_VERSION.length > 0)) {
-  useFhevmSdk = true;
-}
-
-console.log(`useFhevmSdk=${useFhevmSdk}`);
-console.log(`=========================================================`);
-
-// By default use @fhevm/sdk
-// const useFhevmSdk =
-//   !(typeof process.env.RELAYER_SDK_VERSION === "string" && process.env.RELAYER_SDK_VERSION.length > 0) && false;
-//const useFhevmSdk = true;
-
 const defaults = (() => {
   const chainId = network.config.chainId;
-  if (network.name === 'sepolia' || chainId === 11155111) return SepoliaConfig;
-  if (network.name === 'mainnet' || chainId === 1) return MainnetConfig;
+  if (network.name === 'sepolia' || chainId === 11155111) return sdkNetworkDefaults('sepolia');
+  if (network.name === 'mainnet' || chainId === 1) return sdkNetworkDefaults('mainnet');
   return undefined;
 })();
 
@@ -103,10 +85,7 @@ export const createInstance = async () => {
     chainId: hostChainID,
     ...(auth ? { auth } : {}),
   };
-  if (useFhevmSdk) {
-    return FhevmSdk.create(cfg);
-  }
-  return RelayerSdk.create(cfg);
+  return createSdkInstance(cfg);
 };
 
 // Export coprocessor config addresses for smoke tests

--- a/test-suite/e2e/test/multiChain/multiChainHelper.ts
+++ b/test-suite/e2e/test/multiChain/multiChainHelper.ts
@@ -1,10 +1,8 @@
-import { createInstance as createFhevmInstance } from '@zama-fhe/relayer-sdk/node';
 import { ethers } from 'ethers';
 import { ethers as hardhatEthers } from 'hardhat';
 import { vars } from 'hardhat/config';
 
-import { FhevmSdk } from '../sdk/fhevm-sdk/sdk';
-import { RelayerSdk } from '../sdk/relayer-sdk/sdk';
+import { createSdkInstance } from '../sdk/factory';
 
 const defaultMnemonic =
   'adapt mosquito move limb mobile illegal tree voyage juice mosquito burger raise father hope layer';
@@ -14,9 +12,6 @@ const decryptionAddress = process.env.DECRYPTION_ADDRESS!;
 const inputVerificationAddress = process.env.INPUT_VERIFICATION_ADDRESS!;
 const relayerUrl = process.env.RELAYER_URL!;
 const gatewayChainId = Number(process.env.CHAIN_ID_GATEWAY!);
-
-// True by default
-const useFhevmSdk = true;
 
 export interface ChainConfig {
   rpcUrl: string;
@@ -135,10 +130,7 @@ export async function createInstance(chain: ChainConfig) {
     gatewayChainId,
     chainId: chain.chainId,
   };
-  if (useFhevmSdk) {
-    return FhevmSdk.create(cfg);
-  }
-  return RelayerSdk.create(cfg);
+  return createSdkInstance(cfg);
 }
 
 export async function deployContract(

--- a/test-suite/e2e/test/sdk/factory.ts
+++ b/test-suite/e2e/test/sdk/factory.ts
@@ -62,6 +62,20 @@ const packageIdentity =
         version: installedPackageVersion('@zama-fhe/relayer-sdk', '@zama-fhe/relayer-sdk/node'),
       };
 
+const packageEntrypoint = fs.realpathSync(
+  require.resolve(selection.family === 'fhevm-sdk' ? '@fhevm/sdk' : '@zama-fhe/relayer-sdk/node'),
+);
+const vendoredFhevmSdk = fs.realpathSync(path.resolve(__dirname, '../../../../sdk/js-sdk'));
+if (
+  selection.family === 'fhevm-sdk' &&
+  selection.source === 'npm' &&
+  packageEntrypoint.startsWith(`${vendoredFhevmSdk}${path.sep}`)
+) {
+  throw new Error(
+    `Requested ${packageIdentity.name}@${selection.requestedVersion} from npm, but it resolves to the vendored SDK workspace`,
+  );
+}
+
 if (selection.source === 'npm' && packageIdentity.version !== selection.requestedVersion) {
   throw new Error(
     `Requested ${packageIdentity.name}@${selection.requestedVersion}, but the test image contains ${packageIdentity.name}@${packageIdentity.version}`,

--- a/test-suite/e2e/test/sdk/factory.ts
+++ b/test-suite/e2e/test/sdk/factory.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { LEGACY_SDK_SELECTION_WARNING, selectSdk } from './selection';
+import type { Auth, SdkInstance } from './types';
+
+export type SdkConfig = {
+  verifyingContractAddressDecryption: string;
+  verifyingContractAddressInputVerification: string;
+  kmsContractAddress: string;
+  inputVerifierContractAddress: string;
+  aclContractAddress: string;
+  protocolConfigAddress?: string;
+  relayerUrl: string;
+  rpcUrl: string;
+  gatewayChainId: number;
+  chainId: number;
+  auth?: Auth;
+};
+
+const selection = selectSdk(process.env);
+
+type SdkNetworkDefaults = Omit<SdkConfig, 'rpcUrl' | 'auth' | 'protocolConfigAddress'>;
+
+type FhevmChainDefaults = {
+  id: number;
+  fhevm: {
+    contracts: {
+      acl: { address: string };
+      inputVerifier: { address: string };
+      kmsVerifier: { address: string };
+    };
+    relayerUrl: string;
+    gateway: {
+      id: number;
+      contracts: {
+        decryption: { address: string };
+        inputVerification: { address: string };
+      };
+    };
+  };
+};
+
+function installedPackageVersion(packageName: string, entrypoint: string): string {
+  let directory = path.dirname(require.resolve(entrypoint));
+  while (directory !== path.dirname(directory)) {
+    const manifestPath = path.join(directory, 'package.json');
+    if (fs.existsSync(manifestPath)) {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { name?: string; version?: string };
+      if (manifest.name === packageName && manifest.version) return manifest.version;
+    }
+    directory = path.dirname(directory);
+  }
+  throw new Error(`Could not resolve installed version for ${packageName}`);
+}
+
+const packageIdentity =
+  selection.family === 'fhevm-sdk'
+    ? { name: '@fhevm/sdk', version: installedPackageVersion('@fhevm/sdk', '@fhevm/sdk') }
+    : {
+        name: '@zama-fhe/relayer-sdk',
+        version: installedPackageVersion('@zama-fhe/relayer-sdk', '@zama-fhe/relayer-sdk/node'),
+      };
+
+if (selection.source === 'npm' && packageIdentity.version !== selection.requestedVersion) {
+  throw new Error(
+    `Requested ${packageIdentity.name}@${selection.requestedVersion}, but the test image contains ${packageIdentity.name}@${packageIdentity.version}`,
+  );
+}
+
+if (selection.legacy) {
+  console.warn(LEGACY_SDK_SELECTION_WARNING);
+}
+console.log(
+  `E2E SDK identity: ${JSON.stringify({
+    family: selection.family,
+    source: selection.source,
+    requestedVersion: selection.requestedVersion,
+    package: packageIdentity,
+    legacySelection: selection.legacy,
+  })}`,
+);
+
+export function sdkNetworkDefaults(network: 'mainnet' | 'sepolia'): SdkNetworkDefaults {
+  if (selection.family === 'relayer-sdk') {
+    const module = require('@zama-fhe/relayer-sdk/node') as {
+      MainnetConfig: SdkNetworkDefaults;
+      SepoliaConfig: SdkNetworkDefaults;
+    };
+    return network === 'mainnet' ? module.MainnetConfig : module.SepoliaConfig;
+  }
+
+  const module = require('@fhevm/sdk/chains') as { mainnet: FhevmChainDefaults; sepolia: FhevmChainDefaults };
+  const chain = network === 'mainnet' ? module.mainnet : module.sepolia;
+  return {
+    aclContractAddress: chain.fhevm.contracts.acl.address,
+    kmsContractAddress: chain.fhevm.contracts.kmsVerifier.address,
+    inputVerifierContractAddress: chain.fhevm.contracts.inputVerifier.address,
+    verifyingContractAddressDecryption: chain.fhevm.gateway.contracts.decryption.address,
+    verifyingContractAddressInputVerification: chain.fhevm.gateway.contracts.inputVerification.address,
+    relayerUrl: chain.fhevm.relayerUrl,
+    gatewayChainId: chain.fhevm.gateway.id,
+    chainId: chain.id,
+  };
+}
+
+export async function createSdkInstance(config: SdkConfig): Promise<SdkInstance> {
+  if (selection.family === 'fhevm-sdk') {
+    const { FhevmSdk } = await import('./fhevm-sdk/sdk');
+    return FhevmSdk.create(config);
+  }
+  const { RelayerSdk } = await import('./relayer-sdk/sdk');
+  return RelayerSdk.create(config);
+}

--- a/test-suite/e2e/test/sdk/factory.ts
+++ b/test-suite/e2e/test/sdk/factory.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { LEGACY_SDK_SELECTION_WARNING, selectSdk } from './selection';
+import { selectSdk } from './selection';
 import type { Auth, SdkInstance } from './types';
 
 export type SdkConfig = {
@@ -62,18 +62,18 @@ const packageIdentity =
         version: installedPackageVersion('@zama-fhe/relayer-sdk', '@zama-fhe/relayer-sdk/node'),
       };
 
-const packageEntrypoint = fs.realpathSync(
-  require.resolve(selection.family === 'fhevm-sdk' ? '@fhevm/sdk' : '@zama-fhe/relayer-sdk/node'),
-);
-const vendoredFhevmSdk = fs.realpathSync(path.resolve(__dirname, '../../../../sdk/js-sdk'));
-if (
-  selection.family === 'fhevm-sdk' &&
-  selection.source === 'npm' &&
-  packageEntrypoint.startsWith(`${vendoredFhevmSdk}${path.sep}`)
-) {
-  throw new Error(
-    `Requested ${packageIdentity.name}@${selection.requestedVersion} from npm, but it resolves to the vendored SDK workspace`,
-  );
+if (selection.family === 'fhevm-sdk') {
+  const packageEntrypoint = fs.realpathSync(require.resolve('@fhevm/sdk'));
+  const vendoredFhevmSdk = fs.realpathSync(path.resolve(__dirname, '../../../../sdk/js-sdk'));
+  const resolvesToWorkspace = packageEntrypoint.startsWith(`${vendoredFhevmSdk}${path.sep}`);
+  if (selection.source === 'npm' && resolvesToWorkspace) {
+    throw new Error(
+      `Requested ${packageIdentity.name}@${selection.requestedVersion} from npm, but it resolves to the vendored SDK workspace`,
+    );
+  }
+  if (selection.source === 'workspace' && !resolvesToWorkspace) {
+    throw new Error(`Requested the vendored SDK workspace, but ${packageIdentity.name} resolves to ${packageEntrypoint}`);
+  }
 }
 
 if (selection.source === 'npm' && packageIdentity.version !== selection.requestedVersion) {
@@ -82,16 +82,12 @@ if (selection.source === 'npm' && packageIdentity.version !== selection.requeste
   );
 }
 
-if (selection.legacy) {
-  console.warn(LEGACY_SDK_SELECTION_WARNING);
-}
 console.log(
   `E2E SDK identity: ${JSON.stringify({
     family: selection.family,
     source: selection.source,
     requestedVersion: selection.requestedVersion,
     package: packageIdentity,
-    legacySelection: selection.legacy,
   })}`,
 );
 

--- a/test-suite/e2e/test/sdk/fhevm-sdk/sdk.ts
+++ b/test-suite/e2e/test/sdk/fhevm-sdk/sdk.ts
@@ -19,6 +19,27 @@ type FhevmClientProvider = CreateFhevmClientParameters['provider'];
 type Auth = any;
 
 const CLEARTEXT = false;
+const DECRYPTION_PERMIT_DURATION_DAYS = 10;
+
+// fhevm-sdk 1.1.0-alpha.4 accepts durationDays. The workspace SDK accepts
+// durationSeconds so it can model newer protocols. Passing both keeps the
+// adapter compatible while each SDK reads the field its API defines.
+const decryptionPermitValidity = (startTimestamp: number) => ({
+  startTimestamp,
+  durationDays: DECRYPTION_PERMIT_DURATION_DAYS,
+  durationSeconds: DECRYPTION_PERMIT_DURATION_DAYS * 24 * 3600,
+});
+
+const sdkLogger = {
+  debug: (message: string) => console.log(`[debug] ${message}`),
+  warn: (message: string) => console.log(`[warn] ${message}`),
+  error: (message: string, cause: unknown) => {
+    console.log(`[error] ${message}`);
+    if (cause !== undefined) {
+      console.log(`[error] ${cause}`);
+    }
+  },
+} as Parameters<typeof setFhevmRuntimeConfig>[0]['logger'];
 
 export class FhevmSdk implements SdkInstance {
   #fullClient: FhevmClient;
@@ -99,16 +120,7 @@ export class FhevmSdk implements SdkInstance {
     if (!hasFhevmRuntimeConfig()) {
       setFhevmRuntimeConfig({
         singleThread: false,
-        logger: {
-          debug: (message: string) => console.log(`[debug] ${message}`),
-          warn: (message: string) => console.log(`[warn] ${message}`),
-          error: (message: string, cause: unknown) => {
-            console.log(`[error] ${message}`);
-            if (cause !== undefined) {
-              console.log(`[error] ${cause}`);
-            }
-          },
-        },
+        logger: sdkLogger,
       });
     }
     const args = {
@@ -165,8 +177,7 @@ export class FhevmSdk implements SdkInstance {
 
     const signedPermit = await this.#fullClient.signDecryptionPermit({
       contractAddresses: [contractAddress],
-      durationSeconds: 10 * 24 * 3600, // 10 days
-      startTimestamp: parameters.startTimestamp ?? Math.floor(Date.now() / 1000),
+      ...decryptionPermitValidity(parameters.startTimestamp ?? Math.floor(Date.now() / 1000)),
       transportKeyPair,
       signer,
       signerAddress: signer.address,
@@ -204,8 +215,7 @@ export class FhevmSdk implements SdkInstance {
 
     const signedPermit = await this.#fullClient.signDecryptionPermit({
       contractAddresses: [contractAddress],
-      durationSeconds: 10 * 24 * 3600, // 10 days
-      startTimestamp: parameters.startTimestamp ?? Math.floor(Date.now() / 1000),
+      ...decryptionPermitValidity(parameters.startTimestamp ?? Math.floor(Date.now() / 1000)),
       transportKeyPair,
       signer,
       signerAddress: signer.address,

--- a/test-suite/e2e/test/sdk/relayer-sdk/sdk.ts
+++ b/test-suite/e2e/test/sdk/relayer-sdk/sdk.ts
@@ -4,6 +4,13 @@ import type { Signer } from "ethers";
 
 import type { Auth, ClearValueType, ClearValues, EncryptedInputResult, SdkInstance, TypedValue } from "../types";
 
+type ExtraDataRelayerInstance = FhevmInstance & {
+  getExtraData(): Promise<unknown>;
+};
+
+const supportsExtraData = (instance: FhevmInstance): instance is ExtraDataRelayerInstance =>
+  "getExtraData" in instance && typeof instance.getExtraData === "function";
+
 export class RelayerSdk implements SdkInstance {
   #instance: FhevmInstance;
 
@@ -159,15 +166,23 @@ export class RelayerSdk implements SdkInstance {
     const durationDays = 10;
     const contractAddresses = [contractAddress];
 
-    const extraData = await this.#instance.getExtraData?.();
-    // The `delegate` creates a EIP712 with the `delegator` address
-    const eip712 = this.#instance.createDelegatedUserDecryptEIP712(
+    const hasExtraData = supportsExtraData(this.#instance);
+    const extraData = hasExtraData
+      ? await (this.#instance as ExtraDataRelayerInstance).getExtraData()
+      : undefined;
+    // The `delegate` creates a EIP712 with the `delegator` address. relayer-sdk
+    // 0.4.x has no extraData argument; later versions append it positionally.
+    const createEip712 = this.#instance.createDelegatedUserDecryptEIP712 as (...args: unknown[]) => ReturnType<
+      FhevmInstance["createDelegatedUserDecryptEIP712"]
+    >;
+    const eip712 = createEip712.call(
+      this.#instance,
       delegateTransportKeypair.publicKey,
       contractAddresses,
       delegatorAddress,
       startTimeStamp,
       durationDays,
-      extraData,
+      ...(hasExtraData ? [extraData] : []),
     );
 
     // Update the signing to match the new primaryType
@@ -179,7 +194,11 @@ export class RelayerSdk implements SdkInstance {
       eip712.message,
     );
 
-    const result = await this.#instance.delegatedUserDecrypt(
+    const delegatedUserDecrypt = this.#instance.delegatedUserDecrypt as (...args: unknown[]) => ReturnType<
+      FhevmInstance["delegatedUserDecrypt"]
+    >;
+    const result = await delegatedUserDecrypt.call(
+      this.#instance,
       handleContractPairs,
       delegateTransportKeypair.privateKey,
       delegateTransportKeypair.publicKey,
@@ -189,7 +208,7 @@ export class RelayerSdk implements SdkInstance {
       signer.address,
       startTimeStamp,
       durationDays,
-      extraData,
+      ...(hasExtraData ? [extraData] : []),
     );
 
     return result[handle as `0x${string}`];
@@ -225,8 +244,19 @@ export class RelayerSdk implements SdkInstance {
     const { publicKey, privateKey } = transportKeypair ?? this.#instance.generateKeypair();
     const contractAddresses = [contractAddress];
 
-    const extraData = await this.#instance.getExtraData?.();
-    const eip712 = this.#instance.createEIP712(publicKey, contractAddresses, startTimestamp, durationDays, extraData);
+    const hasExtraData = supportsExtraData(this.#instance);
+    const extraData = hasExtraData
+      ? await (this.#instance as ExtraDataRelayerInstance).getExtraData()
+      : undefined;
+    const createEip712 = this.#instance.createEIP712 as (...args: unknown[]) => ReturnType<FhevmInstance["createEIP712"]>;
+    const eip712 = createEip712.call(
+      this.#instance,
+      publicKey,
+      contractAddresses,
+      startTimestamp,
+      durationDays,
+      ...(hasExtraData ? [extraData] : []),
+    );
 
     const signature = await signer.signTypedData(
       eip712.domain,
@@ -236,7 +266,9 @@ export class RelayerSdk implements SdkInstance {
       eip712.message,
     );
 
-    return await this.#instance.userDecrypt(
+    const userDecrypt = this.#instance.userDecrypt as (...args: unknown[]) => ReturnType<FhevmInstance["userDecrypt"]>;
+    return await userDecrypt.call(
+      this.#instance,
       handleContractPairs,
       privateKey,
       publicKey,
@@ -245,7 +277,7 @@ export class RelayerSdk implements SdkInstance {
       signer.address,
       startTimestamp,
       durationDays,
-      extraData,
+      ...(hasExtraData ? [extraData] : []),
     );
   }
 

--- a/test-suite/e2e/test/sdk/selection.test.ts
+++ b/test-suite/e2e/test/sdk/selection.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { LEGACY_SDK_SELECTION_WARNING, selectSdk } from './selection';
+
+describe('selectSdk', () => {
+  it('selects an exact published relayer SDK explicitly', () => {
+    assert.deepEqual(
+      selectSdk({
+        E2E_SDK_FAMILY: 'relayer-sdk',
+        E2E_SDK_SOURCE: 'npm',
+        E2E_SDK_VERSION: '0.4.4',
+      }),
+      { family: 'relayer-sdk', source: 'npm', requestedVersion: '0.4.4', legacy: false },
+    );
+  });
+
+  it('selects a published fhevm SDK independently of the workspace SDK', () => {
+    assert.deepEqual(
+      selectSdk({
+        E2E_SDK_FAMILY: 'fhevm-sdk',
+        E2E_SDK_SOURCE: 'npm',
+        E2E_SDK_VERSION: '1.1.0-alpha.4',
+      }),
+      { family: 'fhevm-sdk', source: 'npm', requestedVersion: '1.1.0-alpha.4', legacy: false },
+    );
+  });
+
+  it('requires a complete explicit selection', () => {
+    assert.throws(() => selectSdk({ E2E_SDK_FAMILY: 'fhevm-sdk' }), /E2E_SDK_SOURCE/);
+  });
+
+  it('rejects npm ranges so an image identifies one package', () => {
+    assert.throws(
+      () =>
+        selectSdk({
+          E2E_SDK_FAMILY: 'relayer-sdk',
+          E2E_SDK_SOURCE: 'npm',
+          E2E_SDK_VERSION: '^0.4.4',
+        }),
+      /exact published version/,
+    );
+  });
+
+  it('retains the old relayer version variable as a marked legacy path', () => {
+    assert.deepEqual(selectSdk({ RELAYER_SDK_VERSION: '0.4.2' }), {
+      family: 'relayer-sdk',
+      source: 'npm',
+      requestedVersion: '0.4.2',
+      legacy: true,
+    });
+  });
+
+  it('rejects ranges through the legacy relayer variable', () => {
+    assert.throws(() => selectSdk({ RELAYER_SDK_VERSION: '^0.4.2' }), /exact published version/);
+  });
+
+  it('retains the old empty selection as a marked workspace fallback', () => {
+    assert.deepEqual(selectSdk({}), {
+      family: 'fhevm-sdk',
+      source: 'workspace',
+      requestedVersion: 'workspace',
+      legacy: true,
+    });
+    assert.match(LEGACY_SDK_SELECTION_WARNING, /E2E_SDK_FAMILY/);
+  });
+});

--- a/test-suite/e2e/test/sdk/selection.test.ts
+++ b/test-suite/e2e/test/sdk/selection.test.ts
@@ -28,6 +28,15 @@ describe('selectSdk', () => {
 
   it('requires a complete explicit selection', () => {
     assert.throws(() => selectSdk({ E2E_SDK_FAMILY: 'fhevm-sdk' }), /E2E_SDK_SOURCE/);
+    assert.throws(
+      () =>
+        selectSdk({
+          E2E_SDK_FAMILY: 'fhevm-sdk',
+          E2E_SDK_SOURCE: 'registry',
+          E2E_SDK_VERSION: '1.1.0-alpha.4',
+        }),
+      /E2E_SDK_SOURCE/,
+    );
   });
 
   it('rejects npm ranges so an image identifies one package', () => {

--- a/test-suite/e2e/test/sdk/selection.test.ts
+++ b/test-suite/e2e/test/sdk/selection.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { LEGACY_SDK_SELECTION_WARNING, selectSdk } from './selection';
+import { selectSdk } from './selection';
 
 describe('selectSdk', () => {
   it('selects an exact published relayer SDK explicitly', () => {
@@ -11,7 +11,7 @@ describe('selectSdk', () => {
         E2E_SDK_SOURCE: 'npm',
         E2E_SDK_VERSION: '0.4.4',
       }),
-      { family: 'relayer-sdk', source: 'npm', requestedVersion: '0.4.4', legacy: false },
+      { family: 'relayer-sdk', source: 'npm', requestedVersion: '0.4.4' },
     );
   });
 
@@ -22,7 +22,7 @@ describe('selectSdk', () => {
         E2E_SDK_SOURCE: 'npm',
         E2E_SDK_VERSION: '1.1.0-alpha.4',
       }),
-      { family: 'fhevm-sdk', source: 'npm', requestedVersion: '1.1.0-alpha.4', legacy: false },
+      { family: 'fhevm-sdk', source: 'npm', requestedVersion: '1.1.0-alpha.4' },
     );
   });
 
@@ -51,26 +51,23 @@ describe('selectSdk', () => {
     );
   });
 
-  it('retains the old relayer version variable as a marked legacy path', () => {
+  it('retains the existing relayer version variable', () => {
     assert.deepEqual(selectSdk({ RELAYER_SDK_VERSION: '0.4.2' }), {
       family: 'relayer-sdk',
       source: 'npm',
       requestedVersion: '0.4.2',
-      legacy: true,
     });
   });
 
-  it('rejects ranges through the legacy relayer variable', () => {
+  it('rejects ranges through the existing relayer variable', () => {
     assert.throws(() => selectSdk({ RELAYER_SDK_VERSION: '^0.4.2' }), /exact published version/);
   });
 
-  it('retains the old empty selection as a marked workspace fallback', () => {
+  it('retains the existing empty selection as the workspace fallback', () => {
     assert.deepEqual(selectSdk({}), {
       family: 'fhevm-sdk',
       source: 'workspace',
       requestedVersion: 'workspace',
-      legacy: true,
     });
-    assert.match(LEGACY_SDK_SELECTION_WARNING, /E2E_SDK_FAMILY/);
   });
 });

--- a/test-suite/e2e/test/sdk/selection.ts
+++ b/test-suite/e2e/test/sdk/selection.ts
@@ -1,0 +1,62 @@
+export type SdkFamily = 'fhevm-sdk' | 'relayer-sdk';
+export type SdkSource = 'workspace' | 'npm';
+
+export type SdkSelection = {
+  family: SdkFamily;
+  source: SdkSource;
+  requestedVersion: string;
+  legacy: boolean;
+};
+
+type SelectionEnv = Readonly<Record<string, string | undefined>>;
+
+const explicitKeys = ['E2E_SDK_FAMILY', 'E2E_SDK_SOURCE', 'E2E_SDK_VERSION'] as const;
+const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export const LEGACY_SDK_SELECTION_WARNING =
+  'Legacy SDK selection is in use. Set E2E_SDK_FAMILY, E2E_SDK_SOURCE, and E2E_SDK_VERSION explicitly.';
+
+export function selectSdk(env: SelectionEnv): SdkSelection {
+  const hasExplicitSelection = explicitKeys.some((key) => Boolean(env[key]));
+  if (hasExplicitSelection) {
+    const family = env.E2E_SDK_FAMILY;
+    const source = env.E2E_SDK_SOURCE;
+    const version = env.E2E_SDK_VERSION;
+
+    if (family !== 'fhevm-sdk' && family !== 'relayer-sdk') {
+      throw new Error('E2E_SDK_FAMILY must be either "fhevm-sdk" or "relayer-sdk"');
+    }
+    if (source !== 'workspace' && source !== 'npm') {
+      throw new Error('E2E_SDK_SOURCE must be either "workspace" or "npm"');
+    }
+    if (!version) {
+      throw new Error('E2E_SDK_VERSION is required when explicit SDK selection is used');
+    }
+    if (source === 'workspace' && (family !== 'fhevm-sdk' || version !== 'workspace')) {
+      throw new Error('workspace SDK selection must use fhevm-sdk with E2E_SDK_VERSION=workspace');
+    }
+    if (source === 'npm' && version === 'workspace') {
+      throw new Error('npm SDK selection requires an exact published version');
+    }
+    if (source === 'npm' && !exactVersion.test(version)) {
+      throw new Error('E2E_SDK_VERSION must be an exact published version when E2E_SDK_SOURCE=npm');
+    }
+
+    return { family, source, requestedVersion: version, legacy: false };
+  }
+
+  const legacyRelayerVersion = env.RELAYER_SDK_VERSION;
+  if (legacyRelayerVersion) {
+    if (!exactVersion.test(legacyRelayerVersion)) {
+      throw new Error('RELAYER_SDK_VERSION must be an exact published version');
+    }
+    return {
+      family: 'relayer-sdk',
+      source: 'npm',
+      requestedVersion: legacyRelayerVersion,
+      legacy: true,
+    };
+  }
+
+  return { family: 'fhevm-sdk', source: 'workspace', requestedVersion: 'workspace', legacy: true };
+}

--- a/test-suite/e2e/test/sdk/selection.ts
+++ b/test-suite/e2e/test/sdk/selection.ts
@@ -5,16 +5,12 @@ export type SdkSelection = {
   family: SdkFamily;
   source: SdkSource;
   requestedVersion: string;
-  legacy: boolean;
 };
 
 type SelectionEnv = Readonly<Record<string, string | undefined>>;
 
 const explicitKeys = ['E2E_SDK_FAMILY', 'E2E_SDK_SOURCE', 'E2E_SDK_VERSION'] as const;
 const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
-
-export const LEGACY_SDK_SELECTION_WARNING =
-  'Legacy SDK selection is in use. Set E2E_SDK_FAMILY, E2E_SDK_SOURCE, and E2E_SDK_VERSION explicitly.';
 
 export function selectSdk(env: SelectionEnv): SdkSelection {
   const hasExplicitSelection = explicitKeys.some((key) => Boolean(env[key]));
@@ -42,21 +38,20 @@ export function selectSdk(env: SelectionEnv): SdkSelection {
       throw new Error('E2E_SDK_VERSION must be an exact published version when E2E_SDK_SOURCE=npm');
     }
 
-    return { family, source, requestedVersion: version, legacy: false };
+    return { family, source, requestedVersion: version };
   }
 
-  const legacyRelayerVersion = env.RELAYER_SDK_VERSION;
-  if (legacyRelayerVersion) {
-    if (!exactVersion.test(legacyRelayerVersion)) {
+  const relayerSdkVersion = env.RELAYER_SDK_VERSION;
+  if (relayerSdkVersion) {
+    if (!exactVersion.test(relayerSdkVersion)) {
       throw new Error('RELAYER_SDK_VERSION must be an exact published version');
     }
     return {
       family: 'relayer-sdk',
       source: 'npm',
-      requestedVersion: legacyRelayerVersion,
-      legacy: true,
+      requestedVersion: relayerSdkVersion,
     };
   }
 
-  return { family: 'fhevm-sdk', source: 'workspace', requestedVersion: 'workspace', legacy: true };
+  return { family: 'fhevm-sdk', source: 'workspace', requestedVersion: 'workspace' };
 }

--- a/test-suite/e2e/tsconfig.sdk-selection.json
+++ b/test-suite/e2e/tsconfig.sdk-selection.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/test-suite/e2e/tsconfig.sdk-selection.json
+++ b/test-suite/e2e/tsconfig.sdk-selection.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "paths": {}
+    "paths": {},
+    "types": ["node"]
   }
 }

--- a/test-suite/fhevm/rollouts/v0.12-to-v0.13/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.12-to-v0.13/versions.ts
@@ -25,7 +25,9 @@ export const from = {
   COPROCESSOR_SNS_WORKER_VERSION: fromTag,
   LISTENER_CORE_VERSION: fromTag,
   TEST_SUITE_VERSION: targetTag,
-  RELAYER_SDK_VERSION: relayerSdkVersion,
+  E2E_SDK_FAMILY: "relayer-sdk",
+  E2E_SDK_SOURCE: "npm",
+  E2E_SDK_VERSION: relayerSdkVersion,
 } satisfies Env;
 
 export const to = {

--- a/test-suite/fhevm/rollouts/v0.13.0-testnet/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.13.0-testnet/versions.ts
@@ -46,7 +46,9 @@ export const from = {
   // supportsHostListenerConsumer), so the value is inert at the v0.12 baseline.
   LISTENER_CORE_VERSION: target,
   TEST_SUITE_VERSION: target,
-  RELAYER_SDK_VERSION: relayerSdkVersion,
+  E2E_SDK_FAMILY: "relayer-sdk",
+  E2E_SDK_SOURCE: "npm",
+  E2E_SDK_VERSION: relayerSdkVersion,
 } satisfies Env;
 
 // Target ("to"). Contracts v0.13.0 are CONFIRMED by gitops#1063. KMS core ->

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -209,6 +209,20 @@ export const assertDockerMemory = async (scenario: State["scenario"]) => {
   );
 };
 const NETWORK_TARGETS: ReadonlySet<string> = new Set(["devnet", "testnet", "mainnet"]);
+const EXPLICIT_E2E_SDK_KEYS = ["E2E_SDK_FAMILY", "E2E_SDK_SOURCE", "E2E_SDK_VERSION"] as const;
+
+/** Prevents version locks from claiming an SDK that a published test image cannot change at runtime. */
+export const assertExplicitSdkSelectionUsesLocalTestSuite = (
+  state: Pick<State, "versions" | "overrides">,
+) => {
+  const selectedKeys = EXPLICIT_E2E_SDK_KEYS.filter((key) => Boolean(state.versions.env[key]));
+  if (!selectedKeys.length || state.overrides.some((item) => item.group === "test-suite")) {
+    return;
+  }
+  throw new PreflightError(
+    `${selectedKeys.join(", ")} require a local test-suite build; add --override test-suite until SDK-specific published image identities are available`,
+  );
+};
 
 const postgresExecOptions = () => ({
   user: process.env.POSTGRES_USER ?? DEFAULT_POSTGRES_USER,
@@ -335,6 +349,7 @@ const partialSchemaOverrides = (overrides: LocalOverride[]) =>
 
 /** Verifies required local tooling and port availability before boot. */
 export const preflight = async (state: State, strictPorts = true, needsGitHub = true) => {
+  assertExplicitSdkSelectionUsesLocalTestSuite(state);
   const requiredCommands = ["bun", "docker", "cast", ...(needsGitHub ? ["gh"] : [])];
   const whichResults = await Promise.all(
     requiredCommands.map(async (command) => {
@@ -1039,6 +1054,7 @@ export const previewStateFromBundle = (
 ): State => {
   assertSupportedTargetScenario(bundle.target, scenario);
   assertSupportedBundleScenario({ versions: bundle, overrides: options.overrides, scenario });
+  assertExplicitSdkSelectionUsesLocalTestSuite({ versions: bundle, overrides: options.overrides });
   return {
     target: bundle.target,
     lockPath: "",
@@ -1061,6 +1077,7 @@ const bootstrapState = async (options: UpOptions) => {
   console.log(`[resolve] bundle ready (${Math.round((Date.now() - resolveStarted) / 1000)}s)`);
   assertSupportedTargetScenario(resolved.bundle.target, scenario);
   assertSupportedBundleScenario({ versions: resolved.bundle, overrides: options.overrides, scenario });
+  assertExplicitSdkSelectionUsesLocalTestSuite({ versions: resolved.bundle, overrides: options.overrides });
   await assertSchemaCompatibility(resolved.bundle, options.overrides, scenario, options.allowSchemaMismatch);
   await ensureLockSnapshot(resolved.lockPath, resolved.bundle);
   return {

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -170,7 +170,12 @@ const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknow
   },
   "test-suite": {
     "test-suite-e2e-debug": buildSpec("../../..", "test-suite/e2e/Dockerfile", {
-      args: { RELAYER_SDK_VERSION: "${RELAYER_SDK_VERSION}" },
+      args: {
+        E2E_SDK_FAMILY: "${E2E_SDK_FAMILY:-}",
+        E2E_SDK_SOURCE: "${E2E_SDK_SOURCE:-}",
+        E2E_SDK_VERSION: "${E2E_SDK_VERSION:-}",
+        RELAYER_SDK_VERSION: "${RELAYER_SDK_VERSION:-}",
+      },
     }),
   },
 };

--- a/test-suite/fhevm/src/rollout-v013-testnet.test.ts
+++ b/test-suite/fhevm/src/rollout-v013-testnet.test.ts
@@ -49,7 +49,9 @@ test("kms then coprocessor then relayer reach the v0.13.0 target (KMS core v0.13
 test("pins the target test harness across every phase", () => {
   for (const phase of Object.values(phaseVersions)) {
     expect(phase.TEST_SUITE_VERSION).toBe("v0.13.0");
-    expect(phase.RELAYER_SDK_VERSION).toBe("0.4.2");
+    expect(phase.E2E_SDK_FAMILY).toBe("relayer-sdk");
+    expect(phase.E2E_SDK_SOURCE).toBe("npm");
+    expect(phase.E2E_SDK_VERSION).toBe("0.4.2");
   }
 });
 

--- a/test-suite/fhevm/src/stack.test.ts
+++ b/test-suite/fhevm/src/stack.test.ts
@@ -25,6 +25,29 @@ describe("stack", () => {
     expect(state.requiresGitHub).toBe(false);
   });
 
+  test("requires a local test-suite build for explicit SDK selections", () => {
+    const base = presetBundle("latest-main", "abcdef0", "sdk.json");
+    const bundle = {
+      ...base,
+      env: {
+        ...base.env,
+        E2E_SDK_FAMILY: "relayer-sdk",
+        E2E_SDK_SOURCE: "npm",
+        E2E_SDK_VERSION: "0.4.4",
+      },
+    };
+    expect(() => previewStateFromBundle({ overrides: [], lockFile: "/tmp/sdk.json" }, bundle, defaultScenario)).toThrow(
+      "require a local test-suite build",
+    );
+    expect(() =>
+      previewStateFromBundle(
+        { overrides: [{ group: "test-suite" }], lockFile: "/tmp/sdk.json" },
+        bundle,
+        defaultScenario,
+      ),
+    ).not.toThrow();
+  });
+
   test("rejects multi-chain scenarios on network targets during preview", () => {
     const bundle = {
       ...presetBundle("latest-main", "abcdef0", "testnet.json"),


### PR DESCRIPTION
## Summary

Makes the E2E SDK family, source, and exact version explicit, and routes normal and multi-chain tests through one test-suite-owned adapter factory.
The harness can reproduce the incident clients (`relayer-sdk@0.4.2`, `relayer-sdk@0.4.4`, and `fhevm-sdk@1.1.0-alpha.4`) without changing SDK or KMS connector source or claiming an SDK support policy.
Build-time selection validation, package-version checks, and a runtime realpath guard prevent a test image from silently claiming npm provenance while executing the vendored workspace SDK; same-version npm/workspace ambiguity fails closed.
Validation passed for the CLI checks, 260 unit tests, compatibility smoke, seven selector tests, and adapter compilation; immutable SDK-specific images and digest receipts remain follow-up work for [fhevm-internal#1712](https://github.com/zama-ai/fhevm-internal/issues/1712).