### PR TITLE
chore(common): runs-on as default e2e test runner

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -176,7 +176,7 @@ jobs:
       ORCHESTRATED: ${{ inputs.orchestrated && 'true' || 'false' }}
       SCENARIO: ${{ inputs.scenario || 'two-of-three-multi-chain' }}
       TEST_PROFILE: ${{ inputs.test-profile || 'standard' }}
-    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64
+    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=80gb
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -176,7 +176,7 @@ jobs:
       ORCHESTRATED: ${{ inputs.orchestrated && 'true' || 'false' }}
       SCENARIO: ${{ inputs.scenario || 'two-of-three-multi-chain' }}
       TEST_PROFILE: ${{ inputs.test-profile || 'standard' }}
-    runs-on: large_ubuntu_32
+    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Use RunsOn runner instead of Github ones as we had multiple outage during the last few days

[Successful e2e run](https://github.com/zama-ai/fhevm/actions/runs/29502336671/job/87634330309?pr=3201)