### PR TITLE
refactor(host-contracts): require owner and compute in token durable audiences by construction

### DIFF
--- a/solana/programs/confidential-token/src/fhe.rs
+++ b/solana/programs/confidential-token/src/fhe.rs
@@ -12,6 +12,68 @@ use crate::{
     ConfidentialTokenAccount, ConfidentialTokenError,
 };
 
+/// Audience for a confidential-token durable output.
+///
+/// Holder-scoped lineages (balances, `transferred_amount`, `burned_amount`) must
+/// always grant the holder's owner key and the mint compute-signer PDA: the owner
+/// keeps decrypt access to their own value, and the compute signer gates the next
+/// eval that reads it. [`DurableAudience::for_owner`] takes both as required
+/// parameters, so a holder output can never be built missing either; extra owners
+/// (the recipient leg of a `transferred_amount` rotation) are additive via
+/// [`DurableAudience::with_owner`]. Mint-scoped lineages with no single holder
+/// (total supply, freshly minted random amounts) use
+/// [`DurableAudience::compute_only`], the one owner-less path.
+///
+/// This is the only way token instructions produce durable-output policies:
+/// [`DurableOutput::new`]/[`DurableOutput::new_public`] accept a `DurableAudience`
+/// and not a raw [`zama_fhe::AccessPolicy`], so the owner+compute invariant holds
+/// by construction rather than by convention at each call site.
+pub(crate) struct DurableAudience {
+    owner: Option<Pubkey>,
+    extra_owners: Vec<Pubkey>,
+    compute: Pubkey,
+}
+
+impl DurableAudience {
+    /// Holder-scoped audience granting `owner` and the mint `compute` signer.
+    pub(crate) fn for_owner(owner: Pubkey, compute: Pubkey) -> Self {
+        Self {
+            owner: Some(owner),
+            extra_owners: Vec::new(),
+            compute,
+        }
+    }
+
+    /// Mint-scoped audience with no holder, granting only the `compute` signer.
+    pub(crate) fn compute_only(compute: Pubkey) -> Self {
+        Self {
+            owner: None,
+            extra_owners: Vec::new(),
+            compute,
+        }
+    }
+
+    /// Adds an extra owner subject (the recipient of a `transferred_amount` leg).
+    pub(crate) fn with_owner(mut self, owner: Pubkey) -> Self {
+        self.extra_owners.push(owner);
+        self
+    }
+
+    /// Renders the audience into host output subjects, ordered owner(s) then
+    /// compute signer.
+    fn into_policy(self) -> zama_fhe::Result<zama_fhe::AccessPolicy> {
+        let mut subjects = Vec::with_capacity(2 + self.extra_owners.len());
+        subjects.extend(self.owner.map(zama_fhe::AccessSubject::owner));
+        subjects.extend(
+            self.extra_owners
+                .into_iter()
+                .map(zama_fhe::AccessSubject::owner),
+        );
+        subjects.push(zama_fhe::AccessSubject::compute(self.compute));
+        zama_fhe::AccessPolicy::from_subjects(subjects)
+    }
+}
+
 /// A durable eval output account bound to the exact `EncryptedValue` lineage
 /// it is allowed to create or supersede.
 pub(crate) struct DurableOutput<'info> {
@@ -28,9 +90,9 @@ impl<'info> DurableOutput<'info> {
     pub(crate) fn new(
         encrypted_value: AccountInfo<'info>,
         slot: zama_fhe::DurableSlot,
-        access: zama_fhe::AccessPolicy,
+        audience: DurableAudience,
     ) -> Result<Self> {
-        Self::new_inner(encrypted_value, slot, access, false)
+        Self::new_inner(encrypted_value, slot, audience, false)
     }
 
     /// Like [`new`], but binds the output born publicly decryptable: the host
@@ -40,15 +102,15 @@ impl<'info> DurableOutput<'info> {
     pub(crate) fn new_public(
         encrypted_value: AccountInfo<'info>,
         slot: zama_fhe::DurableSlot,
-        access: zama_fhe::AccessPolicy,
+        audience: DurableAudience,
     ) -> Result<Self> {
-        Self::new_inner(encrypted_value, slot, access, true)
+        Self::new_inner(encrypted_value, slot, audience, true)
     }
 
     fn new_inner(
         encrypted_value: AccountInfo<'info>,
         slot: zama_fhe::DurableSlot,
-        access: zama_fhe::AccessPolicy,
+        audience: DurableAudience,
         make_public: bool,
     ) -> Result<Self> {
         require_keys_eq!(
@@ -56,6 +118,10 @@ impl<'info> DurableOutput<'info> {
             slot.address(),
             ConfidentialTokenError::AmountAclMismatch
         );
+        let access = audience.into_policy().map_err(|error| {
+            msg!("invalid durable FHE output audience: {:?}", error);
+            error!(ConfidentialTokenError::InvalidFheEvalPlan)
+        })?;
         let output = if *encrypted_value.owner == System::id() {
             require!(
                 encrypted_value.data_is_empty() && !encrypted_value.executable,
@@ -595,6 +661,58 @@ pub(crate) fn allow_subjects<'info>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn audience_subjects(audience: DurableAudience) -> Vec<Pubkey> {
+        audience
+            .into_policy()
+            .unwrap()
+            .subjects()
+            .iter()
+            .map(|subject| subject.pubkey())
+            .collect()
+    }
+
+    #[test]
+    fn holder_audience_grants_owner_then_compute() {
+        let owner = Pubkey::new_unique();
+        let compute = Pubkey::new_unique();
+        assert_eq!(
+            audience_subjects(DurableAudience::for_owner(owner, compute)),
+            vec![owner, compute]
+        );
+    }
+
+    #[test]
+    fn holder_audience_appends_extra_owner_before_compute() {
+        let owner = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let compute = Pubkey::new_unique();
+        assert_eq!(
+            audience_subjects(DurableAudience::for_owner(owner, compute).with_owner(recipient)),
+            vec![owner, recipient, compute]
+        );
+    }
+
+    #[test]
+    fn compute_only_audience_grants_compute_and_no_owner() {
+        let compute = Pubkey::new_unique();
+        assert_eq!(
+            audience_subjects(DurableAudience::compute_only(compute)),
+            vec![compute]
+        );
+    }
+
+    #[test]
+    fn duplicate_owner_and_compute_are_rejected() {
+        let owner = Pubkey::new_unique();
+        let compute = Pubkey::new_unique();
+        // A holder audience whose extra owner repeats the compute signer would
+        // render a duplicate subject; `into_policy` must reject it.
+        assert!(DurableAudience::for_owner(owner, compute)
+            .with_owner(compute)
+            .into_policy()
+            .is_err());
+    }
 
     fn handle(tag: u8) -> [u8; 32] {
         [tag; 32]

--- a/solana/programs/confidential-token/src/instructions/common.rs
+++ b/solana/programs/confidential-token/src/instructions/common.rs
@@ -159,24 +159,19 @@ fn execute_transfer_eval<'info>(
     let from_balance = uint64_from_value(old_from_handle, mint_key, from_key, balance_label())?;
     let to_balance = uint64_from_value(old_to_handle, mint_key, to_key, balance_label())?;
     let compute_signer = accounts.compute_signer.key();
-    let balance_access = |owner| {
-        zama_fhe::AccessPolicy::for_owner_and_compute(owner, compute_signer)
-            .map_err(invalid_eval_plan)
-    };
+    let balance_access = |owner| fhe::DurableAudience::for_owner(owner, compute_signer);
     let transferred_access = {
-        let mut access =
-            zama_fhe::AccessPolicy::for_owner(from_owner).map_err(invalid_eval_plan)?;
+        let access = fhe::DurableAudience::for_owner(from_owner, compute_signer);
         if to_owner != from_owner {
-            access = access.with_owner(to_owner).map_err(invalid_eval_plan)?;
+            access.with_owner(to_owner)
+        } else {
+            access
         }
-        access
-            .with_compute(compute_signer)
-            .map_err(invalid_eval_plan)?
     };
     let from_output = fhe::DurableOutput::new(
         accounts.from_balance_value.clone(),
         durable_slot(mint_key, from_key, balance_label()),
-        balance_access(from_owner)?,
+        balance_access(from_owner),
     )?;
     let transferred_output = fhe::DurableOutput::new(
         accounts.transferred_amount_value.clone(),
@@ -186,7 +181,7 @@ fn execute_transfer_eval<'info>(
     let to_output = fhe::DurableOutput::new(
         accounts.to_balance_value.clone(),
         durable_slot(mint_key, to_key, balance_label()),
-        balance_access(to_owner)?,
+        balance_access(to_owner),
     )?;
     let mut builder =
         zama_fhe::EvalBuilder::new(context_id, zama_fhe::EvalAppAuthority::new(from_key));
@@ -277,12 +272,6 @@ pub(crate) fn uint64_from_value(
         durable_slot(acl_domain_key, app_account, encrypted_value_label),
     )
     .map_err(invalid_eval_plan)
-}
-
-pub(crate) fn access_policy_from_subjects(
-    subjects: Vec<zama_fhe::AccessSubject>,
-) -> Result<zama_fhe::AccessPolicy> {
-    zama_fhe::AccessPolicy::from_subjects(subjects).map_err(invalid_eval_plan)
 }
 
 pub(crate) fn transfer_eval_context(
@@ -829,21 +818,4 @@ pub(crate) fn assert_kms_public_decrypt_cert_for_request(
         ConfidentialTokenError::InvalidKmsCertificate
     );
     Ok(())
-}
-
-pub(crate) fn balance_acl_subjects(
-    owner: Pubkey,
-    compute_signer: Pubkey,
-) -> Vec<zama_fhe::AccessSubject> {
-    vec![
-        zama_fhe::AccessSubject::owner(owner),
-        zama_fhe::AccessSubject::compute(compute_signer),
-    ]
-}
-
-pub(crate) fn burned_amount_acl_subjects(
-    owner: Pubkey,
-    compute_signer: Pubkey,
-) -> Vec<zama_fhe::AccessSubject> {
-    balance_acl_subjects(owner, compute_signer)
 }

--- a/solana/programs/confidential-token/src/instructions/confidential_burn.rs
+++ b/solana/programs/confidential-token/src/instructions/confidential_burn.rs
@@ -96,8 +96,7 @@ pub fn confidential_burn<'info>(
     let balance_output = fhe::DurableOutput::new(
         ctx.accounts.balance_value.to_account_info(),
         durable_slot(mint_key, token_account_key, balance_label()),
-        zama_fhe::AccessPolicy::for_owner_and_compute(owner, compute_signer)
-            .map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::for_owner(owner, compute_signer),
     )?;
     // ERC-7984 `unwrap` parity (`makePubliclyDecryptable(unwrapAmount)`): the burned delta is born
     // publicly decryptable inside this eval CPI, so the burn is permanently redeemable even after a
@@ -105,12 +104,12 @@ pub fn confidential_burn<'info>(
     let burned_output = fhe::DurableOutput::new_public(
         ctx.accounts.burned_amount_value.to_account_info(),
         durable_slot(mint_key, token_account_key, burned_amount_label()),
-        access_policy_from_subjects(burned_amount_acl_subjects(owner, compute_signer))?,
+        fhe::DurableAudience::for_owner(owner, compute_signer),
     )?;
     let total_supply_output = fhe::DurableOutput::new(
         ctx.accounts.total_supply_value.to_account_info(),
         durable_slot(mint_key, total_supply_authority, total_supply_label()),
-        zama_fhe::AccessPolicy::for_compute(compute_signer).map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::compute_only(compute_signer),
     )?;
 
     let balance = uint64_from_value(

--- a/solana/programs/confidential-token/src/instructions/create_random_amount.rs
+++ b/solana/programs/confidential-token/src/instructions/create_random_amount.rs
@@ -85,8 +85,7 @@ fn create_random_amount_inner<'info>(
     let amount_output = fhe::DurableOutput::new(
         ctx.accounts.amount_value.to_account_info(),
         durable_slot(mint_key, owner, encrypted_value_label),
-        zama_fhe::AccessPolicy::for_compute(ctx.accounts.compute_signer.key())
-            .map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::compute_only(ctx.accounts.compute_signer.key()),
     )?;
     let context_tag = if upper_bound.is_some() {
         b"random-bounded-amount".as_slice()

--- a/solana/programs/confidential-token/src/instructions/initialize_mint.rs
+++ b/solana/programs/confidential-token/src/instructions/initialize_mint.rs
@@ -61,7 +61,7 @@ pub fn initialize_mint<'info>(ctx: Context<'info, InitializeMint<'info>>) -> Res
     let total_supply_output = fhe::DurableOutput::new(
         ctx.accounts.total_supply_encrypted_value.to_account_info(),
         durable_slot(mint_key, total_supply_authority, total_supply_label()),
-        zama_fhe::AccessPolicy::for_compute(compute_signer).map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::compute_only(compute_signer),
     )?;
     let context_id = transfer_eval_context(
         b"initialize-total-supply",

--- a/solana/programs/confidential-token/src/instructions/initialize_token_account.rs
+++ b/solana/programs/confidential-token/src/instructions/initialize_token_account.rs
@@ -79,8 +79,7 @@ pub fn initialize_token_account<'info>(
     let balance_output = fhe::DurableOutput::new(
         ctx.accounts.balance_encrypted_value.to_account_info(),
         durable_slot(mint_key, token_account_key, balance_label()),
-        zama_fhe::AccessPolicy::for_owner_and_compute(owner, compute_signer)
-            .map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::for_owner(owner, compute_signer),
     )?;
     let context_id = transfer_eval_context(
         b"initialize-balance",

--- a/solana/programs/confidential-token/src/instructions/wrap_usdc.rs
+++ b/solana/programs/confidential-token/src/instructions/wrap_usdc.rs
@@ -112,13 +112,12 @@ pub fn wrap_usdc<'info>(ctx: Context<'info, WrapUsdc<'info>>, amount: u64) -> Re
     let balance_output = fhe::DurableOutput::new(
         ctx.accounts.balance_value.to_account_info(),
         durable_slot(mint_key, token_account.key(), balance_label()),
-        zama_fhe::AccessPolicy::for_owner_and_compute(token_account.owner, compute_signer)
-            .map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::for_owner(token_account.owner, compute_signer),
     )?;
     let total_supply_output = fhe::DurableOutput::new(
         ctx.accounts.total_supply_value.to_account_info(),
         durable_slot(mint_key, total_supply_authority, total_supply_label()),
-        zama_fhe::AccessPolicy::for_compute(compute_signer).map_err(invalid_eval_plan)?,
+        fhe::DurableAudience::compute_only(compute_signer),
     )?;
 
     spl_token::transfer_checked(

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,6 +1,6 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 330349,
+    "compute_units": 329987,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 348028,
+    "compute_units": 347663,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
-    "compute_units": 62353,
+    "compute_units": 62225,
     "unique_accounts": 11,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,6 +1,6 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 329987,
+    "compute_units": 329975,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 347663,
+    "compute_units": 347651,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 1559
   },
   "initialize_token_account": {
-    "compute_units": 62225,
+    "compute_units": 62222,
     "unique_accounts": 11,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,

--- a/solana/runtime-tests/tests/token_mollusk.rs
+++ b/solana/runtime-tests/tests/token_mollusk.rs
@@ -1242,6 +1242,8 @@ fn mollusk_confidential_transfer_to_second_recipient_rotates_transferred_lineage
 
     let first_receipt = read_encrypted_value(&context, transferred_value_address);
     assert_eq!(first_receipt.leaf_count, 0);
+    // fhevm-internal#1745: the transferred-amount audience must always contain the sender's owner
+    // key and the mint compute signer; this exact-equality assertion pins both membership and order.
     assert_eq!(
         first_receipt.subjects,
         vec![fixture.owner, fixture.bob_owner, fixture.compute_signer]
@@ -1261,7 +1263,8 @@ fn mollusk_confidential_transfer_to_second_recipient_rotates_transferred_lineage
     context.process_and_validate_instruction(&second, &[Check::success()]);
 
     let receipt = read_encrypted_value(&context, transferred_value_address);
-    // Audience rotated to the new recipient.
+    // Audience rotated to the new recipient, still keeping the sender's owner key and the mint
+    // compute signer after rotation across two recipients (fhevm-internal#1745).
     assert_eq!(
         receipt.subjects,
         vec![fixture.owner, charlie_owner, fixture.compute_signer]


### PR DESCRIPTION
> Stacked on #3208 (subject rotation on durable supersede). Rebase onto `feature/solana` after #3208 merges; the diff to review is the single top commit.

## Overview

fhevm-internal#1745. #3208 made subject rotation on durable supersede legal, which turns a hand-built subject list that forgets the holder's owner key or the mint compute-signer into a real footgun (silent loss of the holder's own decryption, or a revert on the next transfer's compute-read gate). Today every audience the token builds is correct — but only by construction at one seam. This promotes that to a compile-level guarantee, in the token crate, where the "a balance audience always contains owner + compute" semantics actually live. Host and `zama-fhe` untouched: rotation stays fully general for other apps.

## What

- `DurableAudience` (token `fhe.rs`): the only constructors are `for_owner(owner, compute)` (+ additive `.with_owner(extra)` for the transferred-amount recipient leg) and `compute_only(compute)` for the genuinely holder-less mint-scoped lineages (total supply, freshly minted random amounts). Omitting owner on a holder-scoped output or compute anywhere is not expressible.
- `DurableOutput::new/new_public` accept only a `DurableAudience`; the raw subject-list helpers (`access_policy_from_subjects`, `balance_acl_subjects`, `burned_amount_acl_subjects`) are deleted.
- All 11 durable-output sites migrated (transfer seam, wrap, burn, init-account, init-mint, random-amount).

## Guarantee boundary (stated honestly)

The guarantee is enforced at the `fhe::DurableOutput` seam. The generic `zama_fhe::Output::durable(slot, raw_policy)` SDK constructor remains reachable by future token code — keeping the shared SDK generic is a deliberate #1745 decision; no token site uses it (verified in review).

## No behavior change

Produced audiences are byte-identical including subject order (load-bearing for `previous_subjects` exact-match and relayer MMR replay) — reconstructed per site against the parent commit by an independent adversarial review. Self-transfer (`to == from`) collapses identically; duplicate rejection is pre-existing SDK behavior, now pinned by a unit test. Instruction ABI, account shapes, IDL, golden ABI: unchanged/in sync. Only drift: three token CU snapshots improve slightly (dropped per-site `map_err` chains), fields otherwise identical.

## Tests

4 new `DurableAudience` unit tests; the #3208 rotation Mollusk test now carries the #1745 exact-equality assertions (membership + order across two rotated recipients). Full runtime-tests gate green (79/379/11/8/38).

Closes zama-ai/fhevm-internal#1745.