### PR TITLE
feat(sdk): submit Solana input proofs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22390,7 +22390,6 @@
     },
     "sdk/js-sdk/node_modules/@scure/base": {
       "version": "1.2.6",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -26113,6 +26112,7 @@
       "dependencies": {
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
+        "@scure/base": "1.2.6",
         "wasm-feature-detect": "^1.8.0"
       },
       "engines": {

--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -106,6 +106,7 @@
     }
   },
   "dependencies": {
+    "@scure/base": "1.2.6",
     "@noble/hashes": "2.0.1",
     "@noble/curves": "2.0.1",
     "wasm-feature-detect": "^1.8.0"

--- a/sdk/js-sdk/src/solana/actions/submitInputProof.test.ts
+++ b/sdk/js-sdk/src/solana/actions/submitInputProof.test.ts
@@ -120,6 +120,35 @@ describe('submitInputProof', () => {
     });
   });
 
+  it('rejects an input proof without handles before contacting the relayer', async () => {
+    const inputProof = new Proxy(proof(), {
+      get(target, property, receiver) {
+        return property === 'getInputHandles' ? () => [] : Reflect.get(target, property, receiver);
+      },
+    });
+    globalThis.fetch = vi.fn();
+
+    await expect(submitInputProof(context(), { inputProof })).rejects.toThrow(
+      'Input proof must contain at least one external handle',
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an input proof for a different Solana chain before contacting the relayer', async () => {
+    const inputProof = proof();
+    const fhevm = context();
+    const mismatchedContext = {
+      ...fhevm,
+      solanaChain: { ...fhevm.solanaChain, id: CHAIN_ID + 1n },
+    };
+    globalThis.fetch = vi.fn();
+
+    await expect(submitInputProof(mismatchedContext, { inputProof })).rejects.toThrow(
+      `Input proof chain id ${CHAIN_ID} does not match Solana client chain id ${CHAIN_ID + 1n}`,
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('uses the existing queued GET path until the request succeeds', async () => {
     const inputProof = proof();
     globalThis.fetch = vi

--- a/sdk/js-sdk/src/solana/actions/submitInputProof.test.ts
+++ b/sdk/js-sdk/src/solana/actions/submitInputProof.test.ts
@@ -1,0 +1,192 @@
+import type { FhevmRuntime } from '../../core/types/coreFhevmRuntime.js';
+import type { InputHandle } from '../../core/types/encryptedTypes-p.js';
+import type { EncryptionBits } from '../../core/types/fheType.js';
+import type { Bytes32Hex } from '../../core/types/primitives.js';
+import type { SolanaZkProof } from '../../core/types/zkProof-p.js';
+import { hexToBytes32 } from '../../core/base/bytes.js';
+import { fetchCoprocessorSignatures } from '../../core/modules/relayer/module/fetchCoprocessorSignatures.js';
+import { toSolanaZkProof } from '../../core/coprocessor/SolanaZkProof-p.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { base58 } from '@scure/base';
+
+import { submitInputProof } from './submitInputProof.js';
+
+const CHAIN_ID = (1n << 63n) | 12345n;
+const ACL = `0x${'11'.repeat(32)}` as Bytes32Hex;
+const CONTRACT = `0x${'22'.repeat(32)}` as Bytes32Hex;
+const USER = `0x${'33'.repeat(32)}` as Bytes32Hex;
+const SIGNATURE = `0x${'44'.repeat(65)}` as const;
+
+function proof(ciphertext = 1, encryptionBits: readonly EncryptionBits[] = [64]): SolanaZkProof {
+  return toSolanaZkProof({
+    chainId: CHAIN_ID,
+    aclContractAddress: ACL,
+    contractAddress: CONTRACT,
+    userAddress: USER,
+    ciphertextWithZkProof: new Uint8Array([ciphertext]),
+    encryptionBits,
+  });
+}
+
+function response(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'retry-after': '1' } });
+}
+
+function queued(requestId = 'post-request'): Response {
+  return response(202, { status: 'queued', requestId, result: { jobId: 'job-1' } });
+}
+
+function pending(requestId = 'get-request'): Response {
+  return response(202, { status: 'queued', requestId });
+}
+
+function succeeded(handles: readonly InputHandle[]): Response {
+  return response(200, {
+    status: 'succeeded',
+    requestId: 'done-request',
+    result: {
+      accepted: true,
+      handles: handles.map((handle) => handle.bytes32Hex),
+      signatures: [SIGNATURE],
+      extraData: '0x00',
+    },
+  });
+}
+
+function context(): { readonly runtime: FhevmRuntime; readonly solanaChain: ReturnType<typeof solanaChain> } {
+  const runtime = {
+    config: { auth: { type: 'ApiKeyHeader', value: 'test-key' } },
+    relayer: { fetchCoprocessorSignatures },
+  } as unknown as FhevmRuntime;
+  return { runtime, solanaChain: solanaChain() };
+}
+
+function solanaChain() {
+  return {
+    id: CHAIN_ID,
+    fhevm: { relayerUrl: 'https://relayer.example.com', acl: { domainKeys: [ACL] } },
+  } as const;
+}
+
+async function settle<T>(promise: Promise<T>, queuedGetCount = 0): Promise<T> {
+  for (let i = 0; i <= queuedGetCount; i++) {
+    await vi.advanceTimersByTimeAsync(1_000);
+  }
+  return promise;
+}
+
+async function expectRejected(promise: Promise<unknown>, message: string): Promise<void> {
+  const expectation = expect(promise).rejects.toThrow(message);
+  await vi.advanceTimersByTimeAsync(1_000);
+  await expectation;
+}
+
+describe('submitInputProof', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('submits base58 identities and returns the matching typed result', async () => {
+    const inputProof = proof();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(queued())
+      .mockResolvedValueOnce(succeeded(inputProof.getInputHandles()));
+    globalThis.fetch = fetchMock;
+
+    const result = await settle(submitInputProof(context(), { inputProof }));
+
+    expect(result.handles.map((handle) => handle.bytes32Hex)).toEqual(
+      inputProof.getInputHandles().map((handle) => handle.bytes32Hex),
+    );
+    expect(result.signatures).toEqual([SIGNATURE]);
+    expect(result.extraData).toBe('0x00');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(new Headers(init.headers).get('x-api-key')).toBe('test-key');
+    expect(JSON.parse(init.body as string)).toEqual({
+      ciphertextWithInputVerification: '01',
+      contractAddress: base58.encode(hexToBytes32(CONTRACT)),
+      contractChainId: '0x8000000000003039',
+      extraData: '0x00',
+      userAddress: base58.encode(hexToBytes32(USER)),
+    });
+  });
+
+  it('uses the existing queued GET path until the request succeeds', async () => {
+    const inputProof = proof();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(queued())
+      .mockResolvedValueOnce(pending())
+      .mockResolvedValueOnce(succeeded(inputProof.getInputHandles()));
+
+    const result = await settle(submitInputProof(context(), { inputProof }), 1);
+
+    expect(result.handles[0]?.bytes32Hex).toBe(inputProof.getInputHandles()[0]?.bytes32Hex);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects a malformed terminal response', async () => {
+    const inputProof = proof();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(queued())
+      .mockResolvedValueOnce(
+        response(200, {
+          status: 'succeeded',
+          requestId: 'done-request',
+          result: { accepted: true, handles: [123], signatures: [SIGNATURE], extraData: '0x00' },
+        }),
+      );
+
+    await expectRejected(submitInputProof(context(), { inputProof }), 'does not match the expected schema');
+  });
+
+  it('rejects returned handle cardinality mismatches', async () => {
+    const inputProof = proof();
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(queued()).mockResolvedValueOnce(succeeded([]));
+
+    await expectRejected(submitInputProof(context(), { inputProof }), 'Unexpected handles list sizes');
+  });
+
+  it('rejects returned handle order mismatches', async () => {
+    const inputProof = proof(1, [8, 16]);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(queued())
+      .mockResolvedValueOnce(succeeded([...inputProof.getInputHandles()].reverse()));
+
+    await expectRejected(submitInputProof(context(), { inputProof }), 'Unexpected handle[0]');
+  });
+
+  it('rejects returned handle value mismatches', async () => {
+    const inputProof = proof();
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(queued())
+      .mockResolvedValueOnce(succeeded(proof(2).getInputHandles()));
+
+    await expectRejected(submitInputProof(context(), { inputProof }), 'Unexpected handle[0]');
+  });
+
+  it('surfaces terminal relayer errors', async () => {
+    const inputProof = proof();
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      response(400, {
+        status: 'failed',
+        requestId: 'failed-request',
+        error: { label: 'request_error', message: 'proof rejected' },
+      }),
+    );
+
+    await expect(submitInputProof(context(), { inputProof })).rejects.toThrow('proof rejected');
+  });
+});

--- a/sdk/js-sdk/src/solana/actions/submitInputProof.ts
+++ b/sdk/js-sdk/src/solana/actions/submitInputProof.ts
@@ -4,6 +4,7 @@ import type { FetchInputProofResult, RelayerInputProofOptions } from '../../core
 import type { ZkProof } from '../../core/types/zkProof-p.js';
 import type { SolanaZkProof } from '../../core/types/zkProof-p.js';
 import { hexToBytes32 } from '../../core/base/bytes.js';
+import { InputProofError } from '../../core/errors/InputProofError.js';
 import { assertHandleArrayEquals } from '../../core/handle/FhevmHandle.js';
 
 import { base58 } from '@scure/base';
@@ -24,13 +25,28 @@ type SolanaSubmitInputProofContext = {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-/** Submits a previously built Solana input proof and verifies the returned handles. */
+/**
+ * Submits a previously built Solana input proof and verifies the returned handles.
+ * The returned coprocessor signatures are verified by the Solana host program when consumed, not
+ * by this SDK action.
+ */
 export async function submitInputProof(
   fhevm: SolanaSubmitInputProofContext,
   parameters: SolanaSubmitInputProofParameters,
 ): Promise<SolanaSubmitInputProofResult> {
   const { inputProof, options } = parameters;
   const expectedHandles = inputProof.getInputHandles();
+
+  if (expectedHandles.length === 0) {
+    throw new InputProofError({
+      message: 'Input proof must contain at least one external handle',
+    });
+  }
+  if (inputProof.chainId !== fhevm.solanaChain.id) {
+    throw new InputProofError({
+      message: `Input proof chain id ${inputProof.chainId} does not match Solana client chain id ${fhevm.solanaChain.id}`,
+    });
+  }
 
   // The relayer payload predates RFC-021 and carries Solana host identities as base58 strings.
   // Keep that wire adaptation here so callers only handle canonical bytes32 identities.

--- a/sdk/js-sdk/src/solana/actions/submitInputProof.ts
+++ b/sdk/js-sdk/src/solana/actions/submitInputProof.ts
@@ -1,0 +1,77 @@
+import type { FhevmRuntime } from '../../core/types/coreFhevmRuntime.js';
+import type { FhevmSolanaChain } from '../../core/types/fhevmSolanaChain.js';
+import type { FetchInputProofResult, RelayerInputProofOptions } from '../../core/types/relayer.js';
+import type { ZkProof } from '../../core/types/zkProof-p.js';
+import type { SolanaZkProof } from '../../core/types/zkProof-p.js';
+import { hexToBytes32 } from '../../core/base/bytes.js';
+import { assertHandleArrayEquals } from '../../core/handle/FhevmHandle.js';
+
+import { base58 } from '@scure/base';
+
+////////////////////////////////////////////////////////////////////////////////
+
+export type SolanaSubmitInputProofParameters = {
+  readonly inputProof: SolanaZkProof;
+  readonly options?: RelayerInputProofOptions | undefined;
+};
+
+export type SolanaSubmitInputProofResult = FetchInputProofResult;
+
+type SolanaSubmitInputProofContext = {
+  readonly runtime: FhevmRuntime;
+  readonly solanaChain: FhevmSolanaChain;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+/** Submits a previously built Solana input proof and verifies the returned handles. */
+export async function submitInputProof(
+  fhevm: SolanaSubmitInputProofContext,
+  parameters: SolanaSubmitInputProofParameters,
+): Promise<SolanaSubmitInputProofResult> {
+  const { inputProof, options } = parameters;
+  const expectedHandles = inputProof.getInputHandles();
+
+  // The relayer payload predates RFC-021 and carries Solana host identities as base58 strings.
+  // Keep that wire adaptation here so callers only handle canonical bytes32 identities.
+  const relayerProof = {
+    chainId: inputProof.chainId,
+    aclContractAddress: inputProof.aclContractAddress,
+    contractAddress: base58.encode(hexToBytes32(inputProof.contractAddress)),
+    userAddress: base58.encode(hexToBytes32(inputProof.userAddress)),
+    ciphertextWithZkProof: inputProof.ciphertextWithZkProof,
+    encryptionBits: inputProof.encryptionBits,
+    getInputHandles: () => expectedHandles,
+    getExtraData: () => '0x00',
+  } as unknown as ZkProof;
+  const relayerOptions: RelayerInputProofOptions = {
+    auth: fhevm.runtime.config.auth,
+    ...options,
+  };
+
+  const result = await fhevm.runtime.relayer.fetchCoprocessorSignatures(
+    {
+      chain: {
+        id: fhevm.solanaChain.id,
+        fhevm: {
+          relayerUrl: fhevm.solanaChain.fhevm.relayerUrl,
+        },
+      },
+      runtime: fhevm.runtime,
+      client: {},
+      options: { batchRpcCalls: false },
+    } as unknown as Parameters<FhevmRuntime['relayer']['fetchCoprocessorSignatures']>[0],
+    { payload: { zkProof: relayerProof }, options: relayerOptions },
+  );
+
+  assertHandleArrayEquals(result.handles, expectedHandles, {
+    actualName: 'relayer response',
+    expectedName: 'input proof',
+  });
+
+  return {
+    handles: result.handles,
+    signatures: result.coprocessorEip712Signatures,
+    extraData: result.extraData,
+  };
+}

--- a/sdk/js-sdk/src/solana/clients/createFhevmEncryptClient.ts
+++ b/sdk/js-sdk/src/solana/clients/createFhevmEncryptClient.ts
@@ -16,10 +16,8 @@ export type FhevmSolanaEncryptClient<chain extends FhevmSolanaChain = FhevmSolan
 > & { readonly solanaChain: chain } & SolanaEncryptActions;
 
 /**
- * Creates a Solana encrypt-only client. `.buildInputProof(...)` packs the values and produces a
- * {@link import('../../core/types/zkProof-p.js').SolanaZkProof} — the RFC-021 bytes32-identity
- * counterpart of the EVM `generateZkProof`. Full parity with the EVM encrypt client, minus the
- * provider (the Solana host has none).
+ * Creates a Solana encrypt-only client. `.buildInputProof(...)` produces the RFC-021 proof and
+ * `.submitInputProof(...)` submits it to the relayer while checking the returned handles.
  *
  * @param parameters.chain - The Solana host chain definition.
  * @param parameters.aclProgramAddress - The zama-host program id as bytes32 (the Solana ACL identity).

--- a/sdk/js-sdk/src/solana/clients/decorators/encrypt.ts
+++ b/sdk/js-sdk/src/solana/clients/decorators/encrypt.ts
@@ -10,16 +10,20 @@ import type {
 } from '../../../core/types/coreFhevmClient.js';
 import type { FhevmRuntime, WithEncrypt } from '../../../core/types/coreFhevmRuntime.js';
 import type { SolanaEncryptInputParameters, SolanaEncryptInputResult } from '../../actions/encryptInput.js';
+import type { SolanaSubmitInputProofParameters, SolanaSubmitInputProofResult } from '../../actions/submitInputProof.js';
 import { asFhevmWith, setResolvedTfheVersion } from '../../../core/runtime/CoreFhevm-p.js';
 import { encryptModule } from '../../../core/modules/encrypt/module/index.js';
 import { DEFAULT_TFHE_VERSION } from '../../../wasm/tfhe/loadTfheLib.js';
 import { encryptInput } from '../../actions/encryptInput.js';
+import { submitInputProof } from '../../actions/submitInputProof.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export type SolanaEncryptActions = {
   /** Builds a Solana input ZK proof (RFC-021 bytes32 identities + 128-byte aux). */
   readonly buildInputProof: (parameters: SolanaEncryptInputParameters) => Promise<SolanaEncryptInputResult>;
+  /** Submits a built Solana input proof and verifies the returned handles. */
+  readonly submitInputProof: (parameters: SolanaSubmitInputProofParameters) => Promise<SolanaSubmitInputProofResult>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,6 +91,7 @@ export function solanaEncryptActions(
           await (fhevm as Fhevm<undefined, FhevmRuntime, undefined>).ready;
           return encryptInput(encryptFhevm, parameters);
         },
+        submitInputProof: async (parameters) => submitInputProof({ runtime, solanaChain }, parameters),
       },
       runtime,
       init: _initEncrypt as (fhevm: FhevmBase) => Promise<void>,

--- a/sdk/js-sdk/src/solana/index.ts
+++ b/sdk/js-sdk/src/solana/index.ts
@@ -8,9 +8,7 @@ export type { FhevmSolanaEncryptClient } from './clients/createFhevmEncryptClien
 
 export { solanaSignerFromSecretKey } from './signer.js';
 export type { SolanaUserDecryptSigner } from './signer.js';
-export {
-  buildSolanaUserDecryptMmrProofExtraData,
-} from '../core/coprocessor/SolanaUserDecrypt-p.js';
+export { buildSolanaUserDecryptMmrProofExtraData } from '../core/coprocessor/SolanaUserDecrypt-p.js';
 export {
   bytesToHex as solanaProofBytesToHex,
   hexToBytes as solanaProofHexToBytes,
@@ -26,6 +24,7 @@ export type {
   SolanaEncryptInputResult,
   SolanaEncryptInputValue,
 } from './actions/encryptInput.js';
+export type { SolanaSubmitInputProofParameters, SolanaSubmitInputProofResult } from './actions/submitInputProof.js';
 export type { SolanaEncryptActions } from './clients/decorators/encrypt.js';
 export type { SolanaZkProof, SolanaZkProofLike } from '../core/types/zkProof-p.js';
 

--- a/solana/scripts/e2e/adversarial-l4.sh
+++ b/solana/scripts/e2e/adversarial-l4.sh
@@ -30,7 +30,6 @@ RPC=http://127.0.0.1:8899
 RELAYER=http://127.0.0.1:3000
 ACL=0x4cd3022dff504a675caf2d9b4f4014d0b3dc3ea17ffb97ba355cec5a933a30ee
 USER="0x$(python3 -c "import json,os;print(bytes(json.load(open(os.path.expanduser('~/.config/solana/id.json')))[32:64]).hex())")"
-USER_B58="$(solana address -k "$HOME/.config/solana/id.json")"
 # extraData = version 0x01 ‖ 32-byte BE gateway KMS context id `0x07..01` (chain-type tag ‖ u64 id 1).
 # The KMS knows only this context; `extract_kms_context_id` derives the low-u64 (1) the Solana host
 # kms_context is keyed on.
@@ -92,29 +91,20 @@ export MINT UNDERLYING_MINT="$UNDER"
 
 wout="$(lc CONSUME_WRAP=1 WRAP_AMOUNT=1000)" || true
 echo "$wout" | grep -q 'OK wrap_usdc' || fail "(b) wrap_usdc: $(echo "$wout" | tail -3)"
-CS_B58="$(echo "$minit" | grep -oE 'compute_signer +[A-Za-z0-9]+' | awk '{print $2}')"
 CS_HEX="$(echo "$minit" | grep -oE 'compute_signer +[A-Za-z0-9]+ 0x[0-9a-f]+' | grep -oE '0x[0-9a-f]+')"
-[ -n "$CS_B58" ] && [ -n "$CS_HEX" ] || fail "(b) could not read compute_signer from mint init: $minit"
+[ -n "$CS_HEX" ] || fail "(b) could not read compute_signer from mint init: $minit"
 berr="$(mktemp)"
 bproof="$(cd "$ROOT/test-suite/fhevm" && \
   IN_RELAYER_URL=http://127.0.0.1:3000 IN_CONTRACTS_CHAIN_ID="$SID" IN_ACL_PROGRAM="$ACL" \
-  IN_CONTRACT="$CS_HEX" IN_USER="$USER" IN_CONTRACT_B58="$CS_B58" IN_USER_B58="$USER_B58" \
+  IN_CONTRACT="$CS_HEX" IN_USER="$USER" \
   IN_VALUE=7 IN_TYPE=uint64 \
   node solana-input.ts 2>"$berr" || true)"
-bpost="$(printf '%s\n' "$bproof" | grep -oE '"jobId":"[^"]+"' | head -1 | cut -d'"' -f4 || true)"
-[ -n "$bpost" ] || fail "(b) burn input-proof POST failed.
+bh="$(echo "$bproof" | python3 -c "import sys,json;print(json.load(sys.stdin)['handles'][0])" 2>/dev/null || true)"
+[ -n "$bh" ] || fail "(b) burn input-proof submission failed.
   client stdout: $(printf '%s' "$bproof" | tail -3)
   client stderr: $(tail -30 "$berr")"
-for i in $(seq 1 40); do
-  br="$(curl -s -m10 "localhost:3000/v2/input-proof/$bpost")"
-  bst="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin).get('status',''))" 2>/dev/null)"
-  [ "$bst" = succeeded ] && break
-  [ "$bst" = failed ] && fail "(b) burn input-proof failed: $br"
-  [ "$i" = 40 ] && fail "(b) burn input-proof timed out"; sleep 4
-done
-bh="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['handles'][0])")"
-bsig="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['signatures'][0])")"
-bextra="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin)['result'].get('extraData','0x00'))")"
+bsig="$(echo "$bproof" | python3 -c "import sys,json;print(json.load(sys.stdin)['signatures'][0])")"
+bextra="$(echo "$bproof" | python3 -c "import sys,json;print(json.load(sys.stdin).get('extraData','0x00'))")"
 bout="$(lc CONSUME_BURN=1 BIND_HANDLE="$bh" BIND_COPRO_SIG="$bsig" BIND_USER="$USER" \
   BIND_CONTRACT="$CS_HEX" BIND_CHAIN_ID="$SID" BIND_EXTRA="$bextra")" || true
 BURNED_ACL="$(echo "$bout" | grep -oE 'burned amount ACL [A-Za-z0-9]+' | awk '{print $4}')"

--- a/solana/scripts/e2e/full-vertical.sh
+++ b/solana/scripts/e2e/full-vertical.sh
@@ -120,7 +120,6 @@ CONTRACT=0x0c26992cb06b8c2de7305099da15554866e2373d80cb0b597156b689d293249b
 # user-decrypt signs with CI's generated key -> "ACL record domain outside the signed auth scope").
 USER="0x$(python3 -c "import json,os;print(bytes(json.load(open(os.path.expanduser('~/.config/solana/id.json')))[32:64]).hex())")"
 ACL=0x4cd3022dff504a675caf2d9b4f4014d0b3dc3ea17ffb97ba355cec5a933a30ee  # zama-host program (bytes32) = Solana ACL identity
-USER_B58="$(solana address -k "$HOME/.config/solana/id.json")"          # deployer pubkey (base58, relayer-facing)
 RPC=http://127.0.0.1:8899
 GW_RPC="${GW_RPC:-http://127.0.0.1:8546}"
 # Live coprocessor signer set (ProtocolConfig-mirrored) for the consume material commitment.
@@ -138,30 +137,22 @@ for _ in $(seq 1 30); do
 done
 # Capture the client output first (piping the launcher into head/grep under pipefail can SIGPIPE).
 # The public @fhevm/sdk/solana encrypt client (test-suite/fhevm/solana-input.ts) builds the ZK proof
-# and POSTs it; it prints the relayer's JSON response (carrying the jobId) on stdout.
+# and submits it; it prints the final typed relayer result on stdout.
 # Run under node (not bun): the TFHE WASM prover resolves its worker/wasm via node's locate-file
 # path, which bun's browser-like environment detection bypasses. Node 24 runs the .ts directly.
 # stderr -> file (not /dev/null): keeps the success path quiet but makes a crash diagnosable.
 ierr="$(mktemp)"
 iout="$(cd "$ROOT/test-suite/fhevm" && \
   IN_RELAYER_URL=http://127.0.0.1:3000 IN_CONTRACTS_CHAIN_ID="$SID" IN_ACL_PROGRAM="$ACL" \
-  IN_CONTRACT="$USER" IN_USER="$USER" IN_CONTRACT_B58="$USER_B58" IN_USER_B58="$USER_B58" \
+  IN_CONTRACT="$USER" IN_USER="$USER" \
   IN_VALUE="$IV" IN_TYPE=uint64 \
   node solana-input.ts 2>"$ierr" || true)"
-ipost="$(printf '%s\n' "$iout" | grep -oE '"jobId":"[^"]+"' | head -1 | cut -d'"' -f4 || true)"
-[ -n "$ipost" ] || fail "input-proof POST failed.
+ih="$(echo "$iout" | python3 -c "import sys,json;print(json.load(sys.stdin)['handles'][0])" 2>/dev/null || true)"
+[ -n "$ih" ] || fail "input-proof submission failed.
   client stdout: $(printf '%s' "$iout" | tail -3)
   client stderr: $(tail -30 "$ierr")"
-for i in $(seq 1 40); do
-  ir="$(curl -s -m10 "localhost:3000/v2/input-proof/$ipost")"
-  ist="$(echo "$ir" | python3 -c "import sys,json;print(json.load(sys.stdin).get('status',''))" 2>/dev/null)"
-  [ "$ist" = succeeded ] && break
-  [ "$ist" = failed ] && fail "input-proof failed: $ir"
-  [ "$i" = 40 ] && fail "input-proof timed out"; sleep 4
-done
-ih="$(echo "$ir" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['handles'][0])")"
-isig="$(echo "$ir" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['signatures'][0])")"
-iextra="$(echo "$ir" | python3 -c "import sys,json;print(json.load(sys.stdin)['result'].get('extraData','0x00'))")"
+isig="$(echo "$iout" | python3 -c "import sys,json;print(json.load(sys.stdin)['signatures'][0])")"
+iextra="$(echo "$iout" | python3 -c "import sys,json;print(json.load(sys.stdin).get('extraData','0x00'))")"
 echo "    input handle=$ih (coprocessor EIP-712 attestation $isig)"
 # The coprocessor attestation is verified in-frame when consumed as an FheEvalOperand::VerifiedInput
 # (the fromExternal path) — exercised by the FHE_EVAL_VERIFIED_INPUT step below. There is no
@@ -501,30 +492,21 @@ echo "$wout" | grep -q 'OK wrap_usdc' || fail "wrap_usdc: $(echo "$wout" | tail 
 # (user = owner, contract = mint compute-signer PDA). Unlike the top input-proof (contract = USER),
 # a transfer/burn amount must attest to the compute-signer PDA (the token + host require
 # contract == compute_signer), so fetch a dedicated compute-signer-bound proof here.
-CS_B58="$(echo "$minit" | grep -oE 'compute_signer +[A-Za-z0-9]+' | awk '{print $2}')"
 CS_HEX="$(echo "$minit" | grep -oE 'compute_signer +[A-Za-z0-9]+ 0x[0-9a-f]+' | grep -oE '0x[0-9a-f]+')"
-[ -n "$CS_B58" ] && [ -n "$CS_HEX" ] || fail "could not read compute_signer from mint init: $minit"
+[ -n "$CS_HEX" ] || fail "could not read compute_signer from mint init: $minit"
 berr="$(mktemp)"
 bproof="$(cd "$ROOT/test-suite/fhevm" && \
   IN_RELAYER_URL=http://127.0.0.1:3000 IN_CONTRACTS_CHAIN_ID="$SID" IN_ACL_PROGRAM="$ACL" \
-  IN_CONTRACT="$CS_HEX" IN_USER="$USER" IN_CONTRACT_B58="$CS_B58" IN_USER_B58="$USER_B58" \
+  IN_CONTRACT="$CS_HEX" IN_USER="$USER" \
   IN_VALUE=7 IN_TYPE=uint64 \
   node solana-input.ts 2>"$berr" || true)"
-bpost="$(printf '%s\n' "$bproof" | grep -oE '"jobId":"[^"]+"' | head -1 | cut -d'"' -f4 || true)"
-[ -n "$bpost" ] || fail "burn input-proof POST failed.
+bh="$(echo "$bproof" | python3 -c "import sys,json;print(json.load(sys.stdin)['handles'][0])" 2>/dev/null || true)"
+[ -n "$bh" ] || fail "burn input-proof submission failed.
   client stdout: $(printf '%s' "$bproof" | tail -3)
   client stderr: $(tail -30 "$berr")"
-for i in $(seq 1 40); do
-  br="$(curl -s -m10 "localhost:3000/v2/input-proof/$bpost")"
-  bst="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin).get('status',''))" 2>/dev/null)"
-  [ "$bst" = succeeded ] && break
-  [ "$bst" = failed ] && fail "burn input-proof failed: $br"
-  [ "$i" = 40 ] && fail "burn input-proof timed out"; sleep 4
-done
-bh="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['handles'][0])")"
-bsig="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin)['result']['signatures'][0])")"
-bextra="$(echo "$br" | python3 -c "import sys,json;print(json.load(sys.stdin)['result'].get('extraData','0x00'))")"
-echo "    burn amount handle=$bh (attested for compute_signer $CS_B58)"
+bsig="$(echo "$bproof" | python3 -c "import sys,json;print(json.load(sys.stdin)['signatures'][0])")"
+bextra="$(echo "$bproof" | python3 -c "import sys,json;print(json.load(sys.stdin).get('extraData','0x00'))")"
+echo "    burn amount handle=$bh (attested for compute_signer $CS_HEX)"
 bout="$(lc CONSUME_BURN=1 BIND_HANDLE="$bh" BIND_COPRO_SIG="$bsig" BIND_USER="$USER" \
   BIND_CONTRACT="$CS_HEX" BIND_CHAIN_ID="$SID" BIND_EXTRA="$bextra")" || true
 BURNED_ACL="$(echo "$bout" | grep -oE 'burned amount ACL [A-Za-z0-9]+' | awk '{print $4}')"

--- a/test-suite/fhevm/solana-input.ts
+++ b/test-suite/fhevm/solana-input.ts
@@ -1,6 +1,6 @@
 // Solana input launcher — builds a REAL ZK input proof through the PUBLIC `@fhevm/sdk/solana`
-// encrypt client (RFC-021 bytes32 identities + 128-byte aux) and POSTs it to the live relayer's
-// `/v2/input-proof` seam. Prints the relayer response (carrying the `jobId`) as JSON on stdout.
+// encrypt client (RFC-021 bytes32 identities + 128-byte aux), submits it to the live relayer, and
+// prints the verified typed result as JSON on stdout.
 //
 // Inputs via env (hex unless noted):
 //   IN_RELAYER_URL          relayer base URL (e.g. http://127.0.0.1:3000)
@@ -8,19 +8,16 @@
 //   IN_ACL_PROGRAM          zama-host program id as bytes32 (0x-hex) — the Solana ACL identity
 //   IN_CONTRACT             bound contract identity as bytes32 (0x-hex)
 //   IN_USER                 bound user identity as bytes32 (0x-hex)
-//   IN_CONTRACT_B58         the relayer-facing contract address (base58) for the POST body
-//   IN_USER_B58             the relayer-facing user address (base58) for the POST body
 //   IN_VALUE                decimal — the value to encrypt (default 42)
 //   IN_TYPE                 FHE type name (default uint64)
 //
-// Output: the relayer's JSON response on stdout (the harness reads `jobId` from it).
+// Output: `{ handles, signatures, extraData }` JSON on stdout.
 //
 // Run under node (e.g. `node solana-input.ts` on Node >= 22.6 / native on Node 24), NOT bun: the
 // TFHE WASM prover resolves its worker/wasm via node's locate-file path, which bun's browser-like
 // environment detection bypasses (throws "Missing locate file function").
-
-import { createFhevmEncryptClient, setFhevmRuntimeConfig } from '@fhevm/sdk/solana';
 import { defineFhevmSolanaChain } from '@fhevm/sdk/chains';
+import { createFhevmEncryptClient, setFhevmRuntimeConfig } from '@fhevm/sdk/solana';
 import type { Bytes32Hex } from '@fhevm/sdk/types';
 
 // The relayer's keyurl points at the docker-internal host `minio:9000`; rewrite it to the
@@ -67,24 +64,15 @@ const proof = await client.buildInputProof({
   userAddress: reqEnv('IN_USER'),
   values: [{ type, value }],
 });
-
-const ctHex = Buffer.from(proof.ciphertextWithZkProof).toString('hex');
-const body = {
-  contractChainId: SID.toString(),
-  contractAddress: reqEnv('IN_CONTRACT_B58'),
-  userAddress: reqEnv('IN_USER_B58'),
-  ciphertextWithInputVerification: ctHex,
-  extraData: '0x00',
-};
-
-const res = await fetch(RELAYER + '/v2/input-proof', {
-  method: 'POST',
-  headers: { 'content-type': 'application/json' },
-  body: JSON.stringify(body),
-});
-const text = await res.text();
-process.stdout.write(text + '\n');
+const result = await client.submitInputProof({ inputProof: proof });
+process.stdout.write(
+  JSON.stringify({
+    handles: result.handles.map((handle) => handle.bytes32Hex),
+    signatures: result.signatures,
+    extraData: result.extraData,
+  }) + '\n',
+);
 
 // The TFHE WASM prover spins up worker threads that keep the event loop alive, so the process
 // never exits on its own; exit explicitly now that the proof is submitted.
-process.exit(res.ok ? 0 : 1);
+process.exit(0);


### PR DESCRIPTION
## Outcome

Add a public Solana SDK action that submits a previously built input proof, waits for the relayer result, and verifies that the returned handles exactly match the locally constructed proof.

`buildInputProof` remains pure. Network ownership is explicit through `submitInputProof`.

## Changes

- add `submitInputProof({ inputProof, options })` to the existing Solana encrypt client;
- derive canonical base58 contract and user identities from the proof’s bytes32 identities;
- reuse the SDK’s existing asynchronous relayer machinery and runtime authentication;
- reject empty proofs, proof/client chain-ID mismatches, and returned-handle cardinality, order, or value mismatches;
- document that the Solana host program verifies the returned coprocessor signatures when they are consumed;
- expose the typed result through the existing decorator and public Solana entrypoint;
- replace three duplicated launcher/shell POST-and-poll implementations;
- remove duplicate base58 identity environment plumbing.

`@scure/base@1.2.6` is promoted from a transitive dependency to a direct published SDK runtime dependency for canonical base58 encoding.

The shared relayer client serializes `contractChainId` as hexadecimal (`0x8000000000003039` for the test Solana chain), whereas the removed shell path serialized it as decimal. The previous exact head passed the Solana full vertical with the hexadecimal payload.

## Validation

- focused submit-input-proof tests: 9/9
- focused ESLint and configured Prettier
- test-suite/fhevm typecheck
- `bash -n` for both modified shell scripts
- `git diff --check`
- pre-commit hooks
- independent exact-head adversarial review; actionable findings addressed in follow-up

The repository-wide SDK TypeScript build retains two errors in untouched base files. Neither appears in the changed-file validation.

## Remaining gates

- current-head CI and relevant Solana full vertical;
- verify the pending issue-level KMS-impact classification; KMS behavior is unchanged;
- reconcile #1684’s Remaining A wording with the already-landed explicit current/historical `aclValueKey` ownership before closing the issue.

Implements the remaining input-proof submission and handle-verification portion of zama-ai/fhevm-internal#1684.
