### PR TITLE
chore(kms-connector): pre-compile mock contracts

### DIFF
--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "fhevm_gateway_bindings"
-version = "0.1.0-rc14"
+version = "0.15.0"
 dependencies = [
  "alloy",
  "serde",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "fhevm_host_bindings"
-version = "0.10.0"
+version = "0.15.0"
 dependencies = [
  "alloy",
  "serde",

--- a/kms-connector/Makefile
+++ b/kms-connector/Makefile
@@ -14,7 +14,10 @@ DATABASE_URL := postgresql://postgres:postgres@localhost:5432/kms-connector
 # Mirror the CI test environment so "passes locally" means "passes in CI".
 TEST_ENV := SQLX_OFFLINE=true RUST_BACKTRACE=full
 
-.PHONY: help db-up db-down test test-ci regen-sqlx-cache
+# Foundry root holding the mock contracts the blockchain tests deploy at runtime.
+CONTRACTS_ROOT := tests
+
+.PHONY: help db-up db-down precompile-mocks test test-ci regen-sqlx-cache
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -26,10 +29,18 @@ db-up: ## Start the shared Postgres server (waits until healthy)
 db-down: ## Stop the Postgres server and delete its volume
 	@$(DB_COMPOSE) down -v
 
-test: db-up ## Fast local loop: ensure DB is up, then run the tests (DB left running)
+# The blockchain tests deploy the mocks with `forge create`, which compiles them
+# lazily. Under nextest's parallelism, many `forge` processes otherwise race to
+# install solc into the shared ~/.svm dir and exec it mid-write, failing with
+# "Text file busy". Building once up front installs solc and warms the artifact
+# cache so the concurrent deploys only deploy.
+precompile-mocks: ## Compile the mock contracts once, serially, before the tests fan out
+	@forge build --root $(CONTRACTS_ROOT)
+
+test: db-up precompile-mocks ## Fast local loop: ensure DB is up, then run the tests (DB left running)
 	@$(TEST_ENV) cargo nextest run
 
-test-ci: ## Self-contained run: up -> test -> guaranteed teardown (mirrors CI)
+test-ci: precompile-mocks ## Self-contained run: up -> test -> guaranteed teardown (mirrors CI)
 	@$(DB_COMPOSE) up -d --wait $(DB_SERVICE)
 	@$(TEST_ENV) cargo nextest run; status=$$?; \
 	$(DB_COMPOSE) down -v; \

--- a/kms-connector/crates/utils/src/tests/setup/blockchain.rs
+++ b/kms-connector/crates/utils/src/tests/setup/blockchain.rs
@@ -10,10 +10,7 @@ use alloy::{
     transports::http::reqwest::Url,
 };
 use anyhow::anyhow;
-use fhevm_gateway_bindings::{
-    decryption::Decryption::{self, DecryptionInstance},
-    gateway_config::GatewayConfig::{self, GatewayConfigInstance},
-};
+use fhevm_gateway_bindings::decryption::Decryption::{self, DecryptionInstance};
 use fhevm_host_bindings::{
     kms_generation::KMSGeneration::{self, KMSGenerationInstance},
     protocol_config::ProtocolConfig::ProtocolConfigInstance,
@@ -38,7 +35,6 @@ pub const DEPLOYER_PRIVATE_KEY: &str =
 pub struct BlockchainInstance {
     pub provider: WalletProvider,
     pub decryption_contract: DecryptionInstance<WalletProvider>,
-    pub gateway_config_contract: GatewayConfigInstance<WalletProvider>,
     pub kms_generation_contract: KMSGenerationInstance<WalletProvider>,
     pub protocol_config_contract: ProtocolConfigInstance<WalletProvider>,
     pub anvil: AnvilInstance,
@@ -50,13 +46,11 @@ impl BlockchainInstance {
         anvil: AnvilInstance,
         provider: WalletProvider,
         decryption_address: Address,
-        gateway_config_address: Address,
         kms_generation_address: Address,
         protocol_config_address: Address,
         block_time: u64,
     ) -> Self {
         let decryption_contract = Decryption::new(decryption_address, provider.clone());
-        let gateway_config_contract = GatewayConfig::new(gateway_config_address, provider.clone());
         let kms_generation_contract = KMSGeneration::new(kms_generation_address, provider.clone());
         let protocol_config_contract =
             ProtocolConfigInstance::new(protocol_config_address, provider.clone());
@@ -64,7 +58,6 @@ impl BlockchainInstance {
         BlockchainInstance {
             provider,
             decryption_contract,
-            gateway_config_contract,
             kms_generation_contract,
             protocol_config_contract,
             anvil,
@@ -95,11 +88,6 @@ impl BlockchainInstance {
         // Deploy mock contracts via forge create
         info!("Deploying Gateway mock contracts via forge...");
 
-        let gateway_contracts_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../../gateway-contracts")
-            .canonicalize()
-            .map_err(|e| anyhow::anyhow!("Could not find gateway-contracts directory: {e}"))?;
-
         let kms_connector_tests_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../tests")
             .canonicalize()
@@ -108,7 +96,7 @@ impl BlockchainInstance {
         let rpc_url = anvil_endpoint.to_string();
         let private_key = DEPLOYER_PRIVATE_KEY.to_string();
 
-        let (decryption_addr, gateway_config_addr, kms_generation_addr, protocol_config_addr) =
+        let (decryption_addr, kms_generation_addr, protocol_config_addr) =
             tokio::task::spawn_blocking(move || {
                 let decryption = deploy_contract(
                     "contracts/DecryptionMock.sol",
@@ -116,14 +104,6 @@ impl BlockchainInstance {
                     &rpc_url,
                     &private_key,
                     &kms_connector_tests_path,
-                )?;
-
-                let gateway_config = deploy_contract(
-                    "contracts/mocks/GatewayConfigMock.sol",
-                    "GatewayConfigMock",
-                    &rpc_url,
-                    &private_key,
-                    &gateway_contracts_path,
                 )?;
 
                 let kms_generation = deploy_contract(
@@ -142,17 +122,11 @@ impl BlockchainInstance {
                     &kms_connector_tests_path,
                 )?;
 
-                Ok::<_, anyhow::Error>((
-                    decryption,
-                    gateway_config,
-                    kms_generation,
-                    protocol_config,
-                ))
+                Ok::<_, anyhow::Error>((decryption, kms_generation, protocol_config))
             })
             .await??;
 
         info!("DecryptionMock deployed at: {}", decryption_addr);
-        info!("GatewayConfigMock deployed at: {}", gateway_config_addr);
         info!("KMSGenerationMock deployed at: {}", kms_generation_addr);
         info!("ProtocolConfigMock deployed at: {}", protocol_config_addr);
 
@@ -160,7 +134,6 @@ impl BlockchainInstance {
             anvil,
             provider,
             decryption_addr,
-            gateway_config_addr,
             kms_generation_addr,
             protocol_config_addr,
             block_time,

--- a/kms-connector/crates/utils/src/tests/setup/instance.rs
+++ b/kms-connector/crates/utils/src/tests/setup/instance.rs
@@ -5,10 +5,7 @@ use crate::{
     },
 };
 use alloy::transports::http::reqwest::Url;
-use fhevm_gateway_bindings::{
-    decryption::Decryption::DecryptionInstance,
-    gateway_config::GatewayConfig::GatewayConfigInstance,
-};
+use fhevm_gateway_bindings::decryption::Decryption::DecryptionInstance;
 use fhevm_host_bindings::{
     kms_generation::KMSGeneration::KMSGenerationInstance,
     protocol_config::ProtocolConfig::ProtocolConfigInstance,
@@ -103,10 +100,6 @@ impl TestInstance {
 
     pub fn decryption_contract(&self) -> &DecryptionInstance<WalletProvider> {
         &self.blockchain().decryption_contract
-    }
-
-    pub fn gateway_config_contract(&self) -> &GatewayConfigInstance<WalletProvider> {
-        &self.blockchain().gateway_config_contract
     }
 
     pub fn kms_generation_contract(&self) -> &KMSGenerationInstance<WalletProvider> {


### PR DESCRIPTION
This PR:
- pre-compile the mock contracts before running the kms-connector tests
  - this avoids such [race scenario](https://github.com/zama-ai/fhevm/actions/runs/29262843733/job/86860437793)
- remove the deployment of the `GatewayConfigMock` contract which was unused and will no longer be available once this other [PR](https://github.com/zama-ai/fhevm/pull/3195) lands on `main`