### PR TITLE
chore(kms-connector): alloy and rust bump

### DIFF
--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "fhevm_gateway_bindings"
-version = "0.1.0-rc14"
+version = "0.15.0"
 dependencies = [
  "alloy",
  "serde",

--- a/gateway-contracts/rust_bindings/Cargo.toml
+++ b/gateway-contracts/rust_bindings/Cargo.toml
@@ -10,7 +10,8 @@ version = "0.15.0"
 unused = "allow"
 
 [dependencies]
-alloy = { version = "1.0", default-features = false, features = [
+# Allow use of alloy version 1.*.* or 2.*.* for the parent crate
+alloy = { version = ">=1, <3", default-features = false, features = [
     "contract",
     "sol-types",
 ] }

--- a/host-contracts/rust_bindings/Cargo.toml
+++ b/host-contracts/rust_bindings/Cargo.toml
@@ -10,7 +10,8 @@ version = "0.15.0"
 unused = "allow"
 
 [dependencies]
-alloy = { version = "1.0", default-features = false, features = [
+# Allow use of alloy version 1.*.* or 2.*.* for the parent crate
+alloy = { version = ">=1, <3", default-features = false, features = [
     "contract",
     "sol-types",
 ] }

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -265,14 +265,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17c19591d57add4f0c47922877a48aae1f47074e3433436545f8948353b3bbb"
+checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
+ "alloy-ens",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
@@ -304,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0dd3ed764953a6b20458b2b7abbfdc93d20d14b38babe1a70fe631a443a9f1"
+checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -315,6 +316,7 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
@@ -330,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9556182afa73cddffa91e64a5aa9508d5e8c912b3a15f26998d2388a824d2c7b"
+checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -344,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19d7092c96defc3d132ee0d8969ca1b79ef512b5eda5c66e3065266b253adf2"
+checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -363,13 +365,14 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca96214615ec8cf3fa2a54b32f486eb49100ca7fe7eb0b8c1137cd316e7250a"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -434,37 +437,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.0.38"
+name = "alloy-eip7928"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fa99b538ca7006b0c03cfed24ec6d82beda67aac857ef4714be24231d15e6"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
  "serde",
  "serde_with",
  "sha2",
+]
+
+[[package]]
+name = "alloy-ens"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a272533715aefc900f89d51db00c96e6fd4f517ea081a12fea482a352c8c815c"
+checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
+ "borsh",
  "serde",
  "serde_with",
 ]
@@ -496,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91676d242c0ced99c0dd6d0096d7337babe9457cc43407d26aa6367fcf90553"
+checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -511,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f82150116b30ba92f588b87f08fa97a46a1bd5ffc0d0597efdf0843d36bfda"
+checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -537,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223612259a080160ce839a4e5df0125ca403a1d5e7206cc911cea54af5d769aa"
+checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -550,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3652a65bacfba0a169755090d4ecd7d3c63fa534b21d09b8e604dc2609760da6"
+checksum = "2ab58d45ceaabba867fc05f018f58e4640df2e6424b4c759d45f66cf075ad8fe"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -561,6 +594,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "k256",
+ "libc",
  "rand 0.8.6",
  "serde_json",
  "tempfile",
@@ -599,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7283b81b6f136100b152e699171bc7ed8184a58802accbc91a7df4ebb944445"
+checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -632,7 +666,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -644,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee7e3d343814ec0dfea69bd1820042a133a9d0b9ac5faf1e6eb133b43366315"
+checksum = "6fa5976a77e32a63152e937fa90d0dae1f8142b41a9a99a6386d6ea58934cfa6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -688,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154b12d470bef59951c62676e106f4ce5de73b987d86b9faa935acebb138ded"
+checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -700,7 +734,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -713,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ab76bf97648a1c6ad8fb00f0d594618942b5a9e008afbfb5c8a8fca800d574"
+checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
@@ -727,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456cfc2c1677260edbd7ce3eddb7de419cb46de0e9826c43401f42b0286a779a"
+checksum = "9f89d27756bf3effdac25d07692724e840ce90ca1ff956a6b47dd2ae1612f597"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -739,22 +773,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cc57ee0c1ac9fb14854195fc249494da7416591dc4a4d981ddfd5dd93b9bce"
+checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ac29dd005c33e3f7e09087accc80843315303685c3f7a1b888002cd27785b"
+checksum = "b9e9c1f9ac81c56b2d96901201db7eb95c4e9fc3c21237a4690f8c652aa62089"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more",
  "serde",
  "serde_with",
@@ -762,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7d47bca1a2a1541e4404aa38b7e262bb4dffd9ac23b4f178729a4ddc5a5caa"
+checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -783,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c331c8e48665607682e8a9549a2347c13674d4fbcbdc342e7032834eba2424f4"
+checksum = "796729a4e1783904c6040f11a503c4d55ddb16f69dc199ad15e50c4ad039f371"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -797,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8468f1a7f9ee3bae73c24eead0239abea720dbf7779384b9c7e20d51bfb6b0"
+checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -808,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33387c90b0a5021f45a5a77c2ce6c49b8f6980e66a318181468fb24cea771670"
+checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -823,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bf90f2355769ad93f790b930434b8d3d2948317f3e484de458010409024462"
+checksum = "1ddacf5492810b4bc33e341dd3213a30cf1f0cc0c526028368ce618f3f07258c"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -842,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55d9e795c85e36dcea08786d2e7ae9b73cb554b6bea6ac4c212def24e1b4d03"
+checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -931,12 +970,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702002659778d89a94cd4ff2044f6b505460df6c162e2f47d1857573845b0ace"
+checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives",
  "auto_impl",
  "base64",
  "derive_more",
@@ -955,13 +993,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6bdc0830e5e8f08a4c70a4c791d400a86679c694a3b4b986caf26fad680438"
+checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "itertools 0.14.0",
+ "reqwest 0.13.4",
  "serde_json",
  "tower",
  "tracing",
@@ -970,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686219dcef201655763bd3d4eabe42388d9368bfbf6f1c8016d14e739ec53aac"
+checksum = "1bea36621cd4e4f06c1243e556b32fdc9c4db7b9b09b72a95a87383c0ffcc625"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -983,6 +1022,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -1004,12 +1044,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.38"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf39928a5e70c9755d6811a2928131b53ba785ad37c8bf85c90175b5d43b818"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
 dependencies = [
- "alloy-primitives",
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2335,6 +2374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,37 +2648,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "serde",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2641,18 +2665,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
  "syn 2.0.117",
 ]
 
@@ -2662,7 +2676,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2948,7 +2962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3442,6 +3456,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
@@ -3657,7 +3682,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3690,7 +3714,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3975,6 +3999,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,11 +4296,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4540,7 +4613,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -4555,7 +4628,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.13.1",
@@ -5084,7 +5157,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5097,6 +5170,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5121,9 +5195,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5379,6 +5453,38 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5388,9 +5494,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5401,7 +5507,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5567,7 +5672,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5609,6 +5714,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5643,6 +5775,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -5907,7 +6048,7 @@ version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6063,6 +6204,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -6468,7 +6625,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6820,9 +6977,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -7174,9 +7331,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -7438,6 +7595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7602,6 +7769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7644,6 +7820,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -265,9 +265,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+checksum = "7bdf7932042b511ad4ad67f7eeac896df62439ac91a8c516d678b79cbe3f9c27"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
+checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
+checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
+checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab58d45ceaabba867fc05f018f58e4640df2e6424b4c759d45f66cf075ad8fe"
+checksum = "bd2d06c4044c3ae7f9b7a70c9a7bb3bde9a08e99f4d9aa91001e17a182b562dc"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
+checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa5976a77e32a63152e937fa90d0dae1f8142b41a9a99a6386d6ea58934cfa6"
+checksum = "71044e076a7c243454619e36279fc4654bc1ff846fbf666663ef574388859c84"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
+checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
+checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-debug",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f89d27756bf3effdac25d07692724e840ce90ca1ff956a6b47dd2ae1612f597"
+checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
+checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e9c1f9ac81c56b2d96901201db7eb95c4e9fc3c21237a4690f8c652aa62089"
+checksum = "7b918cbaadbdcffa4ed64840a5ecbde80a6476ab23adc8c5c8ae6feec081058c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796729a4e1783904c6040f11a503c4d55ddb16f69dc199ad15e50c4ad039f371"
+checksum = "a12cafc0ee2290122ec4e069bb0f2389a356f4b5414f2e82de8288049c2bc98a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
+checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddacf5492810b4bc33e341dd3213a30cf1f0cc0c526028368ce618f3f07258c"
+checksum = "dc1a457df25c6f8cec9cf3fd15db7864780c19c24e372cd4fff66e2bf1cff1c8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
+checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
+checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
+checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bea36621cd4e4f06c1243e556b32fdc9c4db7b9b09b72a95a87383c0ffcc625"
+checksum = "e67177a75a6e8a44f39ccbbc64a3e3a70186ef401d7313285b56735d4285aa34"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2441,6 +2441,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tonic 0.14.6",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2962,7 +2963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3714,7 +3715,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5157,7 +5158,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5195,9 +5196,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5672,7 +5673,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5731,7 +5732,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6625,7 +6626,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7827,7 +7828,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -30,7 +30,7 @@ ciphertext-attestation = { path = "../shared/ciphertext-attestation" }
 #                       External dependencies                       #
 #####################################################################
 actix-web = "=4.11.0"
-alloy = { version = "=2.1.1", default-features = false, features = [
+alloy = { version = "=2.2.0", default-features = false, features = [
     "essentials",
     "provider-debug-api",
     "provider-ws",
@@ -95,6 +95,7 @@ tonic = { version = "=0.14.6", default-features = true, features = [
     "tls-native-roots",
 ] }
 tonic-health = { version = "=0.14.5", default-features = false }
+tower = { version = "=0.5.3", default-features = false, features = ["util"] }
 tracing = { version = "=0.1.44", default-features = true }
 tracing-opentelemetry = "=0.31.0"
 tracing-subscriber = { version = "=0.3.20", default-features = true, features = [

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -30,7 +30,7 @@ ciphertext-attestation = { path = "../shared/ciphertext-attestation" }
 #                       External dependencies                       #
 #####################################################################
 actix-web = "=4.11.0"
-alloy = { version = "=1.0.38", default-features = false, features = [
+alloy = { version = "=2.1.1", default-features = false, features = [
     "essentials",
     "provider-debug-api",
     "provider-ws",

--- a/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use tx_sender::{
     core::{Config, TransactionSender},
     monitoring::{

--- a/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/bin/tx_sender.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 use tx_sender::{
     core::{Config, TransactionSender},
     monitoring::{

--- a/kms-connector/crates/tx-sender/src/core/ethereum.rs
+++ b/kms-connector/crates/tx-sender/src/core/ethereum.rs
@@ -1,17 +1,14 @@
 use crate::core::tx_sender::{Error, get_revert_reason, overprovision_gas};
 use alloy::{
     hex,
-    providers::{Provider, fillers::TxFiller},
+    providers::Provider,
     rpc::types::{TransactionReceipt, TransactionRequest},
     sol_types::SolValue,
 };
 use anyhow::anyhow;
-use connector_utils::{
-    provider::NonceManagedProvider,
-    types::{
-        CrsgenResponse, EpochResultResponse, KeygenResponse, KmsResponseKind,
-        NewKmsContextResponse, PrepKeygenResponse,
-    },
+use connector_utils::types::{
+    CrsgenResponse, EpochResultResponse, KeygenResponse, KmsResponseKind, NewKmsContextResponse,
+    PrepKeygenResponse,
 };
 use fhevm_host_bindings::{
     kms_generation::KMSGeneration::KMSGenerationInstance,
@@ -24,14 +21,13 @@ use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
 /// The struct used to send keygen transactions to Ethereum.
-pub struct EthereumTransactionSender<F, P>
+pub struct EthereumTransactionSender<P>
 where
-    F: TxFiller,
     P: Provider,
 {
-    provider: NonceManagedProvider<F, P>,
-    kms_generation_contract: KMSGenerationInstance<NonceManagedProvider<F, P>>,
-    protocol_config_contract: ProtocolConfigInstance<NonceManagedProvider<F, P>>,
+    provider: P,
+    kms_generation_contract: KMSGenerationInstance<P>,
+    protocol_config_contract: ProtocolConfigInstance<P>,
     config: EthereumSenderConfig,
 }
 
@@ -58,15 +54,14 @@ impl From<&super::Config> for EthereumSenderConfig {
     }
 }
 
-impl<F, P> EthereumTransactionSender<F, P>
+impl<P> EthereumTransactionSender<P>
 where
-    F: TxFiller,
     P: Provider,
 {
     pub fn new(
-        provider: NonceManagedProvider<F, P>,
-        kms_generation_contract: KMSGenerationInstance<NonceManagedProvider<F, P>>,
-        protocol_config_contract: ProtocolConfigInstance<NonceManagedProvider<F, P>>,
+        provider: P,
+        kms_generation_contract: KMSGenerationInstance<P>,
+        protocol_config_contract: ProtocolConfigInstance<P>,
         inner_config: EthereumSenderConfig,
     ) -> Self {
         Self {
@@ -245,9 +240,8 @@ where
     }
 }
 
-impl<F, P> Clone for EthereumTransactionSender<F, P>
+impl<P> Clone for EthereumTransactionSender<P>
 where
-    F: TxFiller,
     P: Provider + Clone,
 {
     fn clone(&self) -> Self {
@@ -268,7 +262,7 @@ mod tests {
         primitives::Address,
         providers::{
             ProviderBuilder, SendableTx,
-            fillers::{FillProvider, FillerControlFlow},
+            fillers::{FillProvider, FillerControlFlow, TxFiller},
             mock::Asserter,
         },
         rpc::types::trace::geth::GethTrace,
@@ -276,6 +270,7 @@ mod tests {
     };
     use connector_utils::{
         config::KmsWallet,
+        provider::NonceManagedProvider,
         tests::rand::{rand_signature, rand_u256},
     };
     use serde::de::DeserializeOwned;

--- a/kms-connector/crates/tx-sender/src/core/ethereum.rs
+++ b/kms-connector/crates/tx-sender/src/core/ethereum.rs
@@ -264,7 +264,7 @@ where
 mod tests {
     use super::*;
     use alloy::{
-        network::{Ethereum, IntoWallet, Network, TransactionBuilder},
+        network::{Ethereum, IntoWallet, Network, NetworkTransactionBuilder, TransactionBuilder},
         primitives::Address,
         providers::{
             ProviderBuilder, SendableTx,

--- a/kms-connector/crates/tx-sender/src/core/gateway.rs
+++ b/kms-connector/crates/tx-sender/src/core/gateway.rs
@@ -6,25 +6,23 @@ use crate::{
 };
 use alloy::{
     hex,
-    providers::{Provider, fillers::TxFiller},
+    providers::Provider,
     rpc::types::{TransactionReceipt, TransactionRequest},
 };
 use anyhow::anyhow;
-use connector_utils::{
-    provider::NonceManagedProvider,
-    types::{KmsResponseKind, PublicDecryptionResponse, UserDecryptionResponse},
+use connector_utils::types::{
+    KmsResponseKind, PublicDecryptionResponse, UserDecryptionResponse,
 };
 use fhevm_gateway_bindings::decryption::Decryption::DecryptionInstance;
 use tracing::{debug, error, info, warn};
 
 /// The struct used to send decryption transactions to the Gateway.
-pub struct GatewayTransactionSender<F, P>
+pub struct GatewayTransactionSender<P>
 where
-    F: TxFiller,
     P: Provider,
 {
-    provider: NonceManagedProvider<F, P>,
-    decryption_contract: DecryptionInstance<NonceManagedProvider<F, P>>,
+    provider: P,
+    decryption_contract: DecryptionInstance<P>,
     config: GatewaySenderConfig,
 }
 
@@ -47,14 +45,13 @@ impl From<&super::Config> for GatewaySenderConfig {
     }
 }
 
-impl<F, P> GatewayTransactionSender<F, P>
+impl<P> GatewayTransactionSender<P>
 where
-    F: TxFiller,
     P: Provider,
 {
     pub fn new(
-        provider: NonceManagedProvider<F, P>,
-        decryption_contract: DecryptionInstance<NonceManagedProvider<F, P>>,
+        provider: P,
+        decryption_contract: DecryptionInstance<P>,
         inner_config: GatewaySenderConfig,
     ) -> Self {
         Self {
@@ -190,9 +187,8 @@ where
     }
 }
 
-impl<F, P> Clone for GatewayTransactionSender<F, P>
+impl<P> Clone for GatewayTransactionSender<P>
 where
-    F: TxFiller,
     P: Provider + Clone,
 {
     fn clone(&self) -> Self {
@@ -212,7 +208,7 @@ mod tests {
         primitives::Address,
         providers::{
             ProviderBuilder, SendableTx,
-            fillers::{FillProvider, FillerControlFlow},
+            fillers::{FillProvider, FillerControlFlow, TxFiller},
             mock::Asserter,
         },
         rpc::types::trace::geth::GethTrace,
@@ -220,6 +216,7 @@ mod tests {
     };
     use connector_utils::{
         config::KmsWallet,
+        provider::NonceManagedProvider,
         tests::rand::{rand_signature, rand_u256},
     };
     use serde::de::DeserializeOwned;

--- a/kms-connector/crates/tx-sender/src/core/gateway.rs
+++ b/kms-connector/crates/tx-sender/src/core/gateway.rs
@@ -10,9 +10,7 @@ use alloy::{
     rpc::types::{TransactionReceipt, TransactionRequest},
 };
 use anyhow::anyhow;
-use connector_utils::types::{
-    KmsResponseKind, PublicDecryptionResponse, UserDecryptionResponse,
-};
+use connector_utils::types::{KmsResponseKind, PublicDecryptionResponse, UserDecryptionResponse};
 use fhevm_gateway_bindings::decryption::Decryption::DecryptionInstance;
 use tracing::{debug, error, info, warn};
 

--- a/kms-connector/crates/tx-sender/src/core/gateway.rs
+++ b/kms-connector/crates/tx-sender/src/core/gateway.rs
@@ -208,7 +208,7 @@ where
 mod tests {
     use super::*;
     use alloy::{
-        network::{Ethereum, IntoWallet, Network, TransactionBuilder},
+        network::{Ethereum, IntoWallet, Network, NetworkTransactionBuilder, TransactionBuilder},
         primitives::Address,
         providers::{
             ProviderBuilder, SendableTx,

--- a/kms-connector/crates/tx-sender/src/core/tx_sender.rs
+++ b/kms-connector/crates/tx-sender/src/core/tx_sender.rs
@@ -6,9 +6,7 @@ use crate::{
     monitoring::{health::State, metrics::register_response_forwarding_latency},
 };
 use alloy::{
-    providers::{
-        PendingTransactionError, Provider, RootProvider, ext::DebugApi, fillers::TxFiller,
-    },
+    providers::{PendingTransactionError, Provider, ext::DebugApi},
     rpc::types::{
         TransactionReceipt, TransactionRequest,
         trace::geth::{CallConfig, GethDebugTracingOptions},
@@ -17,7 +15,7 @@ use alloy::{
 };
 use anyhow::anyhow;
 use connector_utils::{
-    conn::{WalletProviderFillers, connect_to_db, connect_to_rpc_node_with_wallet},
+    conn::{WalletProvider, connect_to_db, connect_to_rpc_node_with_wallet},
     tasks::spawn_with_limit,
     types::{KmsResponse, KmsResponseKind},
 };
@@ -36,35 +34,33 @@ use tracing::{debug, error, info, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Struct sending stored KMS Core's responses to the Gateway and Ethereum.
-pub struct TransactionSender<L, F, P>
+pub struct TransactionSender<L, P>
 where
-    F: TxFiller,
     P: Provider,
 {
     /// The entity used to collect stored KMS Core's responses.
     response_picker: L,
 
     /// The entity responsible to send transactions to the Gateway.
-    gw_sender: GatewayTransactionSender<F, P>,
+    gw_sender: GatewayTransactionSender<P>,
 
     /// The entity responsible to send transactions to Ethereum.
-    eth_sender: EthereumTransactionSender<F, P>,
+    eth_sender: EthereumTransactionSender<P>,
 
     /// The database pool for where the KMS Core's responses are stored.
     db_pool: Pool<Postgres>,
 }
 
-impl<L, F, P> TransactionSender<L, F, P>
+impl<L, P> TransactionSender<L, P>
 where
     L: KmsResponsePicker,
-    F: TxFiller + 'static,
     P: Provider + Clone + 'static,
 {
     /// Creates a new `TransactionSender` instance.
     pub fn new(
         response_picker: L,
-        gw_sender: GatewayTransactionSender<F, P>,
-        eth_sender: EthereumTransactionSender<F, P>,
+        gw_sender: GatewayTransactionSender<P>,
+        eth_sender: EthereumTransactionSender<P>,
         db_pool: Pool<Postgres>,
     ) -> Self {
         Self {
@@ -128,8 +124,8 @@ where
     /// Routes decryption responses to the Gateway and keygen responses to Ethereum.
     #[tracing::instrument(skip(gw_sender, eth_sender, db_pool, cancel_token), fields(response = %response.kind))]
     async fn forward_response(
-        gw_sender: GatewayTransactionSender<F, P>,
-        eth_sender: EthereumTransactionSender<F, P>,
+        gw_sender: GatewayTransactionSender<P>,
+        eth_sender: EthereumTransactionSender<P>,
         db_pool: Pool<Postgres>,
         response: KmsResponse,
         cancel_token: CancellationToken,
@@ -162,7 +158,7 @@ where
     }
 }
 
-impl TransactionSender<DbKmsResponsePicker, WalletProviderFillers, RootProvider> {
+impl TransactionSender<DbKmsResponsePicker, WalletProvider> {
     /// Creates a new `TransactionSender` instance from a valid `Config`.
     pub async fn from_config(config: Config) -> anyhow::Result<(Self, State)> {
         if config.private_key.is_some() {

--- a/kms-connector/crates/utils/Cargo.toml
+++ b/kms-connector/crates/utils/Cargo.toml
@@ -46,8 +46,10 @@ testcontainers = { workspace = true, optional = true }
 toml = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["json-rpc"] }
 serial_test.workspace = true
 toml.workspace = true
+tower.workspace = true
 
 [features]
 tests = [

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -55,7 +55,8 @@ type DefaultFillers = JoinFill<
 pub type DefaultProvider = FillProvider<JoinFill<DefaultFillers, ChainIdFiller>, RootProvider>;
 
 /// The default `alloy::Provider` used to interact with the Gateway/Host chain using a wallet.
-pub type WalletProvider = NonceManagedProvider<WalletProviderFillers, RootProvider>;
+pub type WalletProvider =
+    NonceManagedProvider<FillProvider<WalletProviderFillers, RootProvider>>;
 pub type WalletProviderFillers = JoinFill<
     JoinFill<JoinFill<Identity, ChainIdFiller>, FillersWithoutNonceManagement>,
     WalletFiller<EthereumWallet>,

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -55,8 +55,7 @@ type DefaultFillers = JoinFill<
 pub type DefaultProvider = FillProvider<JoinFill<DefaultFillers, ChainIdFiller>, RootProvider>;
 
 /// The default `alloy::Provider` used to interact with the Gateway/Host chain using a wallet.
-pub type WalletProvider =
-    NonceManagedProvider<FillProvider<WalletProviderFillers, RootProvider>>;
+pub type WalletProvider = NonceManagedProvider<FillProvider<WalletProviderFillers, RootProvider>>;
 pub type WalletProviderFillers = JoinFill<
     JoinFill<JoinFill<Identity, ChainIdFiller>, FillersWithoutNonceManagement>,
     WalletFiller<EthereumWallet>,

--- a/kms-connector/crates/utils/src/provider.rs
+++ b/kms-connector/crates/utils/src/provider.rs
@@ -1,35 +1,14 @@
 use alloy::{
-    consensus::TrieAccount,
-    eips::{BlockId, BlockNumberOrTag, Encodable2718},
-    network::{Ethereum, Network, TransactionBuilder},
-    primitives::{
-        Address, B256, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, U64, U128,
-        U256,
-    },
+    network::{Network, TransactionBuilder},
+    primitives::{Address, Bytes},
     providers::{
-        EthCall, EthCallMany, EthGetBlock, FilterPollerBuilder, GetSubscription,
-        PendingTransaction, PendingTransactionBuilder, PendingTransactionConfig,
-        PendingTransactionError, Provider, ProviderCall, RootProvider, RpcWithBlock, SendableTx,
-        fillers::{
-            BlobGasFiller, CachedNonceManager, FillProvider, GasFiller, JoinFill, NonceManager,
-            TxFiller,
-        },
+        PendingTransactionBuilder, Provider, RootProvider, SendableTx,
+        fillers::{BlobGasFiller, CachedNonceManager, GasFiller, JoinFill, NonceManager},
     },
-    rpc::{
-        client::NoParams,
-        types::{
-            AccessListResult, Bundle, EIP1186AccountProofResponse, EthCallResponse, FeeHistory,
-            Filter, FilterChanges, Index, Log, SyncStatus, TransactionReceipt, TransactionRequest,
-            erc4337::TransactionConditional,
-            pubsub::{Params, SubscriptionKind},
-            simulate::{SimulatePayload, SimulatedBlock},
-        },
-    },
-    transports::{TransportError, TransportResult},
+    transports::TransportResult,
 };
 use futures::lock::Mutex;
-use serde_json::value::RawValue;
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 pub type FillersWithoutNonceManagement = JoinFill<GasFiller, BlobGasFiller>;
 
@@ -38,68 +17,23 @@ pub type FillersWithoutNonceManagement = JoinFill<GasFiller, BlobGasFiller>;
 /// Note that the provider given by the user must not have nonce management enabled, as this
 /// is done by the `NonceManagedProvider` itself.
 /// Users can use the default `FillersWithoutNonceManagement` to create a provider.
-pub struct NonceManagedProvider<F, P, N = Ethereum>
-where
-    N: Network,
-    F: TxFiller<N>,
-    P: Provider<N>,
-{
-    inner: FillProvider<F, P, N>,
+pub struct NonceManagedProvider<P> {
+    inner: P,
     signer_address: Address,
     nonce_manager: Arc<Mutex<CachedNonceManager>>,
 }
 
-impl<F, P> NonceManagedProvider<F, P>
-where
-    F: TxFiller<Ethereum>,
-    P: Provider<Ethereum>,
-{
-    pub fn new(provider: FillProvider<F, P, Ethereum>, signer_address: Address) -> Self {
+impl<P> NonceManagedProvider<P> {
+    pub fn new(provider: P, signer_address: Address) -> Self {
         Self {
             inner: provider,
             signer_address,
             nonce_manager: Default::default(),
         }
     }
-
-    pub async fn send_transaction_sync(
-        &self,
-        mut tx: TransactionRequest,
-    ) -> TransportResult<TransactionReceipt> {
-        let nonce = self
-            .nonce_manager
-            .lock()
-            .await
-            .get_next_nonce(&self.inner, self.signer_address)
-            .await?;
-        tx.set_nonce(nonce);
-
-        let mut tx_bytes = Vec::new();
-        self.inner
-            .fill(tx)
-            .await?
-            .try_into_envelope()
-            .map_err(|e| TransportError::LocalUsageError(Box::new(e)))?
-            .encode_2718(&mut tx_bytes);
-
-        let res = self
-            .client()
-            .request("eth_sendRawTransactionSync", (Bytes::from(tx_bytes),))
-            .await;
-        if res.is_err() {
-            // Reset the nonce manager if the transaction sending failed.
-            *self.nonce_manager.lock().await = Default::default();
-        }
-        res
-    }
 }
 
-impl<F, P, N> Clone for NonceManagedProvider<F, P, N>
-where
-    N: Network,
-    F: TxFiller<N>,
-    P: Provider<N> + Clone,
-{
+impl<P: Clone> Clone for NonceManagedProvider<P> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -109,15 +43,38 @@ where
     }
 }
 
+// Only the transaction sending/signing methods are overridden, as the `TxFiller`s of the inner
+// provider only act on these operations.
+// All other methods intentionally use the trait defaults, which perform their RPC requests via
+// `self.root()`, i.e. the same client the inner provider forwards to. If a layer intercepting
+// other operations is ever added to the inner provider, forward these operations here as well.
 #[async_trait::async_trait]
-impl<F, P, N> Provider<N> for NonceManagedProvider<F, P, N>
+impl<N, P> Provider<N> for NonceManagedProvider<P>
 where
     N: Network,
-    F: TxFiller<N>,
     P: Provider<N>,
 {
     fn root(&self) -> &RootProvider<N> {
         self.inner.root()
+    }
+
+    async fn send_transaction_sync(
+        &self,
+        mut tx: N::TransactionRequest,
+    ) -> TransportResult<N::ReceiptResponse> {
+        let nonce = self
+            .nonce_manager
+            .lock()
+            .await
+            .get_next_nonce(&self.inner, self.signer_address)
+            .await?;
+        tx.set_nonce(nonce);
+        let res = self.inner.send_transaction_sync(tx).await;
+        if res.is_err() {
+            // Reset the nonce manager if the transaction sending failed.
+            *self.nonce_manager.lock().await = Default::default();
+        }
+        res
     }
 
     async fn send_transaction(
@@ -139,330 +96,61 @@ where
         res
     }
 
-    fn get_accounts(&self) -> ProviderCall<NoParams, Vec<Address>> {
-        self.inner.get_accounts()
-    }
-
-    fn get_blob_base_fee(&self) -> ProviderCall<NoParams, U128, u128> {
-        self.inner.get_blob_base_fee()
-    }
-
-    fn get_block_number(&self) -> ProviderCall<NoParams, U64, BlockNumber> {
-        self.inner.get_block_number()
-    }
-
-    fn call<'req>(&self, tx: N::TransactionRequest) -> EthCall<N, Bytes> {
-        self.inner.call(tx)
-    }
-
-    fn call_many<'req>(
+    // Not used but overriden for consistency with other send_transaction methods.
+    async fn send_transaction_sync_internal(
         &self,
-        bundles: &'req [Bundle],
-    ) -> EthCallMany<'req, N, Vec<Vec<EthCallResponse>>> {
-        self.inner.call_many(bundles)
+        tx: SendableTx<N>,
+    ) -> TransportResult<N::ReceiptResponse> {
+        let tx = match tx {
+            SendableTx::Builder(mut tx) => {
+                let nonce = self
+                    .nonce_manager
+                    .lock()
+                    .await
+                    .get_next_nonce(&self.inner, self.signer_address)
+                    .await?;
+                tx.set_nonce(nonce);
+                SendableTx::Builder(tx)
+            }
+            // An envelope is already signed, with its nonce baked in.
+            tx => tx,
+        };
+        let res = self.inner.send_transaction_sync_internal(tx).await;
+        if res.is_err() {
+            // Reset the nonce manager if the transaction sending failed.
+            *self.nonce_manager.lock().await = Default::default();
+        }
+        res
     }
 
-    fn simulate<'req>(
-        &self,
-        payload: &'req SimulatePayload,
-    ) -> RpcWithBlock<&'req SimulatePayload, Vec<SimulatedBlock<N::BlockResponse>>> {
-        self.inner.simulate(payload)
-    }
-
-    fn get_chain_id(&self) -> ProviderCall<NoParams, U64, u64> {
-        self.inner.get_chain_id()
-    }
-
-    fn create_access_list<'a>(
-        &self,
-        request: &'a N::TransactionRequest,
-    ) -> RpcWithBlock<&'a N::TransactionRequest, AccessListResult> {
-        self.inner.create_access_list(request)
-    }
-
-    fn estimate_gas<'req>(&self, tx: N::TransactionRequest) -> EthCall<N, U64, u64> {
-        self.inner.estimate_gas(tx)
-    }
-
-    async fn get_fee_history(
-        &self,
-        block_count: u64,
-        last_block: BlockNumberOrTag,
-        reward_percentiles: &[f64],
-    ) -> TransportResult<FeeHistory> {
-        self.inner
-            .get_fee_history(block_count, last_block, reward_percentiles)
-            .await
-    }
-
-    fn get_gas_price(&self) -> ProviderCall<NoParams, U128, u128> {
-        self.inner.get_gas_price()
-    }
-
-    fn get_account(&self, address: Address) -> RpcWithBlock<Address, TrieAccount> {
-        self.inner.get_account(address)
-    }
-
-    fn get_balance(&self, address: Address) -> RpcWithBlock<Address, U256, U256> {
-        self.inner.get_balance(address)
-    }
-
-    fn get_block(&self, block: BlockId) -> EthGetBlock<N::BlockResponse> {
-        self.inner.get_block(block)
-    }
-
-    fn get_block_by_hash(&self, hash: BlockHash) -> EthGetBlock<N::BlockResponse> {
-        self.inner.get_block_by_hash(hash)
-    }
-
-    fn get_block_by_number(&self, number: BlockNumberOrTag) -> EthGetBlock<N::BlockResponse> {
-        self.inner.get_block_by_number(number)
-    }
-
-    async fn get_block_transaction_count_by_hash(
-        &self,
-        hash: BlockHash,
-    ) -> TransportResult<Option<u64>> {
-        self.inner.get_block_transaction_count_by_hash(hash).await
-    }
-
-    async fn get_block_transaction_count_by_number(
-        &self,
-        block_number: BlockNumberOrTag,
-    ) -> TransportResult<Option<u64>> {
-        self.inner
-            .get_block_transaction_count_by_number(block_number)
-            .await
-    }
-
-    fn get_block_receipts(
-        &self,
-        block: BlockId,
-    ) -> ProviderCall<(BlockId,), Option<Vec<N::ReceiptResponse>>> {
-        self.inner.get_block_receipts(block)
-    }
-
-    fn get_code_at(&self, address: Address) -> RpcWithBlock<Address, Bytes> {
-        self.inner.get_code_at(address)
-    }
-
-    async fn watch_blocks(&self) -> TransportResult<FilterPollerBuilder<B256>> {
-        self.inner.watch_blocks().await
-    }
-
-    async fn watch_pending_transactions(&self) -> TransportResult<FilterPollerBuilder<B256>> {
-        self.inner.watch_pending_transactions().await
-    }
-
-    async fn watch_logs(&self, filter: &Filter) -> TransportResult<FilterPollerBuilder<Log>> {
-        self.inner.watch_logs(filter).await
-    }
-
-    async fn watch_full_pending_transactions(
-        &self,
-    ) -> TransportResult<FilterPollerBuilder<N::TransactionResponse>> {
-        self.inner.watch_full_pending_transactions().await
-    }
-
-    async fn get_filter_changes_dyn(&self, id: U256) -> TransportResult<FilterChanges> {
-        self.inner.get_filter_changes_dyn(id).await
-    }
-
-    async fn get_filter_logs(&self, id: U256) -> TransportResult<Vec<Log>> {
-        self.inner.get_filter_logs(id).await
-    }
-
-    async fn uninstall_filter(&self, id: U256) -> TransportResult<bool> {
-        self.inner.uninstall_filter(id).await
-    }
-
-    async fn watch_pending_transaction(
-        &self,
-        config: PendingTransactionConfig,
-    ) -> Result<PendingTransaction, PendingTransactionError> {
-        self.inner.watch_pending_transaction(config).await
-    }
-
-    async fn get_logs(&self, filter: &Filter) -> TransportResult<Vec<Log>> {
-        self.inner.get_logs(filter).await
-    }
-
-    fn get_proof(
-        &self,
-        address: Address,
-        keys: Vec<StorageKey>,
-    ) -> RpcWithBlock<(Address, Vec<StorageKey>), EIP1186AccountProofResponse> {
-        self.inner.get_proof(address, keys)
-    }
-
-    fn get_storage_at(
-        &self,
-        address: Address,
-        key: U256,
-    ) -> RpcWithBlock<(Address, U256), StorageValue> {
-        self.inner.get_storage_at(address, key)
-    }
-
-    fn get_transaction_by_hash(
-        &self,
-        hash: TxHash,
-    ) -> ProviderCall<(TxHash,), Option<N::TransactionResponse>> {
-        self.inner.get_transaction_by_hash(hash)
-    }
-
-    fn get_transaction_by_block_hash_and_index(
-        &self,
-        block_hash: B256,
-        index: usize,
-    ) -> ProviderCall<(B256, Index), Option<N::TransactionResponse>> {
-        self.inner
-            .get_transaction_by_block_hash_and_index(block_hash, index)
-    }
-
-    fn get_raw_transaction_by_block_hash_and_index(
-        &self,
-        block_hash: B256,
-        index: usize,
-    ) -> ProviderCall<(B256, Index), Option<Bytes>> {
-        self.inner
-            .get_raw_transaction_by_block_hash_and_index(block_hash, index)
-    }
-
-    fn get_transaction_by_block_number_and_index(
-        &self,
-        block_number: BlockNumberOrTag,
-        index: usize,
-    ) -> ProviderCall<(BlockNumberOrTag, Index), Option<N::TransactionResponse>> {
-        self.inner
-            .get_transaction_by_block_number_and_index(block_number, index)
-    }
-
-    fn get_raw_transaction_by_block_number_and_index(
-        &self,
-        block_number: BlockNumberOrTag,
-        index: usize,
-    ) -> ProviderCall<(BlockNumberOrTag, Index), Option<Bytes>> {
-        self.inner
-            .get_raw_transaction_by_block_number_and_index(block_number, index)
-    }
-
-    fn get_raw_transaction_by_hash(&self, hash: TxHash) -> ProviderCall<(TxHash,), Option<Bytes>> {
-        self.inner.get_raw_transaction_by_hash(hash)
-    }
-
-    fn get_transaction_count(
-        &self,
-        address: Address,
-    ) -> RpcWithBlock<Address, U64, u64, fn(U64) -> u64> {
-        self.inner.get_transaction_count(address)
-    }
-
-    fn get_transaction_receipt(
-        &self,
-        hash: TxHash,
-    ) -> ProviderCall<(TxHash,), Option<N::ReceiptResponse>> {
-        self.inner.get_transaction_receipt(hash)
-    }
-
-    async fn get_uncle(&self, tag: BlockId, idx: u64) -> TransportResult<Option<N::BlockResponse>> {
-        self.inner.get_uncle(tag, idx).await
-    }
-
-    async fn get_uncle_count(&self, tag: BlockId) -> TransportResult<u64> {
-        self.inner.get_uncle_count(tag).await
-    }
-
-    fn get_max_priority_fee_per_gas(&self) -> ProviderCall<NoParams, U128, u128> {
-        self.inner.get_max_priority_fee_per_gas()
-    }
-
-    async fn new_block_filter(&self) -> TransportResult<U256> {
-        self.inner.new_block_filter().await
-    }
-
-    async fn new_filter(&self, filter: &Filter) -> TransportResult<U256> {
-        self.inner.new_filter(filter).await
-    }
-
-    async fn new_pending_transactions_filter(&self, full: bool) -> TransportResult<U256> {
-        self.inner.new_pending_transactions_filter(full).await
-    }
-
-    async fn send_raw_transaction(
-        &self,
-        encoded_tx: &[u8],
-    ) -> TransportResult<PendingTransactionBuilder<N>> {
-        self.inner.send_raw_transaction(encoded_tx).await
-    }
-
-    async fn send_raw_transaction_conditional(
-        &self,
-        encoded_tx: &[u8],
-        conditional: TransactionConditional,
-    ) -> TransportResult<PendingTransactionBuilder<N>> {
-        self.inner
-            .send_raw_transaction_conditional(encoded_tx, conditional)
-            .await
-    }
-
+    // Not used but overriden for consistency with other send_transaction methods.
     async fn send_transaction_internal(
         &self,
         tx: SendableTx<N>,
     ) -> TransportResult<PendingTransactionBuilder<N>> {
-        self.inner.send_transaction_internal(tx).await
+        let tx = match tx {
+            SendableTx::Builder(mut tx) => {
+                let nonce = self
+                    .nonce_manager
+                    .lock()
+                    .await
+                    .get_next_nonce(&self.inner, self.signer_address)
+                    .await?;
+                tx.set_nonce(nonce);
+                SendableTx::Builder(tx)
+            }
+            // An envelope is already signed, with its nonce baked in.
+            tx => tx,
+        };
+        let res = self.inner.send_transaction_internal(tx).await;
+        if res.is_err() {
+            // Reset the nonce manager if the transaction sending failed.
+            *self.nonce_manager.lock().await = Default::default();
+        }
+        res
     }
 
     async fn sign_transaction(&self, tx: N::TransactionRequest) -> TransportResult<Bytes> {
         self.inner.sign_transaction(tx).await
-    }
-
-    fn subscribe_blocks(&self) -> GetSubscription<(SubscriptionKind,), N::HeaderResponse> {
-        self.inner.subscribe_blocks()
-    }
-
-    fn subscribe_pending_transactions(&self) -> GetSubscription<(SubscriptionKind,), B256> {
-        self.inner.subscribe_pending_transactions()
-    }
-
-    fn subscribe_full_pending_transactions(
-        &self,
-    ) -> GetSubscription<(SubscriptionKind, Params), N::TransactionResponse> {
-        self.inner.subscribe_full_pending_transactions()
-    }
-
-    fn subscribe_logs(&self, filter: &Filter) -> GetSubscription<(SubscriptionKind, Params), Log> {
-        self.inner.subscribe_logs(filter)
-    }
-
-    async fn unsubscribe(&self, id: B256) -> TransportResult<()> {
-        self.inner.unsubscribe(id).await
-    }
-
-    fn syncing(&self) -> ProviderCall<NoParams, SyncStatus> {
-        self.inner.syncing()
-    }
-
-    fn get_client_version(&self) -> ProviderCall<NoParams, String> {
-        self.inner.get_client_version()
-    }
-
-    fn get_sha3(&self, data: &[u8]) -> ProviderCall<(String,), B256> {
-        self.inner.get_sha3(data)
-    }
-
-    fn get_net_version(&self) -> ProviderCall<NoParams, U64, u64> {
-        self.inner.get_net_version()
-    }
-
-    async fn raw_request_dyn(
-        &self,
-        method: Cow<'static, str>,
-        params: &RawValue,
-    ) -> TransportResult<Box<RawValue>> {
-        self.inner.raw_request_dyn(method, params).await
-    }
-
-    fn transaction_request(&self) -> N::TransactionRequest {
-        self.inner.transaction_request()
     }
 }

--- a/kms-connector/crates/utils/src/provider.rs
+++ b/kms-connector/crates/utils/src/provider.rs
@@ -1,5 +1,5 @@
 use alloy::{
-    consensus::Account,
+    consensus::TrieAccount,
     eips::{BlockId, BlockNumberOrTag, Encodable2718},
     network::{Ethereum, Network, TransactionBuilder},
     primitives::{
@@ -199,7 +199,7 @@ where
         self.inner.get_gas_price()
     }
 
-    fn get_account(&self, address: Address) -> RpcWithBlock<Address, Account> {
+    fn get_account(&self, address: Address) -> RpcWithBlock<Address, TrieAccount> {
         self.inner.get_account(address)
     }
 

--- a/kms-connector/crates/utils/src/provider.rs
+++ b/kms-connector/crates/utils/src/provider.rs
@@ -1,8 +1,8 @@
 use alloy::{
     network::{Network, TransactionBuilder},
-    primitives::{Address, Bytes},
+    primitives::{Address, Bytes, U64},
     providers::{
-        PendingTransactionBuilder, Provider, RootProvider, SendableTx,
+        EthCall, PendingTransactionBuilder, Provider, RootProvider, SendableTx,
         fillers::{BlobGasFiller, CachedNonceManager, GasFiller, JoinFill, NonceManager},
     },
     transports::TransportResult,
@@ -43,11 +43,15 @@ impl<P: Clone> Clone for NonceManagedProvider<P> {
     }
 }
 
-// Only the transaction sending/signing methods are overridden, as the `TxFiller`s of the inner
-// provider only act on these operations.
-// All other methods intentionally use the trait defaults, which perform their RPC requests via
-// `self.root()`, i.e. the same client the inner provider forwards to. If a layer intercepting
-// other operations is ever added to the inner provider, forward these operations here as well.
+// We forward to `self.inner` exactly the methods that rely on the wallet: the `send_*`/
+// `sign_transaction` methods (which build and sign the transaction) and `call`/`estimate_gas`
+// (which need the `from` field set to the signer address). Any other method left to the trait
+// default reaches the same underlying node and behaves identically, so it doesn't need forwarding.
+//
+// If a wallet-dependent method were missing here, it would fall back to the trait default, which
+// skips the fillers: `estimate_gas`, for example, would then run with `from = 0x0` instead of the
+// signer address, and could revert on contracts that restrict callers. This list is complete for
+// the current `alloy` version, and the unit tests below guard the methods our services rely on.
 #[async_trait::async_trait]
 impl<N, P> Provider<N> for NonceManagedProvider<P>
 where
@@ -152,5 +156,111 @@ where
 
     async fn sign_transaction(&self, tx: N::TransactionRequest) -> TransportResult<Bytes> {
         self.inner.sign_transaction(tx).await
+    }
+
+    fn call(&self, tx: N::TransactionRequest) -> EthCall<N, Bytes> {
+        self.inner.call(tx)
+    }
+
+    fn estimate_gas(&self, tx: N::TransactionRequest) -> EthCall<N, U64, u64> {
+        self.inner.estimate_gas(tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{config::KmsWallet, conn::WalletProvider};
+    use alloy::{
+        providers::ProviderBuilder,
+        rpc::{client::RpcClient, json_rpc::RequestPacket, types::TransactionRequest},
+        transports::mock::{Asserter, MockTransport},
+    };
+    use std::sync::Mutex as StdMutex;
+
+    /// The JSON-RPC requests received by the mocked node, serialized, in order.
+    type RecordedRequests = Arc<StdMutex<Vec<String>>>;
+
+    // Builds the exact provider stack used in production on top of a mocked transport that
+    // records every JSON-RPC request it receives.
+    fn wallet_provider(asserter: Asserter) -> (WalletProvider, Address, RecordedRequests) {
+        let wallet = KmsWallet::from_private_key_str(
+            "0x3f45b129a7fd099146e9fe63851a71646231f7743c712695f3b2d2bf0e41c774",
+            None,
+        )
+        .unwrap();
+        let signer_address = wallet.address();
+
+        let requests = RecordedRequests::default();
+        let requests_recorder = requests.clone();
+        let transport = tower::ServiceBuilder::new()
+            .map_request(move |request: RequestPacket| {
+                if let RequestPacket::Single(single) = &request {
+                    let serialized = serde_json::to_string(single).unwrap();
+                    requests_recorder.lock().unwrap().push(serialized);
+                }
+                request
+            })
+            .service(MockTransport::new(asserter));
+
+        let inner_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_chain_id(1)
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(wallet)
+            .connect_client(RpcClient::new(transport, true));
+        let provider = NonceManagedProvider::new(inner_provider, signer_address);
+        (provider, signer_address, requests)
+    }
+
+    // Extracts the `from` field of the single `expected_method` request the node received.
+    fn from_field_received_by_node(
+        requests: &RecordedRequests,
+        expected_method: &str,
+    ) -> Option<Address> {
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let request: serde_json::Value = serde_json::from_str(&requests[0]).unwrap();
+        assert_eq!(request["method"], expected_method);
+        request["params"][0]["from"]
+            .as_str()
+            .map(|from| from.parse().unwrap())
+    }
+
+    // `estimate_gas` must delegate to the inner provider so its wallet filler populates `from`.
+    // If it fell back to the `Provider` trait default (which routes through the fillerless
+    // `RootProvider`), the node would run the estimation with `from = 0x0` instead of the signer
+    // address, which could revert on contracts that restrict callers.
+    #[tokio::test]
+    async fn estimate_gas_goes_through_wallet_filler() {
+        let asserter = Asserter::new();
+        let (provider, signer_address, requests) = wallet_provider(asserter.clone());
+        asserter.push_success(&U64::from(21_000));
+
+        // A request with no `from`, as produced by `CallBuilder::into_transaction_request()`.
+        provider
+            .estimate_gas(TransactionRequest::default())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            from_field_received_by_node(&requests, "eth_estimateGas"),
+            Some(signer_address)
+        );
+    }
+
+    // Same guarantee for `call`, which the tx-sender relies on for caller-gated contract reads.
+    #[tokio::test]
+    async fn call_goes_through_wallet_filler() {
+        let asserter = Asserter::new();
+        let (provider, signer_address, requests) = wallet_provider(asserter.clone());
+        asserter.push_success(&Bytes::new());
+
+        provider.call(TransactionRequest::default()).await.unwrap();
+
+        assert_eq!(
+            from_field_received_by_node(&requests, "eth_call"),
+            Some(signer_address)
+        );
     }
 }

--- a/kms-connector/crates/utils/src/provider.rs
+++ b/kms-connector/crates/utils/src/provider.rs
@@ -96,7 +96,7 @@ where
         res
     }
 
-    // Not used but overriden for consistency with other send_transaction methods.
+    // Not used but overridden for consistency with other send_transaction methods.
     async fn send_transaction_sync_internal(
         &self,
         tx: SendableTx<N>,
@@ -123,7 +123,7 @@ where
         res
     }
 
-    // Not used but overriden for consistency with other send_transaction methods.
+    // Not used but overridden for consistency with other send_transaction methods.
     async fn send_transaction_internal(
         &self,
         tx: SendableTx<N>,

--- a/kms-connector/rust-toolchain.toml
+++ b/kms-connector/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/relayer/Cargo.lock
+++ b/relayer/Cargo.lock
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "fhevm_gateway_bindings"
-version = "0.1.0-rc14"
+version = "0.15.0"
 dependencies = [
  "alloy",
  "serde",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "fhevm_host_bindings"
-version = "0.10.0"
+version = "0.15.0"
 dependencies = [
  "alloy",
  "serde",

--- a/shared/ciphertext-attestation/Cargo.toml
+++ b/shared/ciphertext-attestation/Cargo.toml
@@ -7,7 +7,8 @@ license = "BSD-3-Clause-Clear"
 
 [dependencies]
 alloy-primitives = { version = "1", default-features = false, features = ["std", "serde"] }
-alloy-signer = { version = "1", default-features = false }
+# Allow use of alloy version 1.*.* or 2.*.* for the parent crate
+alloy-signer = { version = ">=1, <3", default-features = false }
 serde = { version = "1", default-features = false, features = ["std", "derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 sha3 = { version = "0.10.8", default-features = false }
@@ -16,5 +17,5 @@ thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-alloy-signer-local = { version = "1", default-features = false }
+alloy-signer-local = { version = ">=1, <3", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/shared/user-decryption-signature/Cargo.toml
+++ b/shared/user-decryption-signature/Cargo.toml
@@ -8,7 +8,8 @@ license = "BSD-3-Clause-Clear"
 [dependencies]
 fhevm_gateway_bindings = { path = "../../gateway-contracts/rust_bindings", default-features = false }
 
-alloy = { version = "1", default-features = false, features = [
+# Allow use of alloy version 1.*.* or 2.*.* for the parent crate
+alloy = { version = ">=1, <3", default-features = false, features = [
     "k256",
     "providers",
     "rpc-types",
@@ -17,7 +18,7 @@ alloy = { version = "1", default-features = false, features = [
 thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]
-alloy = { version = "1", default-features = false, features = [
+alloy = { version = ">=1, <3", default-features = false, features = [
     "json-rpc",
     "signer-local",
 ] }


### PR DESCRIPTION
### What

Bumps `alloy` to `2.2.0` and the KMS connector Rust toolchain to 1.97.1.

- kms-connector: bump alloy =1.0.38 → =2.1.1, Rust 1.92.0 → 1.97.1.
- shared crates & rust bindings: relax the alloy requirement to allow both `1.x` and `2.x`, so parent crates can pick their version.
- tx-sender / provider: simplify provider setup against the new alloy API — the utils/provider.rs helper shrinks significantly (~390 lines removed) and the recursion-limit bump is no longer needed.
- copro & relayer lockfiles updated.
  - they were outdated because of this [PR](https://github.com/zama-ai/fhevm/pull/3182), and I wanted to make sure crates update were not breaking anything
  - confirmed thanks to the CI :slightly_smiling_face: 

###  Notes

Housekeeping only, no functional changes intended