### PR TITLE
docs(test-suite): document stateful rollout runbooks

### DIFF
--- a/test-suite/fhevm/README.md
+++ b/test-suite/fhevm/README.md
@@ -192,26 +192,13 @@ The lock file replaces only the version resolution step — preflight, boot pipe
 
 ## Stateful Rollout Runbooks
 
-Release rollouts are executable TypeScript runbooks under `rollouts/`. A runbook boots one baseline stack, performs each upgrade step in order, preserves chain/database/container state, and runs rollout-safe e2e coverage after each step:
+Release rollouts are executable TypeScript runbooks under `rollouts/`. A runbook boots one baseline stack, performs each upgrade step in order, preserves chain/database/container state, and tests every state that is expected to work.
 
 ```sh
 ./fhevm-cli rollout run ./rollouts/v0.12-to-v0.13/run.ts
 ```
 
-Use `./fhevm-cli rollout receipt` to print the markdown receipt of the most recent rollout run.
-
-Runbooks use the same primitives an operator needs during a release:
-
-- `ctx.up(...)` starts the old baseline once.
-- `ctx.writeVersionLock(...)` writes explicit version locks from the runbook.
-- `ctx.applyVersionLock(...)` applies version changes that do not restart runtime services, then regenerates env/compose.
-- `ctx.runHostContractTask(...)` and `ctx.runGatewayContractTask(...)` run contract migration/upgrade tasks from the selected deploy images.
-- `ctx.upgradeRuntimeGroup(...)` restarts selected runtime components in place and runs their DB migrations when present.
-- `ctx.test(...)` runs the rollout-safe e2e profile after each state.
-
-`rollout-standard` is intentionally narrow: it covers encrypted input, FHE compute/write paths, user decrypt, delegated user decrypt, public decrypt, and ERC20 transfer coverage. Broader profiles such as `multi-chain-isolation`, HCU, pause/unpause, DB revert, and drift recovery stay available as explicit tests but are not part of the per-step rollout gate.
-
-The `test-suite-stateful-rollout` workflow executes the checked-in runbook when the `rollout` label is present, or through manual dispatch with a custom runbook path.
+See [`rollouts/README.md`](rollouts/README.md) for the copyable runbook template, version-lock rules, available operations, local execution steps, CI behavior, and current limitations.
 
 ## Version Override via Environment Variables
 

--- a/test-suite/fhevm/rollouts/README.md
+++ b/test-suite/fhevm/rollouts/README.md
@@ -1,0 +1,142 @@
+# Stateful rollout runbooks
+
+The `run.ts` file in each rollout folder is the runbook. It is an executable TypeScript program that changes one persistent local stack in ordered steps: boot the baseline once, preserve chain and database state, upgrade selected components in place, and test every state that is expected to work.
+
+Start with the smallest runbook that models the upgrade. Add contract tasks or extra test profiles only when the rollout requires them.
+
+## Success criteria
+
+A useful runbook:
+
+1. Pins a real, complete version bundle for every state.
+2. Boots the baseline exactly once with `ctx.up(...)`.
+3. Applies one intentional upgrade step at a time.
+4. Runs `ctx.test("rollout-standard", { parallel: false })` after every state expected to work.
+5. Stops on unexpected failures and leaves a receipt explaining the last completed step.
+
+## Write `run.ts`
+
+Create one folder:
+
+```text
+rollouts/my-rollout/
+├── run.ts
+└── versions.ts
+```
+
+Use an existing runbook or resolved lock as the source for `versions.ts`. Every phase must contain the complete `*_VERSION` map, not only the keys changed in that phase.
+
+```ts
+// rollouts/my-rollout/versions.ts
+type Versions = Record<string, string>;
+
+export const scenario = "two-of-three";
+
+export const baseline = {
+  // Copy a complete, real bundle here.
+  RELAYER_VERSION: "old-relayer",
+  RELAYER_MIGRATE_VERSION: "old-relayer",
+  // ...all other required *_VERSION entries...
+} satisfies Versions;
+
+export const target = {
+  ...baseline,
+  RELAYER_VERSION: "new-relayer",
+  RELAYER_MIGRATE_VERSION: "new-relayer",
+} satisfies Versions;
+
+export const versionSources = ["rollout=my-rollout", "reason=what-this-proves"];
+```
+
+The runbook writes those bundles to generated lock files, boots the baseline, upgrades one runtime group, and gates both states:
+
+```ts
+// rollouts/my-rollout/run.ts
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { baseline, scenario, target, versionSources } from "./versions";
+
+export default async function run(ctx: RolloutRunContext) {
+  const baselineLock = await ctx.writeVersionLock("00-baseline", {
+    versions: baseline,
+    sources: versionSources,
+  });
+  const targetLock = await ctx.writeVersionLock("01-target", {
+    versions: target,
+    sources: versionSources,
+  });
+
+  await ctx.up({
+    lockFile: baselineLock,
+    scenario,
+    // Keep this when the runbook relies on tests from the current checkout.
+    overrides: [{ group: "test-suite" }],
+  });
+  await ctx.test("rollout-standard", { parallel: false });
+
+  await ctx.upgradeRuntimeGroup("relayer", { lockFile: targetLock });
+  await ctx.test("rollout-standard", { parallel: false });
+}
+```
+
+For multiple runtime upgrades, create a complete intermediate bundle and lock for each step. A lock passed to `ctx.upgradeRuntimeGroup(...)` may change only version keys owned by that group.
+
+```ts
+await ctx.upgradeRuntimeGroup("relayer", { lockFile: relayerLock });
+await ctx.test("rollout-standard", { parallel: false });
+
+await ctx.upgradeRuntimeGroup("coprocessor", { lockFile: coprocessorLock });
+await ctx.test("rollout-standard", { parallel: false });
+```
+
+Supported runtime groups are `coprocessor`, `kms-connector`, `kms-core`, `kms`, `listener-core`, `relayer`, and `test-suite`.
+
+Contract upgrades do not use `ctx.upgradeRuntimeGroup(...)`. They normally require `ctx.snapshotContracts(...)`, `ctx.applyVersionLock(...)`, host or gateway contract tasks, and `ctx.refreshDiscovery()`. Copy the ordering from [`./rollouts/v0.12-to-v0.13/run.ts`](./v0.12-to-v0.13/run.ts); contract order is release-specific and should not be guessed.
+
+The runbook context exposes these operations:
+
+- Stack and state: `ctx.up(...)`, `ctx.readState()`, and `ctx.stateDir()`.
+- Version and runtime changes: `ctx.writeVersionLock(...)`, `ctx.applyVersionLock(...)`, and `ctx.upgradeRuntimeGroup(...)`.
+- Contract changes: `ctx.snapshotContracts(...)`, `ctx.runHostContractTask(...)`, `ctx.runHostContractTaskOnChain(...)`, `ctx.runGatewayContractTask(...)`, and `ctx.refreshDiscovery()`.
+- Test gates: `ctx.test(...)`.
+
+## Run it locally
+
+From `test-suite/fhevm`:
+
+```sh
+bun install
+bun run check
+bun test
+
+./fhevm-cli status
+./fhevm-cli rollout run ./rollouts/my-rollout/run.ts
+./fhevm-cli rollout receipt
+```
+
+The generated receipt is stored in `.fhevm/rollout/receipt.md` and `.fhevm/rollout/receipt.jsonl`.
+
+If the existing CLI-owned stack may be discarded, start clean:
+
+```sh
+./fhevm-cli clean --keep-images
+```
+
+`clean` deletes `.fhevm`, including resumable state. Do not run it when the existing stack must be preserved.
+
+## CI
+
+CI support is defined by `.github/workflows/test-suite-stateful-rollout.yml`. If that file is absent on the branch being tested, the rollout runner is local-only on that branch. When it is present, follow the triggers and inputs declared in the workflow itself instead of copying them into this document.
+
+## Current limitations
+
+- The current API upgrades whole runtime groups; it does not upgrade individual KMS nodes.
+- Do not use `kms`, `kms-core`, or `kms-connector` runtime-group upgrades in threshold-KMS scenarios. `kms` and `kms-core` reject them; `kms-connector` currently upgrades only party 1.
+- A failed run stops at the thrown error and records failure diagnostics; it does not roll back automatically.
+- `rollout-standard` is the per-state gate. Run `./fhevm-cli test list` for the current named profiles, and add broader profiles explicitly when the feature requires them.
+
+## Checked-in examples
+
+- [`./rollouts/v0.12-to-v0.13/run.ts`](./v0.12-to-v0.13/run.ts): contracts, relayer, KMS, listener-core, and coprocessor.
+- [`./rollouts/v0.13.0-testnet/run.ts`](./v0.13.0-testnet/run.ts): a network-shaped release rollout.
+
+The documentation test verifies the public runbook operations, supported runtime groups, per-node limitation, and checked-in example paths against the implementation. Update this document when the rollout surface changes.

--- a/test-suite/fhevm/src/flow/repair.ts
+++ b/test-suite/fhevm/src/flow/repair.ts
@@ -14,7 +14,7 @@ import {
 import type { LocalOverride, OverrideGroup, ResolvedCoprocessorScenarioInstance, State, StepName } from "../types";
 import { extraHostChains, hostChainsForState } from "./topology";
 
-const UPGRADEABLE_GROUPS = ["coprocessor", "kms-connector", "kms-core", "kms", "listener-core", "relayer", "test-suite"] as const;
+export const UPGRADEABLE_GROUPS = ["coprocessor", "kms-connector", "kms-core", "kms", "listener-core", "relayer", "test-suite"] as const;
 export type UpgradeGroup = (typeof UPGRADEABLE_GROUPS)[number];
 const UPGRADE_VERSION_KEYS: Record<UpgradeGroup, string[]> = {
   "coprocessor": [

--- a/test-suite/fhevm/src/rollout-docs.test.ts
+++ b/test-suite/fhevm/src/rollout-docs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { createRolloutContext } from "./commands/rollout-run";
+import { UPGRADEABLE_GROUPS } from "./flow/repair";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const DOCS_PATH = path.join(ROOT, "rollouts", "README.md");
+
+describe("rollout documentation", () => {
+  test("references only current rollout context operations", async () => {
+    const docs = await Bun.file(DOCS_PATH).text();
+    const documented = [...new Set([...docs.matchAll(/\bctx\.([A-Za-z][A-Za-z0-9]*)/g)].map((match) => match[1]))];
+    const available = Object.keys(createRolloutContext()).sort();
+
+    expect(documented.sort()).toEqual(available);
+  });
+
+  test("keeps checked-in runbook links valid", async () => {
+    const docs = await Bun.file(DOCS_PATH).text();
+    const runbooks = [...docs.matchAll(/\]\(\.\/([^\s)]+\/run\.ts)\)/g)].map((match) => match[1]);
+
+    expect(runbooks.length).toBeGreaterThan(0);
+    for (const runbook of runbooks) {
+      expect(existsSync(path.join(ROOT, "rollouts", runbook))).toBe(true);
+    }
+  });
+
+  test("keeps runtime groups and per-node limitations current", async () => {
+    const docs = await Bun.file(DOCS_PATH).text();
+    const groupSentence = docs.match(/Supported runtime groups are ([^.]+)\./)?.[1];
+    const documentedGroups = [...(groupSentence ?? "").matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+
+    expect(documentedGroups.sort()).toEqual([...UPGRADEABLE_GROUPS].sort());
+
+    const perNodeLimitation = "The current API upgrades whole runtime groups; it does not upgrade individual KMS nodes.";
+    expect(docs.includes(perNodeLimitation)).toBe(!("upgradeKmsNodes" in createRolloutContext()));
+  });
+});


### PR DESCRIPTION
## Summary

Make `run.ts` explicit as the executable rollout runbook and provide one copyable guide for version locks, runtime steps, local execution, CI availability, receipts, and current limitations.
Remove the stale claim that rollout CI always exists on the checked-out branch.
Add focused tests that keep the documented context operations, runtime groups, per-node limitation, and example links synchronized with the implementation.

## Validation

`bun run check`; `bun run test` (251 passing); focused documentation tests; `git diff --check`.
