### PR TITLE
feat(coprocessor): support rerunning the upgrade process

### DIFF
--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -19,7 +19,7 @@
 //! each pass only re-requests operators it hasn't heard from — a slow operator
 //! simply fills in on a later tick. The FIRST block on a track whose blob is
 //! unanimous across all operators anchors that track: the service stops polling
-//! it and emits `unanimity_consensus(chain_id, block_height, block_hash)` — and
+//! it and emits a proposal-scoped unanimity event — and
 //! re-emits it each pass until the window closes, so a controller that missed the
 //! NOTIFY still latches. One unanimous non-trivial block is a sufficient anchor
 //! because a determinism-breaking upgrade is systematic — any such block reveals
@@ -138,6 +138,7 @@ pub struct NewBlockPayload {
 /// Payload emitted on `unanimity_consensus` / `unanimity_consensus_timeout`.
 #[derive(Debug, Clone, Serialize)]
 struct UnanimityPayload<'a> {
+    proposal_id: &'a [u8],
     chain_id: i64,
     block_height: i64,
     block_hash: &'a str,
@@ -238,28 +239,34 @@ fn all_slots_filled(slots: &[Option<Vec<u8>>]) -> bool {
     !slots.is_empty() && slots.iter().all(Option::is_some)
 }
 
-/// Returns `(start_block, end_block)` for the GCS dry-run when it's active.
+/// Returns `(proposal_id, start_block, end_block)` for the active GCS dry-run.
 /// `None` otherwise. Scoped to `stack_role = 'GCS'` because BCS also stays
 /// `status='in_progress'` during the upgrade and doesn't own the replay window.
-pub(crate) async fn active_upgrade_window<'e, E>(executor: E) -> Result<Option<(i64, i64)>, Error>
+pub(crate) async fn active_upgrade_window<'e, E>(
+    executor: E,
+) -> Result<Option<(Vec<u8>, i64, i64)>, Error>
 where
     E: Executor<'e, Database = Postgres>,
 {
-    let row: Option<(String, Option<i64>, Option<i64>)> = sqlx::query_as(
-        "SELECT state, start_block, end_block FROM upgrade_state
+    type ActiveWindowRow = (String, Option<Vec<u8>>, Option<i64>, Option<i64>);
+    let row: Option<ActiveWindowRow> = sqlx::query_as(
+        "SELECT state, proposal_id, start_block, end_block FROM upgrade_state
           WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
     .fetch_optional(executor)
     .await?;
 
-    let Some((state, start_block, end_block)) = row else {
+    let Some((state, proposal_id, start_block, end_block)) = row else {
         return Ok(None);
     };
     if !matches!(state.as_str(), "UpgradeActivated" | "DryRunStarted") {
         debug!(state = %state, "GCS not in UpgradeActivated/DryRunStarted — ignoring");
         return Ok(None);
     }
-    Ok(start_block.zip(end_block))
+    Ok(proposal_id
+        .zip(start_block)
+        .zip(end_block)
+        .map(|((proposal_id, start), end)| (proposal_id, start, end)))
 }
 
 /// Per-track eager consensus state. We only need ONE unanimous block to anchor
@@ -385,7 +392,7 @@ async fn host_consensus_candidates(
     Ok(rows.into_iter().map(|(b,)| b).collect())
 }
 
-/// True once blocks up to `end_block` have been stored. Starts the timeout clock.
+/// True once finalized blocks reach `end_block`.
 async fn host_reached_end_block(
     pool: &Pool<Postgres>,
     host_chain_id: i64,
@@ -393,7 +400,8 @@ async fn host_reached_end_block(
 ) -> Result<bool, Error> {
     let sql = format!(
         "SELECT COALESCE(
-                  (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.host_chain_blocks_valid WHERE chain_id = $1),
+                  (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.host_chain_blocks_valid
+                    WHERE chain_id = $1 AND block_status = 'finalized'),
                   -1
                 ) >= $2"
     );
@@ -426,9 +434,8 @@ enum WindowTimeout {
 }
 
 struct WindowState {
-    /// The (start, end) window being tracked; when it changes, both consensus
-    /// tracks and the timeout reset for the new window.
-    tracked_window: Option<(i64, i64)>,
+    /// The proposal and window currently being tracked.
+    tracked_window: Option<(Vec<u8>, i64, i64)>,
     timeout: WindowTimeout,
 }
 
@@ -450,11 +457,11 @@ async fn consensus_pass(
     if window_state.tracked_window != window {
         host.reset();
         gateway.reset();
-        // The upgrade window changed, so reset the timeout for the new one.
+        // Reset the timeout for the new proposal or window.
         window_state.timeout = WindowTimeout::NotArmed;
-        window_state.tracked_window = window;
+        window_state.tracked_window = window.clone();
     }
-    let Some((start, end)) = window else {
+    let Some((proposal_id, start, end)) = window else {
         return Ok(());
     };
 
@@ -488,6 +495,7 @@ async fn consensus_pass(
             notify_unanimity(
                 pool,
                 UNANIMITY_CONSENSUS_CHANNEL,
+                &proposal_id,
                 &NewBlockPayload {
                     chain_id: track.chain_id,
                     block_height: block,
@@ -529,6 +537,7 @@ async fn consensus_pass(
                 notify_unanimity(
                     pool,
                     UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL,
+                    &proposal_id,
                     &NewBlockPayload {
                         chain_id: host.chain_id,
                         block_height: end,
@@ -547,9 +556,11 @@ async fn consensus_pass(
 async fn notify_unanimity(
     pool: &Pool<Postgres>,
     channel: &str,
+    proposal_id: &[u8],
     payload: &NewBlockPayload,
 ) -> Result<(), Error> {
     let body = serde_json::to_string(&UnanimityPayload {
+        proposal_id,
         chain_id: payload.chain_id,
         block_height: payload.block_height,
         block_hash: &payload.block_hash,

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -18,17 +18,19 @@
 //! on `new_block` / `gw_new_block` notifications), caching per-operator bytes so
 //! each pass only re-requests operators it hasn't heard from — a slow operator
 //! simply fills in on a later tick. The FIRST block on a track whose blob is
-//! unanimous across all operators anchors that track: the service emits
-//! `unanimity_consensus(chain_id, block_height, block_hash)` and stops polling
-//! it. One unanimous non-trivial block is a sufficient anchor because a
-//! determinism-breaking upgrade is systematic — any such block reveals it
-//! (RFC 021).
+//! unanimous across all operators anchors that track: the service stops polling
+//! it and emits `unanimity_consensus(chain_id, block_height, block_hash)` — and
+//! re-emits it each pass until the window closes, so a controller that missed the
+//! NOTIFY still latches. One unanimous non-trivial block is a sufficient anchor
+//! because a determinism-breaking upgrade is systematic — any such block reveals
+//! it (RFC 021).
 //!
 //! `unanimity_consensus` is consumed only by the upgrade-controller, which
 //! authorizes cutover once BOTH tracks have anchored.
 //!
 //! **Timeout.** If a track is still un-anchored `commitment_timeout` after `end_block`,
-//! `unanimity_consensus_timeout` is emitted once and the upgrade-controller rolls the dry-run back.
+//! `unanimity_consensus_timeout` is emitted (and re-emitted each pass) until the
+//! upgrade-controller rolls the dry-run back.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -65,8 +67,9 @@ pub const GW_NEW_BLOCK_CHANNEL: &str = fhevm_engine_common::gcs_activation::EVEN
 /// `unanimity_consensus` is consumed only by the upgrade procedure — no other
 /// service should treat it as a generic "agreement" signal.
 pub const UNANIMITY_CONSENSUS_CHANNEL: &str = "event_unanimity_consensus";
-/// Emitted once per window when the host reaches `end_block` without both tracks
-/// anchoring within `commitment_timeout`. Consumed by the upgrade-controller.
+/// Emitted (and re-emitted each poll until the row is rolled back) when the host
+/// reaches `end_block` without both tracks anchoring within `commitment_timeout`.
+/// Consumed by the upgrade-controller.
 pub const UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL: &str = "event_unanimity_consensus_timeout";
 
 /// `SupportedFheOperations::FheTrivialEncrypt` opcode (fhevm-engine-common
@@ -260,13 +263,14 @@ pub(crate) async fn active_upgrade_window(
 
 /// Per-track eager consensus state. We only need ONE unanimous block to anchor
 /// a track (RFC 021: a determinism-breaking change is systematic, so any
-/// non-trivial block reveals it), after which `anchor_emitted` short-circuits
-/// the track for the rest of the window. `partial` caches per-operator bytes per
-/// candidate block, so each poll only re-requests operators we haven't heard
-/// from — a slow operator simply fills in on a later tick.
+/// non-trivial block reveals it), after which we stop polling but re-emit the
+/// anchor each pass (so a controller that missed the NOTIFY still latches).
+/// `partial` caches per-operator bytes per candidate block, so each poll only
+/// re-requests operators we haven't heard from — a slow operator fills in later.
 struct ConsensusTrack {
     chain_id: i64,
-    anchor_emitted: bool,
+    /// The anchored block once unanimity is reached; `None` until then.
+    anchored: Option<i64>,
     partial: HashMap<i64, Vec<Option<Vec<u8>>>>,
     /// Blocks we've already logged a divergence warning for. State hashes are
     /// deterministic per block, so a divergence is permanent — warn once per
@@ -278,7 +282,7 @@ impl ConsensusTrack {
     fn new(chain_id: i64) -> Self {
         Self {
             chain_id,
-            anchor_emitted: false,
+            anchored: None,
             partial: HashMap::new(),
             divergence_warned: HashSet::new(),
         }
@@ -286,25 +290,22 @@ impl ConsensusTrack {
 
     /// Clear state for a fresh upgrade window.
     fn reset(&mut self) {
-        self.anchor_emitted = false;
+        self.anchored = None;
         self.partial.clear();
         self.divergence_warned.clear();
     }
 }
 
 /// Poll `candidates` for one track: top up each candidate's cached slots and, on
-/// the FIRST block that reaches unanimity across all operators, emit
-/// `event_unanimity_consensus` (with this track's `chain_id`) and mark the track
-/// anchored. No-op once anchored, or with no operators/candidates. `block_hash`
-/// is empty — the consumer gates on `(chain_id, block_height)` only.
+/// the FIRST block that reaches unanimity across all operators, record it as the
+/// track's anchor. No-op once anchored, or with no operators/candidates.
 async fn poll_track(
-    pool: &Pool<Postgres>,
     http: &reqwest::Client,
     urls: &[String],
     track: &mut ConsensusTrack,
     candidates: &[i64],
 ) -> Result<(), Error> {
-    if track.anchor_emitted || urls.is_empty() {
+    if track.anchored.is_some() || urls.is_empty() {
         return Ok(());
     }
     for &block in candidates {
@@ -323,19 +324,10 @@ async fn poll_track(
                 chain_id = track.chain_id,
                 block,
                 operator_count = urls.len(),
-                "unanimity anchor reached — emitting event_unanimity_consensus"
+                "unanimity anchor reached"
             );
-            notify_unanimity(
-                pool,
-                UNANIMITY_CONSENSUS_CHANNEL,
-                &NewBlockPayload {
-                    chain_id: track.chain_id,
-                    block_height: block,
-                    block_hash: String::new(),
-                },
-            )
-            .await?;
-            track.anchor_emitted = true;
+            // consensus_pass emits (and re-emits) the anchor; here we just record it.
+            track.anchored = Some(block);
             track.partial.clear();
             return Ok(());
         }
@@ -428,10 +420,8 @@ async fn active_host_chain_id(pool: &Pool<Postgres>) -> Result<Option<i64>, Erro
 enum WindowTimeout {
     /// No deadline running.
     NotArmed,
-    /// Give up at this instant.
+    /// Give up at this instant, then re-emit each poll until the row is rolled back.
     Armed(Instant),
-    /// Already emitted.
-    Emitted,
 }
 
 struct WindowState {
@@ -443,9 +433,9 @@ struct WindowState {
 
 /// One consensus pass over both tracks. Reads the active window, resets track
 /// state when the window changes or closes (so a prior upgrade's anchors never
-/// carry over), then polls the host and Gateway candidates. Emits at most one
-/// anchor per track per window, and at most one `unanimity_consensus_timeout` per
-/// window if the deadline elapses before both tracks anchor.
+/// carry over), then polls the host and Gateway candidates. Re-emits each
+/// anchored track's `unanimity_consensus`, and `unanimity_consensus_timeout` once
+/// past the deadline, every pass until the window closes.
 async fn consensus_pass(
     pool: &Pool<Postgres>,
     http: &reqwest::Client,
@@ -471,29 +461,45 @@ async fn consensus_pass(
     let urls = s3_urls.read().await.clone();
 
     // Host track: needs the host chain id (set by upgrade-controller).
-    if !host.anchor_emitted {
+    if host.anchored.is_none() {
         if let Some(host_chain_id) = active_host_chain_id(pool).await? {
             host.chain_id = host_chain_id;
             let candidates = host_consensus_candidates(pool, host_chain_id, start, end).await?;
-            poll_track(pool, http, &urls, host, &candidates).await?;
+            poll_track(http, &urls, host, &candidates).await?;
         }
     }
 
     // Gateway track: needs gw_start_block + the gw-listener tip (sealed blocks).
-    if !gateway.anchor_emitted {
+    if gateway.anchored.is_none() {
         if let (Some(gw_start), Some(gw_tip)) = (
             state_hash::gw_start_block(pool).await?,
             state_hash::gw_listener_tip(pool).await?,
         ) {
             let candidates =
                 pending_gw_consensus_blocks(pool, gateway.chain_id, gw_start, gw_tip).await?;
-            poll_track(pool, http, &urls, gateway, &candidates).await?;
+            poll_track(http, &urls, gateway, &candidates).await?;
+        }
+    }
+
+    // Re-emit each anchor every pass so a controller that missed the NOTIFY still latches.
+    for track in [&*host, &*gateway] {
+        if let Some(block) = track.anchored {
+            notify_unanimity(
+                pool,
+                UNANIMITY_CONSENSUS_CHANNEL,
+                &NewBlockPayload {
+                    chain_id: track.chain_id,
+                    block_height: block,
+                    block_hash: String::new(),
+                },
+            )
+            .await?;
         }
     }
 
     // If we reached the last block but didn't agree in time, give up so the
     // upgrade can be rerun.
-    let both_anchored = host.anchor_emitted && gateway.anchor_emitted;
+    let both_anchored = host.anchored.is_some() && gateway.anchored.is_some();
     if !both_anchored {
         match window_state.timeout {
             // Arm once we reach end_block (chain_id is 0 until then).
@@ -509,13 +515,14 @@ async fn consensus_pass(
                     "host chain reached end_block without unanimity — arming consensus timeout"
                 );
             }
+            // Still armed past the deadline — (re)emit the timeout.
             WindowTimeout::Armed(deadline) if Instant::now() >= deadline => {
                 warn!(
                     host_chain_id = host.chain_id,
                     start_block = start,
                     end_block = end,
-                    host_anchored = host.anchor_emitted,
-                    gateway_anchored = gateway.anchor_emitted,
+                    host_anchored = host.anchored.is_some(),
+                    gateway_anchored = gateway.anchored.is_some(),
                     "consensus timeout elapsed without both-track unanimity — emitting event_unanimity_consensus_timeout"
                 );
                 notify_unanimity(
@@ -528,9 +535,8 @@ async fn consensus_pass(
                     },
                 )
                 .await?;
-                window_state.timeout = WindowTimeout::Emitted;
             }
-            _ => {}
+            WindowTimeout::NotArmed | WindowTimeout::Armed(_) => {}
         }
     }
 

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -42,7 +42,7 @@ use alloy::providers::Provider;
 use fhevm_engine_common::database::GCS_SCHEMA_QUOTED;
 use fhevm_engine_common::utils::DatabaseURL;
 use serde::{Deserialize, Serialize};
-use sqlx::{postgres::PgListener, Pool, Postgres};
+use sqlx::{postgres::PgListener, Executor, Pool, Postgres};
 use thiserror::Error;
 use tokio::select;
 use tokio::sync::RwLock;
@@ -241,14 +241,15 @@ fn all_slots_filled(slots: &[Option<Vec<u8>>]) -> bool {
 /// Returns `(start_block, end_block)` for the GCS dry-run when it's active.
 /// `None` otherwise. Scoped to `stack_role = 'GCS'` because BCS also stays
 /// `status='in_progress'` during the upgrade and doesn't own the replay window.
-pub(crate) async fn active_upgrade_window(
-    pool: &Pool<Postgres>,
-) -> Result<Option<(i64, i64)>, Error> {
+pub(crate) async fn active_upgrade_window<'e, E>(executor: E) -> Result<Option<(i64, i64)>, Error>
+where
+    E: Executor<'e, Database = Postgres>,
+{
     let row: Option<(String, Option<i64>, Option<i64>)> = sqlx::query_as(
         "SELECT state, start_block, end_block FROM upgrade_state
           WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?;
 
     let Some((state, start_block, end_block)) = row else {

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -424,10 +424,21 @@ async fn active_host_chain_id(pool: &Pool<Postgres>) -> Result<Option<i64>, Erro
     Ok(row.and_then(|(v,)| v))
 }
 
+/// Timeout state machine for the tracked window.
+enum WindowTimeout {
+    /// No deadline running.
+    NotArmed,
+    /// Give up at this instant.
+    Armed(Instant),
+    /// Already emitted.
+    Emitted,
+}
+
 struct WindowState {
-    window: Option<(i64, i64)>,
-    timeout_deadline: Option<Instant>,
-    timeout_emitted: bool,
+    /// The (start, end) window being tracked; when it changes, both consensus
+    /// tracks and the timeout reset for the new window.
+    tracked_window: Option<(i64, i64)>,
+    timeout: WindowTimeout,
 }
 
 /// One consensus pass over both tracks. Reads the active window, resets track
@@ -445,13 +456,12 @@ async fn consensus_pass(
     commitment_timeout: Duration,
 ) -> Result<(), Error> {
     let window = active_upgrade_window(pool).await?;
-    if window_state.window != window {
+    if window_state.tracked_window != window {
         host.reset();
         gateway.reset();
         // The upgrade window changed, so reset the timeout for the new one.
-        window_state.timeout_deadline = None;
-        window_state.timeout_emitted = false;
-        window_state.window = window;
+        window_state.timeout = WindowTimeout::NotArmed;
+        window_state.tracked_window = window;
     }
     let Some((start, end)) = window else {
         return Ok(());
@@ -484,44 +494,43 @@ async fn consensus_pass(
     // If we reached the last block but didn't agree in time, give up so the
     // upgrade can be rerun.
     let both_anchored = host.anchor_emitted && gateway.anchor_emitted;
-    if !window_state.timeout_emitted && !both_anchored {
-        // Start the clock once we reach the last block (chain_id is 0 until then).
-        if window_state.timeout_deadline.is_none()
-            && host.chain_id != 0
-            && host_reached_end_block(pool, host.chain_id, end).await?
-        {
-            window_state.timeout_deadline = Some(Instant::now() + commitment_timeout);
-            info!(
-                host_chain_id = host.chain_id,
-                end_block = end,
-                timeout_secs = commitment_timeout.as_secs(),
-                "host chain reached end_block without unanimity — arming consensus timeout"
-            );
-        }
-
-        if window_state
-            .timeout_deadline
-            .is_some_and(|d| Instant::now() >= d)
-        {
-            warn!(
-                host_chain_id = host.chain_id,
-                start_block = start,
-                end_block = end,
-                host_anchored = host.anchor_emitted,
-                gateway_anchored = gateway.anchor_emitted,
-                "consensus timeout elapsed without both-track unanimity — emitting event_unanimity_consensus_timeout"
-            );
-            notify_unanimity(
-                pool,
-                UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL,
-                &NewBlockPayload {
-                    chain_id: host.chain_id,
-                    block_height: end,
-                    block_hash: String::new(),
-                },
-            )
-            .await?;
-            window_state.timeout_emitted = true;
+    if !both_anchored {
+        match window_state.timeout {
+            // Arm once we reach end_block (chain_id is 0 until then).
+            WindowTimeout::NotArmed
+                if host.chain_id != 0
+                    && host_reached_end_block(pool, host.chain_id, end).await? =>
+            {
+                window_state.timeout = WindowTimeout::Armed(Instant::now() + commitment_timeout);
+                info!(
+                    host_chain_id = host.chain_id,
+                    end_block = end,
+                    timeout_secs = commitment_timeout.as_secs(),
+                    "host chain reached end_block without unanimity — arming consensus timeout"
+                );
+            }
+            WindowTimeout::Armed(deadline) if Instant::now() >= deadline => {
+                warn!(
+                    host_chain_id = host.chain_id,
+                    start_block = start,
+                    end_block = end,
+                    host_anchored = host.anchor_emitted,
+                    gateway_anchored = gateway.anchor_emitted,
+                    "consensus timeout elapsed without both-track unanimity — emitting event_unanimity_consensus_timeout"
+                );
+                notify_unanimity(
+                    pool,
+                    UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL,
+                    &NewBlockPayload {
+                        chain_id: host.chain_id,
+                        block_height: end,
+                        block_hash: String::new(),
+                    },
+                )
+                .await?;
+                window_state.timeout = WindowTimeout::Emitted;
+            }
+            _ => {}
         }
     }
 
@@ -705,12 +714,10 @@ where
     // provider-resolved gw_chain_id.
     let mut host_track = ConsensusTrack::new(0);
     let mut gateway_track = ConsensusTrack::new(gw_chain_id);
-    // Last-seen upgrade window; a change (incl. close) resets both tracks.
-    // Timeout tracking: when the clock started, and whether we already gave up.
+    // Tracked window + its timeout state.
     let mut window_state = WindowState {
-        window: None,
-        timeout_deadline: None,
-        timeout_emitted: false,
+        tracked_window: None,
+        timeout: WindowTimeout::NotArmed,
     };
 
     // The consensus poll cadence: re-attempt S3 every commitment_poll_interval,

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -25,12 +25,14 @@
 //! (RFC 021).
 //!
 //! `unanimity_consensus` is consumed only by the upgrade-controller, which
-//! authorizes cutover once BOTH tracks have anchored. A timeout/abort path is
-//! intentionally not implemented yet.
+//! authorizes cutover once BOTH tracks have anchored.
+//!
+//! **Timeout.** If a track is still un-anchored `commitment_timeout` after `end_block`,
+//! `unanimity_consensus_timeout` is emitted once and the upgrade-controller rolls the dry-run back.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alloy::network::Ethereum;
 use alloy::primitives::Address;
@@ -63,7 +65,8 @@ pub const GW_NEW_BLOCK_CHANNEL: &str = fhevm_engine_common::gcs_activation::EVEN
 /// `unanimity_consensus` is consumed only by the upgrade procedure — no other
 /// service should treat it as a generic "agreement" signal.
 pub const UNANIMITY_CONSENSUS_CHANNEL: &str = "event_unanimity_consensus";
-/// Reserved channel for a future timeout/abort path — not emitted today.
+/// Emitted once per window when the host reaches `end_block` without both tracks
+/// anchoring within `commitment_timeout`. Consumed by the upgrade-controller.
 pub const UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL: &str = "event_unanimity_consensus_timeout";
 
 /// `SupportedFheOperations::FheTrivialEncrypt` opcode (fhevm-engine-common
@@ -389,6 +392,26 @@ async fn host_consensus_candidates(
     Ok(rows.into_iter().map(|(b,)| b).collect())
 }
 
+/// True once blocks up to `end_block` have been stored. Starts the timeout clock.
+async fn host_reached_end_block(
+    pool: &Pool<Postgres>,
+    host_chain_id: i64,
+    end_block: i64,
+) -> Result<bool, Error> {
+    let sql = format!(
+        "SELECT COALESCE(
+                  (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.host_chain_blocks_valid WHERE chain_id = $1),
+                  -1
+                ) >= $2"
+    );
+    let (reached,): (bool,) = sqlx::query_as(&sql)
+        .bind(host_chain_id)
+        .bind(end_block)
+        .fetch_one(pool)
+        .await?;
+    Ok(reached)
+}
+
 /// Host chain id of the active GCS upgrade (set by upgrade-controller on
 /// activation). `None` when unset — host consensus is skipped until it appears.
 async fn active_host_chain_id(pool: &Pool<Postgres>) -> Result<Option<i64>, Error> {
@@ -401,23 +424,34 @@ async fn active_host_chain_id(pool: &Pool<Postgres>) -> Result<Option<i64>, Erro
     Ok(row.and_then(|(v,)| v))
 }
 
+struct WindowState {
+    window: Option<(i64, i64)>,
+    timeout_deadline: Option<Instant>,
+    timeout_emitted: bool,
+}
+
 /// One consensus pass over both tracks. Reads the active window, resets track
 /// state when the window changes or closes (so a prior upgrade's anchors never
 /// carry over), then polls the host and Gateway candidates. Emits at most one
-/// anchor per track per window.
+/// anchor per track per window, and at most one `unanimity_consensus_timeout` per
+/// window if the deadline elapses before both tracks anchor.
 async fn consensus_pass(
     pool: &Pool<Postgres>,
     http: &reqwest::Client,
     s3_urls: &Arc<RwLock<Vec<String>>>,
     host: &mut ConsensusTrack,
     gateway: &mut ConsensusTrack,
-    current_window: &mut Option<(i64, i64)>,
+    ws: &mut WindowState,
+    commitment_timeout: Duration,
 ) -> Result<(), Error> {
     let window = active_upgrade_window(pool).await?;
-    if *current_window != window {
+    if ws.window != window {
         host.reset();
         gateway.reset();
-        *current_window = window;
+        // The upgrade window changed, so reset the timeout for the new one.
+        ws.timeout_deadline = None;
+        ws.timeout_emitted = false;
+        ws.window = window;
     }
     let Some((start, end)) = window else {
         return Ok(());
@@ -446,6 +480,48 @@ async fn consensus_pass(
             poll_track(pool, http, &urls, gateway, &candidates).await?;
         }
     }
+
+    // If we reached the last block but didn't agree in time, give up so the
+    // upgrade can be rerun.
+    let both_anchored = host.anchor_emitted && gateway.anchor_emitted;
+    if !ws.timeout_emitted && !both_anchored {
+        // Start the clock once we reach the last block (chain_id is 0 until then).
+        if ws.timeout_deadline.is_none()
+            && host.chain_id != 0
+            && host_reached_end_block(pool, host.chain_id, end).await?
+        {
+            ws.timeout_deadline = Some(Instant::now() + commitment_timeout);
+            info!(
+                host_chain_id = host.chain_id,
+                end_block = end,
+                timeout_secs = commitment_timeout.as_secs(),
+                "host chain reached end_block without unanimity — arming consensus timeout"
+            );
+        }
+
+        if ws.timeout_deadline.is_some_and(|d| Instant::now() >= d) {
+            warn!(
+                host_chain_id = host.chain_id,
+                start_block = start,
+                end_block = end,
+                host_anchored = host.anchor_emitted,
+                gateway_anchored = gateway.anchor_emitted,
+                "consensus timeout elapsed without both-track unanimity — emitting event_unanimity_consensus_timeout"
+            );
+            notify_unanimity(
+                pool,
+                UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL,
+                &NewBlockPayload {
+                    chain_id: host.chain_id,
+                    block_height: end,
+                    block_hash: String::new(),
+                },
+            )
+            .await?;
+            ws.timeout_emitted = true;
+        }
+    }
+
     Ok(())
 }
 
@@ -627,7 +703,12 @@ where
     let mut host_track = ConsensusTrack::new(0);
     let mut gateway_track = ConsensusTrack::new(gw_chain_id);
     // Last-seen upgrade window; a change (incl. close) resets both tracks.
-    let mut current_window: Option<(i64, i64)> = None;
+    // Timeout tracking: when the clock started, and whether we already gave up.
+    let mut window_state = WindowState {
+        window: None,
+        timeout_deadline: None,
+        timeout_emitted: false,
+    };
 
     // The consensus poll cadence: re-attempt S3 every commitment_poll_interval,
     // caching partial per-operator responses so slow operators fill in later.
@@ -645,7 +726,8 @@ where
                     &s3_urls,
                     &mut host_track,
                     &mut gateway_track,
-                    &mut current_window,
+                    &mut window_state,
+                    config.commitment_timeout,
                 )
                 .await
                 {

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -441,17 +441,17 @@ async fn consensus_pass(
     s3_urls: &Arc<RwLock<Vec<String>>>,
     host: &mut ConsensusTrack,
     gateway: &mut ConsensusTrack,
-    ws: &mut WindowState,
+    window_state: &mut WindowState,
     commitment_timeout: Duration,
 ) -> Result<(), Error> {
     let window = active_upgrade_window(pool).await?;
-    if ws.window != window {
+    if window_state.window != window {
         host.reset();
         gateway.reset();
         // The upgrade window changed, so reset the timeout for the new one.
-        ws.timeout_deadline = None;
-        ws.timeout_emitted = false;
-        ws.window = window;
+        window_state.timeout_deadline = None;
+        window_state.timeout_emitted = false;
+        window_state.window = window;
     }
     let Some((start, end)) = window else {
         return Ok(());
@@ -484,13 +484,13 @@ async fn consensus_pass(
     // If we reached the last block but didn't agree in time, give up so the
     // upgrade can be rerun.
     let both_anchored = host.anchor_emitted && gateway.anchor_emitted;
-    if !ws.timeout_emitted && !both_anchored {
+    if !window_state.timeout_emitted && !both_anchored {
         // Start the clock once we reach the last block (chain_id is 0 until then).
-        if ws.timeout_deadline.is_none()
+        if window_state.timeout_deadline.is_none()
             && host.chain_id != 0
             && host_reached_end_block(pool, host.chain_id, end).await?
         {
-            ws.timeout_deadline = Some(Instant::now() + commitment_timeout);
+            window_state.timeout_deadline = Some(Instant::now() + commitment_timeout);
             info!(
                 host_chain_id = host.chain_id,
                 end_block = end,
@@ -499,7 +499,10 @@ async fn consensus_pass(
             );
         }
 
-        if ws.timeout_deadline.is_some_and(|d| Instant::now() >= d) {
+        if window_state
+            .timeout_deadline
+            .is_some_and(|d| Instant::now() >= d)
+        {
             warn!(
                 host_chain_id = host.chain_id,
                 start_block = start,
@@ -518,7 +521,7 @@ async fn consensus_pass(
                 },
             )
             .await?;
-            ws.timeout_emitted = true;
+            window_state.timeout_emitted = true;
         }
     }
 

--- a/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
@@ -494,7 +494,7 @@ async fn compute_and_upload_state_hashes(
 
     // GCS hashes are only produced during an active upgrade window; BCS hashes
     // are not produced because they would never be uploaded or consumed.
-    if let Some((start, end)) = crate::active_upgrade_window(&mut *tx).await? {
+    if let Some((_, start, end)) = crate::active_upgrade_window(&mut *tx).await? {
         compute_and_insert_gcs(&mut tx, start, end, batch_limit).await?;
 
         // Gateway-inputs track: only once the GCS gw-listener has a watermark and

--- a/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use aws_sdk_s3::primitives::ByteStream;
 use fhevm_engine_common::database::{GCS_SCHEMA, GCS_SCHEMA_QUOTED};
 use fhevm_engine_common::gcs_activation::EVENT_GW_NEW_BLOCK;
-use sqlx::{postgres::PgListener, Pool, Postgres, Row};
+use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
+use sqlx::{postgres::PgListener, Pool, Postgres, Row, Transaction};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -27,12 +28,44 @@ pub fn state_hash_key(chain_id: i64, block_number: i64) -> String {
     format!("state_hash/chain={chain_id}/block={block_number}.bin")
 }
 
+/// Outcome of a guarded state-hash insert.
+enum HashInsert {
+    /// Inserted a new row.
+    Wrote,
+    /// The row already exists.
+    Noop,
+}
+
+/// Inserts a state hash in the guarded transaction.
+async fn insert_state_hash(
+    tx: &mut Transaction<'_, Postgres>,
+    chain_id: i64,
+    block_number: i64,
+    hash: &str,
+) -> Result<HashInsert, sqlx::Error> {
+    let affected = sqlx::query(&format!(
+        "INSERT INTO {GCS_SCHEMA_QUOTED}.state_hash (chain_id, block_number, state_hash)
+         VALUES ($1, $2, $3) ON CONFLICT (chain_id, block_number) DO NOTHING"
+    ))
+    .bind(chain_id)
+    .bind(block_number)
+    .bind(hash)
+    .execute(&mut **tx)
+    .await?
+    .rows_affected();
+    Ok(if affected > 0 {
+        HashInsert::Wrote
+    } else {
+        HashInsert::Noop
+    })
+}
+
 /// GCS path: stamp the GCS `state_hash` for blocks in `[start, end]` that don't
 /// already have an entry. Empty blocks (`fhe_event_count = 0`) get
 /// [`EMPTY_BLOCK_STATE_HASH`]; non-empty blocks get the SHA-256 over their
 /// GCS `ciphertexts`.
 async fn compute_and_insert_gcs(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     start: i64,
     end: i64,
     batch_limit: i64,
@@ -73,14 +106,9 @@ async fn compute_and_insert_gcs(
         .bind(start)
         .bind(end)
         .bind(batch_limit)
-        .fetch_all(pool)
+        .fetch_all(&mut **tx)
         .await?;
 
-    let insert_sql = format!(
-        "INSERT INTO {GCS_SCHEMA_QUOTED}.state_hash (chain_id, block_number, state_hash)
-         VALUES ($1, $2, $3)
-         ON CONFLICT (chain_id, block_number) DO NOTHING"
-    );
     for row in pending {
         let chain_id: i64 = row.try_get("chain_id")?;
         let block_number: i64 = row.try_get("block_number")?;
@@ -88,18 +116,12 @@ async fn compute_and_insert_gcs(
         let hash = if is_empty {
             Some(EMPTY_BLOCK_STATE_HASH.to_string())
         } else {
-            compute_gcs_hash(pool, chain_id, block_number).await?
+            compute_gcs_hash(tx, chain_id, block_number).await?
         };
         let Some(hash) = hash else { continue };
-        let affected = sqlx::query(&insert_sql)
-            .bind(chain_id)
-            .bind(block_number)
-            .bind(&hash)
-            .execute(pool)
-            .await?
-            .rows_affected();
-        if affected > 0 {
-            info!(chain_id, block_number, "gcs.state_hash inserted");
+        match insert_state_hash(tx, chain_id, block_number, &hash).await? {
+            HashInsert::Wrote => info!(chain_id, block_number, "gcs.state_hash inserted"),
+            HashInsert::Noop => {}
         }
     }
     Ok(())
@@ -115,7 +137,7 @@ async fn compute_and_insert_gcs(
 /// read public. Runtime `sqlx::query` because the schema name is only known at
 /// runtime.
 async fn compute_gcs_hash(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     chain_id: i64,
     block_number: i64,
 ) -> anyhow::Result<Option<String>> {
@@ -140,7 +162,7 @@ async fn compute_gcs_hash(
     let Some(row) = sqlx::query(&sql)
         .bind(chain_id)
         .bind(block_number)
-        .fetch_optional(pool)
+        .fetch_optional(&mut **tx)
         .await?
     else {
         return Ok(None);
@@ -165,7 +187,7 @@ async fn compute_gcs_hash(
 /// Like [`compute_and_insert_gcs`], every table is explicitly qualified with the
 /// versioned GCS schema and never falls back to `public`.
 async fn compute_and_insert_gw_input_hashes(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     gw_chain_id: i64,
     gw_start_block: i64,
     gw_tip: i64,
@@ -192,33 +214,24 @@ async fn compute_and_insert_gw_input_hashes(
         .bind(gw_tip)
         .bind(gw_chain_id)
         .bind(batch_limit)
-        .fetch_all(pool)
+        .fetch_all(&mut **tx)
         .await?;
 
-    let insert_sql = format!(
-        "INSERT INTO {GCS_SCHEMA_QUOTED}.state_hash (chain_id, block_number, state_hash)
-         VALUES ($1, $2, $3)
-         ON CONFLICT (chain_id, block_number) DO NOTHING"
-    );
     for row in pending {
         let block_number: i64 = row.try_get("block_number")?;
         // `None` when the input ciphertexts aren't all present yet (handle exists
         // in input_handles but its ciphertext row hasn't landed) — retry later.
-        let Some(hash) = compute_gw_input_hash(pool, block_number).await? else {
+        let Some(hash) = compute_gw_input_hash(tx, block_number).await? else {
             continue;
         };
-        let affected = sqlx::query(&insert_sql)
-            .bind(gw_chain_id)
-            .bind(block_number)
-            .bind(&hash)
-            .execute(pool)
-            .await?
-            .rows_affected();
-        if affected > 0 {
-            info!(
-                gw_chain_id,
-                block_number, "gcs.state_hash (gw inputs) inserted"
-            );
+        match insert_state_hash(tx, gw_chain_id, block_number, &hash).await? {
+            HashInsert::Wrote => {
+                info!(
+                    gw_chain_id,
+                    block_number, "gcs.state_hash (gw inputs) inserted"
+                )
+            }
+            HashInsert::Noop => {}
         }
     }
     Ok(())
@@ -231,7 +244,7 @@ async fn compute_and_insert_gw_input_hashes(
 /// two tracks are byte-compatible, but the source is `input_handles` joined to
 /// `is_input` ciphertexts rather than `computations` outputs.
 async fn compute_gw_input_hash(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     block_number: i64,
 ) -> anyhow::Result<Option<String>> {
     let sql = format!(
@@ -249,7 +262,7 @@ async fn compute_gw_input_hash(
     );
     let Some(row) = sqlx::query(&sql)
         .bind(block_number)
-        .fetch_optional(pool)
+        .fetch_optional(&mut **tx)
         .await?
     else {
         return Ok(None);
@@ -261,22 +274,28 @@ async fn compute_gw_input_hash(
 /// The Gateway tip = the GCS gw-listener watermark. `None` when the watermark
 /// row is absent/NULL (listener hasn't ingested any Gateway block yet), which
 /// disables Gateway hashing until it does.
-pub(crate) async fn gw_listener_tip(pool: &Pool<Postgres>) -> Result<Option<i64>, sqlx::Error> {
+pub(crate) async fn gw_listener_tip<'e, E>(executor: E) -> Result<Option<i64>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
     let sql = format!(
         "SELECT last_block_num FROM {GCS_SCHEMA_QUOTED}.gw_listener_last_block
           WHERE dummy_id = true"
     );
-    let row: Option<(Option<i64>,)> = sqlx::query_as(&sql).fetch_optional(pool).await?;
+    let row: Option<(Option<i64>,)> = sqlx::query_as(&sql).fetch_optional(executor).await?;
     Ok(row.and_then(|(v,)| v))
 }
 
 /// `gw_start_block` of the active GCS upgrade row, or `None` when unset.
-pub(crate) async fn gw_start_block(pool: &Pool<Postgres>) -> Result<Option<i64>, sqlx::Error> {
+pub(crate) async fn gw_start_block<'e, E>(executor: E) -> Result<Option<i64>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
     let row: Option<(Option<i64>,)> = sqlx::query_as(
         "SELECT gw_start_block FROM upgrade_state
           WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?;
     Ok(row.and_then(|(v,)| v))
 }
@@ -429,12 +448,12 @@ async fn upload_pending_gw_state_hashes(
 /// Checked against `information_schema.schemata` by exact (unquoted) name, so the
 /// hyphen/dots in the schema name need no identifier quoting. See
 /// [`compute_and_upload_state_hashes`] for why the pass is gated on this.
-async fn gcs_schema_exists(pool: &Pool<Postgres>) -> anyhow::Result<bool> {
+async fn gcs_schema_exists(tx: &mut Transaction<'_, Postgres>) -> anyhow::Result<bool> {
     let (exists,): (bool,) = sqlx::query_as(
         "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)",
     )
     .bind(GCS_SCHEMA)
-    .fetch_one(pool)
+    .fetch_one(&mut **tx)
     .await?;
     Ok(exists)
 }
@@ -450,6 +469,11 @@ async fn compute_and_upload_state_hashes(
     batch_limit: i64,
     gw_chain_id: i64,
 ) -> anyhow::Result<()> {
+    let mut tx = match begin_write_guarded(pool, true, GcsRollbackPolicy::Skip).await? {
+        WriteGuard::Proceed(tx) => tx,
+        WriteGuard::Stop | WriteGuard::Skip => return Ok(()),
+    };
+
     // Every branch below touches the versioned GCS schema — the compute paths and
     // the GW-inputs upload explicitly via GCS_SCHEMA_QUOTED, the host-chain upload
     // implicitly through the gcs-first search_path. That schema is created by the
@@ -459,28 +483,31 @@ async fn compute_and_upload_state_hashes(
     // schema is absent, and the hard-qualified GW upload would fail every pass with
     // `relation "gcs-<ver>.state_hash" does not exist`. There is nothing to compute
     // or upload without the schema, so skip the whole pass cleanly.
-    if !gcs_schema_exists(pool).await? {
+    if !gcs_schema_exists(&mut tx).await? {
         debug!(
             schema = GCS_SCHEMA,
             "GCS schema absent — skipping state_hash pass"
         );
+        tx.rollback().await?;
         return Ok(());
     }
 
     // GCS hashes are only produced during an active upgrade window; BCS hashes
     // are not produced because they would never be uploaded or consumed.
-    if let Some((start, end)) = crate::active_upgrade_window(pool).await? {
-        compute_and_insert_gcs(pool, start, end, batch_limit).await?;
+    if let Some((start, end)) = crate::active_upgrade_window(&mut *tx).await? {
+        compute_and_insert_gcs(&mut tx, start, end, batch_limit).await?;
 
         // Gateway-inputs track: only once the GCS gw-listener has a watermark and
         // gw_start_block is set. Bounded to sealed blocks (< gw_tip).
-        if let (Some(gw_start), Some(gw_tip)) =
-            (gw_start_block(pool).await?, gw_listener_tip(pool).await?)
-        {
-            compute_and_insert_gw_input_hashes(pool, gw_chain_id, gw_start, gw_tip, batch_limit)
+        if let (Some(gw_start), Some(gw_tip)) = (
+            gw_start_block(&mut *tx).await?,
+            gw_listener_tip(&mut *tx).await?,
+        ) {
+            compute_and_insert_gw_input_hashes(&mut tx, gw_chain_id, gw_start, gw_tip, batch_limit)
                 .await?;
         }
     }
+    tx.commit().await?;
 
     // S3 upload: drains pending rows; runs every pass so failed PUTs retry.
     if let Some(s3) = s3 {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/gcs_activation.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/gcs_activation.rs
@@ -46,17 +46,20 @@ pub const EVENT_DRY_RUN_ROLLED_BACK: &str = "event_dry_run_rolled_back";
 pub const GCS_NOT_ACTIVATED: i64 = -1;
 
 /// Pause flag for the tfhe/sns workers: run from `start_block` while dry-running,
-/// pause on rollback, otherwise unchanged.
+/// keep the released value through cutover (`UpgradeAuthorized`/`LIVE`), pause on
+/// any other state — including a fresh re-proposal (`UpgradeActivated`) that races
+/// in after a rollback, so the worker never runs before the new `DryRunStarted`.
 fn host_gate_value(state: &str, start_block: Option<i64>, current: i64) -> i64 {
     match state {
         "DryRunStarted" => start_block.unwrap_or(current),
-        "PAUSED" => GCS_NOT_ACTIVATED,
-        _ => current,
+        "UpgradeAuthorized" | "LIVE" => current,
+        _ => GCS_NOT_ACTIVATED,
     }
 }
 
 /// Pause flag for the zkproof-worker: run from `gw_start_block` once the Gateway
-/// gate clears, pause on rollback, otherwise unchanged.
+/// gate clears, keep the released value through cutover, pause on any other state
+/// (including a racing re-proposal before its gate clears).
 fn gw_gate_value(
     state: &str,
     gw_dry_run_started: bool,
@@ -65,10 +68,10 @@ fn gw_gate_value(
 ) -> i64 {
     if gw_dry_run_started {
         gw_start_block.unwrap_or(current)
-    } else if state == "PAUSED" {
-        GCS_NOT_ACTIVATED
-    } else {
+    } else if state == "UpgradeAuthorized" || state == "LIVE" {
         current
+    } else {
+        GCS_NOT_ACTIVATED
     }
 }
 
@@ -242,6 +245,10 @@ mod tests {
             200
         );
         assert_eq!(gw_gate_value("LIVE", true, Some(200), 200), 200);
+        assert_eq!(
+            gw_gate_value("UpgradeActivated", false, Some(200), 100),
+            GCS_NOT_ACTIVATED
+        );
     }
 
     /// Same lifecycle for the host gate (tfhe/sns workers).
@@ -265,5 +272,9 @@ mod tests {
             200
         );
         assert_eq!(host_gate_value("LIVE", Some(200), 200), 200);
+        assert_eq!(
+            host_gate_value("UpgradeActivated", Some(200), 100),
+            GCS_NOT_ACTIVATED
+        );
     }
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/gcs_activation.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/gcs_activation.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use sqlx::postgres::PgListener;
 use sqlx::{Pool, Postgres};
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 /// pg_notify channel the upgrade-controller fires when the GCS `upgrade_state`
 /// row is created in `UpgradeActivated`. Workers wake on it but stay paused
@@ -37,9 +37,40 @@ pub const EVENT_GW_NEW_BLOCK: &str = "event_gw_new_block";
 /// scoped to the zkproof-worker.
 pub const EVENT_GW_DRY_RUN_STARTED: &str = "event_gw_dry_run_started";
 
+/// Fired when a dry-run is rolled back (unanimity timeout); worker watchers wake
+/// on it to re-pause without waiting for the fallback poll.
+pub const EVENT_DRY_RUN_ROLLED_BACK: &str = "event_dry_run_rolled_back";
+
 /// Sentinel for the activation atomic: the GCS row has not yet been observed in
 /// `DryRunStarted`. Any other value is the real `start_block`.
 pub const GCS_NOT_ACTIVATED: i64 = -1;
+
+/// Pause flag for the tfhe/sns workers: run from `start_block` while dry-running,
+/// pause on rollback, otherwise unchanged.
+fn host_gate_value(state: &str, start_block: Option<i64>, current: i64) -> i64 {
+    match state {
+        "DryRunStarted" => start_block.unwrap_or(current),
+        "PAUSED" => GCS_NOT_ACTIVATED,
+        _ => current,
+    }
+}
+
+/// Pause flag for the zkproof-worker: run from `gw_start_block` once the Gateway
+/// gate clears, pause on rollback, otherwise unchanged.
+fn gw_gate_value(
+    state: &str,
+    gw_dry_run_started: bool,
+    gw_start_block: Option<i64>,
+    current: i64,
+) -> i64 {
+    if gw_dry_run_started {
+        gw_start_block.unwrap_or(current)
+    } else if state == "PAUSED" {
+        GCS_NOT_ACTIVATED
+    } else {
+        current
+    }
+}
 
 /// LISTENs on [`EVENT_UPGRADE_ACTIVATED`] / [`EVENT_DRY_RUN_STARTED`] and
 /// releases the worker only once the GCS `upgrade_state` row reaches
@@ -54,6 +85,7 @@ pub async fn run_gcs_activation_watcher(
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen(EVENT_UPGRADE_ACTIVATED).await?;
     listener.listen(EVENT_DRY_RUN_STARTED).await?;
+    listener.listen(EVENT_DRY_RUN_ROLLED_BACK).await?;
     info!(
         target: "gcs_activation",
         channel = EVENT_DRY_RUN_STARTED,
@@ -70,29 +102,25 @@ pub async fn run_gcs_activation_watcher(
                 .fetch_optional(pool)
                 .await?;
 
-        if let Some((fsm_state, Some(start_block))) = row {
-            if fsm_state == "DryRunStarted" {
-                let prev = state.swap(start_block, Ordering::SeqCst);
-                if prev != start_block {
-                    info!(
-                        target: "gcs_activation",
-                        start_block,
-                        prev,
-                        "GCS DryRunStarted observed; releasing worker at start_block"
-                    );
-                }
-            } else {
-                debug!(
+        let current = state.load(Ordering::SeqCst);
+        let next = row.as_ref().map_or(current, |(fsm_state, start_block)| {
+            host_gate_value(fsm_state, *start_block, current)
+        });
+        if next != current {
+            state.store(next, Ordering::SeqCst);
+            if next == GCS_NOT_ACTIVATED {
+                info!(
                     target: "gcs_activation",
-                    state = %fsm_state,
-                    "GCS not yet in DryRunStarted; worker remains paused"
+                    prev = current,
+                    "GCS dry-run rolled back; re-pausing worker until next start_block"
+                );
+            } else {
+                info!(
+                    target: "gcs_activation",
+                    start_block = next,
+                    "GCS DryRunStarted observed; releasing worker at start_block"
                 );
             }
-        } else {
-            debug!(
-                target: "gcs_activation",
-                "GCS row in upgrade_state has no start_block yet"
-            );
         }
 
         // Fallback poll catches a missed NOTIFY (dropped connection, late start).
@@ -128,6 +156,7 @@ pub async fn run_gcs_gw_activation_watcher(
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen(EVENT_UPGRADE_ACTIVATED).await?;
     listener.listen(EVENT_GW_DRY_RUN_STARTED).await?;
+    listener.listen(EVENT_DRY_RUN_ROLLED_BACK).await?;
     info!(
         target: "gcs_activation",
         channel = EVENT_GW_DRY_RUN_STARTED,
@@ -140,28 +169,35 @@ pub async fn run_gcs_gw_activation_watcher(
         // `gw_start_block` and pre-start proofs were pruned). The
         // `gw_start_block` column itself is populated one state earlier (at
         // `UpgradeActivated`), before the GCS gw-listener has caught up — too
-        // early to begin re-randomizing.
-        let row: Option<(bool, Option<i64>)> = sqlx::query_as(
-            "SELECT gw_dry_run_started, gw_start_block FROM upgrade_state WHERE stack_role = 'GCS'",
+        // early to begin re-randomizing. A `PAUSED` row (rolled-back dry-run)
+        // re-pauses the worker.
+        let row: Option<(String, bool, Option<i64>)> = sqlx::query_as(
+            "SELECT state, gw_dry_run_started, gw_start_block FROM upgrade_state WHERE stack_role = 'GCS'",
         )
         .fetch_optional(pool)
         .await?;
 
-        if let Some((true, Some(gw_start_block))) = row {
-            let prev = state.swap(gw_start_block, Ordering::SeqCst);
-            if prev != gw_start_block {
+        let current = state.load(Ordering::SeqCst);
+        let next = row
+            .as_ref()
+            .map_or(current, |(fsm_state, gw_started, gw_start_block)| {
+                gw_gate_value(fsm_state, *gw_started, *gw_start_block, current)
+            });
+        if next != current {
+            state.store(next, Ordering::SeqCst);
+            if next == GCS_NOT_ACTIVATED {
                 info!(
                     target: "gcs_activation",
-                    gw_start_block,
-                    prev,
+                    prev = current,
+                    "GCS dry-run rolled back; re-pausing zkproof-worker until next gw_start_block"
+                );
+            } else {
+                info!(
+                    target: "gcs_activation",
+                    gw_start_block = next,
                     "GCS gw_dry_run_started observed; releasing zkproof-worker at gw_start_block"
                 );
             }
-        } else {
-            debug!(
-                target: "gcs_activation",
-                "GCS gw_dry_run_started not yet set; zkproof-worker remains paused"
-            );
         }
 
         // Fallback poll catches a missed NOTIFY (dropped connection, late start).
@@ -174,5 +210,60 @@ pub async fn run_gcs_gw_activation_watcher(
             }
             _ = tokio::time::sleep(Duration::from_secs(30)) => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Retry lifecycle: activate -> release -> rollback re-pauses -> stays paused
+    /// until the next window -> cutover keeps it live.
+    #[test]
+    fn gw_gate_repauses_on_rollback_then_holds_until_next_window() {
+        assert_eq!(
+            gw_gate_value("UpgradeActivated", false, Some(100), GCS_NOT_ACTIVATED),
+            GCS_NOT_ACTIVATED
+        );
+        assert_eq!(
+            gw_gate_value("DryRunStarted", true, Some(100), GCS_NOT_ACTIVATED),
+            100
+        );
+        assert_eq!(
+            gw_gate_value("PAUSED", false, Some(100), 100),
+            GCS_NOT_ACTIVATED
+        );
+        assert_eq!(
+            gw_gate_value("DryRunStarted", false, Some(200), GCS_NOT_ACTIVATED),
+            GCS_NOT_ACTIVATED
+        );
+        assert_eq!(
+            gw_gate_value("DryRunStarted", true, Some(200), GCS_NOT_ACTIVATED),
+            200
+        );
+        assert_eq!(gw_gate_value("LIVE", true, Some(200), 200), 200);
+    }
+
+    /// Same lifecycle for the host gate (tfhe/sns workers).
+    #[test]
+    fn host_gate_repauses_on_rollback_then_holds_until_next_window() {
+        assert_eq!(
+            host_gate_value("UpgradeActivated", Some(100), GCS_NOT_ACTIVATED),
+            GCS_NOT_ACTIVATED
+        );
+        assert_eq!(
+            host_gate_value("DryRunStarted", Some(100), GCS_NOT_ACTIVATED),
+            100
+        );
+        assert_eq!(host_gate_value("PAUSED", Some(100), 100), GCS_NOT_ACTIVATED);
+        assert_eq!(
+            host_gate_value("UpgradeActivated", Some(200), GCS_NOT_ACTIVATED),
+            GCS_NOT_ACTIVATED
+        );
+        assert_eq!(
+            host_gate_value("DryRunStarted", Some(200), GCS_NOT_ACTIVATED),
+            200
+        );
+        assert_eq!(host_gate_value("LIVE", Some(200), 200), 200);
     }
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -339,9 +339,9 @@ pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 /// drops. Without the lock a green write committing between cutover's merge read
 /// and its `DROP SCHEMA gcs CASCADE` would be neither merged nor preserved (a
 /// silent-loss window); holding the shared lock makes cutover's exclusive request
-/// block until the write commits, so it is merged before the drop. They skip only
-/// the [`is_retired`] re-check: a green binary is strictly newer than the live
-/// stack, so it can never be retired (`is_retired` is always `false` for it).
+/// block until the write commits, so it is merged before the drop. They skip the
+/// [`is_retired`] re-check (a green binary is never retired), but stop writing once
+/// their dry-run is rolled back (row `PAUSED`).
 pub async fn cutover_gate(
     tx: &mut Transaction<'_, Postgres>,
     gcs_mode: bool,
@@ -351,7 +351,13 @@ pub async fn cutover_gate(
         .execute(&mut **tx)
         .await?;
     if gcs_mode {
-        return Ok(false);
+        // Skip the write once the dry-run is rolled back (row PAUSED), so a stale
+        // in-flight batch can't land in the reset schema.
+        return sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM upgrade_state WHERE stack_role = 'GCS' AND state = 'PAUSED')",
+        )
+        .fetch_one(&mut **tx)
+        .await;
     }
     is_retired(tx).await
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -339,9 +339,9 @@ pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 /// drops. Without the lock a green write committing between cutover's merge read
 /// and its `DROP SCHEMA gcs CASCADE` would be neither merged nor preserved (a
 /// silent-loss window); holding the shared lock makes cutover's exclusive request
-/// block until the write commits, so it is merged before the drop. They skip the
-/// [`is_retired`] re-check (a green binary is never retired), but stop writing once
-/// their dry-run is rolled back (row `PAUSED`).
+/// block until the write commits, so it is merged before the drop. They skip only
+/// the [`is_retired`] re-check: a green binary is strictly newer than the live
+/// stack, so it can never be retired (`is_retired` is always `false` for it).
 pub async fn cutover_gate(
     tx: &mut Transaction<'_, Postgres>,
     gcs_mode: bool,
@@ -351,13 +351,7 @@ pub async fn cutover_gate(
         .execute(&mut **tx)
         .await?;
     if gcs_mode {
-        // Skip the write once the dry-run is rolled back (row PAUSED), so a stale
-        // in-flight batch can't land in the reset schema.
-        return sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM upgrade_state WHERE stack_role = 'GCS' AND state = 'PAUSED')",
-        )
-        .fetch_one(&mut **tx)
-        .await;
+        return Ok(false);
     }
     is_retired(tx).await
 }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -310,19 +310,51 @@ pub async fn begin_guarded_conn(
     Ok(tx)
 }
 
-/// PostgreSQL advisory-lock key serializing BCS writes against `execute_cutover`.
-/// `execute_cutover` (upgrade-controller) takes the **exclusive** form; every BCS
-/// write transaction takes the **shared** form via [`cutover_gate`]. Chosen to be
+/// PostgreSQL advisory-lock key serializing writes against cutover and rollback.
+/// The upgrade-controller takes the **exclusive** form; every guarded write
+/// transaction takes the **shared** form via [`cutover_gate`]. Chosen to be
 /// recognizable in logs (`0x4648_4556_4355_5456` ~ ASCII "FHEVCUTV").
 pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 
-/// Cutover safety gate for a BCS write transaction.
+/// Result of opening a guarded write transaction.
+pub enum WriteGuard<'a> {
+    Proceed(Transaction<'a, Postgres>),
+    Stop,
+    Skip,
+}
+
+impl<'a> WriteGuard<'a> {
+    /// Returns the transaction when the write can proceed.
+    pub fn into_tx(self) -> Option<Transaction<'a, Postgres>> {
+        match self {
+            WriteGuard::Proceed(tx) => Some(tx),
+            WriteGuard::Stop | WriteGuard::Skip => None,
+        }
+    }
+}
+
+/// Controls GCS writes after a rollback.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GcsRollbackPolicy {
+    /// Used by raw chain ingestion.
+    Continue,
+    /// Used by derived output workers.
+    Skip,
+}
+
+#[derive(Clone, Copy)]
+enum GateBlock {
+    Stop,
+    Skip,
+}
+
+/// Cutover and rollback safety gate for a write transaction.
 ///
-/// Takes the **shared** cutover advisory lock on `tx`, then re-checks the
-/// retirement fence ([`is_retired`]) now that this transaction is ordered
-/// against `execute_cutover` (which holds the **exclusive** form). Returns `true`
-/// if a committed cutover has retired this stack — the caller must roll back and
-/// stop, having written nothing into the now-live tables.
+/// Takes the **shared** advisory lock on `tx`, then checks the stack state while
+/// ordered against controller changes, which take the **exclusive** form.
+/// Returns `Stop` when cutover has retired a BCS writer and `Skip` when rollback
+/// has paused derived GCS writes. The caller rolls back either blocked
+/// transaction before returning it.
 ///
 /// Why the lock, not just [`begin_guarded_pool`]'s BEGIN-time check:
 /// `assert_not_retired` runs only at BEGIN, so a transaction opened before
@@ -334,49 +366,64 @@ pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 /// compatible, so this does **not** serialize BCS worker replicas against each
 /// other — only against the one-shot cutover.
 ///
-/// GCS-mode (green) workers also take the shared lock: their writes land in the
-/// `gcs` schema, which `execute_cutover` merges into the live tables and then
-/// drops. Without the lock a green write committing between cutover's merge read
-/// and its `DROP SCHEMA gcs CASCADE` would be neither merged nor preserved (a
-/// silent-loss window); holding the shared lock makes cutover's exclusive request
-/// block until the write commits, so it is merged before the drop. They skip only
-/// the [`is_retired`] re-check: a green binary is strictly newer than the live
-/// stack, so it can never be retired (`is_retired` is always `false` for it).
-pub async fn cutover_gate(
+/// GCS-mode (green) writers also take the shared lock: their writes land in the
+/// `gcs` schema, which cutover merges and rollback resets. Without the lock a
+/// green write could be lost during cutover or land in the recreated schema after
+/// rollback. Holding the shared lock makes either exclusive request wait until
+/// the write commits. Raw ingestion continues after rollback, while derived
+/// workers skip when the GCS row is `PAUSED`. GCS writers skip only the
+/// [`is_retired`] re-check because a green binary is newer than the live stack
+/// and cannot be retired.
+async fn cutover_gate(
     tx: &mut Transaction<'_, Postgres>,
     gcs_mode: bool,
-) -> Result<bool, sqlx::Error> {
+    rollback_policy: GcsRollbackPolicy,
+) -> Result<Option<GateBlock>, sqlx::Error> {
     sqlx::query("SELECT pg_advisory_xact_lock_shared($1)")
         .bind(CUTOVER_LOCK_ID)
         .execute(&mut **tx)
         .await?;
     if gcs_mode {
-        return Ok(false);
+        if rollback_policy == GcsRollbackPolicy::Skip {
+            let paused: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM upgrade_state WHERE stack_role = 'GCS' AND state = 'PAUSED')",
+            )
+            .fetch_one(&mut **tx)
+            .await?;
+            return Ok(paused.then_some(GateBlock::Skip));
+        }
+        return Ok(None);
     }
-    is_retired(tx).await
+    Ok(is_retired(tx).await?.then_some(GateBlock::Stop))
 }
 
-/// Begin a **write** transaction fenced against cutover, in one call.
+/// Begin a **write** transaction fenced against cutover and rollback, in one call.
 ///
 /// Combines [`begin_guarded_pool`] (BEGIN-time `assert_not_retired`) with
-/// [`cutover_gate`] (shared cutover lock + retirement re-check). Returns
-/// `Ok(None)` if a committed cutover has retired this stack — the caller should
-/// skip the write and stop cleanly, having written nothing.
+/// [`cutover_gate`] (shared advisory lock plus the relevant state check). Returns
+/// [`WriteGuard::Stop`] for a retired BCS stack and [`WriteGuard::Skip`] for a
+/// derived GCS write after rollback.
 ///
-/// Use this for every BCS write transaction. Keep [`begin_guarded_pool`] for
-/// **read-only** transactions: reads cannot corrupt merged state, so they should
-/// not take the shared cutover lock (which would make `execute_cutover` block
-/// behind every in-flight read).
+/// Use this for every BCS or GCS write transaction. Keep [`begin_guarded_pool`]
+/// for **read-only** transactions: reads cannot corrupt merged or reset state,
+/// so they should not take the shared lock, which would delay cutover or
+/// rollback behind every in-flight read.
 pub async fn begin_write_guarded(
     pool: &Pool<Postgres>,
     gcs_mode: bool,
-) -> Result<Option<Transaction<'static, Postgres>>, sqlx::Error> {
+    rollback_policy: GcsRollbackPolicy,
+) -> Result<WriteGuard<'static>, sqlx::Error> {
     let mut tx = begin_guarded_pool(pool).await?;
-    if cutover_gate(&mut tx, gcs_mode).await? {
-        tx.rollback().await?;
-        return Ok(None);
+    match cutover_gate(&mut tx, gcs_mode, rollback_policy).await? {
+        None => Ok(WriteGuard::Proceed(tx)),
+        Some(block) => {
+            tx.rollback().await?;
+            Ok(match block {
+                GateBlock::Stop => WriteGuard::Stop,
+                GateBlock::Skip => WriteGuard::Skip,
+            })
+        }
     }
-    Ok(Some(tx))
 }
 
 /// Like [`begin_write_guarded`] but begins on an already-acquired connection
@@ -384,13 +431,19 @@ pub async fn begin_write_guarded(
 pub async fn begin_write_guarded_conn(
     conn: &mut PgConnection,
     gcs_mode: bool,
-) -> Result<Option<Transaction<'_, Postgres>>, sqlx::Error> {
+    rollback_policy: GcsRollbackPolicy,
+) -> Result<WriteGuard<'_>, sqlx::Error> {
     let mut tx = begin_guarded_conn(conn).await?;
-    if cutover_gate(&mut tx, gcs_mode).await? {
-        tx.rollback().await?;
-        return Ok(None);
+    match cutover_gate(&mut tx, gcs_mode, rollback_policy).await? {
+        None => Ok(WriteGuard::Proceed(tx)),
+        Some(block) => {
+            tx.rollback().await?;
+            Ok(match block {
+                GateBlock::Stop => WriteGuard::Stop,
+                GateBlock::Skip => WriteGuard::Skip,
+            })
+        }
     }
-    Ok(Some(tx))
 }
 
 #[cfg(test)]

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -481,17 +481,18 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             .transpose()
             .map_err(|err| anyhow::anyhow!("block_number does not fit in i64: {err}"))?;
 
-        // Cutover safety: fence this write behind the shared cutover lock +
-        // retirement re-check. `verify_proofs` is not a merge target, but this
-        // makes every BCS write uniformly stop the instant a cutover retires the
-        // stack. GCS-mode listeners skip the gate (they write the gcs schema).
+        // Fence this write against cutover and schema reset. Retired BCS
+        // listeners stop, while GCS raw ingestion continues after rollback.
+        // `verify_proofs` is not merged, but follows the same write boundary as
+        // the other listener tables.
         let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
             db_pool,
             self.stack_mode.gcs_mode(),
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
         )
         .await?
-        else {
-            info!("Cutover completed — gw-listener skipping verify_proofs insert (retired stack)");
+        .into_tx() else {
+            info!("Cutover completed — gw-listener skipping verify_proofs insert on retired stack");
             return Ok(());
         };
         // TODO: check if we can avoid the cast from u256 to i64
@@ -567,16 +568,17 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             .earliest_open_ct_commits_block
             .map(i64::try_from)
             .transpose()?;
-        // Cutover safety: gate the watermark write (+ its notify) behind the
-        // shared cutover lock + retirement re-check, so a retired BCS listener
-        // stops advancing the watermark the instant a cutover flips the stack.
+        // Fence the watermark and notification against cutover and schema reset.
+        // Retired BCS listeners stop; GCS raw ingestion continues after rollback.
+        // This keeps the stored progress aligned with the listener's writes.
         let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
             db_pool,
             self.stack_mode.gcs_mode(),
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
         )
         .await?
-        else {
-            info!("Cutover completed — gw-listener skipping watermark update (retired stack)");
+        .into_tx() else {
+            info!("Cutover completed — gw-listener skipping watermark update on retired stack");
             return Ok(());
         };
         sqlx::query(

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -603,21 +603,22 @@ impl Database {
     }
 
     /// Begin a write transaction fenced against cutover. Runs `assert_not_retired`
-    /// at BEGIN (via `begin_guarded_pool`), then takes the shared cutover advisory
-    /// lock and re-checks retirement. Returns `Ok(None)` if a committed cutover has
-    /// retired this stack — the caller must skip the write. GCS-mode connections
-    /// (`self.gcs_mode`) still take the shared lock (their gcs-schema writes are
-    /// merged into the cutover target) but skip the retirement re-check, since a
-    /// green stack can never be retired. See `versioning::cutover_gate`.
+    /// at BEGIN (via `begin_guarded_pool`), then takes the shared advisory lock and
+    /// re-checks retirement. Returns `Ok(None)` if a committed cutover retired
+    /// this stack. GCS-mode connections (`self.gcs_mode`) take the same lock so
+    /// their raw writes cannot overlap cutover or schema reset, but continue after
+    /// rollback to refill the GCS schema. See `versioning::begin_write_guarded`.
     pub async fn new_transaction(
         &self,
     ) -> Result<Option<Transaction<'_>>, SqlxError> {
         let pool = self.pool().await;
-        fhevm_engine_common::versioning::begin_write_guarded(
+        Ok(fhevm_engine_common::versioning::begin_write_guarded(
             &pool,
             self.gcs_mode,
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
         )
-        .await
+        .await?
+        .into_tx())
     }
 
     pub async fn pool(&self) -> sqlx::Pool<Postgres> {

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -15,6 +15,7 @@ use crate::{Config, ExecutionError};
 use aws_sdk_s3::Client;
 use fhevm_engine_common::chain_id::ChainId;
 use fhevm_engine_common::db_keys::DbKeyId;
+use fhevm_engine_common::gcs_activation::GCS_NOT_ACTIVATED;
 use fhevm_engine_common::healthz_server::{HealthCheckService, HealthStatus, Version};
 use fhevm_engine_common::pg_pool::PostgresPoolManager;
 use fhevm_engine_common::pg_pool::ServiceError;
@@ -29,6 +30,7 @@ use sqlx::Pool;
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::fmt;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -76,6 +78,10 @@ pub struct SwitchNSquashService {
     /// Shared blue-green stack mode. While `gcs_mode` is set the worker is the
     /// green stack in its dry-run window and suppresses S3 uploads + GC.
     mode: Arc<StackMode>,
+
+    /// GCS dry-run pause flag, re-checked every iteration so a rollback re-pauses
+    /// the loop. `GCS_NOT_ACTIVATED` parks; a real `start_block` runs.
+    start_block_state: Arc<AtomicI64>,
 }
 impl HealthCheckService for SwitchNSquashService {
     async fn health_check(&self) -> HealthStatus {
@@ -131,6 +137,7 @@ impl HealthCheckService for SwitchNSquashService {
 }
 
 impl SwitchNSquashService {
+    #[allow(clippy::too_many_arguments)]
     pub async fn create(
         pool_mngr: &PostgresPoolManager,
         conf: Config,
@@ -139,6 +146,7 @@ impl SwitchNSquashService {
         s3_client: Arc<Client>,
         events_tx: InternalEvents,
         mode: Arc<StackMode>,
+        start_block_state: Arc<AtomicI64>,
     ) -> Result<SwitchNSquashService, ExecutionError> {
         Ok(SwitchNSquashService {
             pool: pool_mngr.pool(),
@@ -149,6 +157,7 @@ impl SwitchNSquashService {
             tx,
             events_tx,
             mode,
+            start_block_state,
         })
     }
 
@@ -164,6 +173,7 @@ impl SwitchNSquashService {
             let keys_cache = keys_cache.clone();
             let events_tx = self.events_tx.clone();
             let mode = self.mode.clone();
+            let start_block_state = self.start_block_state.clone();
 
             async move {
                 run_loop(
@@ -175,6 +185,7 @@ impl SwitchNSquashService {
                     keys_cache,
                     events_tx,
                     mode,
+                    start_block_state,
                 )
                 .await
                 .map_err(ServiceError::from)
@@ -204,6 +215,7 @@ pub(crate) async fn run_loop(
     keys_cache: Arc<RwLock<lru::LruCache<DbKeyId, KeySet>>>,
     events_tx: InternalEvents,
     mode: Arc<StackMode>,
+    start_block_state: Arc<AtomicI64>,
 ) -> Result<(), ExecutionError> {
     update_last_active(last_active_at.clone()).await;
 
@@ -222,6 +234,16 @@ pub(crate) async fn run_loop(
     loop {
         // Continue looping until the service is cancelled or a critical error occurs
         update_last_active(last_active_at.clone()).await;
+
+        // GCS gating: park while the dry-run flag is unset (pre-activation or after rollback). No-op for BCS.
+        if mode.gcs_mode() && start_block_state.load(Ordering::SeqCst) == GCS_NOT_ACTIVATED {
+            debug!("GCS not activated (or rolled back); sns-worker paused, re-checking shortly");
+            tokio::select! {
+                _ = token.cancelled() => return Ok(()),
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+            }
+            continue;
+        }
 
         let latest_keys = get_keyset(pool.clone(), keys_cache.clone()).await?;
         if let Some((key_id_gw, keyset)) = latest_keys {

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -23,6 +23,7 @@ use fhevm_engine_common::telemetry;
 use fhevm_engine_common::types::{get_ct_type, SupportedFheCiphertexts};
 use fhevm_engine_common::utils::to_hex;
 use fhevm_engine_common::versioning::StackMode;
+use fhevm_engine_common::versioning::{GcsRollbackPolicy, WriteGuard};
 use opentelemetry::trace::{Status, TraceContextExt};
 use rayon::prelude::*;
 use sqlx::postgres::PgListener;
@@ -363,7 +364,12 @@ pub async fn garbage_collect(pool: &PgPool, limit: u32) -> Result<(), ExecutionE
     // shared lock + retirement re-check make that airtight instead of relying on
     // the digest-NULL predicate alone. GC only runs for the live (non-GCS) stack,
     // so gcs_mode is false here.
-    let Some(mut trx) = fhevm_engine_common::versioning::begin_write_guarded(pool, false).await?
+    let WriteGuard::Proceed(mut trx) = fhevm_engine_common::versioning::begin_write_guarded(
+        pool,
+        false,
+        GcsRollbackPolicy::Continue,
+    )
+    .await?
     else {
         info!("Cutover completed — skipping ciphertexts128 GC on retired stack");
         return Ok(());
@@ -440,22 +446,31 @@ async fn fetch_and_execute_sns_tasks(
     uploads_enabled: bool,
     gcs_mode: bool,
 ) -> Result<Option<(bool, usize)>, ExecutionError> {
-    // Cutover safety (BCS only): begin a write tx fenced against cutover before
-    // writing any ct128 / digest rows into the tables execute_cutover merges.
-    // `None` means a committed cutover retired this stack. See
+    // Begin the write tx under the shared controller lock before changing any
+    // ct128 or digest rows. A retired BCS stack stops here; a GCS worker skips
+    // while the dry-run is PAUSED after rollback. See
     // versioning::begin_write_guarded.
-    let mut db_txn =
-        match fhevm_engine_common::versioning::begin_write_guarded(pool, gcs_mode).await {
-            Ok(Some(txn)) => txn,
-            Ok(None) => {
-                info!("Cutover completed — SnS BCS worker stopping");
-                return Ok(None);
-            }
-            Err(err) => {
-                error!(error = %err, "Failed to begin transaction");
-                return Err(err.into());
-            }
-        };
+    let mut db_txn = match fhevm_engine_common::versioning::begin_write_guarded(
+        pool,
+        gcs_mode,
+        GcsRollbackPolicy::Skip,
+    )
+    .await
+    {
+        Ok(WriteGuard::Proceed(txn)) => txn,
+        Ok(WriteGuard::Stop) => {
+            info!("Cutover completed — SnS BCS worker stopping");
+            return Ok(None);
+        }
+        Ok(WriteGuard::Skip) => {
+            debug!("GCS dry-run rolled back — SnS worker skipping cycle");
+            return Ok(Some((false, 0)));
+        }
+        Err(err) => {
+            error!(error = %err, "Failed to begin transaction");
+            return Err(err.into());
+        }
+    };
 
     let order = if conf.db.lifo {
         Order::Desc

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -775,6 +775,7 @@ pub async fn run_all(
             client.clone(),
             events_tx.clone(),
             stack_mode.clone(),
+            start_block_state.clone(),
         )
         .await?,
     );

--- a/coprocessor/fhevm-engine/tfhe-worker/src/bridge.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/bridge.rs
@@ -24,11 +24,13 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use fhevm_engine_common::database::{
-    connect_pool_with_options, resolve_database_url_from_option, EVENT_CIPHERTEXTS_UPLOADED,
+    apply_gcs_mode_search_path, connect_pool_with_options_and_connect_options,
+    resolve_database_url_from_option, EVENT_CIPHERTEXTS_UPLOADED, GCS_SCHEMA,
 };
+use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
 use prometheus::{register_int_counter, register_int_gauge, IntCounter, IntGauge};
 use sqlx::postgres::PgPoolOptions;
-use sqlx::{PgPool, Postgres, Transaction};
+use sqlx::{PgConnection, PgPool, Postgres, Transaction};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -65,11 +67,13 @@ pub async fn run_confidential_bridge(
     cancel_token: CancellationToken,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let db_url = resolve_database_url_from_option(args.database_url.clone())?;
+    let gcs_mode = fhevm_engine_common::versioning::resolve_gcs_mode(db_url.as_str()).await?;
     // A single connection suffices: the worker polls and associates sequentially.
-    let (pool, _pool_refresh_handle) = connect_pool_with_options(
+    let (pool, _pool_refresh_handle) = connect_pool_with_options_and_connect_options(
         &db_url,
         PgPoolOptions::new().max_connections(1),
         Some(&cancel_token),
+        apply_gcs_mode_search_path(gcs_mode),
     )
     .await?;
 
@@ -84,7 +88,14 @@ pub async fn run_confidential_bridge(
         if cancel_token.is_cancelled() {
             break;
         }
-        match drain_associations(&pool, args.bridge_associate_batch_size, &cancel_token).await {
+        match drain_associations(
+            &pool,
+            args.bridge_associate_batch_size,
+            &cancel_token,
+            gcs_mode,
+        )
+        .await
+        {
             Ok(associated) if associated > 0 => {
                 info!(target: "bridge", associated, "Associated bridged handles")
             }
@@ -114,13 +125,14 @@ pub(crate) async fn drain_associations(
     pool: &PgPool,
     batch_size: i64,
     cancel_token: &CancellationToken,
+    gcs_mode: bool,
 ) -> Result<u64, sqlx::Error> {
     let mut total = 0;
     loop {
         if cancel_token.is_cancelled() {
             break;
         }
-        let associated = associate_batch(pool, batch_size).await?;
+        let associated = associate_batch(pool, batch_size, gcs_mode).await?;
         total += associated;
         if associated < batch_size as u64 {
             break;
@@ -155,8 +167,47 @@ async fn count_unassociated_handles(pool: &PgPool) -> Result<i64, sqlx::Error> {
     .await
 }
 
-async fn associate_batch(pool: &PgPool, batch_size: i64) -> Result<u64, sqlx::Error> {
-    let mut txn = pool.begin().await?;
+async fn bridge_writes_enabled(
+    conn: &mut PgConnection,
+    gcs_mode: bool,
+) -> Result<bool, sqlx::Error> {
+    if !gcs_mode {
+        return Ok(true);
+    }
+
+    let state: Option<String> =
+        sqlx::query_scalar("SELECT state FROM upgrade_state WHERE stack_role = 'GCS'")
+            .fetch_optional(&mut *conn)
+            .await?;
+    match state.as_deref() {
+        Some("LIVE") => Ok(true),
+        // Without this schema, unqualified bridge writes would use public.
+        Some("UpgradeActivated" | "DryRunStarted") => {
+            sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)",
+            )
+            .bind(GCS_SCHEMA)
+            .fetch_one(conn)
+            .await
+        }
+        _ => Ok(false),
+    }
+}
+
+async fn associate_batch(
+    pool: &PgPool,
+    batch_size: i64,
+    gcs_mode: bool,
+) -> Result<u64, sqlx::Error> {
+    let mut txn = match begin_write_guarded(pool, gcs_mode, GcsRollbackPolicy::Skip).await? {
+        WriteGuard::Proceed(txn) => txn,
+        WriteGuard::Stop | WriteGuard::Skip => return Ok(0),
+    };
+
+    if !bridge_writes_enabled(txn.as_mut(), gcs_mode).await? {
+        txn.rollback().await?;
+        return Ok(0);
+    }
 
     // A pair is ready to associate when:
     // - the destination handle is not already materialized by another path

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/bridge.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/bridge.rs
@@ -1,5 +1,6 @@
 //! Tests for the confidential-bridge association worker.
 
+use crate::bridge::drain_associations;
 use serial_test::serial;
 use sqlx::PgPool;
 use test_harness::instance::{setup_test_db, DBInstance, ImportMode};
@@ -223,7 +224,7 @@ async fn associates_ready_pair() {
     let dst = handle(2);
     insert_ready_pair(&pool, &src, &dst).await;
 
-    let associated = crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+    let associated = drain_associations(&pool, 128, &CancellationToken::new(), false)
         .await
         .unwrap();
     assert_eq!(associated, 1);
@@ -265,6 +266,32 @@ async fn associates_ready_pair() {
 
 #[tokio::test]
 #[serial]
+async fn gcs_bridge_does_not_fall_back_to_public() {
+    let (_db, pool) = fresh_db().await;
+    let src = handle(3);
+    let dst = handle(4);
+    insert_ready_pair(&pool, &src, &dst).await;
+    sqlx::query(
+        "INSERT INTO upgrade_state
+            (stack_role, state, status, proposal_id, version, start_block, end_block, updated_at)
+         VALUES ('GCS', 'UpgradeActivated', 'in_progress', '\\x02', 'v0.15', 1, 2, NOW())
+         ON CONFLICT (stack_role) DO UPDATE
+         SET state = EXCLUDED.state, status = EXCLUDED.status",
+    )
+    .execute(&pool)
+    .await
+    .expect("seed GCS state");
+
+    let associated = drain_associations(&pool, 128, &CancellationToken::new(), true)
+        .await
+        .unwrap();
+
+    assert_eq!(associated, 0);
+    assert!(!is_associated(&pool, &dst).await);
+}
+
+#[tokio::test]
+#[serial]
 async fn skips_when_source_approval_missing() {
     let (_db, pool) = fresh_db().await;
     let src = handle(1);
@@ -282,7 +309,7 @@ async fn skips_when_source_approval_missing() {
     .await;
     insert_dst_event(&pool, &src, &dst, DST_CHAIN).await;
 
-    let associated = crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+    let associated = drain_associations(&pool, 128, &CancellationToken::new(), false)
         .await
         .unwrap();
     assert_eq!(associated, 0);
@@ -310,7 +337,7 @@ async fn associates_when_source_event_arrives_last() {
     .await;
     insert_dst_event(&pool, &src, &dst, DST_CHAIN).await;
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -320,7 +347,7 @@ async fn associates_when_source_event_arrives_last() {
     // The source `BridgeHandle` approval arrives last -> the pair associates.
     insert_src_event(&pool, &src, SRC_CHAIN, DST_CHAIN).await;
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         1
@@ -350,7 +377,7 @@ async fn skips_events_from_orphaned_bridge_blocks() {
     insert_src_event_with_block_hash(&pool, &src, SRC_CHAIN, DST_CHAIN, SRC_BLOCK_HASH).await;
     insert_dst_event_with_block_hash(&pool, &src, &dst, DST_CHAIN, DST_BLOCK_HASH).await;
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -367,7 +394,7 @@ async fn skips_events_from_orphaned_bridge_blocks() {
     .await
     .unwrap();
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -394,7 +421,7 @@ async fn skips_events_from_orphaned_bridge_blocks() {
     .await
     .unwrap();
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -413,7 +440,7 @@ async fn skips_events_from_orphaned_bridge_blocks() {
     .await
     .unwrap();
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         1
@@ -446,7 +473,7 @@ async fn associates_pending_destination_block() {
 
     // Destination finality is not awaited: the pair associates immediately.
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         1
@@ -466,7 +493,7 @@ async fn associates_only_when_source_fully_materialized() {
     insert_src_event(&pool, &src, SRC_CHAIN, DST_CHAIN).await;
     insert_dst_event(&pool, &src, &dst, DST_CHAIN).await;
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -475,7 +502,7 @@ async fn associates_only_when_source_fully_materialized() {
     // ct64 blob present, but no digest row yet.
     insert_ciphertext(&pool, &src, CT64).await;
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -484,7 +511,7 @@ async fn associates_only_when_source_fully_materialized() {
     // Digest row present but ct128 digest still missing.
     insert_digest(&pool, &src, Some(CT64_DIGEST), None, SRC_CHAIN).await;
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -499,7 +526,7 @@ async fn associates_only_when_source_fully_materialized() {
         .await
         .unwrap();
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         1
@@ -516,14 +543,14 @@ async fn associates_only_once() {
     insert_ready_pair(&pool, &src, &dst).await;
 
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         1
     );
     // A second run finds nothing new: the associated row is skipped.
     assert_eq!(
-        crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+        drain_associations(&pool, 128, &CancellationToken::new(), false)
             .await
             .unwrap(),
         0
@@ -546,7 +573,7 @@ async fn skips_pair_when_destination_already_materialized() {
 
     // The pair is skipped: the destination already has a ciphertext, so there is
     // nothing to copy.
-    let associated = crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+    let associated = drain_associations(&pool, 128, &CancellationToken::new(), false)
         .await
         .unwrap();
     assert_eq!(associated, 0);
@@ -614,7 +641,7 @@ async fn drains_across_multiple_batches() {
         insert_ready_pair(&pool, src, dst).await;
     }
 
-    let associated = crate::bridge::drain_associations(&pool, 2, &CancellationToken::new())
+    let associated = drain_associations(&pool, 2, &CancellationToken::new(), false)
         .await
         .unwrap();
     assert_eq!(associated, 3);
@@ -648,7 +675,7 @@ async fn associates_same_chain_pair() {
     insert_src_event(&pool, &src, SAME_CHAIN, SAME_CHAIN).await;
     insert_dst_event(&pool, &src, &dst, SAME_CHAIN).await;
 
-    let associated = crate::bridge::drain_associations(&pool, 128, &CancellationToken::new())
+    let associated = drain_associations(&pool, 128, &CancellationToken::new(), false)
         .await
         .unwrap();
     assert_eq!(associated, 1);

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -9,6 +9,7 @@ use fhevm_engine_common::gcs_activation::{run_gcs_activation_watcher, GCS_NOT_AC
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::tfhe_ops::check_fhe_operand_types;
 use fhevm_engine_common::types::{FhevmError, Handle, SupportedFheCiphertexts};
+use fhevm_engine_common::versioning::{GcsRollbackPolicy, WriteGuard};
 use fhevm_engine_common::{tfhe_ops::current_ciphertext_version, types::SupportedFheOperations};
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -232,20 +233,31 @@ async fn tfhe_worker_cycle(
             "acquire_connection"
         );
         let mut conn = pool.acquire().instrument(acq_span).await?;
-        // Cutover safety (BCS only): begin a write tx fenced against cutover —
-        // BEGIN-time retirement fence + shared cutover lock + retirement re-check.
-        // `None` means a committed cutover retired this stack: exit the cycle
-        // cleanly without writing. GCS workers write the gcs schema (not the
-        // cutover target), so the gate is a no-op for them. See
-        // versioning::begin_write_guarded.
+        // Begin a write tx under the shared controller lock. A retired BCS stack
+        // stops here; a GCS worker skips while a rolled-back dry-run is PAUSED.
+        // Holding the lock for the transaction keeps cutover and schema reset
+        // from overlapping its reads and writes. Shared locks still allow worker
+        // replicas to run concurrently. The state check runs after taking the
+        // lock. See versioning::begin_write_guarded.
         let txn_span = tracing::info_span!(parent: &loop_span, "begin_transaction");
-        let Some(mut trx) =
-            fhevm_engine_common::versioning::begin_write_guarded_conn(&mut conn, gcs_mode)
-                .instrument(txn_span)
-                .await?
-        else {
-            info!(target: "tfhe_worker", "Cutover completed — BCS worker exiting cycle");
-            return Ok(());
+        let mut trx = match fhevm_engine_common::versioning::begin_write_guarded_conn(
+            &mut conn,
+            gcs_mode,
+            GcsRollbackPolicy::Skip,
+        )
+        .instrument(txn_span)
+        .await?
+        {
+            WriteGuard::Proceed(trx) => trx,
+            WriteGuard::Stop => {
+                info!(target: "tfhe_worker", "Cutover completed — BCS worker exiting cycle");
+                return Ok(());
+            }
+            WriteGuard::Skip => {
+                debug!(target: "tfhe_worker", "GCS dry-run rolled back — skipping cycle");
+                immediately_poll_more_work = false;
+                continue;
+            }
         };
 
         // Query for transactions to execute

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use super::common::{try_extract_non_retryable_config_error, try_into_array};
-use super::TransactionOperation;
+use super::{begin_live_write, TransactionOperation};
 use alloy::{
     network::{Ethereum, TransactionBuilder},
     primitives::{Address, FixedBytes, U256},
@@ -186,20 +186,7 @@ where
         txn_block_number: Option<i64>,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        // Both writes below target tables execute_cutover merges into `public`.
-        // Operations start only after this sender is live, even when it started
-        // as GCS, so the guard must always apply the live-stack retirement check.
-        // These writes run after the on-chain send as plain database writes, so
-        // the lock is not held across the network call. A blocked write leaves
-        // the database unchanged. See
-        // versioning::begin_write_guarded.
-        let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
-            &self.db_pool,
-            false,
-            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
-        )
-        .await?
-        .into_tx() else {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
             info!("Cutover completed — skipping post-send digest/ct128 writes on retired stack");
             return Ok(());
         };
@@ -267,6 +254,9 @@ where
         err: &str,
         current_retry_count: i32,
     ) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         let compact_hex_handle = to_hex(handle);
         if current_retry_count == self.conf.add_ciphertexts_max_retries - 1 {
             error!(
@@ -292,8 +282,9 @@ where
             err,
             handle,
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -303,6 +294,9 @@ where
         err: &str,
         current_unlimited_retries_count: i32,
     ) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         let compact_hex_handle = to_hex(handle);
         if current_unlimited_retries_count >= (self.conf.review_after_unlimited_retries as i32) - 1
         {
@@ -329,8 +323,9 @@ where
             err,
             handle,
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -339,6 +334,9 @@ where
         handle: &[u8],
         error: &str,
     ) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         sqlx::query!(
             "UPDATE ciphertext_digest
             SET
@@ -350,8 +348,9 @@ where
             error,
             handle,
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 }

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -186,16 +186,20 @@ where
         txn_block_number: Option<i64>,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        // Cutover safety: both writes below target tables execute_cutover merges
-        // into `public` (ciphertext_digest, ciphertexts128). Gate them behind the
-        // shared cutover lock + retirement re-check so a retired BCS sender cannot
-        // clobber a re-armed digest or delete the merged green ct128. These run
-        // AFTER the on-chain send as plain DB writes, so no advisory lock is held
-        // across the on-chain call. See versioning::cutover_gate.
-        let Some(mut tx) =
-            fhevm_engine_common::versioning::begin_write_guarded(&self.db_pool, self.conf.gcs_mode)
-                .await?
-        else {
+        // Both writes below target tables execute_cutover merges into `public`.
+        // Operations start only after this sender is live, even when it started
+        // as GCS, so the guard must always apply the live-stack retirement check.
+        // These writes run after the on-chain send as plain database writes, so
+        // the lock is not held across the network call. A blocked write leaves
+        // the database unchanged. See
+        // versioning::begin_write_guarded.
+        let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
+            &self.db_pool,
+            false,
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
+        )
+        .await?
+        .into_tx() else {
             info!("Cutover completed — skipping post-send digest/ct128 writes on retired stack");
             return Ok(());
         };

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/mod.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/mod.rs
@@ -1,5 +1,16 @@
 use alloy::network::Ethereum;
 use async_trait::async_trait;
+use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy};
+use sqlx::{PgPool, Postgres, Transaction};
+
+async fn begin_live_write(pool: &PgPool) -> anyhow::Result<Option<Transaction<'static, Postgres>>> {
+    // The sender writes only after cutover.
+    Ok(
+        begin_write_guarded(pool, false, GcsRollbackPolicy::Continue)
+            .await?
+            .into_tx(),
+    )
+}
 
 #[async_trait]
 pub trait TransactionOperation<P>: Send + Sync

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -1,5 +1,5 @@
 use super::common::try_extract_non_retryable_config_error;
-use super::TransactionOperation;
+use super::{begin_live_write, TransactionOperation};
 use crate::metrics::{VERIFY_PROOF_FAIL_COUNTER, VERIFY_PROOF_SUCCESS_COUNTER};
 use crate::nonce_managed_provider::NonceManagedProvider;
 use crate::AbstractSigner;
@@ -69,13 +69,17 @@ where
     }
 
     async fn remove_proof_by_id(&self, zk_proof_id: i64) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         debug!(zk_proof_id = zk_proof_id, "Removing proof");
         sqlx::query!(
             "DELETE FROM verify_proofs WHERE zk_proof_id = $1",
             zk_proof_id
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -85,6 +89,9 @@ where
         current_retry_count: i32,
         error: &str,
     ) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         if current_retry_count == (self.conf.verify_proof_resp_max_retries as i32) - 1 {
             error!(zk_proof_id = zk_proof_id, "Max retries reached for proof");
         }
@@ -99,12 +106,16 @@ where
             zk_proof_id,
             error
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 
     async fn remove_proofs_by_retry_count(&self) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         debug!(
             max_retries = self.conf.verify_proof_resp_max_retries,
             "Removing proofs with retry count >= max_retries"
@@ -113,8 +124,9 @@ where
             "DELETE FROM verify_proofs WHERE retry_count >= $1",
             self.conf.verify_proof_resp_max_retries as i64
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -252,6 +264,9 @@ where
         zk_proof_id: i64,
         error: &str,
     ) -> anyhow::Result<()> {
+        let Some(mut tx) = begin_live_write(&self.db_pool).await? else {
+            return Ok(());
+        };
         // Intentionally set retry_count to max so existing max-retry cleanup logic can run unchanged when enabled.
         sqlx::query!(
             "UPDATE verify_proofs
@@ -264,8 +279,9 @@ where
             self.conf.verify_proof_resp_max_retries as i32,
             error,
         )
-        .execute(&self.db_pool)
+        .execute(tx.as_mut())
         .await?;
+        tx.commit().await?;
         Ok(())
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -58,11 +58,11 @@ pub use fhevm_engine_common::versioning::EVENT_STACK_VERSION_UPGRADED;
 /// for now; expected to become configurable.
 const READINESS_CONFIRMATIONS: i64 = 100;
 
-/// PostgreSQL advisory-lock key used to serialize cutover against in-flight
-/// BCS writes. `execute_cutover` takes the exclusive form; every BCS-mode
-/// compute worker takes the shared form inside its write tx via
-/// [`fhevm_engine_common::versioning::cutover_gate`]. Re-exported from the common
-/// crate so the controller and all workers agree on one canonical value.
+/// PostgreSQL advisory-lock key used to serialize controller changes against
+/// writes. Cutover and rollback take the exclusive form; write transactions take
+/// the shared form through [`fhevm_engine_common::versioning::begin_write_guarded`].
+/// Re-exported from the common crate so the controller and all writers agree on
+/// one canonical value.
 pub use fhevm_engine_common::versioning::CUTOVER_LOCK_ID;
 
 /// Returns the `upgrade_state.stack_role` value for a given `gcs_mode` flag:
@@ -1036,10 +1036,19 @@ async fn try_cutover_if_consensus(pool: &Pool<Postgres>) -> Result<(), Error> {
     execute_cutover(pool).await
 }
 
-/// Roll back a dry-run: PAUSED/failed, reset schema, wake workers. Scoped to the
-/// `end_block` window so a stale re-emitted timeout can't reset a newer attempt. Returns whether it acted.
+/// Roll back a dry-run under the write lock: PAUSED/failed, reset schema, wake workers.
+/// Scoped to `end_block` so a stale timeout cannot reset a newer attempt. Returns whether it acted.
 async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool, Error> {
     let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(CUTOVER_LOCK_ID)
+        .execute(&mut *tx)
+        .await?;
+    info!(
+        lock_id = CUTOVER_LOCK_ID,
+        "rollback acquired exclusive advisory lock"
+    );
+
     let claimed = sqlx::query(
         r#"
         UPDATE upgrade_state
@@ -1951,5 +1960,90 @@ mod tests {
             .await
             .expect("gw transition");
         assert!(gw_flag(pool.clone()).await, "matching proposal releases gw");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gcs_rollback_policy_distinguishes_derived_and_raw_writes() {
+        use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        assert!(
+            matches!(
+                begin_write_guarded(&pool, true, GcsRollbackPolicy::Skip)
+                    .await
+                    .expect("guard"),
+                WriteGuard::Proceed(_)
+            ),
+            "write proceeds while dry-running"
+        );
+
+        seed_gcs_row(&pool, "PAUSED", "failed").await;
+        assert!(
+            matches!(
+                begin_write_guarded(&pool, true, GcsRollbackPolicy::Skip)
+                    .await
+                    .expect("guard"),
+                WriteGuard::Skip
+            ),
+            "derived output is skipped after rollback"
+        );
+        assert!(
+            matches!(
+                begin_write_guarded(&pool, true, GcsRollbackPolicy::Continue)
+                    .await
+                    .expect("guard"),
+                WriteGuard::Proceed(_)
+            ),
+            "raw ingestion continues after rollback"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rollback_waits_for_in_flight_guarded_write() {
+        use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
+        use tokio::time::{timeout, Duration};
+
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+
+        let guarded_tx = match begin_write_guarded(&pool, true, GcsRollbackPolicy::Continue)
+            .await
+            .expect("guard")
+        {
+            WriteGuard::Proceed(tx) => tx,
+            WriteGuard::Stop | WriteGuard::Skip => panic!("write unexpectedly blocked"),
+        };
+
+        let rollback_pool = pool.clone();
+        let mut rollback = tokio::spawn(async move { rollback_dry_run(&rollback_pool, 200).await });
+
+        assert!(
+            timeout(Duration::from_millis(200), &mut rollback)
+                .await
+                .is_err(),
+            "rollback must block while a writer holds the shared advisory lock"
+        );
+        assert!(
+            marker_exists(&pool).await,
+            "schema must not reset while the guarded write is in flight"
+        );
+
+        guarded_tx.commit().await.expect("release write guard");
+        assert!(
+            timeout(Duration::from_secs(10), rollback)
+                .await
+                .expect("rollback remained blocked")
+                .expect("rollback task panicked")
+                .expect("rollback failed"),
+            "rollback should claim the active dry-run"
+        );
+        assert!(
+            !marker_exists(&pool).await,
+            "schema should reset after the guarded write commits"
+        );
+        assert_eq!(gcs_state(&pool).await, ("PAUSED".into(), "failed".into()));
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -259,6 +259,7 @@ pub async fn handle_upgrade_activated(
             pool,
             cancel,
             readiness,
+            proposal_id_bytes,
             payload.chain_id,
             payload.start_block,
             payload.gw_start_block,
@@ -275,6 +276,7 @@ fn spawn_gcs_dry_run_readiness(
     pool: &Pool<Postgres>,
     cancel: &CancellationToken,
     readiness: &Arc<AtomicBool>,
+    proposal_id: Vec<u8>,
     chain_id: i64,
     start_block: i64,
     gw_start_block: i64,
@@ -334,7 +336,7 @@ fn spawn_gcs_dry_run_readiness(
                             return;
                         }
                     }
-                    if let Err(e) = transition_to_dry_run_started(&pool).await {
+                    if let Err(e) = transition_to_dry_run_started(&pool, &proposal_id).await {
                         error!(error = %e, "failed to transition GCS to DryRunStarted");
                     }
                 }
@@ -590,21 +592,27 @@ async fn wait_until_dry_run_ready(
     }
 }
 
-/// Conditional UPDATE: only flips if the GCS row is still in `UpgradeActivated`.
-async fn transition_to_dry_run_started(pool: &Pool<Postgres>) -> Result<(), Error> {
+/// Conditional UPDATE: only flips if the GCS row is still in `UpgradeActivated`
+/// for `proposal_id`. The `proposal_id` match stops a readiness task left over
+/// from an earlier proposal from advancing a newer one with stale block bounds.
+async fn transition_to_dry_run_started(
+    pool: &Pool<Postgres>,
+    proposal_id: &[u8],
+) -> Result<(), Error> {
     let result = sqlx::query(
         r#"
         UPDATE upgrade_state
         SET state = 'DryRunStarted', updated_at = NOW()
-        WHERE stack_role = 'GCS' AND state = 'UpgradeActivated'
+        WHERE stack_role = 'GCS' AND state = 'UpgradeActivated' AND proposal_id = $1
         "#,
     )
+    .bind(proposal_id)
     .execute(pool)
     .await?;
 
     if result.rows_affected() == 0 {
         warn!(
-            "transition_to_dry_run_started: GCS not in UpgradeActivated — skipping unpause notify"
+            "transition_to_dry_run_started: GCS not in UpgradeActivated for this proposal — skipping unpause notify"
         );
         return Ok(());
     }
@@ -1054,8 +1062,14 @@ async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool,
     Ok(true)
 }
 
-/// GCS row fields reconcile reads: (state, host_chain_id, start_block, gw_start_block).
-type ReconcileRow = (String, Option<i64>, Option<i64>, Option<i64>);
+/// GCS row fields reconcile reads: (state, proposal_id, host_chain_id, start_block, gw_start_block).
+type ReconcileRow = (
+    String,
+    Option<Vec<u8>>,
+    Option<i64>,
+    Option<i64>,
+    Option<i64>,
+);
 
 /// Advance the upgrade from durable state: re-arm readiness, resume a cutover, or
 /// cut over once both consensus signals are in. A stopped readiness task is
@@ -1070,21 +1084,29 @@ async fn reconcile(
         return Ok(());
     }
     let row: Option<ReconcileRow> = sqlx::query_as(
-        "SELECT state, host_chain_id, start_block, gw_start_block
+        "SELECT state, proposal_id, host_chain_id, start_block, gw_start_block
            FROM upgrade_state WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
     .fetch_optional(pool)
     .await?;
-    let Some((state, host_chain_id, start_block, gw_start_block)) = row else {
+    let Some((state, proposal_id, host_chain_id, start_block, gw_start_block)) = row else {
         return Ok(());
     };
     match state.as_str() {
         // Re-arm readiness (no-op if already running).
         "UpgradeActivated" => {
-            if let (Some(chain_id), Some(start), Some(gw_start)) =
-                (host_chain_id, start_block, gw_start_block)
+            if let (Some(proposal_id), Some(chain_id), Some(start), Some(gw_start)) =
+                (proposal_id, host_chain_id, start_block, gw_start_block)
             {
-                spawn_gcs_dry_run_readiness(pool, cancel, readiness, chain_id, start, gw_start);
+                spawn_gcs_dry_run_readiness(
+                    pool,
+                    cancel,
+                    readiness,
+                    proposal_id,
+                    chain_id,
+                    start,
+                    gw_start,
+                );
             }
         }
         "UpgradeAuthorized" => {
@@ -1871,27 +1893,22 @@ mod tests {
         );
     }
 
-    /// GCS writes stop once the dry-run is rolled back, so no stale rows land in the reset schema.
+    /// A readiness task left over from an old proposal must not advance a newer one.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn gcs_write_fenced_after_rollback() {
-        use fhevm_engine_common::versioning::cutover_gate;
+    async fn transition_ignores_other_proposal() {
         let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "UpgradeActivated", "in_progress").await; // proposal_id = [0x02]
 
-        let gate = |state: &'static str| {
-            let pool = pool.clone();
-            async move {
-                seed_gcs_row(&pool, state, "in_progress").await;
-                let mut tx = pool.begin().await.expect("begin");
-                let skip = cutover_gate(&mut tx, true).await.expect("gate");
-                tx.rollback().await.expect("rollback");
-                skip
-            }
-        };
+        // Stale proposal: no-op.
+        transition_to_dry_run_started(&pool, &[0x99])
+            .await
+            .expect("transition");
+        assert_eq!(gcs_state(&pool).await.0, "UpgradeActivated");
 
-        assert!(
-            !gate("DryRunStarted").await,
-            "write allowed while dry-running"
-        );
-        assert!(gate("PAUSED").await, "write fenced after rollback");
+        // Matching proposal: advances.
+        transition_to_dry_run_started(&pool, &[0x02])
+            .await
+            .expect("transition");
+        assert_eq!(gcs_state(&pool).await.0, "DryRunStarted");
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -311,7 +311,7 @@ fn spawn_gcs_dry_run_readiness(
                             return;
                         }
                     }
-                    if let Err(e) = transition_to_gw_dry_run_started(&pool).await {
+                    if let Err(e) = transition_to_gw_dry_run_started(&pool, &proposal_id).await {
                         error!(error = %e, "failed to transition GCS gw_dry_run_started");
                     }
                 }
@@ -782,7 +782,10 @@ async fn prune_gcs_verify_proofs_before_start(
 /// Conditional UPDATE: marks the GCS row's `gw_dry_run_started` and notifies the
 /// zkproof-worker. Only flips a GCS row still in the gw-gateable window with the
 /// flag unset, so a duplicate firing is a no-op.
-async fn transition_to_gw_dry_run_started(pool: &Pool<Postgres>) -> Result<(), Error> {
+async fn transition_to_gw_dry_run_started(
+    pool: &Pool<Postgres>,
+    proposal_id: &[u8],
+) -> Result<(), Error> {
     let result = sqlx::query(
         r#"
         UPDATE upgrade_state
@@ -790,14 +793,16 @@ async fn transition_to_gw_dry_run_started(pool: &Pool<Postgres>) -> Result<(), E
         WHERE stack_role = 'GCS'
           AND gw_dry_run_started = FALSE
           AND state IN ('UpgradeActivated', 'DryRunStarted')
+          AND proposal_id = $1
         "#,
     )
+    .bind(proposal_id)
     .execute(pool)
     .await?;
 
     if result.rows_affected() == 0 {
         warn!(
-            "transition_to_gw_dry_run_started: GCS row not eligible (already set or past window) — skipping notify"
+            "transition_to_gw_dry_run_started: GCS row not eligible (already set, past window, or other proposal) — skipping notify"
         );
         return Ok(());
     }
@@ -1910,5 +1915,41 @@ mod tests {
             .await
             .expect("transition");
         assert_eq!(gcs_state(&pool).await.0, "DryRunStarted");
+    }
+
+    /// Same guard on the gateway track: a stale proposal must not set gw_dry_run_started.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gw_transition_ignores_other_proposal() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "UpgradeActivated", "in_progress").await; // proposal_id = [0x02]
+        sqlx::query("UPDATE upgrade_state SET gw_dry_run_started = FALSE WHERE stack_role = 'GCS'")
+            .execute(&pool)
+            .await
+            .expect("reset flag");
+
+        let gw_flag = |pool: Pool<Postgres>| async move {
+            let (g,): (bool,) = sqlx::query_as(
+                "SELECT gw_dry_run_started FROM upgrade_state WHERE stack_role = 'GCS'",
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("gw flag");
+            g
+        };
+
+        // Stale proposal: no-op.
+        transition_to_gw_dry_run_started(&pool, &[0x99])
+            .await
+            .expect("gw transition");
+        assert!(
+            !gw_flag(pool.clone()).await,
+            "stale proposal must not release gw"
+        );
+
+        // Matching proposal: releases.
+        transition_to_gw_dry_run_started(&pool, &[0x02])
+            .await
+            .expect("gw transition");
+        assert!(gw_flag(pool.clone()).await, "matching proposal releases gw");
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -1040,6 +1040,9 @@ async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool,
     Ok(true)
 }
 
+/// GCS row fields reconcile reads: (state, host_chain_id, start_block, gw_start_block).
+type ReconcileRow = (String, Option<i64>, Option<i64>, Option<i64>);
+
 /// Advance the upgrade from durable state: re-arm readiness, resume a cutover, or
 /// cut over on both latches. `resume_activated` is boot-only.
 async fn reconcile(
@@ -1051,7 +1054,7 @@ async fn reconcile(
     if !gcs_mode {
         return Ok(());
     }
-    let row: Option<(String, Option<i64>, Option<i64>, Option<i64>)> = sqlx::query_as(
+    let row: Option<ReconcileRow> = sqlx::query_as(
         "SELECT state, host_chain_id, start_block, gw_start_block
            FROM upgrade_state WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -856,8 +856,8 @@ async fn merge_gcs_table(
     Ok(merged.rows_affected())
 }
 
-/// Cutover routine — invoked when `event_unanimity_consensus` fires and the
-/// FSM has been transitioned from `DryRunStarted` to `UpgradeAuthorized`.
+/// Cutover routine — run once the GCS row is `UpgradeAuthorized`, from the
+/// unanimity handler or from `reconcile`. Idempotent via the under-lock re-read.
 ///
 /// Runs atomically inside one transaction holding `pg_advisory_xact_lock(CUTOVER_LOCK_ID)`
 /// in exclusive mode. The exclusive lock blocks until every BCS write tx
@@ -866,7 +866,7 @@ async fn merge_gcs_table(
 /// until cutover commits.
 ///
 /// Sequence:
-///   1. Read `start_block` and `version` from the GCS upgrade row.
+///   1. Re-read state under the lock; no-op unless `UpgradeAuthorized`, else take its `version`.
 ///   2. UPDATE `versioning` to the new stack_version.
 ///   3. Merge `gcs.ciphertexts` → `public.ciphertexts`.
 ///   4. DROP SCHEMA gcs CASCADE.
@@ -876,28 +876,6 @@ async fn merge_gcs_table(
 /// acquires it, re-reads its FSM state, sees `PAUSED`, and exits cleanly.
 pub async fn execute_cutover(pool: &Pool<Postgres>) -> Result<(), Error> {
     info!("execute_cutover() starting");
-
-    let row: Option<(Option<i64>, Option<String>)> = sqlx::query_as(
-        "SELECT start_block, version
-         FROM upgrade_state
-         WHERE stack_role = 'GCS'",
-    )
-    .fetch_optional(pool)
-    .await?;
-
-    let (_start_block, stack_version) = match row {
-        Some((Some(s), version)) => (s, version.unwrap_or_default()),
-        Some((s, _)) => {
-            return Err(Error::Payload(format!(
-                "GCS upgrade_state row is missing required fields: start_block={s:?}"
-            )));
-        }
-        None => {
-            return Err(Error::Payload(
-                "no GCS row in upgrade_state — cannot run cutover".to_string(),
-            ));
-        }
-    };
 
     let mut tx = pool.begin().await?;
 
@@ -909,6 +887,30 @@ pub async fn execute_cutover(pool: &Pool<Postgres>) -> Result<(), Error> {
         lock_id = CUTOVER_LOCK_ID,
         "cutover acquired exclusive advisory lock"
     );
+
+    // Re-read under the lock: a concurrent cutover may have already promoted this row.
+    let row: Option<(String, Option<i64>, Option<String>)> = sqlx::query_as(
+        "SELECT state, start_block, version FROM upgrade_state WHERE stack_role = 'GCS'",
+    )
+    .fetch_optional(&mut *tx)
+    .await?;
+    let stack_version = match row {
+        None => {
+            return Err(Error::Payload(
+                "no GCS row in upgrade_state — cannot run cutover".to_string(),
+            ));
+        }
+        Some((state, _, _)) if state != "UpgradeAuthorized" => {
+            info!(state = %state, "cutover: GCS row is not UpgradeAuthorized — skipping (already cut over)");
+            return Ok(());
+        }
+        Some((_, None, _)) => {
+            return Err(Error::Payload(
+                "GCS upgrade_state row is missing start_block".to_string(),
+            ));
+        }
+        Some((_, Some(_start_block), version)) => version.unwrap_or_default(),
+    };
 
     // 2. Promote the new stack version inside the cutover tx. This is the
     //    source of truth read by `resolve_gcs_mode` / `reconcile_stack_mode`:
@@ -978,6 +980,82 @@ pub async fn execute_cutover(pool: &Pool<Postgres>) -> Result<(), Error> {
         channel = EVENT_STACK_VERSION_UPGRADED,
         stack_version, "execute_cutover() committed; stack-version-upgraded notify delivered"
     );
+    Ok(())
+}
+
+/// Flip to `UpgradeAuthorized` and cut over once both latches are set; guarded UPDATE, so duplicates no-op.
+async fn try_cutover_if_consensus(pool: &Pool<Postgres>) -> Result<(), Error> {
+    let result = sqlx::query(
+        r#"
+        UPDATE upgrade_state
+        SET state = 'UpgradeAuthorized', updated_at = NOW()
+        WHERE stack_role = 'GCS' AND state = 'DryRunStarted'
+          AND host_consensus_reached AND gw_consensus_reached
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        debug!("cutover deferred — both consensus latches not yet set");
+        return Ok(());
+    }
+    info!("both host and gateway consensus reached — transitioning to UpgradeAuthorized and running cutover");
+    execute_cutover(pool).await
+}
+
+/// Roll back a dry-run: PAUSED/failed, reset schema, wake workers. Only while dry-running; returns whether it acted.
+async fn rollback_dry_run(pool: &Pool<Postgres>) -> Result<bool, Error> {
+    let mut tx = pool.begin().await?;
+    let claimed = sqlx::query(
+        r#"
+        UPDATE upgrade_state
+           SET state = 'PAUSED', status = 'failed',
+               last_error = 'unanimity_consensus_timeout',
+               host_consensus_reached = FALSE, gw_consensus_reached = FALSE,
+               gw_dry_run_started = FALSE, updated_at = NOW()
+         WHERE stack_role = 'GCS' AND state IN ('UpgradeActivated', 'DryRunStarted')
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+    if claimed.rows_affected() == 0 {
+        tx.rollback().await?;
+        return Ok(false);
+    }
+    reset_gcs_schema(&mut tx).await?;
+    sqlx::query("SELECT pg_notify($1, '')")
+        .bind(fhevm_engine_common::gcs_activation::EVENT_DRY_RUN_ROLLED_BACK)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(true)
+}
+
+/// Advance the upgrade from durable state (boot + poll): resume an interrupted
+/// cutover, or cut over once both latches are set.
+async fn reconcile(pool: &Pool<Postgres>, gcs_mode: bool) -> Result<(), Error> {
+    if !gcs_mode {
+        return Ok(());
+    }
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT state FROM upgrade_state WHERE stack_role = 'GCS' AND status = 'in_progress'",
+    )
+    .fetch_optional(pool)
+    .await?;
+    let Some((state,)) = row else {
+        return Ok(());
+    };
+    match state.as_str() {
+        "UpgradeAuthorized" => {
+            info!("reconcile: GCS in UpgradeAuthorized — resuming cutover");
+            execute_cutover(pool).await?;
+        }
+        // Guarded on both latches, so it no-ops until they're set.
+        "DryRunStarted" => {
+            try_cutover_if_consensus(pool).await?;
+        }
+        _ => {}
+    }
     Ok(())
 }
 
@@ -1056,22 +1134,25 @@ pub async fn handle_unanimity_consensus(
                 // against late/replayed events for a prior upgrade window.
                 match (start_block, end_block) {
                     (Some(start), Some(end)) if (start..=end).contains(&payload.block_height) => {
-                        info!(
-                            chain_id = payload.chain_id,
-                            block_height = payload.block_height,
-                            block_hash = %payload.block_hash,
-                            start_block = start,
-                            end_block = end,
-                            proposal_id = ?proposal_id.as_deref().map(hex_encode),
-                            "event_unanimity_consensus: host-track unanimity within window — setting host_consensus_reached"
-                        );
-                        sqlx::query(
+                        // `AND NOT host_consensus_reached` so a re-emitted anchor no-ops.
+                        let set = sqlx::query(
                             "UPDATE upgrade_state SET host_consensus_reached = TRUE, updated_at = NOW()
                               WHERE stack_role = 'GCS'
-                                AND state IN ('UpgradeActivated', 'DryRunStarted')",
+                                AND state IN ('UpgradeActivated', 'DryRunStarted')
+                                AND NOT host_consensus_reached",
                         )
                         .execute(pool)
                         .await?;
+                        if set.rows_affected() > 0 {
+                            info!(
+                                chain_id = payload.chain_id,
+                                block_height = payload.block_height,
+                                start_block = start,
+                                end_block = end,
+                                proposal_id = ?proposal_id.as_deref().map(hex_encode),
+                                "event_unanimity_consensus: host-track unanimity — host_consensus_reached set"
+                            );
+                        }
                     }
                     (Some(start), Some(end)) => {
                         warn!(
@@ -1099,19 +1180,23 @@ pub async fn handle_unanimity_consensus(
                 // misclassified as Gateway when host_chain_id is NULL (legacy row).
                 match gw_start_block {
                     Some(gw_start) if payload.block_height >= gw_start => {
-                        info!(
-                            chain_id = payload.chain_id,
-                            block_height = payload.block_height,
-                            gw_start_block = gw_start,
-                            "event_unanimity_consensus: gateway-track unanimity at/after gw_start_block — setting gw_consensus_reached"
-                        );
-                        sqlx::query(
+                        // `AND NOT gw_consensus_reached` so a re-emitted anchor no-ops.
+                        let set = sqlx::query(
                             "UPDATE upgrade_state SET gw_consensus_reached = TRUE, updated_at = NOW()
                               WHERE stack_role = 'GCS'
-                                AND state IN ('UpgradeActivated', 'DryRunStarted')",
+                                AND state IN ('UpgradeActivated', 'DryRunStarted')
+                                AND NOT gw_consensus_reached",
                         )
                         .execute(pool)
                         .await?;
+                        if set.rows_affected() > 0 {
+                            info!(
+                                chain_id = payload.chain_id,
+                                block_height = payload.block_height,
+                                gw_start_block = gw_start,
+                                "event_unanimity_consensus: gateway-track unanimity — gw_consensus_reached set"
+                            );
+                        }
                     }
                     Some(gw_start) => {
                         warn!(
@@ -1131,32 +1216,7 @@ pub async fn handle_unanimity_consensus(
                 }
             }
 
-            // Cutover only once BOTH tracks have been observed AND the row is in
-            // DryRunStarted. The `state = 'DryRunStarted'` guard keeps a Gateway
-            // latch recorded early (during UpgradeActivated) from firing cutover
-            // before the host stack has even entered the dry-run; the later host
-            // anchor, which arrives in DryRunStarted, is what completes the pair.
-            // The WHERE reads the freshly-updated latches atomically, so this
-            // flips (and fires cutover) exactly once — whichever track completed
-            // the pair while in DryRunStarted.
-            let result = sqlx::query(
-                r#"
-                UPDATE upgrade_state
-                SET state = 'UpgradeAuthorized', updated_at = NOW()
-                WHERE stack_role = 'GCS' AND state = 'DryRunStarted'
-                  AND host_consensus_reached AND gw_consensus_reached
-                "#,
-            )
-            .execute(pool)
-            .await?;
-            if result.rows_affected() == 0 {
-                info!(
-                    "event_unanimity_consensus: waiting for both host and gateway consensus before cutover"
-                );
-                return Ok(());
-            }
-            info!("event_unanimity_consensus: both host and gateway consensus reached — transitioning to UpgradeAuthorized and running cutover");
-            execute_cutover(pool).await?;
+            try_cutover_if_consensus(pool).await?;
         }
         Some((state, _, _, _, _, _)) => {
             warn!(
@@ -1191,50 +1251,19 @@ pub async fn handle_unanimity_consensus_timeout(
     let payload: UnanimityConsensusPayload =
         serde_json::from_str(raw_payload).map_err(|e| Error::Payload(e.to_string()))?;
 
-    let mut tx = pool.begin().await?;
-
-    // Only roll back while still dry-running; skips duplicates and won't undo a cutover.
-    let claimed = sqlx::query(
-        r#"
-        UPDATE upgrade_state
-           SET state                  = 'PAUSED',
-               status                 = 'failed',
-               last_error             = 'unanimity_consensus_timeout',
-               host_consensus_reached = FALSE,
-               gw_consensus_reached   = FALSE,
-               gw_dry_run_started     = FALSE,
-               updated_at             = NOW()
-         WHERE stack_role = 'GCS'
-           AND state IN ('UpgradeActivated', 'DryRunStarted')
-        "#,
-    )
-    .execute(&mut *tx)
-    .await?;
-
-    if claimed.rows_affected() == 0 {
+    if rollback_dry_run(pool).await? {
+        warn!(
+            chain_id = payload.chain_id,
+            block_height = payload.block_height,
+            "event_unanimity_consensus_timeout: rolled back GCS dry-run — schema reset, upgrade may be rerun"
+        );
+    } else {
         info!(
             chain_id = payload.chain_id,
             block_height = payload.block_height,
             "event_unanimity_consensus_timeout: GCS row not in a rollback-eligible state — skipping rollback"
         );
-        tx.rollback().await?;
-        return Ok(());
     }
-
-    reset_gcs_schema(&mut tx).await?;
-
-    // Wake the worker watchers to re-pause promptly; queued in the tx, delivered only on commit.
-    sqlx::query("SELECT pg_notify($1, '')")
-        .bind(fhevm_engine_common::gcs_activation::EVENT_DRY_RUN_ROLLED_BACK)
-        .execute(&mut *tx)
-        .await?;
-
-    tx.commit().await?;
-    warn!(
-        chain_id = payload.chain_id,
-        block_height = payload.block_height,
-        "event_unanimity_consensus_timeout: rolled back GCS dry-run — schema reset, upgrade may be rerun"
-    );
 
     Ok(())
 }
@@ -1284,6 +1313,11 @@ pub async fn run(
     listener.listen_all(channels).await?;
     info!(?channels, "Listening for notifications");
 
+    // Boot reconcile: recover an upgrade whose NOTIFY was missed while down (LISTEN already registered).
+    if let Err(e) = reconcile(&pool, config.gcs_mode).await {
+        error!(error = %e, "boot reconcile failed");
+    }
+
     let mut poll = tokio::time::interval(config.poll_interval);
     // First tick fires immediately; skip it so we don't double-trigger on startup.
     poll.tick().await;
@@ -1332,7 +1366,10 @@ pub async fn run(
                 }
             }
             _ = poll.tick() => {
-                debug!("poll tick — no notification activity");
+                // Fallback for a missed NOTIFY: re-derive the next step from the row.
+                if let Err(e) = reconcile(&pool, config.gcs_mode).await {
+                    error!(error = %e, "poll reconcile failed");
+                }
             }
         }
     }
@@ -1692,5 +1729,53 @@ mod tests {
             state, "DryRunStarted",
             "BCS-mode timeout must not mutate state"
         );
+    }
+
+    async fn gcs_state(pool: &Pool<Postgres>) -> (String, String) {
+        sqlx::query_as("SELECT state, status FROM upgrade_state WHERE stack_role = 'GCS'")
+            .fetch_one(pool)
+            .await
+            .expect("GCS row")
+    }
+
+    /// Boot/poll reconcile resumes a cutover interrupted in `UpgradeAuthorized`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_resumes_interrupted_cutover() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+
+        reconcile(&pool, true).await.expect("reconcile");
+
+        assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
+        let (sv,): (String,) =
+            sqlx::query_as("SELECT stack_version FROM versioning WHERE singleton = TRUE")
+                .fetch_one(&pool)
+                .await
+                .expect("versioning");
+        assert_eq!(sv, "v0.15");
+    }
+
+    /// Reconcile cuts over on both latches when the unanimity NOTIFY was missed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_cuts_over_when_both_latches_set() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await; // latches TRUE
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+
+        reconcile(&pool, true).await.expect("reconcile");
+
+        assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
+    }
+
+    /// A BCS-mode controller never reconciles GCS state.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_bcs_mode_is_noop() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
+
+        reconcile(&pool, false).await.expect("reconcile");
+
+        assert_eq!(gcs_state(&pool).await.0, "UpgradeAuthorized");
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -23,6 +23,8 @@ pub const UPGRADE_ACTIVATED_CHANNEL: &str =
     fhevm_engine_common::gcs_activation::EVENT_UPGRADE_ACTIVATED;
 /// Must stay in sync with `consensus_detector::UNANIMITY_CONSENSUS_CHANNEL`.
 pub const UNANIMITY_CONSENSUS_CHANNEL: &str = "event_unanimity_consensus";
+/// Sent when a dry-run never reached agreement; triggers the rollback.
+pub const UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL: &str = "event_unanimity_consensus_timeout";
 /// Re-triggers the GCS dry-run readiness check. Must stay in sync with the
 /// names emitted by `host-listener::ingest_block_logs` and the FHE workers.
 pub const NEW_BLOCK_CHANNEL: &str = "event_new_block";
@@ -329,16 +331,11 @@ pub async fn handle_upgrade_activated(
     Ok(())
 }
 
-/// Create the versioned GCS schema (e.g. `"gcs-0.14.0"`) and a
-/// `CREATE TABLE <schema>.X (LIKE public.X INCLUDING ALL)` for every
-/// [`COPROCESSOR_TABLES`] entry with `duplicated = true`. The schema name is
-/// [`GCS_SCHEMA_QUOTED`] so it stays in lockstep with the GCS services'
-/// `search_path`. Idempotent.
-pub async fn create_gcs_schema(pool: &Pool<Postgres>) -> Result<(), Error> {
-    let mut tx = pool.begin().await?;
-
+/// Create the GCS schema with an empty copy of each duplicated table. Returns
+/// their names.
+async fn create_gcs_tables(tx: &mut Transaction<'_, Postgres>) -> Result<Vec<&'static str>, Error> {
     let create_schema = format!("CREATE SCHEMA IF NOT EXISTS {GCS_SCHEMA_QUOTED}");
-    sqlx::query(&create_schema).execute(&mut *tx).await?;
+    sqlx::query(&create_schema).execute(&mut **tx).await?;
 
     let duplicated: Vec<&str> = COPROCESSOR_TABLES
         .iter()
@@ -351,14 +348,37 @@ pub async fn create_gcs_schema(pool: &Pool<Postgres>) -> Result<(), Error> {
             "CREATE TABLE IF NOT EXISTS {GCS_SCHEMA_QUOTED}.{name} \
              (LIKE public.{name} INCLUDING ALL)"
         );
-        sqlx::query(&sql).execute(&mut *tx).await?;
+        sqlx::query(&sql).execute(&mut **tx).await?;
     }
 
+    Ok(duplicated)
+}
+
+/// Idempotently create the versioned GCS schema ([`GCS_SCHEMA_QUOTED`]) and clone every
+/// `duplicated = true` [`COPROCESSOR_TABLES`] table into it with `LIKE public.X INCLUDING ALL`.
+pub async fn create_gcs_schema(pool: &Pool<Postgres>) -> Result<(), Error> {
+    let mut tx = pool.begin().await?;
+    let duplicated = create_gcs_tables(&mut tx).await?;
     tx.commit().await?;
     info!(
         schema = GCS_SCHEMA_QUOTED,
         tables = ?duplicated,
         "GCS schema created with empty table duplicates"
+    );
+    Ok(())
+}
+
+/// Drop the GCS schema and recreate it empty, on `tx` — discards the dry-run's
+/// writes while leaving the still-tailing GCS listeners a valid write target, so
+/// the upgrade can be rerun without restarting the GCS stack.
+async fn reset_gcs_schema(tx: &mut Transaction<'_, Postgres>) -> Result<(), Error> {
+    let drop_sql = format!("DROP SCHEMA IF EXISTS {GCS_SCHEMA_QUOTED} CASCADE");
+    sqlx::query(&drop_sql).execute(&mut **tx).await?;
+    let duplicated = create_gcs_tables(tx).await?;
+    info!(
+        schema = GCS_SCHEMA_QUOTED,
+        tables = ?duplicated,
+        "GCS schema dropped and recreated empty (rollback)"
     );
     Ok(())
 }
@@ -1152,6 +1172,67 @@ pub async fn handle_unanimity_consensus(
     Ok(())
 }
 
+/// The dry-run timed out without agreement: reset the GCS stack so the upgrade
+/// can be rerun. Rolls back the failed dry-run and wipes its schema. Only acts
+/// while still dry-running, so a late timeout can't undo a cutover. BCS is
+/// untouched.
+pub async fn handle_unanimity_consensus_timeout(
+    pool: &Pool<Postgres>,
+    gcs_mode: bool,
+    raw_payload: &str,
+) -> Result<(), Error> {
+    info!("event_unanimity_consensus_timeout received — evaluating rollback");
+
+    if !gcs_mode {
+        debug!("event_unanimity_consensus_timeout: service not in gcs mode, ignoring");
+        return Ok(());
+    }
+
+    let payload: UnanimityConsensusPayload =
+        serde_json::from_str(raw_payload).map_err(|e| Error::Payload(e.to_string()))?;
+
+    let mut tx = pool.begin().await?;
+
+    // Only roll back while still dry-running; skips duplicates and won't undo a cutover.
+    let claimed = sqlx::query(
+        r#"
+        UPDATE upgrade_state
+           SET state                  = 'PAUSED',
+               status                 = 'failed',
+               last_error             = 'unanimity_consensus_timeout',
+               host_consensus_reached = FALSE,
+               gw_consensus_reached   = FALSE,
+               gw_dry_run_started     = FALSE,
+               updated_at             = NOW()
+         WHERE stack_role = 'GCS'
+           AND state IN ('UpgradeActivated', 'DryRunStarted')
+        "#,
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    if claimed.rows_affected() == 0 {
+        info!(
+            chain_id = payload.chain_id,
+            block_height = payload.block_height,
+            "event_unanimity_consensus_timeout: GCS row not in a rollback-eligible state — skipping rollback"
+        );
+        tx.rollback().await?;
+        return Ok(());
+    }
+
+    reset_gcs_schema(&mut tx).await?;
+
+    tx.commit().await?;
+    warn!(
+        chain_id = payload.chain_id,
+        block_height = payload.block_height,
+        "event_unanimity_consensus_timeout: rolled back GCS dry-run — schema reset, upgrade may be rerun"
+    );
+
+    Ok(())
+}
+
 /// Lowercase hex without `0x` prefix; only used for log lines, kept private
 /// to avoid pulling in another crate for a few bytes' worth of formatting.
 fn hex_encode(bytes: &[u8]) -> String {
@@ -1189,13 +1270,13 @@ pub async fn run(
     }
 
     let mut listener = PgListener::connect_with(&pool).await?;
-    listener
-        .listen_all([UPGRADE_ACTIVATED_CHANNEL, UNANIMITY_CONSENSUS_CHANNEL])
-        .await?;
-    info!(
-        channels = ?[UPGRADE_ACTIVATED_CHANNEL, UNANIMITY_CONSENSUS_CHANNEL],
-        "Listening for notifications"
-    );
+    let channels = [
+        UPGRADE_ACTIVATED_CHANNEL,
+        UNANIMITY_CONSENSUS_CHANNEL,
+        UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL,
+    ];
+    listener.listen_all(channels).await?;
+    info!(?channels, "Listening for notifications");
 
     let mut poll = tokio::time::interval(config.poll_interval);
     // First tick fires immediately; skip it so we don't double-trigger on startup.
@@ -1222,6 +1303,11 @@ pub async fn run(
                                 // Emitted by consensus-detector when every operator publishes
                                 // the same state commitment at the upgrade's end_block.
                                 handle_unanimity_consensus(&pool, config.gcs_mode, payload).await
+                            }
+                            UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL => {
+                                // Window never reached unanimity — roll back the dry-run.
+                                handle_unanimity_consensus_timeout(&pool, config.gcs_mode, payload)
+                                    .await
                             }
                             other => {
                                 warn!(channel = other, "ignoring notification on unexpected channel");
@@ -1294,18 +1380,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn handle_upgrade_activated_accepts_new_proposal_after_paused_cutover() {
-        use sqlx::postgres::PgPoolOptions;
         use sqlx::Row;
-        use test_harness::instance::{setup_test_db, ImportMode};
 
-        let instance = setup_test_db(ImportMode::WithKeysNoSns)
-            .await
-            .expect("test db");
-        let pool = PgPoolOptions::new()
-            .max_connections(4)
-            .connect(instance.db_url())
-            .await
-            .expect("pool");
+        let (_instance, pool) = test_pool().await;
 
         sqlx::query(
             r#"
@@ -1368,18 +1445,9 @@ mod tests {
     /// also keeps the test stable as the merged tables' columns evolve).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cutover_merges_match_live_unique_keys() {
-        use sqlx::postgres::PgPoolOptions;
         use sqlx::Row;
-        use test_harness::instance::{setup_test_db, ImportMode};
 
-        let instance = setup_test_db(ImportMode::WithKeysNoSns)
-            .await
-            .expect("test db");
-        let pool = PgPoolOptions::new()
-            .max_connections(4)
-            .connect(instance.db_url())
-            .await
-            .expect("pool");
+        let (_instance, pool) = test_pool().await;
 
         // The GCS row's `version` drives the cutover's stack_version bump.
         sqlx::query(
@@ -1428,5 +1496,195 @@ mod tests {
         .await
         .expect("schema lookup");
         assert!(!schema_exists, "cutover should drop the gcs schema");
+    }
+
+    async fn test_pool() -> (test_harness::instance::DBInstance, Pool<Postgres>) {
+        use sqlx::postgres::PgPoolOptions;
+        use test_harness::instance::{setup_test_db, ImportMode};
+        let instance = setup_test_db(ImportMode::WithKeysNoSns)
+            .await
+            .expect("test db");
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect(instance.db_url())
+            .await
+            .expect("pool");
+        (instance, pool)
+    }
+
+    fn timeout_payload() -> String {
+        serde_json::json!({ "chain_id": 1_i64, "block_height": 200_i64, "block_hash": "0x00" })
+            .to_string()
+    }
+
+    /// Seed a GCS row with all latches + `gw_dry_run_started`.
+    async fn seed_gcs_row(pool: &Pool<Postgres>, state: &str, status: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO upgrade_state (
+                stack_role, state, status, proposal_id, version,
+                start_block, end_block, gw_start_block, host_chain_id,
+                host_consensus_reached, gw_consensus_reached, gw_dry_run_started,
+                updated_at
+            )
+            VALUES ('GCS', $1, $2, $3, 'v0.15', 100, 200, 1, 1,
+                    TRUE, TRUE, TRUE, NOW())
+            ON CONFLICT (stack_role) DO UPDATE
+            SET state = EXCLUDED.state, status = EXCLUDED.status,
+                host_consensus_reached = EXCLUDED.host_consensus_reached,
+                gw_consensus_reached   = EXCLUDED.gw_consensus_reached,
+                gw_dry_run_started     = EXCLUDED.gw_dry_run_started,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(state)
+        .bind(status)
+        .bind(&[0x02u8][..])
+        .execute(pool)
+        .await
+        .expect("seed GCS row");
+    }
+
+    /// A `gcs` table NOT in `COPROCESSOR_TABLES`: only `DROP SCHEMA … CASCADE`
+    /// removes it (the recreate won't restore it), so it proves the reset ran.
+    async fn create_marker(pool: &Pool<Postgres>) {
+        sqlx::query(&format!(
+            "CREATE TABLE {GCS_SCHEMA_QUOTED}.rollback_marker (x int)"
+        ))
+        .execute(pool)
+        .await
+        .expect("create marker");
+    }
+
+    async fn marker_exists(pool: &Pool<Postgres>) -> bool {
+        let (exists,): (bool,) = sqlx::query_as(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                             WHERE table_schema = $1 AND table_name = 'rollback_marker')",
+        )
+        .bind(fhevm_engine_common::database::GCS_SCHEMA)
+        .fetch_one(pool)
+        .await
+        .expect("marker lookup");
+        exists
+    }
+
+    /// A timeout mid dry-run resets the schema and flips the GCS row to PAUSED/failed; a second timeout is a no-op.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_timeout_rolls_back_dry_run_and_is_idempotent() {
+        use sqlx::Row;
+
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+        assert!(marker_exists(&pool).await, "marker present before rollback");
+
+        let payload = timeout_payload();
+
+        handle_unanimity_consensus_timeout(&pool, true, &payload)
+            .await
+            .expect("rollback ok");
+
+        // Marker gone and schema dropped
+        assert!(
+            !marker_exists(&pool).await,
+            "rollback should DROP SCHEMA CASCADE, removing the marker"
+        );
+        // the duplicated tables recreated empty
+        let (ct_exists,): (bool,) = sqlx::query_as(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables
+                             WHERE table_schema = $1 AND table_name = 'computations')",
+        )
+        .bind(fhevm_engine_common::database::GCS_SCHEMA)
+        .fetch_one(&pool)
+        .await
+        .expect("computations lookup");
+        assert!(ct_exists, "rollback should recreate the empty gcs schema");
+
+        // Rerunnable state: PAUSED/failed.
+        let row = sqlx::query(
+            "SELECT state, status, last_error, host_consensus_reached,
+                    gw_consensus_reached, gw_dry_run_started
+               FROM upgrade_state WHERE stack_role = 'GCS'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("GCS row");
+        assert_eq!(row.try_get::<String, _>("state").unwrap(), "PAUSED");
+        assert_eq!(row.try_get::<String, _>("status").unwrap(), "failed");
+        assert_eq!(
+            row.try_get::<String, _>("last_error").unwrap(),
+            "unanimity_consensus_timeout"
+        );
+        assert!(!row.try_get::<bool, _>("host_consensus_reached").unwrap());
+        assert!(!row.try_get::<bool, _>("gw_consensus_reached").unwrap());
+        assert!(!row.try_get::<bool, _>("gw_dry_run_started").unwrap());
+
+        // Second timeout is a no-op: the marker survives (no second reset).
+        create_marker(&pool).await;
+        handle_unanimity_consensus_timeout(&pool, true, &payload)
+            .await
+            .expect("second timeout no-op");
+        assert!(
+            marker_exists(&pool).await,
+            "a duplicate timeout must not reset the schema again"
+        );
+    }
+
+    /// A late timeout must never undo a cutover: rollback is refused once the row is `UpgradeAuthorized`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_timeout_does_not_undo_authorized_cutover() {
+        use sqlx::Row;
+
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+
+        let payload = timeout_payload();
+
+        handle_unanimity_consensus_timeout(&pool, true, &payload)
+            .await
+            .expect("handler ok");
+
+        assert!(
+            marker_exists(&pool).await,
+            "a timeout must not reset the schema once the row is UpgradeAuthorized"
+        );
+        let row = sqlx::query("SELECT state, status FROM upgrade_state WHERE stack_role = 'GCS'")
+            .fetch_one(&pool)
+            .await
+            .expect("GCS row");
+        assert_eq!(
+            row.try_get::<String, _>("state").unwrap(),
+            "UpgradeAuthorized",
+            "the FSM state must be left intact"
+        );
+        assert_eq!(row.try_get::<String, _>("status").unwrap(), "in_progress");
+    }
+
+    /// A timeout on a BCS-mode controller is ignored (BCS never left LIVE).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_timeout_bcs_mode_is_noop() {
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        let payload = timeout_payload();
+
+        handle_unanimity_consensus_timeout(&pool, false, &payload)
+            .await
+            .expect("bcs no-op");
+
+        let (state,): (String,) =
+            sqlx::query_as("SELECT state FROM upgrade_state WHERE stack_role = 'GCS'")
+                .fetch_one(&pool)
+                .await
+                .expect("GCS row");
+        assert_eq!(
+            state, "DryRunStarted",
+            "BCS-mode timeout must not mutate state"
+        );
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -126,11 +126,10 @@ pub struct UpgradeActivatedPayload {
 
 /// Payload published over `unanimity_consensus` by `consensus-detector`.
 ///
-/// `block_height` is matched against the in-DB FSM row's `end_block` to ensure
-/// the event belongs to the upgrade currently in flight — otherwise a late or
-/// replayed event could trigger a cutover for the wrong block window.
+/// `proposal_id` identifies the active upgrade.
 #[derive(Debug, Clone, Deserialize)]
 pub struct UnanimityConsensusPayload {
+    pub proposal_id: Vec<u8>,
     pub chain_id: i64,
     pub block_height: i64,
     pub block_hash: String,
@@ -1037,8 +1036,12 @@ async fn try_cutover_if_consensus(pool: &Pool<Postgres>) -> Result<(), Error> {
 }
 
 /// Roll back a dry-run under the write lock: PAUSED/failed, reset schema, wake workers.
-/// Scoped to `end_block` so a stale timeout cannot reset a newer attempt. Returns whether it acted.
-async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool, Error> {
+/// Scoped to the proposal and end block. Returns whether it acted.
+async fn rollback_dry_run(
+    pool: &Pool<Postgres>,
+    proposal_id: &[u8],
+    end_block: i64,
+) -> Result<bool, Error> {
     let mut tx = pool.begin().await?;
     sqlx::query("SELECT pg_advisory_xact_lock($1)")
         .bind(CUTOVER_LOCK_ID)
@@ -1057,9 +1060,10 @@ async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool,
                host_consensus_reached = FALSE, gw_consensus_reached = FALSE,
                gw_dry_run_started = FALSE, updated_at = NOW()
          WHERE stack_role = 'GCS' AND state IN ('UpgradeActivated', 'DryRunStarted')
-           AND end_block = $1
+           AND proposal_id = $1 AND end_block = $2
         "#,
     )
+    .bind(proposal_id)
     .bind(end_block)
     .execute(&mut *tx)
     .await?;
@@ -1195,6 +1199,11 @@ pub async fn handle_unanimity_consensus(
         Some((state, start_block, end_block, proposal_id, host_chain_id, gw_start_block))
             if state == "UpgradeActivated" || state == "DryRunStarted" =>
         {
+            if proposal_id.as_deref() != Some(payload.proposal_id.as_slice()) {
+                warn!("event_unanimity_consensus: proposal does not match — ignoring");
+                return Ok(());
+            }
+
             // Classify the event. Host track iff chain_id matches the stored
             // host_chain_id; everything else is the Gateway track. For a legacy
             // row predating host_chain_id, fall back to window membership.
@@ -1216,8 +1225,10 @@ pub async fn handle_unanimity_consensus(
                             "UPDATE upgrade_state SET host_consensus_reached = TRUE, updated_at = NOW()
                               WHERE stack_role = 'GCS'
                                 AND state IN ('UpgradeActivated', 'DryRunStarted')
+                                AND proposal_id = $1
                                 AND NOT host_consensus_reached",
                         )
+                        .bind(&payload.proposal_id)
                         .execute(pool)
                         .await?;
                         if set.rows_affected() > 0 {
@@ -1262,8 +1273,10 @@ pub async fn handle_unanimity_consensus(
                             "UPDATE upgrade_state SET gw_consensus_reached = TRUE, updated_at = NOW()
                               WHERE stack_role = 'GCS'
                                 AND state IN ('UpgradeActivated', 'DryRunStarted')
+                                AND proposal_id = $1
                                 AND NOT gw_consensus_reached",
                         )
+                        .bind(&payload.proposal_id)
                         .execute(pool)
                         .await?;
                         if set.rows_affected() > 0 {
@@ -1328,7 +1341,7 @@ pub async fn handle_unanimity_consensus_timeout(
     let payload: UnanimityConsensusPayload =
         serde_json::from_str(raw_payload).map_err(|e| Error::Payload(e.to_string()))?;
 
-    if rollback_dry_run(pool, payload.block_height).await? {
+    if rollback_dry_run(pool, &payload.proposal_id, payload.block_height).await? {
         warn!(
             chain_id = payload.chain_id,
             block_height = payload.block_height,
@@ -1480,11 +1493,13 @@ mod tests {
     #[test]
     fn parses_unanimity_consensus_payload() {
         let json = r#"{
+            "proposal_id": [2],
             "chain_id": 12345,
             "block_height": 200,
             "block_hash": "0xabc0000000000000000000000000000000000000000000000000000000000001"
         }"#;
         let p: UnanimityConsensusPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(p.proposal_id, vec![2]);
         assert_eq!(p.chain_id, 12345);
         assert_eq!(p.block_height, 200);
         assert_eq!(
@@ -1637,7 +1652,7 @@ mod tests {
     }
 
     fn timeout_payload() -> String {
-        serde_json::json!({ "chain_id": 1_i64, "block_height": 200_i64, "block_hash": "0x00" })
+        serde_json::json!({ "proposal_id": [2], "chain_id": 1_i64, "block_height": 200_i64, "block_hash": "0x00" })
             .to_string()
     }
 
@@ -1891,7 +1906,7 @@ mod tests {
 
         // Timeout for a different window (block_height 999 != end_block 200).
         let payload =
-            serde_json::json!({ "chain_id": 1_i64, "block_height": 999_i64, "block_hash": "0x00" })
+            serde_json::json!({ "proposal_id": [2], "chain_id": 1_i64, "block_height": 999_i64, "block_hash": "0x00" })
                 .to_string();
         handle_unanimity_consensus_timeout(&pool, true, &payload)
             .await
@@ -1905,6 +1920,65 @@ mod tests {
             gcs_state(&pool).await,
             ("DryRunStarted".into(), "in_progress".into())
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_timeout_ignores_other_proposal() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+
+        let payload = serde_json::json!({
+            "proposal_id": [0x99],
+            "chain_id": 1_i64,
+            "block_height": 200_i64,
+            "block_hash": "0x00"
+        })
+        .to_string();
+        handle_unanimity_consensus_timeout(&pool, true, &payload)
+            .await
+            .expect("handler ok");
+
+        assert!(marker_exists(&pool).await);
+        assert_eq!(
+            gcs_state(&pool).await,
+            ("DryRunStarted".into(), "in_progress".into())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_consensus_ignores_other_proposal() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "UpgradeActivated", "in_progress").await;
+        sqlx::query(
+            "UPDATE upgrade_state
+                SET host_consensus_reached = FALSE, gw_consensus_reached = FALSE
+              WHERE stack_role = 'GCS'",
+        )
+        .execute(&pool)
+        .await
+        .expect("reset latches");
+
+        let payload = serde_json::json!({
+            "proposal_id": [0x99],
+            "chain_id": 1_i64,
+            "block_height": 150_i64,
+            "block_hash": "0x00"
+        })
+        .to_string();
+        handle_unanimity_consensus(&pool, true, &payload)
+            .await
+            .expect("handler ok");
+
+        let latches: (bool, bool) = sqlx::query_as(
+            "SELECT host_consensus_reached, gw_consensus_reached
+               FROM upgrade_state WHERE stack_role = 'GCS'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("latches");
+        assert_eq!(latches, (false, false));
     }
 
     /// A readiness task left over from an old proposal must not advance a newer one.
@@ -2018,7 +2092,8 @@ mod tests {
         };
 
         let rollback_pool = pool.clone();
-        let mut rollback = tokio::spawn(async move { rollback_dry_run(&rollback_pool, 200).await });
+        let mut rollback =
+            tokio::spawn(async move { rollback_dry_run(&rollback_pool, &[0x02], 200).await });
 
         assert!(
             timeout(Duration::from_millis(200), &mut rollback)

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -252,83 +252,89 @@ pub async fn handle_upgrade_activated(
     // Only GCS gates on the pre-snapshot completeness check; BCS keeps
     // serving live traffic untouched until cutover.
     if gcs_mode {
-        let chain_id = payload.chain_id;
-        let start_block = payload.start_block;
-
-        // Gateway-side gate for the zkproof-worker, run concurrently with the
-        // host-chain readiness loop below. The zkproof-worker switches its
-        // re-randomization strategy at `gw_start_block` (a Gateway block), which
-        // is a different clock from the host-chain `start_block` that releases
-        // the tfhe-/sns-workers — so it gets its own readiness task and its own
-        // release notify. Spawned (not awaited) so it makes progress while the
-        // host-chain loop blocks this handler.
-        {
-            let pool = pool.clone();
-            let cancel = cancel.child_token();
-            let gw_start_block = payload.gw_start_block;
-            tokio::spawn(async move {
-                match wait_until_gw_dry_run_ready(pool.clone(), cancel, gw_start_block).await {
-                    Ok(true) => {
-                        // Prune pre-start proofs so the dry-run snapshot starts
-                        // cleanly at gw_start_block, then release the worker.
-                        match prune_gcs_verify_proofs_before_start(&pool, gw_start_block).await {
-                            Ok(deleted) => info!(
-                                gw_start_block,
-                                deleted, "pruned pre-gw_start_block rows from gcs.verify_proofs"
-                            ),
-                            Err(e) => {
-                                error!(error = %e, "failed to prune gcs.verify_proofs; skipping gw release");
-                                return;
-                            }
-                        }
-                        if let Err(e) = transition_to_gw_dry_run_started(&pool).await {
-                            error!(error = %e, "failed to transition GCS gw_dry_run_started");
-                        }
-                    }
-                    Ok(false) => info!(
-                        gw_start_block,
-                        "gw readiness loop exited without satisfying readiness — skipping prune and release"
-                    ),
-                    Err(e) => error!(error = %e, "GCS gateway dry-run readiness loop failed"),
-                }
-            });
-        }
-
-        // 1. Wait until BCS has fully settled every computation up to start_block.
-        match wait_until_dry_run_ready(pool.clone(), cancel.child_token(), chain_id, start_block)
-            .await
-        {
-            Ok(true) => {
-                // 2. Prune: the GCS stack tails the chain before activation, so
-                //    gcs.computations may hold rows for blocks below start_block.
-                //    Clear them — after readiness, before the internal
-                //    upgrade-activated spawn — so the dry-run snapshot begins
-                //    cleanly at start_block.
-                let deleted =
-                    prune_gcs_computations_before_start(pool, chain_id, start_block).await?;
-                info!(
-                    chain_id,
-                    start_block, deleted, "pruned pre-start_block rows from gcs.computations"
-                );
-
-                // 3. Spawn upgrade_activated internally: flip the GCS row to
-                //    DryRunStarted, releasing the GCS stack into the dry-run.
-                transition_to_dry_run_started(pool).await?;
-            }
-            Ok(false) => {
-                info!(
-                    chain_id,
-                    start_block,
-                    "readiness loop exited without satisfying readiness — skipping prune and transition"
-                );
-            }
-            Err(e) => {
-                error!(error = %e, "GCS dry-run readiness loop failed");
-            }
-        }
+        spawn_gcs_dry_run_readiness(
+            pool,
+            cancel,
+            payload.chain_id,
+            payload.start_block,
+            payload.gw_start_block,
+        );
     }
 
     Ok(())
+}
+
+/// Spawn the GCS readiness gates (gateway + host) that release the workers and flip
+/// the row to `DryRunStarted`. Fire-and-forget, so `reconcile` can re-arm it on restart.
+fn spawn_gcs_dry_run_readiness(
+    pool: &Pool<Postgres>,
+    cancel: &CancellationToken,
+    chain_id: i64,
+    start_block: i64,
+    gw_start_block: i64,
+) {
+    // Gateway gate for the zkproof-worker: gw_start_block is a Gateway block, a
+    // separate clock from the host start_block, so it gets its own task.
+    {
+        let pool = pool.clone();
+        let cancel = cancel.child_token();
+        tokio::spawn(async move {
+            match wait_until_gw_dry_run_ready(pool.clone(), cancel, gw_start_block).await {
+                Ok(true) => {
+                    // Prune pre-start proofs so the snapshot starts clean, then release.
+                    match prune_gcs_verify_proofs_before_start(&pool, gw_start_block).await {
+                        Ok(deleted) => info!(
+                            gw_start_block,
+                            deleted, "pruned pre-gw_start_block rows from gcs.verify_proofs"
+                        ),
+                        Err(e) => {
+                            error!(error = %e, "failed to prune gcs.verify_proofs; skipping gw release");
+                            return;
+                        }
+                    }
+                    if let Err(e) = transition_to_gw_dry_run_started(&pool).await {
+                        error!(error = %e, "failed to transition GCS gw_dry_run_started");
+                    }
+                }
+                Ok(false) => info!(
+                    gw_start_block,
+                    "gw readiness loop exited without satisfying readiness — skipping prune and release"
+                ),
+                Err(e) => error!(error = %e, "GCS gateway dry-run readiness loop failed"),
+            }
+        });
+    }
+
+    // Host gate: wait until BCS settles up to start_block, prune, then flip to DryRunStarted.
+    {
+        let pool = pool.clone();
+        let cancel = cancel.child_token();
+        tokio::spawn(async move {
+            match wait_until_dry_run_ready(pool.clone(), cancel, chain_id, start_block).await {
+                Ok(true) => {
+                    match prune_gcs_computations_before_start(&pool, chain_id, start_block).await {
+                        Ok(deleted) => info!(
+                            chain_id,
+                            start_block, deleted, "pruned pre-start_block rows from gcs.computations"
+                        ),
+                        Err(e) => {
+                            error!(error = %e, "failed to prune gcs.computations; skipping transition");
+                            return;
+                        }
+                    }
+                    if let Err(e) = transition_to_dry_run_started(&pool).await {
+                        error!(error = %e, "failed to transition GCS to DryRunStarted");
+                    }
+                }
+                Ok(false) => info!(
+                    chain_id,
+                    start_block,
+                    "readiness loop exited without satisfying readiness — skipping prune and transition"
+                ),
+                Err(e) => error!(error = %e, "GCS dry-run readiness loop failed"),
+            }
+        });
+    }
 }
 
 /// Create the GCS schema with an empty copy of each duplicated table. Returns
@@ -1003,8 +1009,9 @@ async fn try_cutover_if_consensus(pool: &Pool<Postgres>) -> Result<(), Error> {
     execute_cutover(pool).await
 }
 
-/// Roll back a dry-run: PAUSED/failed, reset schema, wake workers. Only while dry-running; returns whether it acted.
-async fn rollback_dry_run(pool: &Pool<Postgres>) -> Result<bool, Error> {
+/// Roll back a dry-run: PAUSED/failed, reset schema, wake workers. Scoped to the
+/// `end_block` window so a stale re-emitted timeout can't reset a newer attempt. Returns whether it acted.
+async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool, Error> {
     let mut tx = pool.begin().await?;
     let claimed = sqlx::query(
         r#"
@@ -1014,8 +1021,10 @@ async fn rollback_dry_run(pool: &Pool<Postgres>) -> Result<bool, Error> {
                host_consensus_reached = FALSE, gw_consensus_reached = FALSE,
                gw_dry_run_started = FALSE, updated_at = NOW()
          WHERE stack_role = 'GCS' AND state IN ('UpgradeActivated', 'DryRunStarted')
+           AND end_block = $1
         "#,
     )
+    .bind(end_block)
     .execute(&mut *tx)
     .await?;
     if claimed.rows_affected() == 0 {
@@ -1031,21 +1040,36 @@ async fn rollback_dry_run(pool: &Pool<Postgres>) -> Result<bool, Error> {
     Ok(true)
 }
 
-/// Advance the upgrade from durable state (boot + poll): resume an interrupted
-/// cutover, or cut over once both latches are set.
-async fn reconcile(pool: &Pool<Postgres>, gcs_mode: bool) -> Result<(), Error> {
+/// Advance the upgrade from durable state: re-arm readiness, resume a cutover, or
+/// cut over on both latches. `resume_activated` is boot-only.
+async fn reconcile(
+    pool: &Pool<Postgres>,
+    cancel: &CancellationToken,
+    gcs_mode: bool,
+    resume_activated: bool,
+) -> Result<(), Error> {
     if !gcs_mode {
         return Ok(());
     }
-    let row: Option<(String,)> = sqlx::query_as(
-        "SELECT state FROM upgrade_state WHERE stack_role = 'GCS' AND status = 'in_progress'",
+    let row: Option<(String, Option<i64>, Option<i64>, Option<i64>)> = sqlx::query_as(
+        "SELECT state, host_chain_id, start_block, gw_start_block
+           FROM upgrade_state WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
     .fetch_optional(pool)
     .await?;
-    let Some((state,)) = row else {
+    let Some((state, host_chain_id, start_block, gw_start_block)) = row else {
         return Ok(());
     };
     match state.as_str() {
+        // Restart mid-activation dropped the readiness tasks; re-arm them.
+        "UpgradeActivated" if resume_activated => {
+            if let (Some(chain_id), Some(start), Some(gw_start)) =
+                (host_chain_id, start_block, gw_start_block)
+            {
+                info!("reconcile: GCS in UpgradeActivated — re-arming dry-run readiness");
+                spawn_gcs_dry_run_readiness(pool, cancel, chain_id, start, gw_start);
+            }
+        }
         "UpgradeAuthorized" => {
             info!("reconcile: GCS in UpgradeAuthorized — resuming cutover");
             execute_cutover(pool).await?;
@@ -1251,7 +1275,7 @@ pub async fn handle_unanimity_consensus_timeout(
     let payload: UnanimityConsensusPayload =
         serde_json::from_str(raw_payload).map_err(|e| Error::Payload(e.to_string()))?;
 
-    if rollback_dry_run(pool).await? {
+    if rollback_dry_run(pool, payload.block_height).await? {
         warn!(
             chain_id = payload.chain_id,
             block_height = payload.block_height,
@@ -1314,7 +1338,7 @@ pub async fn run(
     info!(?channels, "Listening for notifications");
 
     // Boot reconcile: recover an upgrade whose NOTIFY was missed while down (LISTEN already registered).
-    if let Err(e) = reconcile(&pool, config.gcs_mode).await {
+    if let Err(e) = reconcile(&pool, &cancel, config.gcs_mode, true).await {
         error!(error = %e, "boot reconcile failed");
     }
 
@@ -1367,7 +1391,7 @@ pub async fn run(
             }
             _ = poll.tick() => {
                 // Fallback for a missed NOTIFY: re-derive the next step from the row.
-                if let Err(e) = reconcile(&pool, config.gcs_mode).await {
+                if let Err(e) = reconcile(&pool, &cancel, config.gcs_mode, false).await {
                     error!(error = %e, "poll reconcile failed");
                 }
             }
@@ -1745,7 +1769,9 @@ mod tests {
         seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
         create_gcs_schema(&pool).await.expect("create gcs schema");
 
-        reconcile(&pool, true).await.expect("reconcile");
+        reconcile(&pool, &CancellationToken::new(), true, false)
+            .await
+            .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
         let (sv,): (String,) =
@@ -1763,7 +1789,9 @@ mod tests {
         seed_gcs_row(&pool, "DryRunStarted", "in_progress").await; // latches TRUE
         create_gcs_schema(&pool).await.expect("create gcs schema");
 
-        reconcile(&pool, true).await.expect("reconcile");
+        reconcile(&pool, &CancellationToken::new(), true, false)
+            .await
+            .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
     }
@@ -1774,8 +1802,36 @@ mod tests {
         let (_instance, pool) = test_pool().await;
         seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
 
-        reconcile(&pool, false).await.expect("reconcile");
+        reconcile(&pool, &CancellationToken::new(), false, false)
+            .await
+            .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await.0, "UpgradeAuthorized");
+    }
+
+    /// A stale timeout from a different window must not roll back the current dry-run.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_timeout_ignores_other_window() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await; // end_block = 200
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+
+        // Timeout for a different window (block_height 999 != end_block 200).
+        let payload =
+            serde_json::json!({ "chain_id": 1_i64, "block_height": 999_i64, "block_hash": "0x00" })
+                .to_string();
+        handle_unanimity_consensus_timeout(&pool, true, &payload)
+            .await
+            .expect("handler ok");
+
+        assert!(
+            marker_exists(&pool).await,
+            "a timeout for another window must not reset the schema"
+        );
+        assert_eq!(
+            gcs_state(&pool).await,
+            ("DryRunStarted".into(), "in_progress".into())
+        );
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -5,6 +5,8 @@
 //! `unanimity_consensus` channel is produced by `consensus-detector` once every
 //! operator publishes the same state commitment at the upgrade's `end_block`.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use fhevm_engine_common::database::GCS_SCHEMA_QUOTED;
@@ -177,6 +179,7 @@ fn decode_hex(s: &str) -> Result<Vec<u8>, Error> {
 pub async fn handle_upgrade_activated(
     pool: &Pool<Postgres>,
     cancel: &CancellationToken,
+    readiness: &Arc<AtomicBool>,
     gcs_mode: bool,
     raw_payload: &str,
 ) -> Result<(), Error> {
@@ -255,6 +258,7 @@ pub async fn handle_upgrade_activated(
         spawn_gcs_dry_run_readiness(
             pool,
             cancel,
+            readiness,
             payload.chain_id,
             payload.start_block,
             payload.gw_start_block,
@@ -265,23 +269,36 @@ pub async fn handle_upgrade_activated(
 }
 
 /// Spawn the GCS readiness gates (gateway + host) that release the workers and flip
-/// the row to `DryRunStarted`. Fire-and-forget, so `reconcile` can re-arm it on restart.
+/// the row to `DryRunStarted`. `readiness` keeps one attempt running at a time, so a
+/// re-arm recovers a stopped task without piling up tasks.
 fn spawn_gcs_dry_run_readiness(
     pool: &Pool<Postgres>,
     cancel: &CancellationToken,
+    readiness: &Arc<AtomicBool>,
     chain_id: i64,
     start_block: i64,
     gw_start_block: i64,
 ) {
-    // Gateway gate for the zkproof-worker: gw_start_block is a Gateway block, a
-    // separate clock from the host start_block, so it gets its own task.
+    if readiness
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
     {
-        let pool = pool.clone();
-        let cancel = cancel.child_token();
-        tokio::spawn(async move {
-            match wait_until_gw_dry_run_ready(pool.clone(), cancel, gw_start_block).await {
+        return; // already running
+    }
+    info!(
+        chain_id,
+        start_block, gw_start_block, "arming GCS dry-run readiness"
+    );
+    let pool = pool.clone();
+    let gw_cancel = cancel.child_token();
+    let host_cancel = cancel.child_token();
+    let readiness = readiness.clone();
+    tokio::spawn(async move {
+        // Gateway gate for the zkproof-worker: gw_start_block is a Gateway block,
+        // a separate clock from the host start_block.
+        let gw_gate = async {
+            match wait_until_gw_dry_run_ready(pool.clone(), gw_cancel, gw_start_block).await {
                 Ok(true) => {
-                    // Prune pre-start proofs so the snapshot starts clean, then release.
                     match prune_gcs_verify_proofs_before_start(&pool, gw_start_block).await {
                         Ok(deleted) => info!(
                             gw_start_block,
@@ -302,15 +319,10 @@ fn spawn_gcs_dry_run_readiness(
                 ),
                 Err(e) => error!(error = %e, "GCS gateway dry-run readiness loop failed"),
             }
-        });
-    }
-
-    // Host gate: wait until BCS settles up to start_block, prune, then flip to DryRunStarted.
-    {
-        let pool = pool.clone();
-        let cancel = cancel.child_token();
-        tokio::spawn(async move {
-            match wait_until_dry_run_ready(pool.clone(), cancel, chain_id, start_block).await {
+        };
+        // Host gate: wait until BCS settles up to start_block, prune, then flip to DryRunStarted.
+        let host_gate = async {
+            match wait_until_dry_run_ready(pool.clone(), host_cancel, chain_id, start_block).await {
                 Ok(true) => {
                     match prune_gcs_computations_before_start(&pool, chain_id, start_block).await {
                         Ok(deleted) => info!(
@@ -333,8 +345,10 @@ fn spawn_gcs_dry_run_readiness(
                 ),
                 Err(e) => error!(error = %e, "GCS dry-run readiness loop failed"),
             }
-        });
-    }
+        };
+        tokio::join!(gw_gate, host_gate);
+        readiness.store(false, Ordering::SeqCst);
+    });
 }
 
 /// Create the GCS schema with an empty copy of each duplicated table. Returns
@@ -1044,12 +1058,13 @@ async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool,
 type ReconcileRow = (String, Option<i64>, Option<i64>, Option<i64>);
 
 /// Advance the upgrade from durable state: re-arm readiness, resume a cutover, or
-/// cut over on both latches. `resume_activated` is boot-only.
+/// cut over once both consensus signals are in. A stopped readiness task is
+/// recovered on the next tick (`readiness` keeps it to one attempt at a time).
 async fn reconcile(
     pool: &Pool<Postgres>,
     cancel: &CancellationToken,
+    readiness: &Arc<AtomicBool>,
     gcs_mode: bool,
-    resume_activated: bool,
 ) -> Result<(), Error> {
     if !gcs_mode {
         return Ok(());
@@ -1064,13 +1079,12 @@ async fn reconcile(
         return Ok(());
     };
     match state.as_str() {
-        // Restart mid-activation dropped the readiness tasks; re-arm them.
-        "UpgradeActivated" if resume_activated => {
+        // Re-arm readiness (no-op if already running).
+        "UpgradeActivated" => {
             if let (Some(chain_id), Some(start), Some(gw_start)) =
                 (host_chain_id, start_block, gw_start_block)
             {
-                info!("reconcile: GCS in UpgradeActivated — re-arming dry-run readiness");
-                spawn_gcs_dry_run_readiness(pool, cancel, chain_id, start, gw_start);
+                spawn_gcs_dry_run_readiness(pool, cancel, readiness, chain_id, start, gw_start);
             }
         }
         "UpgradeAuthorized" => {
@@ -1340,8 +1354,11 @@ pub async fn run(
     listener.listen_all(channels).await?;
     info!(?channels, "Listening for notifications");
 
+    // Keeps readiness to one attempt at a time.
+    let readiness = Arc::new(AtomicBool::new(false));
+
     // Boot reconcile: recover an upgrade whose NOTIFY was missed while down (LISTEN already registered).
-    if let Err(e) = reconcile(&pool, &cancel, config.gcs_mode, true).await {
+    if let Err(e) = reconcile(&pool, &cancel, &readiness, config.gcs_mode).await {
         error!(error = %e, "boot reconcile failed");
     }
 
@@ -1364,7 +1381,7 @@ pub async fn run(
 
                         let result = match channel {
                             UPGRADE_ACTIVATED_CHANNEL => {
-                                handle_upgrade_activated(&pool, &cancel, config.gcs_mode, payload).await
+                                handle_upgrade_activated(&pool, &cancel, &readiness, config.gcs_mode, payload).await
                             }
                             UNANIMITY_CONSENSUS_CHANNEL => {
                                 // Emitted by consensus-detector when every operator publishes
@@ -1394,7 +1411,7 @@ pub async fn run(
             }
             _ = poll.tick() => {
                 // Fallback for a missed NOTIFY: re-derive the next step from the row.
-                if let Err(e) = reconcile(&pool, &cancel, config.gcs_mode, false).await {
+                if let Err(e) = reconcile(&pool, &cancel, &readiness, config.gcs_mode).await {
                     error!(error = %e, "poll reconcile failed");
                 }
             }
@@ -1482,7 +1499,8 @@ mod tests {
         .to_string();
 
         let cancel = CancellationToken::new();
-        handle_upgrade_activated(&pool, &cancel, false, &payload)
+        let readiness = Arc::new(AtomicBool::new(false));
+        handle_upgrade_activated(&pool, &cancel, &readiness, false, &payload)
             .await
             .expect("handler ok");
 
@@ -1772,9 +1790,14 @@ mod tests {
         seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
         create_gcs_schema(&pool).await.expect("create gcs schema");
 
-        reconcile(&pool, &CancellationToken::new(), true, false)
-            .await
-            .expect("reconcile");
+        reconcile(
+            &pool,
+            &CancellationToken::new(),
+            &Arc::new(AtomicBool::new(false)),
+            true,
+        )
+        .await
+        .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
         let (sv,): (String,) =
@@ -1792,9 +1815,14 @@ mod tests {
         seed_gcs_row(&pool, "DryRunStarted", "in_progress").await; // latches TRUE
         create_gcs_schema(&pool).await.expect("create gcs schema");
 
-        reconcile(&pool, &CancellationToken::new(), true, false)
-            .await
-            .expect("reconcile");
+        reconcile(
+            &pool,
+            &CancellationToken::new(),
+            &Arc::new(AtomicBool::new(false)),
+            true,
+        )
+        .await
+        .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
     }
@@ -1805,9 +1833,14 @@ mod tests {
         let (_instance, pool) = test_pool().await;
         seed_gcs_row(&pool, "UpgradeAuthorized", "in_progress").await;
 
-        reconcile(&pool, &CancellationToken::new(), false, false)
-            .await
-            .expect("reconcile");
+        reconcile(
+            &pool,
+            &CancellationToken::new(),
+            &Arc::new(AtomicBool::new(false)),
+            false,
+        )
+        .await
+        .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await.0, "UpgradeAuthorized");
     }
@@ -1836,5 +1869,29 @@ mod tests {
             gcs_state(&pool).await,
             ("DryRunStarted".into(), "in_progress".into())
         );
+    }
+
+    /// GCS writes stop once the dry-run is rolled back, so no stale rows land in the reset schema.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gcs_write_fenced_after_rollback() {
+        use fhevm_engine_common::versioning::cutover_gate;
+        let (_instance, pool) = test_pool().await;
+
+        let gate = |state: &'static str| {
+            let pool = pool.clone();
+            async move {
+                seed_gcs_row(&pool, state, "in_progress").await;
+                let mut tx = pool.begin().await.expect("begin");
+                let skip = cutover_gate(&mut tx, true).await.expect("gate");
+                tx.rollback().await.expect("rollback");
+                skip
+            }
+        };
+
+        assert!(
+            !gate("DryRunStarted").await,
+            "write allowed while dry-running"
+        );
+        assert!(gate("PAUSED").await, "write fenced after rollback");
     }
 }

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -1223,6 +1223,12 @@ pub async fn handle_unanimity_consensus_timeout(
 
     reset_gcs_schema(&mut tx).await?;
 
+    // Wake the worker watchers to re-pause promptly; queued in the tx, delivered only on commit.
+    sqlx::query("SELECT pg_notify($1, '')")
+        .bind(fhevm_engine_common::gcs_activation::EVENT_DRY_RUN_ROLLED_BACK)
+        .execute(&mut *tx)
+        .await?;
+
     tx.commit().await?;
     warn!(
         chain_id = payload.chain_id,

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -9,6 +9,7 @@ use fhevm_engine_common::host_chains::HostChainsCache;
 use fhevm_engine_common::pg_pool::{PostgresPoolManager, ServiceError};
 use fhevm_engine_common::tfhe_ops::{current_ciphertext_version, extract_ct_list};
 use fhevm_engine_common::types::{FhevmError, SupportedFheCiphertexts};
+use fhevm_engine_common::versioning::{GcsRollbackPolicy, WriteGuard};
 use fhevm_engine_common::{telemetry, HANDLE_VERSION};
 
 use fhevm_engine_common::utils::safe_deserialize_conformant;
@@ -369,15 +370,26 @@ async fn execute_verify_proof_routine(
     // failure. Enforces the invariant: "one unknown chain on the queue must
     // not stop processing for known chains" — workers simply don't see those
     // rows.
-    // Cutover safety (BCS only): begin a write tx fenced against cutover before
-    // inserting verified input ciphertexts into the `ciphertexts` table
-    // execute_cutover merges. `None` means a committed cutover retired this stack.
+    // Begin the write tx under the shared controller lock before inserting
+    // verified ciphertexts into a table cutover merges. A retired BCS stack
+    // stops; a GCS worker skips while the dry-run is PAUSED after rollback.
     // See versioning::begin_write_guarded.
-    let Some(mut txn) =
-        fhevm_engine_common::versioning::begin_write_guarded(pool, conf.gcs_mode).await?
-    else {
-        info!("Cutover completed — zkproof BCS worker skipping cycle");
-        return Ok(());
+    let mut txn = match fhevm_engine_common::versioning::begin_write_guarded(
+        pool,
+        conf.gcs_mode,
+        GcsRollbackPolicy::Skip,
+    )
+    .await?
+    {
+        WriteGuard::Proceed(txn) => txn,
+        WriteGuard::Stop => {
+            info!("Cutover completed — zkproof BCS worker skipping cycle");
+            return Ok(());
+        }
+        WriteGuard::Skip => {
+            debug!("GCS dry-run rolled back — zkproof skipping cycle");
+            return Ok(());
+        }
     };
 
     if let Ok(row) = sqlx::query!(

--- a/test-suite/fhevm/scenarios/blue-green-two-of-three.yaml
+++ b/test-suite/fhevm/scenarios/blue-green-two-of-three.yaml
@@ -13,7 +13,7 @@ topology:
 bcs:
   source:
     mode: registry
-    tag: v0.14.0-1
+    tag: v0.14.0-4
 
 gcs:
   source:

--- a/test-suite/fhevm/scenarios/blue-green-two-of-two.yaml
+++ b/test-suite/fhevm/scenarios/blue-green-two-of-two.yaml
@@ -12,7 +12,7 @@ topology:
 bcs:
   source:
     mode: registry
-    tag: v0.14.0-1
+    tag: v0.14.0-4
 
 gcs:
   source:

--- a/test-suite/fhevm/scenarios/blue-green.yaml
+++ b/test-suite/fhevm/scenarios/blue-green.yaml
@@ -11,7 +11,7 @@ description: >
 bcs:
   source:
     mode: registry
-    tag: v0.14.0-1
+    tag: v0.14.0-4
 
 gcs:
   source:

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -884,6 +884,11 @@ const startContinuousErc20Traffic = (streams: number): TrafficStream => {
  * `./fhevm-cli up --scenario blue-green*`. Fires the on-chain proposal, sends
  * traffic via `./fhevm-cli test erc20`, waits for cutover, and asserts final
  * state in every operator's database.
+ *
+ * Runs a failed upgrade first: an empty window (no non-trivial FHE op) never
+ * anchors, so the detector's commitment_timeout forces a rollback; the phase
+ * asserts the reset (PAUSED/failed, latches cleared, schema recreated empty,
+ * versioning untouched) and the successful flow then reruns over the residue.
  */
 const runBlueGreenProfile = async (state: State): Promise<boolean> => {
   if (state.scenario.kind !== "blue-green") {
@@ -908,7 +913,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
 
   console.log(`\n==== blue-green E2E: ${opCount} operator(s) ====`);
 
-  console.log(`\n[1/8] verify initial state`);
+  console.log(`\n[1/11] verify initial state`);
   for (const db of operatorDatabases) {
     const version = await psqlQuery(db, "SELECT stack_version FROM versioning;");
     if (version !== "v0.14") {
@@ -928,11 +933,95 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
   }
   console.log(`OK:   ${opCount} DB(s) at v0.14, empty upgrade_state, gcs-${gcsStackVersion} schema present`);
 
+  const defaultHostKey = defaultHostChainKey(state.scenario.hostChains);
+  const hostRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.hosts[defaultHostKey]!.http);
+  const gatewayRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.gateway.http);
+  const { deployerPk, protocolConfig } = await readBlueGreenOnChainCreds();
+
+  // An empty window carries no non-trivial FHE op, so no track can anchor and the
+  // detector's commitment_timeout forces the rollback this phase asserts.
+  console.log(`\n[2/11] failed upgrade: propose empty window (no traffic → no anchor)`);
+  const failHostBlock = Number((await run(
+    ["cast", "block-number", "--rpc-url", hostRpcUrl],
+  )).stdout.trim());
+  const failGwBlock = Number((await run(
+    ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
+  )).stdout.trim());
+  const failStartBlock = failHostBlock + 15;
+  const failEndBlock = failHostBlock + 45;
+  const failGwStartBlock = failGwBlock + 10;
+  await run([
+    "cast", "send", protocolConfig,
+    "--rpc-url", hostRpcUrl,
+    "--private-key", deployerPk,
+    "proposeCoprocessorUpgrade(uint256,string,(uint64,uint64,uint64)[],uint64)",
+    "1", gcsVersionLive,
+    `[(${chainId},${failStartBlock},${failEndBlock})]`,
+    String(failGwStartBlock),
+  ]);
+  console.log(
+    `OK:   activation emitted (start=${failStartBlock} end=${failEndBlock} gw_start=${failGwStartBlock})`,
+  );
+
+  console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted per operator`);
+  for (const db of operatorDatabases) {
+    await waitUntil({
+      label: `${db}  GCS DryRunStarted`,
+      timeoutSecs: 120,
+      check: async () =>
+        (await psqlQuery(db, "SELECT state FROM upgrade_state WHERE stack_role='GCS';")) ===
+        "DryRunStarted",
+    });
+  }
+
+  console.log(`\n[4/11] failed upgrade: wait for unanimity timeout rollback + verify reset`);
+  for (const db of operatorDatabases) {
+    await waitUntil({
+      label: `${db}  GCS rolled back to PAUSED/failed`,
+      timeoutSecs: 300,
+      check: async () =>
+        (await psqlQuery(db, "SELECT state||' '||status FROM upgrade_state WHERE stack_role='GCS';")) ===
+        "PAUSED failed",
+    });
+  }
+  for (const db of operatorDatabases) {
+    const flags = await psqlQuery(
+      db,
+      "SELECT last_error||'|'||host_consensus_reached||'|'||gw_consensus_reached||'|'||gw_dry_run_started " +
+        "FROM upgrade_state WHERE stack_role='GCS';",
+    );
+    if (flags !== "unanimity_consensus_timeout|false|false|false") {
+      throw new Error(
+        `${db} rollback left unexpected flags "${flags}", expected "unanimity_consensus_timeout|false|false|false"`,
+      );
+    }
+    const version = await psqlQuery(db, "SELECT stack_version FROM versioning;");
+    if (version !== "v0.14") {
+      throw new Error(`${db}.versioning = "${version}" after failed upgrade, expected "v0.14"`);
+    }
+    const schema = await psqlQuery(
+      db,
+      `SELECT nspname FROM pg_namespace WHERE nspname='gcs-${gcsStackVersion}';`,
+    );
+    if (schema !== `gcs-${gcsStackVersion}`) {
+      throw new Error(`${db} missing schema "gcs-${gcsStackVersion}" after rollback`);
+    }
+    const residue = await psqlQuery(
+      db,
+      `SELECT (SELECT count(*) FROM "gcs-${gcsStackVersion}".computations) + ` +
+        `(SELECT count(*) FROM "gcs-${gcsStackVersion}".state_hash);`,
+    );
+    if (residue !== "0") {
+      throw new Error(`${db} gcs schema not reset: ${residue} residual computations/state_hash rows`);
+    }
+    console.log(`OK:   ${db}  PAUSED/failed, latches cleared, v0.14 kept, gcs schema recreated empty`);
+  }
+
   // Deploy ERC20 + mint before the proposal so the balance handle lands in
   // public.ciphertexts with block_number < start_block. Transfers during the
   // dry-run window will force GCS's tfhe-worker to fall back to
   // public.ciphertexts for this handle.
-  console.log(`\n[2/8] cross-cutover setup: deploy ERC20 + mint (pre-cutover)`);
+  console.log(`\n[5/11] cross-cutover setup: deploy ERC20 + mint (pre-cutover)`);
   const setupResult = await run(["./fhevm-cli", "test", "cross-cutover-setup"], { allowFailure: true });
   if (setupResult.code !== 0) {
     throw new Error("cross-cutover setup failed — see log above");
@@ -960,10 +1049,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
     console.log(`OK:   ${db}  pre-cutover ciphertexts=${count} (sample handle recorded)`);
   }
 
-  console.log(`\n[3/8] propose upgrade on-chain (ProtocolConfig.proposeCoprocessorUpgrade)`);
-  const defaultHostKey = defaultHostChainKey(state.scenario.hostChains);
-  const hostRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.hosts[defaultHostKey]!.http);
-  const gatewayRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.gateway.http);
+  console.log(`\n[6/11] propose upgrade on-chain (ProtocolConfig.proposeCoprocessorUpgrade)`);
   const hostBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", hostRpcUrl],
   )).stdout.trim());
@@ -973,19 +1059,18 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
   const startBlock = hostBlock + 30;
   const endBlock = hostBlock + 230;
   const gwStartBlock = gwBlock + 10;
-  const { deployerPk, protocolConfig } = await readBlueGreenOnChainCreds();
   await run([
     "cast", "send", protocolConfig,
     "--rpc-url", hostRpcUrl,
     "--private-key", deployerPk,
     "proposeCoprocessorUpgrade(uint256,string,(uint64,uint64,uint64)[],uint64)",
-    "1", gcsVersionLive,
+    "2", gcsVersionLive,
     `[(${chainId},${startBlock},${endBlock})]`,
     String(gwStartBlock),
   ]);
   console.log(`OK:   activation emitted (start=${startBlock} end=${endBlock} gw_start=${gwStartBlock})`);
 
-  console.log(`\n[4/8] wait for GCS DryRunStarted per operator`);
+  console.log(`\n[7/11] wait for GCS DryRunStarted per operator`);
   for (const db of operatorDatabases) {
     await waitUntil({
       label: `${db}  GCS DryRunStarted`,
@@ -997,13 +1082,13 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
   }
 
   console.log(
-    `\n[5/8] start ${BLUE_GREEN_TRAFFIC_STREAMS} background stream(s) ` +
+    `\n[8/11] start ${BLUE_GREEN_TRAFFIC_STREAMS} background stream(s) ` +
       `+ cross-cutover chain (depth ${CROSS_CUTOVER_CHAIN_DEPTH})`,
   );
   const traffic = startContinuousErc20Traffic(BLUE_GREEN_TRAFFIC_STREAMS);
   let trafficStats: { iterations: number; retries: number; failures: number };
   try {
-    // The chain is a stress signal — a fence hit mid-transfer is expected; [8/8] verifies actual transferCount.
+    // The chain is a stress signal — a fence hit mid-transfer is expected; [11/11] verifies actual transferCount.
     const chainPromise = (async () => {
       for (let step = 1; step <= CROSS_CUTOVER_CHAIN_DEPTH; step += 1) {
         console.log(`  cross-cutover transfer ${step}/${CROSS_CUTOVER_CHAIN_DEPTH}`);
@@ -1034,7 +1119,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
     })();
     await Promise.race([chainPromise, traffic.errored]);
 
-    console.log(`\n[6/8] wait for cutover (versioning=${gcsVersionLive} per operator)`);
+    console.log(`\n[9/11] wait for cutover (versioning=${gcsVersionLive} per operator)`);
     for (const db of operatorDatabases) {
       await Promise.race([
         waitUntil({
@@ -1048,7 +1133,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
     }
 
     // BCS has no upgrade_state row — retires implicitly via `resolve_gcs_mode`.
-    console.log(`\n[7/8] verify FSM final state`);
+    console.log(`\n[10/11] verify FSM final state`);
     for (const db of operatorDatabases) {
       const gcsState = await psqlQuery(
         db,
@@ -1070,7 +1155,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
     trafficStats = await traffic.stop();
   }
 
-  console.log(`\n[8/8] stop background traffic + cross-cutover verify + continuity check`);
+  console.log(`\n[11/11] stop background traffic + cross-cutover verify + continuity check`);
   console.log(
     `  traffic stopped: ${trafficStats.iterations} iterations across ${BLUE_GREEN_TRAFFIC_STREAMS} stream(s), ` +
       `${trafficStats.retries} retried, ${trafficStats.failures} failed after retry`,

--- a/test-suite/fhevm/src/scenario.test.ts
+++ b/test-suite/fhevm/src/scenario.test.ts
@@ -172,7 +172,7 @@ topology:
       const scenario = await loadBlueGreenScenario("blue-green");
       expect(scenario.kind).toBe("blue-green");
       expect(scenario.name).toBe("Blue-Green Upgrade");
-      expect(scenario.bcs.source).toEqual({ mode: "registry", tag: "v0.14.0-1" });
+      expect(scenario.bcs.source).toEqual({ mode: "registry", tag: "v0.14.0-4" });
       expect(scenario.gcs.source).toEqual({ mode: "local" });
       expect(scenario.gcs.stackVersion).toBe("0.15.0");
       expect(scenario.hostChains).toHaveLength(1);

--- a/test-suite/fhevm/src/scenario.test.ts
+++ b/test-suite/fhevm/src/scenario.test.ts
@@ -312,11 +312,22 @@ gcs:
       ).rejects.toThrow("predates v0.14");
     });
 
-    test("--override coprocessor is rejected for blue-green scenarios", async () => {
+    test("--override coprocessor is accepted for blue-green scenarios (GCS builds locally)", async () => {
+      const resolved = await resolveScenarioForOptions({
+        scenarioPath: "blue-green",
+        overrides: [{ group: "coprocessor" }],
+      });
+      expect(resolved.kind).toBe("blue-green");
+      if (resolved.kind === "blue-green") {
+        expect(resolved.gcs.source.mode).toBe("local");
+      }
+    });
+
+    test("--override coprocessor:<service> is rejected for blue-green scenarios", async () => {
       await expect(
         resolveScenarioForOptions({
           scenarioPath: "blue-green",
-          overrides: [{ group: "coprocessor" }],
+          overrides: [{ group: "coprocessor", services: ["coprocessor-tfhe-worker"] }],
         }),
       ).rejects.toThrow("not supported with blue-green");
     });

--- a/test-suite/fhevm/src/stack-spec/stack-spec.ts
+++ b/test-suite/fhevm/src/stack-spec/stack-spec.ts
@@ -56,10 +56,14 @@ export const resolveScenarioForOptions = async (
     const sourcePath = await resolveScenarioReference(options.scenarioPath);
     const kind = await peekScenarioKind(sourcePath);
     if (kind === "blue-green") {
-      // --build's implicit all-group overrides are fine (GCS builds from HEAD); only explicit --override conflicts.
-      if (!options.build && options.overrides.some((override) => override.group === "coprocessor")) {
+      // GCS always builds from the local tree, so a full-group --override coprocessor is accepted
+      // as an explicit alias; per-service selections have no GCS granularity and BCS stays pinned.
+      if (
+        !options.build &&
+        options.overrides.some((override) => override.group === "coprocessor" && override.services?.length)
+      ) {
         throw new PreflightError(
-          "--override coprocessor is not supported with blue-green scenarios (BCS/GCS sources are scenario-defined)",
+          "--override coprocessor:<service> is not supported with blue-green scenarios; use --override coprocessor — the GCS fleet builds from the local tree",
         );
       }
       const loaded = await loadBlueGreenScenario(sourcePath);


### PR DESCRIPTION
### Summary

A blue-green upgrade whose window never reaches unanimity previously stalled forever in `DryRunStarted`. 
This PR handles the failure path: the consensus-detector emits `event_unanimity_consensus_timeout` when a track is still un-anchored `commitment_timeout` after `end_block`, and the upgrade-controller rolls the dry-run back so the upgrade can be re-proposed.

The rollback:
-  flips the GCS row to `PAUSED/failed` 
- clears the consensus latches and `gw_dry_run_started` 
- drops and recreates the `gcs-<version>` schema as empty

It only applies while still dry-running. A late or duplicate timeout is a no-op and can never undo a committed cutover.

### Recovering from missed signals

The controller no longer depends on catching a notification at the exact moment it fires. The detector keeps re sending its consensus and timeout signals every pass until the window closes, and the controller re-reads the upgrade row on startup and on a periodic tick to pick up wherever it left off. So if the controller restarts (or misses a signal for any reason) mid-upgrade, it still finishes the cutover or the rollback  instead of stalling. Re-running the cutover is safe: it re-checks the row and does nothing if the upgrade has already gone through.

### Fencing writes against the reset

Dropping and recreating the schema races with the workers still writing to it: a worker mid operation or one reconnecting after a database drop, could finish an old write into the freshly reset schema, poisoning the next attempt and, at cutover, leaking into live data.

Two changes close the race:

- The rollback runs under an exclusive advisory lock and does the pause, schema reset, and notify in one transaction. - Every green write takes the shared form of the same lock, so a write either commits before the reset (and is dropped by it) or runs after it, never during.
- Each write also re checks whether the dry-run is paused before it runs. Raw chain ingestion keeps going, so the stack can rerun without a restart. The other workers wait for the next attempt.

Related: https://github.com/zama-ai/fhevm-internal/issues/1528