### PR TITLE
feat(solana-proof-service): bounded Solana RPC recovery

### DIFF
--- a/solana-proof-service/Cargo.lock
+++ b/solana-proof-service/Cargo.lock
@@ -3054,10 +3054,15 @@ version = "0.1.0"
 dependencies = [
  "bs58",
  "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tonic",
+ "tracing",
  "yellowstone-grpc-proto",
  "zama-solana-transaction",
 ]

--- a/solana-proof-service/README.md
+++ b/solana-proof-service/README.md
@@ -6,11 +6,12 @@ proofs (RFC-024 / fhevm-internal #1682).
 This workspace holds:
 
 - Yellowstone completed-block source (`solana-proof-source`)
+- Bounded confirmed RPC recovery into the same `CompletedBlock` boundary
 - Atomic PostgreSQL store + sequential ingest runner (`solana-proof-store`)
 - Service binary with typed internal proof HTTP API + derived readiness
   (`solana-proof-service`)
 
-Bounded RPC recovery and multi-replica wiring land in later slices.
+Multi-replica wiring and embedded-relayer deletion land in later slices.
 
 ## HTTP surface
 
@@ -53,13 +54,39 @@ typed `chain_error` inside the HTTP window.
 
 **Readiness vs proof trust:** `/health/readiness` is the bootstrap / ingest gate
 (history complete + writer live + at least one Applied / AlreadyApplied on the
-live stream). A bare Yellowstone subscribe is not enough; cursor continuity must
-be proven by progress. After that, program-filtered idle streams are healthy;
-never-proven or reconnecting sources are `source_lagging`. Per-request proof
+live stream, and not mid-recovery). A bare Yellowstone subscribe is not enough;
+cursor continuity must be proven by progress. After that, program-filtered idle
+streams are healthy; never-proven or reconnecting sources are `source_lagging`.
+In-flight bounded RPC recovery reports `recovery_required`. Per-request proof
 trust is peak-equality against confirmed chain state, not the readiness probe.
 
 Readiness classifications: `database_unavailable`, `writer_missing`,
 `source_lagging`, `history_incomplete`, `recovery_required`, `integrity_halted`.
+
+## Recovery
+
+Live ingest remains **filtered confirmed Yellowstone**. When the store or source
+signals a contiguous parent-chain gap (`RecoveryRequired` / `Ancestry`), the
+runner invokes bounded RPC `getBlocks`/`getBlock` (confirmed), normalizes into
+the same `CompletedBlock` shape (program-filtered txs, sparse indexes), applies
+through `SqlProofStore::apply_completed_block`, then **resubscribes from the
+durable checkpoint** (inclusive replay). Cancellation during recovery is safe.
+
+Errors are distinguished:
+
+- **Transport** → `recovery_required` (retryable externally; fail closed for proofs)
+- **History unavailable** (pruned / cleaned) → `recovery_required`, history stays incomplete
+- **Bound exhaustion** (`max_slots_per_attempt` / `max_blocks_per_attempt`) → same; never silent complete
+- **Ancestry conflict** on a recovered block apply → integrity halt
+- **Empty recovery range** → `recovery_required` (never `Filled`, never marks complete)
+- **Cancelled** mid-fetch / mid-apply → clean shutdown
+
+Bootstrap **A**: first applied block keeps `history_complete=false`.
+`history_complete=true` only after an explicit recovery pass proves continuity
+from configured `recovery.bootstrap_slot` through the **confirmed tip** that
+recovery established (`durable_tip.slot == confirmed_tip`). Single-slot
+bootstrap alone does not flip the flag when the chain tip is ahead. Empty
+recovery never marks complete.
 
 ## PoC gaps (non-prod TODOs)
 
@@ -72,19 +99,10 @@ Readiness classifications: `database_unavailable`, `writer_missing`,
 - **Internal only:** intended for localhost / Tailscale-class networks. No
   app auth, mTLS, or rate limits in v1. **TODO(prod):** add auth before any
   broader exposure.
-- **Bootstrap A incomplete until recovery:** a fresh empty Postgres starts
-  with `history_complete=false` on the first applied block. Continuity from
-  the configured start is proven only by an explicit bounded recovery pass
-  (`SqlProofStore::set_history_complete_after_recovery` is the seam; recovery
-  itself is not implemented yet). Readiness stays `history_incomplete` /
-  `recovery_required` until then.
-- **Program-filtered Yellowstone gaps:** the source subscribes with
-  `account_include` for the host program, so empty intermediate slots are
-  omitted. Consecutive filtered blocks may not satisfy
-  `parent_slot == previous applied slot`. Ingest still requires contiguous
-  parent links and surfaces a gap as `RecoveryRequired` / source `Ancestry`
-  (never a silent skip). **TODO:** bounded RPC recovery must fill missing
-  blocks before live ingest can continue across gaps.
+- **Recovery horizon:** default `max_slots_per_attempt=256` /
+  `max_blocks_per_attempt=128` are lean PoC bounds. Exhaustion fails closed
+  (`recovery_required` / incomplete history). **TODO(prod):** size horizons
+  against archive retention and catch-up SLOs; optional longer tip chase.
 - **Ops:** schema is service-owned. Apply migrations via
   `SqlProofStore::migrate` (or `sqlx migrate`) before ingest. Compile-checked
   queries require committed `.sqlx` metadata (`make sqlx-prepare` against a

--- a/solana-proof-service/README.md
+++ b/solana-proof-service/README.md
@@ -66,11 +66,17 @@ Readiness classifications: `database_unavailable`, `writer_missing`,
 ## Recovery
 
 Live ingest remains **filtered confirmed Yellowstone**. When the store or source
-signals a contiguous parent-chain gap (`RecoveryRequired` / `Ancestry`), the
-runner invokes bounded RPC `getBlocks`/`getBlock` (confirmed), normalizes into
-the same `CompletedBlock` shape (program-filtered txs, sparse indexes), applies
-through `SqlProofStore::apply_completed_block`, then **resubscribes from the
+signals a contiguous parent-chain gap (`RecoveryRequired` / `Ancestry`), or when
+a replay-capable geyser reports an **expired** inclusive cursor
+(`ReplayCursorExpired`), the runner invokes bounded RPC `getBlocks`/`getBlock`
+(confirmed), applies each normalized block **before** fetching the next (so the
+durable checkpoint advances during catch-up), then **resubscribes from the
 durable checkpoint** (inclusive replay). Cancellation during recovery is safe.
+
+A geyser that rejects `from_slot` entirely (`ReplayUnsupported`) fails closed:
+RPC catch-up cannot invent replay support, and resubscribing with `from_slot`
+would loop forever. Cursorless live intake + ordered staging is tracked in
+fhevm-internal #1823.
 
 Errors are distinguished:
 

--- a/solana-proof-service/README.md
+++ b/solana-proof-service/README.md
@@ -81,12 +81,12 @@ Errors are distinguished:
 - **Empty recovery range** → `recovery_required` (never `Filled`, never marks complete)
 - **Cancelled** mid-fetch / mid-apply → clean shutdown
 
-Bootstrap **A**: first applied block keeps `history_complete=false`.
-`history_complete=true` only after an explicit recovery pass proves continuity
-from configured `recovery.bootstrap_slot` through the **confirmed tip** that
-recovery established (`durable_tip.slot == confirmed_tip`). Single-slot
-bootstrap alone does not flip the flag when the chain tip is ahead. Empty
-recovery never marks complete.
+Bootstrap **A**: with `recovery.bootstrap_slot` set, the first recovery attempt
+fetches the bounded inclusive range from that slot through the observed
+confirmed tip (`getSlot`), then may flip `history_complete=true` only when
+durable `history_start` matches the configured bootstrap and the durable tip
+equals that confirmed tip. Bound exhaustion stays fail-closed. Empty recovery
+never marks complete.
 
 ## PoC gaps (non-prod TODOs)
 

--- a/solana-proof-service/config/app.yaml
+++ b/solana-proof-service/config/app.yaml
@@ -18,3 +18,11 @@ solana:
 yellowstone:
   grpc_url: http://127.0.0.1:10000
   # x_token: optional
+
+# Bounded confirmed RPC recovery (not the live source).
+# TODO(prod): raise horizons for archive depth / catch-up SLOs; exhaustion fails closed.
+recovery:
+  # rpc_url: optional override; defaults to solana.rpc_url
+  # bootstrap_slot: set for Bootstrap A completeness (history_complete flip)
+  max_slots_per_attempt: 256
+  max_blocks_per_attempt: 128

--- a/solana-proof-service/crates/solana-proof-service/src/chain.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/chain.rs
@@ -1,7 +1,7 @@
 //! Confirmed JSON-RPC chain access for on-chain `EncryptedValue` peak checks.
 //!
-//! Deliberately thin: proof serving only needs `getAccountInfo`. Signature /
-//! transaction catch-up belongs to the future bounded recovery adapter, not the
+//! Deliberately thin: proof serving only needs `getAccountInfo`. Gap fill uses
+//! the separate bounded recovery adapter in `solana-proof-source`, not this
 //! read-only proof path.
 //!
 //! Account payloads travel as Base64 (Base58 is for addresses only). The RPC

--- a/solana-proof-service/crates/solana-proof-service/src/config.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/config.rs
@@ -19,7 +19,14 @@ const KNOWN_ENV_PATHS: &[&[&str]] = &[
     &["solana", "rpc_url"],
     &["yellowstone", "grpc_url"],
     &["yellowstone", "x_token"],
+    &["recovery", "rpc_url"],
+    &["recovery", "bootstrap_slot"],
+    &["recovery", "max_slots_per_attempt"],
+    &["recovery", "max_blocks_per_attempt"],
 ];
+
+/// Connections reserved for ingest writer + readiness (not available to proofs).
+pub const RESERVED_DB_CONNECTIONS: u32 = 2;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -28,6 +35,8 @@ pub struct ServiceConfig {
     pub database: DatabaseConfig,
     pub solana: SolanaConfig,
     pub yellowstone: YellowstoneConfig,
+    #[serde(default)]
+    pub recovery: RecoveryConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -44,6 +53,20 @@ pub struct DatabaseConfig {
     pub max_connections: u32,
 }
 
+impl DatabaseConfig {
+    /// Proof admission slots so the shared pool always keeps
+    /// [`RESERVED_DB_CONNECTIONS`] free for writer/readiness.
+    ///
+    /// [`ServiceConfig::validate`] enforces `max_connections >=
+    /// RESERVED_DB_CONNECTIONS + 1`, so this never underflows.
+    pub fn proof_admission_limit(&self) -> usize {
+        self.max_connections
+            .checked_sub(RESERVED_DB_CONNECTIONS)
+            .expect("database.max_connections validated >= RESERVED_DB_CONNECTIONS + 1")
+            as usize
+    }
+}
+
 fn default_max_connections() -> u32 {
     10
 }
@@ -53,7 +76,9 @@ fn default_max_connections() -> u32 {
 pub struct SolanaConfig {
     /// Base58 host program id.
     pub program_id: String,
-    /// Confirmed JSON-RPC URL used only for on-chain peak checks (read-only).
+    /// Confirmed JSON-RPC URL used for on-chain peak checks (read-only), and
+    /// as the default bounded-recovery RPC endpoint when `recovery.rpc_url`
+    /// is unset.
     pub rpc_url: String,
 }
 
@@ -63,6 +88,44 @@ pub struct YellowstoneConfig {
     pub grpc_url: String,
     #[serde(default)]
     pub x_token: Option<String>,
+}
+
+/// Bounded confirmed-RPC recovery for parent-chain gaps and Bootstrap A.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecoveryConfig {
+    /// Recovery RPC endpoint; defaults to `solana.rpc_url` when unset.
+    #[serde(default)]
+    pub rpc_url: Option<String>,
+    /// Bootstrap A start slot: `history_complete` may flip only after
+    /// recovery proves continuity from this slot through the confirmed tip.
+    #[serde(default)]
+    pub bootstrap_slot: Option<u64>,
+    /// Max slot span (`to_slot - from_slot + 1`) per recovery attempt.
+    #[serde(default = "default_max_slots_per_attempt")]
+    pub max_slots_per_attempt: u64,
+    /// Max `getBlock` fetches (existing slots) per recovery attempt.
+    #[serde(default = "default_max_blocks_per_attempt")]
+    pub max_blocks_per_attempt: u64,
+}
+
+impl Default for RecoveryConfig {
+    fn default() -> Self {
+        Self {
+            rpc_url: None,
+            bootstrap_slot: None,
+            max_slots_per_attempt: default_max_slots_per_attempt(),
+            max_blocks_per_attempt: default_max_blocks_per_attempt(),
+        }
+    }
+}
+
+fn default_max_slots_per_attempt() -> u64 {
+    256
+}
+
+fn default_max_blocks_per_attempt() -> u64 {
+    128
 }
 
 impl ServiceConfig {
@@ -89,11 +152,11 @@ impl ServiceConfig {
         if self.database.connection_string.trim().is_empty() {
             anyhow::bail!("database.connection_string must not be empty");
         }
-        if self.database.max_connections < crate::lifecycle::RESERVED_DB_CONNECTIONS + 1 {
+        if self.database.max_connections < RESERVED_DB_CONNECTIONS + 1 {
             anyhow::bail!(
                 "database.max_connections must be >= {} ({} reserved for ingest/readiness + at least one proof slot)",
-                crate::lifecycle::RESERVED_DB_CONNECTIONS + 1,
-                crate::lifecycle::RESERVED_DB_CONNECTIONS
+                RESERVED_DB_CONNECTIONS + 1,
+                RESERVED_DB_CONNECTIONS
             );
         }
         if self.solana.rpc_url.trim().is_empty() {
@@ -102,12 +165,31 @@ impl ServiceConfig {
         if self.yellowstone.grpc_url.trim().is_empty() {
             anyhow::bail!("yellowstone.grpc_url must not be empty");
         }
+        if let Some(rpc_url) = &self.recovery.rpc_url {
+            if rpc_url.trim().is_empty() {
+                anyhow::bail!("recovery.rpc_url must not be empty when set");
+            }
+        }
+        if self.recovery.max_slots_per_attempt == 0 {
+            anyhow::bail!("recovery.max_slots_per_attempt must be >= 1");
+        }
+        if self.recovery.max_blocks_per_attempt == 0 {
+            anyhow::bail!("recovery.max_blocks_per_attempt must be >= 1");
+        }
         decode_program_id(&self.solana.program_id)?;
         Ok(())
     }
 
     pub fn program_id_bytes(&self) -> anyhow::Result<[u8; 32]> {
         decode_program_id(&self.solana.program_id)
+    }
+
+    /// Recovery RPC endpoint: `recovery.rpc_url` when set, else `solana.rpc_url`.
+    pub fn recovery_rpc_url(&self) -> &str {
+        self.recovery
+            .rpc_url
+            .as_deref()
+            .unwrap_or(&self.solana.rpc_url)
     }
 }
 
@@ -181,7 +263,9 @@ fn is_numeric_env_path(segments: &[&str]) -> bool {
     let lower: Vec<String> = segments.iter().map(|s| s.to_ascii_lowercase()).collect();
     matches!(
         lower.as_slice(),
-        [a, b] if a == "database" && b == "max_connections"
+        [a, b] if (a == "database" && b == "max_connections")
+            || (a == "recovery"
+                && (b == "bootstrap_slot" || b == "max_slots_per_attempt" || b == "max_blocks_per_attempt"))
     )
 }
 
@@ -256,6 +340,34 @@ yellowstone:
         );
         let config = ServiceConfig::load_from_path(file.path()).unwrap();
         assert_eq!(config.server.bind_address.port(), 8080);
+        assert_eq!(config.recovery.max_slots_per_attempt, 256);
+        assert_eq!(config.recovery.max_blocks_per_attempt, 128);
+        assert_eq!(config.recovery.bootstrap_slot, None);
+        assert_eq!(config.recovery_rpc_url(), "http://127.0.0.1:8899");
+        assert_eq!(config.database.proof_admission_limit(), 8);
+        file.close().ok();
+    }
+
+    #[test]
+    fn rejects_max_connections_below_reserved_plus_one() {
+        let _guard = env_lock().lock().unwrap();
+        clear_test_env_overrides();
+        let file = tempfile_config(
+            r#"
+server:
+  bind_address: 127.0.0.1:8080
+database:
+  connection_string: postgres://localhost/solana_proof
+  max_connections: 2
+solana:
+  program_id: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+  rpc_url: http://127.0.0.1:8899
+yellowstone:
+  grpc_url: http://127.0.0.1:10000
+"#,
+        );
+        let err = ServiceConfig::load_from_path(file.path()).unwrap_err();
+        assert!(err.to_string().contains("max_connections"));
         file.close().ok();
     }
 

--- a/solana-proof-service/crates/solana-proof-service/src/http.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/http.rs
@@ -317,7 +317,7 @@ impl<B> MakeSpan<B> for RequestIdMakeSpan {
 /// Proof-only: shed when saturated (no unbounded queue) and enforce a typed timeout.
 ///
 /// Admission capacity is sized to leave reserved DB connections for ingest and
-/// readiness on the shared pool (see [`crate::lifecycle::proof_admission_limit`]).
+/// readiness on the shared pool (see [`crate::config::DatabaseConfig::proof_admission_limit`]).
 async fn proof_admission<C: ChainFetcher, S: ProofSnapshotSource>(
     State(state): State<Arc<AppState<C, S>>>,
     req: Request,

--- a/solana-proof-service/crates/solana-proof-service/src/ingest_health.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/ingest_health.rs
@@ -57,6 +57,7 @@ struct Inner {
 #[derive(Debug)]
 pub struct IngestHealth {
     writer_running: AtomicBool,
+    recovery_in_progress: AtomicBool,
     inner: Mutex<Inner>,
 }
 
@@ -64,6 +65,7 @@ impl IngestHealth {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             writer_running: AtomicBool::new(false),
+            recovery_in_progress: AtomicBool::new(false),
             inner: Mutex::new(Inner {
                 last_slot: None,
                 terminal: None,
@@ -75,9 +77,19 @@ impl IngestHealth {
     /// Writer task entered the ingest loop (not yet continuity-proven).
     pub fn mark_started(&self) {
         self.writer_running.store(true, Ordering::SeqCst);
+        self.recovery_in_progress.store(false, Ordering::SeqCst);
         let mut inner = self.inner.lock().expect("ingest health lock");
         inner.terminal = None;
         inner.source_link = SourceLinkState::Connecting;
+    }
+
+    /// Gates readiness to `recovery_required` while bounded RPC recovery runs.
+    pub fn set_recovery_in_progress(&self, active: bool) {
+        self.recovery_in_progress.store(active, Ordering::SeqCst);
+    }
+
+    pub fn recovery_in_progress(&self) -> bool {
+        self.recovery_in_progress.load(Ordering::SeqCst)
     }
 
     /// Live stream dropped; reconnect/backoff is in progress.
@@ -99,6 +111,7 @@ impl IngestHealth {
 
     pub fn mark_finished(&self, result: Result<(), RunnerError>) {
         self.writer_running.store(false, Ordering::SeqCst);
+        self.recovery_in_progress.store(false, Ordering::SeqCst);
         let mut inner = self.inner.lock().expect("ingest health lock");
         inner.source_link = SourceLinkState::Idle;
         inner.terminal = Some(match result {
@@ -119,6 +132,7 @@ impl IngestHealth {
     /// Unexpected writer exit (panic / missed finish / shutdown deadline).
     pub fn mark_crashed(&self, reason: impl Into<String>) {
         self.writer_running.store(false, Ordering::SeqCst);
+        self.recovery_in_progress.store(false, Ordering::SeqCst);
         let mut inner = self.inner.lock().expect("ingest health lock");
         inner.source_link = SourceLinkState::Idle;
         inner.terminal = Some(IngestTerminal::Crashed {

--- a/solana-proof-service/crates/solana-proof-service/src/ingest_health.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/ingest_health.rs
@@ -84,8 +84,16 @@ impl IngestHealth {
     }
 
     /// Gates readiness to `recovery_required` while bounded RPC recovery runs.
+    /// Demotes a live `Connected` link so recovered progress cannot leave the
+    /// service Ready before Yellowstone resubscribes.
     pub fn set_recovery_in_progress(&self, active: bool) {
         self.recovery_in_progress.store(active, Ordering::SeqCst);
+        if active {
+            let mut inner = self.inner.lock().expect("ingest health lock");
+            if matches!(inner.source_link, SourceLinkState::Connected) {
+                inner.source_link = SourceLinkState::Disconnected;
+            }
+        }
     }
 
     pub fn recovery_in_progress(&self) -> bool {
@@ -102,11 +110,19 @@ impl IngestHealth {
         }
     }
 
-    /// Applied or exact-replay no-op: subscription + cursor continuity proven.
+    /// Applied or exact-replay no-op on the live Yellowstone subscription:
+    /// subscription + cursor continuity proven.
     pub fn mark_progress(&self, slot: u64) {
         let mut inner = self.inner.lock().expect("ingest health lock");
         inner.last_slot = Some(slot);
         inner.source_link = SourceLinkState::Connected;
+    }
+
+    /// Durable progress from bounded RPC recovery only. Updates the last known
+    /// slot without claiming Yellowstone continuity.
+    pub fn mark_recovered_progress(&self, slot: u64) {
+        let mut inner = self.inner.lock().expect("ingest health lock");
+        inner.last_slot = Some(slot);
     }
 
     pub fn mark_finished(&self, result: Result<(), RunnerError>) {
@@ -116,7 +132,7 @@ impl IngestHealth {
         inner.source_link = SourceLinkState::Idle;
         inner.terminal = Some(match result {
             Ok(()) => IngestTerminal::Cancelled,
-            Err(RunnerError::RecoveryRequired(reason)) => {
+            Err(RunnerError::RecoveryRequired { reason, .. }) => {
                 IngestTerminal::RecoveryRequired { reason }
             }
             Err(RunnerError::IntegrityHalted(reason)) => IngestTerminal::IntegrityHalted { reason },

--- a/solana-proof-service/crates/solana-proof-service/src/lifecycle.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/lifecycle.rs
@@ -18,17 +18,6 @@ use crate::ingest_health::IngestHealth;
 /// Bound how long shutdown waits for the ingest writer after cancel.
 pub const INGEST_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(15);
 
-/// Connections reserved for ingest writer + readiness (not available to proofs).
-pub const RESERVED_DB_CONNECTIONS: u32 = 2;
-
-/// Proof admission slots so the shared pool always keeps
-/// [`RESERVED_DB_CONNECTIONS`] free for writer/readiness.
-pub fn proof_admission_limit(max_connections: u32) -> usize {
-    max_connections
-        .saturating_sub(RESERVED_DB_CONNECTIONS)
-        .max(1) as usize
-}
-
 /// Runs HTTP server, ingest writer, and shutdown signal together.
 ///
 /// - Writer panic/exit while serving cancels the shared token and fails after
@@ -172,14 +161,6 @@ mod tests {
     use crate::ingest_health::IngestTerminal;
     use std::sync::Arc;
     use std::time::Duration;
-
-    #[test]
-    fn proof_admission_reserves_ops_slots() {
-        assert_eq!(proof_admission_limit(10), 8);
-        assert_eq!(proof_admission_limit(3), 1);
-        assert_eq!(proof_admission_limit(2), 1);
-        assert_eq!(proof_admission_limit(1), 1);
-    }
 
     #[tokio::test]
     async fn writer_panic_cancels_and_fails_supervision() {

--- a/solana-proof-service/crates/solana-proof-service/src/main.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/main.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use solana_proof_source::{YellowstoneBlockSource, YellowstoneSourceConfig};
+use solana_proof_source::{
+    RecoveryBounds, RpcRecoveryClient, RpcRecoveryConfig, YellowstoneBlockSource,
+    YellowstoneSourceConfig,
+};
 use solana_proof_store::{run_sequential_ingest, IngestHooks, SqlProofStore};
 use sqlx::postgres::PgPoolOptions;
 use tokio::sync::Semaphore;
@@ -18,7 +21,7 @@ use solana_proof_service::config::ServiceConfig;
 use solana_proof_service::http::{router, AppState};
 use solana_proof_service::ingest_health::IngestHealth;
 use solana_proof_service::lifecycle::{
-    proof_admission_limit, supervise_http_and_writer, wait_for_shutdown, INGEST_SHUTDOWN_DEADLINE,
+    supervise_http_and_writer, wait_for_shutdown, INGEST_SHUTDOWN_DEADLINE,
 };
 use solana_proof_service::metrics;
 use solana_proof_service::startup_validation::validate_startup_dependencies;
@@ -57,10 +60,26 @@ async fn main() -> Result<()> {
     })
     .context("invalid yellowstone source config")?;
 
-    let ingest_handle =
-        spawn_ingest_writer(source, store.clone(), Arc::clone(&ingest), cancel.clone());
+    let recovery = RpcRecoveryClient::new(RpcRecoveryConfig {
+        rpc_url: config.recovery_rpc_url().to_owned(),
+        program_id: config.solana.program_id.clone(),
+        bounds: RecoveryBounds {
+            max_slots: config.recovery.max_slots_per_attempt,
+            max_blocks: config.recovery.max_blocks_per_attempt,
+        },
+        bootstrap_slot: config.recovery.bootstrap_slot,
+    })
+    .context("invalid recovery config")?;
 
-    let proof_slots = proof_admission_limit(config.database.max_connections);
+    let ingest_handle = spawn_ingest_writer(
+        source,
+        store.clone(),
+        recovery,
+        Arc::clone(&ingest),
+        cancel.clone(),
+    );
+
+    let proof_slots = config.database.proof_admission_limit();
     tracing::info!(
         max_connections = config.database.max_connections,
         proof_admission = proof_slots,
@@ -106,6 +125,7 @@ async fn main() -> Result<()> {
 fn spawn_ingest_writer(
     source: YellowstoneBlockSource,
     store: SqlProofStore,
+    recovery: RpcRecoveryClient,
     ingest_health: Arc<IngestHealth>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
@@ -117,16 +137,22 @@ fn spawn_ingest_writer(
         let health = Arc::clone(&ingest_health);
         Arc::new(move || health.mark_disconnected())
     };
+    let on_recovery: Arc<dyn Fn(bool) + Send + Sync> = {
+        let health = Arc::clone(&ingest_health);
+        Arc::new(move |active: bool| health.set_recovery_in_progress(active))
+    };
 
     tokio::spawn(async move {
         ingest_health.mark_started();
         let result = run_sequential_ingest(
             &source,
             &store,
+            Some(&recovery),
             cancel,
             IngestHooks {
                 on_progress: Some(on_progress.as_ref()),
                 on_disconnected: Some(on_disconnected.as_ref()),
+                on_recovery: Some(on_recovery.as_ref()),
             },
         )
         .await;

--- a/solana-proof-service/crates/solana-proof-service/src/main.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/main.rs
@@ -133,6 +133,10 @@ fn spawn_ingest_writer(
         let health = Arc::clone(&ingest_health);
         Arc::new(move |slot: u64| health.mark_progress(slot))
     };
+    let on_recovered_progress: Arc<dyn Fn(u64) + Send + Sync> = {
+        let health = Arc::clone(&ingest_health);
+        Arc::new(move |slot: u64| health.mark_recovered_progress(slot))
+    };
     let on_disconnected: Arc<dyn Fn() + Send + Sync> = {
         let health = Arc::clone(&ingest_health);
         Arc::new(move || health.mark_disconnected())
@@ -151,6 +155,7 @@ fn spawn_ingest_writer(
             cancel,
             IngestHooks {
                 on_progress: Some(on_progress.as_ref()),
+                on_recovered_progress: Some(on_recovered_progress.as_ref()),
                 on_disconnected: Some(on_disconnected.as_ref()),
                 on_recovery: Some(on_recovery.as_ref()),
             },

--- a/solana-proof-service/crates/solana-proof-service/src/readiness.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/readiness.rs
@@ -151,6 +151,15 @@ pub fn classify_readiness(
         }
     }
 
+    if ingest.recovery_in_progress() {
+        return report(
+            ReadinessClass::RecoveryRequired,
+            Some("bounded RPC recovery in progress".to_owned()),
+            checkpoint_slot,
+            ingest.last_slot(),
+        );
+    }
+
     if !integrity.history_complete {
         return report(
             ReadinessClass::HistoryIncomplete,
@@ -296,6 +305,22 @@ mod tests {
         let report = classify_readiness(true, Some(&status(true, false)), &ingest);
         assert_eq!(report.status, ReadinessClass::RecoveryRequired);
         assert_eq!(report.reason.as_deref(), Some("gap"));
+    }
+
+    #[test]
+    fn recovery_in_progress_is_recovery_required() {
+        let ingest = IngestHealth::new();
+        ingest.mark_started();
+        ingest.mark_progress(42);
+        ingest.set_recovery_in_progress(true);
+        let report = classify_readiness(true, Some(&status(true, false)), &ingest);
+        assert_eq!(report.status, ReadinessClass::RecoveryRequired);
+        assert!(!report.ready);
+        assert!(report
+            .reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("recovery in progress"));
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-service/src/readiness.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/readiness.rs
@@ -299,9 +299,10 @@ mod tests {
     fn recovery_required_from_ingest_terminal() {
         let ingest = IngestHealth::new();
         ingest.mark_started();
-        ingest.mark_finished(Err(solana_proof_store::RunnerError::RecoveryRequired(
-            "gap".into(),
-        )));
+        ingest.mark_finished(Err(solana_proof_store::RunnerError::RecoveryRequired {
+            reason: "gap".into(),
+            gap_end_slot: Some(42),
+        }));
         let report = classify_readiness(true, Some(&status(true, false)), &ingest);
         assert_eq!(report.status, ReadinessClass::RecoveryRequired);
         assert_eq!(report.reason.as_deref(), Some("gap"));
@@ -321,6 +322,13 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .contains("recovery in progress"));
+        // Recovery demotes the live link; recovered progress alone must not Ready.
+        assert_eq!(ingest.source_link(), SourceLinkState::Disconnected);
+        ingest.set_recovery_in_progress(false);
+        ingest.mark_recovered_progress(43);
+        let after = classify_readiness(true, Some(&status(true, false)), &ingest);
+        assert_eq!(after.status, ReadinessClass::SourceLagging);
+        assert_eq!(after.last_ingest_slot, Some(43));
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-source/Cargo.toml
+++ b/solana-proof-service/crates/solana-proof-source/Cargo.toml
@@ -13,6 +13,7 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
@@ -21,4 +22,3 @@ zama-solana-transaction = { workspace = true }
 
 [dev-dependencies]
 sha2 = { workspace = true }
-tokio = { workspace = true }

--- a/solana-proof-service/crates/solana-proof-source/Cargo.toml
+++ b/solana-proof-service/crates/solana-proof-source/Cargo.toml
@@ -9,8 +9,13 @@ description = "Yellowstone completed-block source for the Solana proof service"
 [dependencies]
 bs58 = { workspace = true }
 futures = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
+tracing = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 zama-solana-transaction = { workspace = true }
 

--- a/solana-proof-service/crates/solana-proof-source/src/lib.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/lib.rs
@@ -1,13 +1,19 @@
-//! Confirmed Yellowstone completed-block source for the Solana proof service.
+//! Confirmed Yellowstone completed-block source and bounded RPC recovery for
+//! the Solana proof service.
 //!
-//! This crate owns provider transport and protobuf normalization only. It does
-//! not own persistence, applied cursor, reconnect policy, recovery, or
-//! readiness — those belong to later service slices.
+//! Yellowstone is the live filtered confirmed source. [`RpcRecoveryClient`] fills
+//! parent-chain gaps into the same [`CompletedBlock`] boundary. Persistence,
+//! reconnect policy, and readiness remain outside this crate.
 
 mod raw_instruction;
+mod rpc_recovery;
 mod yellowstone_source;
 
 pub use raw_instruction::RawInstruction;
+pub use rpc_recovery::{
+    history_complete_justified, normalize_rpc_block_json, RecoveryBounds, RecoveryError,
+    RpcRecoveryClient, RpcRecoveryConfig,
+};
 pub use yellowstone_source::{
     BlockCheckpoint, CanonicalTransaction, CompletedBlock, YellowstoneBlockSource,
     YellowstoneSourceConfig, YellowstoneSourceError, YellowstoneSubscription,

--- a/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
@@ -130,14 +130,31 @@ impl RpcRecoveryClient {
     /// Fetches and normalizes completed blocks for every existing slot in
     /// `[from_slot, to_slot]` (inclusive), enforcing lean attempt bounds.
     ///
-    /// Polls `cancel` before each RPC and selects in-flight `send` / body reads
-    /// against cancellation. Connect/request timeouts match the proof RPC client.
+    /// Prefer [`Self::list_existing_slots`] + [`Self::fetch_completed_block`] in
+    /// the ingest runner so each applied block advances the durable checkpoint
+    /// before the next `getBlock` (fhevm-internal #1823 tracks parallel staging).
     pub async fn fetch_completed_blocks(
         &self,
         from_slot: u64,
         to_slot: u64,
         cancel: &CancellationToken,
     ) -> Result<Vec<CompletedBlock>, RecoveryError> {
+        let slots = self.list_existing_slots(from_slot, to_slot, cancel).await?;
+        let mut blocks = Vec::with_capacity(slots.len());
+        for slot in slots {
+            blocks.push(self.fetch_completed_block(slot, cancel).await?);
+        }
+        Ok(blocks)
+    }
+
+    /// Existing confirmed slots in `[from_slot, to_slot]` (inclusive), with
+    /// attempt bounds enforced before any `getBlock`.
+    pub async fn list_existing_slots(
+        &self,
+        from_slot: u64,
+        to_slot: u64,
+        cancel: &CancellationToken,
+    ) -> Result<Vec<u64>, RecoveryError> {
         if cancel.is_cancelled() {
             return Err(RecoveryError::Cancelled);
         }
@@ -165,20 +182,25 @@ impl RpcRecoveryClient {
                 self.config.bounds.max_blocks
             )));
         }
+        Ok(slots)
+    }
 
-        let mut blocks = Vec::with_capacity(slots.len());
-        for slot in slots {
-            if cancel.is_cancelled() {
-                return Err(RecoveryError::Cancelled);
-            }
-            let Some(block) = self.get_block(slot, cancel).await? else {
-                return Err(RecoveryError::HistoryUnavailable(format!(
-                    "getBlock returned null for slot {slot} (pruned or unavailable at confirmed)"
-                )));
-            };
-            blocks.push(block);
+    /// Fetch and normalize one confirmed block. Prefer this over buffering an
+    /// entire recovery range so the durable checkpoint can advance per block.
+    pub async fn fetch_completed_block(
+        &self,
+        slot: u64,
+        cancel: &CancellationToken,
+    ) -> Result<CompletedBlock, RecoveryError> {
+        if cancel.is_cancelled() {
+            return Err(RecoveryError::Cancelled);
         }
-        Ok(blocks)
+        let Some(block) = self.get_block(slot, cancel).await? else {
+            return Err(RecoveryError::HistoryUnavailable(format!(
+                "getBlock returned null for slot {slot} (pruned or unavailable at confirmed)"
+            )));
+        };
+        Ok(block)
     }
 
     /// Confirmed tip slot (`getSlot`), used to bound catch-up when Yellowstone

--- a/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
@@ -418,9 +418,10 @@ struct RpcCompiledIx {
 struct RpcMeta {
     #[serde(default)]
     err: Option<serde_json::Value>,
-    /// Solana permits null; unrelated / failed / vote txs must not fail closed
-    /// solely because this field is absent. Successful host txs treat null as
-    /// an empty list (no CPI).
+    /// Solana permits null (`innerInstructions` recording disabled). Unrelated /
+    /// failed / vote txs must not fail closed solely because this field is
+    /// absent. Successful host-related txs require `Some(...)` — null is not
+    /// proof that no CPI occurred.
     #[serde(rename = "innerInstructions", default)]
     inner_instructions: Option<Vec<RpcInnerIxGroup>>,
     #[serde(rename = "loadedAddresses", default)]
@@ -531,7 +532,12 @@ fn normalize_rpc_transaction(
     let instructions = if !succeeded || is_vote {
         Vec::new()
     } else {
-        let inner = meta.inner_instructions.as_deref().unwrap_or(&[]);
+        let Some(inner) = meta.inner_instructions.as_deref() else {
+            return Err(RecoveryError::Invalid(format!(
+                "successful host-related transaction {index} has null innerInstructions; \
+                 CPI recording was disabled — cannot faithfully reconstruct"
+            )));
+        };
         resolve_rpc_instructions(
             &static_keys,
             &loaded_writable,
@@ -846,6 +852,40 @@ mod tests {
                     },
                     "meta": { "err": null, "innerInstructions": null },
                 },
+            ],
+        });
+        let block = normalize_rpc_block_json(7, value, &host).unwrap();
+        assert_eq!(block.executed_transaction_count, 1);
+        assert!(block.transactions.is_empty());
+    }
+
+    #[test]
+    fn null_inner_instructions_on_successful_host_tx_rejects_block() {
+        let digest = Sha256::digest(b"global:make_handle_public");
+        let data = b58(&digest[..8]);
+        let host = program();
+        let other = pk(0x99);
+        let value = json!({
+            "blockhash": b58(&pk(7)),
+            "previousBlockhash": b58(&pk(6)),
+            "parentSlot": 6,
+            "blockTime": null,
+            "blockHeight": null,
+            "transactions": [
+                {
+                    "transaction": {
+                        "signatures": [sig(1)],
+                        "message": {
+                            "accountKeys": [b58(&other), b58(&pk(1))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1],
+                                "data": data,
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": null },
+                },
                 {
                     "transaction": {
                         "signatures": [sig(2)],
@@ -862,11 +902,9 @@ mod tests {
                 },
             ],
         });
-        let block = normalize_rpc_block_json(7, value, &host).unwrap();
-        assert_eq!(block.executed_transaction_count, 2);
-        assert_eq!(block.transactions.len(), 1);
-        assert_eq!(block.transactions[0].index, 1);
-        assert!(block.transactions[0].succeeded);
+        let err = normalize_rpc_block_json(7, value, &host).unwrap_err();
+        assert!(matches!(err, RecoveryError::Invalid(_)));
+        assert!(err.to_string().contains("null innerInstructions"));
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
@@ -11,6 +11,8 @@
 //! bound leaves history incomplete / `RecoveryRequired` — never silently marks
 //! history complete. TODO(prod): tune horizons for archive depth and lag SLOs.
 
+use std::time::Duration;
+
 use serde::Deserialize;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
@@ -22,6 +24,9 @@ use zama_solana_transaction::{
 use crate::{BlockCheckpoint, CanonicalTransaction, CompletedBlock, RawInstruction};
 
 const SOLANA_PROOF_COMMITMENT: &str = "confirmed";
+/// Match the proof-path RPC client: stay well inside ingest budgets.
+const RPC_CONNECT_TIMEOUT_SECS: u64 = 3;
+const RPC_REQUEST_TIMEOUT_SECS: u64 = 10;
 
 /// Well-known Solana vote program (`Vote111111111111111111111111111111111111111`).
 fn vote_program_id() -> [u8; 32] {
@@ -102,8 +107,13 @@ impl RpcRecoveryClient {
                 "recovery.rpc_url must not be empty".to_owned(),
             ));
         }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(RPC_CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(RPC_REQUEST_TIMEOUT_SECS))
+            .build()
+            .map_err(|err| RecoveryError::Invalid(format!("failed to build RPC client: {err}")))?;
         Ok(Self {
-            client: reqwest::Client::new(),
+            client,
             config,
             program_id,
         })
@@ -120,8 +130,8 @@ impl RpcRecoveryClient {
     /// Fetches and normalizes completed blocks for every existing slot in
     /// `[from_slot, to_slot]` (inclusive), enforcing lean attempt bounds.
     ///
-    /// Polls `cancel` before `getBlocks` and before each `getBlock` so long
-    /// recovery loops remain cancellation-safe.
+    /// Polls `cancel` before each RPC and selects in-flight `send` / body reads
+    /// against cancellation. Connect/request timeouts match the proof RPC client.
     pub async fn fetch_completed_blocks(
         &self,
         from_slot: u64,
@@ -147,7 +157,7 @@ impl RpcRecoveryClient {
             )));
         }
 
-        let slots = self.get_blocks(from_slot, to_slot).await?;
+        let slots = self.get_blocks(from_slot, to_slot, cancel).await?;
         if slots.len() as u64 > self.config.bounds.max_blocks {
             return Err(RecoveryError::BoundExhausted(format!(
                 "{} existing slots in [{from_slot}, {to_slot}] exceed max_blocks {}",
@@ -161,7 +171,7 @@ impl RpcRecoveryClient {
             if cancel.is_cancelled() {
                 return Err(RecoveryError::Cancelled);
             }
-            let Some(block) = self.get_block(slot).await? else {
+            let Some(block) = self.get_block(slot, cancel).await? else {
                 return Err(RecoveryError::HistoryUnavailable(format!(
                     "getBlock returned null for slot {slot} (pruned or unavailable at confirmed)"
                 )));
@@ -173,11 +183,15 @@ impl RpcRecoveryClient {
 
     /// Confirmed tip slot (`getSlot`), used to bound catch-up when Yellowstone
     /// inclusive replay is unavailable.
-    pub async fn get_confirmed_slot(&self) -> Result<u64, RecoveryError> {
+    pub async fn get_confirmed_slot(
+        &self,
+        cancel: &CancellationToken,
+    ) -> Result<u64, RecoveryError> {
         let result = self
             .call(
                 "getSlot",
                 json!([{ "commitment": SOLANA_PROOF_COMMITMENT }]),
+                cancel,
             )
             .await?;
         result
@@ -185,11 +199,17 @@ impl RpcRecoveryClient {
             .ok_or_else(|| RecoveryError::Invalid("malformed getSlot result".to_owned()))
     }
 
-    async fn get_blocks(&self, from_slot: u64, to_slot: u64) -> Result<Vec<u64>, RecoveryError> {
+    async fn get_blocks(
+        &self,
+        from_slot: u64,
+        to_slot: u64,
+        cancel: &CancellationToken,
+    ) -> Result<Vec<u64>, RecoveryError> {
         let result = self
             .call(
                 "getBlocks",
                 json!([from_slot, to_slot, { "commitment": SOLANA_PROOF_COMMITMENT }]),
+                cancel,
             )
             .await?;
         let slots: Vec<u64> = serde_json::from_value(result)
@@ -210,7 +230,11 @@ impl RpcRecoveryClient {
         Ok(slots)
     }
 
-    async fn get_block(&self, slot: u64) -> Result<Option<CompletedBlock>, RecoveryError> {
+    async fn get_block(
+        &self,
+        slot: u64,
+        cancel: &CancellationToken,
+    ) -> Result<Option<CompletedBlock>, RecoveryError> {
         let result = self
             .call(
                 "getBlock",
@@ -224,6 +248,7 @@ impl RpcRecoveryClient {
                         "commitment": SOLANA_PROOF_COMMITMENT,
                     }
                 ]),
+                cancel,
             )
             .await?;
         if result.is_null() {
@@ -239,6 +264,7 @@ impl RpcRecoveryClient {
         &self,
         method: &str,
         params: serde_json::Value,
+        cancel: &CancellationToken,
     ) -> Result<serde_json::Value, RecoveryError> {
         let body = json!({
             "jsonrpc": "2.0",
@@ -246,17 +272,19 @@ impl RpcRecoveryClient {
             "method": method,
             "params": params,
         });
-        let response = self
-            .client
-            .post(&self.config.rpc_url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|err| RecoveryError::Transport(err.to_string()))?;
-        let value: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|err| RecoveryError::Transport(err.to_string()))?;
+        let request = self.client.post(&self.config.rpc_url).json(&body);
+        let response = tokio::select! {
+            _ = cancel.cancelled() => return Err(RecoveryError::Cancelled),
+            result = request.send() => {
+                result.map_err(|err| RecoveryError::Transport(err.to_string()))?
+            }
+        };
+        let value: serde_json::Value = tokio::select! {
+            _ = cancel.cancelled() => return Err(RecoveryError::Cancelled),
+            result = response.json() => {
+                result.map_err(|err| RecoveryError::Transport(err.to_string()))?
+            }
+        };
         if let Some(error) = value.get("error") {
             let message = error.to_string();
             // Solana archive nodes often use -32007 / BlockCleanedUp / SlotSkipped.
@@ -284,9 +312,10 @@ impl RpcRecoveryClient {
 /// - durable tip extending that start
 /// - durable tip equal to the confirmed tip this recovery established
 ///
-/// Single-slot bootstrap alone is not enough when the chain tip is ahead:
-/// `durable_tip.slot == confirmed_tip_slot` fails until catch-up proves the
-/// full range. Empty recovery must never call this with a vacuous tip match.
+/// Single-slot durable tip matching bootstrap is not enough when the confirmed
+/// tip is ahead: `durable_tip.slot == confirmed_tip_slot` fails until recovery
+/// (or catch-up) proves the full range. Empty recovery must never call this
+/// with a vacuous tip match.
 pub fn history_complete_justified(
     bootstrap_slot: Option<u64>,
     history_start: Option<&BlockCheckpoint>,
@@ -367,8 +396,11 @@ struct RpcCompiledIx {
 struct RpcMeta {
     #[serde(default)]
     err: Option<serde_json::Value>,
+    /// Solana permits null; unrelated / failed / vote txs must not fail closed
+    /// solely because this field is absent. Successful host txs treat null as
+    /// an empty list (no CPI).
     #[serde(rename = "innerInstructions", default)]
-    inner_instructions: Vec<RpcInnerIxGroup>,
+    inner_instructions: Option<Vec<RpcInnerIxGroup>>,
     #[serde(rename = "loadedAddresses", default)]
     loaded_addresses: Option<RpcLoadedAddresses>,
 }
@@ -477,12 +509,13 @@ fn normalize_rpc_transaction(
     let instructions = if !succeeded || is_vote {
         Vec::new()
     } else {
+        let inner = meta.inner_instructions.as_deref().unwrap_or(&[]);
         resolve_rpc_instructions(
             &static_keys,
             &loaded_writable,
             &loaded_readonly,
             &tx.transaction.message.instructions,
-            &meta.inner_instructions,
+            inner,
         )?
     };
 
@@ -762,6 +795,56 @@ mod tests {
         assert!(!block.transactions[0].is_vote);
         assert_eq!(block.transactions[0].instructions.len(), 1);
         assert_eq!(block.transactions[0].instructions[0].program_id, host);
+    }
+
+    #[test]
+    fn null_inner_instructions_on_unrelated_tx_does_not_reject_block() {
+        let digest = Sha256::digest(b"global:make_handle_public");
+        let data = b58(&digest[..8]);
+        let host = program();
+        let other = pk(0x99);
+        let value = json!({
+            "blockhash": b58(&pk(7)),
+            "previousBlockhash": b58(&pk(6)),
+            "parentSlot": 6,
+            "blockTime": null,
+            "blockHeight": null,
+            "transactions": [
+                {
+                    "transaction": {
+                        "signatures": [sig(1)],
+                        "message": {
+                            "accountKeys": [b58(&other), b58(&pk(1))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1],
+                                "data": data,
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": null },
+                },
+                {
+                    "transaction": {
+                        "signatures": [sig(2)],
+                        "message": {
+                            "accountKeys": [b58(&host), b58(&pk(2)), b58(&pk(3))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1, 2],
+                                "data": data,
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": null },
+                },
+            ],
+        });
+        let block = normalize_rpc_block_json(7, value, &host).unwrap();
+        assert_eq!(block.executed_transaction_count, 2);
+        assert_eq!(block.transactions.len(), 1);
+        assert_eq!(block.transactions[0].index, 1);
+        assert!(block.transactions[0].succeeded);
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
@@ -1,0 +1,1006 @@
+//! Bounded confirmed JSON-RPC recovery into the same [`CompletedBlock`] boundary.
+//!
+//! Recovery is **not** the live source. Live ingest remains filtered Yellowstone;
+//! this adapter fills parent-chain gaps (and optional bootstrap ranges) via
+//! `getBlocks` / `getBlock` at confirmed commitment, then the store applies the
+//! resulting blocks through the same atomic path.
+//!
+//! # Bounds (PoC)
+//!
+//! Each attempt is capped by `max_slots` and `max_blocks`. Exhausting either
+//! bound leaves history incomplete / `RecoveryRequired` — never silently marks
+//! history complete. TODO(prod): tune horizons for archive depth and lag SLOs.
+
+use serde::Deserialize;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use zama_solana_transaction::{
+    CompiledInstruction as CanonicalCompiledInstruction,
+    InnerInstructionGroup as CanonicalInnerInstructionGroup,
+};
+
+use crate::{BlockCheckpoint, CanonicalTransaction, CompletedBlock, RawInstruction};
+
+const SOLANA_PROOF_COMMITMENT: &str = "confirmed";
+
+/// Well-known Solana vote program (`Vote111111111111111111111111111111111111111`).
+fn vote_program_id() -> [u8; 32] {
+    // Decoded once per process from the well-known base58; avoids a brittle
+    // hand-maintained byte array in source.
+    static DECODED: std::sync::OnceLock<[u8; 32]> = std::sync::OnceLock::new();
+    *DECODED.get_or_init(|| {
+        decode_hash(
+            "vote program",
+            "Vote111111111111111111111111111111111111111",
+        )
+        .expect("well-known vote program id must decode")
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecoveryBounds {
+    /// Max slot span (`to_slot - from_slot + 1`) per recovery attempt.
+    pub max_slots: u64,
+    /// Max `getBlock` fetches (existing slots) per recovery attempt.
+    pub max_blocks: u64,
+}
+
+impl Default for RecoveryBounds {
+    fn default() -> Self {
+        Self {
+            max_slots: 256,
+            max_blocks: 128,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RpcRecoveryConfig {
+    pub rpc_url: String,
+    pub program_id: String,
+    pub bounds: RecoveryBounds,
+    /// Bootstrap A start: completeness may flip only after recovery proves
+    /// contiguous history from this slot through the durable tip.
+    pub bootstrap_slot: Option<u64>,
+}
+
+#[derive(thiserror::Error, Clone, Debug, PartialEq, Eq)]
+pub enum RecoveryError {
+    #[error("RPC transport error: {0}")]
+    Transport(String),
+    #[error("RPC history unavailable: {0}")]
+    HistoryUnavailable(String),
+    #[error("invalid RPC block or configuration: {0}")]
+    Invalid(String),
+    #[error("recovery cancelled")]
+    Cancelled,
+    #[error("recovery bound exhausted: {0}")]
+    BoundExhausted(String),
+}
+
+pub struct RpcRecoveryClient {
+    client: reqwest::Client,
+    config: RpcRecoveryConfig,
+    program_id: [u8; 32],
+}
+
+impl RpcRecoveryClient {
+    pub fn new(config: RpcRecoveryConfig) -> Result<Self, RecoveryError> {
+        let program_id = decode_hash("program id", &config.program_id)?;
+        if config.bounds.max_slots == 0 {
+            return Err(RecoveryError::Invalid(
+                "recovery.max_slots must be >= 1".to_owned(),
+            ));
+        }
+        if config.bounds.max_blocks == 0 {
+            return Err(RecoveryError::Invalid(
+                "recovery.max_blocks must be >= 1".to_owned(),
+            ));
+        }
+        if config.rpc_url.trim().is_empty() {
+            return Err(RecoveryError::Invalid(
+                "recovery.rpc_url must not be empty".to_owned(),
+            ));
+        }
+        Ok(Self {
+            client: reqwest::Client::new(),
+            config,
+            program_id,
+        })
+    }
+
+    pub fn config(&self) -> &RpcRecoveryConfig {
+        &self.config
+    }
+
+    pub fn program_id(&self) -> [u8; 32] {
+        self.program_id
+    }
+
+    /// Fetches and normalizes completed blocks for every existing slot in
+    /// `[from_slot, to_slot]` (inclusive), enforcing lean attempt bounds.
+    ///
+    /// Polls `cancel` before `getBlocks` and before each `getBlock` so long
+    /// recovery loops remain cancellation-safe.
+    pub async fn fetch_completed_blocks(
+        &self,
+        from_slot: u64,
+        to_slot: u64,
+        cancel: &CancellationToken,
+    ) -> Result<Vec<CompletedBlock>, RecoveryError> {
+        if cancel.is_cancelled() {
+            return Err(RecoveryError::Cancelled);
+        }
+        if to_slot < from_slot {
+            return Err(RecoveryError::Invalid(format!(
+                "recovery range inverted: from_slot {from_slot} > to_slot {to_slot}"
+            )));
+        }
+        let span = to_slot
+            .checked_sub(from_slot)
+            .and_then(|d| d.checked_add(1))
+            .ok_or_else(|| RecoveryError::Invalid("recovery slot span overflow".to_owned()))?;
+        if span > self.config.bounds.max_slots {
+            return Err(RecoveryError::BoundExhausted(format!(
+                "slot span {span} exceeds max_slots {}",
+                self.config.bounds.max_slots
+            )));
+        }
+
+        let slots = self.get_blocks(from_slot, to_slot).await?;
+        if slots.len() as u64 > self.config.bounds.max_blocks {
+            return Err(RecoveryError::BoundExhausted(format!(
+                "{} existing slots in [{from_slot}, {to_slot}] exceed max_blocks {}",
+                slots.len(),
+                self.config.bounds.max_blocks
+            )));
+        }
+
+        let mut blocks = Vec::with_capacity(slots.len());
+        for slot in slots {
+            if cancel.is_cancelled() {
+                return Err(RecoveryError::Cancelled);
+            }
+            let Some(block) = self.get_block(slot).await? else {
+                return Err(RecoveryError::HistoryUnavailable(format!(
+                    "getBlock returned null for slot {slot} (pruned or unavailable at confirmed)"
+                )));
+            };
+            blocks.push(block);
+        }
+        Ok(blocks)
+    }
+
+    /// Confirmed tip slot (`getSlot`), used to bound catch-up when Yellowstone
+    /// inclusive replay is unavailable.
+    pub async fn get_confirmed_slot(&self) -> Result<u64, RecoveryError> {
+        let result = self
+            .call(
+                "getSlot",
+                json!([{ "commitment": SOLANA_PROOF_COMMITMENT }]),
+            )
+            .await?;
+        result
+            .as_u64()
+            .ok_or_else(|| RecoveryError::Invalid("malformed getSlot result".to_owned()))
+    }
+
+    async fn get_blocks(&self, from_slot: u64, to_slot: u64) -> Result<Vec<u64>, RecoveryError> {
+        let result = self
+            .call(
+                "getBlocks",
+                json!([from_slot, to_slot, { "commitment": SOLANA_PROOF_COMMITMENT }]),
+            )
+            .await?;
+        let slots: Vec<u64> = serde_json::from_value(result)
+            .map_err(|err| RecoveryError::Invalid(format!("malformed getBlocks result: {err}")))?;
+        if slots.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(RecoveryError::Invalid(
+                "getBlocks returned non-increasing slots".to_owned(),
+            ));
+        }
+        if slots
+            .iter()
+            .any(|slot| *slot < from_slot || *slot > to_slot)
+        {
+            return Err(RecoveryError::Invalid(
+                "getBlocks returned slot outside requested range".to_owned(),
+            ));
+        }
+        Ok(slots)
+    }
+
+    async fn get_block(&self, slot: u64) -> Result<Option<CompletedBlock>, RecoveryError> {
+        let result = self
+            .call(
+                "getBlock",
+                json!([
+                    slot,
+                    {
+                        "encoding": "json",
+                        "maxSupportedTransactionVersion": 0,
+                        "transactionDetails": "full",
+                        "rewards": false,
+                        "commitment": SOLANA_PROOF_COMMITMENT,
+                    }
+                ]),
+            )
+            .await?;
+        if result.is_null() {
+            return Ok(None);
+        }
+        let parsed: RpcBlock = serde_json::from_value(result).map_err(|err| {
+            RecoveryError::Invalid(format!("malformed getBlock result at slot {slot}: {err}"))
+        })?;
+        Ok(Some(normalize_rpc_block(slot, parsed, &self.program_id)?))
+    }
+
+    async fn call(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, RecoveryError> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        });
+        let response = self
+            .client
+            .post(&self.config.rpc_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|err| RecoveryError::Transport(err.to_string()))?;
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|err| RecoveryError::Transport(err.to_string()))?;
+        if let Some(error) = value.get("error") {
+            let message = error.to_string();
+            // Solana archive nodes often use -32007 / BlockCleanedUp / SlotSkipped.
+            if message.contains("Block cleaned up")
+                || message.contains("Block not available")
+                || message.contains("Slot skipped")
+                || message.contains("-32007")
+                || message.contains("-32009")
+            {
+                return Err(RecoveryError::HistoryUnavailable(message));
+            }
+            return Err(RecoveryError::Transport(message));
+        }
+        value
+            .get("result")
+            .cloned()
+            .ok_or_else(|| RecoveryError::Invalid("missing result field".to_owned()))
+    }
+}
+
+/// Whether Bootstrap A may flip `history_complete` after a successful recovery.
+///
+/// Requires:
+/// - configured `bootstrap_slot` matching durable `history_start`
+/// - durable tip extending that start
+/// - durable tip equal to the confirmed tip this recovery established
+///
+/// Single-slot bootstrap alone is not enough when the chain tip is ahead:
+/// `durable_tip.slot == confirmed_tip_slot` fails until catch-up proves the
+/// full range. Empty recovery must never call this with a vacuous tip match.
+pub fn history_complete_justified(
+    bootstrap_slot: Option<u64>,
+    history_start: Option<&BlockCheckpoint>,
+    durable_tip: Option<&BlockCheckpoint>,
+    confirmed_tip_slot: u64,
+) -> bool {
+    let (Some(bootstrap), Some(start), Some(tip)) = (bootstrap_slot, history_start, durable_tip)
+    else {
+        return false;
+    };
+    start.slot == bootstrap && tip.slot >= start.slot && tip.slot == confirmed_tip_slot
+}
+
+#[derive(Deserialize)]
+struct RpcBlock {
+    blockhash: String,
+    #[serde(rename = "previousBlockhash")]
+    previous_blockhash: String,
+    #[serde(rename = "parentSlot")]
+    parent_slot: u64,
+    #[serde(rename = "blockTime")]
+    block_time: Option<i64>,
+    #[serde(rename = "blockHeight")]
+    block_height: Option<u64>,
+    #[serde(default)]
+    transactions: Vec<RpcBlockTransaction>,
+}
+
+#[derive(Deserialize)]
+struct RpcBlockTransaction {
+    transaction: RpcTxEnvelope,
+    meta: Option<RpcMeta>,
+    /// Present when `maxSupportedTransactionVersion` is set: `"legacy"` or `0`.
+    #[serde(default)]
+    version: Option<RpcTxVersion>,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum RpcTxVersion {
+    Legacy(String),
+    Number(u8),
+}
+
+impl RpcTxVersion {
+    fn is_legacy(&self) -> bool {
+        match self {
+            Self::Legacy(label) => label.eq_ignore_ascii_case("legacy"),
+            Self::Number(_) => false,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RpcTxEnvelope {
+    signatures: Vec<String>,
+    message: RpcMessage,
+}
+
+#[derive(Deserialize)]
+struct RpcMessage {
+    #[serde(rename = "accountKeys")]
+    account_keys: Vec<String>,
+    instructions: Vec<RpcCompiledIx>,
+}
+
+#[derive(Deserialize)]
+struct RpcCompiledIx {
+    #[serde(rename = "programIdIndex")]
+    program_id_index: usize,
+    accounts: Vec<usize>,
+    data: String,
+    #[serde(rename = "stackHeight", default)]
+    stack_height: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct RpcMeta {
+    #[serde(default)]
+    err: Option<serde_json::Value>,
+    #[serde(rename = "innerInstructions", default)]
+    inner_instructions: Vec<RpcInnerIxGroup>,
+    #[serde(rename = "loadedAddresses", default)]
+    loaded_addresses: Option<RpcLoadedAddresses>,
+}
+
+#[derive(Deserialize, Default)]
+struct RpcLoadedAddresses {
+    #[serde(default)]
+    writable: Vec<String>,
+    #[serde(default)]
+    readonly: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct RpcInnerIxGroup {
+    index: usize,
+    instructions: Vec<RpcCompiledIx>,
+}
+
+/// Normalize one confirmed `getBlock` JSON result into a [`CompletedBlock`].
+///
+/// Transactions that do not mention `program_id` are dropped (Yellowstone
+/// `account_include` parity). Failed and vote identities that mention the
+/// program remain with empty instruction lists. Transaction `index` is the
+/// full-block position so sparse indexes match the Yellowstone path.
+fn normalize_rpc_block(
+    slot: u64,
+    block: RpcBlock,
+    program_id: &[u8; 32],
+) -> Result<CompletedBlock, RecoveryError> {
+    let block_hash = decode_hash("blockhash", &block.blockhash)?;
+    let parent_hash = decode_hash("previousBlockhash", &block.previous_blockhash)?;
+    let executed_transaction_count = block.transactions.len() as u64;
+
+    let mut transactions = Vec::new();
+    for (index, tx) in block.transactions.into_iter().enumerate() {
+        let index = index as u64;
+        let Some(normalized) = normalize_rpc_transaction(tx, index, program_id)? else {
+            continue;
+        };
+        transactions.push(normalized);
+    }
+
+    Ok(CompletedBlock {
+        slot,
+        block_hash,
+        parent_slot: block.parent_slot,
+        parent_hash,
+        block_time: block.block_time,
+        block_height: block.block_height,
+        executed_transaction_count,
+        transactions,
+    })
+}
+
+fn normalize_rpc_transaction(
+    tx: RpcBlockTransaction,
+    index: u64,
+    program_id: &[u8; 32],
+) -> Result<Option<CanonicalTransaction>, RecoveryError> {
+    let meta = tx.meta.as_ref().ok_or_else(|| {
+        RecoveryError::Invalid(format!("transaction {index} has no status metadata"))
+    })?;
+
+    let static_keys = tx
+        .transaction
+        .message
+        .account_keys
+        .iter()
+        .map(|key| decode_hash("account key", key))
+        .collect::<Result<Vec<_>, _>>()?;
+    let (loaded_writable, loaded_readonly) = match meta.loaded_addresses.as_ref() {
+        Some(loaded) => (
+            loaded
+                .writable
+                .iter()
+                .map(|key| decode_hash("loaded writable", key))
+                .collect::<Result<Vec<_>, _>>()?,
+            loaded
+                .readonly
+                .iter()
+                .map(|key| decode_hash("loaded readonly", key))
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        None => (Vec::new(), Vec::new()),
+    };
+
+    if !mentions_program(&static_keys, &loaded_writable, &loaded_readonly, program_id) {
+        return Ok(None);
+    }
+
+    let signature =
+        decode_signature(tx.transaction.signatures.first().ok_or_else(|| {
+            RecoveryError::Invalid(format!("transaction {index} has no signature"))
+        })?)?;
+
+    // Match Yellowstone/geyser `is_vote`: Solana simple-vote semantics, not
+    // "vote program appears anywhere in account keys".
+    let is_vote = is_simple_vote_transaction(
+        &tx.transaction.signatures,
+        tx.version.as_ref(),
+        &tx.transaction.message.instructions,
+        &static_keys,
+        meta.loaded_addresses.as_ref(),
+    );
+    let succeeded = meta.err.is_none();
+    let instructions = if !succeeded || is_vote {
+        Vec::new()
+    } else {
+        resolve_rpc_instructions(
+            &static_keys,
+            &loaded_writable,
+            &loaded_readonly,
+            &tx.transaction.message.instructions,
+            &meta.inner_instructions,
+        )?
+    };
+
+    Ok(Some(CanonicalTransaction {
+        signature,
+        index,
+        succeeded,
+        is_vote,
+        instructions,
+    }))
+}
+
+/// Approximate Solana `is_simple_vote_transaction` for JSON-RPC blocks.
+///
+/// Conditions (same as solana-sdk / geyser `is_vote`):
+/// 1. 1 or 2 signatures
+/// 2. legacy message
+/// 3. exactly one top-level instruction
+/// 4. that instruction's program is the vote program
+fn is_simple_vote_transaction(
+    signatures: &[String],
+    version: Option<&RpcTxVersion>,
+    top_level: &[RpcCompiledIx],
+    static_keys: &[[u8; 32]],
+    loaded_addresses: Option<&RpcLoadedAddresses>,
+) -> bool {
+    if signatures.len() >= 3 {
+        return false;
+    }
+    let is_legacy = match version {
+        Some(v) => v.is_legacy(),
+        // Absent version: treat as legacy only when no address-table loads
+        // (v0 messages populate loadedAddresses under maxSupportedTransactionVersion).
+        None => match loaded_addresses {
+            Some(loaded) => loaded.writable.is_empty() && loaded.readonly.is_empty(),
+            None => true,
+        },
+    };
+    if !is_legacy {
+        return false;
+    }
+    if top_level.len() != 1 {
+        return false;
+    }
+    let Some(ix) = top_level.first() else {
+        return false;
+    };
+    static_keys
+        .get(ix.program_id_index)
+        .is_some_and(|program_id| program_id == &vote_program_id())
+}
+
+fn mentions_program(
+    static_keys: &[[u8; 32]],
+    loaded_writable: &[[u8; 32]],
+    loaded_readonly: &[[u8; 32]],
+    program_id: &[u8; 32],
+) -> bool {
+    static_keys.iter().any(|key| key == program_id)
+        || loaded_writable.iter().any(|key| key == program_id)
+        || loaded_readonly.iter().any(|key| key == program_id)
+}
+
+fn resolve_rpc_instructions(
+    static_keys: &[[u8; 32]],
+    loaded_writable: &[[u8; 32]],
+    loaded_readonly: &[[u8; 32]],
+    top_level: &[RpcCompiledIx],
+    inner: &[RpcInnerIxGroup],
+) -> Result<Vec<RawInstruction>, RecoveryError> {
+    let top_level = top_level
+        .iter()
+        .map(|instruction| canonical_instruction(instruction, false))
+        .collect::<Result<Vec<_>, _>>()?;
+    let inner = inner
+        .iter()
+        .map(|group| {
+            Ok(CanonicalInnerInstructionGroup {
+                top_level_index: group.index,
+                instructions: group
+                    .instructions
+                    .iter()
+                    .map(|instruction| canonical_instruction(instruction, true))
+                    .collect::<Result<Vec<_>, RecoveryError>>()?,
+            })
+        })
+        .collect::<Result<Vec<_>, RecoveryError>>()?;
+    zama_solana_transaction::resolve_transaction(
+        static_keys,
+        loaded_writable,
+        loaded_readonly,
+        top_level,
+        inner,
+    )
+    .map_err(|err| RecoveryError::Invalid(format!("invalid transaction instructions: {err}")))
+    .map(|instructions| {
+        instructions
+            .into_iter()
+            .map(|instruction| RawInstruction {
+                program_id: instruction.program_id,
+                accounts: instruction.accounts,
+                data: instruction.data,
+                top_level_index: instruction.top_level_index,
+                stack_height: Some(instruction.stack_height),
+            })
+            .collect()
+    })
+}
+
+fn canonical_instruction(
+    instruction: &RpcCompiledIx,
+    is_inner: bool,
+) -> Result<CanonicalCompiledInstruction, RecoveryError> {
+    Ok(CanonicalCompiledInstruction {
+        program_id_index: instruction.program_id_index,
+        account_indices: instruction.accounts.clone(),
+        data: bs58_decode(&instruction.data)?,
+        stack_height: if is_inner {
+            instruction.stack_height
+        } else {
+            None
+        },
+    })
+}
+
+fn decode_hash(name: &str, encoded: &str) -> Result<[u8; 32], RecoveryError> {
+    let bytes = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|err| RecoveryError::Invalid(format!("invalid {name}: {err}")))?;
+    <[u8; 32]>::try_from(bytes.as_slice()).map_err(|_| {
+        RecoveryError::Invalid(format!(
+            "{name} has invalid length {}, expected 32 bytes",
+            bytes.len()
+        ))
+    })
+}
+
+fn decode_signature(encoded: &str) -> Result<[u8; 64], RecoveryError> {
+    let bytes = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|err| RecoveryError::Invalid(format!("invalid signature: {err}")))?;
+    <[u8; 64]>::try_from(bytes.as_slice()).map_err(|_| {
+        RecoveryError::Invalid(format!(
+            "signature has invalid length {}, expected 64 bytes",
+            bytes.len()
+        ))
+    })
+}
+
+fn bs58_decode(input: &str) -> Result<Vec<u8>, RecoveryError> {
+    bs58::decode(input)
+        .into_vec()
+        .map_err(|err| RecoveryError::Invalid(format!("invalid base58 instruction data: {err}")))
+}
+
+/// Parse RPC block JSON (the `result` object) for unit tests and adapters.
+pub fn normalize_rpc_block_json(
+    slot: u64,
+    value: serde_json::Value,
+    program_id: &[u8; 32],
+) -> Result<CompletedBlock, RecoveryError> {
+    let parsed: RpcBlock = serde_json::from_value(value)
+        .map_err(|err| RecoveryError::Invalid(format!("malformed getBlock JSON: {err}")))?;
+    normalize_rpc_block(slot, parsed, program_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+
+    fn pk(tag: u8) -> [u8; 32] {
+        [tag; 32]
+    }
+
+    fn b58(bytes: &[u8]) -> String {
+        bs58::encode(bytes).into_string()
+    }
+
+    fn sig(tag: u8) -> String {
+        b58(&[tag; 64])
+    }
+
+    fn program() -> [u8; 32] {
+        pk(0x42)
+    }
+
+    fn empty_block_json(slot: u64) -> serde_json::Value {
+        json!({
+            "blockhash": b58(&pk(slot as u8)),
+            "previousBlockhash": b58(&pk(slot.saturating_sub(1) as u8)),
+            "parentSlot": slot.saturating_sub(1),
+            "blockTime": 1_700_000_000,
+            "blockHeight": 99,
+            "transactions": [],
+        })
+    }
+
+    #[test]
+    fn normalizes_empty_block() {
+        let block =
+            normalize_rpc_block_json(7, empty_block_json(7), &program()).expect("empty block");
+        assert_eq!(block.slot, 7);
+        assert_eq!(block.block_hash, pk(7));
+        assert_eq!(block.parent_slot, 6);
+        assert_eq!(block.parent_hash, pk(6));
+        assert_eq!(block.block_time, Some(1_700_000_000));
+        assert_eq!(block.block_height, Some(99));
+        assert_eq!(block.executed_transaction_count, 0);
+        assert!(block.transactions.is_empty());
+    }
+
+    #[test]
+    fn drops_unrelated_transactions_keeps_sparse_indexes() {
+        let digest = Sha256::digest(b"global:make_handle_public");
+        let data = b58(&digest[..8]);
+        let host = program();
+        let other = pk(0x99);
+        let value = json!({
+            "blockhash": b58(&pk(7)),
+            "previousBlockhash": b58(&pk(6)),
+            "parentSlot": 6,
+            "blockTime": null,
+            "blockHeight": null,
+            "transactions": [
+                {
+                    "transaction": {
+                        "signatures": [sig(1)],
+                        "message": {
+                            "accountKeys": [b58(&other), b58(&pk(1))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1],
+                                "data": data,
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": [], "loadedAddresses": { "writable": [], "readonly": [] } },
+                },
+                {
+                    "transaction": {
+                        "signatures": [sig(2)],
+                        "message": {
+                            "accountKeys": [b58(&host), b58(&pk(2)), b58(&pk(3))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1, 2],
+                                "data": data,
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": [], "loadedAddresses": { "writable": [], "readonly": [] } },
+                },
+                {
+                    "transaction": {
+                        "signatures": [sig(3)],
+                        "message": {
+                            "accountKeys": [b58(&other), b58(&pk(4))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1],
+                                "data": data,
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": [], "loadedAddresses": { "writable": [], "readonly": [] } },
+                },
+            ],
+        });
+        let block = normalize_rpc_block_json(7, value, &host).unwrap();
+        assert_eq!(block.executed_transaction_count, 3);
+        assert_eq!(block.transactions.len(), 1);
+        assert_eq!(block.transactions[0].index, 1);
+        assert_eq!(block.transactions[0].signature, [2u8; 64]);
+        assert!(block.transactions[0].succeeded);
+        assert!(!block.transactions[0].is_vote);
+        assert_eq!(block.transactions[0].instructions.len(), 1);
+        assert_eq!(block.transactions[0].instructions[0].program_id, host);
+    }
+
+    #[test]
+    fn failed_and_vote_identities_keep_empty_instructions() {
+        let host = program();
+        let value = json!({
+            "blockhash": b58(&pk(7)),
+            "previousBlockhash": b58(&pk(6)),
+            "parentSlot": 6,
+            "transactions": [
+                {
+                    "transaction": {
+                        "signatures": [sig(1)],
+                        "message": {
+                            "accountKeys": [b58(&host), b58(&pk(1))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [1],
+                                "data": b58(&[1, 2, 3]),
+                            }],
+                        },
+                    },
+                    "meta": { "err": { "InstructionError": [0, "Custom"] }, "innerInstructions": [] },
+                    "version": "legacy",
+                },
+                {
+                    "transaction": {
+                        "signatures": [sig(2)],
+                        "message": {
+                            "accountKeys": [b58(&vote_program_id()), b58(&host), b58(&pk(2))],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [2],
+                                "data": b58(&[9]),
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": [] },
+                    "version": "legacy",
+                },
+            ],
+        });
+        let block = normalize_rpc_block_json(7, value, &host).unwrap();
+        assert_eq!(block.transactions.len(), 2);
+        assert!(!block.transactions[0].succeeded);
+        assert!(block.transactions[0].instructions.is_empty());
+        assert_eq!(block.transactions[0].index, 0);
+        assert!(block.transactions[1].succeeded);
+        assert!(block.transactions[1].is_vote);
+        assert!(block.transactions[1].instructions.is_empty());
+        assert_eq!(block.transactions[1].index, 1);
+    }
+
+    #[test]
+    fn vote_program_in_accounts_alone_is_not_simple_vote() {
+        let host = program();
+        let value = json!({
+            "blockhash": b58(&pk(7)),
+            "previousBlockhash": b58(&pk(6)),
+            "parentSlot": 6,
+            "transactions": [{
+                "transaction": {
+                    "signatures": [sig(2)],
+                    "message": {
+                        "accountKeys": [b58(&host), b58(&pk(2)), b58(&vote_program_id())],
+                        "instructions": [{
+                            "programIdIndex": 0,
+                            "accounts": [1, 2],
+                            "data": b58(&[7]),
+                        }],
+                    },
+                },
+                "meta": { "err": null, "innerInstructions": [] },
+                "version": "legacy",
+            }],
+        });
+        let block = normalize_rpc_block_json(7, value, &host).unwrap();
+        assert_eq!(block.transactions.len(), 1);
+        assert!(!block.transactions[0].is_vote);
+        assert_eq!(block.transactions[0].instructions.len(), 1);
+    }
+
+    #[test]
+    fn resolves_inner_instructions_in_execution_order() {
+        let host = program();
+        let cpi = pk(0x55);
+        let value = json!({
+            "blockhash": b58(&pk(7)),
+            "previousBlockhash": b58(&pk(6)),
+            "parentSlot": 6,
+            "transactions": [{
+                "transaction": {
+                    "signatures": [sig(9)],
+                    "message": {
+                        "accountKeys": [b58(&host), b58(&pk(1)), b58(&pk(2)), b58(&cpi)],
+                        "instructions": [{
+                            "programIdIndex": 0,
+                            "accounts": [1, 2],
+                            "data": b58(&[7, 7]),
+                        }],
+                    },
+                },
+                "meta": {
+                    "err": null,
+                    "innerInstructions": [{
+                        "index": 0,
+                        "instructions": [{
+                            "programIdIndex": 3,
+                            "accounts": [1],
+                            "data": b58(&[8]),
+                            "stackHeight": 2,
+                        }],
+                    }],
+                    "loadedAddresses": { "writable": [], "readonly": [] },
+                },
+            }],
+        });
+        let block = normalize_rpc_block_json(7, value, &host).unwrap();
+        let ixs = &block.transactions[0].instructions;
+        assert_eq!(ixs.len(), 2);
+        assert_eq!(ixs[0].program_id, host);
+        assert_eq!(ixs[0].data, vec![7, 7]);
+        assert_eq!(ixs[1].program_id, cpi);
+        assert_eq!(ixs[1].data, vec![8]);
+        assert_eq!(ixs[1].stack_height, Some(2));
+    }
+
+    #[test]
+    fn history_complete_requires_bootstrap_match_and_confirmed_tip() {
+        let start = BlockCheckpoint {
+            slot: 10,
+            block_hash: pk(10),
+        };
+        let tip = BlockCheckpoint {
+            slot: 20,
+            block_hash: pk(20),
+        };
+        let single = BlockCheckpoint {
+            slot: 10,
+            block_hash: pk(10),
+        };
+        assert!(!history_complete_justified(
+            None,
+            Some(&start),
+            Some(&tip),
+            20
+        ));
+        assert!(!history_complete_justified(
+            Some(5),
+            Some(&start),
+            Some(&tip),
+            20
+        ));
+        assert!(history_complete_justified(
+            Some(10),
+            Some(&start),
+            Some(&tip),
+            20
+        ));
+        assert!(!history_complete_justified(
+            Some(10),
+            Some(&start),
+            Some(&tip),
+            21
+        ));
+        assert!(!history_complete_justified(
+            Some(10),
+            Some(&start),
+            None,
+            20
+        ));
+        // Single-slot bootstrap with tip ahead must not flip complete.
+        assert!(!history_complete_justified(
+            Some(10),
+            Some(&single),
+            Some(&single),
+            99
+        ));
+        // Single-slot bootstrap equals confirmed tip: full proven range.
+        assert!(history_complete_justified(
+            Some(10),
+            Some(&single),
+            Some(&single),
+            10
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_bounds() {
+        let err = RpcRecoveryClient::new(RpcRecoveryConfig {
+            rpc_url: "http://127.0.0.1:8899".to_owned(),
+            program_id: b58(&program()),
+            bounds: RecoveryBounds {
+                max_slots: 0,
+                max_blocks: 1,
+            },
+            bootstrap_slot: None,
+        });
+        assert!(matches!(err, Err(RecoveryError::Invalid(_))));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_span_over_max_slots_without_rpc() {
+        let client = RpcRecoveryClient::new(RpcRecoveryConfig {
+            rpc_url: "http://127.0.0.1:1".to_owned(),
+            program_id: b58(&program()),
+            bounds: RecoveryBounds {
+                max_slots: 2,
+                max_blocks: 128,
+            },
+            bootstrap_slot: None,
+        })
+        .expect("valid recovery client");
+        let cancel = CancellationToken::new();
+        let err = client
+            .fetch_completed_blocks(10, 20, &cancel)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RecoveryError::BoundExhausted(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_respects_cancel_before_rpc() {
+        let client = RpcRecoveryClient::new(RpcRecoveryConfig {
+            rpc_url: "http://127.0.0.1:1".to_owned(),
+            program_id: b58(&program()),
+            bounds: RecoveryBounds {
+                max_slots: 2,
+                max_blocks: 128,
+            },
+            bootstrap_slot: None,
+        })
+        .expect("valid recovery client");
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let err = client
+            .fetch_completed_blocks(10, 11, &cancel)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RecoveryError::Cancelled));
+    }
+}

--- a/solana-proof-service/crates/solana-proof-source/src/yellowstone_source.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/yellowstone_source.rs
@@ -97,8 +97,16 @@ impl std::fmt::Debug for YellowstoneSourceConfig {
 pub enum YellowstoneSourceError {
     #[error("retryable Yellowstone transport failure: {0}")]
     Retryable(String),
-    #[error("inclusive Yellowstone replay is unavailable: {0}")]
-    ReplayUnavailable(String),
+    /// Provider does not support `from_slot` at all. Advancing the durable
+    /// checkpoint cannot fix this; do not RPC-catch-up and resubscribe with
+    /// `from_slot` in a loop. Fail closed until a replay-capable geyser is
+    /// configured or cursorless staging lands (fhevm-internal #1823).
+    #[error("Yellowstone inclusive replay is unsupported by this provider: {0}")]
+    ReplayUnsupported(String),
+    /// Inclusive replay is supported, but the requested cursor is no longer
+    /// available. Bounded RPC catch-up may recover, then resubscribe.
+    #[error("Yellowstone inclusive replay cursor expired: {0}")]
+    ReplayCursorExpired(String),
     #[error("invalid Yellowstone data or configuration: {0}")]
     Invalid(String),
     #[error(
@@ -476,11 +484,13 @@ fn decode_hash(name: &str, encoded: &str) -> Result<[u8; 32], YellowstoneSourceE
 
 fn classify_status(status: tonic::Status, is_replay: bool) -> YellowstoneSourceError {
     let message = status.message();
-    if is_replay
-        && (message == "from_slot is not supported"
-            || (message.starts_with("broadcast from ") && message.contains(" is not available")))
+    if is_replay && message == "from_slot is not supported" {
+        YellowstoneSourceError::ReplayUnsupported(status.to_string())
+    } else if is_replay
+        && message.starts_with("broadcast from ")
+        && message.contains(" is not available")
     {
-        YellowstoneSourceError::ReplayUnavailable(status.to_string())
+        YellowstoneSourceError::ReplayCursorExpired(status.to_string())
     } else {
         YellowstoneSourceError::Retryable(status.to_string())
     }
@@ -898,20 +908,23 @@ mod tests {
     }
 
     #[test]
-    fn replay_unavailable_is_terminal_but_transport_is_retryable() {
-        for message in [
-            "from_slot is not supported",
-            "broadcast from 7 is not available, last available: 12",
-        ] {
-            assert!(matches!(
-                classify_status(tonic::Status::internal(message), true),
-                YellowstoneSourceError::ReplayUnavailable(_)
-            ));
-        }
+    fn replay_unsupported_and_cursor_expired_are_distinct() {
+        assert!(matches!(
+            classify_status(tonic::Status::internal("from_slot is not supported"), true),
+            YellowstoneSourceError::ReplayUnsupported(_)
+        ));
+        assert!(matches!(
+            classify_status(
+                tonic::Status::internal("broadcast from 7 is not available, last available: 12"),
+                true
+            ),
+            YellowstoneSourceError::ReplayCursorExpired(_)
+        ));
         for status in [
             tonic::Status::unavailable("connection reset"),
             tonic::Status::internal("failed to send replay update"),
             tonic::Status::internal("broadcast from 7 is not available"),
+            tonic::Status::internal("from_slot is not supported"),
         ] {
             assert!(matches!(
                 classify_status(status, false),

--- a/solana-proof-service/crates/solana-proof-source/src/yellowstone_source.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/yellowstone_source.rs
@@ -12,8 +12,8 @@
 //! slots are omitted. Consecutive filtered updates therefore may not satisfy
 //! `parent_slot == previous.slot`. This adapter still requires contiguous
 //! parent links between observed blocks and returns [`YellowstoneSourceError::Ancestry`]
-//! on a gap (never silently skips). Bounded RPC recovery (later slice) must
-//! fill missing blocks before ingest can continue.
+//! on a gap (never silently skips). Bounded RPC recovery fills missing blocks
+//! before ingest can continue.
 
 use futures::{Stream, StreamExt};
 use std::collections::HashMap;
@@ -225,15 +225,34 @@ where
         let block = normalize_block(block)?;
         if !*replay_observed {
             let expected = expected_replay.expect("cursor exists when replay is unobserved");
-            if block.slot != expected.slot || block.block_hash != expected.block_hash {
+            if block.slot == expected.slot && block.block_hash == expected.block_hash {
+                // Exact inclusive replay of the durable checkpoint.
+                *replay_observed = true;
+            } else if block.parent_slot == expected.slot && block.parent_hash == expected.block_hash
+            {
+                // Filtered-stream resume after recovery: empty / non-program
+                // checkpoint blocks are not re-emitted by account_include, but a
+                // contiguous parent link still proves continuity from the durable
+                // checkpoint. Do not invent a synthetic CompletedBlock.
+                *replay_observed = true;
+                *last_observed = Some(block.clone());
+                return Ok(block);
+            } else if block.slot == expected.slot {
                 return Err(YellowstoneSourceError::CheckpointChanged {
                     expected_slot: expected.slot,
                     expected_hash: expected.block_hash,
                     observed_slot: block.slot,
                     observed_hash: block.block_hash,
                 });
+            } else {
+                return Err(YellowstoneSourceError::Ancestry {
+                    slot: block.slot,
+                    parent_slot: block.parent_slot,
+                    parent_hash: block.parent_hash,
+                    expected_parent_slot: expected.slot,
+                    expected_parent_hash: expected.block_hash,
+                });
             }
-            *replay_observed = true;
         }
         if let Some(previous) = last_observed.as_ref() {
             if block.slot == previous.slot {
@@ -683,6 +702,59 @@ mod tests {
     }
 
     #[test]
+    fn rpc_simple_vote_matches_yellowstone_is_vote_stripping() {
+        // Yellowstone path trusts geyser `is_vote` (Solana simple-vote).
+        let ys = normalize_block(block(7, vec![vote(0)])).unwrap();
+        assert!(ys.transactions[0].is_vote);
+        assert!(ys.transactions[0].instructions.is_empty());
+
+        // RPC recovery must use the same simple-vote rule, not "vote key present".
+        let vote_program = bs58::decode("Vote111111111111111111111111111111111111111")
+            .into_vec()
+            .expect("vote program");
+        let vote_program: [u8; 32] = vote_program.try_into().expect("32 bytes");
+        let host = hash(0x42);
+        let rpc = crate::normalize_rpc_block_json(
+            7,
+            serde_json::json!({
+                "blockhash": bs58::encode(hash(7)).into_string(),
+                "previousBlockhash": bs58::encode(hash(6)).into_string(),
+                "parentSlot": 6,
+                "transactions": [{
+                    "transaction": {
+                        "signatures": [bs58::encode([1u8; 64]).into_string()],
+                        "message": {
+                            "accountKeys": [
+                                bs58::encode(vote_program).into_string(),
+                                bs58::encode(host).into_string(),
+                                bs58::encode(hash(2)).into_string(),
+                            ],
+                            "instructions": [{
+                                "programIdIndex": 0,
+                                "accounts": [2],
+                                "data": bs58::encode([9u8]).into_string(),
+                            }],
+                        },
+                    },
+                    "meta": { "err": null, "innerInstructions": [] },
+                    "version": "legacy",
+                }],
+            }),
+            &host,
+        )
+        .unwrap();
+        assert_eq!(rpc.transactions.len(), 1);
+        assert!(rpc.transactions[0].is_vote);
+        assert!(rpc.transactions[0].instructions.is_empty());
+        // Parity: both paths strip instructions for vote identities.
+        assert_eq!(
+            ys.transactions[0].instructions.is_empty(),
+            rpc.transactions[0].instructions.is_empty()
+        );
+        assert_eq!(ys.transactions[0].is_vote, rpc.transactions[0].is_vote);
+    }
+
+    #[test]
     fn rejects_malformed_hash_signature_metadata_and_message() {
         let mut malformed = block(7, vec![]);
         malformed.blockhash = "not-base58-0".to_owned();
@@ -740,12 +812,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inclusive_replay_must_be_first_and_match_hash() {
+    async fn inclusive_replay_or_contiguous_resume_from_checkpoint() {
         let checkpoint = BlockCheckpoint {
             slot: 7,
             block_hash: hash(7),
         };
-        let mut stream = futures::stream::iter([Ok(update(block(8, vec![])))]);
+
+        // Gap that does not parent-link to the checkpoint → Ancestry (recovery).
+        let mut gap = block(9, vec![]);
+        gap.parent_slot = 8;
+        gap.parent_blockhash = bs58::encode(hash(8)).into_string();
+        let mut stream = futures::stream::iter([Ok(update(gap))]);
         let mut replay_observed = false;
         let mut last_observed = None;
         let result = next_block(
@@ -757,13 +834,14 @@ mod tests {
         .await;
         assert!(matches!(
             result,
-            Err(YellowstoneSourceError::CheckpointChanged {
-                expected_slot: 7,
-                observed_slot: 8,
+            Err(YellowstoneSourceError::Ancestry {
+                slot: 9,
+                expected_parent_slot: 7,
                 ..
             })
         ));
 
+        // Same slot, wrong hash → CheckpointChanged.
         let mut wrong_hash = block(7, vec![]);
         wrong_hash.blockhash = bs58::encode(hash(9)).into_string();
         let mut stream = futures::stream::iter([Ok(update(wrong_hash))]);
@@ -786,6 +864,7 @@ mod tests {
             }
         );
 
+        // Exact inclusive replay.
         let mut stream = futures::stream::iter([Ok(update(block(7, vec![])))]);
         let mut replay_observed = false;
         let mut last_observed = None;
@@ -798,6 +877,24 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(replay.checkpoint(), checkpoint);
+
+        // Filtered-stream resume: next block parents to checkpoint without
+        // re-emitting the (possibly empty) checkpoint block itself.
+        let mut stream = futures::stream::iter([Ok(update(block(8, vec![])))]);
+        let mut replay_observed = false;
+        let mut last_observed = None;
+        let resumed = next_block(
+            &mut stream,
+            Some(&checkpoint),
+            &mut replay_observed,
+            &mut last_observed,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resumed.slot, 8);
+        assert_eq!(resumed.parent_slot, 7);
+        assert_eq!(resumed.parent_hash, hash(7));
+        assert!(replay_observed);
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-store/src/runner.rs
+++ b/solana-proof-service/crates/solana-proof-store/src/runner.rs
@@ -68,9 +68,12 @@ pub struct IngestHooks<'a> {
 /// treats a bare gRPC subscribe as a live, continuity-checked source.
 ///
 /// When `recovery` is `Some`, [`RunnerError::RecoveryRequired`] and Yellowstone
-/// ancestry / replay-unavailable signals invoke a bounded RPC fill, then the
-/// loop resubscribes from the durable checkpoint. When `recovery` is `None`,
-/// gaps surface as [`RunnerError::RecoveryRequired`] immediately (fail closed).
+/// [`YellowstoneSourceError::ReplayCursorExpired`] invoke a bounded RPC fill,
+/// then the loop resubscribes from the durable checkpoint. Providers that
+/// reject `from_slot` entirely ([`YellowstoneSourceError::ReplayUnsupported`])
+/// fail closed — RPC catch-up cannot change that capability (see
+/// fhevm-internal #1823 for cursorless staging). When `recovery` is `None`,
+/// gaps surface as [`RunnerError::RecoveryRequired`] immediately.
 pub async fn run_sequential_ingest(
     source: &YellowstoneBlockSource,
     store: &SqlProofStore,
@@ -140,8 +143,16 @@ pub async fn run_sequential_ingest(
                     backoff = (backoff * 2).min(MAX_BACKOFF);
                     continue;
                 }
-                Err(YellowstoneSourceError::ReplayUnavailable(message)) => {
-                    warn!(%message, "yellowstone inclusive replay unavailable; attempting RPC recovery");
+                Err(YellowstoneSourceError::ReplayUnsupported(message)) => {
+                    return Err(RunnerError::Source(
+                        YellowstoneSourceError::ReplayUnsupported(message),
+                    ));
+                }
+                Err(YellowstoneSourceError::ReplayCursorExpired(message)) => {
+                    warn!(
+                        %message,
+                        "Yellowstone inclusive replay cursor expired; attempting RPC catch-up"
+                    );
                     match with_recovery_gate(hooks.on_recovery, async {
                         attempt_recovery(
                             recovery,
@@ -179,6 +190,37 @@ pub async fn run_sequential_ingest(
                     _ = tokio::time::sleep(backoff) => {}
                 }
                 backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            Err(RunnerError::Source(YellowstoneSourceError::ReplayUnsupported(message))) => {
+                return Err(RunnerError::Source(
+                    YellowstoneSourceError::ReplayUnsupported(message),
+                ));
+            }
+            Err(RunnerError::Source(YellowstoneSourceError::ReplayCursorExpired(message))) => {
+                warn!(
+                    %message,
+                    "Yellowstone stream reported expired replay cursor; attempting RPC catch-up"
+                );
+                match with_recovery_gate(hooks.on_recovery, async {
+                    attempt_recovery(
+                        recovery,
+                        store,
+                        GapHint::FromCheckpointForward,
+                        &cancel,
+                        hooks.on_recovered_progress,
+                    )
+                    .await
+                })
+                .await?
+                {
+                    Recovered::Filled { confirmed_tip } => {
+                        if let Some(client) = recovery {
+                            maybe_mark_history_complete(client, store, confirmed_tip).await?;
+                        }
+                        continue;
+                    }
+                    Recovered::Cancelled => return Ok(()),
+                }
             }
             Err(RunnerError::RecoveryRequired {
                 reason,
@@ -321,35 +363,17 @@ async fn attempt_recovery(
         to_slot, "fetching bounded RPC recovery blocks at confirmed commitment"
     );
 
-    let blocks = match client
-        .fetch_completed_blocks(from_slot, to_slot, cancel)
-        .await
-    {
-        Ok(blocks) => blocks,
-        Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
-        Err(RecoveryError::BoundExhausted(message)) => {
-            return Err(recovery_required(format!(
-                "recovery bound exhausted: {message}"
-            )));
-        }
-        Err(RecoveryError::HistoryUnavailable(message)) => {
-            return Err(recovery_required(format!(
-                "RPC history unavailable: {message}"
-            )));
-        }
-        Err(RecoveryError::Transport(message)) => {
-            return Err(recovery_required(format!(
-                "RPC recovery transport failure: {message}"
-            )));
-        }
-        Err(RecoveryError::Invalid(message)) => {
-            return Err(recovery_required(format!(
-                "invalid RPC recovery data: {message}"
-            )));
-        }
-    };
-
-    apply_recovered_blocks(store, &blocks, cancel, on_recovered_progress, confirmed_tip).await
+    recover_range_incremental(RecoverRange {
+        client,
+        store,
+        from_slot,
+        to_slot,
+        cancel,
+        on_recovered_progress,
+        confirmed_tip,
+        expect_first_slot: None,
+    })
+    .await
 }
 
 async fn read_confirmed_tip(
@@ -388,45 +412,102 @@ async fn recover_bootstrap_from_start(
     }
     // Recover the bounded inclusive range through the observed confirmed tip.
     // Bound exhaustion stays fail-closed (history_incomplete / recovery_required).
-    let blocks = match client
-        .fetch_completed_blocks(bootstrap_slot, confirmed_tip, cancel)
-        .await
-    {
-        Ok(blocks) => blocks,
-        Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
-        Err(RecoveryError::BoundExhausted(message)) => {
-            return Err(recovery_required(format!(
-                "bootstrap recovery bound exhausted from slot {bootstrap_slot} through tip {confirmed_tip}: {message}"
-            )));
-        }
-        Err(RecoveryError::HistoryUnavailable(message)) => {
-            return Err(recovery_required(format!(
-                "bootstrap RPC history unavailable from slot {bootstrap_slot}: {message}"
-            )));
-        }
-        Err(RecoveryError::Transport(message)) => {
-            return Err(recovery_required(format!(
-                "bootstrap RPC transport failure from slot {bootstrap_slot}: {message}"
-            )));
-        }
-        Err(RecoveryError::Invalid(message)) => {
-            return Err(recovery_required(format!(
-                "bootstrap recovery invalid data from slot {bootstrap_slot}: {message}"
-            )));
-        }
+    recover_range_incremental(RecoverRange {
+        client,
+        store,
+        from_slot: bootstrap_slot,
+        to_slot: confirmed_tip,
+        cancel,
+        on_recovered_progress,
+        confirmed_tip,
+        expect_first_slot: Some(bootstrap_slot),
+    })
+    .await
+}
+
+fn map_recovery_list_error(err: RecoveryError, context: &str) -> Result<Recovered, RunnerError> {
+    match err {
+        RecoveryError::Cancelled => Ok(Recovered::Cancelled),
+        RecoveryError::BoundExhausted(message) => Err(recovery_required(format!(
+            "{context} bound exhausted: {message}"
+        ))),
+        RecoveryError::HistoryUnavailable(message) => Err(recovery_required(format!(
+            "{context} RPC history unavailable: {message}"
+        ))),
+        RecoveryError::Transport(message) => Err(recovery_required(format!(
+            "{context} RPC transport failure: {message}"
+        ))),
+        RecoveryError::Invalid(message) => Err(recovery_required(format!(
+            "{context} invalid RPC data: {message}"
+        ))),
+    }
+}
+
+struct RecoverRange<'a> {
+    client: &'a RpcRecoveryClient,
+    store: &'a SqlProofStore,
+    from_slot: u64,
+    to_slot: u64,
+    cancel: &'a CancellationToken,
+    on_recovered_progress: Option<&'a (dyn Fn(u64) + Send + Sync)>,
+    confirmed_tip: u64,
+    expect_first_slot: Option<u64>,
+}
+
+/// List slots, then fetch+apply each block before the next `getBlock` so the
+/// durable checkpoint advances during catch-up (not only after a full Vec).
+async fn recover_range_incremental(range: RecoverRange<'_>) -> Result<Recovered, RunnerError> {
+    let RecoverRange {
+        client,
+        store,
+        from_slot,
+        to_slot,
+        cancel,
+        on_recovered_progress,
+        confirmed_tip,
+        expect_first_slot,
+    } = range;
+    let slots = match client.list_existing_slots(from_slot, to_slot, cancel).await {
+        Ok(slots) => slots,
+        Err(err) => return map_recovery_list_error(err, "recovery"),
     };
-    if blocks.is_empty() {
+    if slots.is_empty() {
         return Err(recovery_required(format!(
-            "bootstrap range [{bootstrap_slot}, {confirmed_tip}] has no confirmed blocks"
+            "RPC recovery returned no blocks for range [{from_slot}, {to_slot}]"
         )));
     }
-    if blocks[0].slot != bootstrap_slot {
-        return Err(recovery_required(format!(
-            "bootstrap recovery expected first slot {bootstrap_slot}, got {}",
-            blocks[0].slot
-        )));
+    if let Some(expected) = expect_first_slot {
+        if slots[0] != expected {
+            return Err(recovery_required(format!(
+                "bootstrap recovery expected first slot {expected}, got {}",
+                slots[0]
+            )));
+        }
     }
-    apply_recovered_blocks(store, &blocks, cancel, on_recovered_progress, confirmed_tip).await
+
+    for slot in slots {
+        if cancel.is_cancelled() {
+            return Ok(Recovered::Cancelled);
+        }
+        let block = match client.fetch_completed_block(slot, cancel).await {
+            Ok(block) => block,
+            Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
+            Err(err) => return map_recovery_list_error(err, "recovery"),
+        };
+        match apply_recovered_blocks(
+            store,
+            std::slice::from_ref(&block),
+            cancel,
+            on_recovered_progress,
+            confirmed_tip,
+        )
+        .await?
+        {
+            Recovered::Cancelled => return Ok(Recovered::Cancelled),
+            Recovered::Filled { .. } => {}
+        }
+    }
+    Ok(Recovered::Filled { confirmed_tip })
 }
 
 /// Empty successful fetches must fail closed — never `Filled`, never mark complete.
@@ -535,6 +616,12 @@ async fn drive_subscription(
                         ),
                         slot,
                     ));
+                }
+                // Stream-level replay rejection must take the same path as a
+                // subscribe-time rejection (classify_status on gRPC status).
+                Err(error @ YellowstoneSourceError::ReplayUnsupported(_))
+                | Err(error @ YellowstoneSourceError::ReplayCursorExpired(_)) => {
+                    return Err(RunnerError::Source(error));
                 }
                 Err(error) => return Err(RunnerError::Source(error)),
             },

--- a/solana-proof-service/crates/solana-proof-store/src/runner.rs
+++ b/solana-proof-service/crates/solana-proof-store/src/runner.rs
@@ -1,13 +1,15 @@
 //! Cancellation-safe sequential completed-block runner.
 //!
 //! Pulls [`YellowstoneSubscription::next_block`] and applies each block through
-//! [`SqlProofStore`]. The source never owns persistence; reconnect resumes from
-//! the durable checkpoint. Bounded RPC recovery is intentionally not here.
+//! [`SqlProofStore`]. On a contiguous parent-chain gap, bounded RPC recovery
+//! fills missing blocks into the same store boundary, then ingest resumes from
+//! the durable checkpoint (inclusive replay). Recovery is never the live source.
 
 use std::time::Duration;
 
 use solana_proof_source::{
-    YellowstoneBlockSource, YellowstoneSourceError, YellowstoneSubscription,
+    history_complete_justified, RecoveryError, RpcRecoveryClient, YellowstoneBlockSource,
+    YellowstoneSourceError, YellowstoneSubscription,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -22,28 +24,38 @@ pub enum RunnerError {
     Source(#[from] YellowstoneSourceError),
     #[error("ingest integrity halted: {0}")]
     IntegrityHalted(String),
-    /// Contiguous parent link missing (filtered-stream gap). Bounded RPC
-    /// recovery must fill intermediate blocks; this is not a silent skip.
+    /// Contiguous parent link missing, or recovery could not prove/fill history.
+    /// Proofs/readiness stay fail-closed while this is outstanding.
     #[error("contiguous ingest gap requires recovery: {0}")]
     RecoveryRequired(String),
 }
 
-/// Optional hooks for HTTP readiness (disconnect / apply-or-replay progress).
+/// Optional hooks for HTTP readiness (disconnect / apply-or-replay progress / recovery).
 #[derive(Default)]
 pub struct IngestHooks<'a> {
-    /// Fired after a block is applied or recognized as an exact replay no-op.
-    /// That is the continuity proof: subscription + durable cursor are usable.
+    /// Fired after a block is applied or recognized as an exact replay no-op
+    /// (including recovered blocks). That is the continuity proof: subscription
+    /// + durable cursor are usable.
     pub on_progress: Option<&'a (dyn Fn(u64) + Send + Sync)>,
     pub on_disconnected: Option<&'a (dyn Fn() + Send + Sync)>,
+    /// Fired with `true` when bounded RPC recovery starts and `false` when it
+    /// ends, so readiness can return `recovery_required` while a fill is in flight.
+    pub on_recovery: Option<&'a (dyn Fn(bool) + Send + Sync)>,
 }
 
 /// Runs until `cancel` is cancelled or a durable integrity halt is observed.
 ///
 /// Progress hooks fire only after Applied / AlreadyApplied so readiness never
 /// treats a bare gRPC subscribe as a live, continuity-checked source.
+///
+/// When `recovery` is `Some`, [`RunnerError::RecoveryRequired`] and Yellowstone
+/// ancestry / replay-unavailable signals invoke a bounded RPC fill, then the
+/// loop resubscribes from the durable checkpoint. When `recovery` is `None`,
+/// gaps surface as [`RunnerError::RecoveryRequired`] immediately (fail closed).
 pub async fn run_sequential_ingest(
     source: &YellowstoneBlockSource,
     store: &SqlProofStore,
+    recovery: Option<&RpcRecoveryClient>,
     cancel: CancellationToken,
     hooks: IngestHooks<'_>,
 ) -> Result<(), RunnerError> {
@@ -65,6 +77,34 @@ pub async fn run_sequential_ingest(
             ));
         }
 
+        // Bootstrap A: empty store + configured start → recover from bootstrap
+        // before the first Yellowstone subscribe so history_start can match.
+        if checkpoint.is_none() {
+            if let Some(client) = recovery {
+                if let Some(bootstrap_slot) = client.config().bootstrap_slot {
+                    match with_recovery_gate(hooks.on_recovery, async {
+                        recover_bootstrap_from_start(
+                            client,
+                            store,
+                            bootstrap_slot,
+                            &cancel,
+                            hooks.on_progress,
+                        )
+                        .await
+                    })
+                    .await
+                    {
+                        Ok(Recovered::Filled { confirmed_tip }) => {
+                            maybe_mark_history_complete(client, store, confirmed_tip).await?;
+                            continue;
+                        }
+                        Ok(Recovered::Cancelled) => return Ok(()),
+                        Err(error) => return Err(error),
+                    }
+                }
+            }
+        }
+
         // Do not reset backoff on subscribe alone: a flaky stream that
         // connects then dies immediately would otherwise spin at 200ms forever.
         // Select on cancel so connect/subscribe cannot outlive shutdown.
@@ -80,6 +120,29 @@ pub async fn run_sequential_ingest(
                     }
                     backoff = (backoff * 2).min(MAX_BACKOFF);
                     continue;
+                }
+                Err(YellowstoneSourceError::ReplayUnavailable(message)) => {
+                    warn!(%message, "yellowstone inclusive replay unavailable; attempting RPC recovery");
+                    match with_recovery_gate(hooks.on_recovery, async {
+                        attempt_recovery(
+                            recovery,
+                            store,
+                            GapHint::FromCheckpointForward,
+                            &cancel,
+                            hooks.on_progress,
+                        )
+                        .await
+                    })
+                    .await?
+                    {
+                        Recovered::Filled { confirmed_tip } => {
+                            if let Some(client) = recovery {
+                                maybe_mark_history_complete(client, store, confirmed_tip).await?;
+                            }
+                            continue;
+                        }
+                        Recovered::Cancelled => return Ok(()),
+                    }
                 }
                 Err(error) => return Err(RunnerError::Source(error)),
             },
@@ -98,9 +161,327 @@ pub async fn run_sequential_ingest(
                 }
                 backoff = (backoff * 2).min(MAX_BACKOFF);
             }
+            Err(RunnerError::RecoveryRequired(reason)) => {
+                warn!(%reason, "ingest gap requires bounded RPC recovery");
+                let gap_end = parse_gap_end_slot(&reason);
+                match with_recovery_gate(hooks.on_recovery, async {
+                    attempt_recovery(
+                        recovery,
+                        store,
+                        GapHint::UntilExclusive(gap_end),
+                        &cancel,
+                        hooks.on_progress,
+                    )
+                    .await
+                })
+                .await?
+                {
+                    Recovered::Filled { confirmed_tip } => {
+                        if let Some(client) = recovery {
+                            maybe_mark_history_complete(client, store, confirmed_tip).await?;
+                        }
+                        // Resubscribe from durable checkpoint (inclusive replay).
+                        continue;
+                    }
+                    Recovered::Cancelled => return Ok(()),
+                }
+            }
             Err(error) => return Err(error),
         }
     }
+}
+
+enum GapHint {
+    /// Recover `(checkpoint, tip]` is not available without a tip RPC; recover
+    /// nothing beyond signaling unavailability when no checkpoint exists.
+    FromCheckpointForward,
+    /// Fill `[checkpoint+1, gap_end_slot)` when `gap_end_slot` is known.
+    UntilExclusive(Option<u64>),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Recovered {
+    /// Non-empty apply succeeded. `confirmed_tip` is the tip used to justify
+    /// (or refuse) `history_complete`.
+    Filled {
+        confirmed_tip: u64,
+    },
+    Cancelled,
+}
+
+struct RecoveryGate<'a> {
+    on_recovery: Option<&'a (dyn Fn(bool) + Send + Sync)>,
+}
+
+impl<'a> RecoveryGate<'a> {
+    fn enter(on_recovery: Option<&'a (dyn Fn(bool) + Send + Sync)>) -> Self {
+        if let Some(cb) = on_recovery {
+            cb(true);
+        }
+        Self { on_recovery }
+    }
+}
+
+impl Drop for RecoveryGate<'_> {
+    fn drop(&mut self) {
+        if let Some(cb) = self.on_recovery {
+            cb(false);
+        }
+    }
+}
+
+async fn with_recovery_gate<T>(
+    on_recovery: Option<&(dyn Fn(bool) + Send + Sync)>,
+    fut: impl std::future::Future<Output = T>,
+) -> T {
+    let _gate = RecoveryGate::enter(on_recovery);
+    fut.await
+}
+
+async fn attempt_recovery(
+    recovery: Option<&RpcRecoveryClient>,
+    store: &SqlProofStore,
+    hint: GapHint,
+    cancel: &CancellationToken,
+    on_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
+) -> Result<Recovered, RunnerError> {
+    let Some(client) = recovery else {
+        return Err(RunnerError::RecoveryRequired(
+            "bounded RPC recovery is not configured".to_owned(),
+        ));
+    };
+    if cancel.is_cancelled() {
+        return Ok(Recovered::Cancelled);
+    }
+
+    let checkpoint = store.checkpoint().await?.ok_or_else(|| {
+        RunnerError::RecoveryRequired("recovery requested without a durable checkpoint".to_owned())
+    })?;
+
+    let (to_slot, confirmed_tip) = match hint {
+        GapHint::UntilExclusive(Some(gap_end)) if gap_end > checkpoint.slot + 1 => {
+            let confirmed_tip = read_confirmed_tip(client).await?;
+            (gap_end - 1, confirmed_tip)
+        }
+        GapHint::UntilExclusive(Some(gap_end)) if gap_end <= checkpoint.slot + 1 => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "recovery gap end slot {gap_end} does not extend past checkpoint {}",
+                checkpoint.slot
+            )));
+        }
+        GapHint::FromCheckpointForward => {
+            let tip = read_confirmed_tip(client).await?;
+            if tip <= checkpoint.slot {
+                return Err(RunnerError::RecoveryRequired(format!(
+                    "confirmed tip {tip} is not ahead of checkpoint {}; cannot catch up after replay-unavailable",
+                    checkpoint.slot
+                )));
+            }
+            let span = tip - checkpoint.slot;
+            if span > client.config().bounds.max_slots {
+                return Err(RunnerError::RecoveryRequired(format!(
+                    "recovery bound exhausted: tip catch-up span {span} exceeds max_slots {}",
+                    client.config().bounds.max_slots
+                )));
+            }
+            (tip, tip)
+        }
+        GapHint::UntilExclusive(None) => {
+            return Err(RunnerError::RecoveryRequired(
+                "RPC recovery requires a bounded gap end slot".to_owned(),
+            ));
+        }
+        GapHint::UntilExclusive(_) => unreachable!(),
+    };
+
+    let from_slot = checkpoint.slot + 1;
+    info!(
+        from_slot,
+        to_slot, "fetching bounded RPC recovery blocks at confirmed commitment"
+    );
+
+    let blocks = match client
+        .fetch_completed_blocks(from_slot, to_slot, cancel)
+        .await
+    {
+        Ok(blocks) => blocks,
+        Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
+        Err(RecoveryError::BoundExhausted(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "recovery bound exhausted: {message}"
+            )));
+        }
+        Err(RecoveryError::HistoryUnavailable(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "RPC history unavailable: {message}"
+            )));
+        }
+        Err(RecoveryError::Transport(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "RPC recovery transport failure: {message}"
+            )));
+        }
+        Err(RecoveryError::Invalid(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "invalid RPC recovery data: {message}"
+            )));
+        }
+    };
+
+    apply_recovered_blocks(store, &blocks, cancel, on_progress, confirmed_tip).await
+}
+
+async fn read_confirmed_tip(client: &RpcRecoveryClient) -> Result<u64, RunnerError> {
+    match client.get_confirmed_slot().await {
+        Ok(tip) => Ok(tip),
+        Err(RecoveryError::Transport(message)) => Err(RunnerError::RecoveryRequired(format!(
+            "RPC recovery transport failure while reading tip: {message}"
+        ))),
+        Err(RecoveryError::Cancelled) => Err(RunnerError::RecoveryRequired(
+            "RPC recovery cancelled while reading tip".to_owned(),
+        )),
+        Err(err) => Err(RunnerError::RecoveryRequired(format!(
+            "failed to read confirmed tip for recovery: {err}"
+        ))),
+    }
+}
+
+async fn recover_bootstrap_from_start(
+    client: &RpcRecoveryClient,
+    store: &SqlProofStore,
+    bootstrap_slot: u64,
+    cancel: &CancellationToken,
+    on_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
+) -> Result<Recovered, RunnerError> {
+    if cancel.is_cancelled() {
+        return Ok(Recovered::Cancelled);
+    }
+    // Confirmed tip anchors completeness: single-slot bootstrap alone must not
+    // flip history_complete when the chain tip is ahead.
+    let confirmed_tip = read_confirmed_tip(client).await?;
+    // Lean PoC bootstrap: recover a single-slot window at the configured start.
+    // Further continuity to tip is proven by later gap fills / catch-up.
+    // TODO(prod): optional tip-bounded bootstrap catch-up horizon.
+    let blocks = match client
+        .fetch_completed_blocks(bootstrap_slot, bootstrap_slot, cancel)
+        .await
+    {
+        Ok(blocks) => blocks,
+        Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
+        Err(RecoveryError::BoundExhausted(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "bootstrap recovery bound exhausted from slot {bootstrap_slot}: {message}"
+            )));
+        }
+        Err(RecoveryError::HistoryUnavailable(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "bootstrap RPC history unavailable at slot {bootstrap_slot}: {message}"
+            )));
+        }
+        Err(RecoveryError::Transport(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "bootstrap RPC transport failure at slot {bootstrap_slot}: {message}"
+            )));
+        }
+        Err(RecoveryError::Invalid(message)) => {
+            return Err(RunnerError::RecoveryRequired(format!(
+                "bootstrap recovery invalid data at slot {bootstrap_slot}: {message}"
+            )));
+        }
+    };
+    if blocks.is_empty() {
+        return Err(RunnerError::RecoveryRequired(format!(
+            "bootstrap slot {bootstrap_slot} has no confirmed block"
+        )));
+    }
+    if blocks[0].slot != bootstrap_slot {
+        return Err(RunnerError::RecoveryRequired(format!(
+            "bootstrap recovery expected slot {bootstrap_slot}, got {}",
+            blocks[0].slot
+        )));
+    }
+    apply_recovered_blocks(store, &blocks, cancel, on_progress, confirmed_tip).await
+}
+
+/// Empty successful fetches must fail closed — never `Filled`, never mark complete.
+fn reject_empty_recovery(
+    blocks: &[solana_proof_source::CompletedBlock],
+) -> Result<(), RunnerError> {
+    if blocks.is_empty() {
+        Err(RunnerError::RecoveryRequired(
+            "RPC recovery returned no blocks for the requested range".to_owned(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+async fn apply_recovered_blocks(
+    store: &SqlProofStore,
+    blocks: &[solana_proof_source::CompletedBlock],
+    cancel: &CancellationToken,
+    on_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
+    confirmed_tip: u64,
+) -> Result<Recovered, RunnerError> {
+    reject_empty_recovery(blocks)?;
+    for block in blocks {
+        if cancel.is_cancelled() {
+            return Ok(Recovered::Cancelled);
+        }
+        match store.apply_completed_block(block).await? {
+            ApplyOutcome::Applied | ApplyOutcome::AlreadyApplied => {
+                info!(slot = block.slot, "applied recovered completed block");
+                if let Some(on_progress) = on_progress {
+                    on_progress(block.slot);
+                }
+            }
+            ApplyOutcome::RecoveryRequired { reason } => {
+                return Err(RunnerError::RecoveryRequired(format!(
+                    "recovered block still requires recovery: {reason}"
+                )));
+            }
+            ApplyOutcome::IntegrityHalted { reason } => {
+                return Err(RunnerError::IntegrityHalted(format!(
+                    "conflicting recovered ancestry: {reason}"
+                )));
+            }
+        }
+    }
+    Ok(Recovered::Filled { confirmed_tip })
+}
+
+async fn maybe_mark_history_complete(
+    client: &RpcRecoveryClient,
+    store: &SqlProofStore,
+    confirmed_tip: u64,
+) -> Result<(), RunnerError> {
+    let status = store.integrity_status().await?;
+    if status.history_complete || status.integrity_halted {
+        return Ok(());
+    }
+    if history_complete_justified(
+        client.config().bootstrap_slot,
+        status.history_start.as_ref(),
+        status.checkpoint.as_ref(),
+        confirmed_tip,
+    ) {
+        store.set_history_complete_after_recovery(true).await?;
+        info!(
+            bootstrap_slot = ?client.config().bootstrap_slot,
+            confirmed_tip,
+            "history_complete set after recovery proved continuity from configured start through confirmed tip"
+        );
+    }
+    Ok(())
+}
+
+fn parse_gap_end_slot(reason: &str) -> Option<u64> {
+    // Reasons look like:
+    // "contiguous ingest gap at slot N: parent slot ..."
+    const PREFIX: &str = "contiguous ingest gap at slot ";
+    let rest = reason.strip_prefix(PREFIX)?;
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
 }
 
 async fn drive_subscription(
@@ -158,5 +539,114 @@ async fn drive_subscription(
                 return Err(RunnerError::IntegrityHalted(reason));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_proof_source::{history_complete_justified, BlockCheckpoint, CompletedBlock};
+
+    fn cp(slot: u64) -> BlockCheckpoint {
+        BlockCheckpoint {
+            slot,
+            block_hash: [slot as u8; 32],
+        }
+    }
+
+    #[test]
+    fn parses_gap_end_slot_from_store_reason() {
+        let reason = "contiguous ingest gap at slot 42: parent slot 40 does not extend checkpoint 39; recovery required";
+        assert_eq!(parse_gap_end_slot(reason), Some(42));
+    }
+
+    #[test]
+    fn parses_gap_end_slot_from_ancestry_reason() {
+        let reason = "contiguous ingest gap at slot 100: parent slot 99 does not extend previous applied slot 90; recovery required";
+        assert_eq!(parse_gap_end_slot(reason), Some(100));
+    }
+
+    #[test]
+    fn parse_gap_end_rejects_unrelated_reason() {
+        assert_eq!(parse_gap_end_slot("something else"), None);
+    }
+
+    #[test]
+    fn empty_recovery_is_not_filled() {
+        let err = reject_empty_recovery(&[]).unwrap_err();
+        assert!(
+            matches!(err, RunnerError::RecoveryRequired(reason) if reason.contains("no blocks"))
+        );
+    }
+
+    #[test]
+    fn nonempty_recovery_passes_empty_guard() {
+        let block = CompletedBlock {
+            slot: 1,
+            block_hash: [1; 32],
+            parent_slot: 0,
+            parent_hash: [0; 32],
+            block_time: None,
+            block_height: None,
+            executed_transaction_count: 0,
+            transactions: vec![],
+        };
+        assert!(reject_empty_recovery(&[block]).is_ok());
+    }
+
+    #[test]
+    fn bootstrap_single_slot_with_tip_ahead_does_not_justify_complete() {
+        let start = cp(10);
+        assert!(!history_complete_justified(
+            Some(10),
+            Some(&start),
+            Some(&start),
+            50
+        ));
+    }
+
+    #[test]
+    fn catch_up_to_confirmed_tip_justifies_complete() {
+        let start = cp(10);
+        let tip = cp(50);
+        assert!(history_complete_justified(
+            Some(10),
+            Some(&start),
+            Some(&tip),
+            50
+        ));
+    }
+
+    #[test]
+    fn bound_exhaustion_never_justifies_complete_without_tip_match() {
+        // After a partial fill, durable tip behind confirmed tip must not flip.
+        let start = cp(10);
+        let partial = cp(20);
+        assert!(!history_complete_justified(
+            Some(10),
+            Some(&start),
+            Some(&partial),
+            100
+        ));
+    }
+
+    #[test]
+    fn recovery_gate_toggles_callback() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let starts = AtomicUsize::new(0);
+        let ends = AtomicUsize::new(0);
+        let cb = |active: bool| {
+            if active {
+                starts.fetch_add(1, Ordering::SeqCst);
+            } else {
+                ends.fetch_add(1, Ordering::SeqCst);
+            }
+        };
+        {
+            let _gate = RecoveryGate::enter(Some(&cb));
+            assert_eq!(starts.load(Ordering::SeqCst), 1);
+            assert_eq!(ends.load(Ordering::SeqCst), 0);
+        }
+        assert_eq!(ends.load(Ordering::SeqCst), 1);
     }
 }

--- a/solana-proof-service/crates/solana-proof-store/src/runner.rs
+++ b/solana-proof-service/crates/solana-proof-store/src/runner.rs
@@ -26,17 +26,36 @@ pub enum RunnerError {
     IntegrityHalted(String),
     /// Contiguous parent link missing, or recovery could not prove/fill history.
     /// Proofs/readiness stay fail-closed while this is outstanding.
-    #[error("contiguous ingest gap requires recovery: {0}")]
-    RecoveryRequired(String),
+    #[error("{reason}")]
+    RecoveryRequired {
+        reason: String,
+        /// Exclusive end of `[checkpoint+1, gap_end)` when known from a typed gap.
+        gap_end_slot: Option<u64>,
+    },
+}
+
+fn recovery_required(reason: impl Into<String>) -> RunnerError {
+    RunnerError::RecoveryRequired {
+        reason: reason.into(),
+        gap_end_slot: None,
+    }
+}
+
+fn recovery_required_until(reason: impl Into<String>, gap_end_slot: u64) -> RunnerError {
+    RunnerError::RecoveryRequired {
+        reason: reason.into(),
+        gap_end_slot: Some(gap_end_slot),
+    }
 }
 
 /// Optional hooks for HTTP readiness (disconnect / apply-or-replay progress / recovery).
 #[derive(Default)]
 pub struct IngestHooks<'a> {
-    /// Fired after a block is applied or recognized as an exact replay no-op
-    /// (including recovered blocks). That is the continuity proof: subscription
-    /// + durable cursor are usable.
+    /// Fired after a live Yellowstone block is Applied or AlreadyApplied.
+    /// That is the continuity proof: subscription + durable cursor are usable.
     pub on_progress: Option<&'a (dyn Fn(u64) + Send + Sync)>,
+    /// Durable progress from RPC recovery only. Must not prove Yellowstone continuity.
+    pub on_recovered_progress: Option<&'a (dyn Fn(u64) + Send + Sync)>,
     pub on_disconnected: Option<&'a (dyn Fn() + Send + Sync)>,
     /// Fired with `true` when bounded RPC recovery starts and `false` when it
     /// ends, so readiness can return `recovery_required` while a fill is in flight.
@@ -88,7 +107,7 @@ pub async fn run_sequential_ingest(
                             store,
                             bootstrap_slot,
                             &cancel,
-                            hooks.on_progress,
+                            hooks.on_recovered_progress,
                         )
                         .await
                     })
@@ -129,7 +148,7 @@ pub async fn run_sequential_ingest(
                             store,
                             GapHint::FromCheckpointForward,
                             &cancel,
-                            hooks.on_progress,
+                            hooks.on_recovered_progress,
                         )
                         .await
                     })
@@ -161,16 +180,18 @@ pub async fn run_sequential_ingest(
                 }
                 backoff = (backoff * 2).min(MAX_BACKOFF);
             }
-            Err(RunnerError::RecoveryRequired(reason)) => {
-                warn!(%reason, "ingest gap requires bounded RPC recovery");
-                let gap_end = parse_gap_end_slot(&reason);
+            Err(RunnerError::RecoveryRequired {
+                reason,
+                gap_end_slot,
+            }) => {
+                warn!(%reason, ?gap_end_slot, "ingest gap requires bounded RPC recovery");
                 match with_recovery_gate(hooks.on_recovery, async {
                     attempt_recovery(
                         recovery,
                         store,
-                        GapHint::UntilExclusive(gap_end),
+                        GapHint::UntilExclusive(gap_end_slot),
                         &cancel,
-                        hooks.on_progress,
+                        hooks.on_recovered_progress,
                     )
                     .await
                 })
@@ -243,10 +264,10 @@ async fn attempt_recovery(
     store: &SqlProofStore,
     hint: GapHint,
     cancel: &CancellationToken,
-    on_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
+    on_recovered_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
 ) -> Result<Recovered, RunnerError> {
     let Some(client) = recovery else {
-        return Err(RunnerError::RecoveryRequired(
+        return Err(recovery_required(
             "bounded RPC recovery is not configured".to_owned(),
         ));
     };
@@ -255,31 +276,31 @@ async fn attempt_recovery(
     }
 
     let checkpoint = store.checkpoint().await?.ok_or_else(|| {
-        RunnerError::RecoveryRequired("recovery requested without a durable checkpoint".to_owned())
+        recovery_required("recovery requested without a durable checkpoint".to_owned())
     })?;
 
     let (to_slot, confirmed_tip) = match hint {
         GapHint::UntilExclusive(Some(gap_end)) if gap_end > checkpoint.slot + 1 => {
-            let confirmed_tip = read_confirmed_tip(client).await?;
+            let confirmed_tip = read_confirmed_tip(client, cancel).await?;
             (gap_end - 1, confirmed_tip)
         }
         GapHint::UntilExclusive(Some(gap_end)) if gap_end <= checkpoint.slot + 1 => {
-            return Err(RunnerError::RecoveryRequired(format!(
+            return Err(recovery_required(format!(
                 "recovery gap end slot {gap_end} does not extend past checkpoint {}",
                 checkpoint.slot
             )));
         }
         GapHint::FromCheckpointForward => {
-            let tip = read_confirmed_tip(client).await?;
+            let tip = read_confirmed_tip(client, cancel).await?;
             if tip <= checkpoint.slot {
-                return Err(RunnerError::RecoveryRequired(format!(
+                return Err(recovery_required(format!(
                     "confirmed tip {tip} is not ahead of checkpoint {}; cannot catch up after replay-unavailable",
                     checkpoint.slot
                 )));
             }
             let span = tip - checkpoint.slot;
             if span > client.config().bounds.max_slots {
-                return Err(RunnerError::RecoveryRequired(format!(
+                return Err(recovery_required(format!(
                     "recovery bound exhausted: tip catch-up span {span} exceeds max_slots {}",
                     client.config().bounds.max_slots
                 )));
@@ -287,7 +308,7 @@ async fn attempt_recovery(
             (tip, tip)
         }
         GapHint::UntilExclusive(None) => {
-            return Err(RunnerError::RecoveryRequired(
+            return Err(recovery_required(
                 "RPC recovery requires a bounded gap end slot".to_owned(),
             ));
         }
@@ -307,40 +328,43 @@ async fn attempt_recovery(
         Ok(blocks) => blocks,
         Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
         Err(RecoveryError::BoundExhausted(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
+            return Err(recovery_required(format!(
                 "recovery bound exhausted: {message}"
             )));
         }
         Err(RecoveryError::HistoryUnavailable(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
+            return Err(recovery_required(format!(
                 "RPC history unavailable: {message}"
             )));
         }
         Err(RecoveryError::Transport(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
+            return Err(recovery_required(format!(
                 "RPC recovery transport failure: {message}"
             )));
         }
         Err(RecoveryError::Invalid(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
+            return Err(recovery_required(format!(
                 "invalid RPC recovery data: {message}"
             )));
         }
     };
 
-    apply_recovered_blocks(store, &blocks, cancel, on_progress, confirmed_tip).await
+    apply_recovered_blocks(store, &blocks, cancel, on_recovered_progress, confirmed_tip).await
 }
 
-async fn read_confirmed_tip(client: &RpcRecoveryClient) -> Result<u64, RunnerError> {
-    match client.get_confirmed_slot().await {
+async fn read_confirmed_tip(
+    client: &RpcRecoveryClient,
+    cancel: &CancellationToken,
+) -> Result<u64, RunnerError> {
+    match client.get_confirmed_slot(cancel).await {
         Ok(tip) => Ok(tip),
-        Err(RecoveryError::Transport(message)) => Err(RunnerError::RecoveryRequired(format!(
+        Err(RecoveryError::Transport(message)) => Err(recovery_required(format!(
             "RPC recovery transport failure while reading tip: {message}"
         ))),
-        Err(RecoveryError::Cancelled) => Err(RunnerError::RecoveryRequired(
+        Err(RecoveryError::Cancelled) => Err(recovery_required(
             "RPC recovery cancelled while reading tip".to_owned(),
         )),
-        Err(err) => Err(RunnerError::RecoveryRequired(format!(
+        Err(err) => Err(recovery_required(format!(
             "failed to read confirmed tip for recovery: {err}"
         ))),
     }
@@ -351,56 +375,58 @@ async fn recover_bootstrap_from_start(
     store: &SqlProofStore,
     bootstrap_slot: u64,
     cancel: &CancellationToken,
-    on_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
+    on_recovered_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
 ) -> Result<Recovered, RunnerError> {
     if cancel.is_cancelled() {
         return Ok(Recovered::Cancelled);
     }
-    // Confirmed tip anchors completeness: single-slot bootstrap alone must not
-    // flip history_complete when the chain tip is ahead.
-    let confirmed_tip = read_confirmed_tip(client).await?;
-    // Lean PoC bootstrap: recover a single-slot window at the configured start.
-    // Further continuity to tip is proven by later gap fills / catch-up.
-    // TODO(prod): optional tip-bounded bootstrap catch-up horizon.
+    let confirmed_tip = read_confirmed_tip(client, cancel).await?;
+    if confirmed_tip < bootstrap_slot {
+        return Err(recovery_required(format!(
+            "confirmed tip {confirmed_tip} is behind bootstrap slot {bootstrap_slot}"
+        )));
+    }
+    // Recover the bounded inclusive range through the observed confirmed tip.
+    // Bound exhaustion stays fail-closed (history_incomplete / recovery_required).
     let blocks = match client
-        .fetch_completed_blocks(bootstrap_slot, bootstrap_slot, cancel)
+        .fetch_completed_blocks(bootstrap_slot, confirmed_tip, cancel)
         .await
     {
         Ok(blocks) => blocks,
         Err(RecoveryError::Cancelled) => return Ok(Recovered::Cancelled),
         Err(RecoveryError::BoundExhausted(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
-                "bootstrap recovery bound exhausted from slot {bootstrap_slot}: {message}"
+            return Err(recovery_required(format!(
+                "bootstrap recovery bound exhausted from slot {bootstrap_slot} through tip {confirmed_tip}: {message}"
             )));
         }
         Err(RecoveryError::HistoryUnavailable(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
-                "bootstrap RPC history unavailable at slot {bootstrap_slot}: {message}"
+            return Err(recovery_required(format!(
+                "bootstrap RPC history unavailable from slot {bootstrap_slot}: {message}"
             )));
         }
         Err(RecoveryError::Transport(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
-                "bootstrap RPC transport failure at slot {bootstrap_slot}: {message}"
+            return Err(recovery_required(format!(
+                "bootstrap RPC transport failure from slot {bootstrap_slot}: {message}"
             )));
         }
         Err(RecoveryError::Invalid(message)) => {
-            return Err(RunnerError::RecoveryRequired(format!(
-                "bootstrap recovery invalid data at slot {bootstrap_slot}: {message}"
+            return Err(recovery_required(format!(
+                "bootstrap recovery invalid data from slot {bootstrap_slot}: {message}"
             )));
         }
     };
     if blocks.is_empty() {
-        return Err(RunnerError::RecoveryRequired(format!(
-            "bootstrap slot {bootstrap_slot} has no confirmed block"
+        return Err(recovery_required(format!(
+            "bootstrap range [{bootstrap_slot}, {confirmed_tip}] has no confirmed blocks"
         )));
     }
     if blocks[0].slot != bootstrap_slot {
-        return Err(RunnerError::RecoveryRequired(format!(
-            "bootstrap recovery expected slot {bootstrap_slot}, got {}",
+        return Err(recovery_required(format!(
+            "bootstrap recovery expected first slot {bootstrap_slot}, got {}",
             blocks[0].slot
         )));
     }
-    apply_recovered_blocks(store, &blocks, cancel, on_progress, confirmed_tip).await
+    apply_recovered_blocks(store, &blocks, cancel, on_recovered_progress, confirmed_tip).await
 }
 
 /// Empty successful fetches must fail closed — never `Filled`, never mark complete.
@@ -408,7 +434,7 @@ fn reject_empty_recovery(
     blocks: &[solana_proof_source::CompletedBlock],
 ) -> Result<(), RunnerError> {
     if blocks.is_empty() {
-        Err(RunnerError::RecoveryRequired(
+        Err(recovery_required(
             "RPC recovery returned no blocks for the requested range".to_owned(),
         ))
     } else {
@@ -420,7 +446,7 @@ async fn apply_recovered_blocks(
     store: &SqlProofStore,
     blocks: &[solana_proof_source::CompletedBlock],
     cancel: &CancellationToken,
-    on_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
+    on_recovered_progress: Option<&(dyn Fn(u64) + Send + Sync)>,
     confirmed_tip: u64,
 ) -> Result<Recovered, RunnerError> {
     reject_empty_recovery(blocks)?;
@@ -431,14 +457,18 @@ async fn apply_recovered_blocks(
         match store.apply_completed_block(block).await? {
             ApplyOutcome::Applied | ApplyOutcome::AlreadyApplied => {
                 info!(slot = block.slot, "applied recovered completed block");
-                if let Some(on_progress) = on_progress {
-                    on_progress(block.slot);
+                if let Some(on_recovered_progress) = on_recovered_progress {
+                    on_recovered_progress(block.slot);
                 }
             }
-            ApplyOutcome::RecoveryRequired { reason } => {
-                return Err(RunnerError::RecoveryRequired(format!(
-                    "recovered block still requires recovery: {reason}"
-                )));
+            ApplyOutcome::RecoveryRequired {
+                reason,
+                gap_end_slot,
+            } => {
+                return Err(recovery_required_until(
+                    format!("recovered block still requires recovery: {reason}"),
+                    gap_end_slot,
+                ));
             }
             ApplyOutcome::IntegrityHalted { reason } => {
                 return Err(RunnerError::IntegrityHalted(format!(
@@ -475,15 +505,6 @@ async fn maybe_mark_history_complete(
     Ok(())
 }
 
-fn parse_gap_end_slot(reason: &str) -> Option<u64> {
-    // Reasons look like:
-    // "contiguous ingest gap at slot N: parent slot ..."
-    const PREFIX: &str = "contiguous ingest gap at slot ";
-    let rest = reason.strip_prefix(PREFIX)?;
-    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    digits.parse().ok()
-}
-
 async fn drive_subscription(
     mut subscription: YellowstoneSubscription,
     store: &SqlProofStore,
@@ -508,9 +529,12 @@ async fn drive_subscription(
                     expected_parent_slot,
                     ..
                 }) => {
-                    return Err(RunnerError::RecoveryRequired(format!(
-                        "contiguous ingest gap at slot {slot}: parent slot {parent_slot} does not extend previous applied slot {expected_parent_slot}; recovery required"
-                    )));
+                    return Err(recovery_required_until(
+                        format!(
+                            "contiguous ingest gap at slot {slot}: parent slot {parent_slot} does not extend previous applied slot {expected_parent_slot}; recovery required"
+                        ),
+                        slot,
+                    ));
                 }
                 Err(error) => return Err(RunnerError::Source(error)),
             },
@@ -532,8 +556,11 @@ async fn drive_subscription(
                     on_progress(block.slot);
                 }
             }
-            ApplyOutcome::RecoveryRequired { reason } => {
-                return Err(RunnerError::RecoveryRequired(reason));
+            ApplyOutcome::RecoveryRequired {
+                reason,
+                gap_end_slot,
+            } => {
+                return Err(recovery_required_until(reason, gap_end_slot));
             }
             ApplyOutcome::IntegrityHalted { reason } => {
                 return Err(RunnerError::IntegrityHalted(reason));
@@ -555,28 +582,13 @@ mod tests {
     }
 
     #[test]
-    fn parses_gap_end_slot_from_store_reason() {
-        let reason = "contiguous ingest gap at slot 42: parent slot 40 does not extend checkpoint 39; recovery required";
-        assert_eq!(parse_gap_end_slot(reason), Some(42));
-    }
-
-    #[test]
-    fn parses_gap_end_slot_from_ancestry_reason() {
-        let reason = "contiguous ingest gap at slot 100: parent slot 99 does not extend previous applied slot 90; recovery required";
-        assert_eq!(parse_gap_end_slot(reason), Some(100));
-    }
-
-    #[test]
-    fn parse_gap_end_rejects_unrelated_reason() {
-        assert_eq!(parse_gap_end_slot("something else"), None);
-    }
-
-    #[test]
     fn empty_recovery_is_not_filled() {
         let err = reject_empty_recovery(&[]).unwrap_err();
-        assert!(
-            matches!(err, RunnerError::RecoveryRequired(reason) if reason.contains("no blocks"))
-        );
+        assert!(matches!(
+            err,
+            RunnerError::RecoveryRequired { reason, gap_end_slot: None }
+                if reason.contains("no blocks")
+        ));
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-store/src/store.rs
+++ b/solana-proof-service/crates/solana-proof-store/src/store.rs
@@ -238,13 +238,11 @@ impl SqlProofStore {
 
     /// Bootstrap A / recovery seam: completeness becomes true only after an
     /// explicit bounded recovery pass proves continuity from the configured
-    /// start. The recovery adapter itself lands in a later slice.
+    /// start (`bootstrap_slot`). Called by the sequential runner when justified.
     pub async fn set_history_complete_after_recovery(
         &self,
         complete: bool,
     ) -> Result<(), StoreError> {
-        // TODO(solana-proof-service): call only from bounded RPC recovery once
-        // continuity from the configured start is proven.
         sqlx::query!(
             r#"
             UPDATE solana_proof_progress

--- a/solana-proof-service/crates/solana-proof-store/src/store.rs
+++ b/solana-proof-service/crates/solana-proof-store/src/store.rs
@@ -41,8 +41,12 @@ pub enum ApplyOutcome {
     /// Contiguous parent link is missing (typical after a program-filtered
     /// Yellowstone gap). No domain writes; bounded RPC recovery must fill
     /// intermediate blocks before ingest can continue.
+    ///
+    /// `gap_end_slot` is the observed block slot that could not be applied
+    /// (`UntilExclusive` fill target).
     RecoveryRequired {
         reason: String,
+        gap_end_slot: u64,
     },
     IntegrityHalted {
         reason: String,
@@ -419,7 +423,10 @@ impl SqlProofStore {
                     block.slot, block.parent_slot, checkpoint_slot
                 );
                 tx.commit().await?;
-                return Ok(ApplyOutcome::RecoveryRequired { reason });
+                return Ok(ApplyOutcome::RecoveryRequired {
+                    reason,
+                    gap_end_slot: block.slot,
+                });
             }
             if block.parent_hash != checkpoint_hash {
                 let reason = format!(

--- a/solana-proof-service/crates/solana-proof-store/tests/store_postgres.rs
+++ b/solana-proof-service/crates/solana-proof-store/tests/store_postgres.rs
@@ -438,9 +438,13 @@ async fn parent_slot_mismatch_is_recovery_required_without_domain_writes() {
         .unwrap();
     let gap = block(12, 11, pk(0xA1), pk(0xA2), Vec::new());
     match store.apply_completed_block(&gap).await.unwrap() {
-        ApplyOutcome::RecoveryRequired { reason } => {
+        ApplyOutcome::RecoveryRequired {
+            reason,
+            gap_end_slot,
+        } => {
             assert!(reason.contains("recovery required"));
             assert!(reason.contains("contiguous ingest gap"));
+            assert_eq!(gap_end_slot, 12);
         }
         other => panic!("expected RecoveryRequired, got {other:?}"),
     }
@@ -686,8 +690,12 @@ async fn recovered_gap_fill_applies_contiguous_parents() {
     // Program-filtered gap: next observed would be slot 12 with parent 11.
     let observed = block(12, 11, pk(0xB0), pk(0xC0), Vec::new());
     match store.apply_completed_block(&observed).await.unwrap() {
-        ApplyOutcome::RecoveryRequired { reason } => {
+        ApplyOutcome::RecoveryRequired {
+            reason,
+            gap_end_slot,
+        } => {
             assert!(reason.contains("contiguous ingest gap"));
+            assert_eq!(gap_end_slot, 12);
         }
         other => panic!("expected RecoveryRequired, got {other:?}"),
     }

--- a/solana-proof-service/crates/solana-proof-store/tests/store_postgres.rs
+++ b/solana-proof-service/crates/solana-proof-store/tests/store_postgres.rs
@@ -669,6 +669,81 @@ async fn unknown_pre_bootstrap_lineage_halts() {
     assert_eq!(leaves.0, 0);
 }
 
+#[ignore = "requires DATABASE_URL / SOLANA_PROOF_TEST_DATABASE_URL"]
+#[tokio::test]
+async fn recovered_gap_fill_applies_contiguous_parents() {
+    let store = fresh_store().await;
+    // First live block (incomplete bootstrap).
+    assert_eq!(
+        store
+            .apply_completed_block(&block(10, 9, pk(0x90), pk(0xA0), Vec::new()))
+            .await
+            .unwrap(),
+        ApplyOutcome::Applied
+    );
+    assert!(!store.integrity_status().await.unwrap().history_complete);
+
+    // Program-filtered gap: next observed would be slot 12 with parent 11.
+    let observed = block(12, 11, pk(0xB0), pk(0xC0), Vec::new());
+    match store.apply_completed_block(&observed).await.unwrap() {
+        ApplyOutcome::RecoveryRequired { reason } => {
+            assert!(reason.contains("contiguous ingest gap"));
+        }
+        other => panic!("expected RecoveryRequired, got {other:?}"),
+    }
+
+    // Recovered empty intermediate block fills the parent chain.
+    assert_eq!(
+        store
+            .apply_completed_block(&block(11, 10, pk(0xA0), pk(0xB0), Vec::new()))
+            .await
+            .unwrap(),
+        ApplyOutcome::Applied
+    );
+    assert_eq!(
+        store.apply_completed_block(&observed).await.unwrap(),
+        ApplyOutcome::Applied
+    );
+    let status = store.integrity_status().await.unwrap();
+    assert_eq!(status.checkpoint.as_ref().map(|c| c.slot), Some(12));
+    assert!(!status.history_complete);
+
+    // Seam flips only when caller proves start continuity (Bootstrap A).
+    store
+        .set_history_complete_after_recovery(true)
+        .await
+        .unwrap();
+    assert!(store.integrity_status().await.unwrap().history_complete);
+}
+
+#[ignore = "requires DATABASE_URL / SOLANA_PROOF_TEST_DATABASE_URL"]
+#[tokio::test]
+async fn conflicting_recovered_ancestry_halts() {
+    let store = fresh_store().await;
+    store
+        .apply_completed_block(&block(10, 9, pk(0x90), pk(0xA0), Vec::new()))
+        .await
+        .unwrap();
+
+    // Recovered block claims parent slot 10 but wrong parent hash → halt.
+    match store
+        .apply_completed_block(&block(11, 10, pk(0xFF), pk(0xB0), Vec::new()))
+        .await
+        .unwrap()
+    {
+        ApplyOutcome::IntegrityHalted { reason } => {
+            assert!(reason.contains("ancestry") || reason.contains("parent hash"));
+        }
+        other => panic!("expected IntegrityHalted, got {other:?}"),
+    }
+    assert!(store.integrity_status().await.unwrap().integrity_halted);
+    let blocks: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM solana_proof_blocks")
+        .fetch_one(store.pool())
+        .await
+        .unwrap();
+    assert_eq!(blocks.0, 1);
+}
+
 #[tokio::test]
 async fn reduce_unit_leaf_order_matches_instruction_event_subject_order() {
     // Pure reduce path (no DB): two subjects must append in subject order.


### PR DESCRIPTION
## Summary

- Adds confirmed JSON-RPC recovery (`getBlocks`/`getBlock`) that normalizes into the same `CompletedBlock` boundary (program-filtered txs, sparse indexes, failed/vote identities) and applies through `SqlProofStore::apply_completed_block`.
- Wires the sequential runner so `RecoveryRequired` / Yellowstone `Ancestry` (and tip-bounded `ReplayUnavailable` catch-up) invoke bounded recovery, then resume from the durable checkpoint (exact inclusive replay **or** contiguous filtered-stream continuation).
- Bootstrap A: `history_complete` flips via `set_history_complete_after_recovery` **only** when `recovery.bootstrap_slot` matches durable `history_start`. Bound exhaustion / history unavailable / transport stay fail-closed (`recovery_required`); conflicting recovered ancestry halts.
- Lean config: `recovery.max_slots_per_attempt`, `max_blocks_per_attempt`, optional `rpc_url` / `bootstrap_slot` (README documents PoC horizon TODOs).

**Out of scope:** FileLeafStore deletion, provider registry / Carbon / LaserStream / finality queues, multi-replica, auth.

Refs: fhevm-internal #1682 (PR4 recovery slice)

## Test plan

- [x] `cd solana-proof-service && make fmt`
- [x] `cd solana-proof-service && make clippy` (`-D warnings`)
- [x] `cd solana-proof-service && make test` (RPC JSON normalization + bound exhaustion + resume tests)
- [x] `DATABASE_URL=postgres://work@127.0.0.1:55432/solana_proof_service make test-db` (gap fill + conflicting recovered ancestry)
- [ ] CI path-filtered solana-proof-service workflows on this PR