### PR TITLE
refactor(listener): share Solana transaction decoder

### DIFF
--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -157,6 +157,7 @@ jobs:
               # Keep this list aligned with non-excluded solana/Cargo.toml workspace members.
               def components: [
                 {label: "zama-solana-acl", path: "/crates/zama-solana-acl/"},
+                {label: "zama-solana-transaction", path: "/crates/zama-solana-transaction/"},
                 {label: "solana-ed25519-instruction", path: "/crates/solana-ed25519-instruction/"},
                 {label: "zama-fhe", path: "/crates/zama-fhe/"},
                 {label: "zama-host", path: "/programs/zama-host/"},

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -5372,6 +5372,7 @@ dependencies = [
  "yellowstone-grpc-proto",
  "zama-host",
  "zama-solana-acl",
+ "zama-solana-transaction",
 ]
 
 [[package]]
@@ -14077,6 +14078,10 @@ dependencies = [
  "sha2 0.10.9",
  "solana-sha256-hasher",
 ]
+
+[[package]]
+name = "zama-solana-transaction"
+version = "0.1.0"
 
 [[package]]
 name = "zerocopy"

--- a/coprocessor/fhevm-engine/host-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/host-listener/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [features]
 default = []
 test_bypass_key_extraction = []
-solana-grpc = ["dep:yellowstone-grpc-proto", "dep:tonic"]
+solana-grpc = ["dep:yellowstone-grpc-proto", "dep:tonic", "dep:zama-solana-transaction"]
 solana-reconstruct = ["dep:zama-host", "dep:anchor-lang", "dep:zama-solana-acl"]
 
 [[bin]]
@@ -86,6 +86,7 @@ zama-host = { path = "../../../solana/programs/zama-host", default-features = fa
 anchor-lang = { version = "1.0.2", optional = true }
 # derive_value_key for durable fhe_eval output bindings (same parity rationale).
 zama-solana-acl = { path = "../../../solana/crates/zama-solana-acl", optional = true }
+zama-solana-transaction = { path = "../../../solana/crates/zama-solana-transaction", optional = true }
 
 # local dependencies
 fhevm-engine-common = { path = "../fhevm-engine-common" }

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -272,6 +272,28 @@ fn decode_transaction_instructions(
     message: &TransactionMessage,
     meta: &TransactionStatusMeta,
 ) -> Result<Vec<crate::solana_reconstruct::DecodedInstruction>> {
+    resolve_transaction_instructions(message, meta)?
+        .into_iter()
+        .map(|instruction| {
+            Ok(crate::solana_reconstruct::DecodedInstruction {
+                program: bs58::encode(instruction.program_id).into_string(),
+                data: instruction.data,
+                accounts: instruction.accounts,
+                top_level_index: u32::try_from(instruction.top_level_index)
+                    .context("top-level instruction index exceeds u32")?,
+                is_inner: instruction.stack_height != 1,
+            })
+        })
+        .collect()
+}
+
+fn resolve_transaction_instructions(
+    message: &TransactionMessage,
+    meta: &TransactionStatusMeta,
+) -> Result<Vec<zama_solana_transaction::ResolvedInstruction>> {
+    if meta.err.is_some() {
+        anyhow::bail!("failed transaction cannot be decoded");
+    }
     let static_keys = validated_account_keys(&message.account_keys)?;
     let loaded_writable_keys =
         validated_account_keys(&meta.loaded_writable_addresses)?;
@@ -320,19 +342,7 @@ fn decode_transaction_instructions(
         top_level,
         inner_groups,
     )
-    .map_err(anyhow::Error::from)?
-    .into_iter()
-    .map(|instruction| {
-        Ok(crate::solana_reconstruct::DecodedInstruction {
-            program: bs58::encode(instruction.program_id).into_string(),
-            data: instruction.data,
-            accounts: instruction.accounts,
-            top_level_index: u32::try_from(instruction.top_level_index)
-                .context("top-level instruction index exceeds u32")?,
-            is_inner: instruction.stack_height != 1,
-        })
-    })
-    .collect()
+    .map_err(anyhow::Error::from)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -846,10 +856,10 @@ fn compute_result_handle(
 
 #[cfg(test)]
 mod account_resolution_tests {
-    use super::{decode_transaction_instructions, validated_account_keys};
+    use super::{resolve_transaction_instructions, validated_account_keys};
     use yellowstone_grpc_proto::prelude::{
         CompiledInstruction, InnerInstruction, InnerInstructions,
-        Message as TransactionMessage, TransactionStatusMeta,
+        Message as TransactionMessage, TransactionError, TransactionStatusMeta,
     };
 
     mod shared_fixtures {
@@ -860,17 +870,15 @@ mod account_resolution_tests {
     }
 
     use shared_fixtures::{
-        transaction_decoding_fixtures, ExpectedInstruction, ExpectedOutcome,
+        fixture_key, transaction_decoding_fixtures, ExpectedInstruction,
+        ExpectedOutcome,
     };
-
-    fn key(tag: u8) -> Vec<u8> {
-        vec![tag; 32]
-    }
 
     #[test]
     fn rejects_malformed_account_key_length() {
-        let err = validated_account_keys([&key(1), &vec![2; 31]])
-            .expect_err("short account keys must fail closed");
+        let err =
+            validated_account_keys([&fixture_key(1).to_vec(), &vec![2; 31]])
+                .expect_err("short account keys must fail closed");
 
         assert!(err.to_string().contains(
             "account key 1 has invalid length 31, expected 32 bytes"
@@ -912,7 +920,7 @@ mod account_resolution_tests {
                     .static_account_tags
                     .iter()
                     .copied()
-                    .map(key)
+                    .map(|tag| fixture_key(tag).to_vec())
                     .collect(),
                 instructions: top_level,
                 ..Default::default()
@@ -923,18 +931,18 @@ mod account_resolution_tests {
                     .loaded_writable_account_tags
                     .iter()
                     .copied()
-                    .map(key)
+                    .map(|tag| fixture_key(tag).to_vec())
                     .collect(),
                 loaded_readonly_addresses: fixture
                     .loaded_readonly_account_tags
                     .iter()
                     .copied()
-                    .map(key)
+                    .map(|tag| fixture_key(tag).to_vec())
                     .collect(),
                 ..Default::default()
             };
 
-            let decoded = decode_transaction_instructions(&message, &meta);
+            let decoded = resolve_transaction_instructions(&message, &meta);
             match &fixture.expected {
                 ExpectedOutcome::Accept { instructions } => {
                     let actual: Vec<ExpectedInstruction> = decoded
@@ -942,30 +950,45 @@ mod account_resolution_tests {
                             panic!("{}: {error}", fixture.name)
                         })
                         .into_iter()
-                        .map(|instruction| {
-                            let program = bs58::decode(instruction.program)
-                                .into_vec()
-                                .unwrap();
-                            ExpectedInstruction {
-                                program_tag: program[0],
-                                account_tags: instruction
-                                    .accounts
-                                    .iter()
-                                    .map(|account| account[0])
-                                    .collect(),
-                                data: instruction.data,
-                                top_level_index: instruction.top_level_index,
-                                is_inner: instruction.is_inner,
-                            }
+                        .map(|instruction| ExpectedInstruction {
+                            program: instruction.program_id,
+                            accounts: instruction.accounts,
+                            data: instruction.data,
+                            top_level_index: u32::try_from(
+                                instruction.top_level_index,
+                            )
+                            .unwrap(),
+                            stack_height: instruction.stack_height,
                         })
                         .collect();
-                    assert_eq!(actual, *instructions, "{}", fixture.name);
+                    let expected = instructions
+                        .iter()
+                        .map(|instruction| instruction.resolve())
+                        .collect::<Vec<_>>();
+                    assert_eq!(actual, expected, "{}", fixture.name);
                 }
                 ExpectedOutcome::Reject => {
                     assert!(decoded.is_err(), "{}", fixture.name);
                 }
             }
         }
+    }
+
+    #[test]
+    fn failed_transaction_is_rejected_before_instruction_decoding() {
+        let message = TransactionMessage {
+            account_keys: vec![vec![1; 31]],
+            ..Default::default()
+        };
+        let meta = TransactionStatusMeta {
+            err: Some(TransactionError { err: vec![1] }),
+            ..Default::default()
+        };
+
+        let err = resolve_transaction_instructions(&message, &meta)
+            .expect_err("failed transactions must be rejected");
+
+        assert!(err.to_string().contains("failed transaction"));
     }
 }
 

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -292,7 +292,7 @@ fn resolve_transaction_instructions(
     meta: &TransactionStatusMeta,
 ) -> Result<Vec<zama_solana_transaction::ResolvedInstruction>> {
     if meta.err.is_some() {
-        anyhow::bail!("failed transaction cannot be decoded");
+        return Ok(Vec::new());
     }
     let static_keys = validated_account_keys(&message.account_keys)?;
     let loaded_writable_keys =
@@ -975,7 +975,7 @@ mod account_resolution_tests {
     }
 
     #[test]
-    fn failed_transaction_is_rejected_before_instruction_decoding() {
+    fn failed_transaction_is_ignored_before_instruction_decoding() {
         let message = TransactionMessage {
             account_keys: vec![vec![1; 31]],
             ..Default::default()
@@ -985,10 +985,10 @@ mod account_resolution_tests {
             ..Default::default()
         };
 
-        let err = resolve_transaction_instructions(&message, &meta)
-            .expect_err("failed transactions must be rejected");
+        let instructions = resolve_transaction_instructions(&message, &meta)
+            .expect("failed transactions are valid chain history");
 
-        assert!(err.to_string().contains("failed transaction"));
+        assert!(instructions.is_empty());
     }
 }
 

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -19,11 +19,15 @@ use tonic::metadata::{Ascii, MetadataValue};
 use tonic::transport::Channel;
 use yellowstone_grpc_proto::geyser::geyser_client::GeyserClient;
 use yellowstone_grpc_proto::prelude::{
-    subscribe_update::UpdateOneof, CommitmentLevel, CompiledInstruction,
-    InnerInstruction, InnerInstructions, Message as TransactionMessage,
-    SubscribeRequest, SubscribeRequestFilterAccounts,
-    SubscribeRequestFilterBlocksMeta, SubscribeRequestFilterTransactions,
-    SubscribeUpdateTransactionInfo, TransactionStatusMeta,
+    subscribe_update::UpdateOneof, CommitmentLevel,
+    Message as TransactionMessage, SubscribeRequest,
+    SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta,
+    SubscribeRequestFilterTransactions, SubscribeUpdateTransactionInfo,
+    TransactionStatusMeta,
+};
+use zama_solana_transaction::{
+    CompiledInstruction as CanonicalCompiledInstruction,
+    InnerInstructionGroup as CanonicalInnerInstructionGroup,
 };
 
 use crate::database::tfhe_event_propagate::Database;
@@ -264,124 +268,71 @@ fn validated_account_keys<'a>(
         .collect()
 }
 
-fn resolve_instruction(
-    account_keys: &[[u8; 32]],
-    top_level_index: u32,
-    is_inner: bool,
-    program_id_index: u32,
-    data: &[u8],
-    account_indices: &[u8],
-) -> Result<crate::solana_reconstruct::DecodedInstruction> {
-    let program =
-        account_keys.get(program_id_index as usize).ok_or_else(|| {
-            anyhow!("program_id_index {program_id_index} out of range")
-        })?;
-    let accounts = account_indices
-        .iter()
-        .map(|&index| {
-            account_keys.get(index as usize).copied().ok_or_else(|| {
-                anyhow!("instruction account index {index} out of range")
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(crate::solana_reconstruct::DecodedInstruction {
-        program: bs58::encode(program).into_string(),
-        data: data.to_vec(),
-        accounts,
-        top_level_index,
-        is_inner,
-    })
-}
-
-fn resolve_execution_order(
-    account_keys: &[[u8; 32]],
-    top_level: &[CompiledInstruction],
-    inner_groups: &[InnerInstructions],
-) -> Result<Vec<crate::solana_reconstruct::DecodedInstruction>> {
-    let mut inner_by_index: HashMap<u32, &[InnerInstruction]> = HashMap::new();
-    for group in inner_groups {
-        if group.index as usize >= top_level.len() {
-            return Err(anyhow!(
-                "inner-instruction group index {} is out of range",
-                group.index
-            ));
-        }
-        if inner_by_index
-            .insert(group.index, group.instructions.as_slice())
-            .is_some()
-        {
-            return Err(anyhow!(
-                "duplicate inner-instruction group index {}",
-                group.index
-            ));
-        }
-        let mut previous_height = 1u32;
-        for (position, instruction) in group.instructions.iter().enumerate() {
-            let height = instruction.stack_height.ok_or_else(|| {
-                anyhow!(
-                    "inner instruction {position} in group {} has no stackHeight",
-                    group.index
-                )
-            })?;
-            if height < 2
-                || (position == 0 && height != 2)
-                || height > previous_height.saturating_add(1)
-            {
-                return Err(anyhow!(
-                    "impossible stackHeight {height} at inner instruction {position} in group {}",
-                    group.index
-                ));
-            }
-            previous_height = height;
-        }
-    }
-
-    let mut ordered = Vec::new();
-    for (index, instruction) in top_level.iter().enumerate() {
-        let index = index as u32;
-        ordered.push(resolve_instruction(
-            account_keys,
-            index,
-            false,
-            instruction.program_id_index,
-            &instruction.data,
-            &instruction.accounts,
-        )?);
-        if let Some(inner) = inner_by_index.get(&index) {
-            for instruction in inner.iter() {
-                ordered.push(resolve_instruction(
-                    account_keys,
-                    index,
-                    true,
-                    instruction.program_id_index,
-                    &instruction.data,
-                    &instruction.accounts,
-                )?);
-            }
-        }
-    }
-    Ok(ordered)
-}
-
 fn decode_transaction_instructions(
     message: &TransactionMessage,
     meta: &TransactionStatusMeta,
 ) -> Result<Vec<crate::solana_reconstruct::DecodedInstruction>> {
-    // Solana instruction indexes address static keys ++ ALT writable ++ ALT
-    // readonly. Keep assembly and instruction decoding in one production path.
-    let account_keys = validated_account_keys(
-        message
-            .account_keys
-            .iter()
-            .chain(meta.loaded_writable_addresses.iter())
-            .chain(meta.loaded_readonly_addresses.iter()),
-    )?;
-    resolve_execution_order(
-        &account_keys,
-        &message.instructions,
-        &meta.inner_instructions,
+    let static_keys = validated_account_keys(&message.account_keys)?;
+    let loaded_writable_keys =
+        validated_account_keys(&meta.loaded_writable_addresses)?;
+    let loaded_readonly_keys =
+        validated_account_keys(&meta.loaded_readonly_addresses)?;
+    let top_level = message
+        .instructions
+        .iter()
+        .map(|instruction| CanonicalCompiledInstruction {
+            program_id_index: instruction.program_id_index as usize,
+            account_indices: instruction
+                .accounts
+                .iter()
+                .map(|index| *index as usize)
+                .collect(),
+            data: instruction.data.clone(),
+            stack_height: None,
+        })
+        .collect::<Vec<_>>();
+    let inner_groups = meta
+        .inner_instructions
+        .iter()
+        .map(|group| CanonicalInnerInstructionGroup {
+            top_level_index: group.index as usize,
+            instructions: group
+                .instructions
+                .iter()
+                .map(|instruction| CanonicalCompiledInstruction {
+                    program_id_index: instruction.program_id_index as usize,
+                    account_indices: instruction
+                        .accounts
+                        .iter()
+                        .map(|index| *index as usize)
+                        .collect(),
+                    data: instruction.data.clone(),
+                    stack_height: instruction.stack_height,
+                })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+
+    zama_solana_transaction::resolve_transaction(
+        &static_keys,
+        &loaded_writable_keys,
+        &loaded_readonly_keys,
+        top_level,
+        inner_groups,
     )
+    .map_err(anyhow::Error::from)?
+    .into_iter()
+    .map(|instruction| {
+        Ok(crate::solana_reconstruct::DecodedInstruction {
+            program: bs58::encode(instruction.program_id).into_string(),
+            data: instruction.data,
+            accounts: instruction.accounts,
+            top_level_index: u32::try_from(instruction.top_level_index)
+                .context("top-level instruction index exceeds u32")?,
+            is_inner: instruction.stack_height != 1,
+        })
+    })
+    .collect()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "validator",
  "zama-host",
  "zama-solana-acl",
+ "zama-solana-transaction",
 ]
 
 [[package]]
@@ -8095,6 +8096,10 @@ dependencies = [
  "sha2 0.10.9",
  "solana-sha256-hasher",
 ]
+
+[[package]]
+name = "zama-solana-transaction"
+version = "0.1.0"
 
 [[package]]
 name = "zerocopy"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -62,6 +62,7 @@ user-decryption-signature = { path = "../shared/user-decryption-signature" }
 # Shared MMR/lineage proof math for the Solana ACL (RFC-024); source of truth
 # also used by the zama-host program and the KMS connector.
 zama-solana-acl = { path = "../solana/crates/zama-solana-acl" }
+zama-solana-transaction = { path = "../solana/crates/zama-solana-transaction" }
 zama-host = { path = "../solana/programs/zama-host", features = ["no-entrypoint"] }
 borsh = { version = "1", features = ["derive"] }
 utoipa = { version = "5.4.0", features = ["axum_extras", "preserve_path_order"] }

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -245,14 +245,14 @@ fn decode_transaction_result(
     signature: &str,
     parsed: GetTransactionResult,
 ) -> Result<ChainTransaction, ChainError> {
-    if parsed.meta.as_ref().and_then(|m| m.err.as_ref()).is_some() {
+    let meta = parsed
+        .meta
+        .as_ref()
+        .ok_or_else(|| ChainError::Rpc("transaction metadata is missing".to_string()))?;
+    if meta.err.is_some() {
         // This guard deliberately precedes account-key and instruction decoding:
         // failed transactions committed no state and must contribute no leaves.
-        return Ok(ChainTransaction {
-            signature: signature.to_string(),
-            slot: parsed.slot,
-            instructions: Vec::new(),
-        });
+        return Err(ChainError::Rpc("transaction failed".to_string()));
     }
     let static_keys: Vec<[u8; 32]> = parsed
         .transaction
@@ -261,26 +261,23 @@ fn decode_transaction_result(
         .iter()
         .map(|s| base58_to_32(s))
         .collect::<Result<_, _>>()?;
-    let (loaded_writable_keys, loaded_readonly_keys) = if let Some(loaded) = parsed
-        .meta
-        .as_ref()
-        .and_then(|m| m.loaded_addresses.as_ref())
-    {
-        (
-            loaded
-                .writable
-                .iter()
-                .map(|address| base58_to_32(address))
-                .collect::<Result<Vec<_>, _>>()?,
-            loaded
-                .readonly
-                .iter()
-                .map(|address| base58_to_32(address))
-                .collect::<Result<Vec<_>, _>>()?,
-        )
-    } else {
-        (Vec::new(), Vec::new())
-    };
+    let (loaded_writable_keys, loaded_readonly_keys) =
+        if let Some(loaded) = meta.loaded_addresses.as_ref() {
+            (
+                loaded
+                    .writable
+                    .iter()
+                    .map(|address| base58_to_32(address))
+                    .collect::<Result<Vec<_>, _>>()?,
+                loaded
+                    .readonly
+                    .iter()
+                    .map(|address| base58_to_32(address))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
     let top_level = parsed
         .transaction
         .message
@@ -288,26 +285,20 @@ fn decode_transaction_result(
         .iter()
         .map(|instruction| canonical_instruction(instruction, false))
         .collect::<Result<Vec<_>, _>>()?;
-    let inner_groups = parsed
-        .meta
-        .as_ref()
-        .map(|meta| {
-            meta.inner_instructions
-                .iter()
-                .map(|group| {
-                    Ok(CanonicalInnerInstructionGroup {
-                        top_level_index: group.index,
-                        instructions: group
-                            .instructions
-                            .iter()
-                            .map(|instruction| canonical_instruction(instruction, true))
-                            .collect::<Result<Vec<_>, ChainError>>()?,
-                    })
-                })
-                .collect::<Result<Vec<_>, ChainError>>()
+    let inner_groups = meta
+        .inner_instructions
+        .iter()
+        .map(|group| {
+            Ok(CanonicalInnerInstructionGroup {
+                top_level_index: group.index,
+                instructions: group
+                    .instructions
+                    .iter()
+                    .map(|instruction| canonical_instruction(instruction, true))
+                    .collect::<Result<Vec<_>, ChainError>>()?,
+            })
         })
-        .transpose()?
-        .unwrap_or_default();
+        .collect::<Result<Vec<_>, ChainError>>()?;
     let instructions = zama_solana_transaction::resolve_transaction(
         &static_keys,
         &loaded_writable_keys,
@@ -487,8 +478,8 @@ mod tests {
     }
 
     use shared_fixtures::{
-        base58_encode as fixture_base58_encode, transaction_decoding_fixtures, ExpectedInstruction,
-        ExpectedOutcome,
+        base58_encode as fixture_base58_encode, fixture_key, transaction_decoding_fixtures,
+        ExpectedInstruction, ExpectedOutcome,
     };
 
     #[test]
@@ -536,7 +527,7 @@ mod tests {
                         "accountKeys": fixture
                             .static_account_tags
                             .iter()
-                            .map(|tag| fixture_base58_encode(&[*tag; 32]))
+                            .map(|tag| fixture_base58_encode(&fixture_key(*tag)))
                             .collect::<Vec<_>>(),
                         "instructions": top_level,
                     }
@@ -548,12 +539,12 @@ mod tests {
                         "writable": fixture
                             .loaded_writable_account_tags
                             .iter()
-                            .map(|tag| fixture_base58_encode(&[*tag; 32]))
+                            .map(|tag| fixture_base58_encode(&fixture_key(*tag)))
                             .collect::<Vec<_>>(),
                         "readonly": fixture
                             .loaded_readonly_account_tags
                             .iter()
-                            .map(|tag| fixture_base58_encode(&[*tag; 32]))
+                            .map(|tag| fixture_base58_encode(&fixture_key(*tag)))
                             .collect::<Vec<_>>(),
                     }
                 }
@@ -566,18 +557,20 @@ mod tests {
                         .unwrap_or_else(|error| panic!("{}: {error}", fixture.name))
                         .into_iter()
                         .map(|instruction| ExpectedInstruction {
-                            program_tag: instruction.program_id[0],
-                            account_tags: instruction
-                                .accounts
-                                .iter()
-                                .map(|account| account[0])
-                                .collect(),
+                            program: instruction.program_id,
+                            accounts: instruction.accounts,
                             data: instruction.data,
                             top_level_index: instruction.top_level_index as u32,
-                            is_inner: instruction.stack_height != Some(1),
+                            stack_height: instruction
+                                .stack_height
+                                .expect("resolved instruction has stack height"),
                         })
                         .collect();
-                    assert_eq!(actual, *instructions, "{}", fixture.name);
+                    let expected = instructions
+                        .iter()
+                        .map(|instruction| instruction.resolve())
+                        .collect::<Vec<_>>();
+                    assert_eq!(actual, expected, "{}", fixture.name);
                 }
                 ExpectedOutcome::Reject => {
                     assert!(decoded.is_err(), "{}", fixture.name);
@@ -638,9 +631,27 @@ mod tests {
             }
         });
 
-        let transaction = decode_transaction_value("failed", result).unwrap();
+        let error = decode_transaction_value("failed", result)
+            .expect_err("failed transactions must be rejected");
 
-        assert!(transaction.instructions.is_empty());
-        assert_eq!(transaction.slot, 42);
+        assert!(error.to_string().contains("transaction failed"));
+    }
+
+    #[test]
+    fn missing_transaction_meta_is_rejected_before_instruction_decoding() {
+        let result = json!({
+            "slot": 42,
+            "transaction": { "message": {
+                // Deliberately malformed: decoding this key would fail.
+                "accountKeys": ["not-base58!"],
+                "instructions": []
+            }},
+            "meta": null
+        });
+
+        let error = decode_transaction_value("missing-meta", result)
+            .expect_err("transactions without metadata must be rejected");
+
+        assert!(error.to_string().contains("metadata is missing"));
     }
 }

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -252,7 +252,11 @@ fn decode_transaction_result(
     if meta.err.is_some() {
         // This guard deliberately precedes account-key and instruction decoding:
         // failed transactions committed no state and must contribute no leaves.
-        return Err(ChainError::Rpc("transaction failed".to_string()));
+        return Ok(ChainTransaction {
+            signature: signature.to_string(),
+            slot: parsed.slot,
+            instructions: Vec::new(),
+        });
     }
     let static_keys: Vec<[u8; 32]> = parsed
         .transaction
@@ -613,7 +617,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_transaction_is_rejected_before_instruction_decoding() {
+    fn failed_transaction_is_ignored_before_instruction_decoding() {
         let result = json!({
             "slot": 42,
             "transaction": { "message": {
@@ -631,10 +635,11 @@ mod tests {
             }
         });
 
-        let error = decode_transaction_value("failed", result)
-            .expect_err("failed transactions must be rejected");
+        let transaction = decode_transaction_value("failed", result)
+            .expect("failed transactions are valid chain history");
 
-        assert!(error.to_string().contains("transaction failed"));
+        assert!(transaction.instructions.is_empty());
+        assert_eq!(transaction.slot, 42);
     }
 
     #[test]

--- a/relayer/src/solana_proof/chain.rs
+++ b/relayer/src/solana_proof/chain.rs
@@ -13,6 +13,10 @@
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::json;
+use zama_solana_transaction::{
+    CompiledInstruction as CanonicalCompiledInstruction,
+    InnerInstructionGroup as CanonicalInnerInstructionGroup,
+};
 
 use crate::solana_proof::decode::RawInstruction;
 
@@ -250,31 +254,77 @@ fn decode_transaction_result(
             instructions: Vec::new(),
         });
     }
-    let mut account_keys: Vec<[u8; 32]> = parsed
+    let static_keys: Vec<[u8; 32]> = parsed
         .transaction
         .message
         .account_keys
         .iter()
         .map(|s| base58_to_32(s))
         .collect::<Result<_, _>>()?;
-    if let Some(loaded) = parsed
+    let (loaded_writable_keys, loaded_readonly_keys) = if let Some(loaded) = parsed
         .meta
         .as_ref()
         .and_then(|m| m.loaded_addresses.as_ref())
     {
-        for addr in loaded.writable.iter().chain(loaded.readonly.iter()) {
-            account_keys.push(base58_to_32(addr)?);
-        }
-    }
-    let instructions = flatten_execution_order(
-        &parsed.transaction.message.instructions,
-        parsed
-            .meta
-            .as_ref()
-            .map(|m| m.inner_instructions.as_slice())
-            .unwrap_or(&[]),
-        &account_keys,
-    )?;
+        (
+            loaded
+                .writable
+                .iter()
+                .map(|address| base58_to_32(address))
+                .collect::<Result<Vec<_>, _>>()?,
+            loaded
+                .readonly
+                .iter()
+                .map(|address| base58_to_32(address))
+                .collect::<Result<Vec<_>, _>>()?,
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    let top_level = parsed
+        .transaction
+        .message
+        .instructions
+        .iter()
+        .map(|instruction| canonical_instruction(instruction, false))
+        .collect::<Result<Vec<_>, _>>()?;
+    let inner_groups = parsed
+        .meta
+        .as_ref()
+        .map(|meta| {
+            meta.inner_instructions
+                .iter()
+                .map(|group| {
+                    Ok(CanonicalInnerInstructionGroup {
+                        top_level_index: group.index,
+                        instructions: group
+                            .instructions
+                            .iter()
+                            .map(|instruction| canonical_instruction(instruction, true))
+                            .collect::<Result<Vec<_>, ChainError>>()?,
+                    })
+                })
+                .collect::<Result<Vec<_>, ChainError>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let instructions = zama_solana_transaction::resolve_transaction(
+        &static_keys,
+        &loaded_writable_keys,
+        &loaded_readonly_keys,
+        top_level,
+        inner_groups,
+    )
+    .map_err(|error| ChainError::Rpc(error.to_string()))?
+    .into_iter()
+    .map(|instruction| RawInstruction {
+        program_id: instruction.program_id,
+        accounts: instruction.accounts,
+        data: instruction.data,
+        top_level_index: instruction.top_level_index,
+        stack_height: Some(instruction.stack_height),
+    })
+    .collect();
     Ok(ChainTransaction {
         signature: signature.to_string(),
         slot: parsed.slot,
@@ -290,35 +340,21 @@ fn decode_transaction_value(
     decode_transaction_result(signature, parsed)
 }
 
-fn compiled_to_raw(
-    ix: &CompiledIx,
-    account_keys: &[[u8; 32]],
-    top_level_index: usize,
+fn canonical_instruction(
+    instruction: &CompiledIx,
     is_inner: bool,
-) -> Result<RawInstruction, ChainError> {
-    let program_id = *account_keys
-        .get(ix.program_id_index)
-        .ok_or_else(|| ChainError::Rpc("programIdIndex out of range".to_string()))?;
-    let accounts = ix
-        .accounts
-        .iter()
-        .map(|&idx| {
-            account_keys
-                .get(idx)
-                .copied()
-                .ok_or_else(|| ChainError::Rpc("account index out of range".to_string()))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let data = bs58_decode(&ix.data)?;
-    Ok(RawInstruction {
-        program_id,
-        accounts,
-        data,
-        top_level_index,
-        // RPC omits stackHeight on message instructions; their height is known.
-        // Inner instructions retain the RPC field so missing nesting metadata
-        // can be rejected by the lifecycle decoder.
-        stack_height: if is_inner { ix.stack_height } else { Some(1) },
+) -> Result<CanonicalCompiledInstruction, ChainError> {
+    Ok(CanonicalCompiledInstruction {
+        program_id_index: instruction.program_id_index,
+        account_indices: instruction.accounts.clone(),
+        data: bs58_decode(&instruction.data)?,
+        // RPC omits stackHeight on message instructions; the canonical decoder
+        // assigns their known height of one.
+        stack_height: if is_inner {
+            instruction.stack_height
+        } else {
+            None
+        },
     })
 }
 
@@ -404,61 +440,6 @@ impl ChainFetcher for RpcChainFetcher {
             leaf_count: decoded.leaf_count,
         }))
     }
-}
-
-/// Interleaves top-level instructions with the inner instructions they spawned
-/// via CPI, in on-chain execution order: top-level instruction `i` runs, then
-/// (if any) the inner instructions Solana recorded at group `index == i`.
-fn flatten_execution_order(
-    top_level: &[CompiledIx],
-    inner_groups: &[InnerIxGroup],
-    account_keys: &[[u8; 32]],
-) -> Result<Vec<RawInstruction>, ChainError> {
-    let mut by_index: std::collections::HashMap<usize, &Vec<CompiledIx>> =
-        std::collections::HashMap::new();
-    for group in inner_groups {
-        if group.index >= top_level.len() {
-            return Err(ChainError::Rpc(format!(
-                "inner-instruction group index {} is out of range",
-                group.index
-            )));
-        }
-        if by_index.insert(group.index, &group.instructions).is_some() {
-            return Err(ChainError::Rpc(format!(
-                "duplicate inner-instruction group index {}",
-                group.index
-            )));
-        }
-        let mut previous_height = 1u32;
-        for (position, instruction) in group.instructions.iter().enumerate() {
-            let height = instruction.stack_height.ok_or_else(|| {
-                ChainError::Rpc(format!(
-                    "inner instruction {position} in group {} has no stackHeight",
-                    group.index
-                ))
-            })?;
-            if height < 2
-                || (position == 0 && height != 2)
-                || height > previous_height.saturating_add(1)
-            {
-                return Err(ChainError::Rpc(format!(
-                    "impossible stackHeight {height} at inner instruction {position} in group {}",
-                    group.index
-                )));
-            }
-            previous_height = height;
-        }
-    }
-    let mut out = Vec::new();
-    for (i, ix) in top_level.iter().enumerate() {
-        out.push(compiled_to_raw(ix, account_keys, i, false)?);
-        if let Some(inner) = by_index.get(&i) {
-            for inner_ix in inner.iter() {
-                out.push(compiled_to_raw(inner_ix, account_keys, i, true)?);
-            }
-        }
-    }
-    Ok(out)
 }
 
 fn base64_decode(input: &str) -> Result<Vec<u8>, String> {

--- a/sdk/js-sdk/src/solana/actions/confidentialTransfer.ts
+++ b/sdk/js-sdk/src/solana/actions/confidentialTransfer.ts
@@ -185,8 +185,19 @@ export async function confidentialTransfer(
       sigVerify: true,
     })
     .send();
-  if (simulation.value.err !== null)
-    throw new Error(`confidential transfer simulation failed: ${JSON.stringify(simulation.value.err)}`);
+  if (simulation.value.err !== null) {
+    // @solana/kit InstructionError payloads can contain bigint Custom codes;
+    // plain JSON.stringify throws and hides the real on-chain failure.
+    const err = JSON.stringify(simulation.value.err, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
+    const logs = simulation.value.logs?.join('\n') ?? '';
+    throw new Error(
+      logs.length > 0
+        ? `confidential transfer simulation failed: ${err}\n${logs}`
+        : `confidential transfer simulation failed: ${err}`,
+    );
+  }
   await sendAndConfirmTransactionFactory({ rpc: parameters.rpc, rpcSubscriptions: parameters.rpcSubscriptions })(
     transaction,
     {

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -4989,6 +4989,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "zama-solana-transaction"
+version = "0.1.0"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/solana-ed25519-instruction",
     "crates/zama-fhe",
     "crates/zama-solana-acl",
+    "crates/zama-solana-transaction",
     "programs/confidential-deposit-app",
     "programs/confidential-token",
     "programs/demo-vault",

--- a/solana/crates/zama-solana-transaction/Cargo.toml
+++ b/solana/crates/zama-solana-transaction/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "zama-solana-transaction"
+version = "0.1.0"
+edition = "2021"
+license = "BSD-3-Clause-Clear"

--- a/solana/crates/zama-solana-transaction/src/lib.rs
+++ b/solana/crates/zama-solana-transaction/src/lib.rs
@@ -1,0 +1,348 @@
+//! Provider-independent resolution of Solana compiled transaction instructions.
+//!
+//! RPC and streaming adapters parse their own wire formats, then pass raw keys
+//! and compiled instructions here. This crate owns the Solana transaction
+//! semantics shared by both paths without depending on a Solana SDK version.
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompiledInstruction {
+    pub program_id_index: usize,
+    pub account_indices: Vec<usize>,
+    pub data: Vec<u8>,
+    /// Required for inner instructions. Ignored for top-level instructions,
+    /// whose stack height is always one.
+    pub stack_height: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InnerInstructionGroup {
+    pub top_level_index: usize,
+    pub instructions: Vec<CompiledInstruction>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedInstruction {
+    pub program_id: [u8; 32],
+    pub accounts: Vec<[u8; 32]>,
+    pub data: Vec<u8>,
+    pub top_level_index: usize,
+    pub stack_height: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    ProgramIndexOutOfRange {
+        index: usize,
+    },
+    AccountIndexOutOfRange {
+        index: usize,
+    },
+    OrphanInnerGroup {
+        top_level_index: usize,
+    },
+    DuplicateInnerGroup {
+        top_level_index: usize,
+    },
+    MissingStackHeight {
+        top_level_index: usize,
+        position: usize,
+    },
+    InvalidStackHeight {
+        top_level_index: usize,
+        position: usize,
+        height: u32,
+    },
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProgramIndexOutOfRange { index } => {
+                write!(f, "program id index {index} is out of range")
+            }
+            Self::AccountIndexOutOfRange { index } => {
+                write!(f, "account index {index} is out of range")
+            }
+            Self::OrphanInnerGroup { top_level_index } => write!(
+                f,
+                "inner-instruction group index {top_level_index} is out of range"
+            ),
+            Self::DuplicateInnerGroup { top_level_index } => write!(
+                f,
+                "duplicate inner-instruction group index {top_level_index}"
+            ),
+            Self::MissingStackHeight {
+                top_level_index,
+                position,
+            } => write!(
+                f,
+                "inner instruction {position} in group {top_level_index} has no stack height"
+            ),
+            Self::InvalidStackHeight {
+                top_level_index,
+                position,
+                height,
+            } => write!(
+                f,
+                "impossible stack height {height} at inner instruction {position} in group {top_level_index}"
+            ),
+        }
+    }
+}
+
+impl Error for DecodeError {}
+
+/// Resolves a successful transaction's instructions in execution order.
+///
+/// Account indexes address static keys followed by writable ALT keys followed
+/// by readonly ALT keys. Each top-level instruction is immediately followed by
+/// the inner instructions it invoked, in the order recorded by Solana.
+pub fn resolve_transaction(
+    static_keys: &[[u8; 32]],
+    loaded_writable_keys: &[[u8; 32]],
+    loaded_readonly_keys: &[[u8; 32]],
+    top_level: Vec<CompiledInstruction>,
+    inner_groups: Vec<InnerInstructionGroup>,
+) -> Result<Vec<ResolvedInstruction>, DecodeError> {
+    let account_keys: Vec<[u8; 32]> = static_keys
+        .iter()
+        .chain(loaded_writable_keys)
+        .chain(loaded_readonly_keys)
+        .copied()
+        .collect();
+
+    let mut inner_by_index = HashMap::with_capacity(inner_groups.len());
+    for group in inner_groups {
+        if group.top_level_index >= top_level.len() {
+            return Err(DecodeError::OrphanInnerGroup {
+                top_level_index: group.top_level_index,
+            });
+        }
+        if inner_by_index
+            .insert(group.top_level_index, group.instructions)
+            .is_some()
+        {
+            return Err(DecodeError::DuplicateInnerGroup {
+                top_level_index: group.top_level_index,
+            });
+        }
+        validate_inner_stack(
+            inner_by_index
+                .get(&group.top_level_index)
+                .expect("inner group was just inserted"),
+            group.top_level_index,
+        )?;
+    }
+
+    let instruction_count = top_level.len() + inner_by_index.values().map(Vec::len).sum::<usize>();
+    let mut resolved = Vec::with_capacity(instruction_count);
+    for (top_level_index, instruction) in top_level.into_iter().enumerate() {
+        resolved.push(resolve_instruction(
+            &account_keys,
+            instruction,
+            top_level_index,
+            1,
+        )?);
+        if let Some(inner) = inner_by_index.remove(&top_level_index) {
+            for instruction in inner {
+                let stack_height = instruction
+                    .stack_height
+                    .expect("inner stack heights were validated");
+                resolved.push(resolve_instruction(
+                    &account_keys,
+                    instruction,
+                    top_level_index,
+                    stack_height,
+                )?);
+            }
+        }
+    }
+    Ok(resolved)
+}
+
+fn validate_inner_stack(
+    instructions: &[CompiledInstruction],
+    top_level_index: usize,
+) -> Result<(), DecodeError> {
+    let mut previous_height = 1u32;
+    for (position, instruction) in instructions.iter().enumerate() {
+        let height = instruction
+            .stack_height
+            .ok_or(DecodeError::MissingStackHeight {
+                top_level_index,
+                position,
+            })?;
+        if height < 2
+            || (position == 0 && height != 2)
+            || height > previous_height.saturating_add(1)
+        {
+            return Err(DecodeError::InvalidStackHeight {
+                top_level_index,
+                position,
+                height,
+            });
+        }
+        previous_height = height;
+    }
+    Ok(())
+}
+
+fn resolve_instruction(
+    account_keys: &[[u8; 32]],
+    instruction: CompiledInstruction,
+    top_level_index: usize,
+    stack_height: u32,
+) -> Result<ResolvedInstruction, DecodeError> {
+    let program_id = account_keys
+        .get(instruction.program_id_index)
+        .copied()
+        .ok_or(DecodeError::ProgramIndexOutOfRange {
+            index: instruction.program_id_index,
+        })?;
+    let accounts = instruction
+        .account_indices
+        .iter()
+        .map(|index| {
+            account_keys
+                .get(*index)
+                .copied()
+                .ok_or(DecodeError::AccountIndexOutOfRange { index: *index })
+        })
+        .collect::<Result<_, _>>()?;
+
+    Ok(ResolvedInstruction {
+        program_id,
+        accounts,
+        data: instruction.data,
+        top_level_index,
+        stack_height,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(tag: u8) -> [u8; 32] {
+        [tag; 32]
+    }
+
+    fn instruction(
+        program_id_index: usize,
+        account_indices: &[usize],
+        stack_height: Option<u32>,
+    ) -> CompiledInstruction {
+        CompiledInstruction {
+            program_id_index,
+            account_indices: account_indices.to_vec(),
+            data: vec![program_id_index as u8],
+            stack_height,
+        }
+    }
+
+    #[test]
+    fn assembles_alt_keys_and_preserves_execution_order() {
+        let resolved = resolve_transaction(
+            &[key(1), key(2)],
+            &[key(3)],
+            &[key(4)],
+            vec![instruction(3, &[2], None), instruction(1, &[0], None)],
+            vec![InnerInstructionGroup {
+                top_level_index: 0,
+                instructions: vec![instruction(2, &[3], Some(2)), instruction(1, &[0], Some(3))],
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved
+                .iter()
+                .map(|instruction| (
+                    instruction.program_id[0],
+                    instruction.accounts[0][0],
+                    instruction.top_level_index,
+                    instruction.stack_height,
+                ))
+                .collect::<Vec<_>>(),
+            vec![(4, 3, 0, 1), (3, 4, 0, 2), (2, 1, 0, 3), (2, 1, 1, 1)]
+        );
+    }
+
+    #[test]
+    fn rejects_orphan_and_duplicate_inner_groups() {
+        let top_level = [instruction(0, &[], None)];
+        let orphan = [InnerInstructionGroup {
+            top_level_index: 1,
+            instructions: vec![],
+        }];
+        assert_eq!(
+            resolve_transaction(&[key(1)], &[], &[], top_level.to_vec(), orphan.to_vec(),),
+            Err(DecodeError::OrphanInnerGroup { top_level_index: 1 })
+        );
+
+        let duplicate = [
+            InnerInstructionGroup {
+                top_level_index: 0,
+                instructions: vec![],
+            },
+            InnerInstructionGroup {
+                top_level_index: 0,
+                instructions: vec![],
+            },
+        ];
+        assert_eq!(
+            resolve_transaction(&[key(1)], &[], &[], top_level.to_vec(), duplicate.to_vec(),),
+            Err(DecodeError::DuplicateInnerGroup { top_level_index: 0 })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_indexes_and_stack_traces() {
+        assert_eq!(
+            resolve_transaction(&[key(1)], &[], &[], vec![instruction(1, &[], None)], vec![],),
+            Err(DecodeError::ProgramIndexOutOfRange { index: 1 })
+        );
+        assert_eq!(
+            resolve_transaction(
+                &[key(1)],
+                &[],
+                &[],
+                vec![instruction(0, &[1], None)],
+                vec![],
+            ),
+            Err(DecodeError::AccountIndexOutOfRange { index: 1 })
+        );
+
+        let top_level = [instruction(0, &[], None)];
+        for (stack_height, expected) in [
+            (
+                None,
+                DecodeError::MissingStackHeight {
+                    top_level_index: 0,
+                    position: 0,
+                },
+            ),
+            (
+                Some(3),
+                DecodeError::InvalidStackHeight {
+                    top_level_index: 0,
+                    position: 0,
+                    height: 3,
+                },
+            ),
+        ] {
+            let groups = [InnerInstructionGroup {
+                top_level_index: 0,
+                instructions: vec![instruction(0, &[], stack_height)],
+            }];
+            assert_eq!(
+                resolve_transaction(&[key(1)], &[], &[], top_level.to_vec(), groups.to_vec(),),
+                Err(expected)
+            );
+        }
+    }
+}

--- a/solana/test-fixtures/transaction_decoding.rs
+++ b/solana/test-fixtures/transaction_decoding.rs
@@ -34,18 +34,45 @@ pub struct InnerInstructionGroupFixture {
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum ExpectedOutcome {
     Accept {
-        instructions: Vec<ExpectedInstruction>,
+        instructions: Vec<ExpectedInstructionFixture>,
     },
     Reject,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-pub struct ExpectedInstruction {
+#[derive(Debug, Deserialize)]
+pub struct ExpectedInstructionFixture {
     pub program_tag: u8,
     pub account_tags: Vec<u8>,
     pub data: Vec<u8>,
     pub top_level_index: u32,
-    pub is_inner: bool,
+    pub stack_height: u32,
+}
+
+impl ExpectedInstructionFixture {
+    pub fn resolve(&self) -> ExpectedInstruction {
+        ExpectedInstruction {
+            program: fixture_key(self.program_tag),
+            accounts: self.account_tags.iter().copied().map(fixture_key).collect(),
+            data: self.data.clone(),
+            top_level_index: self.top_level_index,
+            stack_height: self.stack_height,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ExpectedInstruction {
+    pub program: [u8; 32],
+    pub accounts: Vec<[u8; 32]>,
+    pub data: Vec<u8>,
+    pub top_level_index: u32,
+    pub stack_height: u32,
+}
+
+/// Expands a compact fixture tag into a full, deliberately nonuniform key.
+/// Full-key comparisons then catch truncation or partial-key adapter bugs.
+pub fn fixture_key(tag: u8) -> [u8; 32] {
+    std::array::from_fn(|index| tag.wrapping_add(index as u8))
 }
 
 pub fn transaction_decoding_fixtures() -> Vec<TransactionDecodingFixture> {

--- a/solana/test-fixtures/transaction_decoding_v1.json
+++ b/solana/test-fixtures/transaction_decoding_v1.json
@@ -39,21 +39,21 @@
           "account_tags": [3, 2],
           "data": [10, 11],
           "top_level_index": 0,
-          "is_inner": false
+          "stack_height": 1
         },
         {
           "program_tag": 3,
           "account_tags": [1, 4],
           "data": [13],
           "top_level_index": 0,
-          "is_inner": true
+          "stack_height": 2
         },
         {
           "program_tag": 2,
           "account_tags": [4],
           "data": [12],
           "top_level_index": 1,
-          "is_inner": false
+          "stack_height": 1
         }
       ]
     }
@@ -108,35 +108,35 @@
           "account_tags": [],
           "data": [],
           "top_level_index": 0,
-          "is_inner": false
+          "stack_height": 1
         },
         {
           "program_tag": 1,
           "account_tags": [],
           "data": [],
           "top_level_index": 0,
-          "is_inner": true
+          "stack_height": 2
         },
         {
           "program_tag": 1,
           "account_tags": [],
           "data": [],
           "top_level_index": 0,
-          "is_inner": true
+          "stack_height": 3
         },
         {
           "program_tag": 1,
           "account_tags": [],
           "data": [],
           "top_level_index": 0,
-          "is_inner": true
+          "stack_height": 3
         },
         {
           "program_tag": 1,
           "account_tags": [],
           "data": [],
           "top_level_index": 0,
-          "is_inner": true
+          "stack_height": 2
         }
       ]
     }


### PR DESCRIPTION
## What

- add a small, std-only canonical Solana transaction instruction decoder
- resolve static, writable ALT, and readonly ALT account keys once
- enforce program/account indexes, inner-group uniqueness/range, stack metadata, and execution order once
- use the shared decoder from both the real Yellowstone listener and RPC relayer paths

## Why

The listener and relayer independently implemented the same Solana transaction semantics. Keeping provider parsing at the edges while sharing one pure decoder prevents those paths from drifting and leaves their separate compute/material and lineage/MMR reducers unchanged.

## Validation

- `NO_DNA=1 cargo test --manifest-path solana/Cargo.toml -p zama-solana-transaction`
- `NO_DNA=1 cargo test --manifest-path coprocessor/fhevm-engine/Cargo.toml -p host-listener --features solana-grpc,solana-reconstruct account_resolution_tests`
- `NO_DNA=1 cargo test --manifest-path relayer/Cargo.toml --lib solana_proof::chain::tests`
- `NO_DNA=1 cargo clippy --manifest-path solana/Cargo.toml -p zama-solana-transaction --all-targets -- -D warnings`
- `NO_DNA=1 cargo clippy --manifest-path relayer/Cargo.toml --lib -- -D warnings`
- repository pre-commit formatting, check, and CI-aligned Clippy gates

Stacked on #3192. Tracks zama-ai/fhevm-internal#1686.
