### PR TITLE
fix(host-contracts): use fully-qualified EmptyUUPSProxy name in bridg…

### DIFF
--- a/host-contracts/tasks/taskDeploy.ts
+++ b/host-contracts/tasks/taskDeploy.ts
@@ -500,7 +500,10 @@ task('task:deployBridge').setAction(async function (_, { ethers, upgrades }) {
     return;
   }
 
-  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  const currentImplementation = await ethers.getContractFactory(
+    'contracts/emptyProxy/EmptyUUPSProxy.sol:EmptyUUPSProxy',
+    deployer,
+  );
   const newImplem = await ethers.getContractFactory('ConfidentialBridge', deployer);
 
   const proxy = await upgrades.forceImport(proxyAddress, currentImplementation);

--- a/host-contracts/tasks/utils/upgradeProposal.ts
+++ b/host-contracts/tasks/utils/upgradeProposal.ts
@@ -47,7 +47,10 @@ export async function buildUpgradeProposal(
   const { ethers, upgrades } = hre;
   const privateKey = getRequiredEnvVar('DEPLOYER_PRIVATE_KEY');
   const deployer = new ethers.Wallet(privateKey).connect(ethers.provider);
-  const currentImplementation = await ethers.getContractFactory('EmptyUUPSProxy', deployer);
+  const currentImplementation = await ethers.getContractFactory(
+    'contracts/emptyProxy/EmptyUUPSProxy.sol:EmptyUUPSProxy',
+    deployer,
+  );
   const newImplementation = await ethers.getContractFactory(params.contractName, deployer);
   await upgrades.forceImport(params.proxyAddress, currentImplementation);
   const newImplementationAddress = String(


### PR DESCRIPTION
### Summary

Qualify the `EmptyUUPSProxy` lookup in `task:deployBridge` and `buildUpgradeProposal` with its fully-qualified name so the bridge deploy and upgrade paths resolve unambiguously during upgrades, where both contracts/ and oldContracts/ are compiled and the bare name fails with HH701.