### PR TITLE
refactor(listener): ingest sealed Solana blocks

### DIFF
--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -40,6 +40,7 @@ jobs:
               - coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
               - coprocessor/fhevm-engine/host-listener/src/solana_reconstruct.rs
               - coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+              - coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
 
   build-and-test:
     name: solana-tests/build-and-test

--- a/coprocessor/fhevm-engine/host-listener/src/bin/solana_host_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/solana_host_listener.rs
@@ -1,5 +1,5 @@
 //! Solana host listener: reconstructs coprocessor work from confirmed Yellowstone
-//! transaction updates and ingests it into the shared database.
+//! sealed blocks and ingests it into the shared database.
 
 use std::{str::FromStr, time::Duration};
 
@@ -15,7 +15,7 @@ use fhevm_engine_common::{chain_id::ChainId, telemetry, utils::DatabaseURL};
 use host_listener::{
     cmd::DEFAULT_DEPENDENCE_CACHE_SIZE,
     database::tfhe_event_propagate::Database,
-    solana_grpc_listener::{run, SolanaGrpcListenerConfig},
+    solana_grpc_listener::{run, SolanaGrpcListenerConfig, StartPosition},
     solana_reconstruct::{parse_host_config, HOST_CONFIG_SEED},
 };
 
@@ -121,10 +121,10 @@ async fn main() -> Result<()> {
         &SolanaGrpcListenerConfig {
             grpc_url: args.grpc_url,
             x_token: args.grpc_x_token,
-            rpc_fallback_url: args.url,
             program_id: program_id.to_string(),
             chain_id: host_config_chain_id,
         },
+        StartPosition::Tip,
         cancel,
     )
     .await

--- a/coprocessor/fhevm-engine/host-listener/src/lib.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/lib.rs
@@ -9,6 +9,8 @@ pub mod poller;
 pub mod solana_adapter;
 #[cfg(all(feature = "solana-grpc", feature = "solana-reconstruct"))]
 pub mod solana_grpc_listener;
+#[cfg(all(feature = "solana-grpc", feature = "solana-reconstruct"))]
+mod solana_grpc_source;
 #[cfg(feature = "solana-reconstruct")]
 pub mod solana_reconstruct;
 pub mod solana_slot_hashes;

--- a/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_adapter.rs
@@ -53,6 +53,8 @@ pub enum SolanaMappedEvent {
 pub struct SolanaBlockMeta {
     pub block_number: u64,
     pub block_timestamp: time::PrimitiveDateTime,
+    pub block_hash: [u8; 32],
+    pub parent_hash: [u8; 32],
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -191,18 +193,9 @@ pub async fn insert_solana_events(
 
     // Populate the dependence_chain scheduling table the tfhe-worker locks against; without
     // it the inserted computations are never scheduled (the EVM ingest path likewise calls
-    // update_dependence_chain after inserting tfhe events). Solana host slots carry no
-    // EVM-style block hash, so derive a unique per-slot hash from the slot number — it is used
-    // only for reorg bookkeeping, which a single local validator never exercises.
+    // update_dependence_chain after inserting tfhe events).
     if inserted_compute {
-        let mut block_hash = [0u8; 32];
-        block_hash[24..32].copy_from_slice(&block.block_number.to_be_bytes());
-        let block_summary = BlockSummary {
-            number: block.block_number,
-            hash: FixedBytes::<32>::from(block_hash),
-            parent_hash: FixedBytes::<32>::ZERO,
-            timestamp: 0,
-        };
+        let block_summary = solana_block_summary(block);
         db.update_dependence_chain(
             tx,
             chains,
@@ -218,6 +211,15 @@ pub async fn insert_solana_events(
         material_requests: material_requests.len(),
         inserted_rows,
     })
+}
+
+fn solana_block_summary(block: SolanaBlockMeta) -> BlockSummary {
+    BlockSummary {
+        number: block.block_number,
+        hash: FixedBytes::<32>::from(block.block_hash),
+        parent_hash: FixedBytes::<32>::from(block.parent_hash),
+        timestamp: 0,
+    }
 }
 
 pub fn to_log_tfhe(
@@ -727,6 +729,24 @@ mod tests {
     }
 
     #[test]
+    fn dependence_chain_uses_validator_block_hashes() {
+        let block_timestamp = PrimitiveDateTime::new(
+            Date::from_calendar_date(2026, Month::May, 9).unwrap(),
+            Time::MIDNIGHT,
+        );
+        let summary = solana_block_summary(SolanaBlockMeta {
+            block_number: 42,
+            block_timestamp,
+            block_hash: [7; 32],
+            parent_hash: [6; 32],
+        });
+
+        assert_eq!(summary.number, 42);
+        assert_eq!(summary.hash, FixedBytes::<32>::from([7; 32]));
+        assert_eq!(summary.parent_hash, FixedBytes::<32>::from([6; 32]));
+    }
+
+    #[test]
     fn builds_existing_db_log_shape() {
         let tx_id = solana_transaction_id(&[1_u8; 64]);
         let block_timestamp = PrimitiveDateTime::new(
@@ -749,6 +769,8 @@ mod tests {
             SolanaBlockMeta {
                 block_number: 42,
                 block_timestamp,
+                block_hash: [1; 32],
+                parent_hash: [0; 32],
             },
             true,
             7,
@@ -788,6 +810,8 @@ mod tests {
             SolanaBlockMeta {
                 block_number: 42,
                 block_timestamp,
+                block_hash: [1; 32],
+                parent_hash: [0; 32],
             },
         );
 
@@ -817,6 +841,8 @@ mod tests {
             SolanaBlockMeta {
                 block_number: 42,
                 block_timestamp,
+                block_hash: [1; 32],
+                parent_hash: [0; 32],
             },
         );
 
@@ -854,6 +880,8 @@ mod tests {
             SolanaBlockMeta {
                 block_number: 42,
                 block_timestamp,
+                block_hash: [1; 32],
+                parent_hash: [0; 32],
             },
         );
 
@@ -903,6 +931,8 @@ mod tests {
             SolanaBlockMeta {
                 block_number: 42,
                 block_timestamp,
+                block_hash: [1; 32],
+                parent_hash: [0; 32],
             },
         );
 

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -17,6 +17,7 @@ use yellowstone_grpc_proto::prelude::{
     subscribe_update::UpdateOneof, Message as TransactionMessage,
     SubscribeRequest, SubscribeUpdateTransactionInfo, TransactionStatusMeta,
 };
+use yellowstone_grpc_proto::prost::Message as _;
 use zama_solana_transaction::{
     CompiledInstruction as CanonicalCompiledInstruction,
     InnerInstructionGroup as CanonicalInnerInstructionGroup,
@@ -32,6 +33,10 @@ use crate::solana_grpc_source::{
 
 const MAX_DECODING_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 const MAX_PENDING_CONTEXT_BLOCKS: usize = 256;
+// A single decoded gRPC message is capped at 64 MiB. Keeping the cumulative
+// encoded size of queued blocks within the same bound prevents the 256-block
+// count limit from multiplying the transport's worst-case allocation.
+const MAX_PENDING_BLOCK_BYTES: usize = MAX_DECODING_MESSAGE_SIZE;
 const SOLANA_GRPC_INGEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -129,6 +134,36 @@ pub enum StartPosition {
     Resume(BlockCheckpoint),
 }
 
+#[derive(Debug, Default)]
+struct IngestionProgress {
+    applied: Option<BlockCheckpoint>,
+    retry: Option<BlockCheckpoint>,
+}
+
+impl IngestionProgress {
+    fn subscription_start(&self) -> (Option<BlockCheckpoint>, bool) {
+        match &self.retry {
+            Some(checkpoint) => (Some(checkpoint.clone()), false),
+            None => (self.applied.clone(), self.applied.is_some()),
+        }
+    }
+
+    fn observe_unapplied(&mut self, checkpoint: BlockCheckpoint) {
+        if self.retry.is_none() {
+            self.retry = Some(checkpoint);
+        }
+    }
+
+    fn commit(
+        &mut self,
+        checkpoint: BlockCheckpoint,
+        next_unapplied: Option<BlockCheckpoint>,
+    ) {
+        self.applied = Some(checkpoint);
+        self.retry = next_unapplied;
+    }
+}
+
 /// Connects, subscribes, and ingests until `cancel` fires. Reconnects with a
 /// `from_slot` cursor on stream errors; inserts are idempotent so replay is safe.
 pub async fn run(
@@ -142,25 +177,25 @@ pub async fn run(
         grpc_url = %config.grpc_url,
         "Starting Solana host listener (Yellowstone gRPC transport)"
     );
-    let mut applied_checkpoint = match start {
-        StartPosition::Tip => None,
-        StartPosition::Resume(checkpoint) => Some(checkpoint),
+    let mut progress = IngestionProgress {
+        applied: match start {
+            StartPosition::Tip => None,
+            StartPosition::Resume(checkpoint) => Some(checkpoint),
+        },
+        retry: None,
     };
-    let mut retry_cursor = None;
 
     loop {
         if cancel.is_cancelled() {
             return Ok(());
         }
-        let (resume, resume_is_applied) =
-            subscription_start(&applied_checkpoint, &retry_cursor);
+        let (resume, resume_is_applied) = progress.subscription_start();
         match subscribe_loop(
             db,
             config,
             resume,
             resume_is_applied,
-            &mut applied_checkpoint,
-            &mut retry_cursor,
+            &mut progress,
             &cancel,
         )
         .await
@@ -169,11 +204,11 @@ pub async fn run(
             Err(err) => match err.downcast::<FatalListenerError>() {
                 Ok(fatal) => {
                     let err = fatal.into_inner();
-                    error!(error = %err, checkpoint = ?applied_checkpoint, retry_cursor = ?retry_cursor, "gRPC listener stopped on fail-closed ingestion error");
+                    error!(error = %err, checkpoint = ?progress.applied, retry_cursor = ?progress.retry, "gRPC listener stopped on fail-closed ingestion error");
                     return Err(err);
                 }
                 Err(err) => {
-                    error!(error = %err, checkpoint = ?applied_checkpoint, retry_cursor = ?retry_cursor, "gRPC subscription dropped; reconnecting inclusively");
+                    error!(error = %err, checkpoint = ?progress.applied, retry_cursor = ?progress.retry, "gRPC subscription dropped; reconnecting inclusively");
                     tokio::select! {
                         _ = cancel.cancelled() => return Ok(()),
                         _ = tokio::time::sleep(Duration::from_secs(2)) => {}
@@ -181,16 +216,6 @@ pub async fn run(
                 }
             },
         }
-    }
-}
-
-fn subscription_start(
-    applied_checkpoint: &Option<BlockCheckpoint>,
-    retry_cursor: &Option<BlockCheckpoint>,
-) -> (Option<BlockCheckpoint>, bool) {
-    match retry_cursor {
-        Some(checkpoint) => (Some(checkpoint.clone()), false),
-        None => (applied_checkpoint.clone(), applied_checkpoint.is_some()),
     }
 }
 
@@ -314,8 +339,7 @@ async fn subscribe_loop(
     config: &SolanaGrpcListenerConfig,
     resume: Option<BlockCheckpoint>,
     resume_is_applied: bool,
-    applied_checkpoint: &mut Option<BlockCheckpoint>,
-    retry_cursor: &mut Option<BlockCheckpoint>,
+    progress: &mut IngestionProgress,
     cancel: &CancellationToken,
 ) -> Result<()> {
     let endpoint = Channel::from_shared(config.grpc_url.clone())
@@ -358,6 +382,7 @@ async fn subscribe_loop(
     };
     let mut stream = response.into_inner();
     let mut pending_blocks = VecDeque::new();
+    let mut pending_encoded_bytes = 0;
 
     loop {
         tokio::select! {
@@ -394,13 +419,14 @@ async fn subscribe_loop(
                             config,
                             &mut validator,
                             &mut pending_blocks,
-                            applied_checkpoint,
-                            retry_cursor,
+                            &mut pending_encoded_bytes,
+                            progress,
                             cancel,
                         )
                         .await?;
                     }
                     Some(UpdateOneof::Block(block)) => {
+                        let encoded_len = block.encoded_len();
                         let decision = validator.seal(block).map_err(|error| {
                             FatalListenerError::new(error.context(
                                 "validate sealed Solana block",
@@ -414,26 +440,24 @@ async fn subscribe_loop(
                                     "sealed Solana blocks exceeded {MAX_PENDING_CONTEXT_BLOCKS} pending context slots"
                                 )).into());
                             }
-                            let requires_context = block_requires_reconstruction_context(config, &block)
-                                .map_err(|error| {
-                                    FatalListenerError::new(error.context(
-                                        "inspect sealed Solana block",
-                                    ))
-                                })?;
-                            if retry_cursor.is_none() {
-                                *retry_cursor = Some(block.checkpoint());
-                            }
-                            pending_blocks.push_back(PendingBlock {
-                                block,
-                                requires_context,
-                            });
+                            let pending = prepare_block(config, block, encoded_len).map_err(|error| {
+                                FatalListenerError::new(error.context(
+                                    "prepare sealed Solana block",
+                                ))
+                            })?;
+                            pending_encoded_bytes = checked_pending_bytes(
+                                pending_encoded_bytes,
+                                pending.encoded_len,
+                            ).map_err(FatalListenerError::new)?;
+                            progress.observe_unapplied(pending.block.checkpoint());
+                            pending_blocks.push_back(pending);
                             drain_pending_blocks(
                                 db,
                                 config,
                                 &mut validator,
                                 &mut pending_blocks,
-                                applied_checkpoint,
-                                retry_cursor,
+                                &mut pending_encoded_bytes,
+                                progress,
                                 cancel,
                             )
                             .await?;
@@ -450,7 +474,124 @@ async fn subscribe_loop(
 #[derive(Debug)]
 struct PendingBlock {
     block: SealedBlock,
-    requires_context: bool,
+    transactions: Vec<PreparedTransaction>,
+    requirement: ContextRequirement,
+    matching_transaction_count: usize,
+    encoded_len: usize,
+}
+
+#[derive(Debug)]
+struct PreparedTransaction {
+    info: SubscribeUpdateTransactionInfo,
+    instructions: Vec<crate::solana_reconstruct::DecodedInstruction>,
+    requirement: ContextRequirement,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ContextRequirement {
+    slot_hashes: bool,
+    clock: bool,
+}
+
+impl ContextRequirement {
+    fn union(self, other: Self) -> Self {
+        Self {
+            slot_hashes: self.slot_hashes || other.slot_hashes,
+            clock: self.clock || other.clock,
+        }
+    }
+
+    fn is_satisfied_by(self, block: &SealedBlock) -> bool {
+        (!self.slot_hashes || block.previous_bank_hash.is_some())
+            && (!self.clock || block.clock_unix_timestamp.is_some())
+    }
+}
+
+fn prepare_block(
+    config: &SolanaGrpcListenerConfig,
+    mut block: SealedBlock,
+    encoded_len: usize,
+) -> Result<PendingBlock> {
+    let matching_transaction_count = block.transactions.len();
+    let mut requirement = ContextRequirement::default();
+    let mut transactions = Vec::new();
+    for info in std::mem::take(&mut block.transactions) {
+        let meta = info
+            .meta
+            .as_ref()
+            .ok_or_else(|| anyhow!("transaction has no status meta"))?;
+        if meta.err.is_some() || info.is_vote {
+            continue;
+        }
+        let tx = info.transaction.as_ref().ok_or_else(|| {
+            anyhow!("successful transaction has no transaction")
+        })?;
+        let message = tx
+            .message
+            .as_ref()
+            .ok_or_else(|| anyhow!("successful transaction has no message"))?;
+        let instructions = decode_transaction_instructions(message, meta)?;
+        let transaction_requirement = transaction_context_requirement(
+            config,
+            &instructions,
+            block.block_time.is_some(),
+        );
+        requirement = requirement.union(transaction_requirement);
+        transactions.push(PreparedTransaction {
+            info,
+            instructions,
+            requirement: transaction_requirement,
+        });
+    }
+    Ok(PendingBlock {
+        block,
+        transactions,
+        requirement,
+        matching_transaction_count,
+        encoded_len,
+    })
+}
+
+fn transaction_context_requirement(
+    config: &SolanaGrpcListenerConfig,
+    instructions: &[crate::solana_reconstruct::DecodedInstruction],
+    has_block_time: bool,
+) -> ContextRequirement {
+    use crate::solana_reconstruct::{
+        decode_encrypted_value_instruction, encrypted_value_material_requests,
+        is_fhe_eval_instruction,
+    };
+
+    let mut requirement = ContextRequirement::default();
+    for instruction in instructions
+        .iter()
+        .filter(|instruction| instruction.program == config.program_id)
+    {
+        if is_fhe_eval_instruction(&instruction.data) {
+            requirement.slot_hashes = true;
+            requirement.clock = true;
+        } else if !has_block_time
+            && decode_encrypted_value_instruction(&instruction.data)
+                .is_some_and(|decoded| {
+                    !encrypted_value_material_requests(&decoded).is_empty()
+                })
+        {
+            requirement.clock = true;
+        }
+    }
+    requirement
+}
+
+fn checked_pending_bytes(current: usize, added: usize) -> Result<usize> {
+    let total = current
+        .checked_add(added)
+        .ok_or_else(|| anyhow!("pending sealed block byte count overflow"))?;
+    if total > MAX_PENDING_BLOCK_BYTES {
+        anyhow::bail!(
+            "sealed Solana blocks exceeded {MAX_PENDING_BLOCK_BYTES} pending encoded bytes"
+        );
+    }
+    Ok(total)
 }
 
 async fn drain_pending_blocks(
@@ -458,28 +599,33 @@ async fn drain_pending_blocks(
     config: &SolanaGrpcListenerConfig,
     validator: &mut BlockValidator,
     pending_blocks: &mut VecDeque<PendingBlock>,
-    applied_checkpoint: &mut Option<BlockCheckpoint>,
-    retry_cursor: &mut Option<BlockCheckpoint>,
+    pending_encoded_bytes: &mut usize,
+    progress: &mut IngestionProgress,
     cancel: &CancellationToken,
 ) -> Result<()> {
     while let Some(front) = pending_blocks.front_mut() {
         validator.refresh_context(&mut front.block);
-        if front.requires_context
-            && !block_has_reconstruction_context(&front.block)
-        {
+        if !front.requirement.is_satisfied_by(&front.block) {
             return Ok(());
         }
 
         let pending = pending_blocks
             .pop_front()
             .expect("front was present immediately before pop");
-        match ingest_block(db, config, &pending.block, cancel).await {
+        *pending_encoded_bytes -= pending.encoded_len;
+        match ingest_block(db, config, &pending, cancel).await {
             Ok(BlockIngestOutcome::Complete) => {
-                validator.commit(&pending.block);
-                *applied_checkpoint = Some(pending.block.checkpoint());
-                *retry_cursor = pending_blocks
-                    .front()
-                    .map(|pending| pending.block.checkpoint());
+                validator.commit(
+                    &pending.block,
+                    pending.requirement.slot_hashes,
+                    pending.requirement.clock,
+                );
+                progress.commit(
+                    pending.block.checkpoint(),
+                    pending_blocks
+                        .front()
+                        .map(|pending| pending.block.checkpoint()),
+                );
             }
             Ok(BlockIngestOutcome::Cancelled) => return Ok(()),
             Err(err) if err.kind() == IngestFailureKind::Retryable => {
@@ -509,10 +655,14 @@ fn is_terminal_replay_status(status: &tonic::Status) -> bool {
 #[cfg(test)]
 mod replay_status_tests {
     use super::{
-        is_terminal_replay_status, sealed_block_timestamp, subscription_start,
-        BlockCheckpoint,
+        checked_pending_bytes, is_terminal_replay_status,
+        sealed_block_timestamp, IngestionProgress, MAX_PENDING_BLOCK_BYTES,
     };
-    use crate::solana_grpc_source::SealedBlock;
+    use crate::solana_grpc_listener::StartPosition;
+    use crate::solana_grpc_source::{
+        BlockValidator, SealDecision, SealedBlock,
+    };
+    use yellowstone_grpc_proto::prelude::SubscribeUpdateBlock;
 
     #[test]
     fn classifies_replay_gaps_without_treating_transport_as_terminal() {
@@ -533,17 +683,53 @@ mod replay_status_tests {
     }
 
     #[test]
-    fn first_unapplied_block_is_an_inclusive_retry_cursor() {
-        let applied = None;
-        let retry = Some(BlockCheckpoint {
+    fn retryable_first_block_replays_as_unapplied_then_commits() {
+        let update = SubscribeUpdateBlock {
             slot: 5,
-            block_hash: [5; 32],
-        });
+            blockhash: bs58::encode([5; 32]).into_string(),
+            parent_slot: 4,
+            parent_blockhash: bs58::encode([4; 32]).into_string(),
+            ..Default::default()
+        };
+        let mut first_validator = BlockValidator::new(StartPosition::Tip, true);
+        let SealDecision::Process(first) =
+            first_validator.seal(update.clone()).unwrap()
+        else {
+            panic!()
+        };
+        let checkpoint = first.checkpoint();
+        let mut progress = IngestionProgress::default();
+        progress.observe_unapplied(checkpoint.clone());
 
-        let (resume, resume_is_applied) = subscription_start(&applied, &retry);
-
-        assert_eq!(resume, retry);
+        // A retryable apply failure does not mutate progress.
+        let (resume, resume_is_applied) = progress.subscription_start();
+        assert_eq!(resume, Some(checkpoint.clone()));
         assert!(!resume_is_applied);
+        assert!(progress.applied.is_none());
+
+        let mut retry_validator = BlockValidator::new(
+            StartPosition::Resume(checkpoint.clone()),
+            resume_is_applied,
+        );
+        let SealDecision::Process(retried) =
+            retry_validator.seal(update).unwrap()
+        else {
+            panic!()
+        };
+        retry_validator.commit(&retried, false, false);
+        progress.commit(retried.checkpoint(), None);
+
+        assert_eq!(progress.applied, Some(checkpoint));
+        assert!(progress.retry.is_none());
+    }
+
+    #[test]
+    fn pending_byte_budget_fails_without_large_allocations() {
+        assert_eq!(
+            checked_pending_bytes(MAX_PENDING_BLOCK_BYTES - 1, 1).unwrap(),
+            MAX_PENDING_BLOCK_BYTES
+        );
+        assert!(checked_pending_bytes(MAX_PENDING_BLOCK_BYTES - 1, 2).is_err());
     }
 
     #[test]
@@ -568,42 +754,6 @@ mod replay_status_tests {
     }
 }
 
-fn block_requires_reconstruction_context(
-    config: &SolanaGrpcListenerConfig,
-    block: &SealedBlock,
-) -> Result<bool> {
-    for transaction in &block.transactions {
-        let meta = transaction
-            .meta
-            .as_ref()
-            .ok_or_else(|| anyhow!("transaction has no status meta"))?;
-        if meta.err.is_some() || transaction.is_vote {
-            continue;
-        }
-        let tx = transaction.transaction.as_ref().ok_or_else(|| {
-            anyhow!("successful transaction has no transaction")
-        })?;
-        let message = tx
-            .message
-            .as_ref()
-            .ok_or_else(|| anyhow!("successful transaction has no message"))?;
-        let instructions = decode_transaction_instructions(message, meta)?;
-        if instructions.iter().any(|instruction| {
-            instruction.program == config.program_id
-                && crate::solana_reconstruct::is_fhe_eval_instruction(
-                    &instruction.data,
-                )
-        }) {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-fn block_has_reconstruction_context(block: &SealedBlock) -> bool {
-    block.previous_bank_hash.is_some() && block.clock_unix_timestamp.is_some()
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BlockIngestOutcome {
     Complete,
@@ -613,21 +763,22 @@ enum BlockIngestOutcome {
 async fn ingest_block(
     db: &Database,
     config: &SolanaGrpcListenerConfig,
-    block: &SealedBlock,
+    pending: &PendingBlock,
     cancel: &CancellationToken,
 ) -> std::result::Result<BlockIngestOutcome, IngestFailure> {
-    for transaction in &block.transactions {
-        let meta = transaction.meta.as_ref().ok_or_else(|| {
-            IngestFailure::fatal(anyhow!("transaction has no status meta"))
-        })?;
-        if meta.err.is_some() || transaction.is_vote {
-            continue;
+    for transaction in &pending.transactions {
+        if !transaction.requirement.is_satisfied_by(&pending.block) {
+            return Err(IngestFailure::fatal(anyhow!(
+                "missing required Solana reconstruction context for transaction {} in slot {}",
+                transaction.info.index,
+                pending.block.slot
+            )));
         }
         let result = tokio::select! {
             _ = cancel.cancelled() => return Ok(BlockIngestOutcome::Cancelled),
             result = tokio::time::timeout(
                 SOLANA_GRPC_INGEST_TIMEOUT,
-                ingest_transaction(db, config, block, transaction),
+                ingest_transaction(db, config, &pending.block, transaction),
             ) => result,
         };
         match result {
@@ -635,18 +786,18 @@ async fn ingest_block(
             Err(_) => {
                 return Err(IngestFailure::retryable(anyhow!(
                     "timed out ingesting Solana transaction {} in slot {}",
-                    transaction.index,
-                    block.slot
+                    transaction.info.index,
+                    pending.block.slot
                 )))
             }
         }
     }
     info!(
-        slot = block.slot,
-        parent_slot = block.parent_slot,
-        block_height = ?block.block_height,
-        executed_transaction_count = block.executed_transaction_count,
-        matching_transaction_count = block.transactions.len(),
+        slot = pending.block.slot,
+        parent_slot = pending.block.parent_slot,
+        block_height = ?pending.block.block_height,
+        executed_transaction_count = pending.block.executed_transaction_count,
+        matching_transaction_count = pending.matching_transaction_count,
         "ingested sealed Solana block"
     );
     Ok(BlockIngestOutcome::Complete)
@@ -656,26 +807,8 @@ async fn ingest_transaction(
     db: &Database,
     config: &SolanaGrpcListenerConfig,
     sealed_block: &SealedBlock,
-    info: &SubscribeUpdateTransactionInfo,
+    transaction: &PreparedTransaction,
 ) -> std::result::Result<(), IngestFailure> {
-    let meta = info
-        .meta
-        .as_ref()
-        .ok_or_else(|| IngestFailure::fatal(anyhow!("tx has no meta")))?;
-    let tx = info.transaction.as_ref().ok_or_else(|| {
-        IngestFailure::fatal(anyhow!("tx has no transaction"))
-    })?;
-    let message = tx
-        .message
-        .as_ref()
-        .ok_or_else(|| IngestFailure::fatal(anyhow!("tx has no message")))?;
-
-    // Top-level + inner instruction invocations with resolved accounts (a
-    // zama-host instruction is called directly as top-level, or via CPI as inner
-    // for token flows); scanned by the reconstruction shadow-compare and ingest.
-    let all_instructions = decode_transaction_instructions(message, meta)
-        .map_err(IngestFailure::fatal)?;
-
     let slot_bank_hash = sealed_block
         .previous_bank_hash
         .map(|hash| HashMap::from([(sealed_block.slot, hash)]))
@@ -687,7 +820,7 @@ async fn ingest_transaction(
 
     let events = match reconstruct_events_for_insert(
         config,
-        &all_instructions,
+        &transaction.instructions,
         sealed_block.slot,
         &slot_bank_hash,
         &slot_clock_ts,
@@ -718,7 +851,7 @@ async fn ingest_transaction(
         parent_hash: sealed_block.parent_block_hash,
     };
 
-    let transaction_id = solana_transaction_id(&info.signature);
+    let transaction_id = solana_transaction_id(&transaction.info.signature);
     let mut db_tx = db
         .new_transaction()
         .await
@@ -736,8 +869,8 @@ async fn ingest_transaction(
 
     info!(
         slot = sealed_block.slot,
-        transaction_index = info.index,
-        signature = %bs58::encode(&info.signature).into_string(),
+        transaction_index = transaction.info.index,
+        signature = %bs58::encode(&transaction.info.signature).into_string(),
         tfhe_events = stats.tfhe_events,
         material_requests = stats.material_requests,
         inserted_rows = stats.inserted_rows,
@@ -1083,7 +1216,8 @@ mod account_resolution_tests {
 mod fhe_eval_acl_tests {
     use super::{
         fhe_eval_durable_encrypted_value, reconstruct_events_for_insert,
-        ReconstructionOutcome, SolanaGrpcListenerConfig,
+        sealed_block_timestamp, transaction_context_requirement,
+        ContextRequirement, ReconstructionOutcome, SolanaGrpcListenerConfig,
     };
     use anchor_lang::AnchorSerialize;
     use sha2::{Digest, Sha256};
@@ -1095,9 +1229,10 @@ mod fhe_eval_acl_tests {
 
     use crate::database::tfhe_event_propagate::Handle;
     use crate::solana_adapter::SolanaHostEvent;
+    use crate::solana_grpc_source::SealedBlock;
     use crate::solana_reconstruct::{
         AllowSubjectsArgs, DecodedInstruction, EncryptedValueSubjectGrant,
-        ENCRYPTED_VALUE_ACCOUNT_INDEX,
+        MakeHandlePublicArgs, ENCRYPTED_VALUE_ACCOUNT_INDEX,
     };
     use zama_host::state::AclSubjectEntry;
 
@@ -1250,6 +1385,82 @@ mod fhe_eval_acl_tests {
         // the caller must surface, not silently drop.
         let accounts: Vec<[u8; 32]> = (0..9).map(acct).collect();
         assert_eq!(fhe_eval_durable_encrypted_value(&accounts, 0), None);
+    }
+
+    #[test]
+    fn context_requirement_matches_persisted_work() {
+        let make_public = decoded_ix(
+            encode_instruction(
+                "make_handle_public",
+                MakeHandlePublicArgs { handle: [4; 32] },
+            ),
+            encrypted_value_accounts(),
+            0,
+            false,
+        );
+        let lifecycle_requirement = transaction_context_requirement(
+            &config(),
+            &[make_public.clone()],
+            false,
+        );
+        assert_eq!(
+            lifecycle_requirement,
+            ContextRequirement {
+                slot_hashes: false,
+                clock: true,
+            }
+        );
+        let mut lifecycle_block = SealedBlock {
+            slot: 42,
+            block_hash: [4; 32],
+            parent_slot: 41,
+            parent_block_hash: [3; 32],
+            block_time: None,
+            block_height: None,
+            executed_transaction_count: 1,
+            transactions: vec![],
+            previous_bank_hash: None,
+            clock_unix_timestamp: None,
+        };
+        assert!(!lifecycle_requirement.is_satisfied_by(&lifecycle_block));
+        lifecycle_block.clock_unix_timestamp = Some(1_700_000_000);
+        assert!(lifecycle_requirement.is_satisfied_by(&lifecycle_block));
+        assert_eq!(
+            sealed_block_timestamp(&lifecycle_block),
+            super::unix_to_pdt(1_700_000_000)
+        );
+        assert_eq!(
+            transaction_context_requirement(&config(), &[make_public], true),
+            ContextRequirement::default()
+        );
+
+        let allow = decoded_ix(
+            encode_instruction(
+                "allow_subjects",
+                AllowSubjectsArgs {
+                    subjects: vec![EncryptedValueSubjectGrant {
+                        subject: [7; 32],
+                    }],
+                },
+            ),
+            encrypted_value_accounts(),
+            0,
+            false,
+        );
+        assert_eq!(
+            transaction_context_requirement(&config(), &[allow], false),
+            ContextRequirement::default()
+        );
+
+        let fhe_eval =
+            decoded_ix(discriminator("fhe_eval").to_vec(), vec![], 0, false);
+        assert_eq!(
+            transaction_context_requirement(&config(), &[fhe_eval], true),
+            ContextRequirement {
+                slot_hashes: true,
+                clock: true,
+            }
+        );
     }
 
     #[tokio::test]

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -1,8 +1,4 @@
 //! Yellowstone gRPC reconstruction path for the Solana host listener.
-//!
-//! gRPC transaction updates do not carry block time, so we track a
-//! `slot -> block_time` map from `blocks_meta` updates and fall back to a single
-//! RPC `getBlockTime` on a miss.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -10,20 +6,16 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use futures_util::stream::StreamExt;
-use solana_client::nonblocking::rpc_client::RpcClient;
 use time::{OffsetDateTime, PrimitiveDateTime};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::transport::Channel;
 use yellowstone_grpc_proto::geyser::geyser_client::GeyserClient;
 use yellowstone_grpc_proto::prelude::{
-    subscribe_update::UpdateOneof, CommitmentLevel,
-    Message as TransactionMessage, SubscribeRequest,
-    SubscribeRequestFilterAccounts, SubscribeRequestFilterBlocksMeta,
-    SubscribeRequestFilterTransactions, SubscribeUpdateTransactionInfo,
-    TransactionStatusMeta,
+    subscribe_update::UpdateOneof, Message as TransactionMessage,
+    SubscribeRequest, SubscribeUpdateTransactionInfo, TransactionStatusMeta,
 };
 use zama_solana_transaction::{
     CompiledInstruction as CanonicalCompiledInstruction,
@@ -34,18 +26,15 @@ use crate::database::tfhe_event_propagate::Database;
 use crate::solana_adapter::{
     insert_solana_events, solana_transaction_id, SolanaBlockMeta,
 };
-use crate::solana_slot_hashes::{
-    clock_unix_timestamp, previous_bank_hash_from_slot_hashes, CLOCK_SYSVAR,
-    SLOT_HASHES_SYSVAR,
+use crate::solana_grpc_source::{
+    build_subscribe_request, BlockValidator, SealDecision, SealedBlock,
 };
 
 const MAX_DECODING_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
-const SOLANA_RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const SOLANA_GRPC_INGEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum IngestFailureKind {
-    Permanent,
     Retryable,
     Fatal,
 }
@@ -57,13 +46,6 @@ struct IngestFailure {
 }
 
 impl IngestFailure {
-    fn permanent(error: impl Into<anyhow::Error>) -> Self {
-        Self {
-            kind: IngestFailureKind::Permanent,
-            error: error.into(),
-        }
-    }
-
     fn retryable(error: impl Into<anyhow::Error>) -> Self {
         Self {
             kind: IngestFailureKind::Retryable,
@@ -121,41 +103,12 @@ impl fmt::Display for FatalListenerError {
 
 impl std::error::Error for FatalListenerError {}
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CursorDecision {
-    Advance,
-    RetrySameCursor,
-    FatalSameCursor,
-}
-
-fn cursor_decision_for_ingest_failure(
-    kind: IngestFailureKind,
-) -> CursorDecision {
-    match kind {
-        IngestFailureKind::Permanent => CursorDecision::Advance,
-        IngestFailureKind::Retryable => CursorDecision::RetrySameCursor,
-        IngestFailureKind::Fatal => CursorDecision::FatalSameCursor,
-    }
-}
-
-fn apply_cursor_decision(
-    from_slot: &mut Option<u64>,
-    slot: u64,
-    decision: CursorDecision,
-) {
-    if decision == CursorDecision::Advance {
-        *from_slot = Some(slot);
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct SolanaGrpcListenerConfig {
     /// Yellowstone gRPC endpoint, e.g. `http://poc-solana-validator:10000`.
     pub grpc_url: String,
     /// Optional `x-token` auth metadata (None for a local validator).
     pub x_token: Option<String>,
-    /// RPC endpoint used only as a `getBlockTime` fallback for block timestamps.
-    pub rpc_fallback_url: String,
     /// Base58 zama-host program id whose instructions are reconstructed.
     pub program_id: String,
     /// On-chain HostConfig chain_id used in handle derivation (distinct from the
@@ -163,11 +116,24 @@ pub struct SolanaGrpcListenerConfig {
     pub chain_id: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockCheckpoint {
+    pub slot: u64,
+    pub block_hash: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StartPosition {
+    Tip,
+    Resume(BlockCheckpoint),
+}
+
 /// Connects, subscribes, and ingests until `cancel` fires. Reconnects with a
 /// `from_slot` cursor on stream errors; inserts are idempotent so replay is safe.
 pub async fn run(
     db: &Database,
     config: &SolanaGrpcListenerConfig,
+    start: StartPosition,
     cancel: CancellationToken,
 ) -> Result<()> {
     info!(
@@ -175,25 +141,10 @@ pub async fn run(
         grpc_url = %config.grpc_url,
         "Starting Solana host listener (Yellowstone gRPC transport)"
     );
-    // Authorization is revalidated by KMS before plaintext release. Confirmed
-    // data is sufficient for eager ciphertext-material preparation.
-    let rpc = RpcClient::new_with_timeout_and_commitment(
-        config.rpc_fallback_url.clone(),
-        SOLANA_RPC_REQUEST_TIMEOUT,
-        solana_commitment_config::CommitmentConfig::confirmed(),
-    );
-    // TODO(unbounded-cache): these per-slot maps are insert/get only — never
-    // evicted — so they grow without bound in this long-lived process. Only recent
-    // slots are ever read (txs arrive near the tip), so prune on insert (retain
-    // slots >= newest - WINDOW) or use a bounded/LRU map.
-    let mut slot_time: HashMap<u64, PrimitiveDateTime> = HashMap::new();
-    // `slot -> previous_bank_hash` sourced from the SlotHashes sysvar stream;
-    // consumed by the reconstruction path (recompute of trivial/rand/fhe_eval).
-    let mut slot_bank_hash: HashMap<u64, [u8; 32]> = HashMap::new();
-    // `slot -> Clock.unix_timestamp` from the Clock sysvar stream (the value the
-    // program uses in handle derivation, which differs from getBlockTime).
-    let mut slot_clock_ts: HashMap<u64, i64> = HashMap::new();
-    let mut from_slot: Option<u64> = None;
+    let mut checkpoint = match start {
+        StartPosition::Tip => None,
+        StartPosition::Resume(checkpoint) => Some(checkpoint),
+    };
 
     loop {
         if cancel.is_cancelled() {
@@ -201,12 +152,9 @@ pub async fn run(
         }
         match subscribe_loop(
             db,
-            &rpc,
             config,
-            &mut slot_time,
-            &mut slot_bank_hash,
-            &mut slot_clock_ts,
-            &mut from_slot,
+            checkpoint.clone(),
+            &mut checkpoint,
             &cancel,
         )
         .await
@@ -215,11 +163,11 @@ pub async fn run(
             Err(err) => match err.downcast::<FatalListenerError>() {
                 Ok(fatal) => {
                     let err = fatal.into_inner();
-                    error!(error = %err, from_slot = ?from_slot, "gRPC listener stopped on fail-closed ingestion error");
+                    error!(error = %err, checkpoint = ?checkpoint, "gRPC listener stopped on fail-closed ingestion error");
                     return Err(err);
                 }
                 Err(err) => {
-                    error!(error = %err, from_slot = ?from_slot, "gRPC subscription dropped; reconnecting");
+                    error!(error = %err, checkpoint = ?checkpoint, "gRPC subscription dropped; reconnecting inclusively");
                     tokio::select! {
                         _ = cancel.cancelled() => return Ok(()),
                         _ = tokio::time::sleep(Duration::from_secs(2)) => {}
@@ -345,22 +293,19 @@ fn resolve_transaction_instructions(
     .map_err(anyhow::Error::from)
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn subscribe_loop(
     db: &Database,
-    rpc: &RpcClient,
     config: &SolanaGrpcListenerConfig,
-    slot_time: &mut HashMap<u64, PrimitiveDateTime>,
-    slot_bank_hash: &mut HashMap<u64, [u8; 32]>,
-    slot_clock_ts: &mut HashMap<u64, i64>,
-    from_slot: &mut Option<u64>,
+    resume: Option<BlockCheckpoint>,
+    checkpoint: &mut Option<BlockCheckpoint>,
     cancel: &CancellationToken,
 ) -> Result<()> {
-    let channel = Channel::from_shared(config.grpc_url.clone())
-        .context("invalid grpc url")?
-        .connect()
-        .await
-        .context("connect grpc endpoint")?;
+    let endpoint = Channel::from_shared(config.grpc_url.clone())
+        .context("invalid grpc url")?;
+    let channel = tokio::select! {
+        _ = cancel.cancelled() => return Ok(()),
+        result = endpoint.connect() => result.context("connect grpc endpoint")?,
+    };
 
     let token: Option<MetadataValue<Ascii>> = config
         .x_token
@@ -380,26 +325,38 @@ async fn subscribe_loop(
     )
     .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
 
-    let request = build_subscribe_request(config, *from_slot);
+    let is_resume = resume.is_some();
+    let start = resume
+        .map(StartPosition::Resume)
+        .unwrap_or(StartPosition::Tip);
+    let request = build_subscribe_request(&config.program_id, &start);
+    let mut validator = BlockValidator::new(start);
     let outbound = futures_util::stream::once(async move { request })
         .chain(futures_util::stream::pending::<SubscribeRequest>());
 
-    let mut stream = client
-        .subscribe(outbound)
-        .await
-        .context("subscribe")?
-        .into_inner();
+    let response = tokio::select! {
+        _ = cancel.cancelled() => return Ok(()),
+        result = client.subscribe(outbound) => result.context("subscribe")?,
+    };
+    let mut stream = response.into_inner();
 
     loop {
         tokio::select! {
             _ = cancel.cancelled() => return Ok(()),
-            // The subscription requests blocks_meta (see build_subscribe_request), which the
-            // validator emits every slot, so prolonged total silence means the stream stalled
-            // rather than the chain being idle. Bound the await so a stall reconnects instead of
-            // hanging forever waiting on a stream that will never produce again.
+            // Sealed blocks are emitted for every produced slot, including slots with zero
+            // matching transactions. Prolonged silence therefore means the stream stalled.
             msg = tokio::time::timeout(Duration::from_secs(30), stream.message()) => {
                 let msg = msg.map_err(|_| anyhow!("grpc stream idle for 30s; reconnecting"))?;
-                let Some(update) = msg.context("grpc stream")? else {
+                let msg = match msg {
+                    Ok(message) => message,
+                    Err(status) if is_resume && is_terminal_replay_status(&status) => {
+                        return Err(FatalListenerError::new(anyhow!(
+                            "inclusive Yellowstone replay unavailable: {status}"
+                        )).into());
+                    }
+                    Err(status) => return Err(anyhow!(status).context("grpc stream")),
+                };
+                let Some(update) = msg else {
                     // A None message means the server closed the stream. This is NOT a
                     // cancellation (handled above) — return an error so the outer loop reconnects
                     // and resumes from `from_slot`, rather than exiting silently and missing every
@@ -407,113 +364,51 @@ async fn subscribe_loop(
                     return Err(anyhow!("grpc stream closed by server"));
                 };
                 match update.update_oneof {
-                    Some(UpdateOneof::BlockMeta(bm)) => {
-                        if let Some(ts) = bm.block_time.and_then(|t| unix_to_pdt(t.timestamp)) {
-                            slot_time.insert(bm.slot, ts);
-                        }
-                    }
                     Some(UpdateOneof::Account(acc)) => {
-                        // Cache per-slot derivation inputs from the sysvar stream:
-                        // SlotHashes -> previous_bank_hash, Clock -> unix_timestamp.
-                        if let Some(info) = acc.account {
-                            let pubkey =
-                                bs58::encode(&info.pubkey).into_string();
-                            if pubkey == SLOT_HASHES_SYSVAR {
-                                if let Some(prev) =
-                                    previous_bank_hash_from_slot_hashes(
-                                        &info.data, acc.slot,
-                                    )
-                                {
-                                    slot_bank_hash.insert(acc.slot, prev);
-                                }
-                            } else if pubkey == CLOCK_SYSVAR {
-                                if let Some(ts) =
-                                    clock_unix_timestamp(&info.data)
-                                {
-                                    slot_clock_ts.insert(acc.slot, ts);
-                                }
-                            }
-                        }
+                        validator.observe_account(acc).map_err(|error| {
+                            FatalListenerError::new(error.context(
+                                "validate Solana sysvar update",
+                            ))
+                        })?;
                     }
-                    Some(UpdateOneof::Transaction(txu)) => {
-                        let slot = txu.slot;
-                        if let Some(info) = txu.transaction {
-                            let signature =
-                                bs58::encode(&info.signature).into_string();
-                            if info.is_vote {
-                                *from_slot = Some(slot);
-                                continue;
-                            }
-                            match tokio::time::timeout(
-                                SOLANA_GRPC_INGEST_TIMEOUT,
-                                ingest_transaction(
-                                    db, rpc, config, slot, &info, slot_time,
-                                    &*slot_bank_hash, &*slot_clock_ts,
-                                ),
-                            )
-                            .await
-                            {
-                                Ok(Ok(())) => {}
+                    Some(UpdateOneof::Block(block)) => {
+                        let decision = validator.seal(block).map_err(|error| {
+                            FatalListenerError::new(error.context(
+                                "validate sealed Solana block",
+                            ))
+                        })?;
+                        if let SealDecision::Process(block) = decision {
+                            let ingest = tokio::select! {
+                                _ = cancel.cancelled() => return Ok(()),
+                                result = tokio::time::timeout(
+                                    SOLANA_GRPC_INGEST_TIMEOUT,
+                                    ingest_block(db, config, &block),
+                                ) => result,
+                            };
+                            match ingest {
+                                Ok(Ok(())) => {
+                                    *checkpoint = Some(block.checkpoint());
+                                }
+                                Ok(Err(err)) if err.kind() == IngestFailureKind::Retryable => {
+                                    return Err(err.into_error().context(
+                                        "retryable sealed block ingest failure",
+                                    ));
+                                }
                                 Ok(Err(err)) => {
-                                    let decision =
-                                        cursor_decision_for_ingest_failure(
-                                            err.kind(),
-                                        );
-                                    apply_cursor_decision(
-                                        from_slot, slot, decision,
-                                    );
-                                    match decision {
-                                        CursorDecision::Advance => {
-                                            error!(
-                                                slot,
-                                                signature = %signature,
-                                                error = %err,
-                                                "permanently failed to ingest gRPC transaction; skipping"
-                                            );
-                                            continue;
-                                        }
-                                        CursorDecision::RetrySameCursor => {
-                                            error!(
-                                                slot,
-                                                signature = %signature,
-                                                from_slot = ?from_slot,
-                                                error = %err,
-                                                "retryable gRPC transaction ingest failure; reconnecting without advancing cursor"
-                                            );
-                                            return Err(err
-                                                .into_error()
-                                                .context("retryable gRPC transaction ingest failure"));
-                                        }
-                                        CursorDecision::FatalSameCursor => {
-                                            error!(
-                                                slot,
-                                                signature = %signature,
-                                                from_slot = ?from_slot,
-                                                error = %err,
-                                                "fatal gRPC transaction ingest failure; stopping without advancing cursor"
-                                            );
-                                            return Err(FatalListenerError::new(
-                                                err.into_error(),
-                                            )
-                                            .into());
-                                        }
-                                    }
+                                    return Err(FatalListenerError::new(
+                                        err.into_error().context(
+                                            "fatal sealed block ingest failure",
+                                        ),
+                                    ).into());
                                 }
                                 Err(_) => {
-                                    warn!(
-                                        slot,
-                                        signature = %signature,
-                                        timeout = ?SOLANA_GRPC_INGEST_TIMEOUT,
-                                        from_slot = ?from_slot,
-                                        "timed out ingesting gRPC transaction; reconnecting without advancing cursor"
-                                    );
                                     return Err(anyhow!(
-                                        "timed out ingesting gRPC transaction {signature} in slot {slot}"
+                                        "timed out ingesting sealed Solana block {}",
+                                        block.slot
                                     ));
                                 }
                             }
                         }
-                        *from_slot = Some(slot);
                     }
                     Some(UpdateOneof::Ping(_)) => debug!("grpc ping"),
                     _ => {}
@@ -523,91 +418,103 @@ async fn subscribe_loop(
     }
 }
 
-fn build_subscribe_request(
-    config: &SolanaGrpcListenerConfig,
-    from_slot: Option<u64>,
-) -> SubscribeRequest {
-    let mut transactions = HashMap::new();
-    transactions.insert(
-        "zama_host".to_string(),
-        SubscribeRequestFilterTransactions {
-            vote: Some(false),
-            failed: Some(false),
-            signature: None,
-            account_include: vec![config.program_id.clone()],
-            account_exclude: vec![],
-            account_required: vec![],
-        },
-    );
+fn is_terminal_replay_status(status: &tonic::Status) -> bool {
+    let message = status.message();
+    message == "from_slot is not supported"
+        || message == "failed to send from_slot request"
+        || message.starts_with("broadcast from ")
+            && message.contains(" is not available")
+}
 
-    let mut blocks_meta = HashMap::new();
-    blocks_meta.insert("meta".to_string(), SubscribeRequestFilterBlocksMeta {});
+#[cfg(test)]
+mod replay_status_tests {
+    use super::is_terminal_replay_status;
 
-    // Stream the SlotHashes + Clock sysvar accounts to source
-    // `previous_bank_hash` and `unix_timestamp` per slot for handle reconstruction.
-    let mut accounts = HashMap::new();
-    accounts.insert(
-        "sysvars".to_string(),
-        SubscribeRequestFilterAccounts {
-            account: vec![
-                SLOT_HASHES_SYSVAR.to_string(),
-                CLOCK_SYSVAR.to_string(),
-            ],
-            owner: vec![],
-            filters: vec![],
-            nonempty_txn_signature: None,
-        },
-    );
-
-    SubscribeRequest {
-        accounts,
-        slots: HashMap::new(),
-        transactions,
-        transactions_status: HashMap::new(),
-        blocks: HashMap::new(),
-        blocks_meta,
-        entry: HashMap::new(),
-        commitment: Some(CommitmentLevel::Confirmed as i32),
-        accounts_data_slice: vec![],
-        ping: None,
-        from_slot,
+    #[test]
+    fn classifies_replay_gaps_without_treating_transport_as_terminal() {
+        for message in [
+            "from_slot is not supported",
+            "failed to send from_slot request",
+            "broadcast from 7 is not available, last available: 12",
+        ] {
+            assert!(is_terminal_replay_status(&tonic::Status::internal(
+                message
+            )));
+        }
+        assert!(!is_terminal_replay_status(&tonic::Status::unavailable(
+            "connection reset"
+        )));
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+async fn ingest_block(
+    db: &Database,
+    config: &SolanaGrpcListenerConfig,
+    block: &SealedBlock,
+) -> std::result::Result<(), IngestFailure> {
+    for transaction in &block.transactions {
+        let meta = transaction.meta.as_ref().ok_or_else(|| {
+            IngestFailure::fatal(anyhow!("transaction has no status meta"))
+        })?;
+        if meta.err.is_some() || transaction.is_vote {
+            continue;
+        }
+        ingest_transaction(db, config, block, transaction).await?;
+    }
+    info!(
+        slot = block.slot,
+        parent_slot = block.parent_slot,
+        block_height = ?block.block_height,
+        executed_transaction_count = block.executed_transaction_count,
+        matching_transaction_count = block.transactions.len(),
+        "ingested sealed Solana block"
+    );
+    Ok(())
+}
+
 async fn ingest_transaction(
     db: &Database,
-    rpc: &RpcClient,
     config: &SolanaGrpcListenerConfig,
-    slot: u64,
+    sealed_block: &SealedBlock,
     info: &SubscribeUpdateTransactionInfo,
-    slot_time: &mut HashMap<u64, PrimitiveDateTime>,
-    slot_bank_hash: &HashMap<u64, [u8; 32]>,
-    slot_clock_ts: &HashMap<u64, i64>,
 ) -> std::result::Result<(), IngestFailure> {
     let meta = info
         .meta
         .as_ref()
-        .ok_or_else(|| IngestFailure::permanent(anyhow!("tx has no meta")))?;
+        .ok_or_else(|| IngestFailure::fatal(anyhow!("tx has no meta")))?;
     let tx = info.transaction.as_ref().ok_or_else(|| {
-        IngestFailure::permanent(anyhow!("tx has no transaction"))
+        IngestFailure::fatal(anyhow!("tx has no transaction"))
     })?;
-    let message = tx.message.as_ref().ok_or_else(|| {
-        IngestFailure::permanent(anyhow!("tx has no message"))
-    })?;
+    let message = tx
+        .message
+        .as_ref()
+        .ok_or_else(|| IngestFailure::fatal(anyhow!("tx has no message")))?;
 
     // Top-level + inner instruction invocations with resolved accounts (a
     // zama-host instruction is called directly as top-level, or via CPI as inner
     // for token flows); scanned by the reconstruction shadow-compare and ingest.
     let all_instructions = decode_transaction_instructions(message, meta)
-        .map_err(IngestFailure::permanent)?;
+        .map_err(IngestFailure::fatal)?;
+
+    let slot_bank_hash = HashMap::from([(
+        sealed_block.slot,
+        sealed_block.previous_bank_hash.ok_or_else(|| {
+            IngestFailure::fatal(anyhow!("missing SlotHashes context"))
+        })?,
+    )]);
+    let slot_clock_ts = HashMap::from([(
+        sealed_block.slot,
+        sealed_block.clock_unix_timestamp.ok_or_else(|| {
+            IngestFailure::fatal(anyhow!("missing Clock context"))
+        })?,
+    )]);
 
     let events = match reconstruct_events_for_insert(
         config,
         &all_instructions,
-        slot,
-        slot_bank_hash,
-        slot_clock_ts,
+        sealed_block.slot,
+        &slot_bank_hash,
+        &slot_clock_ts,
     )
     .await
     .map_err(|err| {
@@ -621,22 +528,20 @@ async fn ingest_transaction(
         return Ok(());
     }
 
-    let block_timestamp = match slot_time.get(&slot) {
-        Some(ts) => *ts,
-        None => {
-            let ts = rpc.get_block_time(slot).await.map_err(|err| {
-                IngestFailure::retryable(err).context("getBlockTime fallback")
-            })?;
-            let pdt = unix_to_pdt(ts).ok_or_else(|| {
-                IngestFailure::permanent(anyhow!("invalid block_time {ts}"))
-            })?;
-            slot_time.insert(slot, pdt);
-            pdt
-        }
-    };
+    let block_timestamp = sealed_block
+        .block_time
+        .and_then(unix_to_pdt)
+        .ok_or_else(|| {
+            IngestFailure::fatal(anyhow!(
+                "missing or invalid block time for slot {}",
+                sealed_block.slot
+            ))
+        })?;
     let block = SolanaBlockMeta {
-        block_number: slot,
+        block_number: sealed_block.slot,
         block_timestamp,
+        block_hash: sealed_block.block_hash,
+        parent_hash: sealed_block.parent_block_hash,
     };
 
     let transaction_id = solana_transaction_id(&info.signature);
@@ -656,7 +561,8 @@ async fn ingest_transaction(
         .map_err(|err| IngestFailure::retryable(err).context("commit db tx"))?;
 
     info!(
-        slot,
+        slot = sealed_block.slot,
+        transaction_index = info.index,
         signature = %bs58::encode(&info.signature).into_string(),
         tfhe_events = stats.tfhe_events,
         material_requests = stats.material_requests,
@@ -993,38 +899,6 @@ mod account_resolution_tests {
 }
 
 #[cfg(test)]
-mod ingest_cursor_tests {
-    use super::{
-        apply_cursor_decision, cursor_decision_for_ingest_failure,
-        CursorDecision, IngestFailureKind,
-    };
-
-    #[test]
-    fn retryable_ingest_failure_keeps_cursor_for_replay() {
-        let mut from_slot = Some(40);
-        let decision =
-            cursor_decision_for_ingest_failure(IngestFailureKind::Retryable);
-
-        apply_cursor_decision(&mut from_slot, 42, decision);
-
-        assert_eq!(decision, CursorDecision::RetrySameCursor);
-        assert_eq!(from_slot, Some(40));
-    }
-
-    #[test]
-    fn permanent_ingest_failure_advances_cursor() {
-        let mut from_slot = Some(40);
-        let decision =
-            cursor_decision_for_ingest_failure(IngestFailureKind::Permanent);
-
-        apply_cursor_decision(&mut from_slot, 42, decision);
-
-        assert_eq!(decision, CursorDecision::Advance);
-        assert_eq!(from_slot, Some(42));
-    }
-}
-
-#[cfg(test)]
 mod fhe_eval_acl_tests {
     use super::{
         fhe_eval_durable_encrypted_value, reconstruct_events_for_insert,
@@ -1054,7 +928,6 @@ mod fhe_eval_acl_tests {
         SolanaGrpcListenerConfig {
             grpc_url: "http://127.0.0.1:1".to_owned(),
             x_token: None,
-            rpc_fallback_url: "http://127.0.0.1:1".to_owned(),
             program_id: ZAMA_HOST.to_owned(),
             chain_id: zama_host::SOLANA_POC_CHAIN_ID,
         }

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -1,6 +1,6 @@
 //! Yellowstone gRPC reconstruction path for the Solana host listener.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::time::Duration;
 
@@ -31,6 +31,7 @@ use crate::solana_grpc_source::{
 };
 
 const MAX_DECODING_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+const MAX_PENDING_CONTEXT_BLOCKS: usize = 256;
 const SOLANA_GRPC_INGEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,20 +142,25 @@ pub async fn run(
         grpc_url = %config.grpc_url,
         "Starting Solana host listener (Yellowstone gRPC transport)"
     );
-    let mut checkpoint = match start {
+    let mut applied_checkpoint = match start {
         StartPosition::Tip => None,
         StartPosition::Resume(checkpoint) => Some(checkpoint),
     };
+    let mut retry_cursor = None;
 
     loop {
         if cancel.is_cancelled() {
             return Ok(());
         }
+        let (resume, resume_is_applied) =
+            subscription_start(&applied_checkpoint, &retry_cursor);
         match subscribe_loop(
             db,
             config,
-            checkpoint.clone(),
-            &mut checkpoint,
+            resume,
+            resume_is_applied,
+            &mut applied_checkpoint,
+            &mut retry_cursor,
             &cancel,
         )
         .await
@@ -163,11 +169,11 @@ pub async fn run(
             Err(err) => match err.downcast::<FatalListenerError>() {
                 Ok(fatal) => {
                     let err = fatal.into_inner();
-                    error!(error = %err, checkpoint = ?checkpoint, "gRPC listener stopped on fail-closed ingestion error");
+                    error!(error = %err, checkpoint = ?applied_checkpoint, retry_cursor = ?retry_cursor, "gRPC listener stopped on fail-closed ingestion error");
                     return Err(err);
                 }
                 Err(err) => {
-                    error!(error = %err, checkpoint = ?checkpoint, "gRPC subscription dropped; reconnecting inclusively");
+                    error!(error = %err, checkpoint = ?applied_checkpoint, retry_cursor = ?retry_cursor, "gRPC subscription dropped; reconnecting inclusively");
                     tokio::select! {
                         _ = cancel.cancelled() => return Ok(()),
                         _ = tokio::time::sleep(Duration::from_secs(2)) => {}
@@ -175,6 +181,16 @@ pub async fn run(
                 }
             },
         }
+    }
+}
+
+fn subscription_start(
+    applied_checkpoint: &Option<BlockCheckpoint>,
+    retry_cursor: &Option<BlockCheckpoint>,
+) -> (Option<BlockCheckpoint>, bool) {
+    match retry_cursor {
+        Some(checkpoint) => (Some(checkpoint.clone()), false),
+        None => (applied_checkpoint.clone(), applied_checkpoint.is_some()),
     }
 }
 
@@ -297,7 +313,9 @@ async fn subscribe_loop(
     db: &Database,
     config: &SolanaGrpcListenerConfig,
     resume: Option<BlockCheckpoint>,
-    checkpoint: &mut Option<BlockCheckpoint>,
+    resume_is_applied: bool,
+    applied_checkpoint: &mut Option<BlockCheckpoint>,
+    retry_cursor: &mut Option<BlockCheckpoint>,
     cancel: &CancellationToken,
 ) -> Result<()> {
     let endpoint = Channel::from_shared(config.grpc_url.clone())
@@ -330,7 +348,7 @@ async fn subscribe_loop(
         .map(StartPosition::Resume)
         .unwrap_or(StartPosition::Tip);
     let request = build_subscribe_request(&config.program_id, &start);
-    let mut validator = BlockValidator::new(start);
+    let mut validator = BlockValidator::new(start, resume_is_applied);
     let outbound = futures_util::stream::once(async move { request })
         .chain(futures_util::stream::pending::<SubscribeRequest>());
 
@@ -339,6 +357,7 @@ async fn subscribe_loop(
         result = client.subscribe(outbound) => result.context("subscribe")?,
     };
     let mut stream = response.into_inner();
+    let mut pending_blocks = VecDeque::new();
 
     loop {
         tokio::select! {
@@ -370,6 +389,16 @@ async fn subscribe_loop(
                                 "validate Solana sysvar update",
                             ))
                         })?;
+                        drain_pending_blocks(
+                            db,
+                            config,
+                            &mut validator,
+                            &mut pending_blocks,
+                            applied_checkpoint,
+                            retry_cursor,
+                            cancel,
+                        )
+                        .await?;
                     }
                     Some(UpdateOneof::Block(block)) => {
                         let decision = validator.seal(block).map_err(|error| {
@@ -378,36 +407,36 @@ async fn subscribe_loop(
                             ))
                         })?;
                         if let SealDecision::Process(block) = decision {
-                            let ingest = tokio::select! {
-                                _ = cancel.cancelled() => return Ok(()),
-                                result = tokio::time::timeout(
-                                    SOLANA_GRPC_INGEST_TIMEOUT,
-                                    ingest_block(db, config, &block),
-                                ) => result,
-                            };
-                            match ingest {
-                                Ok(Ok(())) => {
-                                    *checkpoint = Some(block.checkpoint());
-                                }
-                                Ok(Err(err)) if err.kind() == IngestFailureKind::Retryable => {
-                                    return Err(err.into_error().context(
-                                        "retryable sealed block ingest failure",
-                                    ));
-                                }
-                                Ok(Err(err)) => {
-                                    return Err(FatalListenerError::new(
-                                        err.into_error().context(
-                                            "fatal sealed block ingest failure",
-                                        ),
-                                    ).into());
-                                }
-                                Err(_) => {
-                                    return Err(anyhow!(
-                                        "timed out ingesting sealed Solana block {}",
-                                        block.slot
-                                    ));
-                                }
+                            if pending_blocks.len()
+                                == MAX_PENDING_CONTEXT_BLOCKS
+                            {
+                                return Err(FatalListenerError::new(anyhow!(
+                                    "sealed Solana blocks exceeded {MAX_PENDING_CONTEXT_BLOCKS} pending context slots"
+                                )).into());
                             }
+                            let requires_context = block_requires_reconstruction_context(config, &block)
+                                .map_err(|error| {
+                                    FatalListenerError::new(error.context(
+                                        "inspect sealed Solana block",
+                                    ))
+                                })?;
+                            if retry_cursor.is_none() {
+                                *retry_cursor = Some(block.checkpoint());
+                            }
+                            pending_blocks.push_back(PendingBlock {
+                                block,
+                                requires_context,
+                            });
+                            drain_pending_blocks(
+                                db,
+                                config,
+                                &mut validator,
+                                &mut pending_blocks,
+                                applied_checkpoint,
+                                retry_cursor,
+                                cancel,
+                            )
+                            .await?;
                         }
                     }
                     Some(UpdateOneof::Ping(_)) => debug!("grpc ping"),
@@ -418,23 +447,77 @@ async fn subscribe_loop(
     }
 }
 
+#[derive(Debug)]
+struct PendingBlock {
+    block: SealedBlock,
+    requires_context: bool,
+}
+
+async fn drain_pending_blocks(
+    db: &Database,
+    config: &SolanaGrpcListenerConfig,
+    validator: &mut BlockValidator,
+    pending_blocks: &mut VecDeque<PendingBlock>,
+    applied_checkpoint: &mut Option<BlockCheckpoint>,
+    retry_cursor: &mut Option<BlockCheckpoint>,
+    cancel: &CancellationToken,
+) -> Result<()> {
+    while let Some(front) = pending_blocks.front_mut() {
+        validator.refresh_context(&mut front.block);
+        if front.requires_context
+            && !block_has_reconstruction_context(&front.block)
+        {
+            return Ok(());
+        }
+
+        let pending = pending_blocks
+            .pop_front()
+            .expect("front was present immediately before pop");
+        match ingest_block(db, config, &pending.block, cancel).await {
+            Ok(BlockIngestOutcome::Complete) => {
+                validator.commit(&pending.block);
+                *applied_checkpoint = Some(pending.block.checkpoint());
+                *retry_cursor = pending_blocks
+                    .front()
+                    .map(|pending| pending.block.checkpoint());
+            }
+            Ok(BlockIngestOutcome::Cancelled) => return Ok(()),
+            Err(err) if err.kind() == IngestFailureKind::Retryable => {
+                return Err(err
+                    .into_error()
+                    .context("retryable sealed block ingest failure"));
+            }
+            Err(err) => {
+                return Err(FatalListenerError::new(
+                    err.into_error()
+                        .context("fatal sealed block ingest failure"),
+                )
+                .into());
+            }
+        }
+    }
+    Ok(())
+}
+
 fn is_terminal_replay_status(status: &tonic::Status) -> bool {
     let message = status.message();
     message == "from_slot is not supported"
-        || message == "failed to send from_slot request"
         || message.starts_with("broadcast from ")
             && message.contains(" is not available")
 }
 
 #[cfg(test)]
 mod replay_status_tests {
-    use super::is_terminal_replay_status;
+    use super::{
+        is_terminal_replay_status, sealed_block_timestamp, subscription_start,
+        BlockCheckpoint,
+    };
+    use crate::solana_grpc_source::SealedBlock;
 
     #[test]
     fn classifies_replay_gaps_without_treating_transport_as_terminal() {
         for message in [
             "from_slot is not supported",
-            "failed to send from_slot request",
             "broadcast from 7 is not available, last available: 12",
         ] {
             assert!(is_terminal_replay_status(&tonic::Status::internal(
@@ -444,14 +527,95 @@ mod replay_status_tests {
         assert!(!is_terminal_replay_status(&tonic::Status::unavailable(
             "connection reset"
         )));
+        assert!(!is_terminal_replay_status(&tonic::Status::internal(
+            "failed to send from_slot request"
+        )));
     }
+
+    #[test]
+    fn first_unapplied_block_is_an_inclusive_retry_cursor() {
+        let applied = None;
+        let retry = Some(BlockCheckpoint {
+            slot: 5,
+            block_hash: [5; 32],
+        });
+
+        let (resume, resume_is_applied) = subscription_start(&applied, &retry);
+
+        assert_eq!(resume, retry);
+        assert!(!resume_is_applied);
+    }
+
+    #[test]
+    fn clock_timestamp_is_the_block_time_fallback() {
+        let block = SealedBlock {
+            slot: 5,
+            block_hash: [5; 32],
+            parent_slot: 4,
+            parent_block_hash: [4; 32],
+            block_time: None,
+            block_height: None,
+            executed_transaction_count: 0,
+            transactions: vec![],
+            previous_bank_hash: None,
+            clock_unix_timestamp: Some(1_700_000_000),
+        };
+
+        assert_eq!(
+            sealed_block_timestamp(&block),
+            super::unix_to_pdt(1_700_000_000)
+        );
+    }
+}
+
+fn block_requires_reconstruction_context(
+    config: &SolanaGrpcListenerConfig,
+    block: &SealedBlock,
+) -> Result<bool> {
+    for transaction in &block.transactions {
+        let meta = transaction
+            .meta
+            .as_ref()
+            .ok_or_else(|| anyhow!("transaction has no status meta"))?;
+        if meta.err.is_some() || transaction.is_vote {
+            continue;
+        }
+        let tx = transaction.transaction.as_ref().ok_or_else(|| {
+            anyhow!("successful transaction has no transaction")
+        })?;
+        let message = tx
+            .message
+            .as_ref()
+            .ok_or_else(|| anyhow!("successful transaction has no message"))?;
+        let instructions = decode_transaction_instructions(message, meta)?;
+        if instructions.iter().any(|instruction| {
+            instruction.program == config.program_id
+                && crate::solana_reconstruct::is_fhe_eval_instruction(
+                    &instruction.data,
+                )
+        }) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn block_has_reconstruction_context(block: &SealedBlock) -> bool {
+    block.previous_bank_hash.is_some() && block.clock_unix_timestamp.is_some()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BlockIngestOutcome {
+    Complete,
+    Cancelled,
 }
 
 async fn ingest_block(
     db: &Database,
     config: &SolanaGrpcListenerConfig,
     block: &SealedBlock,
-) -> std::result::Result<(), IngestFailure> {
+    cancel: &CancellationToken,
+) -> std::result::Result<BlockIngestOutcome, IngestFailure> {
     for transaction in &block.transactions {
         let meta = transaction.meta.as_ref().ok_or_else(|| {
             IngestFailure::fatal(anyhow!("transaction has no status meta"))
@@ -459,7 +623,23 @@ async fn ingest_block(
         if meta.err.is_some() || transaction.is_vote {
             continue;
         }
-        ingest_transaction(db, config, block, transaction).await?;
+        let result = tokio::select! {
+            _ = cancel.cancelled() => return Ok(BlockIngestOutcome::Cancelled),
+            result = tokio::time::timeout(
+                SOLANA_GRPC_INGEST_TIMEOUT,
+                ingest_transaction(db, config, block, transaction),
+            ) => result,
+        };
+        match result {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(IngestFailure::retryable(anyhow!(
+                    "timed out ingesting Solana transaction {} in slot {}",
+                    transaction.index,
+                    block.slot
+                )))
+            }
+        }
     }
     info!(
         slot = block.slot,
@@ -469,7 +649,7 @@ async fn ingest_block(
         matching_transaction_count = block.transactions.len(),
         "ingested sealed Solana block"
     );
-    Ok(())
+    Ok(BlockIngestOutcome::Complete)
 }
 
 async fn ingest_transaction(
@@ -496,18 +676,14 @@ async fn ingest_transaction(
     let all_instructions = decode_transaction_instructions(message, meta)
         .map_err(IngestFailure::fatal)?;
 
-    let slot_bank_hash = HashMap::from([(
-        sealed_block.slot,
-        sealed_block.previous_bank_hash.ok_or_else(|| {
-            IngestFailure::fatal(anyhow!("missing SlotHashes context"))
-        })?,
-    )]);
-    let slot_clock_ts = HashMap::from([(
-        sealed_block.slot,
-        sealed_block.clock_unix_timestamp.ok_or_else(|| {
-            IngestFailure::fatal(anyhow!("missing Clock context"))
-        })?,
-    )]);
+    let slot_bank_hash = sealed_block
+        .previous_bank_hash
+        .map(|hash| HashMap::from([(sealed_block.slot, hash)]))
+        .unwrap_or_default();
+    let slot_clock_ts = sealed_block
+        .clock_unix_timestamp
+        .map(|timestamp| HashMap::from([(sealed_block.slot, timestamp)]))
+        .unwrap_or_default();
 
     let events = match reconstruct_events_for_insert(
         config,
@@ -528,10 +704,8 @@ async fn ingest_transaction(
         return Ok(());
     }
 
-    let block_timestamp = sealed_block
-        .block_time
-        .and_then(unix_to_pdt)
-        .ok_or_else(|| {
+    let block_timestamp =
+        sealed_block_timestamp(sealed_block).ok_or_else(|| {
             IngestFailure::fatal(anyhow!(
                 "missing or invalid block time for slot {}",
                 sealed_block.slot
@@ -575,6 +749,13 @@ async fn ingest_transaction(
 fn unix_to_pdt(ts: i64) -> Option<PrimitiveDateTime> {
     let dt = OffsetDateTime::from_unix_timestamp(ts).ok()?;
     Some(PrimitiveDateTime::new(dt.date(), dt.time()))
+}
+
+fn sealed_block_timestamp(block: &SealedBlock) -> Option<PrimitiveDateTime> {
+    block
+        .block_time
+        .or(block.clock_unix_timestamp)
+        .and_then(unix_to_pdt)
 }
 
 /// Builds the handle-derivation context for `slot` from the streamed sysvars,
@@ -1081,14 +1262,13 @@ mod fhe_eval_acl_tests {
         );
         let instructions =
             vec![decoded_ix(allow_data, encrypted_value_accounts(), 0, false)];
-        let (slot_bank_hash, slot_clock_ts) = slot_context();
         let events = complete_events(
             reconstruct_events_for_insert(
                 &config(),
                 &instructions,
                 42,
-                &slot_bank_hash,
-                &slot_clock_ts,
+                &HashMap::new(),
+                &HashMap::new(),
             )
             .await
             .expect("reconstruction should return lifecycle events"),

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
@@ -1,0 +1,593 @@
+//! Concrete Yellowstone source validation for sealed Solana blocks.
+//!
+//! `SubscribeUpdateBlock` is emitted only after the server has observed the
+//! block's declared transaction count. Account filters remain a separate,
+//! bounded source of the two sysvars needed for handle reconstruction; they do
+//! not imply that arbitrary account state is complete.
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::{anyhow, bail, Context, Result};
+use yellowstone_grpc_proto::prelude::{
+    SubscribeRequest, SubscribeRequestFilterAccounts,
+    SubscribeRequestFilterBlocks, SubscribeUpdateAccount, SubscribeUpdateBlock,
+    SubscribeUpdateTransactionInfo,
+};
+
+use crate::solana_grpc_listener::{BlockCheckpoint, StartPosition};
+use crate::solana_slot_hashes::{
+    clock_unix_timestamp, previous_bank_hash_from_slot_hashes, CLOCK_SYSVAR,
+    SLOT_HASHES_SYSVAR,
+};
+
+const MAX_CONTEXT_SLOTS: usize = 256;
+
+#[derive(Clone, Debug)]
+pub(super) struct SealedBlock {
+    pub slot: u64,
+    pub block_hash: [u8; 32],
+    pub parent_slot: u64,
+    pub parent_block_hash: [u8; 32],
+    pub block_time: Option<i64>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    pub transactions: Vec<SubscribeUpdateTransactionInfo>,
+    pub previous_bank_hash: Option<[u8; 32]>,
+    pub clock_unix_timestamp: Option<i64>,
+}
+
+impl SealedBlock {
+    pub(super) fn checkpoint(&self) -> BlockCheckpoint {
+        BlockCheckpoint {
+            slot: self.slot,
+            block_hash: self.block_hash,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AccountIdentity {
+    data: Vec<u8>,
+    write_version: u64,
+    transaction_signature: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SlotContext {
+    slot_hashes: Option<AccountIdentity>,
+    clock: Option<AccountIdentity>,
+}
+
+impl SlotContext {
+    fn insert(
+        &mut self,
+        pubkey: &[u8],
+        identity: AccountIdentity,
+    ) -> Result<()> {
+        let target = if bs58::encode(pubkey).into_string() == SLOT_HASHES_SYSVAR
+        {
+            &mut self.slot_hashes
+        } else if bs58::encode(pubkey).into_string() == CLOCK_SYSVAR {
+            &mut self.clock
+        } else {
+            bail!("unexpected account in Solana sysvar stream")
+        };
+
+        match target {
+            Some(current) if current != &identity => {
+                bail!("conflicting Solana sysvar account identity")
+            }
+            Some(_) => Ok(()),
+            None => {
+                *target = Some(identity);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BlockIdentity {
+    block_hash: [u8; 32],
+    parent_slot: u64,
+    parent_block_hash: [u8; 32],
+    transactions: Vec<(u64, Vec<u8>)>,
+}
+
+#[derive(Debug)]
+pub(super) enum SealDecision {
+    Replay,
+    Process(SealedBlock),
+}
+
+#[derive(Debug)]
+pub(super) struct BlockValidator {
+    start: StartPosition,
+    checkpoint_observed: bool,
+    last_block: Option<(BlockCheckpoint, BlockIdentity)>,
+    contexts: BTreeMap<u64, SlotContext>,
+}
+
+impl BlockValidator {
+    pub fn new(start: StartPosition) -> Self {
+        Self {
+            checkpoint_observed: matches!(start, StartPosition::Tip),
+            start,
+            last_block: None,
+            contexts: BTreeMap::new(),
+        }
+    }
+
+    pub fn observe_account(
+        &mut self,
+        update: SubscribeUpdateAccount,
+    ) -> Result<()> {
+        let info = update
+            .account
+            .ok_or_else(|| anyhow!("Solana account update has no account"))?;
+        if self
+            .last_block
+            .as_ref()
+            .is_some_and(|(checkpoint, _)| update.slot <= checkpoint.slot)
+        {
+            bail!(
+                "late Solana sysvar account update for slot {} after checkpoint",
+                update.slot
+            );
+        }
+        if !self.contexts.contains_key(&update.slot)
+            && self.contexts.len() == MAX_CONTEXT_SLOTS
+        {
+            bail!(
+                "Solana sysvar context exceeded {MAX_CONTEXT_SLOTS} pending slots"
+            );
+        }
+        self.contexts.entry(update.slot).or_default().insert(
+            &info.pubkey,
+            AccountIdentity {
+                data: info.data,
+                write_version: info.write_version,
+                transaction_signature: info.txn_signature,
+            },
+        )
+    }
+
+    pub fn seal(
+        &mut self,
+        mut block: SubscribeUpdateBlock,
+    ) -> Result<SealDecision> {
+        let block_hash = decode_hash("blockhash", &block.blockhash)?;
+        let parent_block_hash =
+            decode_hash("parent blockhash", &block.parent_blockhash)?;
+        block
+            .transactions
+            .sort_by_key(|transaction| transaction.index);
+        validate_transactions(&block.transactions)?;
+        let identity = block_identity(&block, block_hash, parent_block_hash);
+
+        if !self.checkpoint_observed {
+            let StartPosition::Resume(checkpoint) = &self.start else {
+                unreachable!("tip starts with checkpoint observed")
+            };
+            if block.slot != checkpoint.slot {
+                bail!(
+                    "inclusive replay did not begin at checkpoint slot {}; observed {}",
+                    checkpoint.slot,
+                    block.slot
+                );
+            }
+            if block_hash != checkpoint.block_hash {
+                bail!("checkpoint block hash changed at slot {}", block.slot);
+            }
+            self.checkpoint_observed = true;
+            self.last_block = Some((checkpoint.clone(), identity));
+            self.contexts.remove(&block.slot);
+            return Ok(SealDecision::Replay);
+        }
+
+        if let Some((checkpoint, previous_identity)) = &self.last_block {
+            if block.slot == checkpoint.slot {
+                if &identity == previous_identity {
+                    self.contexts.remove(&block.slot);
+                    return Ok(SealDecision::Replay);
+                }
+                bail!("conflicting sealed block replay at slot {}", block.slot);
+            }
+            if block.slot < checkpoint.slot {
+                bail!("out-of-order sealed block at slot {}", block.slot);
+            }
+            if block.parent_slot != checkpoint.slot
+                || parent_block_hash != checkpoint.block_hash
+            {
+                bail!(
+                    "sealed block ancestry mismatch at slot {} (parent slot {})",
+                    block.slot,
+                    block.parent_slot
+                );
+            }
+        }
+
+        let has_successful_transaction = block
+            .transactions
+            .iter()
+            .any(|tx| tx.meta.as_ref().is_some_and(|meta| meta.err.is_none()));
+        let context = self.contexts.remove(&block.slot);
+        let (previous_bank_hash, clock_unix_timestamp) = match context {
+            Some(context) => (
+                context.slot_hashes.as_ref().and_then(|account| {
+                    previous_bank_hash_from_slot_hashes(
+                        &account.data,
+                        block.slot,
+                    )
+                }),
+                context
+                    .clock
+                    .as_ref()
+                    .and_then(|account| clock_unix_timestamp(&account.data)),
+            ),
+            None => (None, None),
+        };
+        if has_successful_transaction
+            && (previous_bank_hash.is_none() || clock_unix_timestamp.is_none())
+        {
+            bail!(
+                "missing or malformed SlotHashes/Clock context for successful transactions in slot {}",
+                block.slot
+            );
+        }
+
+        let sealed = SealedBlock {
+            slot: block.slot,
+            block_hash,
+            parent_slot: block.parent_slot,
+            parent_block_hash,
+            block_time: block.block_time.map(|time| time.timestamp),
+            block_height: block.block_height.map(|height| height.block_height),
+            executed_transaction_count: block.executed_transaction_count,
+            transactions: block.transactions,
+            previous_bank_hash,
+            clock_unix_timestamp,
+        };
+        self.last_block = Some((sealed.checkpoint(), identity));
+        Ok(SealDecision::Process(sealed))
+    }
+
+    #[cfg(test)]
+    fn current_checkpoint(&self) -> Option<&BlockCheckpoint> {
+        self.last_block
+            .as_ref()
+            .map(|(checkpoint, _)| checkpoint)
+            .or_else(|| match &self.start {
+                StartPosition::Resume(checkpoint) => Some(checkpoint),
+                StartPosition::Tip => None,
+            })
+    }
+}
+
+pub(super) fn build_subscribe_request(
+    program_id: &str,
+    start: &StartPosition,
+) -> SubscribeRequest {
+    let mut blocks = HashMap::new();
+    blocks.insert(
+        "zama_host".to_owned(),
+        SubscribeRequestFilterBlocks {
+            account_include: vec![program_id.to_owned()],
+            include_transactions: Some(true),
+            include_accounts: Some(false),
+            include_entries: Some(false),
+        },
+    );
+    let mut accounts = HashMap::new();
+    for (name, address) in
+        [("slot_hashes", SLOT_HASHES_SYSVAR), ("clock", CLOCK_SYSVAR)]
+    {
+        accounts.insert(
+            name.to_owned(),
+            SubscribeRequestFilterAccounts {
+                account: vec![address.to_owned()],
+                owner: vec![],
+                filters: vec![],
+                nonempty_txn_signature: None,
+            },
+        );
+    }
+    SubscribeRequest {
+        accounts,
+        slots: HashMap::new(),
+        transactions: HashMap::new(),
+        transactions_status: HashMap::new(),
+        blocks,
+        blocks_meta: HashMap::new(),
+        entry: HashMap::new(),
+        commitment: Some(
+            yellowstone_grpc_proto::prelude::CommitmentLevel::Confirmed as i32,
+        ),
+        accounts_data_slice: vec![],
+        ping: None,
+        from_slot: match start {
+            StartPosition::Tip => None,
+            StartPosition::Resume(checkpoint) => Some(checkpoint.slot),
+        },
+    }
+}
+
+fn decode_hash(name: &str, value: &str) -> Result<[u8; 32]> {
+    let bytes = bs58::decode(value)
+        .into_vec()
+        .with_context(|| format!("invalid {name}"))?;
+    <[u8; 32]>::try_from(bytes.as_slice())
+        .with_context(|| format!("{name} is not 32 bytes"))
+}
+
+fn validate_transactions(
+    transactions: &[SubscribeUpdateTransactionInfo],
+) -> Result<()> {
+    for pair in transactions.windows(2) {
+        if pair[0].index == pair[1].index {
+            bail!("duplicate Yellowstone transaction index {}", pair[0].index);
+        }
+    }
+    for transaction in transactions {
+        let Some(meta) = &transaction.meta else {
+            bail!("transaction {} has no status meta", transaction.index);
+        };
+        if meta.err.is_none() {
+            let tx = transaction.transaction.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "successful transaction {} has no transaction",
+                    transaction.index
+                )
+            })?;
+            if tx.message.is_none() {
+                bail!(
+                    "successful transaction {} has no message",
+                    transaction.index
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn block_identity(
+    block: &SubscribeUpdateBlock,
+    block_hash: [u8; 32],
+    parent_block_hash: [u8; 32],
+) -> BlockIdentity {
+    BlockIdentity {
+        block_hash,
+        parent_slot: block.parent_slot,
+        parent_block_hash,
+        transactions: block
+            .transactions
+            .iter()
+            .map(|transaction| {
+                (transaction.index, transaction.signature.clone())
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yellowstone_grpc_proto::prelude::{
+        Message, SubscribeUpdateAccountInfo, Transaction, TransactionError,
+        TransactionStatusMeta,
+    };
+
+    fn hash(tag: u8) -> [u8; 32] {
+        [tag; 32]
+    }
+
+    fn successful(index: u64) -> SubscribeUpdateTransactionInfo {
+        SubscribeUpdateTransactionInfo {
+            signature: vec![index as u8; 64],
+            is_vote: false,
+            transaction: Some(Transaction {
+                message: Some(Message::default()),
+                ..Default::default()
+            }),
+            meta: Some(TransactionStatusMeta::default()),
+            index,
+        }
+    }
+
+    fn failed(index: u64) -> SubscribeUpdateTransactionInfo {
+        SubscribeUpdateTransactionInfo {
+            meta: Some(TransactionStatusMeta {
+                err: Some(TransactionError { err: vec![1] }),
+                ..Default::default()
+            }),
+            index,
+            ..Default::default()
+        }
+    }
+
+    fn block(
+        slot: u64,
+        block_hash: [u8; 32],
+        parent_slot: u64,
+        parent_hash: [u8; 32],
+        transactions: Vec<SubscribeUpdateTransactionInfo>,
+    ) -> SubscribeUpdateBlock {
+        SubscribeUpdateBlock {
+            slot,
+            blockhash: bs58::encode(block_hash).into_string(),
+            parent_slot,
+            parent_blockhash: bs58::encode(parent_hash).into_string(),
+            transactions,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_block_advances_checkpoint() {
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let decision = validator
+            .seal(block(2, hash(2), 1, hash(1), vec![]))
+            .unwrap();
+        assert!(matches!(decision, SealDecision::Process(_)));
+        assert_eq!(validator.current_checkpoint().unwrap().slot, 2);
+    }
+
+    #[test]
+    fn transactions_are_sorted_and_failed_transactions_are_retained_for_ignore()
+    {
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let decision = validator
+            .seal(block(2, hash(2), 1, hash(1), vec![failed(3), failed(1)]))
+            .unwrap();
+        let SealDecision::Process(block) = decision else {
+            panic!()
+        };
+        assert_eq!(
+            block
+                .transactions
+                .iter()
+                .map(|tx| tx.index)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+    }
+
+    #[test]
+    fn malformed_successful_transaction_halts() {
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut transaction = successful(0);
+        transaction.meta = None;
+        assert!(validator
+            .seal(block(2, hash(2), 1, hash(1), vec![transaction]))
+            .is_err());
+    }
+
+    #[test]
+    fn inclusive_replay_is_idempotent_but_conflicts_halt() {
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let original = block(2, hash(2), 1, hash(1), vec![failed(1)]);
+        assert!(matches!(
+            validator.seal(original.clone()).unwrap(),
+            SealDecision::Process(_)
+        ));
+        assert!(matches!(
+            validator.seal(original).unwrap(),
+            SealDecision::Replay
+        ));
+        assert!(validator
+            .seal(block(2, hash(2), 1, hash(1), vec![failed(2)]))
+            .is_err());
+        assert!(validator
+            .seal(block(2, hash(9), 1, hash(1), vec![failed(1)]))
+            .is_err());
+    }
+
+    #[test]
+    fn resume_must_observe_checkpoint_hash_before_descendant() {
+        let checkpoint = BlockCheckpoint {
+            slot: 5,
+            block_hash: hash(5),
+        };
+        let mut validator =
+            BlockValidator::new(StartPosition::Resume(checkpoint));
+        assert!(validator
+            .seal(block(6, hash(6), 5, hash(5), vec![]))
+            .is_err());
+
+        let checkpoint = BlockCheckpoint {
+            slot: 5,
+            block_hash: hash(5),
+        };
+        let mut validator =
+            BlockValidator::new(StartPosition::Resume(checkpoint));
+        assert!(matches!(
+            validator
+                .seal(block(5, hash(5), 4, hash(4), vec![]))
+                .unwrap(),
+            SealDecision::Replay
+        ));
+        assert!(validator
+            .seal(block(6, hash(6), 4, hash(4), vec![]))
+            .is_err());
+    }
+
+    #[test]
+    fn missing_context_prevents_successful_block_advance() {
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        assert!(validator
+            .seal(block(2, hash(2), 1, hash(1), vec![successful(0)]))
+            .is_err());
+        assert!(validator.current_checkpoint().is_none());
+    }
+
+    #[test]
+    fn account_identity_conflict_and_context_overflow_halt() {
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let account = |slot, data: Vec<u8>| SubscribeUpdateAccount {
+            slot,
+            account: Some(SubscribeUpdateAccountInfo {
+                pubkey: bs58::decode(CLOCK_SYSVAR).into_vec().unwrap(),
+                data,
+                write_version: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        validator.observe_account(account(1, vec![1])).unwrap();
+        assert!(validator.observe_account(account(1, vec![2])).is_err());
+
+        let mut validator = BlockValidator::new(StartPosition::Tip);
+        for slot in 0..MAX_CONTEXT_SLOTS as u64 {
+            validator.observe_account(account(slot, vec![1])).unwrap();
+        }
+        assert!(validator
+            .observe_account(account(MAX_CONTEXT_SLOTS as u64, vec![1]))
+            .is_err());
+    }
+
+    #[test]
+    fn request_uses_sealed_blocks_and_separate_sysvars() {
+        let checkpoint = BlockCheckpoint {
+            slot: 9,
+            block_hash: hash(9),
+        };
+        let request = build_subscribe_request(
+            "ZamaHost11111111111111111111111111111111",
+            &StartPosition::Resume(checkpoint),
+        );
+        assert!(request.transactions.is_empty());
+        assert!(request.blocks_meta.is_empty());
+        assert_eq!(request.blocks.len(), 1);
+        assert_eq!(request.accounts.len(), 2);
+        assert_eq!(request.from_slot, Some(9));
+    }
+
+    #[test]
+    fn resume_accepts_checkpoint_context_then_rejects_late_updates() {
+        let account = || SubscribeUpdateAccount {
+            slot: 9,
+            account: Some(SubscribeUpdateAccountInfo {
+                pubkey: bs58::decode(CLOCK_SYSVAR).into_vec().unwrap(),
+                data: vec![1],
+                write_version: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let checkpoint = BlockCheckpoint {
+            slot: 9,
+            block_hash: hash(9),
+        };
+        let mut validator =
+            BlockValidator::new(StartPosition::Resume(checkpoint));
+
+        validator.observe_account(account()).unwrap();
+        assert!(matches!(
+            validator
+                .seal(block(9, hash(9), 8, hash(8), vec![]))
+                .unwrap(),
+            SealDecision::Replay
+        ));
+        assert!(validator.observe_account(account()).is_err());
+    }
+}

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
@@ -84,15 +84,29 @@ impl SlotContext {
             }
         }
     }
+
+    fn verify_replay(
+        &self,
+        pubkey: &[u8],
+        identity: &AccountIdentity,
+    ) -> Result<()> {
+        let retained =
+            if bs58::encode(pubkey).into_string() == SLOT_HASHES_SYSVAR {
+                &self.slot_hashes
+            } else if bs58::encode(pubkey).into_string() == CLOCK_SYSVAR {
+                &self.clock
+            } else {
+                bail!("unexpected account in Solana sysvar stream")
+            };
+        if retained.as_ref().is_some_and(|current| current != identity) {
+            bail!("conflicting committed Solana sysvar account replay")
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct BlockIdentity {
-    block_hash: [u8; 32],
-    parent_slot: u64,
-    parent_block_hash: [u8; 32],
-    transactions: Vec<SubscribeUpdateTransactionInfo>,
-}
+struct BlockIdentity(SubscribeUpdateBlock);
 
 #[derive(Debug)]
 pub(super) enum SealDecision {
@@ -107,6 +121,7 @@ pub(super) struct BlockValidator {
     checkpoint_observed: bool,
     last_observed: Option<(BlockCheckpoint, BlockIdentity)>,
     last_committed: Option<BlockCheckpoint>,
+    last_committed_context: Option<(u64, SlotContext)>,
     contexts: BTreeMap<u64, SlotContext>,
 }
 
@@ -118,6 +133,7 @@ impl BlockValidator {
             resume_is_applied,
             last_observed: None,
             last_committed: None,
+            last_committed_context: None,
             contexts: BTreeMap::new(),
         }
     }
@@ -129,15 +145,22 @@ impl BlockValidator {
         let info = update
             .account
             .ok_or_else(|| anyhow!("Solana account update has no account"))?;
+        let identity = AccountIdentity {
+            data: info.data,
+            write_version: info.write_version,
+            transaction_signature: info.txn_signature,
+        };
         if self
             .last_committed
             .as_ref()
             .is_some_and(|checkpoint| update.slot <= checkpoint.slot)
         {
-            bail!(
-                "late Solana sysvar account update for slot {} after checkpoint",
-                update.slot
-            );
+            if let Some((slot, context)) = &self.last_committed_context {
+                if update.slot == *slot {
+                    context.verify_replay(&info.pubkey, &identity)?;
+                }
+            }
+            return Ok(());
         }
         if !self.contexts.contains_key(&update.slot)
             && self.contexts.len() == MAX_CONTEXT_SLOTS
@@ -146,14 +169,10 @@ impl BlockValidator {
                 "Solana sysvar context exceeded {MAX_CONTEXT_SLOTS} pending slots"
             );
         }
-        self.contexts.entry(update.slot).or_default().insert(
-            &info.pubkey,
-            AccountIdentity {
-                data: info.data,
-                write_version: info.write_version,
-                transaction_signature: info.txn_signature,
-            },
-        )
+        self.contexts
+            .entry(update.slot)
+            .or_default()
+            .insert(&info.pubkey, identity)
     }
 
     pub fn seal(
@@ -170,7 +189,7 @@ impl BlockValidator {
             &block.transactions,
             block.executed_transaction_count,
         )?;
-        let identity = block_identity(&block, block_hash, parent_block_hash);
+        let identity = block_identity(&block);
 
         if !self.checkpoint_observed {
             let StartPosition::Resume(checkpoint) = &self.start else {
@@ -190,6 +209,7 @@ impl BlockValidator {
             if self.resume_is_applied {
                 self.last_observed = Some((checkpoint.clone(), identity));
                 self.last_committed = Some(checkpoint.clone());
+                self.last_committed_context = None;
                 self.contexts.remove(&block.slot);
                 return Ok(SealDecision::Replay);
             }
@@ -269,9 +289,24 @@ impl BlockValidator {
             .and_then(|account| clock_unix_timestamp(&account.data));
     }
 
-    pub fn commit(&mut self, block: &SealedBlock) {
+    pub fn commit(
+        &mut self,
+        block: &SealedBlock,
+        retain_slot_hashes: bool,
+        retain_clock: bool,
+    ) {
         self.last_committed = Some(block.checkpoint());
-        self.contexts.remove(&block.slot);
+        self.last_committed_context =
+            self.contexts.remove(&block.slot).and_then(|mut context| {
+                if !retain_slot_hashes {
+                    context.slot_hashes = None;
+                }
+                if !retain_clock {
+                    context.clock = None;
+                }
+                (context.slot_hashes.is_some() || context.clock.is_some())
+                    .then_some((block.slot, context))
+            });
     }
 
     #[cfg(test)]
@@ -379,17 +414,8 @@ fn validate_transactions(
     Ok(())
 }
 
-fn block_identity(
-    block: &SubscribeUpdateBlock,
-    block_hash: [u8; 32],
-    parent_block_hash: [u8; 32],
-) -> BlockIdentity {
-    BlockIdentity {
-        block_hash,
-        parent_slot: block.parent_slot,
-        parent_block_hash,
-        transactions: block.transactions.clone(),
-    }
+fn block_identity(block: &SubscribeUpdateBlock) -> BlockIdentity {
+    BlockIdentity(block.clone())
 }
 
 #[cfg(test)]
@@ -461,7 +487,7 @@ mod tests {
         let SealDecision::Process(block) = decision else {
             panic!()
         };
-        validator.commit(&block);
+        validator.commit(&block, false, false);
         assert_eq!(validator.current_checkpoint().unwrap().slot, 2);
     }
 
@@ -498,19 +524,24 @@ mod tests {
     #[test]
     fn inclusive_replay_is_idempotent_but_conflicts_halt() {
         let mut validator = BlockValidator::new(StartPosition::Tip, true);
-        let original = block(2, hash(2), 1, hash(1), vec![failed(1)]);
+        let mut original = block(2, hash(2), 1, hash(1), vec![failed(1)]);
+        original.block_time = Some(Default::default());
+        original.block_time.as_mut().unwrap().timestamp = 100;
         let SealDecision::Process(processed) =
             validator.seal(original.clone()).unwrap()
         else {
             panic!()
         };
-        validator.commit(&processed);
+        validator.commit(&processed, false, false);
         assert!(matches!(
-            validator.seal(original).unwrap(),
+            validator.seal(original.clone()).unwrap(),
             SealDecision::Replay
         ));
-        let mut changed_payload = failed(1);
-        changed_payload
+        let mut changed_time = original.clone();
+        changed_time.block_time.as_mut().unwrap().timestamp = 101;
+        assert!(validator.seal(changed_time).is_err());
+        let mut changed_payload = original.clone();
+        changed_payload.transactions[0]
             .meta
             .as_mut()
             .unwrap()
@@ -518,12 +549,11 @@ mod tests {
             .as_mut()
             .unwrap()
             .err = vec![2];
-        assert!(validator
-            .seal(block(2, hash(2), 1, hash(1), vec![changed_payload]))
-            .is_err());
-        assert!(validator
-            .seal(block(2, hash(2), 1, hash(1), vec![failed(2)]))
-            .is_err());
+        assert!(validator.seal(changed_payload).is_err());
+
+        let mut changed_count = original.clone();
+        changed_count.executed_transaction_count += 1;
+        assert!(validator.seal(changed_count).is_err());
         assert!(validator
             .seal(block(2, hash(9), 1, hash(1), vec![failed(1)]))
             .is_err());
@@ -644,7 +674,7 @@ mod tests {
         assert_eq!(sealed.previous_bank_hash, Some(hash(1)));
         assert_eq!(sealed.clock_unix_timestamp, Some(1_700_000_000));
         assert!(validator.current_checkpoint().is_none());
-        validator.commit(&sealed);
+        validator.commit(&sealed, true, true);
         assert_eq!(validator.current_checkpoint().unwrap().slot, 2);
     }
 
@@ -740,12 +770,12 @@ mod tests {
     }
 
     #[test]
-    fn resume_accepts_checkpoint_context_then_rejects_late_updates() {
-        let account = || SubscribeUpdateAccount {
+    fn irrelevant_late_context_is_harmless_but_retained_conflicts_halt() {
+        let account = |data: Vec<u8>| SubscribeUpdateAccount {
             slot: 9,
             account: Some(SubscribeUpdateAccountInfo {
                 pubkey: bs58::decode(CLOCK_SYSVAR).into_vec().unwrap(),
-                data: vec![1],
+                data,
                 write_version: 1,
                 ..Default::default()
             }),
@@ -758,13 +788,25 @@ mod tests {
         let mut validator =
             BlockValidator::new(StartPosition::Resume(checkpoint), true);
 
-        validator.observe_account(account()).unwrap();
+        validator.observe_account(account(vec![1])).unwrap();
         assert!(matches!(
             validator
                 .seal(block(9, hash(9), 8, hash(8), vec![]))
                 .unwrap(),
             SealDecision::Replay
         ));
-        assert!(validator.observe_account(account()).is_err());
+        validator.observe_account(account(vec![2])).unwrap();
+
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
+        validator.observe_account(account(vec![1])).unwrap();
+        let SealDecision::Process(sealed) = validator
+            .seal(block(9, hash(9), 8, hash(8), vec![]))
+            .unwrap()
+        else {
+            panic!()
+        };
+        validator.commit(&sealed, false, true);
+        validator.observe_account(account(vec![1])).unwrap();
+        assert!(validator.observe_account(account(vec![2])).is_err());
     }
 }

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
@@ -86,12 +86,12 @@ impl SlotContext {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 struct BlockIdentity {
     block_hash: [u8; 32],
     parent_slot: u64,
     parent_block_hash: [u8; 32],
-    transactions: Vec<(u64, Vec<u8>)>,
+    transactions: Vec<SubscribeUpdateTransactionInfo>,
 }
 
 #[derive(Debug)]
@@ -103,17 +103,21 @@ pub(super) enum SealDecision {
 #[derive(Debug)]
 pub(super) struct BlockValidator {
     start: StartPosition,
+    resume_is_applied: bool,
     checkpoint_observed: bool,
-    last_block: Option<(BlockCheckpoint, BlockIdentity)>,
+    last_observed: Option<(BlockCheckpoint, BlockIdentity)>,
+    last_committed: Option<BlockCheckpoint>,
     contexts: BTreeMap<u64, SlotContext>,
 }
 
 impl BlockValidator {
-    pub fn new(start: StartPosition) -> Self {
+    pub fn new(start: StartPosition, resume_is_applied: bool) -> Self {
         Self {
             checkpoint_observed: matches!(start, StartPosition::Tip),
             start,
-            last_block: None,
+            resume_is_applied,
+            last_observed: None,
+            last_committed: None,
             contexts: BTreeMap::new(),
         }
     }
@@ -126,9 +130,9 @@ impl BlockValidator {
             .account
             .ok_or_else(|| anyhow!("Solana account update has no account"))?;
         if self
-            .last_block
+            .last_committed
             .as_ref()
-            .is_some_and(|(checkpoint, _)| update.slot <= checkpoint.slot)
+            .is_some_and(|checkpoint| update.slot <= checkpoint.slot)
         {
             bail!(
                 "late Solana sysvar account update for slot {} after checkpoint",
@@ -162,7 +166,10 @@ impl BlockValidator {
         block
             .transactions
             .sort_by_key(|transaction| transaction.index);
-        validate_transactions(&block.transactions)?;
+        validate_transactions(
+            &block.transactions,
+            block.executed_transaction_count,
+        )?;
         let identity = block_identity(&block, block_hash, parent_block_hash);
 
         if !self.checkpoint_observed {
@@ -180,15 +187,24 @@ impl BlockValidator {
                 bail!("checkpoint block hash changed at slot {}", block.slot);
             }
             self.checkpoint_observed = true;
-            self.last_block = Some((checkpoint.clone(), identity));
-            self.contexts.remove(&block.slot);
-            return Ok(SealDecision::Replay);
+            if self.resume_is_applied {
+                self.last_observed = Some((checkpoint.clone(), identity));
+                self.last_committed = Some(checkpoint.clone());
+                self.contexts.remove(&block.slot);
+                return Ok(SealDecision::Replay);
+            }
         }
 
-        if let Some((checkpoint, previous_identity)) = &self.last_block {
+        if let Some((checkpoint, previous_identity)) = &self.last_observed {
             if block.slot == checkpoint.slot {
                 if &identity == previous_identity {
-                    self.contexts.remove(&block.slot);
+                    if self
+                        .last_committed
+                        .as_ref()
+                        .is_some_and(|committed| committed.slot == block.slot)
+                    {
+                        self.contexts.remove(&block.slot);
+                    }
                     return Ok(SealDecision::Replay);
                 }
                 bail!("conflicting sealed block replay at slot {}", block.slot);
@@ -207,11 +223,7 @@ impl BlockValidator {
             }
         }
 
-        let has_successful_transaction = block
-            .transactions
-            .iter()
-            .any(|tx| tx.meta.as_ref().is_some_and(|meta| meta.err.is_none()));
-        let context = self.contexts.remove(&block.slot);
+        let context = self.contexts.get(&block.slot);
         let (previous_bank_hash, clock_unix_timestamp) = match context {
             Some(context) => (
                 context.slot_hashes.as_ref().and_then(|account| {
@@ -227,15 +239,6 @@ impl BlockValidator {
             ),
             None => (None, None),
         };
-        if has_successful_transaction
-            && (previous_bank_hash.is_none() || clock_unix_timestamp.is_none())
-        {
-            bail!(
-                "missing or malformed SlotHashes/Clock context for successful transactions in slot {}",
-                block.slot
-            );
-        }
-
         let sealed = SealedBlock {
             slot: block.slot,
             block_hash,
@@ -248,19 +251,32 @@ impl BlockValidator {
             previous_bank_hash,
             clock_unix_timestamp,
         };
-        self.last_block = Some((sealed.checkpoint(), identity));
+        self.last_observed = Some((sealed.checkpoint(), identity));
         Ok(SealDecision::Process(sealed))
+    }
+
+    pub fn refresh_context(&self, block: &mut SealedBlock) {
+        let Some(context) = self.contexts.get(&block.slot) else {
+            return;
+        };
+        block.previous_bank_hash =
+            context.slot_hashes.as_ref().and_then(|account| {
+                previous_bank_hash_from_slot_hashes(&account.data, block.slot)
+            });
+        block.clock_unix_timestamp = context
+            .clock
+            .as_ref()
+            .and_then(|account| clock_unix_timestamp(&account.data));
+    }
+
+    pub fn commit(&mut self, block: &SealedBlock) {
+        self.last_committed = Some(block.checkpoint());
+        self.contexts.remove(&block.slot);
     }
 
     #[cfg(test)]
     fn current_checkpoint(&self) -> Option<&BlockCheckpoint> {
-        self.last_block
-            .as_ref()
-            .map(|(checkpoint, _)| checkpoint)
-            .or_else(|| match &self.start {
-                StartPosition::Resume(checkpoint) => Some(checkpoint),
-                StartPosition::Tip => None,
-            })
+        self.last_committed.as_ref()
     }
 }
 
@@ -278,20 +294,18 @@ pub(super) fn build_subscribe_request(
             include_entries: Some(false),
         },
     );
-    let mut accounts = HashMap::new();
-    for (name, address) in
-        [("slot_hashes", SLOT_HASHES_SYSVAR), ("clock", CLOCK_SYSVAR)]
-    {
-        accounts.insert(
-            name.to_owned(),
-            SubscribeRequestFilterAccounts {
-                account: vec![address.to_owned()],
-                owner: vec![],
-                filters: vec![],
-                nonempty_txn_signature: None,
-            },
-        );
-    }
+    let accounts = HashMap::from([(
+        "sysvars".to_owned(),
+        SubscribeRequestFilterAccounts {
+            account: vec![
+                SLOT_HASHES_SYSVAR.to_owned(),
+                CLOCK_SYSVAR.to_owned(),
+            ],
+            owner: vec![],
+            filters: vec![],
+            nonempty_txn_signature: None,
+        },
+    )]);
     SubscribeRequest {
         accounts,
         slots: HashMap::new(),
@@ -322,6 +336,7 @@ fn decode_hash(name: &str, value: &str) -> Result<[u8; 32]> {
 
 fn validate_transactions(
     transactions: &[SubscribeUpdateTransactionInfo],
+    executed_transaction_count: u64,
 ) -> Result<()> {
     for pair in transactions.windows(2) {
         if pair[0].index == pair[1].index {
@@ -329,6 +344,20 @@ fn validate_transactions(
         }
     }
     for transaction in transactions {
+        if transaction.signature.len() != 64 {
+            bail!(
+                "transaction {} signature has invalid length {}, expected 64 bytes",
+                transaction.index,
+                transaction.signature.len()
+            );
+        }
+        if transaction.index >= executed_transaction_count {
+            bail!(
+                "transaction index {} is outside executed transaction count {}",
+                transaction.index,
+                executed_transaction_count
+            );
+        }
         let Some(meta) = &transaction.meta else {
             bail!("transaction {} has no status meta", transaction.index);
         };
@@ -359,13 +388,7 @@ fn block_identity(
         block_hash,
         parent_slot: block.parent_slot,
         parent_block_hash,
-        transactions: block
-            .transactions
-            .iter()
-            .map(|transaction| {
-                (transaction.index, transaction.signature.clone())
-            })
-            .collect(),
+        transactions: block.transactions.clone(),
     }
 }
 
@@ -396,6 +419,7 @@ mod tests {
 
     fn failed(index: u64) -> SubscribeUpdateTransactionInfo {
         SubscribeUpdateTransactionInfo {
+            signature: vec![index as u8; 64],
             meta: Some(TransactionStatusMeta {
                 err: Some(TransactionError { err: vec![1] }),
                 ..Default::default()
@@ -412,30 +436,39 @@ mod tests {
         parent_hash: [u8; 32],
         transactions: Vec<SubscribeUpdateTransactionInfo>,
     ) -> SubscribeUpdateBlock {
+        let executed_transaction_count = transactions
+            .iter()
+            .map(|transaction| transaction.index + 1)
+            .max()
+            .unwrap_or(0);
         SubscribeUpdateBlock {
             slot,
             blockhash: bs58::encode(block_hash).into_string(),
             parent_slot,
             parent_blockhash: bs58::encode(parent_hash).into_string(),
             transactions,
+            executed_transaction_count,
             ..Default::default()
         }
     }
 
     #[test]
     fn empty_block_advances_checkpoint() {
-        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
         let decision = validator
             .seal(block(2, hash(2), 1, hash(1), vec![]))
             .unwrap();
-        assert!(matches!(decision, SealDecision::Process(_)));
+        let SealDecision::Process(block) = decision else {
+            panic!()
+        };
+        validator.commit(&block);
         assert_eq!(validator.current_checkpoint().unwrap().slot, 2);
     }
 
     #[test]
     fn transactions_are_sorted_and_failed_transactions_are_retained_for_ignore()
     {
-        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
         let decision = validator
             .seal(block(2, hash(2), 1, hash(1), vec![failed(3), failed(1)]))
             .unwrap();
@@ -454,7 +487,7 @@ mod tests {
 
     #[test]
     fn malformed_successful_transaction_halts() {
-        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
         let mut transaction = successful(0);
         transaction.meta = None;
         assert!(validator
@@ -464,21 +497,54 @@ mod tests {
 
     #[test]
     fn inclusive_replay_is_idempotent_but_conflicts_halt() {
-        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
         let original = block(2, hash(2), 1, hash(1), vec![failed(1)]);
-        assert!(matches!(
-            validator.seal(original.clone()).unwrap(),
-            SealDecision::Process(_)
-        ));
+        let SealDecision::Process(processed) =
+            validator.seal(original.clone()).unwrap()
+        else {
+            panic!()
+        };
+        validator.commit(&processed);
         assert!(matches!(
             validator.seal(original).unwrap(),
             SealDecision::Replay
         ));
+        let mut changed_payload = failed(1);
+        changed_payload
+            .meta
+            .as_mut()
+            .unwrap()
+            .err
+            .as_mut()
+            .unwrap()
+            .err = vec![2];
+        assert!(validator
+            .seal(block(2, hash(2), 1, hash(1), vec![changed_payload]))
+            .is_err());
         assert!(validator
             .seal(block(2, hash(2), 1, hash(1), vec![failed(2)]))
             .is_err());
         assert!(validator
             .seal(block(2, hash(9), 1, hash(1), vec![failed(1)]))
+            .is_err());
+    }
+
+    #[test]
+    fn malformed_signature_and_out_of_range_index_halt() {
+        for length in [0, 63] {
+            let mut transaction = failed(0);
+            transaction.signature = vec![1; length];
+            let mut invalid = block(2, hash(2), 1, hash(1), vec![transaction]);
+            invalid.executed_transaction_count = 1;
+            assert!(BlockValidator::new(StartPosition::Tip, true)
+                .seal(invalid)
+                .is_err());
+        }
+
+        let mut invalid = block(2, hash(2), 1, hash(1), vec![failed(1)]);
+        invalid.executed_transaction_count = 1;
+        assert!(BlockValidator::new(StartPosition::Tip, true)
+            .seal(invalid)
             .is_err());
     }
 
@@ -489,7 +555,7 @@ mod tests {
             block_hash: hash(5),
         };
         let mut validator =
-            BlockValidator::new(StartPosition::Resume(checkpoint));
+            BlockValidator::new(StartPosition::Resume(checkpoint), true);
         assert!(validator
             .seal(block(6, hash(6), 5, hash(5), vec![]))
             .is_err());
@@ -499,7 +565,7 @@ mod tests {
             block_hash: hash(5),
         };
         let mut validator =
-            BlockValidator::new(StartPosition::Resume(checkpoint));
+            BlockValidator::new(StartPosition::Resume(checkpoint), true);
         assert!(matches!(
             validator
                 .seal(block(5, hash(5), 4, hash(4), vec![]))
@@ -512,17 +578,123 @@ mod tests {
     }
 
     #[test]
-    fn missing_context_prevents_successful_block_advance() {
-        let mut validator = BlockValidator::new(StartPosition::Tip);
-        assert!(validator
+    fn unapplied_resume_processes_the_checkpoint_block() {
+        let checkpoint = BlockCheckpoint {
+            slot: 5,
+            block_hash: hash(5),
+        };
+        let mut validator =
+            BlockValidator::new(StartPosition::Resume(checkpoint), false);
+
+        let decision = validator
+            .seal(block(5, hash(5), 4, hash(4), vec![]))
+            .unwrap();
+
+        assert!(matches!(decision, SealDecision::Process(_)));
+        assert!(validator.current_checkpoint().is_none());
+    }
+
+    #[test]
+    fn missing_context_does_not_commit_the_sealed_block() {
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
+        let decision = validator
             .seal(block(2, hash(2), 1, hash(1), vec![successful(0)]))
-            .is_err());
+            .unwrap();
+        let SealDecision::Process(block) = decision else {
+            panic!()
+        };
+        assert!(block.previous_bank_hash.is_none());
+        assert!(block.clock_unix_timestamp.is_none());
+        assert!(validator.current_checkpoint().is_none());
+    }
+
+    #[test]
+    fn sealed_block_can_wait_for_later_sysvar_context() {
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
+        let SealDecision::Process(mut sealed) = validator
+            .seal(block(2, hash(2), 1, hash(1), vec![successful(0)]))
+            .unwrap()
+        else {
+            panic!()
+        };
+
+        let mut slot_hashes = 1_u64.to_le_bytes().to_vec();
+        slot_hashes.extend_from_slice(&1_u64.to_le_bytes());
+        slot_hashes.extend_from_slice(&hash(1));
+        let mut clock = vec![0; 40];
+        clock[32..40].copy_from_slice(&1_700_000_000_i64.to_le_bytes());
+        for (address, data) in
+            [(SLOT_HASHES_SYSVAR, slot_hashes), (CLOCK_SYSVAR, clock)]
+        {
+            validator
+                .observe_account(SubscribeUpdateAccount {
+                    slot: 2,
+                    account: Some(SubscribeUpdateAccountInfo {
+                        pubkey: bs58::decode(address).into_vec().unwrap(),
+                        data,
+                        write_version: 1,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+
+        validator.refresh_context(&mut sealed);
+        assert_eq!(sealed.previous_bank_hash, Some(hash(1)));
+        assert_eq!(sealed.clock_unix_timestamp, Some(1_700_000_000));
+        assert!(validator.current_checkpoint().is_none());
+        validator.commit(&sealed);
+        assert_eq!(validator.current_checkpoint().unwrap().slot, 2);
+    }
+
+    #[test]
+    fn context_can_lag_past_a_later_sealed_block() {
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
+        let SealDecision::Process(mut first) = validator
+            .seal(block(2, hash(2), 1, hash(1), vec![successful(0)]))
+            .unwrap()
+        else {
+            panic!()
+        };
+        assert!(matches!(
+            validator
+                .seal(block(3, hash(3), 2, hash(2), vec![successful(0)]))
+                .unwrap(),
+            SealDecision::Process(_)
+        ));
+
+        let mut slot_hashes = 1_u64.to_le_bytes().to_vec();
+        slot_hashes.extend_from_slice(&1_u64.to_le_bytes());
+        slot_hashes.extend_from_slice(&hash(1));
+        let mut clock = vec![0; 40];
+        clock[32..40].copy_from_slice(&1_700_000_000_i64.to_le_bytes());
+        for (address, data) in
+            [(SLOT_HASHES_SYSVAR, slot_hashes), (CLOCK_SYSVAR, clock)]
+        {
+            validator
+                .observe_account(SubscribeUpdateAccount {
+                    slot: 2,
+                    account: Some(SubscribeUpdateAccountInfo {
+                        pubkey: bs58::decode(address).into_vec().unwrap(),
+                        data,
+                        write_version: 1,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+
+        validator.refresh_context(&mut first);
+        assert_eq!(first.previous_bank_hash, Some(hash(1)));
+        assert_eq!(first.clock_unix_timestamp, Some(1_700_000_000));
         assert!(validator.current_checkpoint().is_none());
     }
 
     #[test]
     fn account_identity_conflict_and_context_overflow_halt() {
-        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
         let account = |slot, data: Vec<u8>| SubscribeUpdateAccount {
             slot,
             account: Some(SubscribeUpdateAccountInfo {
@@ -536,7 +708,7 @@ mod tests {
         validator.observe_account(account(1, vec![1])).unwrap();
         assert!(validator.observe_account(account(1, vec![2])).is_err());
 
-        let mut validator = BlockValidator::new(StartPosition::Tip);
+        let mut validator = BlockValidator::new(StartPosition::Tip, true);
         for slot in 0..MAX_CONTEXT_SLOTS as u64 {
             validator.observe_account(account(slot, vec![1])).unwrap();
         }
@@ -558,7 +730,12 @@ mod tests {
         assert!(request.transactions.is_empty());
         assert!(request.blocks_meta.is_empty());
         assert_eq!(request.blocks.len(), 1);
-        assert_eq!(request.accounts.len(), 2);
+        assert_eq!(request.accounts.len(), 1);
+        let account_filter = request.accounts.get("sysvars").unwrap();
+        assert_eq!(
+            account_filter.account,
+            vec![SLOT_HASHES_SYSVAR.to_owned(), CLOCK_SYSVAR.to_owned()]
+        );
         assert_eq!(request.from_slot, Some(9));
     }
 
@@ -579,7 +756,7 @@ mod tests {
             block_hash: hash(9),
         };
         let mut validator =
-            BlockValidator::new(StartPosition::Resume(checkpoint));
+            BlockValidator::new(StartPosition::Resume(checkpoint), true);
 
         validator.observe_account(account()).unwrap();
         assert!(matches!(

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
@@ -95,6 +95,8 @@ async fn confidential_transfer_reconstructs_computes_and_decrypts(
 
     let block = SolanaBlockMeta {
         block_number: 1,
+        block_hash: [1; 32],
+        parent_hash: [0; 32],
         block_timestamp: PrimitiveDateTime::new(
             Date::from_calendar_date(2026, Month::May, 11)?,
             Time::MIDNIGHT,

--- a/solana/geyser/yellowstone-config.json
+++ b/solana/geyser/yellowstone-config.json
@@ -10,7 +10,7 @@
     "channel_capacity": "100_000",
     "unary_concurrency_limit": 100,
     "unary_disabled": false,
-    "replay_stored_slots": 0,
+    "replay_stored_slots": 256,
     "filter_name_size_limit": 128,
     "filter_names_size_limit": 4096,
     "filter_names_cleanup_interval": "1s",


### PR DESCRIPTION
## What

- consume Yellowstone `SubscribeUpdateBlock` seals instead of independently correlating transaction and block-meta streams
- process successful matching transactions in Yellowstone index order, ignore failed transactions, and advance an in-memory `{ slot, block_hash }` checkpoint only after the whole matching block has been ingested
- retain the validator block hash and parent hash for dependence-chain bookkeeping
- bound the separate SlotHashes/Clock context to 256 pending slots and fail closed on missing, conflicting, late, or overflowing context
- resume inclusively and require the checkpoint slot/hash before accepting descendants
- keep 256 Yellowstone replay slots and include the new focused source tests in the Solana workflow trigger

## Why

The previous cursor advanced per transaction, could permanently skip malformed successful transactions, used unbounded per-slot maps, and synthesized block identity from the slot. A server-sealed block is the smallest transaction-complete unit available from the pinned Yellowstone plugin. It also emits blocks whose host-program transaction subset is empty, so empty blocks can advance ancestry without pretending that arbitrary account state is complete.

This remains a concrete host-listener adapter. It does not add a provider framework, persistence, MMR/proof readiness changes, RPC recovery, or fork rollback policy. Durable checkpoint and atomic storage remain in #1682 follow-up work.

Stacked on #3198 (`elias/solana-canonical-transaction`).

Closes no issue; advances zama-ai/fhevm-internal#1682.

## Validation

- `cargo test -p host-listener --features solana-grpc,solana-reconstruct solana_grpc_ --lib` (22 passed)
- `cargo test -p host-listener --features solana-grpc,solana-reconstruct dependence_chain_uses_validator_block_hashes --lib`
- `cargo clippy -p host-listener --features solana-grpc,solana-reconstruct --lib -- -D warnings`
- `cargo check -p host-listener --features solana-grpc,solana-reconstruct --bin solana_host_listener`
- repository pre-commit formatting, cargo check, and CI-aligned Clippy
