### PR TITLE
fix(host-contracts): reject persist-nothing fhe_eval frames under a finite HCU block cap

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/idl/confidential_token.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/confidential_token.json
@@ -2334,86 +2334,81 @@
     },
     {
       "code": 6020,
-      "name": "HcuAuthorityMismatch",
-      "msg": "HCU authority does not match mint"
-    },
-    {
-      "code": 6021,
       "name": "InvalidKmsCertificate",
       "msg": "KMS public-decrypt certificate is invalid"
     },
     {
-      "code": 6022,
+      "code": 6021,
       "name": "PublicDecryptProofInvalid",
       "msg": "public-decrypt MMR proof is invalid for this lineage"
     },
     {
-      "code": 6023,
+      "code": 6022,
       "name": "GatewayVerifierConfigUnset",
       "msg": "gateway verifier config is not set"
     },
     {
-      "code": 6024,
+      "code": 6023,
       "name": "InvalidKmsContext",
       "msg": "KMS context is not valid for this request"
     },
     {
-      "code": 6025,
+      "code": 6024,
       "name": "RequestWitnessMismatch",
       "msg": "request witness does not match"
     },
     {
-      "code": 6026,
+      "code": 6025,
       "name": "RequestWitnessUnavailable",
       "msg": "request witness is expired or already consumed"
     },
     {
-      "code": 6027,
+      "code": 6026,
       "name": "MaterialCommitmentMismatch",
       "msg": "material commitment witness does not match"
     },
     {
-      "code": 6028,
+      "code": 6027,
       "name": "PublicDecryptNotReleased",
       "msg": "handle is not released for public decrypt"
     },
     {
-      "code": 6029,
+      "code": 6028,
       "name": "InvalidFheEvalPlan",
       "msg": "FHE eval plan is invalid"
     },
     {
-      "code": 6030,
+      "code": 6029,
       "name": "DuplicateFheEvalAccount",
       "msg": "FHE eval account list contains a duplicate account"
     },
     {
-      "code": 6031,
+      "code": 6030,
       "name": "UnexpectedFheEvalAccount",
       "msg": "FHE eval account list contains an unexpected account"
     },
     {
-      "code": 6032,
+      "code": 6031,
       "name": "MissingFheEvalAccount",
       "msg": "FHE eval plan is missing a required dynamic account"
     },
     {
-      "code": 6033,
+      "code": 6032,
       "name": "FheEvalAccountNotWritable",
       "msg": "FHE eval dynamic account must be writable"
     },
     {
-      "code": 6034,
+      "code": 6033,
       "name": "DuplicateFheOutputAuthority",
       "msg": "FHE eval output authority list contains a duplicate authority"
     },
     {
-      "code": 6035,
+      "code": 6034,
       "name": "UnexpectedFheOutputAuthority",
       "msg": "FHE eval output authority list contains an unexpected authority"
     },
     {
-      "code": 6036,
+      "code": 6035,
       "name": "MissingFheOutputAuthority",
       "msg": "FHE eval plan is missing a required output authority"
     }

--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -1988,6 +1988,11 @@
       "code": 6069,
       "name": "InvalidChainTypeBit",
       "msg": "host chain id must set the Solana chain-type high bit and the gateway chain id must not"
+    },
+    {
+      "code": 6070,
+      "name": "FheEvalUnanchoredUnderBlockCap",
+      "msg": "FHE eval frame anchors no durable/verified binding under a finite HCU block cap"
     }
   ],
   "types": [

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/solana_poc.rs
@@ -403,7 +403,7 @@ fn transfer_ix(
         program_id: fixture.token_program_id,
         accounts: token::accounts::ConfidentialTransfer {
             // Block-cap optional accounts threaded through the transfer CPI; the default
-            // unrestricted cap means None/None here. The mint's HCU authority is mandatory.
+            // unrestricted cap means None/None here.
             hcu_block_meter: None,
             hcu_trusted_app_record: None,
             owner: fixture.alice.pubkey(),

--- a/solana/crates/zama-fhe/src/lib.rs
+++ b/solana/crates/zama-fhe/src/lib.rs
@@ -2237,6 +2237,12 @@ impl EvalBuilder {
     /// Mirrors the host admission checks (`context_id != 0`, non-empty steps,
     /// `steps.len() <= MAX_FHE_EVAL_OPS`) so a malformed frame fails locally
     /// instead of on-chain.
+    ///
+    /// Not mirrored (it depends on the deployed `hcu_block_cap_per_app`, unknown here): under a
+    /// finite block cap the host rejects a persist-nothing frame — one binding no durable input, no
+    /// verified input, and no durable output — with `FheEvalUnanchoredUnderBlockCap`
+    /// (fhevm-internal#1744). Give such a frame a durable output (the bootstrap/mint path) or a
+    /// verified input if it must run under a finite cap.
     pub fn finish(self) -> Result<EvalPlan> {
         validate_app_authority(self.app_authority)?;
         if self.context_id.bytes() == [0u8; 32] {

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1507,11 +1507,28 @@ something the caller cannot freely re-pick:
   unrelated key loses input access. No other account the caller controls (`payer`,
   `app_account_authority`, output authorities) yields a fresh meter.
 
-It does NOT, by itself, constrain an **input-free frame** — `Rand` / `TrivialEncrypt` / scalar-only
-work with a transient (non-durable) output — submitted by a direct caller: there `compute_subject` is
-an unconstrained signer, so such a caller can still rotate it for a fresh per-slot meter. Closing that
-residual case (e.g. requiring input-free direct frames to meter a stable caller identity) is tracked
-as a follow-up; it does not affect the token program, whose compute subject is always the mint PDA.
+Metering the `compute_subject` does NOT, by itself, constrain a **persist-nothing frame** — `Rand` /
+`TrivialEncrypt` / scalar-only work with a transient (non-durable) output and no verified input —
+submitted by a direct caller: there `compute_subject` is an unconstrained signer, so such a caller
+could still rotate it for a fresh per-slot meter. The value-less part of that residual case
+(fhevm-internal#1744) is now closed: when `hcu_block_cap_per_app` is finite (`!= u64::MAX`),
+`fhe_eval` preflight rejects any frame that binds no `AllowedDurable` operand, no `VerifiedInput`
+operand, and no `AllowedDurable` output (`FheEvalUnanchoredUnderBlockCap`). Such a frame persists
+nothing and verifies nothing — `compute_subject` is a free variable and the frame is also value-less
+(its transient outputs create no ACL leaf and are undecryptable) — so nothing legitimate is
+forbidden. Under the ship default (`u64::MAX`) the check short-circuits, so behavior is unchanged
+where no finite cap is deployed. This never affected the token program, whose compute subject is
+always the mint PDA and whose frames always bind durable balance inputs.
+
+This is #1744's Option 1 broadened by a durable-output allowance to preserve the legitimate
+trivial-encrypt/`Rand` -> durable-output bootstrap/mint path. That allowance is not a full close: a
+durable output does NOT pin `compute_subject` (output binding authorizes against
+`app_account_authority`, never the subject), so a caller can still rotate the subject while binding a
+throwaway output lineage and get a fresh per-slot meter each time. That vector remains open but is
+now rent-bounded — each rotation costs ~one `HcuBlockMeter` PDA rent rather than being free —
+whereas the persist-nothing rotation was free. Closing it fully requires a host-registered app
+identity an input-free frame must present to be metered (#1708 Option B / #1744 Option 2), still
+deferred as speculative until input-free frames become a real metered workload.
 
 `hcu_authority` is removed everywhere: the host `fhe_eval` account list (an intended ABI break,
 resynced in the host-listener IDL), the `zama-fhe` CPI account struct, the confidential-token

--- a/solana/programs/confidential-token/src/errors.rs
+++ b/solana/programs/confidential-token/src/errors.rs
@@ -65,9 +65,6 @@ pub enum ConfidentialTokenError {
     /// Total-supply authority PDA did not match the mint.
     #[msg("total supply authority does not match mint")]
     TotalSupplyAuthorityMismatch,
-    /// HCU authority PDA did not match the mint.
-    #[msg("HCU authority does not match mint")]
-    HcuAuthorityMismatch,
     /// The KMS EIP-712 public-decrypt certificate failed secp256k1 threshold verification.
     #[msg("KMS public-decrypt certificate is invalid")]
     InvalidKmsCertificate,

--- a/solana/programs/zama-host/src/errors.rs
+++ b/solana/programs/zama-host/src/errors.rs
@@ -233,4 +233,12 @@ pub enum ZamaHostError {
         "host chain id must set the Solana chain-type high bit and the gateway chain id must not"
     )]
     InvalidChainTypeBit,
+
+    /// Under a finite `hcu_block_cap_per_app`, a frame that binds no durable input, no verified
+    /// input, and no durable output leaves `compute_subject` a free variable: the caller could
+    /// rotate fresh subjects to mint fresh per-slot meters and evade the cap (fhevm-internal#1744).
+    /// Such a frame is also value-less — its transient outputs create no ACL leaf and are
+    /// undecryptable — so it is rejected outright.
+    #[msg("FHE eval frame anchors no durable/verified binding under a finite HCU block cap")]
+    FheEvalUnanchoredUnderBlockCap,
 }

--- a/solana/programs/zama-host/src/instructions/fhe_eval/preflight.rs
+++ b/solana/programs/zama-host/src/instructions/fhe_eval/preflight.rs
@@ -4,12 +4,113 @@ pub(super) fn preflight_eval_frame<'info>(
     ctx: &Context<'info, FheEval<'info>>,
     args: &FheEvalArgs,
 ) -> Result<()> {
+    assert_frame_pins_or_persists_under_cap(args, ctx.accounts.host_config.hcu_block_cap_per_app)?;
     preflight_eval_frame_accounts(
         ctx.remaining_accounts,
         args,
         ctx.accounts.app_account_authority.key(),
         ctx.accounts.host_config.grant_deny_list_enabled,
     )
+}
+
+/// Rejects the value-less persist-nothing frame class under a finite block cap (fhevm-internal#1744).
+///
+/// The per-slot HCU meter keys on the signed `compute_subject`. A durable input requires the
+/// subject to be an allowed ACL subject, and a verified input requires it to equal the attested
+/// contract, so either operand pins the subject — the caller cannot swap in a fresh key without
+/// losing input access. A frame with neither pinning operand and no durable output persists nothing
+/// and verifies nothing: `compute_subject` is a free variable AND the frame produces nothing of
+/// value (its transient outputs create no ACL leaf and are undecryptable). That class is what the
+/// keypair-rotation bypass rode, so it is rejected before compute.
+///
+/// A durable OUTPUT is allowed through here, but note it does NOT pin the subject: output binding
+/// authorizes against `app_account_authority`, never `compute_subject`. So a throwaway-lineage
+/// create/supersede still lets a caller rotate the subject for a fresh per-slot meter — that vector
+/// remains open, but is rent-bounded (~one `HcuBlockMeter` PDA rent per rotation) rather than free,
+/// and closing it fully needs a registered app identity (the issue's Option 2, deferred). The
+/// allowance is kept because it is also the legitimate trivial-encrypt/`Rand` -> durable-output
+/// bootstrap/mint path. The deactivated cap (`u64::MAX`, the ship default) short-circuits, so
+/// behavior is unchanged wherever a finite cap is not deployed.
+fn assert_frame_pins_or_persists_under_cap(
+    args: &FheEvalArgs,
+    hcu_block_cap_per_app: u64,
+) -> Result<()> {
+    if hcu_block_cap_per_app == u64::MAX {
+        return Ok(());
+    }
+    require!(
+        args.steps.iter().any(step_pins_or_persists),
+        ZamaHostError::FheEvalUnanchoredUnderBlockCap
+    );
+    Ok(())
+}
+
+/// True for an operand that pins `compute_subject`: a durable ACL input (the subject must be an
+/// allowed subject) or a verified input (the subject must equal the attested contract). Exhaustive
+/// so a future operand variant must classify itself rather than default to "does not pin".
+fn operand_pins_subject(operand: &FheEvalOperand) -> bool {
+    match operand {
+        FheEvalOperand::AllowedDurable { .. } | FheEvalOperand::VerifiedInput { .. } => true,
+        FheEvalOperand::AllowedLocal { .. } | FheEvalOperand::Scalar(_) => false,
+    }
+}
+
+/// True for an output that persists durable state. Exhaustive so a future output variant must
+/// classify itself rather than default to "does not persist".
+fn output_persists(output: &FheEvalOutput) -> bool {
+    match output {
+        FheEvalOutput::AllowedDurable { .. } => true,
+        FheEvalOutput::AllowedLocal => false,
+    }
+}
+
+/// True when a step carries a subject-pinning operand or a durable output.
+fn step_pins_or_persists(step: &FheEvalStep) -> bool {
+    let (output, operand_pins) = match step {
+        FheEvalStep::Binary {
+            lhs, rhs, output, ..
+        } => (
+            output,
+            operand_pins_subject(lhs) || operand_pins_subject(rhs),
+        ),
+        FheEvalStep::Ternary {
+            control,
+            if_true,
+            if_false,
+            output,
+            ..
+        } => (
+            output,
+            operand_pins_subject(control)
+                || operand_pins_subject(if_true)
+                || operand_pins_subject(if_false),
+        ),
+        FheEvalStep::TrivialEncrypt { output, .. }
+        | FheEvalStep::Rand { output, .. }
+        | FheEvalStep::RandBounded { output, .. } => (output, false),
+        FheEvalStep::Unary {
+            operand, output, ..
+        } => (output, operand_pins_subject(operand)),
+        FheEvalStep::Sum {
+            operands, output, ..
+        } => (output, operands.iter().any(operand_pins_subject)),
+        FheEvalStep::IsIn {
+            value, set, output, ..
+        } => (
+            output,
+            operand_pins_subject(value) || set.iter().any(operand_pins_subject),
+        ),
+        FheEvalStep::MulDiv {
+            factor1,
+            factor2,
+            output,
+            ..
+        } => (
+            output,
+            operand_pins_subject(factor1) || operand_pins_subject(factor2),
+        ),
+    };
+    operand_pins || output_persists(output)
 }
 
 fn preflight_eval_frame_accounts(
@@ -285,5 +386,107 @@ mod tests {
         let data = Box::leak(Vec::new().into_boxed_slice());
         let owner = Box::leak(Box::new(System::id()));
         AccountInfo::new(key, false, false, lamports, data, owner, false)
+    }
+
+    fn frame(steps: Vec<FheEvalStep>) -> FheEvalArgs {
+        FheEvalArgs {
+            context_id: [1; 32],
+            steps,
+        }
+    }
+
+    fn trivial_local() -> FheEvalStep {
+        FheEvalStep::TrivialEncrypt {
+            plaintext: [0; 32],
+            fhe_type: 5,
+            output: FheEvalOutput::AllowedLocal,
+        }
+    }
+
+    fn durable_output() -> FheEvalOutput {
+        FheEvalOutput::AllowedDurable {
+            output_encrypted_value_index: 0,
+            output_app_account_authority_index: None,
+            output_acl_domain_key: Pubkey::new_unique(),
+            output_app_account: Pubkey::new_unique(),
+            output_encrypted_value_label: [0; 32],
+            output_subjects: Vec::new(),
+            previous_handle: None,
+            previous_subjects: None,
+            make_public: false,
+        }
+    }
+
+    fn verified_input() -> FheEvalOperand {
+        FheEvalOperand::VerifiedInput {
+            attestation: Box::new(CoprocessorInputAttestation {
+                input_handle: [0; 32],
+                ct_handles: Vec::new(),
+                handle_index: 0,
+                user_address: [0; 32],
+                contract_address: [0; 32],
+                contract_chain_id: 0,
+                extra_data: Vec::new(),
+                signatures: Vec::new(),
+            }),
+        }
+    }
+
+    const FINITE_CAP: u64 = 500_000;
+
+    #[test]
+    fn deactivated_cap_never_rejects_persist_nothing_frame() {
+        // u64::MAX (ship default) short-circuits: behavior is unchanged where the cap is not deployed.
+        assert!(
+            assert_frame_pins_or_persists_under_cap(&frame(vec![trivial_local()]), u64::MAX)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn finite_cap_rejects_persist_nothing_frame() {
+        assert!(
+            assert_frame_pins_or_persists_under_cap(&frame(vec![trivial_local()]), FINITE_CAP)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn finite_cap_accepts_durable_output_frame() {
+        // The trivial-encrypt -> durable-output bootstrap/mint path stays legal.
+        let step = FheEvalStep::TrivialEncrypt {
+            plaintext: [0; 32],
+            fhe_type: 5,
+            output: durable_output(),
+        };
+        assert!(assert_frame_pins_or_persists_under_cap(&frame(vec![step]), FINITE_CAP).is_ok());
+    }
+
+    #[test]
+    fn finite_cap_accepts_durable_input_frame() {
+        let step = FheEvalStep::Binary {
+            op: FheBinaryOpCode::Add,
+            lhs: FheEvalOperand::AllowedDurable {
+                handle: [1; 32],
+                encrypted_value_index: 0,
+            },
+            rhs: FheEvalOperand::Scalar([2; 32]),
+            output_fhe_type: 5,
+            output: FheEvalOutput::AllowedLocal,
+        };
+        assert!(assert_frame_pins_or_persists_under_cap(&frame(vec![step]), FINITE_CAP).is_ok());
+    }
+
+    #[test]
+    fn finite_cap_accepts_verified_input_transient_frame() {
+        // A verified input pins the subject (attested contract must equal it), so a transient-output
+        // frame that carries one is anchored and not persist-nothing.
+        let step = FheEvalStep::Unary {
+            op: FheUnaryOpCode::Not,
+            operand: verified_input(),
+            output_fhe_type: 5,
+            output: FheEvalOutput::AllowedLocal,
+        };
+        assert!(assert_frame_pins_or_persists_under_cap(&frame(vec![step]), FINITE_CAP).is_ok());
     }
 }

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -1,6 +1,6 @@
 {
   "fhe_eval/max_op_frame": {
-    "compute_units": 150997,
+    "compute_units": 150922,
     "unique_accounts": 9,
     "instruction_data_bytes": 921,
     "cpi_instructions": 3,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 36
   },
   "fhe_eval/three_op_frame": {
-    "compute_units": 61299,
+    "compute_units": 61250,
     "unique_accounts": 9,
     "instruction_data_bytes": 375,
     "cpi_instructions": 3,

--- a/solana/runtime-tests/cost-snapshots/host_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/host_mollusk.json
@@ -1,6 +1,6 @@
 {
   "fhe_eval/max_op_frame": {
-    "compute_units": 150922,
+    "compute_units": 150975,
     "unique_accounts": 9,
     "instruction_data_bytes": 921,
     "cpi_instructions": 3,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 36
   },
   "fhe_eval/three_op_frame": {
-    "compute_units": 61250,
+    "compute_units": 61290,
     "unique_accounts": 9,
     "instruction_data_bytes": 375,
     "cpi_instructions": 3,

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,6 +1,6 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 329808,
+    "compute_units": 330349,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 347277,
+    "compute_units": 348028,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
-    "compute_units": 62270,
+    "compute_units": 62353,
     "unique_accounts": 11,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,6 +1,6 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 330361,
+    "compute_units": 329808,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 348040,
+    "compute_units": 347277,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
-    "compute_units": 62356,
+    "compute_units": 62270,
     "unique_accounts": 11,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -3564,6 +3564,92 @@ impl EvalFixture {
         ix
     }
 
+    /// A persist-nothing frame: a single `TrivialEncrypt` with an `AllowedLocal` output — no
+    /// durable input, no verified input, no durable output. Binds no metering identity, so under a
+    /// finite cap `compute_subject` would be a free variable (fhevm-internal#1744). No
+    /// remaining accounts.
+    fn persist_nothing_instruction(
+        &self,
+        meter: Option<Pubkey>,
+        trust: Option<Pubkey>,
+    ) -> Instruction {
+        anchor_ix(
+            self.program_id,
+            host::accounts::FheEval {
+                payer: self.authority,
+                compute_subject: self.compute_subject,
+                app_account_authority: self.app_account,
+                host_config: self.host_config,
+                system_program: system_program::ID,
+                hcu_block_meter: meter,
+                hcu_trusted_app_record: trust,
+                event_authority: event_authority(self.program_id),
+                program: self.program_id,
+            },
+            host::instruction::FheEval {
+                args: FheEvalArgs {
+                    context_id: label("persist-nothing"),
+                    steps: vec![FheEvalStep::TrivialEncrypt {
+                        plaintext: [7; 32],
+                        fhe_type: 5,
+                        output: FheEvalOutput::AllowedLocal,
+                    }],
+                },
+            },
+        )
+    }
+
+    /// An input-free frame that DOES persist: a single `TrivialEncrypt` bound into a fresh durable
+    /// output lineage — the legitimate bootstrap/mint path. Anchored by its durable output, so it
+    /// survives the persist-nothing rejection. Returns the output lineage address and instruction.
+    fn input_free_durable_instruction(&self, meter: Option<Pubkey>) -> (Pubkey, Instruction) {
+        let output_label = label("input-free-bootstrap");
+        let output_value_key = zama_solana_acl::derive_value_key(
+            self.authority.to_bytes(),
+            self.app_account.to_bytes(),
+            output_label,
+        );
+        let (output_value, _bump) = host::encrypted_value_address(output_value_key);
+        let mut ix = anchor_ix(
+            self.program_id,
+            host::accounts::FheEval {
+                payer: self.authority,
+                compute_subject: self.compute_subject,
+                app_account_authority: self.app_account,
+                host_config: self.host_config,
+                system_program: system_program::ID,
+                hcu_block_meter: meter,
+                hcu_trusted_app_record: None,
+                event_authority: event_authority(self.program_id),
+                program: self.program_id,
+            },
+            host::instruction::FheEval {
+                args: FheEvalArgs {
+                    context_id: output_label,
+                    steps: vec![FheEvalStep::TrivialEncrypt {
+                        plaintext: [7; 32],
+                        fhe_type: 5,
+                        output: FheEvalOutput::AllowedDurable {
+                            output_encrypted_value_index: 0,
+                            output_app_account_authority_index: None,
+                            output_acl_domain_key: self.authority,
+                            output_app_account: self.app_account,
+                            output_encrypted_value_label: output_label,
+                            output_subjects: vec![host::AclSubjectEntry {
+                                pubkey: self.authority,
+                            }],
+                            previous_handle: None,
+                            previous_subjects: None,
+                            make_public: false,
+                        },
+                    }],
+                },
+            },
+        );
+        ix.accounts.push(writable(output_value));
+        (output_value, ix)
+    }
+
     /// A durable-output frame that reuses the fixture's `compute_subject` (and thus its meter) but
     /// with a caller-chosen `payer` and `app_account_authority`, binding its own fresh output
     /// lineage under that authority. Everything a caller controls is varied except the ACL-bound
@@ -4247,6 +4333,52 @@ fn mollusk_fhe_eval_transient_only_frame_is_metered_via_compute_subject() {
     let meter = read_hcu_block_meter(&fixture.context, meter_pda).expect("meter created");
     assert_eq!(meter.app, fixture.block_cap_app());
     assert_eq!(meter.used_hcu, TRANSIENT_FRAME_HCU);
+}
+
+#[test]
+fn mollusk_fhe_eval_finite_cap_rejects_persist_nothing_frame() {
+    // fhevm-internal#1744: under a finite cap, a frame that binds no durable input, no verified
+    // input, and no durable output leaves `compute_subject` a free variable — the caller could
+    // rotate fresh subjects to mint fresh per-slot meters. Rejected in preflight, before compute,
+    // so no meter is created even though one is supplied.
+    let fixture = EvalFixture::with_block_cap(500_000);
+    let meter_pda = fixture.meter_pda();
+    fixture.context.process_and_validate_instruction(
+        &fixture.persist_nothing_instruction(Some(meter_pda), None),
+        &[custom_error(
+            host::errors::ZamaHostError::FheEvalUnanchoredUnderBlockCap,
+        )],
+    );
+    assert!(read_hcu_block_meter(&fixture.context, meter_pda).is_none());
+}
+
+#[test]
+fn mollusk_fhe_eval_finite_cap_allows_input_free_durable_output_bootstrap() {
+    // The bootstrap/mint path (trivial-encrypt -> durable output) is input-free but persists an
+    // ACL record, so it anchors the frame and stays legal under a finite cap.
+    let fixture = EvalFixture::with_block_cap(500_000);
+    let meter_pda = fixture.meter_pda();
+    let (output_value, ix) = fixture.input_free_durable_instruction(Some(meter_pda));
+    fixture
+        .context
+        .process_and_validate_instruction(&ix, &[Check::success()]);
+    read_encrypted_value_from_context(&fixture.context, output_value);
+    // The durable frame WAS metered onto the compute subject (a single euint64 TrivialEncrypt).
+    const TRIVIAL_ENCRYPT_EUINT64_HCU: u64 = 900;
+    let meter = read_hcu_block_meter(&fixture.context, meter_pda).expect("meter created");
+    assert_eq!(meter.app, fixture.block_cap_app());
+    assert_eq!(meter.used_hcu, TRIVIAL_ENCRYPT_EUINT64_HCU);
+}
+
+#[test]
+fn mollusk_fhe_eval_deactivated_cap_allows_persist_nothing_frame() {
+    // Under the ship default (u64::MAX) the persist-nothing rejection short-circuits, so behavior
+    // is unchanged wherever a finite cap is not deployed.
+    let fixture = EvalFixture::with_block_cap(u64::MAX);
+    fixture.context.process_and_validate_instruction(
+        &fixture.persist_nothing_instruction(None, None),
+        &[Check::success()],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Overview

Folds two follow-ups to #3212:

1. **Cleanup**: drops the stale "mint's HCU authority is mandatory" comment (`solana_poc.rs`) and the now-unreferenced `HcuAuthorityMismatch` error variant from the confidential-token program (IDL resynced; token error codes after the removed variant shift down one — intentional ABI break on this no-compat branch).
2. **fhevm-internal#1744, Option 1 (broadened)**: with the block meter keyed on the signed `compute_subject`, a frame with no pinning input and no durable output left the subject a free variable — rotate fresh keypairs, mint fresh per-slot meters, evade any finite `hcu_block_cap_per_app`.

## The check

`preflight.rs::assert_frame_pins_or_persists_under_cap`, first thing in preflight, before any meter state or compute: when `hcu_block_cap_per_app != u64::MAX`, reject plans containing no `AllowedDurable` operand, no `VerifiedInput` operand, and no `AllowedDurable` output (`FheEvalUnanchoredUnderBlockCap`, appended at enum end — no host error-code shift). Under the shipped `u64::MAX` default the check short-circuits: zero behavior change.

Boundary choice: input-free frames **with** a durable output stay legal — that is the trivial-encrypt bootstrap/mint path. A frame that persists nothing has zero legitimate value (a local-only output produces no ACL leaf and is undecryptable by construction, including by its creator), so rejecting it costs nothing.

## Honest residual

A durable **output** does not pin `compute_subject` (output binding authorizes `app_account_authority`, never the subject), so a throwaway-lineage supersede still permits meter rotation — now rent-bounded (~one `HcuBlockMeter` PDA per rotation) instead of free. Closing that fully needs registered app identity (issue's Option 2, deferred). DD-039 and the preflight docs state this explicitly.

## Verification

- Exhaustive `match` classifiers over `FheEvalStep`/`FheEvalOperand`/`FheEvalOutput` — a future variant fails to compile rather than silently classifying.
- 6 preflight unit tests + 3 new Mollusk tests (finite cap rejects persist-nothing with no meter state created; bootstrap allowed and metered; deactivated cap unchanged).
- Full runtime-tests gate green (80/379/11/8/33), IDL + golden ABI in sync, cost snapshots regenerated under the pinned 2.1.0 toolchain (few-unit binary-layout drift; snapshot fixtures run with the cap deactivated, so the check itself adds no measured CU).
- Adversarially reviewed by a separate agent; its one substantive finding (the durable-output residual above) is what the docs now state.

Closes zama-ai/fhevm-internal#1744.