### PR TITLE
feat: add Polygon Amoy testnet chain config

### DIFF
--- a/library-solidity/config/ZamaConfig.sol
+++ b/library-solidity/config/ZamaConfig.sol
@@ -19,6 +19,8 @@ library ZamaConfig {
             config = _getEthereumConfig();
         } else if (block.chainid == 11155111) {
             config = _getSepoliaConfig();
+        } else if (block.chainid == 80002) {
+            config = _getPolygonAmoyConfig();
         } else if (block.chainid == 31337) {
             config = _getLocalConfig();
         } else {
@@ -31,6 +33,8 @@ library ZamaConfig {
             return _getEthereumProtocolId();
         } else if (block.chainid == 11155111) {
             return _getSepoliaProtocolId();
+        } else if (block.chainid == 80002) {
+            return _getPolygonAmoyProtocolId();
         } else if (block.chainid == 31337) {
             return _getLocalProtocolId();
         }
@@ -71,6 +75,21 @@ library ZamaConfig {
             });
     }
 
+    /// @dev chainid == 80002
+    function _getPolygonAmoyProtocolId() private pure returns (uint256) {
+        return 80002;
+    }
+
+    /// @dev chainid == 80002
+    function _getPolygonAmoyConfig() private pure returns (CoprocessorConfig memory) {
+        return
+            CoprocessorConfig({
+                ACLAddress: 0xD99Cb9Fc3c42c87f2A4A12e8Fd60318d6bDdf985,
+                CoprocessorAddress: 0x89420269f61e4db00545cd99da0aEcA7fF0912f9,
+                KMSVerifierAddress: 0xCD1D89E311bce4C8DEa9a0857a0c9A4E153D4041
+            });
+    }
+
     /// @dev chainid == 31337
     function _getLocalProtocolId() private pure returns (uint256) {
         return type(uint256).max;
@@ -89,7 +108,8 @@ library ZamaConfig {
 /**
  * @title   ZamaEthereumConfig.
  * @dev     This contract can be inherited by a contract wishing to use the FHEVM contracts provided by Zama
- *          on the Ethereum (mainnet) network (chainId = 1) or Sepolia (testnet) network (chainId = 11155111).
+ *          on the Ethereum (mainnet) network (chainId = 1), the Sepolia (testnet) network (chainId = 11155111),
+ *          or the Polygon Amoy (testnet) network (chainId = 80002).
  *          Other providers may offer similar contracts deployed at different addresses.
  *          If you wish to use them, you should rely on the instructions from these providers.
  */

--- a/library-solidity/package.json
+++ b/library-solidity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fhevm/solidity",
   "description": "A Solidity library for interacting with fhevm protocol",
-  "version": "0.11.1",
+  "version": "0.14.0",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/library-solidity/test/EthereumConfig.t.sol
+++ b/library-solidity/test/EthereumConfig.t.sol
@@ -76,6 +76,31 @@ contract EthereumConfigTest is Test {
         assertTrue(testFhevmContract.confidentialProtocolId() == ZamaConfig.getConfidentialProtocolId());
     }
 
+    function test_ZamaConfigPolygonAmoy() public {
+        vm.chainId(80002);
+
+        TestFHEVMContract testFhevmContract = new TestFHEVMContract();
+        CoprocessorConfig memory cfg = testFhevmContract.getCoprocessorConfig();
+        // chainid == 80002
+        CoprocessorConfig memory amoyCfg = ZamaConfig.getEthereumCoprocessorConfig();
+
+        assertTrue(cfg.ACLAddress == 0xD99Cb9Fc3c42c87f2A4A12e8Fd60318d6bDdf985);
+        assertTrue(cfg.CoprocessorAddress == 0x89420269f61e4db00545cd99da0aEcA7fF0912f9);
+        assertTrue(cfg.KMSVerifierAddress == 0xCD1D89E311bce4C8DEa9a0857a0c9A4E153D4041);
+
+        assertTrue(cfg.ACLAddress == amoyCfg.ACLAddress);
+        assertTrue(cfg.CoprocessorAddress == amoyCfg.CoprocessorAddress);
+        assertTrue(cfg.KMSVerifierAddress == amoyCfg.KMSVerifierAddress);
+    }
+
+    function test_ZamaProtocolIdPolygonAmoy() public {
+        vm.chainId(80002);
+
+        TestFHEVMContract testFhevmContract = new TestFHEVMContract();
+        assertTrue(testFhevmContract.confidentialProtocolId() == 80002);
+        assertTrue(testFhevmContract.confidentialProtocolId() == ZamaConfig.getConfidentialProtocolId());
+    }
+
     function test_ZamaConfigLocalChainId() public {
         vm.chainId(31337);
 

--- a/sdk/js-sdk/src/core/chains/definitions/polygonAmoy.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/polygonAmoy.ts
@@ -1,0 +1,34 @@
+import type { FhevmChain } from '../../types/fhevmChain.js';
+import { defineFhevmChain } from '../utils.js';
+
+export const polygonAmoy: FhevmChain = /*#__PURE__*/ defineFhevmChain({
+  id: 80_002,
+  fhevm: {
+    contracts: {
+      acl: {
+        address: '0xD99Cb9Fc3c42c87f2A4A12e8Fd60318d6bDdf985',
+      },
+      inputVerifier: {
+        address: '0x6e5A7D8b0c645467Cba7e62D6624917085118631',
+      },
+      kmsVerifier: {
+        address: '0xCD1D89E311bce4C8DEa9a0857a0c9A4E153D4041',
+      },
+      protocolConfig: undefined, // To be filled
+    },
+    // Polygon Amoy is a host chain on the same testnet protocol as Sepolia,
+    // so it shares the same relayer and gateway.
+    relayerUrl: 'https://relayer.testnet.zama.org',
+    gateway: {
+      id: 10_901,
+      contracts: {
+        decryption: {
+          address: '0x5D8BD78e2ea6bbE41f26dFe9fdaEAa349e077478',
+        },
+        inputVerification: {
+          address: '0x483b9dE06E4E4C7D35CCf5837A1668487406D955',
+        },
+      },
+    },
+  },
+});

--- a/sdk/js-sdk/src/core/chains/index.ts
+++ b/sdk/js-sdk/src/core/chains/index.ts
@@ -3,4 +3,5 @@ export type { FhevmChain } from '../types/fhevmChain.js';
 export { defineFhevmChain } from './utils.js';
 
 export { mainnet } from './definitions/mainnet.js';
+export { polygonAmoy } from './definitions/polygonAmoy.js';
 export { sepolia } from './definitions/sepolia.js';


### PR DESCRIPTION
## Summary

Adds **Polygon Amoy (chainId 80002)** as a host chain to both the Solidity config library and the JS SDK, using addresses verified against the [Zama Protocol registry](https://github.com/zama-ai/protocol-registry/blob/main/testnet.md#polygon-amoy-polygon_amoy) and cross-checked on-chain.

## Changes

### `library-solidity` (`config/ZamaConfig.sol`)
- New `block.chainid == 80002` branches in `getEthereumCoprocessorConfig()` and `getConfidentialProtocolId()`
- `_getPolygonAmoyConfig()`:
  - `ACLAddress` `0xD99Cb9Fc3c42c87f2A4A12e8Fd60318d6bDdf985` (`AMOY_ACL_HOST`)
  - `CoprocessorAddress` `0x89420269f61e4db00545cd99da0aEcA7fF0912f9` (`AMOY_FHEVM_EXECUTOR`)
  - `KMSVerifierAddress` `0xCD1D89E311bce4C8DEa9a0857a0c9A4E153D4041` (`AMOY_KMS_VERIFIER`)
- `_getPolygonAmoyProtocolId()` → `80002`
- Updated `ZamaEthereumConfig` NatSpec + matching tests in `test/EthereumConfig.t.sol`
- Bumped `package.json` version `0.11.1` → `0.14.0`

### `sdk` (`sdk/js-sdk`)
- New `polygonAmoy` `FhevmChain` definition (`src/core/chains/definitions/polygonAmoy.ts`), mirroring `sepolia` and sharing the same testnet relayer + gateway (chain id `10901`)
- Exported from `src/core/chains/index.ts`

## Verification
- All contract addresses match the protocol registry verbatim and were confirmed live on Polygon Amoy (`getVersion()` → `ACL v0.4.0` / `FHEVMExecutor v0.4.0`; `executor.getInputVerifierAddress()` and `getACLAddress()` cross-check against the registry).
- Host chain id (80002) and gateway chain id (10901) confirmed against the internal registry `chains.yaml`.
- `library-solidity/config/ZamaConfig.sol` compiles cleanly; js-sdk `tsc --noEmit` passes.

## Notes
- `protocolConfig` in the js-sdk definition is left `undefined`, matching the existing `mainnet`/`sepolia` convention (registry address `0x4CcF009Aba90D04f52b31fc7aDdE240578aFe10F` is available if we decide to fill it).
- `confidentialProtocolId` is set to `80002` — the first entry where protocolId equals the chain id (mainnet=1, sepolia=10001 differ from their chain ids).