### PR TITLE
fix(host-contracts): allow explicit subject rotation on durable supersede

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -2500,7 +2500,9 @@
                 "name": "output_subjects",
                 "docs": [
                   "Subjects on the output lineage. On create these are the initial",
-                  "subjects; on supersede they must equal the stored subjects exactly."
+                  "subjects; on supersede they become the new audience, which may rotate",
+                  "away from the stored set (the outgoing audience is sealed into",
+                  "historical leaves first; added subjects pass the grant deny-list)."
                 ],
                 "type": {
                   "vec": {

--- a/relayer/src/solana_proof/ingest.rs
+++ b/relayer/src/solana_proof/ingest.rs
@@ -173,6 +173,32 @@ fn recovered_already_applied_event(
             )])
         }
         (
+            DecodedInstruction::FheEvalUpdateEncryptedValue {
+                encrypted_value,
+                previous_handle,
+                previous_subjects,
+                output_subjects,
+                make_public_handle,
+            },
+            ReplayError::PreviousStateMismatch(error_lineage),
+        ) if error_lineage == encrypted_value
+            && state.current_handle == *make_public_handle
+            && state.subjects.as_slice() == output_subjects.as_slice() =>
+        {
+            // Already applied: the lineage is at this supersede's post-state (a rotation moved
+            // subjects to `output_subjects`, so a re-apply trips PreviousStateMismatch). Replay
+            // the same leaves the fresh apply would have — the outgoing audience sealed first,
+            // then the born-public leaf if any — mirroring the raw UpdateEncryptedValue arm.
+            let mut events = vec![LineageEvent::handle_superseded(
+                *previous_handle,
+                previous_subjects,
+            )];
+            if let Some(handle) = make_public_handle {
+                events.push(LineageEvent::MarkedPublic { handle: *handle });
+            }
+            Some(events)
+        }
+        (
             DecodedInstruction::RemoveSubject {
                 encrypted_value,
                 subject,
@@ -432,6 +458,35 @@ mod tests {
                 previous_subjects,
             },
         )
+    }
+
+    #[test]
+    fn recovers_already_applied_fhe_eval_rotation_idempotently() {
+        let ev = pk(0x40);
+        let owner = pk(0x30);
+        let old_recipient = pk(0x31);
+        let new_recipient = pk(0x32);
+        // State already advanced to the post-rotation audience by a prior application.
+        let mut state = Some(LineageReplayState {
+            current_handle: None,
+            subjects: vec![owner, new_recipient],
+        });
+        let instruction = DecodedInstruction::FheEvalUpdateEncryptedValue {
+            encrypted_value: ev,
+            previous_handle: pk(0x10),
+            previous_subjects: vec![owner, old_recipient],
+            output_subjects: vec![owner, new_recipient],
+            make_public_handle: None,
+        };
+
+        let events = apply_or_recover_instruction(&mut state, &instruction).unwrap();
+
+        // Replays the outgoing-audience leaves without double-advancing the state.
+        assert_eq!(
+            events,
+            vec![LineageEvent::handle_superseded(pk(0x10), &[owner, old_recipient])]
+        );
+        assert_eq!(state.unwrap().subjects, vec![owner, new_recipient]);
     }
 
     fn make_public_ix(program_id: [u8; 32], lineage: [u8; 32], handle: [u8; 32]) -> RawInstruction {

--- a/relayer/src/solana_proof/ingest.rs
+++ b/relayer/src/solana_proof/ingest.rs
@@ -484,7 +484,10 @@ mod tests {
         // Replays the outgoing-audience leaves without double-advancing the state.
         assert_eq!(
             events,
-            vec![LineageEvent::handle_superseded(pk(0x10), &[owner, old_recipient])]
+            vec![LineageEvent::handle_superseded(
+                pk(0x10),
+                &[owner, old_recipient]
+            )]
         );
         assert_eq!(state.unwrap().subjects, vec![owner, new_recipient]);
     }

--- a/relayer/src/solana_proof/replay.rs
+++ b/relayer/src/solana_proof/replay.rs
@@ -383,7 +383,10 @@ mod tests {
         // The outgoing audience (owner, old_recipient) is sealed into historical leaves.
         assert_eq!(
             events,
-            vec![LineageEvent::handle_superseded(pk(0x10), &[owner, old_recipient])]
+            vec![LineageEvent::handle_superseded(
+                pk(0x10),
+                &[owner, old_recipient]
+            )]
         );
         // Current membership rotated to the new audience.
         assert_eq!(state.unwrap().subjects, vec![owner, new_recipient]);

--- a/relayer/src/solana_proof/replay.rs
+++ b/relayer/src/solana_proof/replay.rs
@@ -182,13 +182,14 @@ pub fn apply_instruction(
                 .as_mut()
                 .ok_or(ReplayError::UnknownLineage(*encrypted_value))?;
             validate_previous_state(state, *encrypted_value, *previous_handle, previous_subjects)?;
-            if state.subjects.as_slice() != output_subjects.as_slice() {
-                return Err(ReplayError::PreviousStateMismatch(*encrypted_value));
-            }
+            // The outgoing audience (`state.subjects`) is sealed into historical leaves first,
+            // then the audience rotates to `output_subjects` — matching the on-chain order, where
+            // a supersede may explicitly rotate the subject set.
             let mut events = vec![LineageEvent::handle_superseded(
                 *previous_handle,
                 &state.subjects,
             )];
+            state.subjects = output_subjects.clone();
             match make_public_handle {
                 Some(handle) => {
                     state.current_handle = Some(*handle);
@@ -349,6 +350,100 @@ mod tests {
             vec![
                 historical_access_leaf_commitment(ev, 0, pk(0x10), owner),
                 historical_access_leaf_commitment(ev, 1, pk(0x10), spender),
+            ]
+        );
+    }
+
+    #[test]
+    fn fhe_eval_supersession_rotates_subjects_and_seals_the_outgoing_audience() {
+        let ev = pk(0x07);
+        let owner = pk(0x30);
+        let old_recipient = pk(0x31);
+        let new_recipient = pk(0x32);
+        let create = DecodedInstruction::CreateEncryptedValue {
+            encrypted_value: ev,
+            handle: pk(0x10),
+            subjects: vec![
+                SubjectGrant { subject: owner },
+                SubjectGrant {
+                    subject: old_recipient,
+                },
+            ],
+        };
+        let rotate = DecodedInstruction::FheEvalUpdateEncryptedValue {
+            encrypted_value: ev,
+            previous_handle: pk(0x10),
+            previous_subjects: vec![owner, old_recipient],
+            output_subjects: vec![owner, new_recipient],
+            make_public_handle: None,
+        };
+
+        let (state, events) = replay(&[create, rotate]).unwrap();
+
+        // The outgoing audience (owner, old_recipient) is sealed into historical leaves.
+        assert_eq!(
+            events,
+            vec![LineageEvent::handle_superseded(pk(0x10), &[owner, old_recipient])]
+        );
+        // Current membership rotated to the new audience.
+        assert_eq!(state.unwrap().subjects, vec![owner, new_recipient]);
+        let reconstructed = reconstruct(ev, &events).unwrap();
+        assert_eq!(
+            reconstructed.leaves,
+            vec![
+                historical_access_leaf_commitment(ev, 0, pk(0x10), owner),
+                historical_access_leaf_commitment(ev, 1, pk(0x10), old_recipient),
+            ]
+        );
+    }
+
+    #[test]
+    fn fhe_eval_supersession_rotates_subjects_and_marks_public_in_one_output() {
+        let ev = pk(0x08);
+        let owner = pk(0x30);
+        let old_recipient = pk(0x31);
+        let new_recipient = pk(0x32);
+        let public_handle = pk(0x50);
+        let create = DecodedInstruction::CreateEncryptedValue {
+            encrypted_value: ev,
+            handle: pk(0x10),
+            subjects: vec![
+                SubjectGrant { subject: owner },
+                SubjectGrant {
+                    subject: old_recipient,
+                },
+            ],
+        };
+        let rotate_public = DecodedInstruction::FheEvalUpdateEncryptedValue {
+            encrypted_value: ev,
+            previous_handle: pk(0x10),
+            previous_subjects: vec![owner, old_recipient],
+            output_subjects: vec![owner, new_recipient],
+            make_public_handle: Some(public_handle),
+        };
+
+        let (state, events) = replay(&[create, rotate_public]).unwrap();
+
+        // Outgoing audience sealed first, then the born-public leaf for the new handle.
+        assert_eq!(
+            events,
+            vec![
+                LineageEvent::handle_superseded(pk(0x10), &[owner, old_recipient]),
+                LineageEvent::MarkedPublic {
+                    handle: public_handle
+                },
+            ]
+        );
+        let state = state.unwrap();
+        assert_eq!(state.subjects, vec![owner, new_recipient]);
+        assert_eq!(state.current_handle, Some(public_handle));
+        let reconstructed = reconstruct(ev, &events).unwrap();
+        assert_eq!(
+            reconstructed.leaves,
+            vec![
+                historical_access_leaf_commitment(ev, 0, pk(0x10), owner),
+                historical_access_leaf_commitment(ev, 1, pk(0x10), old_recipient),
+                public_decrypt_leaf_commitment(ev, 2, public_handle),
             ]
         );
     }

--- a/solana/crates/zama-fhe/src/lib.rs
+++ b/solana/crates/zama-fhe/src/lib.rs
@@ -1234,6 +1234,46 @@ impl EvalPlan {
             })
             .map(|account| account.pubkey)
     }
+
+    /// Subjects this plan grants through a supersede that were not already on the
+    /// stored lineage — `output_subjects \ previous_subjects` for each durable
+    /// output that rotates its audience. The host deny-list-checks each of these
+    /// exactly like `allow_subjects`, so an app forwarding deny-record witnesses
+    /// must cover them alongside the output authorities.
+    pub fn rotation_added_subjects(&self) -> Vec<Pubkey> {
+        let mut added = Vec::new();
+        for step in &self.args.steps {
+            let FheEvalOutput::AllowedDurable {
+                output_subjects,
+                previous_subjects: Some(previous_subjects),
+                ..
+            } = fhe_eval_step_output(step)
+            else {
+                continue;
+            };
+            for entry in output_subjects {
+                if !previous_subjects.contains(&entry.pubkey) && !added.contains(&entry.pubkey) {
+                    added.push(entry.pubkey);
+                }
+            }
+        }
+        added
+    }
+}
+
+/// The output policy of an eval step, independent of step kind.
+fn fhe_eval_step_output(step: &FheEvalStep) -> &FheEvalOutput {
+    match step {
+        FheEvalStep::Binary { output, .. }
+        | FheEvalStep::Ternary { output, .. }
+        | FheEvalStep::TrivialEncrypt { output, .. }
+        | FheEvalStep::Rand { output, .. }
+        | FheEvalStep::Unary { output, .. }
+        | FheEvalStep::RandBounded { output, .. }
+        | FheEvalStep::Sum { output, .. }
+        | FheEvalStep::IsIn { output, .. }
+        | FheEvalStep::MulDiv { output, .. } => output,
+    }
 }
 
 #[cfg(feature = "cpi")]

--- a/solana/crates/zama-solana-acl/src/lib.rs
+++ b/solana/crates/zama-solana-acl/src/lib.rs
@@ -51,9 +51,11 @@ pub enum AclError {
 
 /// Current authorization state and compact history for one encrypted-value lineage.
 ///
-/// One account per lineage, reused across every handle update. `peaks`/`subjects`
-/// grow with use (the on-chain account is `realloc`-grown), so a current-only
-/// lineage (`leaf_count == 0`) stays tiny and pays nothing for history.
+/// One account per lineage, reused across every handle update. The on-chain
+/// account is `realloc`-grown and never shrunk, so its byte size tracks the
+/// high-water mark of `peaks` plus `subjects` (`subjects` may rotate rather than
+/// only grow); a current-only lineage (`leaf_count == 0`) stays tiny and pays
+/// nothing for history.
 #[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct EncryptedValue {
     /// App-level ACL domain, such as a confidential token mint.

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1173,6 +1173,15 @@ user-decrypt authorization in the KMS connector, delegation-mediated user decryp
 and public leaf creation. Historical authorization is the sealed `HistoricalAccessLeaf` for the
 subject at the time of supersession, not a later live-role lookup.
 
+Amendment (fhevm-internal#1741): current membership is immutable by default but not frozen — a
+durable-output supersede may explicitly rotate the subject set (`output_subjects` need not equal the
+stored set). Order is load-bearing: the outgoing audience is sealed into historical leaves first, then
+the new set replaces current membership, so past authorization stays exactly as sealed. Every subject a
+rotation adds passes the grant deny-list exactly as `allow_subjects` does (so rotation is not a
+deny-list bypass); `previous_handle`/`previous_subjects` still pin the outgoing state exactly, keeping
+supersedes stateless-replayable (DD-033). This lets a per-sender lineage (e.g. confidential-token's
+`transferred_amount`) re-target its audience across recipients instead of reverting.
+
 ## DD-033: No ACL-Lifecycle Events — Self-Describing Args + Instruction-Replay Indexing
 
 Status: adopted

--- a/solana/docs/MMR_ACL_MVP.md
+++ b/solana/docs/MMR_ACL_MVP.md
@@ -44,6 +44,11 @@ this note records the operational model in one place.
   instead of relying on implicit vector or arithmetic limits.
 - Subject removal changes only current and future authorization. No new historical leaf is written for
   the removed subject after removal; access sealed before removal remains valid.
+- Audience membership is immutable by default, but a durable-output supersede may explicitly rotate the
+  subject set: `output_subjects` need not equal the stored set. The outgoing audience is sealed into
+  historical leaves first (below), then the new set replaces current membership, and every subject the
+  rotation adds passes the grant deny-list exactly as `allow_subjects` does. `previous_handle` and
+  `previous_subjects` still pin the outgoing state exactly.
 
 ## History And Decrypt
 
@@ -91,7 +96,7 @@ stateDiagram-v2
     [*] --> Live : fhe_eval durable output<br/>(≥1 subject, leaf_count=0)
     Live --> Live : allow_subjects<br/>(add subject, NO leaf)
     Live --> Live : make_handle_public<br/>(+1 PublicDecryptLeaf for current handle)
-    Live --> Live : fhe_eval durable output<br/>(supersede: +1 HistoricalAccessLeaf per then-subject,<br/>then rewrite current_handle)
+    Live --> Live : fhe_eval durable output<br/>(supersede: +1 HistoricalAccessLeaf per then-subject,<br/>rewrite current_handle, then optionally rotate subjects<br/>— added subjects pass the grant deny-list)
     Live --> Live : fhe_eval durable output with make_public=true<br/>(supersede leaves, rewrite handle,<br/>then +1 PublicDecryptLeaf for the NEW handle — DD-036)
     note right of Live
         Account ≤ 2457 bytes for all time

--- a/solana/programs/confidential-token/src/fhe.rs
+++ b/solana/programs/confidential-token/src/fhe.rs
@@ -443,11 +443,12 @@ pub(crate) fn eval<'info>(request: Eval<'_, 'info>) -> Result<()> {
     for seeds in &extra_output_authority_seeds {
         signer_seed_vec.push(seeds.as_slice());
     }
-    validate_deny_subject_records_for_output_authorities(
+    validate_deny_subject_records_for_grant_subjects(
         request.context.host_config.grant_deny_list_enabled,
         request.context.deny_subject_records,
         app_authority.key(),
         &extra_output_authorities,
+        &request.plan.rotation_added_subjects(),
     )?;
 
     zama_fhe::invoke_eval_signed_resolved(
@@ -470,11 +471,12 @@ pub(crate) fn eval<'info>(request: Eval<'_, 'info>) -> Result<()> {
     Ok(())
 }
 
-fn validate_deny_subject_records_for_output_authorities<'info>(
+fn validate_deny_subject_records_for_grant_subjects<'info>(
     deny_list_enabled: bool,
     supplied_records: &[AccountInfo<'info>],
     app_authority: Pubkey,
     extra_output_authorities: &[OutputAuthority<'info>],
+    rotation_added_subjects: &[Pubkey],
 ) -> Result<()> {
     if !deny_list_enabled {
         require!(
@@ -491,11 +493,17 @@ fn validate_deny_subject_records_for_output_authorities<'info>(
                 .any(|later| later.key() == supplied.key()),
             ConfidentialTokenError::UnexpectedRemainingAccounts
         );
+        // A supplied deny record must witness either an output authority or a subject a
+        // supersede grants for the first time (rotation-added) — the host deny-list-checks
+        // both, so both may reach it through remaining accounts.
         require!(
             is_deny_record_for_authority(supplied.key(), app_authority)
                 || extra_output_authorities
                     .iter()
-                    .any(|authority| is_deny_record_for_authority(supplied.key(), authority.key())),
+                    .any(|authority| is_deny_record_for_authority(supplied.key(), authority.key()))
+                || rotation_added_subjects
+                    .iter()
+                    .any(|subject| is_deny_record_for_authority(supplied.key(), *subject)),
             ConfidentialTokenError::UnexpectedRemainingAccounts
         );
     }

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -492,11 +492,7 @@ fn bind_eval_output<'info>(
         // exactly, so indexers can reconstruct the appended MMR leaves from
         // instruction data alone. `output_subjects` may rotate the audience.
         let mut value = read_canonical_encrypted_value(output_info)?;
-        validate_durable_output_previous_state(
-            &value,
-            previous_handle,
-            previous_subjects,
-        )?;
+        validate_durable_output_previous_state(&value, previous_handle, previous_subjects)?;
         check_rotation_grants_not_denied(
             &ctx.accounts.host_config,
             ctx.remaining_accounts,
@@ -674,8 +670,10 @@ mod tests {
     fn durable_output_previous_state_accepts_exact_previous_match() {
         let subjects = vec![Pubkey::new_unique(), Pubkey::new_unique()];
         let value = lineage([9; 32], &subjects);
-        assert!(validate_durable_output_previous_state(&value, &Some([9; 32]), &Some(subjects),)
-            .is_ok());
+        assert!(
+            validate_durable_output_previous_state(&value, &Some([9; 32]), &Some(subjects),)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -742,8 +740,15 @@ mod tests {
         .try_serialize(&mut &mut data[..])
         .unwrap();
         let owner = crate::ID;
-        let record =
-            AccountInfo::new(&record_key, false, false, &mut lamports, &mut data, &owner, false);
+        let record = AccountInfo::new(
+            &record_key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+        );
         let remaining = [record];
 
         let config = deny_enabled_config();

--- a/solana/programs/zama-host/src/instructions/fhe_eval.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval.rs
@@ -490,15 +490,24 @@ fn bind_eval_output<'info>(
     if output_info.owner == &crate::ID {
         // Supersede: the plan's previous_* fields must match the stored state
         // exactly, so indexers can reconstruct the appended MMR leaves from
-        // instruction data alone.
+        // instruction data alone. `output_subjects` may rotate the audience.
         let mut value = read_canonical_encrypted_value(output_info)?;
         validate_durable_output_previous_state(
             &value,
-            output_subjects,
             previous_handle,
             previous_subjects,
         )?;
+        check_rotation_grants_not_denied(
+            &ctx.accounts.host_config,
+            ctx.remaining_accounts,
+            Some(remaining_accounts_used),
+            &value.subjects,
+            output_subjects,
+        )?;
         supersede_current_handle(output_info, &mut value, result)?;
+        // Seal the outgoing audience into historical leaves first (above), then rotate
+        // to the new set — every added subject cleared the deny-list check above.
+        value.subjects = output_subjects.iter().map(|entry| entry.pubkey).collect();
         // Born-public opt-in: after the outgoing handle's historical leaves, seal a
         // public-decrypt leaf for the NEW current handle (leaf order: historical(old)
         // per subject FIRST, then public(new) LAST). Same commitment as
@@ -551,13 +560,15 @@ fn bind_eval_output<'info>(
     Ok(output_info.key())
 }
 
-/// Shared create-or-supersede plan validation against an existing lineage.
-/// Membership is immutable through eval binding: the plan's subject pubkeys
-/// must equal the stored subjects (membership is extended only via
-/// `allow_subjects`).
+/// Supersede plan validation against an existing lineage. The plan's
+/// `previous_handle`/`previous_subjects` must equal the stored state exactly, so
+/// indexers reconstruct the appended MMR leaves from instruction data alone. The
+/// audience (`output_subjects`) is NOT constrained to the stored set: a supersede
+/// may explicitly rotate it — the outgoing audience is sealed into historical
+/// leaves before the new set replaces it, and every added subject passes the
+/// grant deny-list via [`check_rotation_grants_not_denied`].
 pub(super) fn validate_durable_output_previous_state(
     value: &EncryptedValue,
-    output_subjects: &[AclSubjectEntry],
     previous_handle: &Option<[u8; 32]>,
     previous_subjects: &Option<Vec<Pubkey>>,
 ) -> Result<()> {
@@ -569,14 +580,37 @@ pub(super) fn validate_durable_output_previous_state(
         previous_subjects.as_deref() == Some(value.subjects.as_slice()),
         ZamaHostError::PreviousStateMismatch
     );
-    require!(
-        output_subjects.len() == value.subjects.len()
-            && output_subjects
-                .iter()
-                .zip(value.subjects.iter())
-                .all(|(planned, stored)| planned.pubkey == *stored),
-        ZamaHostError::PreviousStateMismatch
-    );
+    Ok(())
+}
+
+/// Deny-list gate for a supersede that rotates the audience. Every subject present
+/// in `output_subjects` but absent from the stored set is a new grant and must
+/// clear the grant deny-list exactly as `allow_subjects` gates added subjects, so
+/// rotation cannot bypass the deny list. Respects `grant_deny_list_enabled` and
+/// (via the shared helpers) pause-independent deny semantics; the deny record for
+/// each added subject is located in `remaining_accounts` by canonical address.
+pub(super) fn check_rotation_grants_not_denied<'info>(
+    host_config: &HostConfig,
+    remaining_accounts: &[AccountInfo<'info>],
+    mut remaining_accounts_used: Option<&mut [bool]>,
+    stored_subjects: &[Pubkey],
+    output_subjects: &[AclSubjectEntry],
+) -> Result<()> {
+    if !host_config.grant_deny_list_enabled {
+        return Ok(());
+    }
+    for entry in output_subjects {
+        if stored_subjects.contains(&entry.pubkey) {
+            continue;
+        }
+        let deny_record = deny_subject_record_for(
+            host_config,
+            remaining_accounts,
+            remaining_accounts_used.as_deref_mut(),
+            entry.pubkey,
+        )?;
+        check_grant_not_denied_info(host_config, entry.pubkey, deny_record)?;
+    }
     Ok(())
 }
 
@@ -610,6 +644,25 @@ mod tests {
         }
     }
 
+    fn deny_enabled_config() -> HostConfig {
+        HostConfig {
+            admin: Pubkey::default(),
+            chain_id: 0,
+            gateway_chain_id: 0,
+            input_verification_contract: [0; 20],
+            coprocessor_signer: [0; 20],
+            decryption_contract: [0; 20],
+            current_kms_context_id: 0,
+            paused: false,
+            grant_deny_list_enabled: true,
+            max_hcu_per_tx: 0,
+            max_hcu_depth_per_tx: 0,
+            hcu_block_cap_per_app: u64::MAX,
+            updated_slot: 0,
+            bump: 0,
+        }
+    }
+
     fn grants(subjects: &[Pubkey]) -> Vec<AclSubjectEntry> {
         subjects
             .iter()
@@ -618,26 +671,20 @@ mod tests {
     }
 
     #[test]
-    fn durable_output_previous_state_accepts_exact_match() {
+    fn durable_output_previous_state_accepts_exact_previous_match() {
         let subjects = vec![Pubkey::new_unique(), Pubkey::new_unique()];
         let value = lineage([9; 32], &subjects);
-        assert!(validate_durable_output_previous_state(
-            &value,
-            &grants(&subjects),
-            &Some([9; 32]),
-            &Some(subjects),
-        )
-        .is_ok());
+        assert!(validate_durable_output_previous_state(&value, &Some([9; 32]), &Some(subjects),)
+            .is_ok());
     }
 
     #[test]
-    fn durable_output_previous_state_rejects_mismatches() {
+    fn durable_output_previous_state_rejects_previous_mismatch() {
         let subjects = vec![Pubkey::new_unique()];
         let value = lineage([9; 32], &subjects);
         // Wrong previous handle.
         assert!(validate_durable_output_previous_state(
             &value,
-            &grants(&subjects),
             &Some([8; 32]),
             &Some(subjects.clone()),
         )
@@ -645,23 +692,67 @@ mod tests {
         // Wrong previous subjects.
         assert!(validate_durable_output_previous_state(
             &value,
-            &grants(&subjects),
             &Some([9; 32]),
             &Some(vec![Pubkey::new_unique()]),
         )
         .is_err());
         // Missing previous_* on an existing lineage (create shape on supersede).
+        assert!(validate_durable_output_previous_state(&value, &None, &None).is_err());
+    }
+
+    #[test]
+    fn durable_output_previous_state_ignores_output_audience() {
+        // Validation pins only the outgoing state (previous_handle/previous_subjects); it no
+        // longer constrains the new audience, so a supersede may rotate `output_subjects`.
+        let subjects = vec![Pubkey::new_unique()];
+        let value = lineage([9; 32], &subjects);
         assert!(
-            validate_durable_output_previous_state(&value, &grants(&subjects), &None, &None)
-                .is_err()
+            validate_durable_output_previous_state(&value, &Some([9; 32]), &Some(subjects)).is_ok()
         );
-        // Planned output subjects diverge from stored membership.
-        assert!(validate_durable_output_previous_state(
-            &value,
-            &grants(&[Pubkey::new_unique()]),
-            &Some([9; 32]),
-            &Some(subjects),
-        )
-        .is_err());
+    }
+
+    #[test]
+    fn assert_output_acl_metadata_rejects_empty_and_over_cap_rotations() {
+        let app_account = Pubkey::new_unique();
+        // Empty rotated set is rejected, mirroring remove_subject's last-subject rule.
+        assert!(assert_output_acl_metadata(app_account, app_account, &[]).is_err());
+        // A rotated set above MAX_ACL_SUBJECTS (8) is rejected.
+        let over_cap = grants(
+            &(0..=zama_solana_acl::MAX_ENCRYPTED_VALUE_SUBJECTS)
+                .map(|_| Pubkey::new_unique())
+                .collect::<Vec<_>>(),
+        );
+        assert!(assert_output_acl_metadata(app_account, app_account, &over_cap).is_err());
+    }
+
+    #[test]
+    fn rotation_added_denied_subject_is_rejected() {
+        let stored = vec![Pubkey::new_unique()];
+        let added = Pubkey::new_unique();
+        let rotated = grants(&[stored[0], added]);
+        let (record_key, bump) = deny_subject_address(added);
+
+        let mut lamports = 1_000_000u64;
+        let mut data = vec![0u8; 8 + crate::state::DenySubjectRecord::SPACE];
+        crate::state::DenySubjectRecord {
+            subject: added,
+            denied: true,
+            bump,
+        }
+        .try_serialize(&mut &mut data[..])
+        .unwrap();
+        let owner = crate::ID;
+        let record =
+            AccountInfo::new(&record_key, false, false, &mut lamports, &mut data, &owner, false);
+        let remaining = [record];
+
+        let config = deny_enabled_config();
+
+        // A stored subject that stays put needs no record; only `added` is checked, and it is denied.
+        assert_eq!(
+            check_rotation_grants_not_denied(&config, &remaining, None, &stored, &rotated)
+                .unwrap_err(),
+            error!(ZamaHostError::AclSubjectDenied)
+        );
     }
 }

--- a/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/admission.rs
@@ -68,6 +68,7 @@ impl<'a, 'info> AdmissionState<'a, 'info> {
     #[allow(clippy::too_many_arguments)]
     fn admit_durable_output_account(
         &mut self,
+        host_config: &crate::state::HostConfig,
         remaining_accounts: &[AccountInfo],
         output_encrypted_value_index: u16,
         output_acl_domain_key: Pubkey,
@@ -104,9 +105,15 @@ impl<'a, 'info> AdmissionState<'a, 'info> {
             let value = read_canonical_encrypted_value(output_info)?;
             super::validate_durable_output_previous_state(
                 &value,
-                output_subjects,
                 previous_handle,
                 previous_subjects,
+            )?;
+            super::check_rotation_grants_not_denied(
+                host_config,
+                remaining_accounts,
+                None,
+                &value.subjects,
+                output_subjects,
             )?;
         } else {
             require!(
@@ -197,6 +204,7 @@ impl EvalStepVisitor for AdmissionState<'_, '_> {
                     output_subjects,
                 )?;
                 self.admit_durable_output_account(
+                    &ctx.accounts.host_config,
                     ctx.remaining_accounts,
                     *output_encrypted_value_index,
                     *output_acl_domain_key,

--- a/solana/programs/zama-host/src/instructions/fhe_eval/preflight.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/preflight.rs
@@ -225,11 +225,25 @@ fn preflight_output(output: &FheEvalOutput, preflight: &mut EvalPreflight<'_, '_
         FheEvalOutput::AllowedDurable {
             output_encrypted_value_index,
             output_app_account_authority_index,
+            output_subjects,
+            previous_subjects,
             ..
         } => {
             preflight.mark_account(*output_encrypted_value_index)?;
             let authority = preflight.mark_output_authority(*output_app_account_authority_index)?;
             preflight.mark_deny_record(authority)?;
+            // A supersede that rotates the audience deny-checks each added subject in the bind
+            // pass; mark their deny records here so finish() accounts for them. The added set is
+            // `output_subjects \ previous_subjects` from instruction data alone — a lying
+            // previous_subjects is rejected later with PreviousStateMismatch, so trusting it for
+            // account-marking is safe. `None` previous is a create (no rotation, nothing added).
+            if let Some(previous_subjects) = previous_subjects {
+                for subject in output_subjects {
+                    if !previous_subjects.contains(&subject.pubkey) {
+                        preflight.mark_deny_record(subject.pubkey)?;
+                    }
+                }
+            }
         }
     }
     Ok(())

--- a/solana/programs/zama-host/src/state/mod.rs
+++ b/solana/programs/zama-host/src/state/mod.rs
@@ -339,7 +339,9 @@ pub enum FheEvalOutput {
         /// Encrypted value label for the output lineage.
         output_encrypted_value_label: [u8; 32],
         /// Subjects on the output lineage. On create these are the initial
-        /// subjects; on supersede they must equal the stored subjects exactly.
+        /// subjects; on supersede they become the new audience, which may rotate
+        /// away from the stored set (the outgoing audience is sealed into
+        /// historical leaves first; added subjects pass the grant deny-list).
         output_subjects: Vec<AclSubjectEntry>,
         /// Superseded handle: `None` on create, `Some(current_handle)` on update.
         /// Carried in instruction data so indexers can reconstruct the appended

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -1,6 +1,6 @@
 {
   "fhe_eval/max_op_frame": {
-    "compute_units": 151136,
+    "compute_units": 150997,
     "unique_accounts": 9,
     "instruction_data_bytes": 921,
     "cpi_instructions": 3,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 36
   },
   "fhe_eval/three_op_frame": {
-    "compute_units": 61438,
+    "compute_units": 61299,
     "unique_accounts": 9,
     "instruction_data_bytes": 375,
     "cpi_instructions": 3,

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -1,6 +1,6 @@
 {
   "fhe_eval/max_op_frame": {
-    "compute_units": 150944,
+    "compute_units": 151136,
     "unique_accounts": 9,
     "instruction_data_bytes": 921,
     "cpi_instructions": 3,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 36
   },
   "fhe_eval/three_op_frame": {
-    "compute_units": 61259,
+    "compute_units": 61438,
     "unique_accounts": 9,
     "instruction_data_bytes": 375,
     "cpi_instructions": 3,

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,23 +1,23 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 333137,
-    "unique_accounts": 15,
+    "compute_units": 330361,
+    "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
     "total_cpi_instruction_data_bytes": 2212,
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 350816,
-    "unique_accounts": 15,
+    "compute_units": 348040,
+    "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
     "total_cpi_instruction_data_bytes": 2296,
     "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
-    "compute_units": 65268,
-    "unique_accounts": 12,
+    "compute_units": 62356,
+    "unique_accounts": 11,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,
     "total_cpi_instruction_data_bytes": 603,

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,23 +1,23 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 329820,
-    "unique_accounts": 14,
+    "compute_units": 333137,
+    "unique_accounts": 15,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
     "total_cpi_instruction_data_bytes": 2212,
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 347289,
-    "unique_accounts": 14,
+    "compute_units": 350816,
+    "unique_accounts": 15,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
     "total_cpi_instruction_data_bytes": 2296,
     "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
-    "compute_units": 62273,
-    "unique_accounts": 11,
+    "compute_units": 65268,
+    "unique_accounts": 12,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,
     "total_cpi_instruction_data_bytes": 603,

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -1228,6 +1228,158 @@ fn mollusk_fhe_eval_supersedes_and_appends_allowed_subject_leaves() {
 }
 
 #[test]
+fn mollusk_fhe_eval_supersede_rotates_subjects_and_seals_the_outgoing_audience() {
+    let authority = Pubkey::new_unique();
+    let (host_config, host_config_account) = host_config_account(authority);
+    let subject_a = Pubkey::new_unique();
+    let old_recipient = Pubkey::new_unique();
+    let new_recipient = Pubkey::new_unique();
+    let old_handle = handle_for_chain(3, 5);
+    let (address, value) = new_lineage(
+        Pubkey::new_unique(),
+        authority,
+        label("balance"),
+        old_handle,
+        &[subject_a, old_recipient],
+    );
+
+    let args = FheEvalArgs {
+        context_id: [7; 32],
+        steps: vec![FheEvalStep::TrivialEncrypt {
+            plaintext: [7; 32],
+            fhe_type: 5,
+            output: FheEvalOutput::AllowedDurable {
+                output_encrypted_value_index: 0,
+                output_app_account_authority_index: None,
+                output_acl_domain_key: value.acl_domain_key,
+                output_app_account: value.app_account,
+                output_encrypted_value_label: value.encrypted_value_label,
+                // Rotate the audience: drop `old_recipient`, grant `new_recipient`.
+                output_subjects: vec![
+                    host::AclSubjectEntry { pubkey: subject_a },
+                    host::AclSubjectEntry {
+                        pubkey: new_recipient,
+                    },
+                ],
+                previous_handle: Some(old_handle),
+                previous_subjects: Some(value.subjects.clone()),
+                make_public: false,
+            },
+        }],
+    };
+    let ix = fhe_eval_ix(
+        authority,
+        subject_a,
+        value.app_account,
+        host_config,
+        args,
+        vec![writable(address)],
+    );
+    let accounts = vec![
+        (system_program::ID, system_program_account()),
+        (authority, funded_system_account()),
+        (subject_a, funded_system_account()),
+        (value.app_account, funded_system_account()),
+        (address, encrypted_value_account(&value)),
+        (host_config, host_config_account),
+        (event_authority(host::id()), Account::default()),
+    ];
+    let result = mollusk().process_and_validate_instruction(&ix, &accounts, &[Check::success()]);
+    let updated = read_encrypted_value(&result, address);
+
+    // Historical leaves seal the OLD audience (subject_a, old_recipient) at the old handle.
+    assert_eq!(updated.leaf_count, 2);
+    let mut expected_peaks = Vec::new();
+    let mut expected_count = 0u64;
+    for (index, subject) in [subject_a, old_recipient].iter().enumerate() {
+        let expected_leaf = zama_solana_acl::historical_access_leaf_commitment(
+            address.to_bytes(),
+            index as u64,
+            old_handle,
+            subject.to_bytes(),
+        );
+        zama_solana_acl::mmr_append(&mut expected_peaks, &mut expected_count, expected_leaf)
+            .unwrap();
+    }
+    assert_eq!(updated.peaks, expected_peaks);
+    // Current membership rotated to the new audience.
+    assert_ne!(updated.current_handle, old_handle);
+    assert_eq!(updated.subjects, vec![subject_a, new_recipient]);
+}
+
+#[test]
+fn mollusk_fhe_eval_supersede_shrinks_audience_and_seals_the_outgoing_set() {
+    // A rotation that removes a subject (3 -> 2): the outgoing 3-subject audience is sealed, the
+    // new 2-subject set becomes current membership, and the account never shrinks.
+    let authority = Pubkey::new_unique();
+    let (host_config, host_config_account) = host_config_account(authority);
+    let subject_a = Pubkey::new_unique();
+    let subject_b = Pubkey::new_unique();
+    let subject_c = Pubkey::new_unique();
+    let old_handle = handle_for_chain(3, 5);
+    let (address, value) = new_lineage(
+        Pubkey::new_unique(),
+        authority,
+        label("balance"),
+        old_handle,
+        &[subject_a, subject_b, subject_c],
+    );
+    let bytes_before = encrypted_value_account(&value).data.len();
+
+    let args = FheEvalArgs {
+        context_id: [8; 32],
+        steps: vec![FheEvalStep::TrivialEncrypt {
+            plaintext: [8; 32],
+            fhe_type: 5,
+            output: FheEvalOutput::AllowedDurable {
+                output_encrypted_value_index: 0,
+                output_app_account_authority_index: None,
+                output_acl_domain_key: value.acl_domain_key,
+                output_app_account: value.app_account,
+                output_encrypted_value_label: value.encrypted_value_label,
+                output_subjects: vec![
+                    host::AclSubjectEntry { pubkey: subject_a },
+                    host::AclSubjectEntry { pubkey: subject_b },
+                ],
+                previous_handle: Some(old_handle),
+                previous_subjects: Some(value.subjects.clone()),
+                make_public: false,
+            },
+        }],
+    };
+    let ix = fhe_eval_ix(
+        authority,
+        subject_a,
+        value.app_account,
+        host_config,
+        args,
+        vec![writable(address)],
+    );
+    let accounts = vec![
+        (system_program::ID, system_program_account()),
+        (authority, funded_system_account()),
+        (subject_a, funded_system_account()),
+        (value.app_account, funded_system_account()),
+        (address, encrypted_value_account(&value)),
+        (host_config, host_config_account),
+        (event_authority(host::id()), Account::default()),
+    ];
+    let result = mollusk().process_and_validate_instruction(&ix, &accounts, &[Check::success()]);
+    let updated = read_encrypted_value(&result, address);
+
+    assert_eq!(updated.leaf_count, 3);
+    assert_eq!(updated.subjects, vec![subject_a, subject_b]);
+    // Account bytes are never reduced by a shrinking rotation (realloc only grows).
+    let resulting_bytes = result
+        .resulting_accounts
+        .iter()
+        .find(|(key, _)| *key == address)
+        .map(|(_, account)| account.data.len())
+        .expect("encrypted value account present in result");
+    assert!(resulting_bytes >= bytes_before);
+}
+
+#[test]
 fn mollusk_update_encrypted_value_rejects_raw_handle_without_provenance() {
     let authority = Pubkey::new_unique();
     let (host_config, host_config_account) = host_config_account(authority);

--- a/solana/runtime-tests/tests/token_mollusk.rs
+++ b/solana/runtime-tests/tests/token_mollusk.rs
@@ -1219,7 +1219,10 @@ fn mollusk_confidential_transfer_to_second_recipient_rotates_transferred_lineage
         charlie_initial,
         &[charlie_owner, fixture.compute_signer],
     );
-    accounts.insert(charlie_balance_value, encrypted_value_account(&charlie_value));
+    accounts.insert(
+        charlie_balance_value,
+        encrypted_value_account(&charlie_value),
+    );
     let context = mollusk().with_context(accounts);
 
     let transferred_value_address = fixture.transferred_amount_value_address(fixture.alice_token);
@@ -1298,7 +1301,10 @@ fn seed_third_account(
         initial,
         &[charlie_owner, fixture.compute_signer],
     );
-    accounts.insert(charlie_balance_value, encrypted_value_account(&charlie_value));
+    accounts.insert(
+        charlie_balance_value,
+        encrypted_value_account(&charlie_value),
+    );
     (charlie_owner, charlie_token, charlie_balance_value)
 }
 
@@ -1308,8 +1314,11 @@ fn mollusk_confidential_transfer_rotates_back_to_previous_recipient() {
     // audience each time and seals every outgoing audience into historical leaves.
     let fixture = TokenFixture::new();
     let mut accounts = fixture.base_accounts();
-    let (charlie_owner, charlie_token, charlie_balance_value) =
-        seed_third_account(&fixture, &mut accounts, handle_for_chain(3, BALANCE_FHE_TYPE));
+    let (charlie_owner, charlie_token, charlie_balance_value) = seed_third_account(
+        &fixture,
+        &mut accounts,
+        handle_for_chain(3, BALANCE_FHE_TYPE),
+    );
     let context = mollusk().with_context(accounts);
     let receipt_address = fixture.transferred_amount_value_address(fixture.alice_token);
 
@@ -1443,10 +1452,16 @@ fn mollusk_confidential_transfer_deny_list_enabled_rotation_to_new_recipient_suc
     let mut accounts = fixture.base_accounts();
     accounts.insert(
         fixture.host_config,
-        deny_enabled_host_config_account(fixture.owner, secp_evm_address(&coprocessor_signing_key())),
+        deny_enabled_host_config_account(
+            fixture.owner,
+            secp_evm_address(&coprocessor_signing_key()),
+        ),
     );
-    let (charlie_owner, charlie_token, charlie_balance_value) =
-        seed_third_account(&fixture, &mut accounts, handle_for_chain(3, BALANCE_FHE_TYPE));
+    let (charlie_owner, charlie_token, charlie_balance_value) = seed_third_account(
+        &fixture,
+        &mut accounts,
+        handle_for_chain(3, BALANCE_FHE_TYPE),
+    );
 
     let alice_deny = host::deny_subject_address(fixture.alice_token).0;
     let bob_deny = host::deny_subject_address(fixture.bob_token).0;
@@ -1510,10 +1525,16 @@ fn mollusk_confidential_transfer_deny_list_rejects_denied_rotation_added_subject
     let mut accounts = fixture.base_accounts();
     accounts.insert(
         fixture.host_config,
-        deny_enabled_host_config_account(fixture.owner, secp_evm_address(&coprocessor_signing_key())),
+        deny_enabled_host_config_account(
+            fixture.owner,
+            secp_evm_address(&coprocessor_signing_key()),
+        ),
     );
-    let (charlie_owner, charlie_token, charlie_balance_value) =
-        seed_third_account(&fixture, &mut accounts, handle_for_chain(3, BALANCE_FHE_TYPE));
+    let (charlie_owner, charlie_token, charlie_balance_value) = seed_third_account(
+        &fixture,
+        &mut accounts,
+        handle_for_chain(3, BALANCE_FHE_TYPE),
+    );
 
     let alice_deny = host::deny_subject_address(fixture.alice_token).0;
     let bob_deny = host::deny_subject_address(fixture.bob_token).0;

--- a/solana/runtime-tests/tests/token_mollusk.rs
+++ b/solana/runtime-tests/tests/token_mollusk.rs
@@ -1195,6 +1195,384 @@ fn mollusk_confidential_transfer_updates_lineages_and_cleartext_balances() {
 }
 
 #[test]
+fn mollusk_confidential_transfer_to_second_recipient_rotates_transferred_lineage_subjects() {
+    // Regression: a sender's second transfer to a DIFFERENT recipient must succeed. The
+    // per-sender transferred-amount lineage rotates its audience to the new recipient, sealing
+    // the first receipt's audience into historical leaves (previously reverted 6053).
+    let fixture = TokenFixture::new();
+    let charlie_owner = Pubkey::new_unique();
+    let charlie_token = token::token_account_address(fixture.mint, charlie_owner).0;
+    let charlie_balance_value =
+        token::balance_encrypted_value_address(fixture.mint, charlie_token).0;
+    let charlie_initial = handle_for_chain(3, BALANCE_FHE_TYPE);
+
+    let mut accounts = fixture.base_accounts();
+    accounts.insert(charlie_owner, system_account(5_000_000_000));
+    accounts.insert(
+        charlie_token,
+        fixture.confidential_token_account(charlie_owner, charlie_balance_value),
+    );
+    let (_, charlie_value) = new_encrypted_value(
+        fixture.mint,
+        charlie_token,
+        token::balance_label(),
+        charlie_initial,
+        &[charlie_owner, fixture.compute_signer],
+    );
+    accounts.insert(charlie_balance_value, encrypted_value_account(&charlie_value));
+    let context = mollusk().with_context(accounts);
+
+    let transferred_value_address = fixture.transferred_amount_value_address(fixture.alice_token);
+
+    // First transfer Alice -> Bob: births the transferred lineage with audience
+    // {alice_owner, bob_owner, compute_signer}.
+    let first_amount = handle_for_chain(21, BALANCE_FHE_TYPE);
+    let first = confidential_transfer_ix(
+        &fixture,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_attestation_for(first_amount, fixture.owner, fixture.compute_signer),
+    );
+    context.process_and_validate_instruction(&first, &[Check::success()]);
+
+    let first_receipt = read_encrypted_value(&context, transferred_value_address);
+    assert_eq!(first_receipt.leaf_count, 0);
+    assert_eq!(
+        first_receipt.subjects,
+        vec![fixture.owner, fixture.bob_owner, fixture.compute_signer]
+    );
+    let first_receipt_handle = first_receipt.current_handle;
+
+    // Second transfer Alice -> Charlie: must now SUCCEED and rotate the lineage audience.
+    let second_amount = handle_for_chain(22, BALANCE_FHE_TYPE);
+    let second = confidential_transfer_ix(
+        &fixture,
+        fixture.alice_token,
+        charlie_token,
+        fixture.alice_balance_value,
+        charlie_balance_value,
+        amount_attestation_for(second_amount, fixture.owner, fixture.compute_signer),
+    );
+    context.process_and_validate_instruction(&second, &[Check::success()]);
+
+    let receipt = read_encrypted_value(&context, transferred_value_address);
+    // Audience rotated to the new recipient.
+    assert_eq!(
+        receipt.subjects,
+        vec![fixture.owner, charlie_owner, fixture.compute_signer]
+    );
+    // Historical leaves seal the FIRST receipt's audience {alice_owner, bob_owner, compute_signer}.
+    assert_eq!(receipt.leaf_count, 3);
+    assert_eq!(
+        receipt.peaks,
+        expected_historical_peaks(
+            transferred_value_address,
+            first_receipt_handle,
+            &[fixture.owner, fixture.bob_owner, fixture.compute_signer],
+        )
+    );
+}
+
+/// Seeds Charlie's token account + balance lineage into `accounts` and returns
+/// (charlie_owner, charlie_token, charlie_balance_value).
+fn seed_third_account(
+    fixture: &TokenFixture,
+    accounts: &mut HashMap<Pubkey, Account>,
+    initial: [u8; 32],
+) -> (Pubkey, Pubkey, Pubkey) {
+    let charlie_owner = Pubkey::new_unique();
+    let charlie_token = token::token_account_address(fixture.mint, charlie_owner).0;
+    let charlie_balance_value =
+        token::balance_encrypted_value_address(fixture.mint, charlie_token).0;
+    accounts.insert(charlie_owner, system_account(5_000_000_000));
+    accounts.insert(
+        charlie_token,
+        fixture.confidential_token_account(charlie_owner, charlie_balance_value),
+    );
+    let (_, charlie_value) = new_encrypted_value(
+        fixture.mint,
+        charlie_token,
+        token::balance_label(),
+        initial,
+        &[charlie_owner, fixture.compute_signer],
+    );
+    accounts.insert(charlie_balance_value, encrypted_value_account(&charlie_value));
+    (charlie_owner, charlie_token, charlie_balance_value)
+}
+
+#[test]
+fn mollusk_confidential_transfer_rotates_back_to_previous_recipient() {
+    // Alice -> Bob, Alice -> Charlie, Alice -> Bob: the per-sender transferred lineage rotates its
+    // audience each time and seals every outgoing audience into historical leaves.
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    let (charlie_owner, charlie_token, charlie_balance_value) =
+        seed_third_account(&fixture, &mut accounts, handle_for_chain(3, BALANCE_FHE_TYPE));
+    let context = mollusk().with_context(accounts);
+    let receipt_address = fixture.transferred_amount_value_address(fixture.alice_token);
+
+    let transfer = |to_token, to_balance, tag| {
+        confidential_transfer_ix(
+            &fixture,
+            fixture.alice_token,
+            to_token,
+            fixture.alice_balance_value,
+            to_balance,
+            amount_attestation_for(
+                handle_for_chain(tag, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+        )
+    };
+
+    context.process_and_validate_instruction(
+        &transfer(fixture.bob_token, fixture.bob_balance_value, 21),
+        &[Check::success()],
+    );
+    let handle_after_bob = read_encrypted_value(&context, receipt_address).current_handle;
+
+    context.process_and_validate_instruction(
+        &transfer(charlie_token, charlie_balance_value, 22),
+        &[Check::success()],
+    );
+    let after_charlie = read_encrypted_value(&context, receipt_address);
+    assert_eq!(after_charlie.leaf_count, 3);
+    assert_eq!(
+        after_charlie.subjects,
+        vec![fixture.owner, charlie_owner, fixture.compute_signer]
+    );
+    let handle_after_charlie = after_charlie.current_handle;
+
+    context.process_and_validate_instruction(
+        &transfer(fixture.bob_token, fixture.bob_balance_value, 23),
+        &[Check::success()],
+    );
+    let after_bob_again = read_encrypted_value(&context, receipt_address);
+
+    // Audience rotated back to Bob; both prior audiences are sealed in order.
+    assert_eq!(
+        after_bob_again.subjects,
+        vec![fixture.owner, fixture.bob_owner, fixture.compute_signer]
+    );
+    assert_eq!(after_bob_again.leaf_count, 6);
+    let mut expected_peaks = Vec::new();
+    let mut count = 0u64;
+    for (handle, audience) in [
+        (
+            handle_after_bob,
+            [fixture.owner, fixture.bob_owner, fixture.compute_signer],
+        ),
+        (
+            handle_after_charlie,
+            [fixture.owner, charlie_owner, fixture.compute_signer],
+        ),
+    ] {
+        for subject in audience {
+            let leaf = zama_solana_acl::historical_access_leaf_commitment(
+                receipt_address.to_bytes(),
+                count,
+                handle,
+                subject.to_bytes(),
+            );
+            zama_solana_acl::mmr_append(&mut expected_peaks, &mut count, leaf).unwrap();
+        }
+    }
+    assert_eq!(after_bob_again.peaks, expected_peaks);
+}
+
+#[test]
+fn mollusk_confidential_transfer_self_transfer_after_receipt_is_no_op() {
+    // A self-transfer short-circuits before the eval (execute_transfer returns early when
+    // from == to), so it never rotates the receipt. After a real transfer birthed the receipt,
+    // a subsequent A -> A succeeds and leaves that receipt untouched.
+    let fixture = TokenFixture::new();
+    let context = mollusk().with_context(fixture.base_accounts());
+    let receipt_address = fixture.transferred_amount_value_address(fixture.alice_token);
+
+    context.process_and_validate_instruction(
+        &confidential_transfer_ix(
+            &fixture,
+            fixture.alice_token,
+            fixture.bob_token,
+            fixture.alice_balance_value,
+            fixture.bob_balance_value,
+            amount_attestation_for(
+                handle_for_chain(21, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+        ),
+        &[Check::success()],
+    );
+    let receipt_before = read_encrypted_value(&context, receipt_address);
+    assert_eq!(
+        receipt_before.subjects,
+        vec![fixture.owner, fixture.bob_owner, fixture.compute_signer]
+    );
+
+    // Self-transfer: succeeds as a no-op.
+    context.process_and_validate_instruction(
+        &confidential_transfer_ix(
+            &fixture,
+            fixture.alice_token,
+            fixture.alice_token,
+            fixture.alice_balance_value,
+            fixture.alice_balance_value,
+            amount_attestation_for(
+                handle_for_chain(22, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+        ),
+        &[Check::success()],
+    );
+    let receipt_after = read_encrypted_value(&context, receipt_address);
+    assert_eq!(receipt_after.subjects, receipt_before.subjects);
+    assert_eq!(receipt_after.current_handle, receipt_before.current_handle);
+    assert_eq!(receipt_after.leaf_count, receipt_before.leaf_count);
+}
+
+#[test]
+fn mollusk_confidential_transfer_deny_list_enabled_rotation_to_new_recipient_succeeds() {
+    // Deny-list ENABLED + rotation: the second transfer to a new recipient adds that recipient's
+    // owner to the transferred audience, so its deny record must reach the host and clear.
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    accounts.insert(
+        fixture.host_config,
+        deny_enabled_host_config_account(fixture.owner, secp_evm_address(&coprocessor_signing_key())),
+    );
+    let (charlie_owner, charlie_token, charlie_balance_value) =
+        seed_third_account(&fixture, &mut accounts, handle_for_chain(3, BALANCE_FHE_TYPE));
+
+    let alice_deny = host::deny_subject_address(fixture.alice_token).0;
+    let bob_deny = host::deny_subject_address(fixture.bob_token).0;
+    let charlie_token_deny = host::deny_subject_address(charlie_token).0;
+    let charlie_owner_deny = host::deny_subject_address(charlie_owner).0;
+    for record in [alice_deny, bob_deny, charlie_token_deny, charlie_owner_deny] {
+        accounts.insert(record, system_account(0));
+    }
+    let context = mollusk().with_context(accounts);
+    let receipt_address = fixture.transferred_amount_value_address(fixture.alice_token);
+
+    // First transfer (create): only the two token-account authorities are deny-checked.
+    context.process_and_validate_instruction(
+        &confidential_transfer_ix_with_remaining(
+            &fixture,
+            fixture.alice_token,
+            fixture.bob_token,
+            fixture.alice_balance_value,
+            fixture.bob_balance_value,
+            amount_attestation_for(
+                handle_for_chain(21, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+            vec![alice_deny, bob_deny],
+        ),
+        &[Check::success()],
+    );
+
+    // Second transfer (rotation): authorities alice_token + charlie_token, plus the rotation-added
+    // subject charlie_owner, each needs a (non-denied) deny witness.
+    context.process_and_validate_instruction(
+        &confidential_transfer_ix_with_remaining(
+            &fixture,
+            fixture.alice_token,
+            charlie_token,
+            fixture.alice_balance_value,
+            charlie_balance_value,
+            amount_attestation_for(
+                handle_for_chain(22, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+            vec![alice_deny, charlie_token_deny, charlie_owner_deny],
+        ),
+        &[Check::success()],
+    );
+
+    let receipt = read_encrypted_value(&context, receipt_address);
+    assert_eq!(
+        receipt.subjects,
+        vec![fixture.owner, charlie_owner, fixture.compute_signer]
+    );
+}
+
+#[test]
+fn mollusk_confidential_transfer_deny_list_rejects_denied_rotation_added_subject() {
+    // Deny-list ENABLED + rotation where the added recipient's owner IS denied: the transfer must
+    // fail with the deny error (not InvalidFheEvalAccount from an unconsumed remaining account).
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    accounts.insert(
+        fixture.host_config,
+        deny_enabled_host_config_account(fixture.owner, secp_evm_address(&coprocessor_signing_key())),
+    );
+    let (charlie_owner, charlie_token, charlie_balance_value) =
+        seed_third_account(&fixture, &mut accounts, handle_for_chain(3, BALANCE_FHE_TYPE));
+
+    let alice_deny = host::deny_subject_address(fixture.alice_token).0;
+    let bob_deny = host::deny_subject_address(fixture.bob_token).0;
+    let charlie_token_deny = host::deny_subject_address(charlie_token).0;
+    let charlie_owner_deny = host::deny_subject_address(charlie_owner).0;
+    accounts.insert(alice_deny, system_account(0));
+    accounts.insert(bob_deny, system_account(0));
+    accounts.insert(charlie_token_deny, system_account(0));
+    // charlie_owner is denied.
+    accounts.insert(
+        charlie_owner_deny,
+        deny_subject_record_account(charlie_owner, true).1,
+    );
+    let context = mollusk().with_context(accounts);
+    let receipt_address = fixture.transferred_amount_value_address(fixture.alice_token);
+
+    context.process_and_validate_instruction(
+        &confidential_transfer_ix_with_remaining(
+            &fixture,
+            fixture.alice_token,
+            fixture.bob_token,
+            fixture.alice_balance_value,
+            fixture.bob_balance_value,
+            amount_attestation_for(
+                handle_for_chain(21, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+            vec![alice_deny, bob_deny],
+        ),
+        &[Check::success()],
+    );
+
+    context.process_and_validate_instruction(
+        &confidential_transfer_ix_with_remaining(
+            &fixture,
+            fixture.alice_token,
+            charlie_token,
+            fixture.alice_balance_value,
+            charlie_balance_value,
+            amount_attestation_for(
+                handle_for_chain(22, BALANCE_FHE_TYPE),
+                fixture.owner,
+                fixture.compute_signer,
+            ),
+            vec![alice_deny, charlie_token_deny, charlie_owner_deny],
+        ),
+        &[host_error(host::errors::ZamaHostError::AclSubjectDenied)],
+    );
+
+    // The denied rotation left the receipt at its first-transfer audience.
+    let receipt = read_encrypted_value(&context, receipt_address);
+    assert_eq!(
+        receipt.subjects,
+        vec![fixture.owner, fixture.bob_owner, fixture.compute_signer]
+    );
+}
+
+#[test]
 fn mollusk_confidential_transfer_with_deny_list_succeeds_when_neither_authority_is_denied() {
     let fixture = TokenFixture::new();
     let (accounts, deny_records) = deny_enabled_transfer_accounts(&fixture, None);


### PR DESCRIPTION
Fixes zama-ai/fhevm-internal#1741.

## What

On `feature/solana`, a sender's second confidential transfer to a **different** recipient reverts with `PreviousStateMismatch` (6053): the transferred-amount lineage is per-sender, its ACL is built per-call (including the recipient), and the host froze membership through eval binding.

This PR keeps that freeze as the default and adds **explicit subject rotation at durable-output supersede**:

- `previous_handle` / `previous_subjects` must still match the stored state exactly (unchanged — this is what lets the relayer/indexers reconstruct MMR leaves from instruction data alone).
- `output_subjects` may now differ from the stored set. The outgoing handle's historical leaves are sealed for the **old** audience first, then the new set is installed. Net semantics: each handle has exactly one ACL, fixed at birth, sealed at supersession (EVM parity — per-handle ACL epochs).
- Every rotation-**added** subject passes the grant deny-list, like `allow_subjects` (kept subjects are not re-checked, consistent with existing grant semantics). The `fhe_eval` preflight pass learns to account for the added subjects' deny-record witnesses so the all-accounts-consumed guard holds with the deny-list enabled.
- Authorization unchanged: the app-account authority signer gate on durable outputs.

The confidential-token transfer then works for arbitrary recipient sequences with **no app-side change**. Relayer replay rotates its reconstructed state at the identical point in the leaf sequence, and its idempotent-recovery path gains an arm for the fhe_eval supersede shape.

## Tests

- Regression: Alice→Bob then Alice→Charlie now succeeds; asserts exact post-rotation subjects and that the first receipt's sealed leaves carry the old audience `{alice, bob, compute}`.
- Rotate-back (Alice→Bob→Charlie→Bob), audience shrink (host-level 3→2), self-transfer no-op, deny-list **enabled** rotation (positive and denied-added-subject negative), relayer replay of rotation+make_public in one output, relayer ingest idempotent recovery.
- Full suites green: zama-host unit 83, zama-fhe 27, relayer replay 12 + ingest 12, host_mollusk 79, token_mollusk 39.

## Cost snapshots

Regenerated under the pinned 2.1.0 toolchain; `compute_units` only, no shape change (accounts / instruction bytes / CPI fields identical):

| profile | before | after |
|---|---|---|
| fhe_eval/three_op_frame | 61,398 | 61,438 |
| fhe_eval/max_op_frame | 151,083 | 151,136 |
| confidential_transfer/direct | 332,592 | 333,137 |
| confidential_transfer/steady_state | 350,061 | 350,816 |
| initialize_token_account | 65,180 | 65,268 |

## Open questions for reviewers

1. **Subject continuity.** The removed equality check was also a structural guarantee that a supersede could never change a lineage's audience. With rotation, the host no longer guarantees that any particular subject (owner, compute signer) survives — audience continuity becomes the app's responsibility. All current call sites keep owner+compute invariant (audited), but a host-level "must-keep" rule (e.g. the superseding authority must remain in `output_subjects`) would restore defense-in-depth. Deliberately not implemented here — semantics call for the host team.
2. **Deny-after-grant.** A subject deny-listed after being granted keeps standing membership across rotations (deny gates grants, not membership; removal stays `remove_subject`). This matches existing `allow_subjects` semantics and is unchanged here — flagged so it's a conscious choice.
3. Create-path subjects remain un-deny-checked (pre-existing asymmetry, unchanged): a denied subject can still enter a lineage at birth or via `allow_subjects`' member set; rotation is now the strictest of the three grant routes.

Design discussion and alternatives considered (per-pair lineages, per-party split, born-sealed receipts, CPI reconciliation) are in fhevm-internal#1741.
