### PR TITLE
fix(listener): align Solana transaction decoding

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -19,7 +19,8 @@ use tonic::metadata::{Ascii, MetadataValue};
 use tonic::transport::Channel;
 use yellowstone_grpc_proto::geyser::geyser_client::GeyserClient;
 use yellowstone_grpc_proto::prelude::{
-    subscribe_update::UpdateOneof, CommitmentLevel, SubscribeRequest,
+    subscribe_update::UpdateOneof, CommitmentLevel, CompiledInstruction,
+    InnerInstruction, InnerInstructions, SubscribeRequest,
     SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta,
     SubscribeRequestFilterTransactions, SubscribeUpdateTransactionInfo,
 };
@@ -292,6 +293,76 @@ fn resolve_instruction(
     })
 }
 
+fn resolve_execution_order(
+    account_keys: &[[u8; 32]],
+    top_level: &[CompiledInstruction],
+    inner_groups: &[InnerInstructions],
+) -> Result<Vec<crate::solana_reconstruct::DecodedInstruction>> {
+    let mut inner_by_index: HashMap<u32, &[InnerInstruction]> = HashMap::new();
+    for group in inner_groups {
+        if group.index as usize >= top_level.len() {
+            return Err(anyhow!(
+                "inner-instruction group index {} is out of range",
+                group.index
+            ));
+        }
+        if inner_by_index
+            .insert(group.index, group.instructions.as_slice())
+            .is_some()
+        {
+            return Err(anyhow!(
+                "duplicate inner-instruction group index {}",
+                group.index
+            ));
+        }
+        let mut previous_height = 1u32;
+        for (position, instruction) in group.instructions.iter().enumerate() {
+            let height = instruction.stack_height.ok_or_else(|| {
+                anyhow!(
+                    "inner instruction {position} in group {} has no stackHeight",
+                    group.index
+                )
+            })?;
+            if height < 2
+                || (position == 0 && height != 2)
+                || height > previous_height.saturating_add(1)
+            {
+                return Err(anyhow!(
+                    "impossible stackHeight {height} at inner instruction {position} in group {}",
+                    group.index
+                ));
+            }
+            previous_height = height;
+        }
+    }
+
+    let mut ordered = Vec::new();
+    for (index, instruction) in top_level.iter().enumerate() {
+        let index = index as u32;
+        ordered.push(resolve_instruction(
+            account_keys,
+            index,
+            false,
+            instruction.program_id_index,
+            &instruction.data,
+            &instruction.accounts,
+        )?);
+        if let Some(inner) = inner_by_index.get(&index) {
+            for instruction in inner.iter() {
+                ordered.push(resolve_instruction(
+                    account_keys,
+                    index,
+                    true,
+                    instruction.program_id_index,
+                    &instruction.data,
+                    &instruction.accounts,
+                )?);
+            }
+        }
+    }
+    Ok(ordered)
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn subscribe_loop(
     db: &Database,
@@ -559,57 +630,12 @@ async fn ingest_transaction(
     // Top-level + inner instruction invocations with resolved accounts (a
     // zama-host instruction is called directly as top-level, or via CPI as inner
     // for token flows); scanned by the reconstruction shadow-compare and ingest.
-    let all_instructions: Vec<crate::solana_reconstruct::DecodedInstruction> =
-        {
-            let decode = |top_level_index: u32,
-                          is_inner: bool,
-                          program_id_index: u32,
-                          data: &[u8],
-                          accounts: &[u8]| {
-                resolve_instruction(
-                    &account_keys,
-                    top_level_index,
-                    is_inner,
-                    program_id_index,
-                    data,
-                    accounts,
-                )
-                .map_err(IngestFailure::permanent)
-            };
-            let mut inner_by_index: HashMap<u32, Vec<_>> = HashMap::new();
-            for group in &meta.inner_instructions {
-                let inner = group
-                    .instructions
-                    .iter()
-                    .map(|ix| {
-                        decode(
-                            group.index,
-                            true,
-                            ix.program_id_index,
-                            &ix.data,
-                            &ix.accounts,
-                        )
-                    })
-                    .collect::<std::result::Result<Vec<_>, _>>()?;
-                inner_by_index.insert(group.index, inner);
-            }
-            let mut ordered = Vec::new();
-            for (index, ix) in message.instructions.iter().enumerate() {
-                let index = index as u32;
-                ordered.push(decode(
-                    index,
-                    false,
-                    ix.program_id_index,
-                    &ix.data,
-                    &ix.accounts,
-                )?);
-                if let Some(inner) = inner_by_index.remove(&index) {
-                    ordered.extend(inner);
-                }
-            }
-            ordered.extend(inner_by_index.into_values().flatten());
-            std::result::Result::<_, IngestFailure>::Ok(ordered)
-        }?;
+    let all_instructions = resolve_execution_order(
+        &account_keys,
+        &message.instructions,
+        &meta.inner_instructions,
+    )
+    .map_err(IngestFailure::permanent)?;
 
     let events = match reconstruct_events_for_insert(
         config,
@@ -865,7 +891,21 @@ fn compute_result_handle(
 
 #[cfg(test)]
 mod account_resolution_tests {
-    use super::{resolve_instruction, validated_account_keys};
+    use super::{resolve_execution_order, validated_account_keys};
+    use yellowstone_grpc_proto::prelude::{
+        CompiledInstruction, InnerInstruction, InnerInstructions,
+    };
+
+    mod shared_fixtures {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../solana/test-fixtures/transaction_decoding.rs"
+        ));
+    }
+
+    use shared_fixtures::{
+        transaction_decoding_fixtures, ExpectedInstruction, ExpectedOutcome,
+    };
 
     fn key(tag: u8) -> Vec<u8> {
         vec![tag; 32]
@@ -882,51 +922,75 @@ mod account_resolution_tests {
     }
 
     #[test]
-    fn rejects_out_of_range_program_index() {
-        let err = resolve_instruction(&[[1; 32]], 0, false, 1, &[7], &[0])
-            .expect_err("invalid program indexes must fail closed");
+    fn shared_transaction_decoding_contract() {
+        for fixture in transaction_decoding_fixtures() {
+            let key_bytes: Vec<Vec<u8>> =
+                fixture.account_tags().map(key).collect();
+            let account_keys =
+                validated_account_keys(key_bytes.iter()).unwrap();
+            let top_level: Vec<CompiledInstruction> = fixture
+                .top_level
+                .iter()
+                .map(|instruction| CompiledInstruction {
+                    program_id_index: instruction.program_id_index,
+                    accounts: instruction.accounts.clone(),
+                    data: instruction.data.clone(),
+                })
+                .collect();
+            let inner_groups: Vec<InnerInstructions> = fixture
+                .inner_groups
+                .iter()
+                .map(|group| InnerInstructions {
+                    index: group.index,
+                    instructions: group
+                        .instructions
+                        .iter()
+                        .map(|instruction| InnerInstruction {
+                            program_id_index: instruction.program_id_index,
+                            accounts: instruction.accounts.clone(),
+                            data: instruction.data.clone(),
+                            stack_height: instruction.stack_height,
+                        })
+                        .collect(),
+                })
+                .collect();
 
-        assert_eq!(err.to_string(), "program_id_index 1 out of range");
-    }
-
-    #[test]
-    fn rejects_out_of_range_account_index_without_compacting_positions() {
-        let err = resolve_instruction(
-            &[[1; 32], [2; 32], [3; 32]],
-            0,
-            false,
-            0,
-            &[7],
-            &[1, 9, 2],
-        )
-        .expect_err(
-            "invalid account indexes must reject the complete instruction",
-        );
-
-        assert_eq!(err.to_string(), "instruction account index 9 out of range");
-    }
-
-    #[test]
-    fn resolves_valid_top_level_and_inner_instructions_without_reordering_accounts(
-    ) {
-        let keys = validated_account_keys([&key(1), &key(2), &key(3)]).unwrap();
-        let top_level =
-            resolve_instruction(&keys, 4, false, 0, &[10, 11], &[2, 1])
-                .unwrap();
-        let inner =
-            resolve_instruction(&keys, 4, true, 1, &[12], &[0, 2]).unwrap();
-
-        assert_eq!(top_level.program, bs58::encode([1; 32]).into_string());
-        assert_eq!(top_level.data, vec![10, 11]);
-        assert_eq!(top_level.accounts, vec![[3; 32], [2; 32]]);
-        assert_eq!(top_level.top_level_index, 4);
-        assert!(!top_level.is_inner);
-
-        assert_eq!(inner.program, bs58::encode([2; 32]).into_string());
-        assert_eq!(inner.data, vec![12]);
-        assert_eq!(inner.accounts, vec![[1; 32], [3; 32]]);
-        assert_eq!(inner.top_level_index, 4);
-        assert!(inner.is_inner);
+            let decoded = resolve_execution_order(
+                &account_keys,
+                &top_level,
+                &inner_groups,
+            );
+            match &fixture.expected {
+                ExpectedOutcome::Accept { instructions } => {
+                    let actual: Vec<ExpectedInstruction> = decoded
+                        .unwrap_or_else(|error| {
+                            panic!("{}: {error}", fixture.name)
+                        })
+                        .into_iter()
+                        .map(|instruction| {
+                            let program = bs58::decode(instruction.program)
+                                .into_vec()
+                                .unwrap();
+                            ExpectedInstruction {
+                                program_tag: program[0],
+                                account_tags: instruction
+                                    .accounts
+                                    .iter()
+                                    .map(|account| account[0])
+                                    .collect(),
+                                data: instruction.data,
+                                top_level_index: instruction.top_level_index,
+                                is_inner: instruction.is_inner,
+                            }
+                        })
+                        .collect();
+                    assert_eq!(actual, *instructions, "{}", fixture.name);
+                }
+                ExpectedOutcome::Reject => {
+                    assert!(decoded.is_err(), "{}", fixture.name);
+                }
+            }
+        }
     }
 }
 

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -20,9 +20,10 @@ use tonic::transport::Channel;
 use yellowstone_grpc_proto::geyser::geyser_client::GeyserClient;
 use yellowstone_grpc_proto::prelude::{
     subscribe_update::UpdateOneof, CommitmentLevel, CompiledInstruction,
-    InnerInstruction, InnerInstructions, SubscribeRequest,
-    SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta,
-    SubscribeRequestFilterTransactions, SubscribeUpdateTransactionInfo,
+    InnerInstruction, InnerInstructions, Message as TransactionMessage,
+    SubscribeRequest, SubscribeRequestFilterAccounts,
+    SubscribeRequestFilterBlocksMeta, SubscribeRequestFilterTransactions,
+    SubscribeUpdateTransactionInfo, TransactionStatusMeta,
 };
 
 use crate::database::tfhe_event_propagate::Database;
@@ -363,6 +364,26 @@ fn resolve_execution_order(
     Ok(ordered)
 }
 
+fn decode_transaction_instructions(
+    message: &TransactionMessage,
+    meta: &TransactionStatusMeta,
+) -> Result<Vec<crate::solana_reconstruct::DecodedInstruction>> {
+    // Solana instruction indexes address static keys ++ ALT writable ++ ALT
+    // readonly. Keep assembly and instruction decoding in one production path.
+    let account_keys = validated_account_keys(
+        message
+            .account_keys
+            .iter()
+            .chain(meta.loaded_writable_addresses.iter())
+            .chain(meta.loaded_readonly_addresses.iter()),
+    )?;
+    resolve_execution_order(
+        &account_keys,
+        &message.instructions,
+        &meta.inner_instructions,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn subscribe_loop(
     db: &Database,
@@ -614,28 +635,11 @@ async fn ingest_transaction(
         IngestFailure::permanent(anyhow!("tx has no message"))
     })?;
 
-    // Resolved account-key list: static keys ++ ALT writable ++ ALT readonly,
-    // the order `program_id_index` and instruction account indexes address. Reject
-    // malformed provider data before reconstruction so positional accounts can
-    // never be shifted or replaced with sentinel values.
-    let account_keys = validated_account_keys(
-        message
-            .account_keys
-            .iter()
-            .chain(meta.loaded_writable_addresses.iter())
-            .chain(meta.loaded_readonly_addresses.iter()),
-    )
-    .map_err(IngestFailure::permanent)?;
-
     // Top-level + inner instruction invocations with resolved accounts (a
     // zama-host instruction is called directly as top-level, or via CPI as inner
     // for token flows); scanned by the reconstruction shadow-compare and ingest.
-    let all_instructions = resolve_execution_order(
-        &account_keys,
-        &message.instructions,
-        &meta.inner_instructions,
-    )
-    .map_err(IngestFailure::permanent)?;
+    let all_instructions = decode_transaction_instructions(message, meta)
+        .map_err(IngestFailure::permanent)?;
 
     let events = match reconstruct_events_for_insert(
         config,
@@ -891,9 +895,10 @@ fn compute_result_handle(
 
 #[cfg(test)]
 mod account_resolution_tests {
-    use super::{resolve_execution_order, validated_account_keys};
+    use super::{decode_transaction_instructions, validated_account_keys};
     use yellowstone_grpc_proto::prelude::{
         CompiledInstruction, InnerInstruction, InnerInstructions,
+        Message as TransactionMessage, TransactionStatusMeta,
     };
 
     mod shared_fixtures {
@@ -924,10 +929,6 @@ mod account_resolution_tests {
     #[test]
     fn shared_transaction_decoding_contract() {
         for fixture in transaction_decoding_fixtures() {
-            let key_bytes: Vec<Vec<u8>> =
-                fixture.account_tags().map(key).collect();
-            let account_keys =
-                validated_account_keys(key_bytes.iter()).unwrap();
             let top_level: Vec<CompiledInstruction> = fixture
                 .top_level
                 .iter()
@@ -955,11 +956,34 @@ mod account_resolution_tests {
                 })
                 .collect();
 
-            let decoded = resolve_execution_order(
-                &account_keys,
-                &top_level,
-                &inner_groups,
-            );
+            let message = TransactionMessage {
+                account_keys: fixture
+                    .static_account_tags
+                    .iter()
+                    .copied()
+                    .map(key)
+                    .collect(),
+                instructions: top_level,
+                ..Default::default()
+            };
+            let meta = TransactionStatusMeta {
+                inner_instructions: inner_groups,
+                loaded_writable_addresses: fixture
+                    .loaded_writable_account_tags
+                    .iter()
+                    .copied()
+                    .map(key)
+                    .collect(),
+                loaded_readonly_addresses: fixture
+                    .loaded_readonly_account_tags
+                    .iter()
+                    .copied()
+                    .map(key)
+                    .collect(),
+                ..Default::default()
+            };
+
+            let decoded = decode_transaction_instructions(&message, &meta);
             match &fixture.expected {
                 ExpectedOutcome::Accept { instructions } => {
                     let actual: Vec<ExpectedInstruction> = decoded

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -492,130 +492,83 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, String> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn flatten_interleaves_inner_after_its_top_level_instruction() {
-        let account_keys = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
-        let top_level = vec![
-            CompiledIx {
-                program_id_index: 0,
-                accounts: vec![],
-                data: "".to_string(),
-                stack_height: None,
-            },
-            CompiledIx {
-                program_id_index: 1,
-                accounts: vec![],
-                data: "".to_string(),
-                stack_height: None,
-            },
-        ];
-        let inner_groups = vec![InnerIxGroup {
-            index: 0,
-            instructions: vec![CompiledIx {
-                program_id_index: 2,
-                accounts: vec![],
-                data: "".to_string(),
-                stack_height: Some(2),
-            }],
-        }];
-        let out = flatten_execution_order(&top_level, &inner_groups, &account_keys).unwrap();
-        assert_eq!(out.len(), 3);
-        assert_eq!(out[0].program_id, [1u8; 32]);
-        assert_eq!(out[0].stack_height, Some(1));
-        assert_eq!(out[1].program_id, [3u8; 32]); // inner CPI spawned by top-level 0
-        assert_eq!(out[1].stack_height, Some(2));
-        assert_eq!(out[1].top_level_index, 0);
-        assert_eq!(out[2].program_id, [2u8; 32]);
-    }
-
-    #[test]
-    fn flatten_rejects_duplicate_and_orphan_inner_groups() {
-        let account_keys = vec![[1u8; 32]];
-        let top_level = vec![CompiledIx {
-            program_id_index: 0,
-            accounts: vec![],
-            data: "".to_string(),
-            stack_height: None,
-        }];
-        let duplicate = vec![
-            InnerIxGroup {
-                index: 0,
-                instructions: vec![],
-            },
-            InnerIxGroup {
-                index: 0,
-                instructions: vec![],
-            },
-        ];
-        assert!(matches!(
-            flatten_execution_order(&top_level, &duplicate, &account_keys),
-            Err(ChainError::Rpc(message)) if message.contains("duplicate")
-        ));
-
-        let orphan = vec![InnerIxGroup {
-            index: 1,
-            instructions: vec![],
-        }];
-        assert!(matches!(
-            flatten_execution_order(&top_level, &orphan, &account_keys),
-            Err(ChainError::Rpc(message)) if message.contains("out of range")
+    mod shared_fixtures {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../solana/test-fixtures/transaction_decoding.rs"
         ));
     }
 
-    #[test]
-    fn flatten_rejects_impossible_inner_stack_traces() {
-        let account_keys = vec![[1u8; 32]];
-        let top_level = vec![CompiledIx {
-            program_id_index: 0,
-            accounts: vec![],
-            data: "".to_string(),
-            stack_height: None,
-        }];
-        for heights in [vec![3], vec![2, 4], vec![2, 1], vec![2, 2, 4]] {
-            let group = vec![InnerIxGroup {
-                index: 0,
-                instructions: heights
-                    .into_iter()
-                    .map(|height| CompiledIx {
-                        program_id_index: 0,
-                        accounts: vec![],
-                        data: "".to_string(),
-                        stack_height: Some(height),
-                    })
-                    .collect(),
-            }];
-            assert!(matches!(
-                flatten_execution_order(&top_level, &group, &account_keys),
-                Err(ChainError::Rpc(message)) if message.contains("impossible")
-            ));
-        }
-        let missing = vec![InnerIxGroup {
-            index: 0,
-            instructions: vec![CompiledIx {
-                program_id_index: 0,
-                accounts: vec![],
-                data: "".to_string(),
-                stack_height: None,
-            }],
-        }];
-        assert!(matches!(
-            flatten_execution_order(&top_level, &missing, &account_keys),
-            Err(ChainError::Rpc(message)) if message.contains("no stackHeight")
-        ));
+    use shared_fixtures::{
+        base58_encode as fixture_base58_encode, transaction_decoding_fixtures, ExpectedInstruction,
+        ExpectedOutcome,
+    };
 
-        let valid = vec![InnerIxGroup {
-            index: 0,
-            instructions: [2, 3, 3, 2]
-                .into_iter()
-                .map(|height| CompiledIx {
-                    program_id_index: 0,
-                    accounts: vec![],
-                    data: "".to_string(),
-                    stack_height: Some(height),
+    #[test]
+    fn shared_transaction_decoding_contract() {
+        for fixture in transaction_decoding_fixtures() {
+            let account_keys: Vec<[u8; 32]> = fixture.account_tags().map(|tag| [tag; 32]).collect();
+            let top_level: Vec<CompiledIx> = fixture
+                .top_level
+                .iter()
+                .map(|instruction| CompiledIx {
+                    program_id_index: instruction.program_id_index as usize,
+                    accounts: instruction
+                        .accounts
+                        .iter()
+                        .map(|index| *index as usize)
+                        .collect(),
+                    data: fixture_base58_encode(&instruction.data),
+                    stack_height: instruction.stack_height,
                 })
-                .collect(),
-        }];
-        assert!(flatten_execution_order(&top_level, &valid, &account_keys).is_ok());
+                .collect();
+            let inner_groups: Vec<InnerIxGroup> = fixture
+                .inner_groups
+                .iter()
+                .map(|group| InnerIxGroup {
+                    index: group.index as usize,
+                    instructions: group
+                        .instructions
+                        .iter()
+                        .map(|instruction| CompiledIx {
+                            program_id_index: instruction.program_id_index as usize,
+                            accounts: instruction
+                                .accounts
+                                .iter()
+                                .map(|index| *index as usize)
+                                .collect(),
+                            data: fixture_base58_encode(&instruction.data),
+                            stack_height: instruction.stack_height,
+                        })
+                        .collect(),
+                })
+                .collect();
+
+            let decoded = flatten_execution_order(&top_level, &inner_groups, &account_keys);
+            match &fixture.expected {
+                ExpectedOutcome::Accept { instructions } => {
+                    let actual: Vec<ExpectedInstruction> = decoded
+                        .unwrap_or_else(|error| panic!("{}: {error}", fixture.name))
+                        .into_iter()
+                        .map(|instruction| ExpectedInstruction {
+                            program_tag: instruction.program_id[0],
+                            account_tags: instruction
+                                .accounts
+                                .iter()
+                                .map(|account| account[0])
+                                .collect(),
+                            data: instruction.data,
+                            top_level_index: instruction.top_level_index as u32,
+                            is_inner: instruction.stack_height != Some(1),
+                        })
+                        .collect();
+                    assert_eq!(actual, *instructions, "{}", fixture.name);
+                }
+                ExpectedOutcome::Reject => {
+                    assert!(decoded.is_err(), "{}", fixture.name);
+                }
+            }
+        }
     }
 
     #[test]

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -282,6 +282,14 @@ fn decode_transaction_result(
     })
 }
 
+fn decode_transaction_value(
+    signature: &str,
+    value: serde_json::Value,
+) -> Result<ChainTransaction, ChainError> {
+    let parsed = serde_json::from_value(value).map_err(|e| ChainError::Rpc(e.to_string()))?;
+    decode_transaction_result(signature, parsed)
+}
+
 fn compiled_to_raw(
     ix: &CompiledIx,
     account_keys: &[[u8; 32]],
@@ -372,9 +380,7 @@ impl ChainFetcher for RpcChainFetcher {
         if result.is_null() {
             return Ok(None);
         }
-        let parsed: GetTransactionResult =
-            serde_json::from_value(result).map_err(|e| ChainError::Rpc(e.to_string()))?;
-        Ok(Some(decode_transaction_result(signature, parsed)?))
+        Ok(Some(decode_transaction_value(signature, result)?))
     }
 
     async fn get_lineage_state(
@@ -507,72 +513,71 @@ mod tests {
     #[test]
     fn shared_transaction_decoding_contract() {
         for fixture in transaction_decoding_fixtures() {
-            let top_level: Vec<CompiledIx> = fixture
+            let top_level: Vec<serde_json::Value> = fixture
                 .top_level
                 .iter()
-                .map(|instruction| CompiledIx {
-                    program_id_index: instruction.program_id_index as usize,
-                    accounts: instruction
-                        .accounts
-                        .iter()
-                        .map(|index| *index as usize)
-                        .collect(),
-                    data: fixture_base58_encode(&instruction.data),
-                    stack_height: instruction.stack_height,
+                .map(|instruction| {
+                    json!({
+                        "programIdIndex": instruction.program_id_index,
+                        "accounts": instruction.accounts,
+                        "data": fixture_base58_encode(&instruction.data),
+                        "stackHeight": instruction.stack_height,
+                    })
                 })
                 .collect();
-            let inner_groups: Vec<InnerIxGroup> = fixture
+            let inner_groups: Vec<serde_json::Value> = fixture
                 .inner_groups
                 .iter()
-                .map(|group| InnerIxGroup {
-                    index: group.index as usize,
-                    instructions: group
+                .map(|group| {
+                    let instructions: Vec<serde_json::Value> = group
                         .instructions
                         .iter()
-                        .map(|instruction| CompiledIx {
-                            program_id_index: instruction.program_id_index as usize,
-                            accounts: instruction
-                                .accounts
-                                .iter()
-                                .map(|index| *index as usize)
-                                .collect(),
-                            data: fixture_base58_encode(&instruction.data),
-                            stack_height: instruction.stack_height,
+                        .map(|instruction| {
+                            json!({
+                                "programIdIndex": instruction.program_id_index,
+                                "accounts": instruction.accounts,
+                                "data": fixture_base58_encode(&instruction.data),
+                                "stackHeight": instruction.stack_height,
+                            })
                         })
-                        .collect(),
+                        .collect();
+                    json!({
+                        "index": group.index,
+                        "instructions": instructions,
+                    })
                 })
                 .collect();
 
-            let parsed = GetTransactionResult {
-                slot: 0,
-                transaction: TxEnvelope {
-                    message: Message {
-                        account_keys: fixture
+            let result = json!({
+                "slot": 0,
+                "transaction": {
+                    "message": {
+                        "accountKeys": fixture
                             .static_account_tags
                             .iter()
                             .map(|tag| fixture_base58_encode(&[*tag; 32]))
-                            .collect(),
-                        instructions: top_level,
-                    },
+                            .collect::<Vec<_>>(),
+                        "instructions": top_level,
+                    }
                 },
-                meta: Some(Meta {
-                    inner_instructions: inner_groups,
-                    err: None,
-                    loaded_addresses: Some(LoadedAddresses {
-                        writable: fixture
+                "meta": {
+                    "err": null,
+                    "innerInstructions": inner_groups,
+                    "loadedAddresses": {
+                        "writable": fixture
                             .loaded_writable_account_tags
                             .iter()
                             .map(|tag| fixture_base58_encode(&[*tag; 32]))
-                            .collect(),
-                        readonly: fixture
+                            .collect::<Vec<_>>(),
+                        "readonly": fixture
                             .loaded_readonly_account_tags
                             .iter()
                             .map(|tag| fixture_base58_encode(&[*tag; 32]))
-                            .collect(),
-                    }),
-                }),
-            };
-            let decoded = decode_transaction_result("fixture", parsed)
+                            .collect::<Vec<_>>(),
+                    }
+                }
+            });
+            let decoded = decode_transaction_value("fixture", result)
                 .map(|transaction| transaction.instructions);
             match &fixture.expected {
                 ExpectedOutcome::Accept { instructions } => {
@@ -635,7 +640,7 @@ mod tests {
 
     #[test]
     fn failed_transaction_is_rejected_before_instruction_decoding() {
-        let parsed: GetTransactionResult = serde_json::from_value(json!({
+        let result = json!({
             "slot": 42,
             "transaction": { "message": {
                 // Deliberately malformed: decoding this key would fail.
@@ -650,10 +655,9 @@ mod tests {
                 "err": { "InstructionError": [0, "Custom"] },
                 "innerInstructions": []
             }
-        }))
-        .unwrap();
+        });
 
-        let transaction = decode_transaction_result("failed", parsed).unwrap();
+        let transaction = decode_transaction_value("failed", result).unwrap();
 
         assert!(transaction.instructions.is_empty());
         assert_eq!(transaction.slot, 42);

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -507,7 +507,6 @@ mod tests {
     #[test]
     fn shared_transaction_decoding_contract() {
         for fixture in transaction_decoding_fixtures() {
-            let account_keys: Vec<[u8; 32]> = fixture.account_tags().map(|tag| [tag; 32]).collect();
             let top_level: Vec<CompiledIx> = fixture
                 .top_level
                 .iter()
@@ -544,7 +543,37 @@ mod tests {
                 })
                 .collect();
 
-            let decoded = flatten_execution_order(&top_level, &inner_groups, &account_keys);
+            let parsed = GetTransactionResult {
+                slot: 0,
+                transaction: TxEnvelope {
+                    message: Message {
+                        account_keys: fixture
+                            .static_account_tags
+                            .iter()
+                            .map(|tag| fixture_base58_encode(&[*tag; 32]))
+                            .collect(),
+                        instructions: top_level,
+                    },
+                },
+                meta: Some(Meta {
+                    inner_instructions: inner_groups,
+                    err: None,
+                    loaded_addresses: Some(LoadedAddresses {
+                        writable: fixture
+                            .loaded_writable_account_tags
+                            .iter()
+                            .map(|tag| fixture_base58_encode(&[*tag; 32]))
+                            .collect(),
+                        readonly: fixture
+                            .loaded_readonly_account_tags
+                            .iter()
+                            .map(|tag| fixture_base58_encode(&[*tag; 32]))
+                            .collect(),
+                    }),
+                }),
+            };
+            let decoded = decode_transaction_result("fixture", parsed)
+                .map(|transaction| transaction.instructions);
             match &fixture.expected {
                 ExpectedOutcome::Accept { instructions } => {
                     let actual: Vec<ExpectedInstruction> = decoded

--- a/solana/test-fixtures/transaction_decoding.rs
+++ b/solana/test-fixtures/transaction_decoding.rs
@@ -1,0 +1,93 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct TransactionDecodingFixture {
+    pub name: String,
+    pub static_account_tags: Vec<u8>,
+    #[serde(default)]
+    pub loaded_writable_account_tags: Vec<u8>,
+    #[serde(default)]
+    pub loaded_readonly_account_tags: Vec<u8>,
+    pub top_level: Vec<CompiledInstructionFixture>,
+    #[serde(default)]
+    pub inner_groups: Vec<InnerInstructionGroupFixture>,
+    pub expected: ExpectedOutcome,
+}
+
+impl TransactionDecodingFixture {
+    pub fn account_tags(&self) -> impl Iterator<Item = u8> + '_ {
+        self.static_account_tags
+            .iter()
+            .chain(&self.loaded_writable_account_tags)
+            .chain(&self.loaded_readonly_account_tags)
+            .copied()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CompiledInstructionFixture {
+    pub program_id_index: u32,
+    #[serde(default)]
+    pub accounts: Vec<u8>,
+    #[serde(default)]
+    pub data: Vec<u8>,
+    pub stack_height: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InnerInstructionGroupFixture {
+    pub index: u32,
+    pub instructions: Vec<CompiledInstructionFixture>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ExpectedOutcome {
+    Accept {
+        instructions: Vec<ExpectedInstruction>,
+    },
+    Reject,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct ExpectedInstruction {
+    pub program_tag: u8,
+    pub account_tags: Vec<u8>,
+    pub data: Vec<u8>,
+    pub top_level_index: u32,
+    pub is_inner: bool,
+}
+
+pub fn transaction_decoding_fixtures() -> Vec<TransactionDecodingFixture> {
+    serde_json::from_str(include_str!("transaction_decoding_v1.json"))
+        .expect("shared transaction decoding fixtures must be valid JSON")
+}
+
+#[allow(dead_code)] // The Geyser adapter consumes raw bytes directly.
+pub fn base58_encode(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 58] =
+        b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    if bytes.is_empty() {
+        return String::new();
+    }
+
+    let leading_zeros = bytes.iter().take_while(|byte| **byte == 0).count();
+    let mut digits = Vec::new();
+    for &byte in bytes {
+        let mut carry = byte as u32;
+        for digit in &mut digits {
+            carry += (*digit as u32) << 8;
+            *digit = (carry % 58) as u8;
+            carry /= 58;
+        }
+        while carry > 0 {
+            digits.push((carry % 58) as u8);
+            carry /= 58;
+        }
+    }
+
+    let mut encoded: Vec<u8> =
+        std::iter::repeat_n(ALPHABET[0], leading_zeros).collect();
+    encoded.extend(digits.iter().rev().map(|digit| ALPHABET[*digit as usize]));
+    String::from_utf8(encoded).expect("base58 alphabet is valid UTF-8")
+}

--- a/solana/test-fixtures/transaction_decoding.rs
+++ b/solana/test-fixtures/transaction_decoding.rs
@@ -14,16 +14,6 @@ pub struct TransactionDecodingFixture {
     pub expected: ExpectedOutcome,
 }
 
-impl TransactionDecodingFixture {
-    pub fn account_tags(&self) -> impl Iterator<Item = u8> + '_ {
-        self.static_account_tags
-            .iter()
-            .chain(&self.loaded_writable_account_tags)
-            .chain(&self.loaded_readonly_account_tags)
-            .copied()
-    }
-}
-
 #[derive(Debug, Deserialize)]
 pub struct CompiledInstructionFixture {
     pub program_id_index: u32,

--- a/solana/test-fixtures/transaction_decoding_v1.json
+++ b/solana/test-fixtures/transaction_decoding_v1.json
@@ -1,0 +1,255 @@
+[
+  {
+    "name": "top-level and inner instructions preserve loaded account order",
+    "static_account_tags": [1, 2],
+    "loaded_writable_account_tags": [3],
+    "loaded_readonly_account_tags": [4],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [2, 1],
+        "data": [10, 11],
+        "stack_height": null
+      },
+      {
+        "program_id_index": 1,
+        "accounts": [3],
+        "data": [12],
+        "stack_height": null
+      }
+    ],
+    "inner_groups": [
+      {
+        "index": 0,
+        "instructions": [
+          {
+            "program_id_index": 2,
+            "accounts": [0, 3],
+            "data": [13],
+            "stack_height": 2
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "outcome": "accept",
+      "instructions": [
+        {
+          "program_tag": 1,
+          "account_tags": [3, 2],
+          "data": [10, 11],
+          "top_level_index": 0,
+          "is_inner": false
+        },
+        {
+          "program_tag": 3,
+          "account_tags": [1, 4],
+          "data": [13],
+          "top_level_index": 0,
+          "is_inner": true
+        },
+        {
+          "program_tag": 2,
+          "account_tags": [4],
+          "data": [12],
+          "top_level_index": 1,
+          "is_inner": false
+        }
+      ]
+    }
+  },
+  {
+    "name": "nested inner stack transitions preserve execution order",
+    "static_account_tags": [1],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "inner_groups": [
+      {
+        "index": 0,
+        "instructions": [
+          {
+            "program_id_index": 0,
+            "accounts": [],
+            "data": [],
+            "stack_height": 2
+          },
+          {
+            "program_id_index": 0,
+            "accounts": [],
+            "data": [],
+            "stack_height": 3
+          },
+          {
+            "program_id_index": 0,
+            "accounts": [],
+            "data": [],
+            "stack_height": 3
+          },
+          {
+            "program_id_index": 0,
+            "accounts": [],
+            "data": [],
+            "stack_height": 2
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "outcome": "accept",
+      "instructions": [
+        {
+          "program_tag": 1,
+          "account_tags": [],
+          "data": [],
+          "top_level_index": 0,
+          "is_inner": false
+        },
+        {
+          "program_tag": 1,
+          "account_tags": [],
+          "data": [],
+          "top_level_index": 0,
+          "is_inner": true
+        },
+        {
+          "program_tag": 1,
+          "account_tags": [],
+          "data": [],
+          "top_level_index": 0,
+          "is_inner": true
+        },
+        {
+          "program_tag": 1,
+          "account_tags": [],
+          "data": [],
+          "top_level_index": 0,
+          "is_inner": true
+        },
+        {
+          "program_tag": 1,
+          "account_tags": [],
+          "data": [],
+          "top_level_index": 0,
+          "is_inner": true
+        }
+      ]
+    }
+  },
+  {
+    "name": "program index out of range rejects the transaction",
+    "static_account_tags": [1],
+    "top_level": [
+      {
+        "program_id_index": 1,
+        "accounts": [],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "expected": { "outcome": "reject" }
+  },
+  {
+    "name": "account index out of range rejects the transaction",
+    "static_account_tags": [1, 2],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [1, 9],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "expected": { "outcome": "reject" }
+  },
+  {
+    "name": "duplicate inner groups reject the transaction",
+    "static_account_tags": [1],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "inner_groups": [
+      { "index": 0, "instructions": [] },
+      { "index": 0, "instructions": [] }
+    ],
+    "expected": { "outcome": "reject" }
+  },
+  {
+    "name": "orphan inner group rejects the transaction",
+    "static_account_tags": [1],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "inner_groups": [
+      { "index": 1, "instructions": [] }
+    ],
+    "expected": { "outcome": "reject" }
+  },
+  {
+    "name": "missing inner stack height rejects the transaction",
+    "static_account_tags": [1],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "inner_groups": [
+      {
+        "index": 0,
+        "instructions": [
+          {
+            "program_id_index": 0,
+            "accounts": [],
+            "data": [],
+            "stack_height": null
+          }
+        ]
+      }
+    ],
+    "expected": { "outcome": "reject" }
+  },
+  {
+    "name": "impossible inner stack transition rejects the transaction",
+    "static_account_tags": [1],
+    "top_level": [
+      {
+        "program_id_index": 0,
+        "accounts": [],
+        "data": [],
+        "stack_height": null
+      }
+    ],
+    "inner_groups": [
+      {
+        "index": 0,
+        "instructions": [
+          {
+            "program_id_index": 0,
+            "accounts": [],
+            "data": [],
+            "stack_height": 3
+          }
+        ]
+      }
+    ],
+    "expected": { "outcome": "reject" }
+  }
+]


### PR DESCRIPTION
## What

- add one small, readable transaction-decoding fixture corpus shared by the Geyser host-listener and RPC relayer tests
- cover static and loaded account ordering, top-level/CPI execution order, nested stack heights, and malformed index/group/stack inputs
- make the host listener reject duplicate or orphan inner-instruction groups and invalid stack traces instead of silently overwriting or appending them

## Why

The Geyser and RPC adapters decode the same Solana transaction semantics through different transport shapes. A shared behavioral contract prevents the two paths from drifting without introducing a shared production abstraction.

This is a bounded first slice of zama-ai/fhevm-internal#1686. It does not add lifecycle replay fixtures, proof discovery, request/decrypt flows, RPC/Geyser abstractions, or KMS changes.

## Validation

- `NO_DNA=1 cargo test --manifest-path coprocessor/fhevm-engine/Cargo.toml -p host-listener --features solana-grpc,solana-reconstruct solana_grpc_listener::account_resolution_tests --lib`
- `NO_DNA=1 cargo test --manifest-path relayer/Cargo.toml solana_proof::chain::tests --lib`
- repository coprocessor pre-commit hook (format, cargo check, CI-aligned Clippy)
- `NO_DNA=1 cargo clippy --manifest-path relayer/Cargo.toml --lib --tests -- -D warnings`
