### PR TITLE
feat(relayer): add Solana block source

### DIFF
--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +398,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "wasmtimer",
 ]
@@ -438,7 +444,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -639,7 +645,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -656,7 +662,7 @@ dependencies = [
  "itertools 0.14.0",
  "reqwest",
  "serde_json",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -1277,6 +1283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "aws-config"
 version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,7 +1556,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -1693,11 +1708,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1707,7 +1749,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1718,10 +1760,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2028,7 +2090,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63585cdf8572aa7adf0e30a253f988f2b77233bfac1973d52efb6dd53a75920e"
 dependencies = [
- "petgraph",
+ "petgraph 0.8.3",
  "semver 1.0.28",
  "serde",
  "toml 0.9.12+spec-1.1.0",
@@ -2335,6 +2397,15 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -2899,8 +2970,9 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
- "axum",
+ "axum 0.8.9",
  "borsh",
+ "bs58",
  "built",
  "chrono",
  "clap",
@@ -2932,6 +3004,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tonic",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
@@ -2940,6 +3013,7 @@ dependencies = [
  "utoipa-redoc",
  "uuid",
  "validator",
+ "yellowstone-grpc-proto",
  "zama-host",
  "zama-solana-acl",
  "zama-solana-transaction",
@@ -3015,6 +3089,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -3563,6 +3647,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,7 +3676,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3924,7 +4021,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -3964,7 +4061,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -4176,6 +4273,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -4201,6 +4304,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -4232,6 +4345,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nonzero_ext"
@@ -4524,6 +4643,16 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
@@ -4640,6 +4769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4725,6 +4864,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.118",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,6 +4924,15 @@ dependencies = [
  "once_cell",
  "protobuf-support",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]
@@ -4778,7 +4978,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4816,7 +5016,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5064,7 +5264,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -5805,6 +6005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5833,6 +6039,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6922,7 +7138,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7064,6 +7280,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7091,7 +7373,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",
@@ -7383,7 +7665,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6427547f6db7ec006cbbef95f7565952a16f362e298b416d2d497d9706fef72d"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "serde",
  "serde_json",
  "utoipa",
@@ -8051,6 +8333,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "yellowstone-grpc-proto"
+version = "5.0.0+solana.2.1.21"
+source = "git+https://github.com/rpcpool/yellowstone-grpc?tag=v5.0.1%2Bsolana.2.1.21#eeaab8a1c40d5779fff012be87e0e647e440ba20"
+dependencies = [
+ "anyhow",
+ "prost",
+ "prost-types",
+ "protobuf-src",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8200,3 +8495,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -31,6 +31,7 @@ dashmap = "6.1.0"
 derivative = "2.2"
 ed25519-dalek = "2"
 futures = "0.3.32"
+bs58 = "0.5.1"
 hex = "0.4.3"
 moka = { version = "0.12.13", features = ["future"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -38,6 +39,8 @@ serde_json = "1.0.149"
 sha2 = "0.10"
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "signal"] }
 tokio-util = "0.7.18"
+tonic = "0.12.3"
+yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc", tag = "v5.0.1+solana.2.1.21", default-features = false, features = ["tonic", "tonic-compression"] }
 async-trait = "0.1.51"
 thiserror = "2.0.18"
 config = "0.15.19"

--- a/relayer/src/solana_proof/mod.rs
+++ b/relayer/src/solana_proof/mod.rs
@@ -26,6 +26,10 @@ pub mod poller;
 pub mod proof;
 pub mod replay;
 pub mod store;
+// This behavior-neutral source seam is consumed by the stacked SQL ingestion
+// cutover; keeping it private avoids publishing an intermediate provider API.
+#[allow(dead_code)]
+pub(crate) mod yellowstone_source;
 
 pub use chain::{ChainFetcher, RpcChainFetcher};
 pub use config::SolanaProofConfig;

--- a/relayer/src/solana_proof/yellowstone_source.rs
+++ b/relayer/src/solana_proof/yellowstone_source.rs
@@ -1,0 +1,856 @@
+//! Confirmed Yellowstone completed blocks for the Solana MMR proof service.
+//!
+//! This adapter owns only provider transport and protobuf normalization. The
+//! next stack persists each [`CompletedBlock`] and its checkpoint in one SQL
+//! transaction. The caller pulls the next block only after that commit; this
+//! module has no queue, retry policy, or notion of a committed checkpoint.
+
+use futures::{Stream, StreamExt};
+use std::collections::HashMap;
+use tonic::metadata::{Ascii, MetadataValue};
+use tonic::transport::Channel;
+use yellowstone_grpc_proto::geyser::geyser_client::GeyserClient;
+use yellowstone_grpc_proto::prelude::{
+    subscribe_update::UpdateOneof, Message, SubscribeRequest, SubscribeRequestFilterBlocks,
+    SubscribeUpdate, SubscribeUpdateBlock, SubscribeUpdateTransactionInfo, TransactionStatusMeta,
+};
+use zama_solana_transaction::{
+    CompiledInstruction as CanonicalCompiledInstruction,
+    InnerInstructionGroup as CanonicalInnerInstructionGroup,
+};
+
+use super::decode::RawInstruction;
+
+const MAX_DECODING_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BlockCheckpoint {
+    pub slot: u64,
+    pub block_hash: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CanonicalTransaction {
+    pub signature: [u8; 64],
+    pub index: u64,
+    pub succeeded: bool,
+    pub is_vote: bool,
+    /// Successful non-vote instructions in on-chain execution order. Failed
+    /// and vote transactions remain present with an empty instruction list so
+    /// the store can retain their position without producing MMR leaves.
+    pub instructions: Vec<RawInstruction>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CompletedBlock {
+    pub slot: u64,
+    pub block_hash: [u8; 32],
+    pub parent_slot: u64,
+    pub parent_hash: [u8; 32],
+    pub block_time: Option<i64>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    /// Sparse, provider-filtered transactions sorted by their block index.
+    pub transactions: Vec<CanonicalTransaction>,
+}
+
+impl CompletedBlock {
+    pub(crate) fn checkpoint(&self) -> BlockCheckpoint {
+        BlockCheckpoint {
+            slot: self.slot,
+            block_hash: self.block_hash,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct YellowstoneSourceConfig {
+    pub grpc_url: String,
+    pub x_token: Option<String>,
+    pub program_id: String,
+}
+
+#[derive(thiserror::Error, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum YellowstoneSourceError {
+    #[error("retryable Yellowstone transport failure: {0}")]
+    Retryable(String),
+    #[error("inclusive Yellowstone replay is unavailable: {0}")]
+    ReplayUnavailable(String),
+    #[error("invalid Yellowstone data or configuration: {0}")]
+    Invalid(String),
+    #[error(
+        "inclusive replay changed checkpoint: expected slot {expected_slot}, observed slot {observed_slot}"
+    )]
+    CheckpointChanged {
+        expected_slot: u64,
+        expected_hash: [u8; 32],
+        observed_slot: u64,
+        observed_hash: [u8; 32],
+    },
+    #[error(
+        "block {slot} ancestry does not extend slot {expected_parent_slot}: observed parent slot {parent_slot}"
+    )]
+    Ancestry {
+        slot: u64,
+        parent_slot: u64,
+        parent_hash: [u8; 32],
+        expected_parent_slot: u64,
+        expected_parent_hash: [u8; 32],
+    },
+    #[error("conflicting normalized block replay at slot {slot}")]
+    ConflictingReplay { slot: u64 },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct YellowstoneBlockSource {
+    config: YellowstoneSourceConfig,
+}
+
+impl YellowstoneBlockSource {
+    pub(crate) fn new(config: YellowstoneSourceConfig) -> Result<Self, YellowstoneSourceError> {
+        decode_hash("program id", &config.program_id)?;
+        Ok(Self { config })
+    }
+
+    /// Opens one confirmed completed-block subscription. The caller owns
+    /// cancellation by selecting over this future and later `next_block`
+    /// futures, and owns reconnect from its last durable checkpoint.
+    pub(crate) async fn subscribe(
+        &self,
+        cursor: Option<BlockCheckpoint>,
+    ) -> Result<YellowstoneSubscription, YellowstoneSourceError> {
+        let endpoint = Channel::from_shared(self.config.grpc_url.clone()).map_err(|error| {
+            YellowstoneSourceError::Invalid(format!("invalid gRPC URL: {error}"))
+        })?;
+        let channel = endpoint.connect().await.map_err(|error| {
+            YellowstoneSourceError::Retryable(format!("connect gRPC endpoint: {error}"))
+        })?;
+        let token: Option<MetadataValue<Ascii>> = self
+            .config
+            .x_token
+            .as_ref()
+            .map(|token| token.parse())
+            .transpose()
+            .map_err(|error| {
+                YellowstoneSourceError::Invalid(format!("invalid Yellowstone x-token: {error}"))
+            })?;
+        let mut client =
+            GeyserClient::with_interceptor(channel, move |mut request: tonic::Request<()>| {
+                if let Some(token) = &token {
+                    request.metadata_mut().insert("x-token", token.clone());
+                }
+                Ok(request)
+            })
+            .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
+        let request = build_subscribe_request(&self.config.program_id, cursor.as_ref());
+        let outbound = futures::stream::once(async move { request })
+            .chain(futures::stream::pending::<SubscribeRequest>());
+        let response = client
+            .subscribe(outbound)
+            .await
+            .map_err(|status| classify_status(status, cursor.is_some()))?;
+        Ok(YellowstoneSubscription {
+            stream: response.into_inner(),
+            replay_observed: cursor.is_none(),
+            expected_replay: cursor,
+            last_observed: None,
+        })
+    }
+}
+
+pub(crate) struct YellowstoneSubscription {
+    stream: tonic::Streaming<SubscribeUpdate>,
+    expected_replay: Option<BlockCheckpoint>,
+    replay_observed: bool,
+    last_observed: Option<CompletedBlock>,
+}
+
+impl YellowstoneSubscription {
+    /// Pulls exactly one normalized completed block. No later provider update
+    /// is read until the caller awaits this method again.
+    pub(crate) async fn next_block(&mut self) -> Result<CompletedBlock, YellowstoneSourceError> {
+        next_block(
+            &mut self.stream,
+            self.expected_replay.as_ref(),
+            &mut self.replay_observed,
+            &mut self.last_observed,
+        )
+        .await
+    }
+}
+
+async fn next_block<S>(
+    stream: &mut S,
+    expected_replay: Option<&BlockCheckpoint>,
+    replay_observed: &mut bool,
+    last_observed: &mut Option<CompletedBlock>,
+) -> Result<CompletedBlock, YellowstoneSourceError>
+where
+    S: Stream<Item = Result<SubscribeUpdate, tonic::Status>> + Unpin,
+{
+    loop {
+        let update = stream.next().await;
+        let Some(update) = update else {
+            return Err(YellowstoneSourceError::Retryable(
+                "gRPC stream closed by provider".to_owned(),
+            ));
+        };
+        let update = update.map_err(|status| classify_status(status, expected_replay.is_some()))?;
+        let Some(UpdateOneof::Block(block)) = update.update_oneof else {
+            continue;
+        };
+        let block = normalize_block(block)?;
+        if !*replay_observed {
+            let expected = expected_replay.expect("cursor exists when replay is unobserved");
+            if block.slot != expected.slot || block.block_hash != expected.block_hash {
+                return Err(YellowstoneSourceError::CheckpointChanged {
+                    expected_slot: expected.slot,
+                    expected_hash: expected.block_hash,
+                    observed_slot: block.slot,
+                    observed_hash: block.block_hash,
+                });
+            }
+            *replay_observed = true;
+        }
+        if let Some(previous) = last_observed.as_ref() {
+            if block.slot == previous.slot {
+                if &block != previous {
+                    return Err(YellowstoneSourceError::ConflictingReplay { slot: block.slot });
+                }
+                return Ok(block);
+            }
+            if block.parent_slot != previous.slot || block.parent_hash != previous.block_hash {
+                return Err(YellowstoneSourceError::Ancestry {
+                    slot: block.slot,
+                    parent_slot: block.parent_slot,
+                    parent_hash: block.parent_hash,
+                    expected_parent_slot: previous.slot,
+                    expected_parent_hash: previous.block_hash,
+                });
+            }
+        }
+        *last_observed = Some(block.clone());
+        return Ok(block);
+    }
+}
+
+fn build_subscribe_request(program_id: &str, cursor: Option<&BlockCheckpoint>) -> SubscribeRequest {
+    let blocks = HashMap::from([(
+        "zama_host".to_owned(),
+        SubscribeRequestFilterBlocks {
+            account_include: vec![program_id.to_owned()],
+            include_transactions: Some(true),
+            include_accounts: Some(false),
+            include_entries: Some(false),
+        },
+    )]);
+    SubscribeRequest {
+        accounts: HashMap::new(),
+        slots: HashMap::new(),
+        transactions: HashMap::new(),
+        transactions_status: HashMap::new(),
+        blocks,
+        blocks_meta: HashMap::new(),
+        entry: HashMap::new(),
+        commitment: Some(yellowstone_grpc_proto::prelude::CommitmentLevel::Confirmed as i32),
+        accounts_data_slice: vec![],
+        ping: None,
+        from_slot: cursor.map(|checkpoint| checkpoint.slot),
+    }
+}
+
+fn normalize_block(
+    mut block: SubscribeUpdateBlock,
+) -> Result<CompletedBlock, YellowstoneSourceError> {
+    let block_hash = decode_hash("blockhash", &block.blockhash)?;
+    let parent_hash = decode_hash("parent blockhash", &block.parent_blockhash)?;
+    block
+        .transactions
+        .sort_by_key(|transaction| transaction.index);
+    for pair in block.transactions.windows(2) {
+        if pair[0].index == pair[1].index {
+            return Err(YellowstoneSourceError::Invalid(format!(
+                "duplicate transaction index {}",
+                pair[0].index
+            )));
+        }
+    }
+    let transactions = block
+        .transactions
+        .into_iter()
+        .map(|transaction| normalize_transaction(transaction, block.executed_transaction_count))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(CompletedBlock {
+        slot: block.slot,
+        block_hash,
+        parent_slot: block.parent_slot,
+        parent_hash,
+        block_time: block.block_time.map(|time| time.timestamp),
+        block_height: block.block_height.map(|height| height.block_height),
+        executed_transaction_count: block.executed_transaction_count,
+        transactions,
+    })
+}
+
+fn normalize_transaction(
+    transaction: SubscribeUpdateTransactionInfo,
+    executed_transaction_count: u64,
+) -> Result<CanonicalTransaction, YellowstoneSourceError> {
+    if transaction.index >= executed_transaction_count {
+        return Err(YellowstoneSourceError::Invalid(format!(
+            "transaction index {} is outside executed transaction count {}",
+            transaction.index, executed_transaction_count
+        )));
+    }
+    let signature = <[u8; 64]>::try_from(transaction.signature.as_slice()).map_err(|_| {
+        YellowstoneSourceError::Invalid(format!(
+            "transaction {} signature has invalid length {}, expected 64 bytes",
+            transaction.index,
+            transaction.signature.len()
+        ))
+    })?;
+    let meta = transaction.meta.as_ref().ok_or_else(|| {
+        YellowstoneSourceError::Invalid(format!(
+            "transaction {} has no status metadata",
+            transaction.index
+        ))
+    })?;
+    let succeeded = meta.err.is_none();
+    let instructions = if !succeeded || transaction.is_vote {
+        Vec::new()
+    } else {
+        let message = transaction
+            .transaction
+            .as_ref()
+            .and_then(|transaction| transaction.message.as_ref())
+            .ok_or_else(|| {
+                YellowstoneSourceError::Invalid(format!(
+                    "successful transaction {} has no message",
+                    transaction.index
+                ))
+            })?;
+        resolve_instructions(message, meta)?
+    };
+    Ok(CanonicalTransaction {
+        signature,
+        index: transaction.index,
+        succeeded,
+        is_vote: transaction.is_vote,
+        instructions,
+    })
+}
+
+fn resolve_instructions(
+    message: &Message,
+    meta: &TransactionStatusMeta,
+) -> Result<Vec<RawInstruction>, YellowstoneSourceError> {
+    let static_keys = validated_keys(&message.account_keys)?;
+    let loaded_writable = validated_keys(&meta.loaded_writable_addresses)?;
+    let loaded_readonly = validated_keys(&meta.loaded_readonly_addresses)?;
+    let top_level = message
+        .instructions
+        .iter()
+        .map(|instruction| CanonicalCompiledInstruction {
+            program_id_index: instruction.program_id_index as usize,
+            account_indices: instruction
+                .accounts
+                .iter()
+                .map(|index| *index as usize)
+                .collect(),
+            data: instruction.data.clone(),
+            stack_height: None,
+        })
+        .collect();
+    let inner = meta
+        .inner_instructions
+        .iter()
+        .map(|group| CanonicalInnerInstructionGroup {
+            top_level_index: group.index as usize,
+            instructions: group
+                .instructions
+                .iter()
+                .map(|instruction| CanonicalCompiledInstruction {
+                    program_id_index: instruction.program_id_index as usize,
+                    account_indices: instruction
+                        .accounts
+                        .iter()
+                        .map(|index| *index as usize)
+                        .collect(),
+                    data: instruction.data.clone(),
+                    stack_height: instruction.stack_height,
+                })
+                .collect(),
+        })
+        .collect();
+    zama_solana_transaction::resolve_transaction(
+        &static_keys,
+        &loaded_writable,
+        &loaded_readonly,
+        top_level,
+        inner,
+    )
+    .map_err(|error| {
+        YellowstoneSourceError::Invalid(format!("invalid transaction instructions: {error}"))
+    })
+    .map(|instructions| {
+        instructions
+            .into_iter()
+            .map(|instruction| RawInstruction {
+                program_id: instruction.program_id,
+                accounts: instruction.accounts,
+                data: instruction.data,
+                top_level_index: instruction.top_level_index,
+                stack_height: Some(instruction.stack_height),
+            })
+            .collect()
+    })
+}
+
+fn validated_keys(keys: &[Vec<u8>]) -> Result<Vec<[u8; 32]>, YellowstoneSourceError> {
+    keys.iter()
+        .enumerate()
+        .map(|(index, key)| {
+            <[u8; 32]>::try_from(key.as_slice()).map_err(|_| {
+                YellowstoneSourceError::Invalid(format!(
+                    "account key {index} has invalid length {}, expected 32 bytes",
+                    key.len()
+                ))
+            })
+        })
+        .collect()
+}
+
+fn decode_hash(name: &str, encoded: &str) -> Result<[u8; 32], YellowstoneSourceError> {
+    let bytes = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|error| YellowstoneSourceError::Invalid(format!("invalid {name}: {error}")))?;
+    <[u8; 32]>::try_from(bytes.as_slice()).map_err(|_| {
+        YellowstoneSourceError::Invalid(format!(
+            "{name} has invalid length {}, expected 32 bytes",
+            bytes.len()
+        ))
+    })
+}
+
+fn classify_status(status: tonic::Status, is_replay: bool) -> YellowstoneSourceError {
+    let message = status.message();
+    if is_replay
+        && (message == "from_slot is not supported"
+            || (message.starts_with("broadcast from ") && message.contains(" is not available")))
+    {
+        YellowstoneSourceError::ReplayUnavailable(status.to_string())
+    } else {
+        YellowstoneSourceError::Retryable(status.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+
+    use super::*;
+    use yellowstone_grpc_proto::prelude::{
+        BlockHeight, CompiledInstruction, InnerInstruction, InnerInstructions, Transaction,
+        TransactionError, UnixTimestamp,
+    };
+
+    fn hash(tag: u8) -> [u8; 32] {
+        [tag; 32]
+    }
+
+    fn failed(index: u64) -> SubscribeUpdateTransactionInfo {
+        SubscribeUpdateTransactionInfo {
+            signature: vec![index as u8; 64],
+            meta: Some(TransactionStatusMeta {
+                err: Some(TransactionError { err: vec![1] }),
+                ..Default::default()
+            }),
+            index,
+            ..Default::default()
+        }
+    }
+
+    fn successful(index: u64) -> SubscribeUpdateTransactionInfo {
+        let digest = Sha256::digest(b"global:make_handle_public");
+        let mut lifecycle_data = digest[..8].to_vec();
+        lifecycle_data.extend_from_slice(&[9; 32]);
+        SubscribeUpdateTransactionInfo {
+            signature: vec![index as u8; 64],
+            transaction: Some(Transaction {
+                message: Some(Message {
+                    account_keys: vec![
+                        hash(1).to_vec(),
+                        hash(2).to_vec(),
+                        hash(3).to_vec(),
+                        hash(4).to_vec(),
+                        hash(5).to_vec(),
+                    ],
+                    instructions: vec![CompiledInstruction {
+                        program_id_index: 0,
+                        accounts: vec![1, 2, 3],
+                        data: lifecycle_data,
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            meta: Some(TransactionStatusMeta {
+                inner_instructions: vec![InnerInstructions {
+                    index: 0,
+                    instructions: vec![InnerInstruction {
+                        program_id_index: 4,
+                        accounts: vec![1],
+                        data: vec![8],
+                        stack_height: Some(2),
+                    }],
+                }],
+                ..Default::default()
+            }),
+            index,
+            ..Default::default()
+        }
+    }
+
+    fn vote(index: u64) -> SubscribeUpdateTransactionInfo {
+        SubscribeUpdateTransactionInfo {
+            is_vote: true,
+            ..successful(index)
+        }
+    }
+
+    fn block(slot: u64, transactions: Vec<SubscribeUpdateTransactionInfo>) -> SubscribeUpdateBlock {
+        SubscribeUpdateBlock {
+            slot,
+            blockhash: bs58::encode(hash(slot as u8)).into_string(),
+            parent_slot: slot - 1,
+            parent_blockhash: bs58::encode(hash((slot - 1) as u8)).into_string(),
+            block_time: Some(UnixTimestamp {
+                timestamp: 1_700_000_000,
+            }),
+            block_height: Some(BlockHeight { block_height: 99 }),
+            executed_transaction_count: transactions
+                .iter()
+                .map(|transaction| transaction.index + 1)
+                .max()
+                .unwrap_or(0),
+            transactions,
+            ..Default::default()
+        }
+    }
+
+    fn update(block: SubscribeUpdateBlock) -> SubscribeUpdate {
+        SubscribeUpdate {
+            update_oneof: Some(UpdateOneof::Block(block)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn request_is_one_confirmed_filtered_block_subscription() {
+        let checkpoint = BlockCheckpoint {
+            slot: 9,
+            block_hash: hash(9),
+        };
+        let request = build_subscribe_request(
+            "ZamaHost11111111111111111111111111111111",
+            Some(&checkpoint),
+        );
+        assert_eq!(request.blocks.len(), 1);
+        assert!(request.accounts.is_empty());
+        assert!(request.slots.is_empty());
+        assert!(request.transactions.is_empty());
+        assert!(request.transactions_status.is_empty());
+        assert!(request.blocks_meta.is_empty());
+        assert!(request.entry.is_empty());
+        assert_eq!(request.from_slot, Some(9));
+        assert_eq!(
+            request.commitment,
+            Some(yellowstone_grpc_proto::prelude::CommitmentLevel::Confirmed as i32)
+        );
+        let filter = request.blocks.get("zama_host").unwrap();
+        assert_eq!(
+            filter.account_include,
+            vec!["ZamaHost11111111111111111111111111111111"]
+        );
+        assert_eq!(filter.include_transactions, Some(true));
+        assert_eq!(filter.include_accounts, Some(false));
+        assert_eq!(filter.include_entries, Some(false));
+    }
+
+    #[test]
+    fn source_rejects_invalid_program_id_before_connecting() {
+        let result = YellowstoneBlockSource::new(YellowstoneSourceConfig {
+            grpc_url: "http://127.0.0.1:10000".to_owned(),
+            x_token: None,
+            program_id: "not-a-program-id".to_owned(),
+        });
+        assert!(matches!(result, Err(YellowstoneSourceError::Invalid(_))));
+    }
+
+    #[test]
+    fn normalizes_empty_block_and_full_metadata() {
+        let normalized = normalize_block(block(7, vec![])).unwrap();
+        assert_eq!(normalized.slot, 7);
+        assert_eq!(normalized.block_hash, hash(7));
+        assert_eq!(normalized.parent_slot, 6);
+        assert_eq!(normalized.parent_hash, hash(6));
+        assert_eq!(normalized.block_time, Some(1_700_000_000));
+        assert_eq!(normalized.block_height, Some(99));
+        assert_eq!(normalized.executed_transaction_count, 0);
+        assert!(normalized.transactions.is_empty());
+    }
+
+    #[test]
+    fn resolves_successful_instruction_payload_in_execution_order() {
+        let normalized = normalize_block(block(7, vec![successful(0)])).unwrap();
+        let transaction = &normalized.transactions[0];
+        assert_eq!(transaction.signature, [0; 64]);
+        assert!(transaction.succeeded);
+        assert!(!transaction.is_vote);
+        assert_eq!(transaction.instructions.len(), 2);
+        assert_eq!(transaction.instructions[0].program_id, hash(1));
+        assert_eq!(
+            transaction.instructions[0].accounts,
+            vec![hash(2), hash(3), hash(4)]
+        );
+        assert_eq!(transaction.instructions[0].stack_height, Some(1));
+        assert_eq!(transaction.instructions[1].program_id, hash(5));
+        assert_eq!(transaction.instructions[1].data, vec![8]);
+        assert_eq!(transaction.instructions[1].stack_height, Some(2));
+        let lifecycle =
+            super::super::decode::decode_program_instructions(hash(1), &transaction.instructions)
+                .unwrap();
+        assert!(matches!(
+            lifecycle.as_slice(),
+            [super::super::decode::DecodedInstruction::MakeHandlePublic {
+                encrypted_value,
+                handle,
+            }] if *encrypted_value == hash(4) && *handle == [9; 32]
+        ));
+    }
+
+    #[test]
+    fn retains_sorted_failed_and_vote_transaction_identities() {
+        let normalized = normalize_block(block(7, vec![vote(3), failed(1)])).unwrap();
+        assert_eq!(
+            normalized
+                .transactions
+                .iter()
+                .map(|transaction| transaction.index)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        assert!(!normalized.transactions[0].succeeded);
+        assert!(normalized.transactions[0].instructions.is_empty());
+        assert!(normalized.transactions[1].succeeded);
+        assert!(normalized.transactions[1].is_vote);
+        assert!(normalized.transactions[1].instructions.is_empty());
+    }
+
+    #[test]
+    fn rejects_malformed_hash_signature_metadata_and_message() {
+        let mut malformed = block(7, vec![]);
+        malformed.blockhash = "not-base58-0".to_owned();
+        assert!(matches!(
+            normalize_block(malformed),
+            Err(YellowstoneSourceError::Invalid(_))
+        ));
+
+        let mut transaction = failed(0);
+        transaction.signature.pop();
+        assert!(normalize_block(block(7, vec![transaction])).is_err());
+
+        let mut transaction = failed(0);
+        transaction.meta = None;
+        assert!(normalize_block(block(7, vec![transaction])).is_err());
+
+        let mut transaction = successful(0);
+        transaction.transaction.as_mut().unwrap().message = None;
+        assert!(normalize_block(block(7, vec![transaction])).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_and_out_of_range_sparse_indexes() {
+        assert!(normalize_block(block(7, vec![failed(1), failed(1)])).is_err());
+        let mut invalid = block(7, vec![failed(2)]);
+        invalid.executed_transaction_count = 2;
+        assert!(normalize_block(invalid).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_account_keys_and_shared_decoder_failures() {
+        let mut short_key = successful(0);
+        short_key
+            .transaction
+            .as_mut()
+            .unwrap()
+            .message
+            .as_mut()
+            .unwrap()
+            .account_keys[0]
+            .pop();
+        assert!(normalize_block(block(7, vec![short_key])).is_err());
+
+        let mut bad_index = successful(0);
+        bad_index
+            .transaction
+            .as_mut()
+            .unwrap()
+            .message
+            .as_mut()
+            .unwrap()
+            .instructions[0]
+            .program_id_index = 9;
+        assert!(normalize_block(block(7, vec![bad_index])).is_err());
+    }
+
+    #[tokio::test]
+    async fn inclusive_replay_must_be_first_and_match_hash() {
+        let checkpoint = BlockCheckpoint {
+            slot: 7,
+            block_hash: hash(7),
+        };
+        let mut stream = futures::stream::iter([Ok(update(block(8, vec![])))]);
+        let mut replay_observed = false;
+        let mut last_observed = None;
+        let result = next_block(
+            &mut stream,
+            Some(&checkpoint),
+            &mut replay_observed,
+            &mut last_observed,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(YellowstoneSourceError::CheckpointChanged {
+                expected_slot: 7,
+                observed_slot: 8,
+                ..
+            })
+        ));
+
+        let mut wrong_hash = block(7, vec![]);
+        wrong_hash.blockhash = bs58::encode(hash(9)).into_string();
+        let mut stream = futures::stream::iter([Ok(update(wrong_hash))]);
+        let mut replay_observed = false;
+        let mut last_observed = None;
+        let result = next_block(
+            &mut stream,
+            Some(&checkpoint),
+            &mut replay_observed,
+            &mut last_observed,
+        )
+        .await;
+        assert_eq!(
+            result.unwrap_err(),
+            YellowstoneSourceError::CheckpointChanged {
+                expected_slot: 7,
+                expected_hash: hash(7),
+                observed_slot: 7,
+                observed_hash: hash(9),
+            }
+        );
+
+        let mut stream = futures::stream::iter([Ok(update(block(7, vec![])))]);
+        let mut replay_observed = false;
+        let mut last_observed = None;
+        let replay = next_block(
+            &mut stream,
+            Some(&checkpoint),
+            &mut replay_observed,
+            &mut last_observed,
+        )
+        .await
+        .unwrap();
+        assert_eq!(replay.checkpoint(), checkpoint);
+    }
+
+    #[test]
+    fn replay_unavailable_is_terminal_but_transport_is_retryable() {
+        for message in [
+            "from_slot is not supported",
+            "broadcast from 7 is not available, last available: 12",
+        ] {
+            assert!(matches!(
+                classify_status(tonic::Status::internal(message), true),
+                YellowstoneSourceError::ReplayUnavailable(_)
+            ));
+        }
+        for status in [
+            tonic::Status::unavailable("connection reset"),
+            tonic::Status::internal("failed to send replay update"),
+            tonic::Status::internal("broadcast from 7 is not available"),
+        ] {
+            assert!(matches!(
+                classify_status(status, false),
+                YellowstoneSourceError::Retryable(_)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn pulls_one_block_per_await_and_checks_ancestry() {
+        let mut stream =
+            futures::stream::iter([Ok(update(block(7, vec![]))), Ok(update(block(8, vec![])))]);
+        let mut replay_observed = true;
+        let mut last_observed = None;
+        assert_eq!(
+            next_block(&mut stream, None, &mut replay_observed, &mut last_observed,)
+                .await
+                .unwrap()
+                .slot,
+            7
+        );
+        assert_eq!(
+            next_block(&mut stream, None, &mut replay_observed, &mut last_observed,)
+                .await
+                .unwrap()
+                .slot,
+            8
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_block_replay_is_exposed_but_conflict_halts() {
+        let original = block(7, vec![successful(0)]);
+        let mut changed = original.clone();
+        changed.block_time.as_mut().unwrap().timestamp += 1;
+        let mut stream = futures::stream::iter([
+            Ok(update(original.clone())),
+            Ok(update(original)),
+            Ok(update(changed)),
+        ]);
+        let mut replay_observed = true;
+        let mut last_observed = None;
+        let first = next_block(&mut stream, None, &mut replay_observed, &mut last_observed)
+            .await
+            .unwrap();
+        let replay = next_block(&mut stream, None, &mut replay_observed, &mut last_observed)
+            .await
+            .unwrap();
+        assert_eq!(first, replay);
+        assert_eq!(
+            next_block(&mut stream, None, &mut replay_observed, &mut last_observed,)
+                .await
+                .unwrap_err(),
+            YellowstoneSourceError::ConflictingReplay { slot: 7 }
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_live_ancestry_mismatch() {
+        let mut second = block(8, vec![]);
+        second.parent_slot = 6;
+        second.parent_blockhash = bs58::encode(hash(6)).into_string();
+        let mut stream = futures::stream::iter([Ok(update(block(7, vec![]))), Ok(update(second))]);
+        let mut replay_observed = true;
+        let mut last_observed = None;
+        next_block(&mut stream, None, &mut replay_observed, &mut last_observed)
+            .await
+            .unwrap();
+        assert!(matches!(
+            next_block(&mut stream, None, &mut replay_observed, &mut last_observed,).await,
+            Err(YellowstoneSourceError::Ancestry { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## What

- add a private relayer Yellowstone adapter that subscribes to one confirmed completed-block filter for the zama-host program
- normalize provider protobufs into completed blocks with slot/hash ancestry, full block metadata, sparse transaction positions, signatures, success/vote identity, and shared-decoder instruction order
- expose direct `subscribe(checkpoint)` / awaited `next_block()` semantics with no intermediate queue
- classify transport failures, unavailable inclusive replay, malformed input, changed checkpoints, conflicting replay, and ancestry mismatches explicitly
- pin `tonic` and `yellowstone-grpc-proto` to the exact versions already used by the host listener

## Why

The relayer MMR path needs a lossless block boundary before its leaf history and checkpoint can move from `FileLeafStore` to one atomic PostgreSQL transaction. A separate reduced Yellowstone subscription keeps the relayer independent from the host-listener process and database while reusing the shared provider-independent transaction decoder.

This is a behavior-neutral stacked dependency, not a terminal ingestion implementation. It deliberately does not wire configuration/startup, persist blocks, replace the RPC poller, publish a provider framework, or add recovery policy.

## Stack and cutover constraints

- stacked on #3200 (`elias/solana-sealed-block-ingestion`)
- part of zama-ai/fhevm-internal#1682
- the next SQL cutover owns durable checkpoint selection, awaited apply, reconnect/backoff, readiness, and bounded RPC recovery
- the existing `FileLeafStore` signature cursor cannot be translated into a block checkpoint; bootstrap/recovery must be explicit and must not silently start at tip
- exact replay is exposed unchanged so the SQL transaction can decide idempotence from the full normalized identity

## Validation

- `NO_DNA=1 SQLX_OFFLINE=true cargo test --manifest-path relayer/Cargo.toml -p fhevm-relayer solana_proof::yellowstone_source::` (13 passed)
- `NO_DNA=1 SQLX_OFFLINE=true cargo test --manifest-path relayer/Cargo.toml -p fhevm-relayer solana_proof::` (77 passed)
- `NO_DNA=1 SQLX_OFFLINE=true cargo clippy --manifest-path relayer/Cargo.toml -p fhevm-relayer --lib --tests -- -D warnings`
- file-scoped Rust formatting and `git diff --check`
