### PR TITLE
test(test-suite): prove Solana two-holder SDK transfer

### DIFF
--- a/solana/scripts/e2e/full-vertical.sh
+++ b/solana/scripts/e2e/full-vertical.sh
@@ -406,6 +406,10 @@ MDH_ACL="$(echo "$mdout" | grep -oE 'output encrypted value [A-Za-z0-9]+' | awk 
 [ -n "$MDH_ACL" ] || fail "no mulDiv output ACL record: $mdout"
 assert_decrypt "mulDiv" "$MDH" "$MDH_ACL" "$EXPECTED_MULDIV"
 
+echo "==> [sdk-transfer] two holders: Alice 1000 -> confidentialTransfer(400) -> Alice 600, Bob 400"
+( cd "$ROOT/test-suite/fhevm" && ./fhevm-cli test solana-two-holder-transfer ) \
+  || fail "SDK two-holder confidential transfer failed"
+
 echo "==> [consume] confidential mint + USDC; wrap -> burn -> release -> public-decrypt -> redeem(secp) + disclose(secp)"
 LCDIR="$ROOT/solana/scripts/e2e/live-client"
 lc() { ( cd "$LCDIR" && env "$@" ./target/debug/poc-live-client 2>&1 ); }

--- a/solana/scripts/e2e/live-client/main.rs
+++ b/solana/scripts/e2e/live-client/main.rs
@@ -398,7 +398,7 @@ fn token_balance_state(
     }
     if encrypted_value_info.owner != zama_host::ID
         || encrypted_value_info.data.len() < 8
-        || encrypted_value_info.data[..8] != zama_host::EncryptedValue::DISCRIMINATOR
+        || &encrypted_value_info.data[..8] != zama_host::EncryptedValue::DISCRIMINATOR
     {
         return Err("invalid balance encrypted value owner or discriminator".into());
     }
@@ -435,7 +435,7 @@ fn token_balance_state(
     }
     if config_info.owner != zama_host::ID
         || config_info.data.len() != 8 + zama_host::HostConfig::SPACE
-        || config_info.data[..8] != zama_host::HostConfig::DISCRIMINATOR
+        || &config_info.data[..8] != zama_host::HostConfig::DISCRIMINATOR
     {
         return Err("invalid HostConfig owner, size, or discriminator".into());
     }

--- a/solana/scripts/e2e/live-client/main.rs
+++ b/solana/scripts/e2e/live-client/main.rs
@@ -16,8 +16,8 @@ use std::str::FromStr;
 
 use anchor_client::{Client, Cluster, CommitmentConfig, Program, Signer};
 use anchor_lang::solana_program::{pubkey::Pubkey, system_program};
-use anchor_lang::{AccountDeserialize, AnchorDeserialize};
-use serde::Deserialize;
+use anchor_lang::{AccountDeserialize, AnchorDeserialize, Discriminator};
+use serde::{Deserialize, Serialize};
 use solana_keypair::{read_keypair_file, Keypair};
 
 const EVENT_AUTHORITY_SEED: &[u8] = b"__event_authority";
@@ -45,6 +45,19 @@ struct DurableEvalResult {
     handle: [u8; 32],
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenBalanceState {
+    version: u8,
+    mint: String,
+    owner: String,
+    token_account: String,
+    encrypted_value_account: String,
+    acl_value_key: String,
+    current_handle: String,
+    chain_id: String,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let home = std::env::var("HOME")?;
     let payer =
@@ -62,6 +75,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the former bootstrap.mjs (@solana/web3.js); mock-input + test-shims OFF.
     if std::env::var("BOOTSTRAP").is_ok() {
         bootstrap(&host, &payer, host_config)?;
+        return Ok(());
+    }
+
+    // TOKEN_BALANCE_STATE is a read-only test probe for the canonical current balance lineage.
+    // Inputs: MINT + TOKEN_OWNER. The final stdout line is stable JSON for fhevm-cli consumers.
+    if std::env::var("TOKEN_BALANCE_STATE").is_ok() {
+        token_balance_state(&host, &token, host_config)?;
+        return Ok(());
+    }
+
+    // INITIALIZE_TOKEN_ACCOUNT creates only the canonical zero-balance account for the payer.
+    // It is a test setup seam for multi-holder flows; unlike CONSUME_WRAP it needs no SPL ATA.
+    if std::env::var("INITIALIZE_TOKEN_ACCOUNT").is_ok() {
+        let mint = Pubkey::from_str(&std::env::var("MINT")?)?;
+        initialize_token_account_if_missing(&token, &payer, host_config, mint)?;
         return Ok(());
     }
 
@@ -296,6 +324,141 @@ fn fetch_encrypted_value(
     let account = program.rpc().get_account(&encrypted_value)?;
     let mut data: &[u8] = &account.data;
     Ok(zama_host::EncryptedValue::try_deserialize(&mut data)?)
+}
+
+fn token_balance_state(
+    host: &Program<Rc<Keypair>>,
+    token: &Program<Rc<Keypair>>,
+    host_config: Pubkey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mint = Pubkey::from_str(&std::env::var("MINT")?)?;
+    let owner = Pubkey::from_str(&std::env::var("TOKEN_OWNER")?)?;
+    let (token_account_key, token_account_bump) =
+        confidential_token::token_account_address(mint, owner);
+    let token_account_info = token.rpc().get_account(&token_account_key)?;
+    if token_account_info.owner != confidential_token::ID
+        || token_account_info.data.len() != 8 + confidential_token::ConfidentialTokenAccount::SPACE
+        || token_account_info.data[..8]
+            != confidential_token::ConfidentialTokenAccount::DISCRIMINATOR
+    {
+        return Err("invalid confidential token account owner, size, or discriminator".into());
+    }
+    let mut token_data: &[u8] = &token_account_info.data;
+    let token_account =
+        confidential_token::ConfidentialTokenAccount::try_deserialize(&mut token_data)?;
+    if token_account.owner != owner
+        || token_account.mint != mint
+        || token_account.bump != token_account_bump
+    {
+        return Err("confidential token account body does not match its canonical PDA".into());
+    }
+
+    let label = confidential_token::balance_label();
+    let value_key =
+        zama_solana_acl::derive_value_key(mint.to_bytes(), token_account_key.to_bytes(), label);
+    let (encrypted_value_key, encrypted_value_bump) = zama_host::encrypted_value_address(value_key);
+    if token_account.balance_encrypted_value != encrypted_value_key {
+        return Err(
+            "token balance pointer does not match the canonical encrypted value PDA".into(),
+        );
+    }
+    // Re-read the pointer, lineage, and HostConfig in one RPC response. Rejecting a changed pointer
+    // prevents the probe from combining a token account from one bank state with a newer lineage.
+    let mut accounts =
+        host.rpc()
+            .get_multiple_accounts(&[token_account_key, encrypted_value_key, host_config])?;
+    let config_info = accounts
+        .pop()
+        .flatten()
+        .ok_or("HostConfig account missing")?;
+    let encrypted_value_info = accounts
+        .pop()
+        .flatten()
+        .ok_or("balance encrypted value account missing")?;
+    let token_account_info = accounts
+        .pop()
+        .flatten()
+        .ok_or("confidential token account missing during coherent re-read")?;
+    if token_account_info.owner != confidential_token::ID
+        || token_account_info.data.len() != 8 + confidential_token::ConfidentialTokenAccount::SPACE
+        || token_account_info.data[..8]
+            != confidential_token::ConfidentialTokenAccount::DISCRIMINATOR
+    {
+        return Err("invalid confidential token account during coherent re-read".into());
+    }
+    let mut token_data: &[u8] = &token_account_info.data;
+    let token_account =
+        confidential_token::ConfidentialTokenAccount::try_deserialize(&mut token_data)?;
+    if token_account.owner != owner
+        || token_account.mint != mint
+        || token_account.bump != token_account_bump
+        || token_account.balance_encrypted_value != encrypted_value_key
+    {
+        return Err("confidential token account changed during balance-state read".into());
+    }
+    if encrypted_value_info.owner != zama_host::ID
+        || encrypted_value_info.data.len() < 8
+        || encrypted_value_info.data[..8] != zama_host::EncryptedValue::DISCRIMINATOR
+    {
+        return Err("invalid balance encrypted value owner or discriminator".into());
+    }
+    let mut encrypted_value_data: &[u8] = &encrypted_value_info.data;
+    let encrypted_value = zama_host::EncryptedValue::try_deserialize(&mut encrypted_value_data)?;
+    if encrypted_value_info.data.len()
+        != 8 + zama_host::EncryptedValue::space(
+            encrypted_value.subjects.len(),
+            encrypted_value.peaks.len(),
+        )
+    {
+        return Err("balance encrypted value account has trailing or truncated data".into());
+    }
+    if encrypted_value.acl_domain_key != mint
+        || encrypted_value.app_account != token_account_key
+        || encrypted_value.encrypted_value_label != label
+        || encrypted_value.bump != encrypted_value_bump
+        || encrypted_value.value_key() != value_key
+    {
+        return Err("balance encrypted value body does not match its canonical lineage".into());
+    }
+    let compute_signer = confidential_token::compute_signer_address(mint).0;
+    if encrypted_value.subjects != [owner, compute_signer] {
+        return Err(
+            "balance encrypted value subjects are not exactly owner + mint compute signer".into(),
+        );
+    }
+    let handle = encrypted_value.current_handle;
+    if handle == [0; 32]
+        || handle[31] != zama_host::HANDLE_VERSION
+        || zama_host::handle_fhe_type(handle) != 5
+    {
+        return Err("balance handle is not a nonzero version-0 euint64 handle".into());
+    }
+    if config_info.owner != zama_host::ID
+        || config_info.data.len() != 8 + zama_host::HostConfig::SPACE
+        || config_info.data[..8] != zama_host::HostConfig::DISCRIMINATOR
+    {
+        return Err("invalid HostConfig owner, size, or discriminator".into());
+    }
+    let mut config_data: &[u8] = &config_info.data;
+    let config = zama_host::HostConfig::try_deserialize(&mut config_data)?;
+    if zama_host::handle_chain_id(handle) != config.chain_id || config.chain_id & (1 << 63) == 0 {
+        return Err("balance handle chain id does not match the Solana HostConfig".into());
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string(&TokenBalanceState {
+            version: 1,
+            mint: mint.to_string(),
+            owner: owner.to_string(),
+            token_account: token_account_key.to_string(),
+            encrypted_value_account: encrypted_value_key.to_string(),
+            acl_value_key: format!("0x{}", hex(&value_key)),
+            current_handle: format!("0x{}", hex(&handle)),
+            chain_id: config.chain_id.to_string(),
+        })?
+    );
+    Ok(())
 }
 
 fn bytes32_env(name: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
@@ -1158,46 +1321,20 @@ fn consume_wrap(
     let (vault_authority, _) = confidential_token::vault_authority_address(mint);
     let vault_usdc = confidential_token::vault_token_account_address(mint, underlying);
     let (compute_signer, _) = confidential_token::compute_signer_address(mint);
-    let (token_account, _) = confidential_token::token_account_address(mint, owner);
+    let (token_account, balance_value) =
+        initialize_token_account_if_missing(token, payer, host_config, mint)?;
     let (ts_authority, _) = confidential_token::total_supply_authority_address(mint);
     let (user_usdc, _) = Pubkey::find_program_address(
         &[owner.as_ref(), spl_token_id.as_ref(), underlying.as_ref()],
         &ata_prog,
     );
 
-    let (balance_value, _) =
-        confidential_token::balance_encrypted_value_address(mint, token_account);
     let mint_state: confidential_token::ConfidentialMint = token.account(mint)?;
     let total_supply_value = mint_state.total_supply_encrypted_value;
     // The wrap amount is trivial-encrypted as a transient inside wrap_usdc's eval frame.
     let (zama_evt, _) = Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &zama_host::ID);
     let (token_evt, _) =
         Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &confidential_token::ID);
-
-    // The confidential token account must exist before wrap draws from it; create it if missing.
-    if token.rpc().get_account(&token_account).is_err() {
-        let init_sig = token
-            .request()
-            .accounts(confidential_token::accounts::InitializeTokenAccount {
-                owner,
-                mint,
-                compute_signer,
-                token_account,
-                balance_encrypted_value: balance_value,
-                zama_event_authority: zama_evt,
-                zama_program: zama_host::ID,
-                host_config,
-                system_program: system_program::ID,
-                hcu_authority: confidential_token::hcu_authority_address(mint).0,
-                hcu_block_meter: None,
-                hcu_trusted_app_record: None,
-                event_authority: token_evt,
-                program: confidential_token::ID,
-            })
-            .args(confidential_token::instruction::InitializeTokenAccount { initial_balance: 0 })
-            .send()?;
-        println!("OK initialize_token_account: {init_sig}");
-    }
 
     // The vault's USDC ATA must exist before wrap; create it (idempotent) if missing.
     if token.rpc().get_account(&vault_usdc).is_err() {
@@ -1270,6 +1407,48 @@ fn consume_wrap(
     println!("OK wrap_usdc({amount}): {sig}");
     println!("  new balance ACL {balance_value}");
     Ok(())
+}
+
+fn initialize_token_account_if_missing(
+    token: &Program<Rc<Keypair>>,
+    payer: &Rc<Keypair>,
+    host_config: Pubkey,
+    mint: Pubkey,
+) -> Result<(Pubkey, Pubkey), Box<dyn std::error::Error>> {
+    let owner = payer.pubkey();
+    let (token_account, _) = confidential_token::token_account_address(mint, owner);
+    let (balance_value, _) =
+        confidential_token::balance_encrypted_value_address(mint, token_account);
+    if token.rpc().get_account(&token_account).is_ok() {
+        return Ok((token_account, balance_value));
+    }
+    let compute_signer = confidential_token::compute_signer_address(mint).0;
+    let (zama_event_authority, _) =
+        Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &zama_host::ID);
+    let (event_authority, _) =
+        Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &confidential_token::ID);
+    let signature = token
+        .request()
+        .accounts(confidential_token::accounts::InitializeTokenAccount {
+            owner,
+            mint,
+            compute_signer,
+            token_account,
+            balance_encrypted_value: balance_value,
+            zama_event_authority,
+            zama_program: zama_host::ID,
+            host_config,
+            system_program: system_program::ID,
+            hcu_authority: confidential_token::hcu_authority_address(mint).0,
+            hcu_block_meter: None,
+            hcu_trusted_app_record: None,
+            event_authority,
+            program: confidential_token::ID,
+        })
+        .args(confidential_token::instruction::InitializeTokenAccount { initial_balance: 0 })
+        .send()?;
+    println!("OK initialize_token_account: {signature}");
+    Ok((token_account, balance_value))
 }
 
 /// Burns an encrypted amount from the confidential balance (confidential_burn): the heaviest

--- a/solana/scripts/e2e/live-client/main.rs
+++ b/solana/scripts/e2e/live-client/main.rs
@@ -338,7 +338,7 @@ fn token_balance_state(
     let token_account_info = token.rpc().get_account(&token_account_key)?;
     if token_account_info.owner != confidential_token::ID
         || token_account_info.data.len() != 8 + confidential_token::ConfidentialTokenAccount::SPACE
-        || token_account_info.data[..8]
+        || &token_account_info.data[..8]
             != confidential_token::ConfidentialTokenAccount::DISCRIMINATOR
     {
         return Err("invalid confidential token account owner, size, or discriminator".into());
@@ -381,7 +381,7 @@ fn token_balance_state(
         .ok_or("confidential token account missing during coherent re-read")?;
     if token_account_info.owner != confidential_token::ID
         || token_account_info.data.len() != 8 + confidential_token::ConfidentialTokenAccount::SPACE
-        || token_account_info.data[..8]
+        || &token_account_info.data[..8]
             != confidential_token::ConfidentialTokenAccount::DISCRIMINATOR
     {
         return Err("invalid confidential token account during coherent re-read".into());

--- a/test-suite/fhevm/bun.lock
+++ b/test-suite/fhevm/bun.lock
@@ -6,6 +6,7 @@
       "name": "@fhevm/local-cli",
       "dependencies": {
         "@fhevm/sdk": "file:../../sdk/js-sdk/src",
+        "@solana/kit": "6.10.0",
         "citty": "^0.1.6",
         "yaml": "^2.8.1",
       },
@@ -22,11 +23,99 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
+    "@solana/accounts": ["@solana/accounts@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/rpc-spec": "6.10.0", "@solana/rpc-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q=="],
+
+    "@solana/addresses": ["@solana/addresses@6.10.0", "", { "dependencies": { "@solana/assertions": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/nominal-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw=="],
+
+    "@solana/assertions": ["@solana/assertions@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg=="],
+
+    "@solana/codecs": ["@solana/codecs@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/codecs-data-structures": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/fixed-points": "6.10.0", "@solana/options": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ=="],
+
+    "@solana/codecs-core": ["@solana/codecs-core@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ=="],
+
+    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A=="],
+
+    "@solana/codecs-numbers": ["@solana/codecs-numbers@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ=="],
+
+    "@solana/codecs-strings": ["@solana/codecs-strings@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.4.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA=="],
+
+    "@solana/errors": ["@solana/errors@6.10.0", "", { "dependencies": { "chalk": "5.6.2", "commander": "15.0.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg=="],
+
+    "@solana/fast-stable-stringify": ["@solana/fast-stable-stringify@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw=="],
+
+    "@solana/fixed-points": ["@solana/fixed-points@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg=="],
+
+    "@solana/functional": ["@solana/functional@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ=="],
+
+    "@solana/instruction-plans": ["@solana/instruction-plans@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/instructions": "6.10.0", "@solana/keys": "6.10.0", "@solana/promises": "6.10.0", "@solana/transaction-messages": "6.10.0", "@solana/transactions": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg=="],
+
+    "@solana/instructions": ["@solana/instructions@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A=="],
+
+    "@solana/keys": ["@solana/keys@6.10.0", "", { "dependencies": { "@solana/assertions": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/nominal-types": "6.10.0", "@solana/promises": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA=="],
+
+    "@solana/kit": ["@solana/kit@6.10.0", "", { "dependencies": { "@solana/accounts": "6.10.0", "@solana/addresses": "6.10.0", "@solana/codecs": "6.10.0", "@solana/errors": "6.10.0", "@solana/functional": "6.10.0", "@solana/instruction-plans": "6.10.0", "@solana/instructions": "6.10.0", "@solana/keys": "6.10.0", "@solana/offchain-messages": "6.10.0", "@solana/plugin-core": "6.10.0", "@solana/plugin-interfaces": "6.10.0", "@solana/program-client-core": "6.10.0", "@solana/programs": "6.10.0", "@solana/rpc": "6.10.0", "@solana/rpc-api": "6.10.0", "@solana/rpc-parsed-types": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "@solana/rpc-subscriptions": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/signers": "6.10.0", "@solana/subscribable": "6.10.0", "@solana/sysvars": "6.10.0", "@solana/transaction-confirmation": "6.10.0", "@solana/transaction-messages": "6.10.0", "@solana/transactions": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ=="],
+
+    "@solana/nominal-types": ["@solana/nominal-types@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA=="],
+
+    "@solana/offchain-messages": ["@solana/offchain-messages@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-data-structures": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/keys": "6.10.0", "@solana/nominal-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg=="],
+
+    "@solana/options": ["@solana/options@6.10.0", "", { "dependencies": { "@solana/codecs-core": "6.10.0", "@solana/codecs-data-structures": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg=="],
+
+    "@solana/plugin-core": ["@solana/plugin-core@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ=="],
+
+    "@solana/plugin-interfaces": ["@solana/plugin-interfaces@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/instruction-plans": "6.10.0", "@solana/keys": "6.10.0", "@solana/rpc-spec": "6.10.0", "@solana/rpc-subscriptions-spec": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/signers": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q=="],
+
+    "@solana/program-client-core": ["@solana/program-client-core@6.10.0", "", { "dependencies": { "@solana/accounts": "6.10.0", "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/errors": "6.10.0", "@solana/instruction-plans": "6.10.0", "@solana/instructions": "6.10.0", "@solana/plugin-interfaces": "6.10.0", "@solana/rpc-api": "6.10.0", "@solana/signers": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA=="],
+
+    "@solana/programs": ["@solana/programs@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/errors": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ=="],
+
+    "@solana/promises": ["@solana/promises@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg=="],
+
+    "@solana/rpc": ["@solana/rpc@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/fast-stable-stringify": "6.10.0", "@solana/functional": "6.10.0", "@solana/rpc-api": "6.10.0", "@solana/rpc-spec": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "@solana/rpc-transformers": "6.10.0", "@solana/rpc-transport-http": "6.10.0", "@solana/rpc-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg=="],
+
+    "@solana/rpc-api": ["@solana/rpc-api@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/keys": "6.10.0", "@solana/rpc-parsed-types": "6.10.0", "@solana/rpc-spec": "6.10.0", "@solana/rpc-transformers": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/transaction-messages": "6.10.0", "@solana/transactions": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg=="],
+
+    "@solana/rpc-parsed-types": ["@solana/rpc-parsed-types@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ=="],
+
+    "@solana/rpc-spec": ["@solana/rpc-spec@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "@solana/subscribable": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ=="],
+
+    "@solana/rpc-spec-types": ["@solana/rpc-spec-types@6.10.0", "", { "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ=="],
+
+    "@solana/rpc-subscriptions": ["@solana/rpc-subscriptions@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/fast-stable-stringify": "6.10.0", "@solana/functional": "6.10.0", "@solana/promises": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "@solana/rpc-subscriptions-api": "6.10.0", "@solana/rpc-subscriptions-channel-websocket": "6.10.0", "@solana/rpc-subscriptions-spec": "6.10.0", "@solana/rpc-transformers": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/subscribable": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q=="],
+
+    "@solana/rpc-subscriptions-api": ["@solana/rpc-subscriptions-api@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/keys": "6.10.0", "@solana/rpc-subscriptions-spec": "6.10.0", "@solana/rpc-transformers": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/transaction-messages": "6.10.0", "@solana/transactions": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg=="],
+
+    "@solana/rpc-subscriptions-channel-websocket": ["@solana/rpc-subscriptions-channel-websocket@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/functional": "6.10.0", "@solana/rpc-subscriptions-spec": "6.10.0", "@solana/subscribable": "6.10.0", "ws": "^8.21.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw=="],
+
+    "@solana/rpc-subscriptions-spec": ["@solana/rpc-subscriptions-spec@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/promises": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "@solana/subscribable": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w=="],
+
+    "@solana/rpc-transformers": ["@solana/rpc-transformers@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/functional": "6.10.0", "@solana/nominal-types": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "@solana/rpc-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug=="],
+
+    "@solana/rpc-transport-http": ["@solana/rpc-transport-http@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/rpc-spec": "6.10.0", "@solana/rpc-spec-types": "6.10.0", "undici-types": "^8.4.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA=="],
+
+    "@solana/rpc-types": ["@solana/rpc-types@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/fixed-points": "6.10.0", "@solana/nominal-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg=="],
+
+    "@solana/signers": ["@solana/signers@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/errors": "6.10.0", "@solana/instructions": "6.10.0", "@solana/keys": "6.10.0", "@solana/nominal-types": "6.10.0", "@solana/offchain-messages": "6.10.0", "@solana/transaction-messages": "6.10.0", "@solana/transactions": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A=="],
+
+    "@solana/subscribable": ["@solana/subscribable@6.10.0", "", { "dependencies": { "@solana/errors": "6.10.0", "@solana/promises": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw=="],
+
+    "@solana/sysvars": ["@solana/sysvars@6.10.0", "", { "dependencies": { "@solana/accounts": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-data-structures": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/errors": "6.10.0", "@solana/rpc-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg=="],
+
+    "@solana/transaction-confirmation": ["@solana/transaction-confirmation@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/keys": "6.10.0", "@solana/promises": "6.10.0", "@solana/rpc": "6.10.0", "@solana/rpc-subscriptions": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/transaction-messages": "6.10.0", "@solana/transactions": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ=="],
+
+    "@solana/transaction-messages": ["@solana/transaction-messages@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-data-structures": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/errors": "6.10.0", "@solana/functional": "6.10.0", "@solana/instructions": "6.10.0", "@solana/nominal-types": "6.10.0", "@solana/rpc-types": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ=="],
+
+    "@solana/transactions": ["@solana/transactions@6.10.0", "", { "dependencies": { "@solana/addresses": "6.10.0", "@solana/codecs-core": "6.10.0", "@solana/codecs-data-structures": "6.10.0", "@solana/codecs-numbers": "6.10.0", "@solana/codecs-strings": "6.10.0", "@solana/errors": "6.10.0", "@solana/functional": "6.10.0", "@solana/instructions": "6.10.0", "@solana/keys": "6.10.0", "@solana/nominal-types": "6.10.0", "@solana/rpc-types": "6.10.0", "@solana/transaction-messages": "6.10.0" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA=="],
+
     "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
+
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
@@ -36,6 +125,10 @@
 
     "wasm-feature-detect": ["wasm-feature-detect@1.8.0", "", {}, "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
+    "@solana/rpc-transport-http/undici-types": ["undici-types@8.7.0", "", {}, "sha512-gbsS+hAjHg9iV+T8XWdFqnOZEk4f5xrrX3eb9Y1GDe+B5u9H68P6SzYXXUw/rkRvJHRgKIdNfAcrcVj/JvayVA=="],
   }
 }

--- a/test-suite/fhevm/package.json
+++ b/test-suite/fhevm/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fhevm/sdk": "file:../../sdk/js-sdk/src",
+    "@solana/kit": "6.10.0",
     "citty": "^0.1.6",
     "yaml": "^2.8.1"
   },

--- a/test-suite/fhevm/solana-two-holder-transfer.ts
+++ b/test-suite/fhevm/solana-two-holder-transfer.ts
@@ -1,0 +1,85 @@
+// One-shot Node worker for the real Solana SDK transfer seam. The proof object stays in memory
+// from build -> submit -> transfer; this process is never retried after submission ambiguity.
+import fs from 'node:fs/promises';
+
+import { defineFhevmSolanaChain } from '@fhevm/sdk/chains';
+import { createFhevmEncryptClient, setFhevmRuntimeConfig } from '@fhevm/sdk/solana';
+import type { Bytes32Hex } from '@fhevm/sdk/types';
+import {
+  address,
+  createKeyPairSignerFromBytes,
+  createSolanaRpc,
+  createSolanaRpcSubscriptions,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+} from '@solana/kit';
+
+const HOST_PROGRAM = address('6AtbvED1rfX68aCT1tYgU1aeu4kFksPDxZG9gtB1Fgtu');
+const HOST_CONFIG_SEED = new TextEncoder().encode('host-config');
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`missing env ${name}`);
+  return value;
+}
+
+const bytes32 = (value: string): Bytes32Hex => {
+  if (!/^0x[0-9a-f]{64}$/i.test(value)) throw new Error(`expected bytes32 hex, got ${value}`);
+  return value as Bytes32Hex;
+};
+
+const addressHex = (value: string): Bytes32Hex =>
+  `0x${Buffer.from(getAddressEncoder().encode(address(value))).toString('hex')}` as Bytes32Hex;
+
+const _fetch = globalThis.fetch;
+globalThis.fetch = ((url: string | URL | Request, options?: RequestInit) =>
+  _fetch(typeof url === 'string' ? url.replace('//minio:9000', '//127.0.0.1:9000') : url, options)) as typeof fetch;
+
+const keypairBytes = Uint8Array.from(JSON.parse(await fs.readFile(required('TRANSFER_OWNER_KEYPAIR'), 'utf8')) as number[]);
+const owner = await createKeyPairSignerFromBytes(keypairBytes);
+if (owner.address !== required('TRANSFER_OWNER')) throw new Error('transfer signer does not match the probed Alice owner');
+if (owner.address === required('TRANSFER_RECIPIENT')) throw new Error('Alice and Bob must use distinct owners');
+
+const chainId = BigInt(required('TRANSFER_CHAIN_ID'));
+if ((chainId & (1n << 63n)) === 0n) throw new Error('transfer chain id is not a Solana high-bit chain id');
+const aclProgramAddress = bytes32(required('TRANSFER_ACL_PROGRAM'));
+if (addressHex(HOST_PROGRAM) !== aclProgramAddress) throw new Error('configured ACL program is not the fixed Zama host program');
+const chain = defineFhevmSolanaChain({
+  id: chainId,
+  fhevm: { relayerUrl: required('TRANSFER_RELAYER_URL'), acl: { domainKeys: [addressHex(required('TRANSFER_MINT'))] } },
+});
+setFhevmRuntimeConfig({ auth: { type: 'ApiKeyHeader', value: process.env.ZAMA_FHEVM_API_KEY ?? 'local' } });
+const client = createFhevmEncryptClient({ chain, aclProgramAddress });
+const inputProof = await client.buildInputProof({
+  contractAddress: addressHex(required('TRANSFER_COMPUTE_SIGNER')),
+  userAddress: addressHex(owner.address),
+  values: [{ type: 'uint64', value: 400n }],
+});
+const inputProofResult = await client.submitInputProof({ inputProof });
+const [hostConfig] = await getProgramDerivedAddress({
+  programAddress: HOST_PROGRAM,
+  seeds: [HOST_CONFIG_SEED],
+});
+const rpc = createSolanaRpc(required('TRANSFER_RPC_URL'));
+const rpcSubscriptions = createSolanaRpcSubscriptions(required('TRANSFER_WS_URL'));
+const signature = await client.confidentialTransfer({
+  rpc,
+  rpcSubscriptions,
+  inputProof,
+  inputProofResult,
+  inputIndex: 0,
+  owner,
+  feePayer: owner,
+  mint: address(required('TRANSFER_MINT')),
+  fromAccount: address(required('TRANSFER_FROM_ACCOUNT')),
+  toAccount: address(required('TRANSFER_TO_ACCOUNT')),
+  fromBalanceValue: address(required('TRANSFER_FROM_BALANCE')),
+  toBalanceValue: address(required('TRANSFER_TO_BALANCE')),
+  hostConfig,
+});
+const inputHandle = inputProof.getInputHandles()[0]?.bytes32Hex;
+if (inputHandle === undefined) throw new Error('SDK transfer proof did not contain its euint64 handle');
+process.stdout.write(
+  `${JSON.stringify({ version: 1, signature, inputHandle })}\n`,
+);
+process.exit(0);

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -21,6 +21,11 @@ import {
   SOLANA_PUBLIC_DECRYPT_PROFILE,
   runSolanaPublicDecrypt,
 } from "../solana/public-decrypt";
+import {
+  SOLANA_TWO_HOLDER_TRANSFER_DESCRIPTION,
+  SOLANA_TWO_HOLDER_TRANSFER_PROFILE,
+  runSolanaTwoHolderTransfer,
+} from "../solana/two-holder-transfer";
 import { topologyForState } from "../stack-spec/stack-spec";
 import {
   COPROCESSOR_DB_CONTAINER,
@@ -77,6 +82,7 @@ const TEST_PROFILE_NAMES = [
   "rollout-standard",
   SOLANA_CURRENT_USER_DECRYPT_PROFILE,
   SOLANA_PUBLIC_DECRYPT_PROFILE,
+  SOLANA_TWO_HOLDER_TRANSFER_PROFILE,
   "standard",
 ].sort();
 // The below-quorum probe is expected to hang waiting for KMS responses, so it is killed after
@@ -131,6 +137,7 @@ const TEST_PROFILE_DESCRIPTIONS: Partial<Record<(typeof TEST_PROFILE_NAMES)[numb
     "Drive RFC-005 NewKmsContext + NewKmsEpoch on the host ProtocolConfig and prove the KMS reshares, activates, and still decrypts under each (threshold-mode KMS).",
   [SOLANA_CURRENT_USER_DECRYPT_PROFILE]: SOLANA_CURRENT_USER_DECRYPT_DESCRIPTION,
   [SOLANA_PUBLIC_DECRYPT_PROFILE]: SOLANA_PUBLIC_DECRYPT_DESCRIPTION,
+  [SOLANA_TWO_HOLDER_TRANSFER_PROFILE]: SOLANA_TWO_HOLDER_TRANSFER_DESCRIPTION,
 };
 
 /** Validates whether a named profile supports an extra grep narrowing expression. */
@@ -889,6 +896,12 @@ export const test = async (testName: string | undefined, options: TestOptions) =
   const state = await loadState();
   if (!state?.discovery?.actualFheKeyId) {
     throw new PreflightError("Stack has not completed bootstrap; run `fhevm-cli up` first");
+  }
+  if (testName === SOLANA_TWO_HOLDER_TRANSFER_PROFILE) {
+    console.log(`[test] ${SOLANA_TWO_HOLDER_TRANSFER_PROFILE}`);
+    const started = Date.now();
+    await runLogged(SOLANA_TWO_HOLDER_TRANSFER_PROFILE, started, runSolanaTwoHolderTransfer);
+    return;
   }
 
   const ciphertextDriftRequirement = () => {

--- a/test-suite/fhevm/src/solana/two-holder-transfer.test.ts
+++ b/test-suite/fhevm/src/solana/two-holder-transfer.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseBalanceState,
+  parseTransferWorkerResult,
+  runSolanaTwoHolderTransfer,
+  solanaUserDecryptContext,
+  type BalanceState,
+  type TwoHolderDependencies,
+  type TwoHolderScenario,
+} from "./two-holder-transfer";
+
+const hex32 = (byte: string) => `0x${byte.repeat(64)}`;
+const alice = { owner: "1".repeat(32), keypairPath: "/alice.json", secretKey: hex32("1") };
+const bob = { owner: "2".repeat(32), keypairPath: "/bob.json", secretKey: hex32("2") };
+const scenario: TwoHolderScenario = {
+  mint: "3".repeat(32),
+  computeSigner: "4".repeat(32),
+  alice,
+  bob,
+};
+const balance = (owner: string, handleByte: string): BalanceState => ({
+  version: 1,
+  mint: scenario.mint,
+  owner,
+  tokenAccount: owner === alice.owner ? "5".repeat(32) : "6".repeat(32),
+  encryptedValueAccount: owner === alice.owner ? "7".repeat(32) : "8".repeat(32),
+  aclValueKey: hex32("a"),
+  currentHandle: hex32(handleByte),
+  chainId: "9223372036854788153",
+});
+
+describe("solana-two-holder-transfer", () => {
+  test("proves initial balances, transfers once, then proves both latest balances", async () => {
+    const events: string[] = [];
+    let reads = 0;
+    const dependencies: TwoHolderDependencies = {
+      provision: async () => scenario,
+      readBalance: async (_scenario, holder) => {
+        const final = reads++ >= 2;
+        events.push(`read:${holder.owner}:${final ? "final" : "initial"}`);
+        return balance(holder.owner, holder === alice ? (final ? "3" : "1") : final ? "4" : "2");
+      },
+      waitForHandle: async (handle) => {
+        events.push(`wait:${handle.at(-1)}`);
+      },
+      transfer: async () => {
+        events.push("transfer");
+      },
+      decrypt: async (_scenario, holder, _state, expected) => {
+        events.push(`decrypt:${holder.owner}:${expected}`);
+        return expected;
+      },
+      cleanup: async () => {
+        events.push("cleanup");
+      },
+    };
+
+    await runSolanaTwoHolderTransfer(dependencies);
+
+    expect(events.filter((event) => event === "transfer")).toHaveLength(1);
+    expect(events).toEqual([
+      `read:${alice.owner}:initial`,
+      `read:${bob.owner}:initial`,
+      "wait:1",
+      "wait:2",
+      `decrypt:${alice.owner}:1000`,
+      `decrypt:${bob.owner}:0`,
+      "transfer",
+      `read:${alice.owner}:final`,
+      `read:${bob.owner}:final`,
+      "wait:3",
+      "wait:4",
+      `decrypt:${alice.owner}:600`,
+      `decrypt:${bob.owner}:400`,
+      "cleanup",
+    ]);
+  });
+
+  test("rejects a stale post-transfer handle and still cleans up", async () => {
+    let cleaned = false;
+    let reads = 0;
+    const dependencies: TwoHolderDependencies = {
+      provision: async () => scenario,
+      readBalance: async (_scenario, holder) => balance(holder.owner, reads++ < 2 ? (holder === alice ? "1" : "2") : "1"),
+      waitForHandle: async () => undefined,
+      transfer: async () => undefined,
+      decrypt: async (_scenario, _holder, _state, expected) => expected,
+      cleanup: async () => {
+        cleaned = true;
+      },
+    };
+    await expect(runSolanaTwoHolderTransfer(dependencies)).rejects.toThrow("did not rotate both current balance handles");
+    expect(cleaned).toBe(true);
+  });
+
+  test("strictly validates versioned balance probe identity and high-bit chain id", () => {
+    const state = balance(alice.owner, "1");
+    expect(parseBalanceState(`${JSON.stringify(state)}\n`, scenario.mint, alice.owner)).toEqual(state);
+    expect(() => parseBalanceState(JSON.stringify({ ...state, version: 2 }), scenario.mint, alice.owner)).toThrow(
+      "identity or version mismatch",
+    );
+    expect(() => parseBalanceState(JSON.stringify({ ...state, chainId: "12345" }), scenario.mint, alice.owner)).toThrow(
+      "invalid Solana chainId",
+    );
+    expect(() => parseBalanceState(JSON.stringify({ ...state, extra: true }), scenario.mint, alice.owner)).toThrow(
+      "identity or version mismatch",
+    );
+  });
+
+  test("encodes a decimal user-decrypt context as bytes32", () => {
+    expect(solanaUserDecryptContext("1")).toBe(`0x${"0".repeat(63)}1`);
+    expect(() => solanaUserDecryptContext("0x01")).toThrow("unsigned decimal integer");
+    expect(() => solanaUserDecryptContext((1n << 256n).toString())).toThrow("fit in 32 bytes");
+  });
+
+  test("strictly validates the one-shot SDK worker result", () => {
+    const result = { version: 1, signature: "9".repeat(88), inputHandle: hex32("1") };
+    expect(() => parseTransferWorkerResult(JSON.stringify(result))).not.toThrow();
+    expect(() => parseTransferWorkerResult(JSON.stringify({ ...result, extra: true }))).toThrow(
+      "malformed versioned JSON",
+    );
+  });
+});

--- a/test-suite/fhevm/src/solana/two-holder-transfer.ts
+++ b/test-suite/fhevm/src/solana/two-holder-transfer.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { address, createKeyPairSignerFromBytes, getAddressEncoder } from "@solana/kit";
+
+import { COPROCESSOR_DB_CONTAINER, REPO_ROOT } from "../layout";
+import { runSolanaCurrentUserDecrypt } from "./current-user-decrypt";
+import { run } from "../utils/process";
+
+export const SOLANA_TWO_HOLDER_TRANSFER_PROFILE = "solana-two-holder-transfer";
+export const SOLANA_TWO_HOLDER_TRANSFER_DESCRIPTION =
+  "Transfer an SDK-encrypted euint64 between two real Solana holders and decrypt both latest balances.";
+
+const RPC_URL = "http://127.0.0.1:8899";
+const WS_URL = "ws://127.0.0.1:8900";
+const RELAYER_URL = "http://127.0.0.1:3000";
+const ACL_PROGRAM = "0x4cd3022dff504a675caf2d9b4f4014d0b3dc3ea17ffb97ba355cec5a933a30ee";
+const DEFAULT_USER_DECRYPT_CONTEXT =
+  "3166189940082864718613269121331309980362851143201109172953918312716374638593";
+const LIVE_CLIENT = path.join(REPO_ROOT, "solana/scripts/e2e/live-client/target/debug/poc-live-client");
+const LIVE_CLIENT_DIR = path.join(REPO_ROOT, "solana/scripts/e2e/live-client");
+const SDK_WORKER = path.join(REPO_ROOT, "test-suite/fhevm/solana-two-holder-transfer.ts");
+const CLI_DIR = path.join(REPO_ROOT, "test-suite/fhevm");
+const BASE58 = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const SIGNATURE = /^[1-9A-HJ-NP-Za-km-z]{87,88}$/;
+const BYTES32 = /^0x[0-9a-f]{64}$/i;
+
+export type BalanceState = {
+  version: 1;
+  mint: string;
+  owner: string;
+  tokenAccount: string;
+  encryptedValueAccount: string;
+  aclValueKey: string;
+  currentHandle: string;
+  chainId: string;
+};
+
+export type Holder = { owner: string; keypairPath: string; secretKey: string };
+export type TwoHolderScenario = {
+  mint: string;
+  computeSigner: string;
+  alice: Holder;
+  bob: Holder;
+};
+
+export type TwoHolderDependencies = {
+  provision(): Promise<TwoHolderScenario>;
+  readBalance(scenario: TwoHolderScenario, holder: Holder): Promise<BalanceState>;
+  waitForHandle(handle: string): Promise<void>;
+  transfer(scenario: TwoHolderScenario, alice: BalanceState, bob: BalanceState): Promise<void>;
+  decrypt(scenario: TwoHolderScenario, holder: Holder, state: BalanceState, expected: bigint): Promise<bigint>;
+  cleanup(scenario: TwoHolderScenario | undefined): Promise<void>;
+};
+
+const parseJsonLine = (output: string): unknown => {
+  const line = output.trim().split(/\r?\n/).at(-1);
+  if (!line) throw new Error("command did not emit final-line JSON");
+  return JSON.parse(line) as unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasExactKeys = (value: Record<string, unknown>, keys: readonly string[]) =>
+  Object.keys(value).sort().join(",") === [...keys].sort().join(",");
+
+export const parseBalanceState = (output: string, expectedMint: string, expectedOwner: string): BalanceState => {
+  const value = parseJsonLine(output);
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "version",
+      "mint",
+      "owner",
+      "tokenAccount",
+      "encryptedValueAccount",
+      "aclValueKey",
+      "currentHandle",
+      "chainId",
+    ]) ||
+    value.version !== 1 ||
+    value.mint !== expectedMint ||
+    value.owner !== expectedOwner
+  ) {
+    throw new Error("balance-state probe identity or version mismatch");
+  }
+  for (const name of ["tokenAccount", "encryptedValueAccount"] as const) {
+    if (typeof value[name] !== "string" || !BASE58.test(value[name])) {
+      throw new Error(`balance-state probe has invalid ${name}`);
+    }
+  }
+  for (const name of ["aclValueKey", "currentHandle"] as const) {
+    if (typeof value[name] !== "string" || !BYTES32.test(value[name])) {
+      throw new Error(`balance-state probe has invalid ${name}`);
+    }
+  }
+  if (typeof value.chainId !== "string" || !/^\d+$/.test(value.chainId) || (BigInt(value.chainId) & (1n << 63n)) === 0n) {
+    throw new Error("balance-state probe has invalid Solana chainId");
+  }
+  return {
+    version: 1,
+    mint: value.mint,
+    owner: value.owner,
+    tokenAccount: value.tokenAccount as string,
+    encryptedValueAccount: value.encryptedValueAccount as string,
+    aclValueKey: value.aclValueKey as string,
+    currentHandle: value.currentHandle as string,
+    chainId: value.chainId,
+  };
+};
+
+export const parseTransferWorkerResult = (output: string): void => {
+  const value = parseJsonLine(output);
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["version", "signature", "inputHandle"]) ||
+    value.version !== 1 ||
+    typeof value.signature !== "string" ||
+    !SIGNATURE.test(value.signature) ||
+    typeof value.inputHandle !== "string" ||
+    !BYTES32.test(value.inputHandle)
+  ) {
+    throw new Error("SDK transfer worker returned malformed versioned JSON");
+  }
+};
+
+const keypair = async (file: string, expectedOwner: string): Promise<{ secretKey: string }> => {
+  const bytes = JSON.parse(await fs.readFile(file, "utf8")) as unknown;
+  if (!Array.isArray(bytes) || bytes.length !== 64 || bytes.some((byte) => !Number.isInteger(byte) || byte < 0 || byte > 255)) {
+    throw new Error(`invalid Solana keypair ${file}`);
+  }
+  const signer = await createKeyPairSignerFromBytes(Uint8Array.from(bytes));
+  if (signer.address !== expectedOwner) throw new Error(`keypair ${file} does not match owner ${expectedOwner}`);
+  return { secretKey: `0x${Buffer.from(bytes.slice(0, 32)).toString("hex")}` };
+};
+
+export const solanaUserDecryptContext = (
+  decimal = process.env.SOLANA_UD_CONTEXT_ID ?? DEFAULT_USER_DECRYPT_CONTEXT,
+): string => {
+  if (!/^\d+$/.test(decimal)) throw new Error("SOLANA_UD_CONTEXT_ID must be an unsigned decimal integer");
+  const value = BigInt(decimal);
+  if (value >= 1n << 256n) throw new Error("SOLANA_UD_CONTEXT_ID must fit in 32 bytes");
+  return `0x${value.toString(16).padStart(64, "0")}`;
+};
+
+const runLiveClient = (environment: Record<string, string>, home?: string) =>
+  run([LIVE_CLIENT], { cwd: LIVE_CLIENT_DIR, env: { ...environment, ...(home ? { HOME: home } : {}) } });
+
+const captureAddress = (output: string, label: string): string => {
+  const match = output.match(new RegExp(`${label}\\s+([1-9A-HJ-NP-Za-km-z]{32,44})`, "i"));
+  if (!match?.[1]) throw new Error(`could not parse ${label}`);
+  return match[1];
+};
+
+const realDependencies = (): TwoHolderDependencies => {
+  let bobHome: string | undefined;
+  return {
+    async provision() {
+      await fs.access(LIVE_CLIENT);
+      const aliceKeypair = path.join(os.homedir(), ".config/solana/id.json");
+      const aliceOwner = (await run(["solana", "address", "-k", aliceKeypair])).stdout.trim();
+      if (!BASE58.test(aliceOwner)) throw new Error("invalid Alice address");
+      bobHome = await fs.mkdtemp(path.join(os.tmpdir(), "fhevm-solana-bob-"));
+      const bobKeypair = path.join(bobHome, ".config/solana/id.json");
+      await fs.mkdir(path.dirname(bobKeypair), { recursive: true });
+      await run(["solana-keygen", "new", "--no-bip39-passphrase", "--silent", "--force", "--outfile", bobKeypair]);
+      const bobOwner = (await run(["solana", "address", "-k", bobKeypair])).stdout.trim();
+      if (!BASE58.test(bobOwner) || bobOwner === aliceOwner) throw new Error("Bob must have a distinct valid address");
+      await run(["solana", "airdrop", "5", bobOwner, "--url", RPC_URL]);
+
+      const underlyingOutput = await run(["spl-token", "create-token", "--decimals", "9", "--url", RPC_URL]);
+      const underlying = captureAddress(`${underlyingOutput.stdout}\n${underlyingOutput.stderr}`, "Creating token");
+      await run(["spl-token", "create-account", underlying, "--url", RPC_URL]);
+      await run(["spl-token", "mint", underlying, "1000000", "--url", RPC_URL]);
+      const mintOutput = await runLiveClient({ UNDERLYING_MINT: underlying });
+      const mintText = `${mintOutput.stdout}\n${mintOutput.stderr}`;
+      const mint = captureAddress(mintText, "confidential mint");
+      const computeSigner = captureAddress(mintText, "compute_signer");
+      await runLiveClient({ CONSUME_WRAP: "1", MINT: mint, UNDERLYING_MINT: underlying, WRAP_AMOUNT: "1000" });
+      await runLiveClient({ INITIALIZE_TOKEN_ACCOUNT: "1", MINT: mint }, bobHome);
+      const alice = { owner: aliceOwner, keypairPath: aliceKeypair, ...(await keypair(aliceKeypair, aliceOwner)) };
+      const bob = { owner: bobOwner, keypairPath: bobKeypair, ...(await keypair(bobKeypair, bobOwner)) };
+      return { mint, computeSigner, alice, bob };
+    },
+    async readBalance(scenario, holder) {
+      const result = await runLiveClient({ TOKEN_BALANCE_STATE: "1", MINT: scenario.mint, TOKEN_OWNER: holder.owner });
+      return parseBalanceState(result.stdout, scenario.mint, holder.owner);
+    },
+    async waitForHandle(handle) {
+      if (!BYTES32.test(handle)) throw new Error("invalid handle before ciphertext wait");
+      const hex = handle.slice(2);
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const result = await run(
+          [
+            "docker",
+            "exec",
+            COPROCESSOR_DB_CONTAINER,
+            "psql",
+            "-U",
+            "postgres",
+            "-d",
+            "coprocessor",
+            "-tAc",
+            `SELECT ciphertext IS NOT NULL AND ciphertext128 IS NOT NULL FROM ciphertext_digest WHERE handle=decode('${hex}','hex')`,
+          ],
+          { allowFailure: true },
+        );
+        if (result.code === 0 && result.stdout.trim() === "t") return;
+        await Bun.sleep(3_000);
+      }
+      throw new Error(`ciphertext materialization timed out for ${handle}`);
+    },
+    async transfer(scenario, alice, bob) {
+      if (alice.chainId !== bob.chainId) throw new Error("Alice and Bob balance handles disagree on chain id");
+      const result = await run(["node", SDK_WORKER], {
+        cwd: CLI_DIR,
+        env: {
+          TRANSFER_RPC_URL: RPC_URL,
+          TRANSFER_WS_URL: WS_URL,
+          TRANSFER_RELAYER_URL: RELAYER_URL,
+          TRANSFER_ACL_PROGRAM: ACL_PROGRAM,
+          TRANSFER_CHAIN_ID: alice.chainId,
+          TRANSFER_OWNER_KEYPAIR: scenario.alice.keypairPath,
+          TRANSFER_OWNER: scenario.alice.owner,
+          TRANSFER_RECIPIENT: scenario.bob.owner,
+          TRANSFER_MINT: scenario.mint,
+          TRANSFER_COMPUTE_SIGNER: scenario.computeSigner,
+          TRANSFER_FROM_ACCOUNT: alice.tokenAccount,
+          TRANSFER_TO_ACCOUNT: bob.tokenAccount,
+          TRANSFER_FROM_BALANCE: alice.encryptedValueAccount,
+          TRANSFER_TO_BALANCE: bob.encryptedValueAccount,
+        },
+      });
+      parseTransferWorkerResult(result.stdout);
+    },
+    decrypt: (scenario, holder, state, expected) =>
+      runSolanaCurrentUserDecrypt({
+        UD_RELAYER_URL: RELAYER_URL,
+        UD_CONTRACTS_CHAIN_ID: state.chainId,
+        UD_HANDLE: state.currentHandle,
+        UD_SECRET_KEY: holder.secretKey,
+        UD_CONTEXT_ID: solanaUserDecryptContext(),
+        UD_ALLOWED_DOMAIN_KEYS: `0x${Buffer.from(getAddressEncoder().encode(address(scenario.mint))).toString("hex")}`,
+        UD_ACL_VALUE_KEY: state.aclValueKey,
+        UD_EXPECTED: expected.toString(),
+      }),
+    async cleanup() {
+      if (bobHome) await fs.rm(bobHome, { recursive: true, force: true });
+      bobHome = undefined;
+    },
+  };
+};
+
+/** Runs one real two-holder transfer and proves both current balances through independent SDK decrypts. */
+export const runSolanaTwoHolderTransfer = async (dependencies: TwoHolderDependencies = realDependencies()) => {
+  let scenario: TwoHolderScenario | undefined;
+  try {
+    scenario = await dependencies.provision();
+    const initialAlice = await dependencies.readBalance(scenario, scenario.alice);
+    const initialBob = await dependencies.readBalance(scenario, scenario.bob);
+    await dependencies.waitForHandle(initialAlice.currentHandle);
+    await dependencies.waitForHandle(initialBob.currentHandle);
+    await dependencies.decrypt(scenario, scenario.alice, initialAlice, 1000n);
+    await dependencies.decrypt(scenario, scenario.bob, initialBob, 0n);
+
+    await dependencies.transfer(scenario, initialAlice, initialBob);
+    const finalAlice = await dependencies.readBalance(scenario, scenario.alice);
+    const finalBob = await dependencies.readBalance(scenario, scenario.bob);
+    if (finalAlice.currentHandle === initialAlice.currentHandle || finalBob.currentHandle === initialBob.currentHandle) {
+      throw new Error("confidential transfer did not rotate both current balance handles");
+    }
+    await dependencies.waitForHandle(finalAlice.currentHandle);
+    await dependencies.waitForHandle(finalBob.currentHandle);
+    await dependencies.decrypt(scenario, scenario.alice, finalAlice, 600n);
+    await dependencies.decrypt(scenario, scenario.bob, finalBob, 400n);
+    console.log("[solana-two-holder-transfer] Alice=600 Bob=400");
+  } finally {
+    await dependencies.cleanup(scenario);
+  }
+};


### PR DESCRIPTION
## What

Add one named real-stack acceptance profile:

```text
fhevm-cli test solana-two-holder-transfer
```

The profile:

- creates a fresh confidential mint;
- wraps 1000 into Alice's encrypted balance;
- creates Bob's canonical zero-balance token account;
- builds a real public-SDK `euint64(400)` proof;
- submits that exact proof through the public SDK;
- calls public `confidentialTransfer` exactly once;
- independently decrypts the initial balances as Alice=1000 and Bob=0;
- independently decrypts the post-transfer current handles as Alice=600 and Bob=400.

The decisive Solana full vertical invokes the profile through one thin `fhevm-cli` call.

## Design boundaries

- The same in-memory `SolanaZkProof` flows through build, submit, and transfer in a one-shot Node worker.
- Alice and Bob use distinct generated keypairs and decrypt secrets.
- The transfer owner and fee payer remain explicit Kit signers.
- Transactions use the SDK's signed simulation and confirmed send path.
- A test-only Rust `TOKEN_BALANCE_STATE` probe validates canonical token/EncryptedValue PDAs, owners, discriminators, exact account sizes, value-key domain, exact subjects, euint64/version metadata, and high-bit HostConfig chain ID before returning strict versioned JSON.
- Bob's zero account uses the program's real typed `InitializeTokenAccount { initial_balance: 0 }` instruction.
- No public-decrypt call, JavaScript account decoder, public SDK balance reader, generic provider, KMS change, or replacement-free live-client deletion is introduced.

## Validation

- `bun test src/solana/two-holder-transfer.test.ts src/solana/current-user-decrypt.test.ts` — 11 passed
- `bun test src/cli.test.ts` — 37 passed (independent review)
- `bun run check`
- `bun install --frozen-lockfile`
- `./fhevm-cli test list` exposes the three Solana profiles
- `cargo fmt --manifest-path solana/scripts/e2e/live-client/Cargo.toml -- --check`
- `bash -n solana/scripts/e2e/full-vertical.sh`
- `git diff --check`

Local `cargo check` could not reach project code because the machine's cached `cc-1.2.63` extraction is missing upstream `target/*.rs` files. Exact-head Solana build/test and the full vertical are therefore required before this draft is ready.

## Review

An independent adversarial implementation review found no actionable correctness, security, regression, or scope issue. The PR should remain draft until the exact-head full vertical proves the built SDK worker and the real 1000/0 -> 600/400 outcome.

Closes zama-ai/fhevm-internal#1625 after merge and terminal acceptance evidence.

KMS impact: none.
