### PR TITLE
fix(sdk): set sepolia (testnet) and devnet protocol config addresses

### DIFF
--- a/sdk/js-sdk/src/core/chains/definitions/sepolia.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/sepolia.ts
@@ -14,7 +14,9 @@ export const sepolia: FhevmChain = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0xbE0E383937d564D7FF0BC3b46c51f0bF8d5C311A',
       },
-      protocolConfig: undefined, // To be filled
+      protocolConfig: {
+        address: '0x51f9AFBc89Ea792e1a21a12AB802ab58D4dbee83',
+      },
     },
     relayerUrl: 'https://relayer.testnet.zama.org',
     gateway: {

--- a/sdk/js-sdk/test/chains/devnet.ts
+++ b/sdk/js-sdk/test/chains/devnet.ts
@@ -13,7 +13,9 @@ export const devnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0x3F3819BeBE4bD0EFEf8078Df6f9B574ADa80CCA4',
       },
-      protocolConfig: undefined, // To be filled
+      protocolConfig: {
+        address: '0x1aa1E8f03E6aC23EEd65305fF6C89A3Fc55f13a0',
+      },
     },
     relayerUrl: 'https://relayer.dev.zama.cloud',
     gateway: {


### PR DESCRIPTION
## What

Fills in the previously-empty `protocolConfig` for both Sepolia-based chain definitions:

- **`src/core/chains/definitions/sepolia.ts`** (testnet) → `0x51f9AFBc89Ea792e1a21a12AB802ab58D4dbee83`
- **`test/chains/devnet.ts`** (devnet) → `0x1aa1E8f03E6aC23EEd65305fF6C89A3Fc55f13a0`

Both were `protocolConfig: undefined // To be filled`.

## Source / verification

**Testnet** — from the Zama protocol registry (`protocol-registry-internal/data/testnet/chains.yaml`, `protocol-registry/testnet.md`: `PROTOCOL_CONFIG`). Cross-checked against `charts/coprocessor/configs/ethereum-testnet.yaml` (`protocol_config.address`) — matches. All other Sepolia addresses in the file (ACL, KMS verifier, input verifier, decryption, input verification) line up with the same testnet entry. On-chain this contract reports `ProtocolConfig v0.1.0`.

**Devnet** — not present in the registry (registry only covers testnet/mainnet). Resolved on-chain by calling `getProtocolConfigAddress()` on the devnet KMS verifier (`0x3F3819BeBE4bD0EFEf8078Df6f9B574ADa80CCA4`, from `charts/coprocessor/configs/ethereum-devnet.yaml`) on Sepolia:

```
cast call 0x3F3819BeBE4bD0EFEf8078Df6f9B574ADa80CCA4 "getProtocolConfigAddress()(address)" --rpc-url <sepolia>
# -> 0x1aa1E8f03E6aC23EEd65305fF6C89A3Fc55f13a0
```

The returned contract self-reports `ProtocolConfig v0.2.0` via `getVersion()`, confirming it is a live ProtocolConfig. (Devnet runs v0.2.0; testnet still runs v0.1.0, which is why devnet's address was never in the registry.)

## Not included

- **Polygon Amoy** chain config is still missing and is being handled separately (see PR #3194). Registry address is ready (`AMOY_PROTOCOL_CONFIG` = `0x4CcF009Aba90D04f52b31fc7aDdE240578aFe10F`) for a follow-up once #3194 merges.