### PR TITLE
test(e2e): add corrupted-share user-decrypt tests

### DIFF
--- a/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
+++ b/test-suite/e2e/test/delegatedUserDecryption/delegatedUserDecryption.ts
@@ -5,6 +5,7 @@ import { ethers } from 'hardhat';
 import { EncryptedERC20, SmartWalletWithDelegation, WildcardDelegationTarget } from '../../types';
 import { aclAddress, createInstances } from '../instance';
 import { isLiveNetwork } from '../network';
+import { bitFlipPayload, corruptSignature, expectCorruptedShareDecryptToFail } from '../sdk/corruption/interceptShares';
 import { ClearValueType, SdkInstance } from '../sdk/types';
 import { Signers, getSigners, initSigners } from '../signers';
 import { FhevmInstances } from '../types';
@@ -140,6 +141,51 @@ describe('Delegated user decryption', function () {
         'transfer(address,bytes32,bytes)'
       ](smartWalletAddress, encryptedTransferAmount.handles[0], encryptedTransferAmount.inputProof);
     await transferTx.wait();
+  });
+
+  describe('corrupted shares', function () {
+    // Same delegation as the happy-path test below, but the KMS signcrypted
+    // shares are corrupted before client-side reconstruction. We assert only
+    // that delegated decryption fails and print the error (see interceptShares).
+    let balanceHandle: string;
+
+    before(async function () {
+      this.timeout(SLOW_TEST_TIMEOUT_MS);
+      // Bob (smartWallet owner) delegates his own EOA to decrypt the balance.
+      const expirationTimestamp = Math.floor(Date.now() / 1000) + ONE_DAY_SECONDS;
+      const delegateTx = await smartWallet
+        .connect(signers.bob)
+        .delegateUserDecryption(signers.bob.address, tokenAddress, expirationTimestamp);
+      await delegateTx.wait();
+
+      // Wait for the coprocessor to absorb the ACL change.
+      const currentBlock = await ethers.provider.getBlockNumber();
+      await waitForBlock(currentBlock + PROPAGATION_BLOCKS);
+
+      balanceHandle = await token.balanceOf(smartWalletAddress);
+    });
+
+    it('case 1: bit-flipped payload makes delegated user decryption fail', async function () {
+      await expectCorruptedShareDecryptToFail('delegated/payload', bitFlipPayload, () =>
+        instances.bob.delegatedUserDecryptSingleHandle({
+          handle: balanceHandle,
+          contractAddress: tokenAddress,
+          delegatorAddress: smartWalletAddress,
+          signer: signers.bob,
+        }),
+      );
+    });
+
+    it('case 2: corrupted signature makes delegated user decryption fail', async function () {
+      await expectCorruptedShareDecryptToFail('delegated/signature', corruptSignature, () =>
+        instances.bob.delegatedUserDecryptSingleHandle({
+          handle: balanceHandle,
+          contractAddress: tokenAddress,
+          delegatorAddress: smartWalletAddress,
+          signer: signers.bob,
+        }),
+      );
+    });
   });
 
   it('test delegated user decryption - smartWallet owner delegates his own EOA to decrypt the smartWallet balance', async function () {

--- a/test-suite/e2e/test/sdk/corruption/interceptShares.ts
+++ b/test-suite/e2e/test/sdk/corruption/interceptShares.ts
@@ -1,0 +1,187 @@
+import { expect } from 'chai';
+
+/**
+ * Client-side corruption of KMS signcrypted shares for user decryption.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * We want to observe how the SDK behaves when it receives corrupted shares
+ * (see the RFC-016 discussion: "what concrete errors are reported by the wasm
+ * today"). For user decryption the relayer only *collects and forwards* the
+ * KMS parties' signcrypted shares — reconstruction happens client-side inside
+ * the SDK's wasm (tkms) module. So the corruption has to be injected between
+ * the relayer HTTP response and the SDK's reconstruction step.
+ *
+ * HOW
+ * ---
+ * We intercept `globalThis.fetch` for the duration of a single decrypt call.
+ * Both `@fhevm/sdk` and `@zama-fhe/relayer-sdk` call the bare global `fetch`
+ * dynamically at request time, so one interception in the test process catches
+ * either SDK. The poll (GET) response for every user-decrypt endpoint
+ * (`/user-decrypt`, `/v2/user-decrypt`, `/v3/user-decrypt`,
+ * `/delegated-user-decrypt`, and their `/{jobId}` poll URLs) carries the same
+ * wire shape:
+ *
+ *   { status: "succeeded", requestId, result: { result: [ { payload, signature, extraData } ] } }
+ *
+ * We mutate a fixed number of those shares and hand the SDK a corrupted-but-
+ * well-formed response.
+ *
+ * SCOPE / SAFETY
+ * --------------
+ * The patch is installed and restored around a single callback (`try/finally`),
+ * so only the wrapped decrypt call is affected and the original `fetch` is
+ * always put back — even when the decrypt throws (the expected outcome here).
+ * Only responses whose URL contains `user-decrypt` and that actually carry a
+ * `result.result[]` share array are touched; everything else passes through.
+ *
+ * BUILDING ON THIS LATER
+ * ----------------------
+ * The corruption itself is a pluggable `ShareCorruptor`. Today we ship the two
+ * naive strategies from the RFC-016 thread (bit-flip the payload; corrupt the
+ * signature). The systematic cases discussed there — wrong signature, correct
+ * sig but wrong key, correct key but wrong share — slot in as additional
+ * `ShareCorruptor` implementations without touching the interception plumbing.
+ */
+
+/** One signcrypted share as it appears on the wire (hex, no `0x` prefix). */
+export interface WireShare {
+  payload: string;
+  signature: string;
+  extraData?: string;
+  [key: string]: unknown;
+}
+
+/** Transforms a single share into a corrupted one. Pure; returns a new object. */
+export type ShareCorruptor = (share: WireShare, index: number) => WireShare;
+
+/** Number of shares corrupted by default (see the "2 out of 9" RFC-016 case). */
+export const DEFAULT_CORRUPT_COUNT = 2;
+
+/** Flip every bit of the first byte of a hex-no-0x string (guaranteed change). */
+export function flipFirstByte(hex: string): string {
+  if (hex.length < 2) {
+    return hex;
+  }
+  const firstByte = parseInt(hex.slice(0, 2), 16);
+  const flipped = ((firstByte ^ 0xff) & 0xff).toString(16).padStart(2, '0');
+  return flipped + hex.slice(2);
+}
+
+/** Case 1: bit-flip the signcrypted payload. */
+export const bitFlipPayload: ShareCorruptor = (share) => ({
+  ...share,
+  payload: flipFirstByte(share.payload),
+});
+
+/** Case 2: corrupt the KMS party's signature (length preserved, so it clears
+ * the SDK's 65-byte length guard and reaches wasm signature verification). */
+export const corruptSignature: ShareCorruptor = (share) => ({
+  ...share,
+  signature: flipFirstByte(share.signature),
+});
+
+/** Locate the shares array in a parsed relayer response, if present. */
+function findShares(body: unknown): WireShare[] | undefined {
+  const result = (body as { result?: { result?: unknown } } | null)?.result?.result;
+  if (Array.isArray(result) && result.length > 0 && typeof (result[0] as WireShare)?.payload === 'string') {
+    return result as WireShare[];
+  }
+  return undefined;
+}
+
+/** Rebuild a Response from consumed text, dropping length/encoding headers. */
+function rebuildResponse(original: Response, text: string): Response {
+  const headers = new Headers();
+  original.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (lower === 'content-length' || lower === 'content-encoding') {
+      return;
+    }
+    headers.set(key, value);
+  });
+  return new Response(text, {
+    status: original.status,
+    statusText: original.statusText,
+    headers,
+  });
+}
+
+export interface CorruptionOptions {
+  /** How to corrupt each targeted share. */
+  corrupt: ShareCorruptor;
+  /** How many shares to corrupt (default {@link DEFAULT_CORRUPT_COUNT}). */
+  count?: number;
+}
+
+/**
+ * Run `fn` with `globalThis.fetch` patched so that user-decrypt share responses
+ * are corrupted before the SDK reconstructs them. Restores `fetch` afterwards.
+ */
+export async function withCorruptedUserDecryptShares<T>(options: CorruptionOptions, fn: () => Promise<T>): Promise<T> {
+  const { corrupt } = options;
+  const count = options.count ?? DEFAULT_CORRUPT_COUNT;
+  const realFetch = globalThis.fetch;
+
+  const patched: typeof fetch = async (input, init) => {
+    const response = await realFetch(input, init);
+    const url = input instanceof Request ? input.url : String(input);
+    if (!url.includes('user-decrypt')) {
+      return response;
+    }
+
+    const text = await response.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // Not JSON (e.g. an error page) — hand back the original body untouched.
+      return rebuildResponse(response, text);
+    }
+
+    const shares = findShares(body);
+    if (shares === undefined) {
+      // Submit (202) / still-processing polls carry no shares — pass through.
+      return rebuildResponse(response, text);
+    }
+
+    const corruptCount = Math.min(count, shares.length);
+    // eslint-disable-next-line no-console
+    console.log(`[corruption] user-decrypt response: ${shares.length} shares received, corrupting ${corruptCount}`);
+    for (let i = 0; i < corruptCount; i++) {
+      shares[i] = corrupt(shares[i], i);
+    }
+
+    return rebuildResponse(response, JSON.stringify(body));
+  };
+
+  globalThis.fetch = patched;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+/**
+ * Run a decrypt with corrupted shares, print the resulting error, and assert
+ * that the decrypt failed. Shared by the direct / delegated / unified suites.
+ */
+export async function expectCorruptedShareDecryptToFail(
+  label: string,
+  corrupt: ShareCorruptor,
+  decrypt: () => Promise<unknown>,
+): Promise<void> {
+  let thrown: unknown;
+  try {
+    await withCorruptedUserDecryptShares({ corrupt }, decrypt);
+  } catch (error) {
+    thrown = error;
+  }
+
+  const message = thrown instanceof Error ? thrown.message : String(thrown);
+  // eslint-disable-next-line no-console
+  console.log(`[corruption] ${label}: error = ${message}`);
+
+  expect(thrown, `Expected user decryption to fail with corrupted shares (${label})`).to.not.be.undefined;
+}

--- a/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
+++ b/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
@@ -9,6 +9,7 @@ import {
   relayerUrl,
   verifyingContractAddressDecryption,
 } from '../instance';
+import { bitFlipPayload, corruptSignature, expectCorruptedShareDecryptToFail } from '../sdk/corruption/interceptShares';
 import { Signers, getSigners, initSigners } from '../signers';
 import { FhevmInstances } from '../types';
 import { waitForBlock } from '../utils';
@@ -115,6 +116,36 @@ describe('Unified user decryption', function () {
     bobContractAddress = await bobContract.getAddress();
 
     publicKey = (await instances.alice.generateKeypair()).publicKey;
+  });
+
+  describe('corrupted shares', function () {
+    // Unified path: the SDK reconstructs the shares client-side (the unified v3
+    // relayer helper only checks job status and does not reconstruct), so the
+    // corruption is observed by driving the SDK's reconstruction directly. We
+    // assert only that decryption fails and print the error (see interceptShares).
+    it('case 1: bit-flipped payload makes user decryption fail', async function () {
+      this.timeout(POSITIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
+      const handle = await aliceContract.xUint64();
+      await expectCorruptedShareDecryptToFail('unified/payload', bitFlipPayload, () =>
+        instances.alice.userDecryptSingleHandle({
+          handle,
+          contractAddress: aliceContractAddress,
+          signer: signers.alice,
+        }),
+      );
+    });
+
+    it('case 2: corrupted signature makes user decryption fail', async function () {
+      this.timeout(POSITIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
+      const handle = await aliceContract.xUint64();
+      await expectCorruptedShareDecryptToFail('unified/signature', corruptSignature, () =>
+        instances.alice.userDecryptSingleHandle({
+          handle,
+          contractAddress: aliceContractAddress,
+          signer: signers.alice,
+        }),
+      );
+    });
   });
 
   it('test unified user decrypt permissive mode (empty allowedContracts) succeeds', async function () {

--- a/test-suite/e2e/test/userDecryption/userDecryption.ts
+++ b/test-suite/e2e/test/userDecryption/userDecryption.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 
 import { createInstances } from '../instance';
+import { bitFlipPayload, corruptSignature, expectCorruptedShareDecryptToFail } from '../sdk/corruption/interceptShares';
 import { getSigners, initSigners } from '../signers';
 
 describe('User decryption', function () {
@@ -95,6 +96,36 @@ describe('User decryption', function () {
       signer: this.signers.alice,
     });
     expect(decryptedValue).to.equal(74285495974541385002137713624115238327312291047062397922780925695323480915729n);
+  });
+
+  describe('corrupted shares', function () {
+    // Observe how the SDK behaves when the KMS signcrypted shares it receives
+    // are corrupted before client-side reconstruction. The corruption is
+    // injected at the SDK's HTTP input boundary (see interceptShares).
+    // For now we assert only that decryption fails and print the error; whether
+    // 2 bad shares are always enough to break reconstruction is exactly the
+    // open question this test is meant to surface.
+    it('case 1: bit-flipped payload makes user decryption fail', async function () {
+      const handle = await this.contract.xUint64();
+      await expectCorruptedShareDecryptToFail('direct/payload', bitFlipPayload, () =>
+        this.instances.alice.userDecryptSingleHandle({
+          handle,
+          contractAddress: this.contractAddress,
+          signer: this.signers.alice,
+        }),
+      );
+    });
+
+    it('case 2: corrupted signature makes user decryption fail', async function () {
+      const handle = await this.contract.xUint64();
+      await expectCorruptedShareDecryptToFail('direct/signature', corruptSignature, () =>
+        this.instances.alice.userDecryptSingleHandle({
+          handle,
+          contractAddress: this.contractAddress,
+          signer: this.signers.alice,
+        }),
+      );
+    });
   });
 
   describe('negative-acl', function () {


### PR DESCRIPTION
Adds e2e tests observing SDK behavior when it receives corrupted user-decryption shares (direct, delegated, unified), via a client-side `fetch` interception that bit-flips the payload / corrupts the signature. Client-side POC; genuine source-side corruption is tracked separately.

Two cases per path: bit-flipped payload, corrupted signature. 2 shares corrupted per run; received share count logged. Works for both `@fhevm/sdk` and `@zama-fhe/relayer-sdk`.

Run:
```bash
cd test-suite/e2e
npx hardhat test --grep "corrupted shares" --network staging
RELAYER_SDK_VERSION=0.5.0 npx hardhat test --grep "corrupted shares" --network staging
```

Part of zama-ai/fhevm-internal#1736
Closes zama-ai/fhevm-internal#1738