### PR TITLE
fix(kms-connector): send typed Solana decrypt identity

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1885,7 +1885,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bc2wrap"
 version = "2.0.1"
-source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
+source = "git+https://github.com/zama-ai/kms.git?rev=b14d45dcd459328f9a1ded2410de953beae28a95#b14d45dcd459328f9a1ded2410de953beae28a95"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "kms-grpc"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
+source = "git+https://github.com/zama-ai/kms.git?rev=b14d45dcd459328f9a1ded2410de953beae28a95#b14d45dcd459328f9a1ded2410de953beae28a95"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6864,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "threshold-hashing"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
+source = "git+https://github.com/zama-ai/kms.git?rev=b14d45dcd459328f9a1ded2410de953beae28a95#b14d45dcd459328f9a1ded2410de953beae28a95"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -6877,7 +6877,7 @@ dependencies = [
 [[package]]
 name = "threshold-types"
 version = "0.15.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
+source = "git+https://github.com/zama-ai/kms.git?rev=b14d45dcd459328f9a1ded2410de953beae28a95#b14d45dcd459328f9a1ded2410de953beae28a95"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -299,7 +299,7 @@ checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
@@ -1885,7 +1885,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bc2wrap"
 version = "2.0.1"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -3747,7 +3747,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4097,8 +4097,8 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.14.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+version = "0.15.0-0"
+source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4110,8 +4110,8 @@ dependencies = [
  "prost 0.14.4",
  "rand 0.8.6",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "tfhe",
  "tfhe-versionable",
  "thiserror 2.0.18",
@@ -5148,7 +5148,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5185,7 +5185,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6536,8 +6536,14 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
 ]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -6549,6 +6555,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -6680,7 +6698,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha3 0.10.8",
- "strum",
+ "strum 0.27.1",
  "tfhe-csprng",
  "tfhe-fft",
  "tfhe-ntt",
@@ -6845,8 +6863,8 @@ dependencies = [
 
 [[package]]
 name = "threshold-hashing"
-version = "0.14.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+version = "0.15.0-0"
+source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -6858,8 +6876,8 @@ dependencies = [
 
 [[package]]
 name = "threshold-types"
-version = "0.14.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+version = "0.15.0-0"
+source = "git+https://github.com/zama-ai/kms.git?rev=c51add468c126a50bc0efd281fd266cd24c5bbba#c51add468c126a50bc0efd281fd266cd24c5bbba"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -20,8 +20,8 @@ tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
 fhevm_gateway_bindings = { path = "../gateway-contracts/rust_bindings", default-features = false }
 fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
-kms-grpc = { git = "https://github.com/zama-ai/kms.git", rev = "b9087af025de26cd6ada5033e8044b05a518cf22", default-features = true }
-bc2wrap = { git = "https://github.com/zama-ai/kms.git", rev = "b9087af025de26cd6ada5033e8044b05a518cf22", default-features = true }
+kms-grpc = { git = "https://github.com/zama-ai/kms.git", rev = "c51add468c126a50bc0efd281fd266cd24c5bbba", default-features = true }
+bc2wrap = { git = "https://github.com/zama-ai/kms.git", rev = "c51add468c126a50bc0efd281fd266cd24c5bbba", default-features = true }
 tfhe = { version = "=1.6.2", default-features = false }
 user-decryption-signature = { path = "../shared/user-decryption-signature", default-features = false }
 ciphertext-attestation = { path = "../shared/ciphertext-attestation" }

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -20,8 +20,8 @@ tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
 fhevm_gateway_bindings = { path = "../gateway-contracts/rust_bindings", default-features = false }
 fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
-kms-grpc = { git = "https://github.com/zama-ai/kms.git", rev = "c51add468c126a50bc0efd281fd266cd24c5bbba", default-features = true }
-bc2wrap = { git = "https://github.com/zama-ai/kms.git", rev = "c51add468c126a50bc0efd281fd266cd24c5bbba", default-features = true }
+kms-grpc = { git = "https://github.com/zama-ai/kms.git", rev = "b14d45dcd459328f9a1ded2410de953beae28a95", default-features = true }
+bc2wrap = { git = "https://github.com/zama-ai/kms.git", rev = "b14d45dcd459328f9a1ded2410de953beae28a95", default-features = true }
 tfhe = { version = "=1.6.2", default-features = false }
 user-decryption-signature = { path = "../shared/user-decryption-signature", default-features = false }
 ciphertext-attestation = { path = "../shared/ciphertext-attestation" }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -473,9 +473,8 @@ where
         UserDecryptionExtraData::new(payload.userAddress, payload.publicKey.clone())
     }
 
-    /// Picks the `client_address` for a Solana user-decryption KMS gRPC request: `solana:<hex
-    /// identity>`, with the ed25519 identity taken from the typed request payload (the authorization
-    /// check runs before this, so the identity is trustworthy here).
+    /// Sets the typed Solana pubkey from the authorized request payload. The legacy
+    /// `client_address` is intentionally empty.
     pub fn user_decryption_extra_data_for_solana(
         request: &UserDecryptionRequestSolana,
     ) -> UserDecryptionExtraData {
@@ -727,6 +726,7 @@ where
         if let Some(user_decrypt_data) = user_decrypt_data {
             let client_address = user_decrypt_data.client_address;
             let enc_key = user_decrypt_data.public_key.to_vec();
+            let solana_pubkey = user_decrypt_data.solana_pubkey;
             let user_decryption_request = UserDecryptionRequest {
                 request_id,
                 client_address,
@@ -737,6 +737,7 @@ where
                 extra_data: kms_extra_data,
                 epoch_id: parsed_extra_data.epoch_id.map(u256_to_request_id),
                 context_id: parsed_extra_data.context_id.map(u256_to_request_id),
+                solana_pubkey,
             };
 
             Ok(user_decryption_request.into())
@@ -813,11 +814,11 @@ fn kms_decryption_extra_data(extra_data: &Bytes) -> Vec<u8> {
 }
 
 pub struct UserDecryptionExtraData {
-    /// The `client_address` set on the KMS gRPC request. For EVM this is the checksummed
-    /// `userAddress`; for Solana it is `solana:<hex identity>` (kms#637's parser keys on the
-    /// `solana:` prefix).
+    /// The checksummed EVM user address. Empty for Solana requests.
     pub client_address: String,
     pub public_key: Bytes,
+    /// The exact Solana user identity. Unset for EVM requests.
+    pub solana_pubkey: Option<Vec<u8>>,
 }
 
 impl UserDecryptionExtraData {
@@ -826,15 +827,16 @@ impl UserDecryptionExtraData {
         Self {
             client_address: user_address.to_checksum(None),
             public_key,
+            solana_pubkey: None,
         }
     }
 
-    /// Solana user-decryption: `client_address` is `solana:<hex identity>` — lowercase, exactly
-    /// 64 hex chars, no `0x`.
+    /// Solana user-decryption uses the typed 32-byte ed25519 identity only.
     pub fn new_solana(identity: [u8; 32], public_key: Bytes) -> Self {
         Self {
-            client_address: format!("solana:{}", hex::encode(identity)),
+            client_address: String::new(),
             public_key,
+            solana_pubkey: Some(identity.to_vec()),
         }
     }
 }
@@ -961,6 +963,24 @@ mod tests {
             kms_decryption_extra_data(&Bytes::from_static(&[0x01, 0x02])),
             vec![0x01, 0x02]
         );
+    }
+
+    #[test]
+    fn evm_user_decryption_keeps_the_checksummed_address() {
+        let address = Address::repeat_byte(0x11);
+        let data = UserDecryptionExtraData::new(address, Bytes::from_static(&[0x22]));
+
+        assert_eq!(data.client_address, address.to_checksum(None));
+        assert_eq!(data.solana_pubkey, None);
+    }
+
+    #[test]
+    fn solana_user_decryption_uses_only_the_typed_pubkey() {
+        let identity = [0x33; 32];
+        let data = UserDecryptionExtraData::new_solana(identity, Bytes::from_static(&[0x44]));
+
+        assert!(data.client_address.is_empty());
+        assert_eq!(data.solana_pubkey, Some(identity.to_vec()));
     }
 
     enum PubDecryptACLMock {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -190,8 +190,7 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
             }
             ProtocolEventKind::UserDecryptionSolana(req) => {
                 // RFC-021: the ed25519 auth fields are typed on the event. The check verifies the
-                // ed25519 binding + Solana ACL; the client-address keys on the `solana:<hex
-                // identity>` prefix (kms#637). `extraData` carries only the KMS context.
+                // ed25519 binding + Solana ACL before the typed pubkey is sent to KMS.
                 self.decryption_processor
                     .check_user_decryption_request_solana(req)
                     .await

--- a/kms-connector/crates/utils/src/tests/setup/kms.rs
+++ b/kms-connector/crates/utils/src/tests/setup/kms.rs
@@ -25,11 +25,8 @@ impl KmsInstance {
         // between parallel tests.
         let s3_port: u16 = s3_url.split(":").nth(2).unwrap().parse()?;
         let s3_internal_url = format!("http://host.docker.internal:{s3_port}");
-        let cmd = format!(
-            "kms-gen-keys --public-storage s3 --public-s3-bucket '{KMS_PUBLIC_VAULT_URL}' \\
-            --aws-s3-endpoint '{s3_internal_url}' --private-storage file --private-file-path \\
-            '{KMS_PRIVATE_VAULT_URL}' centralized && kms-server --config-file config/config.toml"
-        );
+        let cmd = "kms-gen-keys --config-file config/compose_centralized_keygen.toml \
+             && kms-server --config-file config/config.toml";
         let version = ROOT_CARGO_TOML.get_kms_grpc_version();
         let container = GenericImage::new("ghcr.io/zama-ai/kms/core-service", &version)
             .with_exposed_port(ContainerPort::Tcp(50051))
@@ -57,7 +54,7 @@ impl KmsInstance {
                 ))
                 .unwrap(),
             )
-            .with_cmd(["-c", &cmd])
+            .with_cmd(["-c", cmd])
             .with_startup_timeout(Duration::from_secs(180))
             .start()
             .await?;

--- a/test-suite/fhevm/solana-images.env
+++ b/test-suite/fhevm/solana-images.env
@@ -5,11 +5,11 @@
 #
 # All images are pinned to reproducible COMMIT-SHA tags rebuilt from the feature branches
 # (the earlier `solana-ud*` PoC tags were pruned from ghcr). CORE_VERSION (the kms-core server)
-# and the vendored TKMS WASM client (sdk/js-sdk/src/wasm/tkms/KMS_BUILT_FROM) are BOTH built from
-# kms `feature/solana` @ 37658beb, so they are link-compatible by construction (same commit —
-# same Solana de-signcryption wire format + `compute_link_solana` digest). The connector +
-# relayer images are built from fhevm `feature/solana` @ 4f42734.
-CORE_VERSION=37658be
+# is built from kms `feature/solana` @ b14d45dc. The vendored TKMS WASM client remains built from
+# 37658beb because b14d45dc changes only request identity transport; the Solana response wire
+# format and `compute_link_solana` digest are unchanged. The connector + relayer images are built
+# from fhevm `feature/solana` @ 4f42734.
+CORE_VERSION=b14d45d
 CONNECTOR_GW_LISTENER_VERSION=4f42734
 CONNECTOR_KMS_WORKER_VERSION=4f42734
 RELAYER_IMAGE_REPOSITORY=ghcr.io/zama-ai/fhevm/relayer


### PR DESCRIPTION
## What

- pin the Connector KMS dependencies to the merged KMS typed-identity revision;
- send the Solana Ed25519 identity as protobuf field 11, `solana_pubkey`;
- leave `client_address` empty for Solana instead of emitting `solana:<hex>`;
- preserve the EVM path: checksummed `client_address`, no Solana pubkey;
- run the Solana vertical against the KMS core image built from the same merged revision.

## Why

The Solana PoC does not need a compatibility rollout. A single typed 32-byte identity removes string parsing and representation ambiguity at the KMS boundary.

The EVM semantic outcome remains unchanged: the KMS request carries one exact wallet identity. EVM continues using its existing EIP-55/EIP-712 path; Solana uses its native Ed25519 public key. No EVM request behavior or DTO is generalized.

## Dependency and artifact

Depends on merged [KMS#719](https://github.com/zama-ai/kms/pull/719):

- merge SHA: `b14d45dcd459328f9a1ded2410de953beae28a95`;
- Connector `kms-grpc` and `bc2wrap` dependencies pin that full SHA;
- `CORE_VERSION=b14d45d` selects the core-service image built from that SHA;
- image build: [KMS workflow 29483035548](https://github.com/zama-ai/kms/actions/runs/29483035548).

The vertical therefore exercises the typed Connector request against the merged KMS server that rejects legacy and mixed identity representations.

SDK TKMS WASM regeneration is not required: this change affects Connector-to-KMS gRPC request serialization, not client-side Solana de-signcryption. KMS#719 did not change the Solana response wire format or `compute_link_solana` digest, so the existing WASM remains compatible.

Context:

- [fhevm-internal#1727](https://github.com/zama-ai/fhevm-internal/issues/1727)
- [fhevm-internal#1689](https://github.com/zama-ai/fhevm-internal/issues/1689)
- [fhevm-internal#1690](https://github.com/zama-ai/fhevm-internal/issues/1690)
- [KMS#719](https://github.com/zama-ai/kms/pull/719)
- [KMS#714](https://github.com/zama-ai/kms/pull/714)
- [fhevm#3155](https://github.com/zama-ai/fhevm/pull/3155)

## Validation

- `cargo check -p kms-worker --locked`
- `cargo test -p kms-worker --lib --locked` — 102 passed
- `cargo fmt -p kms-worker -- --check`
- `git diff --check`
- `solana-images.env` shell parsing confirms `CORE_VERSION=b14d45d`

The previous independent adversarial review found no blocking issue. The remaining integration gate is the refreshed CI and full Solana vertical against `b14d45d`.
