### PR TITLE
feat(test-suite): test partial KMS upgrades

### DIFF
--- a/.github/workflows/test-suite-stateful-rollout.yml
+++ b/.github/workflows/test-suite-stateful-rollout.yml
@@ -1,0 +1,104 @@
+name: test-suite-stateful-rollout
+
+on:
+  workflow_dispatch:
+    inputs:
+      runbook:
+        description: "Path relative to test-suite/fhevm (for example rollouts/v0.13.0-testnet/run.ts)"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  fhevm-rollout: # zizmor: ignore[secrets-outside-env] Manual dispatch is the authorization boundary; PRs cannot trigger this job.
+    name: fhevm-rollout
+    permissions:
+      contents: "read" # Required to checkout repository code.
+      packages: "read" # Required when a runbook resolves GitHub package metadata.
+    runs-on: large_ubuntu_32
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ROLLOUT_RUNBOOK: ${{ inputs.runbook }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: "false"
+          fetch-depth: 0
+
+      - name: Setup Docker
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+
+      - name: Login to GitHub Container Registry
+        uses: zama-ai/ci-templates/.github/actions/retry@542103e14b9ae6a9aea27787b8724b3b35bb3918 # v1.0.9
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_READ_TOKEN }}
+        with:
+          command: |
+            echo "Logging into ghcr.io..."
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+      - name: Login to Chainguard Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CGR_USERNAME }}
+          password: ${{ secrets.CGR_PASSWORD }}
+
+      - name: Install safe-chain
+        shell: bash
+        run: |
+          # safe-chain v1.5.3 is distributed as an immutable GitHub release asset —
+          # its content is permanently fixed and cannot be modified after the tag is published.
+          # Verify immutability: curl -fsSL https://api.github.com/repos/AikidoSec/safe-chain/releases/tags/1.5.3 | grep immutable
+          curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
+
+      - name: Install CLI dependencies
+        working-directory: test-suite/fhevm
+        run: bun install --frozen-lockfile
+
+      - name: Execute stateful rollout
+        working-directory: test-suite/fhevm
+        timeout-minutes: 185
+        run: ./fhevm-cli rollout run "$ROLLOUT_RUNBOOK"
+
+      - name: Show rollout receipt
+        if: ${{ always() }}
+        continue-on-error: true
+        working-directory: test-suite/fhevm
+        run: ./fhevm-cli rollout receipt
+
+      - name: Upload rollout receipt
+        if: ${{ always() }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: stateful-rollout-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .fhevm/rollout/receipt.md
+            .fhevm/rollout/receipt.jsonl
+          include-hidden-files: true
+          if-no-files-found: error
+
+      - name: Cleanup
+        if: ${{ always() }}
+        working-directory: test-suite/fhevm
+        timeout-minutes: 15
+        run: ./fhevm-cli clean

--- a/test-suite/fhevm/README.md
+++ b/test-suite/fhevm/README.md
@@ -211,7 +211,7 @@ Runbooks use the same primitives an operator needs during a release:
 
 `rollout-standard` is intentionally narrow: it covers encrypted input, FHE compute/write paths, user decrypt, delegated user decrypt, public decrypt, and ERC20 transfer coverage. Broader profiles such as `multi-chain-isolation`, HCU, pause/unpause, DB revert, and drift recovery stay available as explicit tests but are not part of the per-step rollout gate.
 
-The `test-suite-stateful-rollout` workflow executes the checked-in runbook when the `rollout` label is present, or through manual dispatch with a custom runbook path.
+The `test-suite-stateful-rollout` workflow executes a checked-in runbook through manual dispatch with a path relative to `test-suite/fhevm`.
 
 ## Version Override via Environment Variables
 

--- a/test-suite/fhevm/rollouts/kms-core-progressive/run.ts
+++ b/test-suite/fhevm/rollouts/kms-core-progressive/run.ts
@@ -1,0 +1,51 @@
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { from, scenario, to, versionSources } from "./versions";
+
+const testRollout = (ctx: RolloutRunContext) => ctx.test("rollout-standard", { parallel: false });
+const testRequiredNode = (ctx: RolloutRunContext) =>
+  ctx.test("user-decryption", { grep: "test user decrypt ebool$", parallel: false });
+
+type KmsCoreVersions = Record<string, string> & { CORE_VERSION: string };
+
+export type ProgressiveKmsCoreRunbook = {
+  from: KmsCoreVersions;
+  overrides?: Parameters<RolloutRunContext["up"]>[0]["overrides"];
+  scenario: string;
+  to: KmsCoreVersions;
+  versionSources: string[];
+};
+
+export const runProgressiveKmsCoreRollout = async (
+  ctx: RolloutRunContext,
+  config: ProgressiveKmsCoreRunbook,
+) => {
+  const baselineLock = await ctx.writeVersionLock("00-kms-core-baseline", {
+    versions: config.from,
+    sources: config.versionSources,
+  });
+  const targetLock = await ctx.writeVersionLock("01-kms-core-target", {
+    versions: config.to,
+    sources: config.versionSources,
+  });
+
+  await ctx.up({ lockFile: baselineLock, overrides: config.overrides, scenario: config.scenario });
+  await testRollout(ctx);
+
+  const state = await ctx.readState();
+  const nodeIds = Array.from({ length: state.scenario.kms.committeeSize }, (_, index) => index + 1);
+  for (const nodeId of nodeIds) {
+    await ctx.upgradeKmsNodes([nodeId], { lockFile: targetLock });
+    await ctx.withRequiredKmsNode(nodeId, () => testRequiredNode(ctx));
+    await testRollout(ctx);
+  }
+};
+
+export const run = (ctx: RolloutRunContext) =>
+  runProgressiveKmsCoreRollout(ctx, {
+    from,
+    scenario,
+    to,
+    versionSources,
+  });
+
+export default run;

--- a/test-suite/fhevm/rollouts/kms-core-progressive/versions.ts
+++ b/test-suite/fhevm/rollouts/kms-core-progressive/versions.ts
@@ -1,0 +1,34 @@
+type Env = Record<string, string>;
+
+export const scenario = "four-party-threshold-kms";
+
+const release = "v0.13.0";
+
+export const from = {
+  RELAYER_VERSION: release,
+  RELAYER_MIGRATE_VERSION: release,
+  GATEWAY_VERSION: release,
+  HOST_VERSION: release,
+  CORE_VERSION: "v0.13.10",
+  CONNECTOR_DB_MIGRATION_VERSION: release,
+  CONNECTOR_GW_LISTENER_VERSION: release,
+  CONNECTOR_KMS_WORKER_VERSION: release,
+  CONNECTOR_TX_SENDER_VERSION: release,
+  COPROCESSOR_DB_MIGRATION_VERSION: release,
+  COPROCESSOR_HOST_LISTENER_VERSION: release,
+  COPROCESSOR_GW_LISTENER_VERSION: release,
+  COPROCESSOR_TX_SENDER_VERSION: release,
+  COPROCESSOR_TFHE_WORKER_VERSION: release,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: release,
+  COPROCESSOR_SNS_WORKER_VERSION: release,
+  LISTENER_CORE_VERSION: release,
+  TEST_SUITE_VERSION: release,
+} satisfies Env;
+
+export const to = { ...from, CORE_VERSION: "v0.13.20" } satisfies Env;
+
+export const versionSources = [
+  "rollout=kms-core-progressive",
+  "kms-core=v0.13.10->v0.13.20",
+  "other-components=v0.13.0",
+];

--- a/test-suite/fhevm/rollouts/mainnet-v0.11-to-v0.12-kms/run.ts
+++ b/test-suite/fhevm/rollouts/mainnet-v0.11-to-v0.12-kms/run.ts
@@ -1,0 +1,28 @@
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { from, scenario, to, versionSources } from "./versions";
+
+// relayer-sdk v0.4.2 contains this typo. Keep the split local instead of
+// accepting the misspelling repository-wide in the spell checker.
+export const relayerSdkV042DecryptionError = "An error occur" + "ed during decryption";
+
+export const run = async (ctx: RolloutRunContext) => {
+  const baselineLock = await ctx.writeVersionLock("00-kms-core-baseline", { versions: from, sources: versionSources });
+  const targetLock = await ctx.writeVersionLock("01-kms-core-target", { versions: to, sources: versionSources });
+
+  await ctx.up({ lockFile: baselineLock, overrides: [{ group: "test-suite" }], scenario });
+  await ctx.test("rollout-standard", { parallel: false });
+
+  await ctx.upgradeKmsNodes([1, 2], { lockFile: targetLock });
+  // v0.4.2 exposes only this generic WASM reconstruction wrapper. Successful
+  // homogeneous checks on both sides keep unrelated stack failures visible.
+  await ctx.expectTestFailure("user-decryption", {
+    errorIncludes: relayerSdkV042DecryptionError,
+    grep: "test user decrypt ebool$",
+    parallel: false,
+  });
+
+  await ctx.upgradeKmsNodes([3, 4], { lockFile: targetLock });
+  await ctx.test("rollout-standard", { parallel: false });
+};
+
+export default run;

--- a/test-suite/fhevm/rollouts/mainnet-v0.11-to-v0.12-kms/versions.ts
+++ b/test-suite/fhevm/rollouts/mainnet-v0.11-to-v0.12-kms/versions.ts
@@ -1,0 +1,41 @@
+type Env = Record<string, string>;
+
+export const scenario = "four-party-threshold-kms";
+
+const coprocessor = "v0.11.0";
+const connector = "v0.12.0";
+
+// Mainnet cutover state on 2026-07-13. Contracts and the relayer had already
+// moved; coprocessor services had not. The serving KMS cores were then replaced
+// one operator at a time while the connector stayed on v0.12.0.
+export const from = {
+  RELAYER_VERSION: "v0.11.1",
+  RELAYER_MIGRATE_VERSION: "v0.11.0",
+  GATEWAY_VERSION: "v0.12.1",
+  HOST_VERSION: "v0.12.1",
+  CORE_VERSION: "v0.13.3",
+  CONNECTOR_DB_MIGRATION_VERSION: connector,
+  CONNECTOR_GW_LISTENER_VERSION: connector,
+  CONNECTOR_KMS_WORKER_VERSION: connector,
+  CONNECTOR_TX_SENDER_VERSION: connector,
+  COPROCESSOR_DB_MIGRATION_VERSION: coprocessor,
+  COPROCESSOR_HOST_LISTENER_VERSION: coprocessor,
+  COPROCESSOR_GW_LISTENER_VERSION: coprocessor,
+  COPROCESSOR_TX_SENDER_VERSION: coprocessor,
+  COPROCESSOR_TFHE_WORKER_VERSION: coprocessor,
+  COPROCESSOR_ZKPROOF_WORKER_VERSION: coprocessor,
+  COPROCESSOR_SNS_WORKER_VERSION: coprocessor,
+  LISTENER_CORE_VERSION: "v0.13.0",
+  TEST_SUITE_VERSION: "v0.13.0",
+  RELAYER_SDK_VERSION: "0.4.2",
+} satisfies Env;
+
+export const to = { ...from, CORE_VERSION: "v0.13.10" } satisfies Env;
+
+export const versionSources = [
+  "rollout=mainnet-v0.11-to-v0.12-kms",
+  "incident=2026-07-13-mainnet-kms-rollout",
+  "kms-core=v0.13.3->v0.13.10",
+  "kms-connector=v0.12.0",
+  "relayer-sdk=0.4.2",
+];

--- a/test-suite/fhevm/src/commands/rollout-receipt.ts
+++ b/test-suite/fhevm/src/commands/rollout-receipt.ts
@@ -65,6 +65,15 @@ const versionChanges = (previous: Record<string, string> | undefined, next: Reco
 
 type InspectResult = { containers: ReceiptContainer[]; error?: string };
 
+export const requireDockerSnapshot = (snapshot: InspectResult) => {
+  if (snapshot.error) {
+    throw new PreflightError(`Required Docker snapshot failed: ${snapshot.error}`);
+  }
+  if (!snapshot.containers.length) {
+    throw new PreflightError("Required Docker snapshot contained no project containers");
+  }
+};
+
 const inspectFailed = (error: string): InspectResult => {
   console.warn(`[receipt] docker inspect failed: ${error}`);
   return { containers: [], error };
@@ -200,7 +209,9 @@ const markdownEntry = (entry: ReceiptEntry) => {
   return `${lines.join("\n")}\n`;
 };
 
-export const createRolloutReceipt = () => {
+export const createRolloutReceipt = (
+  operations: { inspectContainers?: typeof inspectContainers } = {},
+) => {
   let seq = 0;
   let started = false;
   let currentEnv: Record<string, string> | undefined;
@@ -239,7 +250,9 @@ export const createRolloutReceipt = () => {
     if (lock) {
       currentEnv = lock.env;
     }
-    const docker = options.docker || options.diagnostics ? await inspectContainers() : undefined;
+    const docker = options.docker || options.diagnostics
+      ? await (operations.inspectContainers ?? inspectContainers)()
+      : undefined;
     const diagnostics = options.diagnostics ? await collectFailureDiagnostics() : undefined;
     const entry: ReceiptEntry = {
       seq: ++seq,
@@ -256,6 +269,9 @@ export const createRolloutReceipt = () => {
     await fs.appendFile(receiptJsonlPath(), `${JSON.stringify(entry)}\n`);
     await fs.appendFile(receiptMarkdownPath(), markdownEntry(entry));
     console.log(`[receipt] ${entry.seq}. ${kind}: ${title}`);
+    if (options.docker && docker) {
+      requireDockerSnapshot(docker);
+    }
   };
 
   return { record, start };

--- a/test-suite/fhevm/src/commands/rollout-run.ts
+++ b/test-suite/fhevm/src/commands/rollout-run.ts
@@ -4,7 +4,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { PreflightError } from "../errors";
+import { CommandError, PreflightError } from "../errors";
 import { runContractTask, snapshotContractSources } from "../flow/contracts";
 import { waitForTestSuite } from "../flow/readiness";
 import { composeUp } from "../flow/runtime-compose";
@@ -12,12 +12,15 @@ import {
   applyVersionLock as applyStackVersionLock,
   refreshDiscovery as refreshStackDiscovery,
   up,
+  upgradeThresholdKmsNode,
   upgradeRuntimeGroup as upgradeStackRuntimeGroup,
 } from "../flow/up-flow";
 import { STATE_DIR, composePath, hostChainRuntimes } from "../layout";
+import { reconstructionThreshold } from "../kms-party";
 import { loadState } from "../state/state";
 import type { LocalOverride, State, UpOptions, VersionBundle, VersionTarget } from "../types";
 import { ensureDir, writeJson } from "../utils/fs";
+import { partyContainers, setRunning, waitForPartiesRunning, waitForPartiesStopped } from "./kms-generation";
 import { type RolloutReceipt, createRolloutReceipt } from "./rollout-receipt";
 import { test as runTest } from "./test";
 
@@ -30,6 +33,9 @@ type RolloutUpOptions = {
 type RolloutRuntimeUpgradeOptions = {
   lockFile?: string;
 };
+type RolloutKmsNodeUpgradeOptions = {
+  lockFile: string;
+};
 type RolloutVersionLockOptions = {
   allowedVersionKeys: string[];
   lockFile: string;
@@ -37,9 +43,13 @@ type RolloutVersionLockOptions = {
 };
 
 type RolloutTestOptions = {
+  grep?: string;
   network?: string;
   noHardhatCompile?: boolean;
   parallel?: boolean;
+};
+type RolloutExpectedTestFailureOptions = RolloutTestOptions & {
+  errorIncludes: string;
 };
 type RolloutContractTaskOptions = {
   env?: Record<string, string>;
@@ -52,6 +62,7 @@ type RolloutLockOptions = {
 
 export type RolloutRunContext = {
   applyVersionLock(label: string, options: RolloutVersionLockOptions): Promise<void>;
+  expectTestFailure(profile: string, options: RolloutExpectedTestFailureOptions): Promise<void>;
   readState(): Promise<State>;
   refreshDiscovery(): Promise<void>;
   runGatewayContractTask(command: string, options?: RolloutContractTaskOptions): Promise<void>;
@@ -63,11 +74,22 @@ export type RolloutRunContext = {
   stateDir(): string;
   test(profile?: string, options?: RolloutTestOptions): Promise<void>;
   up(options: RolloutUpOptions): Promise<void>;
+  /** Sequentially applies one CORE_VERSION lock to exactly the listed serving KMS nodes. */
+  upgradeKmsNodes(nodeIds: readonly number[], options: RolloutKmsNodeUpgradeOptions): Promise<void>;
+  /** Runs a check with an exact reconstruction quorum that must include this KMS node. */
+  withRequiredKmsNode(nodeId: number, task: () => Promise<void>): Promise<void>;
   upgradeRuntimeGroup(group: string, options?: RolloutRuntimeUpgradeOptions): Promise<void>;
   writeVersionLock(name: string, options: RolloutLockOptions): Promise<string>;
 };
 
 export type RolloutRunbook = (ctx: RolloutRunContext) => Promise<void> | void;
+
+type RolloutContextOperations = {
+  setRunning: typeof setRunning;
+  upgradeThresholdKmsNode: typeof upgradeThresholdKmsNode;
+  waitForPartiesRunning: typeof waitForPartiesRunning;
+  waitForPartiesStopped: typeof waitForPartiesStopped;
+};
 
 const upOptions = (options: RolloutUpOptions): UpOptions => ({
   target: "latest-main",
@@ -86,7 +108,27 @@ const refreshTestSuiteContainer = async () => {
   await waitForTestSuite();
 };
 
-export const createRolloutContext = (receipt: RolloutReceipt = createRolloutReceipt()): RolloutRunContext => ({
+const runRolloutTest = async (receipt: RolloutReceipt, profile: string, options: RolloutTestOptions) => {
+  await refreshTestSuiteContainer();
+  await receipt.record("refresh-test-suite", "recreated test-suite container with current env", {
+    details: { profile },
+  });
+  await runTest(profile, {
+    network: options.network ?? "staging",
+    verbose: false,
+    noHardhatCompile: options.noHardhatCompile ?? true,
+    parallel: options.parallel,
+    grep: options.grep,
+  });
+};
+
+export const matchesExpectedTestFailure = (error: unknown, errorIncludes: string): error is CommandError =>
+  error instanceof CommandError && error.stderr.includes(errorIncludes);
+
+export const createRolloutContext = (
+  receipt: RolloutReceipt = createRolloutReceipt(),
+  operationOverrides: Partial<RolloutContextOperations> = {},
+): RolloutRunContext => ({
   async applyVersionLock(label, options) {
     await applyStackVersionLock(label, options.lockFile, options.allowedVersionKeys, { overrides: options.overrides });
     await receipt.record("apply-version-lock", label, {
@@ -96,6 +138,24 @@ export const createRolloutContext = (receipt: RolloutReceipt = createRolloutRece
       },
       lockFile: options.lockFile,
     });
+  },
+  async expectTestFailure(profile, options) {
+    try {
+      await runRolloutTest(receipt, profile, options);
+    } catch (error) {
+      if (!matchesExpectedTestFailure(error, options.errorIncludes)) {
+        throw error;
+      }
+      await receipt.record("test", `${profile} failed as expected`, {
+        details: {
+          errorIncludes: options.errorIncludes,
+          ...(options.grep === undefined ? {} : { grep: options.grep }),
+          observedError: error.stderr.slice(-2_000),
+        },
+      });
+      return;
+    }
+    throw new PreflightError(`${profile} unexpectedly passed; expected an error containing ${JSON.stringify(options.errorIncludes)}`);
   },
   async readState() {
     const state = await loadState();
@@ -145,20 +205,12 @@ export const createRolloutContext = (receipt: RolloutReceipt = createRolloutRece
     return STATE_DIR;
   },
   async test(profile = "rollout-standard", options = {}) {
-    await refreshTestSuiteContainer();
-    await receipt.record("refresh-test-suite", "recreated test-suite container with current env", {
-      details: { profile },
-    });
-    await runTest(profile, {
-      network: options.network ?? "staging",
-      verbose: false,
-      noHardhatCompile: options.noHardhatCompile ?? true,
-      parallel: options.parallel,
-    });
+    await runRolloutTest(receipt, profile, options);
     await receipt.record("test", `${profile} passed`, {
       details: {
         network: options.network ?? "staging",
         noHardhatCompile: options.noHardhatCompile ?? true,
+        ...(options.grep === undefined ? {} : { grep: options.grep }),
         ...(options.parallel === undefined ? {} : { parallel: options.parallel }),
       },
     });
@@ -169,6 +221,117 @@ export const createRolloutContext = (receipt: RolloutReceipt = createRolloutRece
       details: { overrides: (options.overrides ?? []).map((override) => override.group), scenario: options.scenario },
       lockFile: options.lockFile,
     });
+  },
+  async upgradeKmsNodes(nodeIds, options) {
+    const state = await loadState();
+    if (!state || state.scenario.kms.mode !== "threshold") {
+      throw new PreflightError("upgradeKmsNodes requires a running threshold KMS cluster");
+    }
+    if (nodeIds.length === 0) {
+      throw new PreflightError("upgradeKmsNodes requires at least one node id");
+    }
+    const selected = new Set<number>();
+    for (const nodeId of nodeIds) {
+      if (!Number.isInteger(nodeId) || nodeId < 1 || nodeId > state.scenario.kms.committeeSize) {
+        throw new PreflightError(
+          `upgradeKmsNodes expects serving node ids between 1 and ${state.scenario.kms.committeeSize}; received ${nodeId}`,
+        );
+      }
+      if (selected.has(nodeId)) {
+        throw new PreflightError(`upgradeKmsNodes received duplicate node id ${nodeId}`);
+      }
+      selected.add(nodeId);
+    }
+    for (const nodeId of nodeIds) {
+      try {
+        await (operationOverrides.upgradeThresholdKmsNode ?? upgradeThresholdKmsNode)(nodeId, options);
+      } catch (error) {
+        try {
+          await receipt.record("upgrade-kms-node-failed", `KMS node ${nodeId}`, {
+            details: { error: error instanceof Error ? error.message : String(error), nodeId },
+            docker: true,
+            lockFile: options.lockFile,
+          });
+        } catch (receiptError) {
+          throw new AggregateError(
+            [error, receiptError],
+            `KMS node ${nodeId} upgrade failed and its required receipt snapshot also failed`,
+          );
+        }
+        throw error;
+      }
+      await receipt.record("upgrade-kms-node", `KMS node ${nodeId}`, {
+        details: { nodeId },
+        docker: true,
+        lockFile: options.lockFile,
+      });
+    }
+  },
+  async withRequiredKmsNode(nodeId, task) {
+    const state = await loadState();
+    if (!state || state.scenario.kms.mode !== "threshold") {
+      throw new PreflightError("withRequiredKmsNode requires a running threshold KMS cluster");
+    }
+    const { committeeSize, threshold } = state.scenario.kms;
+    if (!Number.isInteger(nodeId) || nodeId < 1 || nodeId > committeeSize) {
+      throw new PreflightError(
+        `withRequiredKmsNode expects a serving node id between 1 and ${committeeSize}; received ${nodeId}`,
+      );
+    }
+    const requiredCount = reconstructionThreshold(threshold);
+    const running = [nodeId];
+    for (let candidate = 1; running.length < requiredCount && candidate <= committeeSize; candidate += 1) {
+      if (candidate !== nodeId) {
+        running.push(candidate);
+      }
+    }
+    const stopped = Array.from({ length: committeeSize }, (_, index) => index + 1).filter(
+      (candidate) => !running.includes(candidate),
+    );
+    if (stopped.length === 0) {
+      throw new PreflightError(
+        `withRequiredKmsNode cannot require one node when all ${committeeSize} serving nodes are needed for reconstruction`,
+      );
+    }
+
+    let taskError: unknown;
+    let taskFailed = false;
+    try {
+      await (operationOverrides.setRunning ?? setRunning)(stopped.flatMap(partyContainers), "stop");
+      await (operationOverrides.waitForPartiesStopped ?? waitForPartiesStopped)(stopped);
+      await receipt.record(
+        "require-kms-node",
+        `KMS node ${nodeId} required in ${requiredCount}/${committeeSize} quorum`,
+        {
+          details: { nodeId, running, stopped },
+          docker: true,
+        },
+      );
+      await task();
+    } catch (error) {
+      taskError = error;
+      taskFailed = true;
+    }
+
+    try {
+      await (operationOverrides.setRunning ?? setRunning)(stopped.flatMap(partyContainers), "start");
+      await (operationOverrides.waitForPartiesRunning ?? waitForPartiesRunning)(stopped);
+      await receipt.record("restore-kms-nodes", `restored KMS nodes ${stopped.join(", ")}`, {
+        details: { stopped },
+        docker: true,
+      });
+    } catch (restoreError) {
+      if (taskFailed) {
+        throw new AggregateError(
+          [taskError, restoreError],
+          "KMS quorum check failed and stopped nodes could not be restored",
+        );
+      }
+      throw restoreError;
+    }
+    if (taskFailed) {
+      throw taskError;
+    }
   },
   async upgradeRuntimeGroup(group, options = {}) {
     await upgradeStackRuntimeGroup(group, options);

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -100,7 +100,7 @@ import {
   writeJson,
 } from "../utils/fs";
 import { ensureDiscovery, createDiscovery, defaultEndpoints, discoverContracts, minioIp, validateDiscovery } from "./discovery";
-import { kmsConnectorEnvName } from "../kms-party";
+import { kmsConnectorEnvName, kmsCoreName } from "../kms-party";
 import { defaultHostChain, extraHostChains, hostChainsForState } from "./topology";
 import {
   kmsConnectorHealthContainers,
@@ -1650,6 +1650,91 @@ export const upgradeRuntimeGroup = async (groupValue: string | undefined, option
   for (const step of plan.steps) {
     await markStep(nextState, step);
   }
+};
+
+type ThresholdKmsNodeUpgradeOperations = {
+  composeUp: typeof composeUp;
+  ensureRuntimeArtifacts: typeof ensureRuntimeArtifacts;
+  generateRuntime: typeof generateRuntime;
+  loadState: typeof loadState;
+  projectContainers: typeof projectContainers;
+  saveState: typeof saveState;
+  waitForContainer: typeof waitForContainer;
+};
+
+const thresholdKmsNodeUpgradeOperations: ThresholdKmsNodeUpgradeOperations = {
+  composeUp,
+  ensureRuntimeArtifacts,
+  generateRuntime,
+  loadState,
+  projectContainers,
+  saveState,
+  waitForContainer,
+};
+
+/** Recreates exactly one serving threshold KMS core with the CORE_VERSION from a lock file. */
+export const upgradeThresholdKmsNode = async (
+  nodeId: number,
+  options: { lockFile: string },
+  operations: ThresholdKmsNodeUpgradeOperations = thresholdKmsNodeUpgradeOperations,
+) => {
+  const state = await operations.loadState();
+  if (!state || !(await operations.projectContainers()).length) {
+    throw new PreflightError("Stack is not running; start a threshold KMS scenario first");
+  }
+  if (state.scenario.kms.mode !== "threshold") {
+    throw new PreflightError("upgradeKmsNode requires a threshold-mode KMS cluster");
+  }
+  if (!Number.isInteger(nodeId) || nodeId < 1 || nodeId > state.scenario.kms.committeeSize) {
+    throw new PreflightError(
+      `upgradeKmsNode expects a serving node id between 1 and ${state.scenario.kms.committeeSize}; received ${nodeId}`,
+    );
+  }
+  if (!state.completedSteps.includes("base")) {
+    throw new PreflightError("upgradeKmsNode requires a stack that has completed the base step");
+  }
+
+  await operations.ensureRuntimeArtifacts(state, "upgrade");
+  const lockedState = (await applyRuntimeUpgradeLock(state, "kms-core", ["CORE_VERSION"], options.lockFile)).state;
+  await assertSchemaCompatibility(lockedState.versions, lockedState.overrides, lockedState.scenario, false);
+
+  const targetVersion = lockedState.versions.env.CORE_VERSION;
+  if (!targetVersion?.trim()) {
+    throw new PreflightError("upgradeKmsNodes requires CORE_VERSION in its lock file");
+  }
+  const versionByNodeId = Object.fromEntries(
+    Array.from({ length: state.scenario.kms.parties }, (_, index) => {
+      const id = index + 1;
+      return [id, state.kmsCoreVersionByNodeId?.[id] ?? state.versions.env.CORE_VERSION];
+    }),
+  );
+  versionByNodeId[nodeId] = targetVersion;
+  const servingNodesAtTarget = Array.from(
+    { length: state.scenario.kms.committeeSize },
+    (_, index) => versionByNodeId[index + 1] === targetVersion,
+  ).every(Boolean);
+  const globalVersion = servingNodesAtTarget ? targetVersion : state.versions.env.CORE_VERSION;
+  const perNodeVersions = Object.fromEntries(
+    Object.entries(versionByNodeId).filter(([, version]) => version !== globalVersion),
+  );
+  const nextState: State = servingNodesAtTarget
+    ? {
+        ...lockedState,
+        kmsCoreVersionByNodeId: Object.keys(perNodeVersions).length ? perNodeVersions : undefined,
+      }
+    : {
+        ...state,
+        kmsCoreVersionByNodeId: perNodeVersions,
+        updatedAt: new Date().toISOString(),
+      };
+
+  await operations.saveState(nextState);
+  await operations.generateRuntime(nextState, stackSpecForState(nextState));
+
+  const container = kmsCoreName(nodeId);
+  console.log(`[upgrade] KMS node ${nodeId} (${container})`);
+  await operations.composeUp("core-threshold", [container], { noDeps: true, forceRecreate: true });
+  await operations.waitForContainer(container, "healthy");
 };
 
 const RESUME_HINT_BLOCKERS = new Set([

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -616,7 +616,11 @@ const buildComposeOverride = async (component: string, plan: StackSpec) => {
   if (component === "core-threshold") {
     // Dedicated threshold-cluster component (gen-keys + N cores + kms-init).
     // Separate from `core` so it never merges with the centralized template.
-    return buildKmsThresholdOverride(plan.kms, kmsRenderOptionsFor(plan.versions.env.CORE_VERSION));
+    return buildKmsThresholdOverride(
+      plan.kms,
+      kmsRenderOptionsFor(plan.versions.env.CORE_VERSION),
+      plan.kmsCoreVersionByNodeId,
+    );
   }
   if (component === "kms-connector" && plan.kms.mode === "threshold") {
     // One connector per KMS party (each cores↔connector pair is independent).

--- a/test-suite/fhevm/src/generate/kms-core.ts
+++ b/test-suite/fhevm/src/generate/kms-core.ts
@@ -172,6 +172,7 @@ const genKeysCommand = (topology: ResolvedKmsTopology, opts: KmsRenderOptions) =
 export const buildKmsThresholdOverride = (
   topology: ResolvedKmsTopology,
   opts: KmsRenderOptions,
+  coreVersionByNodeId: Readonly<Record<string, string>> = {},
 ): ComposeDoc => {
   if (topology.mode !== "threshold") {
     throw new Error("buildKmsThresholdOverride called for a non-threshold topology");
@@ -195,7 +196,9 @@ export const buildKmsThresholdOverride = (
       partyId > topology.committeeSize ? KMS_THRESHOLD_SPARE_CONFIG_NAME : KMS_THRESHOLD_CONFIG_NAME;
     services[name] = {
       container_name: name,
-      image: opts.coreImage,
+      image: coreVersionByNodeId[partyId]
+        ? kmsRenderOptionsFor(coreVersionByNodeId[partyId]).coreImage
+        : opts.coreImage,
       // No shell wrapper: per-party config comes from KMS_CORE__* env and AWS creds
       // come from the environment, so the core binary runs directly.
       entrypoint: ["kms-server", "--config-file", `config/${configName}`],

--- a/test-suite/fhevm/src/kms-threshold.test.ts
+++ b/test-suite/fhevm/src/kms-threshold.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 
 import { partyContainers, quorumPlan } from "./commands/kms-generation";
 import { resolveUpgradePlan } from "./flow/repair";
+import { upgradeThresholdKmsNode } from "./flow/up-flow";
 import { buildKmsConnectorOverride } from "./generate/compose";
 import { buildGatewayScSwapEnv, buildHostScSwapEnv, renderEnvMaps } from "./generate/env";
 import {
@@ -28,8 +29,9 @@ import { presetBundle } from "./resolve/target";
 import { resolveKmsTopology } from "./scenario/resolve";
 import { stackSpecForState, type StackSpec } from "./stack-spec/stack-spec";
 import { testDefaultScenario } from "./test-fixtures";
+import { withTempStateDir } from "./test-state";
 import type { State } from "./types";
-import { readEnvFile } from "./utils/fs";
+import { readEnvFile, writeJson } from "./utils/fs";
 
 const RENDER_OPTS = kmsRenderOptionsFor("c57f52f");
 const fourParty = resolveKmsTopology({ mode: "threshold", parties: 4, threshold: 1 });
@@ -186,6 +188,14 @@ describe("buildKmsThresholdOverride", () => {
     expect(JSON.stringify(core.entrypoint)).toContain(KMS_THRESHOLD_CONFIG_NAME);
     expect(JSON.stringify(core.entrypoint)).not.toContain("/bin/sh");
     expect(JSON.stringify(core.volumes)).not.toContain("minio_secrets");
+  });
+
+  test("renders an explicitly selected core version without changing the other nodes", () => {
+    const services = buildKmsThresholdOverride(fourParty, RENDER_OPTS, { 2: "target-core" }).services;
+    expect(services["kms-core"].image).toBe(RENDER_OPTS.coreImage);
+    expect(services["kms-core-2"].image).toBe("ghcr.io/zama-ai/kms/core-service:target-core");
+    expect(services["kms-core-3"].image).toBe(RENDER_OPTS.coreImage);
+    expect(services["kms-core-gen-keys"].image).toBe(RENDER_OPTS.coreImage);
   });
 
   test("cores publish no host ports (everything dials them over the docker network)", () => {
@@ -424,5 +434,186 @@ describe("resolveUpgradePlan (threshold guard)", () => {
   test("refuses to upgrade the single-core/connector KMS groups on a threshold-mode cluster", () => {
     expect(() => resolveUpgradePlan(thresholdState, "kms", { lockFile: true })).toThrow(/threshold-mode KMS/);
     expect(() => resolveUpgradePlan(thresholdState, "kms-core", { lockFile: true })).toThrow(/threshold-mode KMS/);
+  });
+});
+
+describe("upgradeThresholdKmsNode", () => {
+  test("persists a mixed fleet and recreates only the selected serving core", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const versions = presetBundle("latest-main", "abcdef0", "baseline.json");
+      const state: State = {
+        target: "latest-main",
+        lockPath: "/tmp/baseline.json",
+        requiresGitHub: true,
+        versions,
+        overrides: [],
+        scenario: testDefaultScenario({
+          kms: { mode: "threshold", parties: 4, threshold: 1, committeeSize: 4, fheParams: "Test" },
+        }),
+        completedSteps: ["base"],
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      };
+      const lockFile = path.join(stateDir, "target.json");
+      await writeJson(lockFile, {
+        ...versions,
+        lockName: "target.json",
+        env: { ...versions.env, CORE_VERSION: "target-core" },
+      });
+      const calls: string[] = [];
+      let persisted = state;
+
+      await upgradeThresholdKmsNode(3, { lockFile }, {
+        async loadState() {
+          return persisted;
+        },
+        async projectContainers() {
+          return ["kms-core", "kms-core-2", "kms-core-3", "kms-core-4"];
+        },
+        async ensureRuntimeArtifacts() {
+          calls.push("artifacts");
+        },
+        async saveState(next) {
+          persisted = next;
+          calls.push(`save:${next.versions.env.CORE_VERSION}:${next.kmsCoreVersionByNodeId?.[3]}`);
+        },
+        async generateRuntime(_next, plan) {
+          calls.push(`generate:${plan.versions.env.CORE_VERSION}:${plan.kmsCoreVersionByNodeId?.[3]}`);
+        },
+        async composeUp(component, services = [], options = {}) {
+          calls.push(`up:${component}:${services.join(",")}:${options.noDeps}:${options.forceRecreate}`);
+        },
+        async waitForContainer(container, want) {
+          calls.push(`wait:${container}:${want}`);
+        },
+      });
+
+      expect(calls).toEqual([
+        "artifacts",
+        `save:${versions.env.CORE_VERSION}:target-core`,
+        `generate:${versions.env.CORE_VERSION}:target-core`,
+        "up:core-threshold:kms-core-3:true:true",
+        "wait:kms-core-3:healthy",
+      ]);
+      expect(persisted.versions.env.CORE_VERSION).toBe(versions.env.CORE_VERSION);
+      expect(persisted.kmsCoreVersionByNodeId).toEqual({ 3: "target-core" });
+    });
+  });
+
+  test("moves the global version only after every serving core reaches the target", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const versions = presetBundle("latest-main", "abcdef0", "baseline.json");
+      let persisted: State = {
+        target: "latest-main",
+        lockPath: "/tmp/baseline.json",
+        requiresGitHub: true,
+        versions,
+        overrides: [],
+        scenario: testDefaultScenario({
+          kms: { mode: "threshold", parties: 4, threshold: 1, committeeSize: 4, fheParams: "Test" },
+        }),
+        completedSteps: ["base"],
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      };
+      const lockFile = path.join(stateDir, "target.json");
+      await writeJson(lockFile, {
+        ...versions,
+        lockName: "target.json",
+        env: { ...versions.env, CORE_VERSION: "target-core" },
+      });
+      const operations = {
+        async loadState() {
+          return persisted;
+        },
+        async projectContainers() {
+          return ["kms-core"];
+        },
+        async ensureRuntimeArtifacts() {},
+        async saveState(next: State) {
+          persisted = next;
+        },
+        async generateRuntime() {},
+        async composeUp() {},
+        async waitForContainer() {},
+      };
+
+      for (const nodeId of [1, 2, 3, 4]) {
+        await upgradeThresholdKmsNode(nodeId, { lockFile }, operations);
+      }
+
+      expect(persisted.versions.env.CORE_VERSION).toBe("target-core");
+      expect(persisted.kmsCoreVersionByNodeId).toBeUndefined();
+    });
+  });
+
+  test("keeps a spare core on its prior version when the serving committee reaches the target", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const versions = presetBundle("latest-main", "abcdef0", "baseline.json");
+      let persisted: State = {
+        target: "latest-main",
+        lockPath: "/tmp/baseline.json",
+        requiresGitHub: true,
+        versions,
+        overrides: [],
+        scenario: testDefaultScenario({
+          kms: { mode: "threshold", parties: 5, threshold: 1, committeeSize: 4, fheParams: "Test" },
+        }),
+        completedSteps: ["base"],
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      };
+      const lockFile = path.join(stateDir, "target.json");
+      await writeJson(lockFile, {
+        ...versions,
+        lockName: "target.json",
+        env: { ...versions.env, CORE_VERSION: "target-core" },
+      });
+      const operations = {
+        async loadState() {
+          return persisted;
+        },
+        async projectContainers() {
+          return ["kms-core"];
+        },
+        async ensureRuntimeArtifacts() {},
+        async saveState(next: State) {
+          persisted = next;
+        },
+        async generateRuntime() {},
+        async composeUp() {},
+        async waitForContainer() {},
+      };
+
+      for (const nodeId of [1, 2, 3, 4]) {
+        await upgradeThresholdKmsNode(nodeId, { lockFile }, operations);
+      }
+
+      expect(persisted.versions.env.CORE_VERSION).toBe("target-core");
+      expect(persisted.kmsCoreVersionByNodeId).toEqual({ 5: versions.env.CORE_VERSION });
+    });
+  });
+
+  test("rejects a spare node before changing runtime artifacts", async () => {
+    const state = {
+      scenario: testDefaultScenario({
+        kms: { mode: "threshold", parties: 5, threshold: 1, committeeSize: 4, fheParams: "Test" },
+      }),
+      completedSteps: ["base"],
+    } as State;
+    let touched = false;
+    await expect(upgradeThresholdKmsNode(5, { lockFile: "unused" }, {
+      async loadState() {
+        return state;
+      },
+      async projectContainers() {
+        return ["kms-core"];
+      },
+      async ensureRuntimeArtifacts() {
+        touched = true;
+      },
+      async saveState() {},
+      async generateRuntime() {},
+      async composeUp() {},
+      async waitForContainer() {},
+    })).rejects.toThrow(/between 1 and 4/);
+    expect(touched).toBe(false);
   });
 });

--- a/test-suite/fhevm/src/process.test.ts
+++ b/test-suite/fhevm/src/process.test.ts
@@ -1,13 +1,24 @@
 import { describe, expect, test } from "bun:test";
 
 import { CommandError } from "./errors";
-import { runStreaming } from "./utils/process";
+import { runStreaming, runWithHeartbeat } from "./utils/process";
 
 describe("runStreaming", () => {
   test("preserves stderr in command failures", async () => {
     await expect(runStreaming(["sh", "-lc", "echo boom >&2; exit 7"])).rejects.toMatchObject({
       name: "CommandError",
       stderr: "boom",
+    } satisfies Partial<CommandError>);
+  });
+});
+
+describe("runWithHeartbeat", () => {
+  test("preserves streamed output in command failures", async () => {
+    await expect(
+      runWithHeartbeat(["sh", "-lc", "echo reconstruction-failed; echo warning >&2; exit 7"], "test"),
+    ).rejects.toMatchObject({
+      name: "CommandError",
+      stderr: "reconstruction-failed\nwarning",
     } satisfies Partial<CommandError>);
   });
 });

--- a/test-suite/fhevm/src/rollout-kms-core-progressive.test.ts
+++ b/test-suite/fhevm/src/rollout-kms-core-progressive.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import type { RolloutRunContext } from "./commands/rollout-run";
+import { loadRolloutRunbook } from "./commands/rollout-run";
+import { resolveKmsTopology } from "./scenario/resolve";
+import { from, scenario, to } from "../rollouts/kms-core-progressive/versions";
+
+const RUNBOOK = path.resolve(import.meta.dir, "../rollouts/kms-core-progressive/run.ts");
+
+describe("progressive KMS core rollout", () => {
+  test("keeps SDK and connector versions unchanged", () => {
+    expect(scenario).toBe("four-party-threshold-kms");
+    expect("RELAYER_SDK_VERSION" in from).toBe(false);
+    const baseline = from as Record<string, string>;
+    expect(Object.entries(to).filter(([key, value]) => baseline[key] !== value)).toEqual([
+      ["CORE_VERSION", "v0.13.20"],
+    ]);
+  });
+
+  test("upgrades every core and requires each upgraded node in a healthy quorum", async () => {
+    const calls: string[] = [];
+    const context = {
+      async writeVersionLock(name: string, options: { versions: Record<string, string> }) {
+        calls.push(`lock:${name}:${options.versions.CORE_VERSION}`);
+        return `/tmp/${name}.lock.json`;
+      },
+      async up(options: { lockFile: string; scenario?: string }) {
+        calls.push(`up:${options.scenario}:${options.lockFile}`);
+      },
+      async readState() {
+        calls.push("state");
+        return { scenario: { kms: resolveKmsTopology({ mode: "threshold", parties: 4, threshold: 1 }) } };
+      },
+      async upgradeKmsNodes(nodeIds: readonly number[], options: { lockFile: string }) {
+        calls.push(`upgrade:${nodeIds.join(",")}:${options.lockFile}`);
+      },
+      async test(profile: string, options?: { grep?: string }) {
+        calls.push(`test:${profile}${options?.grep ? `:${options.grep}` : ""}`);
+      },
+      async withRequiredKmsNode(nodeId: number, task: () => Promise<void>) {
+        calls.push(`require:${nodeId}`);
+        await task();
+      },
+    } as unknown as RolloutRunContext;
+
+    await (await loadRolloutRunbook(RUNBOOK))(context);
+
+    expect(calls).toEqual([
+      "lock:00-kms-core-baseline:v0.13.10",
+      "lock:01-kms-core-target:v0.13.20",
+      "up:four-party-threshold-kms:/tmp/00-kms-core-baseline.lock.json",
+      "test:rollout-standard",
+      "state",
+      "upgrade:1:/tmp/01-kms-core-target.lock.json",
+      "require:1",
+      "test:user-decryption:test user decrypt ebool$",
+      "test:rollout-standard",
+      "upgrade:2:/tmp/01-kms-core-target.lock.json",
+      "require:2",
+      "test:user-decryption:test user decrypt ebool$",
+      "test:rollout-standard",
+      "upgrade:3:/tmp/01-kms-core-target.lock.json",
+      "require:3",
+      "test:user-decryption:test user decrypt ebool$",
+      "test:rollout-standard",
+      "upgrade:4:/tmp/01-kms-core-target.lock.json",
+      "require:4",
+      "test:user-decryption:test user decrypt ebool$",
+      "test:rollout-standard",
+    ]);
+  });
+});

--- a/test-suite/fhevm/src/rollout-mainnet-v011-v012-kms.test.ts
+++ b/test-suite/fhevm/src/rollout-mainnet-v011-v012-kms.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import { relayerSdkV042DecryptionError } from "../rollouts/mainnet-v0.11-to-v0.12-kms/run";
+import { from, scenario, to } from "../rollouts/mainnet-v0.11-to-v0.12-kms/versions";
+import type { RolloutRunContext } from "./commands/rollout-run";
+import { loadRolloutRunbook } from "./commands/rollout-run";
+import { resolveKmsTopology } from "./scenario/resolve";
+
+const RUNBOOK = path.resolve(import.meta.dir, "../rollouts/mainnet-v0.11-to-v0.12-kms/run.ts");
+
+describe("mainnet v0.11 to v0.12 KMS rollout", () => {
+  test("pins the incident versions and changes only the KMS core", () => {
+    expect(scenario).toBe("four-party-threshold-kms");
+    expect(from).toMatchObject({
+      RELAYER_VERSION: "v0.11.1",
+      RELAYER_MIGRATE_VERSION: "v0.11.0",
+      GATEWAY_VERSION: "v0.12.1",
+      HOST_VERSION: "v0.12.1",
+      CORE_VERSION: "v0.13.3",
+      CONNECTOR_KMS_WORKER_VERSION: "v0.12.0",
+      COPROCESSOR_TFHE_WORKER_VERSION: "v0.11.0",
+      RELAYER_SDK_VERSION: "0.4.2",
+    });
+    expect(Object.entries(to).filter(([key, value]) => from[key as keyof typeof from] !== value)).toEqual([
+      ["CORE_VERSION", "v0.13.10"],
+    ]);
+  });
+
+  test("reproduces the incident at the two-old two-new boundary", async () => {
+    const calls: string[] = [];
+    const context = {
+      async writeVersionLock(name: string, options: { versions: Record<string, string> }) {
+        calls.push(`lock:${name}:${options.versions.CORE_VERSION}`);
+        return `/tmp/${name}.lock.json`;
+      },
+      async up(options: { overrides?: Array<{ group: string }>; scenario?: string }) {
+        calls.push(`up:${options.scenario}:${options.overrides?.map((override) => override.group).join(",")}`);
+      },
+      async readState() {
+        return { scenario: { kms: resolveKmsTopology({ mode: "threshold", parties: 4, threshold: 1 }) } };
+      },
+      async upgradeKmsNodes(nodeIds: readonly number[], options: { lockFile: string }) {
+        calls.push(`upgrade:${nodeIds.join(",")}:${options.lockFile}`);
+      },
+      async test(profile: string) {
+        calls.push(`test:${profile}`);
+      },
+      async expectTestFailure(profile: string, options: { errorIncludes: string; grep?: string }) {
+        calls.push(`expected-failure:${profile}:${options.grep}:${options.errorIncludes}`);
+      },
+    } as unknown as RolloutRunContext;
+
+    await (await loadRolloutRunbook(RUNBOOK))(context);
+
+    expect(calls).toEqual([
+      "lock:00-kms-core-baseline:v0.13.3",
+      "lock:01-kms-core-target:v0.13.10",
+      "up:four-party-threshold-kms:test-suite",
+      "test:rollout-standard",
+      "upgrade:1,2:/tmp/01-kms-core-target.lock.json",
+      `expected-failure:user-decryption:test user decrypt ebool$:${relayerSdkV042DecryptionError}`,
+      "upgrade:3,4:/tmp/01-kms-core-target.lock.json",
+      "test:rollout-standard",
+    ]);
+  });
+});

--- a/test-suite/fhevm/src/rollout-run.test.ts
+++ b/test-suite/fhevm/src/rollout-run.test.ts
@@ -3,9 +3,18 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { receiptJsonlPath, receiptMarkdownPath } from "./commands/rollout-receipt";
-import { type RolloutRunContext, loadRolloutRunbook, runRolloutRunbook } from "./commands/rollout-run";
+import { receiptJsonlPath, receiptMarkdownPath, requireDockerSnapshot } from "./commands/rollout-receipt";
+import {
+  type RolloutRunContext,
+  loadRolloutRunbook,
+  matchesExpectedTestFailure,
+  runRolloutRunbook,
+} from "./commands/rollout-run";
+import { CommandError, PreflightError } from "./errors";
 import { withTempStateDir } from "./test-state";
+import { saveState } from "./state/state";
+import { presetBundle } from "./resolve/target";
+import { testDefaultScenario } from "./test-fixtures";
 import type { State, VersionBundle } from "./types";
 import { readJson, remove, writeJson } from "./utils/fs";
 
@@ -21,6 +30,9 @@ const fakeContext = () => {
   const ctx: RolloutRunContext = {
     async applyVersionLock(label, options) {
       calls.push(`apply-version-lock:${label}:${options.lockFile}`);
+    },
+    async expectTestFailure(profile, options) {
+      calls.push(`expected-test-failure:${profile}:${options.errorIncludes}`);
     },
     async readState() {
       calls.push("state");
@@ -50,6 +62,13 @@ const fakeContext = () => {
     async up(options) {
       calls.push(`up:${options.lockFile}`);
     },
+    async upgradeKmsNodes(nodeIds, options) {
+      calls.push(`upgrade-kms-nodes:${nodeIds.join(",")}:${options.lockFile}`);
+    },
+    async withRequiredKmsNode(nodeId, task) {
+      calls.push(`require-kms-node:${nodeId}`);
+      await task();
+    },
     async upgradeRuntimeGroup(group, options = {}) {
       calls.push(`upgrade:${group}:${options.lockFile ?? ""}`);
     },
@@ -62,6 +81,13 @@ const fakeContext = () => {
 };
 
 describe("rollout runbook", () => {
+  test("matches only command failures containing the expected test error", () => {
+    const expected = "expected test failure";
+    expect(matchesExpectedTestFailure(new CommandError(["test"], 1, expected), expected)).toBe(true);
+    expect(matchesExpectedTestFailure(new CommandError(["test"], 1, "connection refused"), expected)).toBe(false);
+    expect(matchesExpectedTestFailure(new PreflightError(expected), expected)).toBe(false);
+  });
+
   test("loads a default exported runbook", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "fhevm-rollout-run-"));
     tempDirs.push(root);
@@ -158,6 +184,156 @@ describe("rollout runbook", () => {
       expect(entries[0].versionChanges).toEqual([{ key: "RELAYER_VERSION", to: "old" }]);
       expect(entries[1].versionChanges).toEqual([{ key: "RELAYER_VERSION", from: "old", to: "new" }]);
       expect(await Bun.file(receiptMarkdownPath()).text()).toContain("RELAYER_VERSION");
+    });
+  });
+
+  test("requires audit-critical Docker snapshots to contain inspected containers", () => {
+    expect(() => requireDockerSnapshot({ containers: [], error: "docker inspect failed" })).toThrow(
+      "Required Docker snapshot failed: docker inspect failed",
+    );
+    expect(() => requireDockerSnapshot({ containers: [] })).toThrow("contained no project containers");
+    expect(() =>
+      requireDockerSnapshot({
+        containers: [{ image: "image", imageId: "sha256:id", name: "kms-core", state: "running" }],
+      }),
+    ).not.toThrow();
+  });
+
+  test("records a failed required Docker snapshot before rejecting it", async () => {
+    await withTempStateDir(async () => {
+      const { createRolloutReceipt } = await import("./commands/rollout-receipt");
+      const receipt = createRolloutReceipt({
+        async inspectContainers() {
+          return { containers: [], error: "daemon unavailable" };
+        },
+      });
+      await receipt.start("rollout.ts");
+      await expect(receipt.record("upgrade-kms-node", "KMS node 2", { docker: true })).rejects.toThrow(
+        "Required Docker snapshot failed: daemon unavailable",
+      );
+
+      const entry = JSON.parse((await Bun.file(receiptJsonlPath()).text()).trim());
+      expect(entry.dockerInspectError).toBe("daemon unavailable");
+      expect(await Bun.file(receiptMarkdownPath()).text()).toContain("Docker inspect failed: `daemon unavailable`");
+    });
+  });
+
+  test("records Docker evidence when a KMS node changes but readiness fails", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const versions = presetBundle("latest-main", "abcdef0", "baseline.json");
+      await saveState({
+        target: "latest-main",
+        lockPath: "/tmp/baseline.json",
+        requiresGitHub: true,
+        versions,
+        overrides: [],
+        scenario: testDefaultScenario({
+          kms: { mode: "threshold", parties: 4, threshold: 1, committeeSize: 4, fheParams: "Test" },
+        }),
+        completedSteps: ["base"],
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      });
+      const lockFile = path.join(stateDir, "target.json");
+      await writeJson(lockFile, {
+        ...versions,
+        lockName: "target.json",
+        env: { ...versions.env, CORE_VERSION: "target-core" },
+      });
+      const { createRolloutContext } = await import("./commands/rollout-run");
+      const { createRolloutReceipt } = await import("./commands/rollout-receipt");
+      const receipt = createRolloutReceipt({
+        async inspectContainers() {
+          return {
+            containers: [
+              {
+                image: "ghcr.io/zama-ai/kms/core-service:target-core",
+                imageId: "sha256:target",
+                name: "kms-core-2",
+                state: "running",
+              },
+            ],
+          };
+        },
+      });
+      await receipt.start("rollout.ts");
+      const context = createRolloutContext(receipt, {
+        async upgradeThresholdKmsNode() {
+          throw new Error("readiness failed");
+        },
+      });
+
+      await expect(context.upgradeKmsNodes([2], { lockFile })).rejects.toThrow("readiness failed");
+
+      const entry = JSON.parse((await Bun.file(receiptJsonlPath()).text()).trim());
+      expect(entry.kind).toBe("upgrade-kms-node-failed");
+      expect(entry.details).toMatchObject({ error: "readiness failed", nodeId: 2 });
+      expect(entry.containers[0]).toMatchObject({ imageId: "sha256:target", name: "kms-core-2" });
+    });
+  });
+
+  test("requires the selected KMS node in the live quorum and restores the stopped node", async () => {
+    await withTempStateDir(async () => {
+      const versions = presetBundle("latest-main", "abcdef0", "baseline.json");
+      await saveState({
+        target: "latest-main",
+        lockPath: "/tmp/baseline.json",
+        requiresGitHub: true,
+        versions,
+        overrides: [],
+        scenario: testDefaultScenario({
+          kms: { mode: "threshold", parties: 4, threshold: 1, committeeSize: 4, fheParams: "Test" },
+        }),
+        completedSteps: ["base"],
+        updatedAt: "2026-07-14T00:00:00.000Z",
+      });
+      const { createRolloutContext } = await import("./commands/rollout-run");
+      const { createRolloutReceipt } = await import("./commands/rollout-receipt");
+      const receipt = createRolloutReceipt({
+        async inspectContainers() {
+          return {
+            containers: [{ image: "core", imageId: "sha256:core", name: "kms-core", state: "running" }],
+          };
+        },
+      });
+      await receipt.start("rollout.ts");
+      const calls: string[] = [];
+      const context = createRolloutContext(receipt, {
+        async setRunning(containers, action) {
+          calls.push(`${action}:${containers.join(",")}`);
+        },
+        async waitForPartiesRunning(parties) {
+          calls.push(`running:${parties.join(",")}`);
+        },
+        async waitForPartiesStopped(parties) {
+          calls.push(`stopped:${parties.join(",")}`);
+        },
+      });
+
+      let rejected = false;
+      try {
+        await context.withRequiredKmsNode(4, async () => {
+          calls.push("test");
+          throw undefined;
+        });
+      } catch (error) {
+        rejected = true;
+        expect(error).toBeUndefined();
+      }
+
+      expect(rejected).toBe(true);
+      expect(calls).toEqual([
+        "stop:kms-core-3,kms-connector-3-gw-listener,kms-connector-3-kms-worker,kms-connector-3-tx-sender",
+        "stopped:3",
+        "test",
+        "start:kms-core-3,kms-connector-3-gw-listener,kms-connector-3-kms-worker,kms-connector-3-tx-sender",
+        "running:3",
+      ]);
+      const entries = (await Bun.file(receiptJsonlPath()).text())
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(entries.map((entry) => entry.kind)).toEqual(["require-kms-node", "restore-kms-nodes"]);
+      expect(entries[0].details).toEqual({ nodeId: 4, running: [4, 1, 2], stopped: [3] });
     });
   });
 });

--- a/test-suite/fhevm/src/stack-spec/stack-spec.ts
+++ b/test-suite/fhevm/src/stack-spec/stack-spec.ts
@@ -39,6 +39,7 @@ export type StackSpec = {
   requiresGitHub: boolean;
   target: State["target"];
   versions: VersionBundle;
+  kmsCoreVersionByNodeId?: State["kmsCoreVersionByNodeId"];
   overrides: State["overrides"];
   topology: Topology;
   hostChains: HostChainScenario[];
@@ -104,6 +105,7 @@ export const topologyForState = (state: Pick<State, "scenario">): Topology => ({
 const stackSpecFromResolved = (input: {
   target: State["target"];
   versions: VersionBundle;
+  kmsCoreVersionByNodeId?: State["kmsCoreVersionByNodeId"];
   overrides: State["overrides"];
   scenario: ResolvedScenario;
   requiresGitHub: boolean;
@@ -132,6 +134,7 @@ const stackSpecFromResolved = (input: {
       requiresGitHub: input.requiresGitHub,
       target: input.target,
       versions: input.versions,
+      kmsCoreVersionByNodeId: input.kmsCoreVersionByNodeId,
       overrides: input.overrides,
       topology: bg.topology,
       hostChains: bg.hostChains,
@@ -144,6 +147,7 @@ const stackSpecFromResolved = (input: {
     requiresGitHub: input.requiresGitHub,
     target: input.target,
     versions: input.versions,
+    kmsCoreVersionByNodeId: input.kmsCoreVersionByNodeId,
     overrides: input.overrides,
     topology: topologyFromScenario(input.scenario),
     hostChains: input.scenario.hostChains,
@@ -154,12 +158,13 @@ const stackSpecFromResolved = (input: {
 
 /** Rebuilds a stack spec from persisted state. */
 export const stackSpecForState = (
-  state: Pick<State, "requiresGitHub" | "target" | "versions" | "overrides" | "scenario">,
+  state: Pick<State, "requiresGitHub" | "target" | "versions" | "kmsCoreVersionByNodeId" | "overrides" | "scenario">,
 ): StackSpec =>
   stackSpecFromResolved({
     requiresGitHub: state.requiresGitHub ?? true,
     target: state.target,
     versions: state.versions,
+    kmsCoreVersionByNodeId: state.kmsCoreVersionByNodeId,
     overrides: state.overrides,
     scenario: state.scenario,
   });

--- a/test-suite/fhevm/src/types.ts
+++ b/test-suite/fhevm/src/types.ts
@@ -232,6 +232,8 @@ export type State = {
   lockPath: string;
   requiresGitHub?: boolean;
   versions: VersionBundle;
+  /** Per-node threshold KMS core versions while a rollout is intentionally mixed. */
+  kmsCoreVersionByNodeId?: Record<string, string>;
   overrides: LocalOverride[];
   scenario: ResolvedScenario;
   scenarioSourcePath?: string;

--- a/test-suite/fhevm/src/utils/process.ts
+++ b/test-suite/fhevm/src/utils/process.ts
@@ -133,7 +133,6 @@ export const runWithHeartbeat = async (
 ) => {
   let stdout = "";
   let stderr = "";
-  let sawOutput = false;
   const readLive = async (
     stream: ReadableStream<Uint8Array> | number | null | undefined,
     writer: NodeJS.WriteStream,
@@ -151,13 +150,12 @@ export const runWithHeartbeat = async (
           return;
         }
         if (value?.length) {
-          sawOutput = true;
           onOutput();
           const chunk = Buffer.from(value);
           if (capture === "stdout") {
-            stdout += chunk.toString();
+            stdout = appendBounded(stdout, chunk.toString());
           } else {
-            stderr += chunk.toString();
+            stderr = appendBounded(stderr, chunk.toString());
           }
           writer.write(chunk);
         }
@@ -201,7 +199,8 @@ export const runWithHeartbeat = async (
       }, "stderr"),
     ]);
     if (code !== 0 && !options.allowFailure) {
-      throw new CommandError(argv, code, sawOutput ? "" : `${argv.join(" ")} failed (${code})`);
+      const output = appendBounded("", [stdout.trim(), stderr.trim()].filter(Boolean).join("\n"));
+      throw new CommandError(argv, code, output || `${argv.join(" ")} failed (${code})`);
     }
     return { stdout, stderr, code };
   } finally {


### PR DESCRIPTION
## Summary

Adds a rollout API that applies a KMS core version to any chosen serving nodes while preserving the rest of the fleet:

```ts
await ctx.upgradeKmsNodes([1, 2], { lockFile: targetLock });
```

Nodes are recreated sequentially, mixed fleets survive resume and repair, and each checkpoint records the observed Docker images. The runbook chooses the node combinations and tests; the executor does not prescribe a rollout matrix.

This PR also includes the dispatch-only stateful rollout workflow previously proposed in [#3162](https://github.com/zama-ai/fhevm/pull/3162), so the implementation, its runbooks, and its CI entry point can be reviewed together.

## Progressive KMS rollout

The generic runbook upgrades threshold KMS nodes one by one. After each replacement it:

1. Leaves exactly a `2t+1` quorum online that must include the node just upgraded.
2. Runs one deterministic user-decryption probe, proving that node supplied a usable share.
3. Restores the stopped KMS parties, including when the probe fails.
4. Runs `rollout-standard` against the complete healthy fleet.

The baseline also runs `rollout-standard`. Receipts retain the live and stopped node IDs, applied versions, Docker evidence, test results, and restoration outcome.

## Mainnet incident reproduction

`rollouts/mainnet-v0.11-to-v0.12-kms/run.ts` pins the deployed component versions from the 2026-07-13 incident, including KMS core `v0.13.3` to `v0.13.10` and relayer-sdk `0.4.2`.

It exercises the required checkpoints:

1. Four old nodes pass `rollout-standard`.
2. Nodes 1 and 2 are upgraded. The complete 2-old/2-new fleet must fail one deterministic `ebool` user-decryption probe with the relayer-sdk `0.4.2` reconstruction wrapper.
3. Nodes 3 and 4 are upgraded. Four target-version nodes pass `rollout-standard`.

The test-suite override makes the SDK pin effective without changing SDK source. Expected-failure output and Docker image evidence are retained in the receipt. If recreation or readiness fails after a node may have changed, the failed-upgrade evidence is recorded before the original error is rethrown.

## CI execution

`.github/workflows/test-suite-stateful-rollout.yml` accepts a checked-in runbook path through manual dispatch. It uses the same pinned setup actions and registry credentials as the existing E2E workflows, bounds the rollout step to 185 minutes, uploads Markdown and JSONL receipts even on failure, and always attempts cleanup.

Because GitHub registers a new `workflow_dispatch` workflow only after it exists on the default branch, the first isolated rollout must be dispatched on the resulting `main` commit immediately after merge. It cannot run against this PR head before merge while the workflow remains dispatch-only.

## Scope

- Changes are confined to the test suite and its CI entry point.
- No SDK, KMS Connector, or KMS source is changed.
- The generic runbook temporarily stops only enough KMS parties to require the newly upgraded node in the reconstruction quorum, then restores them.
- No broad quorum enumeration, upgrade planner, label trigger, or normal-PR rollout execution is introduced.
- Rollout integration is not run by normal local validation commands.

## Validation

- `bun run check`
- `bun test src` — 302 tests, 985 assertions
- `bun run compat-smoke`
- `zizmor --persona auditor --offline .github/workflows/test-suite-stateful-rollout.yml`
- repository pre-commit workflow checks
- `git diff --check`
- adversarial review of failure isolation, required-node participation, evidence retention, dispatch security, action pins, timeouts, and cleanup

Rollout integration was not run locally. Post-merge acceptance requires dispatching `rollouts/mainnet-v0.11-to-v0.12-kms/run.ts` and inspecting the retained receipt for the old healthy quorum, expected mixed-fleet failure, final healthy quorum, and responder/image evidence at every audit-critical checkpoint.

Tracks zama-ai/fhevm-internal#1714.