### PR TITLE
feat(host-contracts): let a transfer spend an existing encrypted amount

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/idl/confidential_token.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/confidential_token.json
@@ -408,6 +408,163 @@
       ]
     },
     {
+      "name": "confidential_transfer_from_value",
+      "docs": [
+        "Transfers an encrypted amount taken from an existing on-chain `EncryptedValue` (a computed or",
+        "received handle) instead of a freshly attested client-side encryption — the path that lets a",
+        "contract be the sender of a computed amount (fhevm-internal#1680). The signing owner must be",
+        "in the amount value's subject set (the token spend gate); the amount is spent read-only."
+      ],
+      "discriminator": [
+        107,
+        168,
+        52,
+        232,
+        133,
+        153,
+        185,
+        191
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Sender and transfer authority. Must be in `amount_value`'s subject set (the spend gate)."
+          ],
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Pays rent for the transferred-amount lineage on its first bind."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Confidential mint."
+          ]
+        },
+        {
+          "name": "from_account",
+          "docs": [
+            "Sender token account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "to_account",
+          "writable": true
+        },
+        {
+          "name": "compute_signer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  104,
+                  101,
+                  45,
+                  99,
+                  111,
+                  109,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "from_balance_value",
+          "docs": [
+            "Sender's stable balance `EncryptedValue` lineage; read for the current",
+            "handle and superseded in place by this eval's CPI."
+          ],
+          "writable": true
+        },
+        {
+          "name": "to_balance_value",
+          "docs": [
+            "Recipient's stable balance `EncryptedValue` lineage."
+          ],
+          "writable": true
+        },
+        {
+          "name": "transferred_amount_value",
+          "docs": [
+            "the sender's first transfer, superseded thereafter."
+          ],
+          "writable": true
+        },
+        {
+          "name": "amount_value",
+          "docs": [
+            "The existing encrypted amount to spend: a computed or received `euint64` handle. Read-only",
+            "durable operand — never superseded, never consumed. Its address is the canonical PDA of its",
+            "own `(acl_domain_key, app_account, encrypted_value_label)` fields, so a lineage from any app",
+            "may be passed here once its owner has granted the mint's compute subject via `allow_subjects`."
+          ]
+        },
+        {
+          "name": "zama_event_authority"
+        },
+        {
+          "name": "zama_program",
+          "docs": [
+            "ZamaHost program used for FHE operations."
+          ],
+          "address": "6AtbvED1rfX68aCT1tYgU1aeu4kFksPDxZG9gtB1Fgtu"
+        },
+        {
+          "name": "host_config",
+          "docs": [
+            "ZamaHost config used for handle derivation."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program used for ACL account creation."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "hcu_block_meter",
+          "docs": [
+            "canonical `[\"hcu-block-meter\", compute_signer]` PDA. The per-mint HCU block meter — supplied",
+            "by an untrusted mint under a metering-band cap, omitted otherwise."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "hcu_trusted_app_record",
+          "docs": [
+            "trust witness — present + valid bypasses the cap; absent means untrusted (metered)."
+          ],
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "disclose_secp",
       "docs": [
         "Consumes a KMS public-decrypt certificate through the stateless host verifier and emits a",
@@ -1778,96 +1935,101 @@
     },
     {
       "code": 6019,
+      "name": "AmountSpendSubjectMismatch",
+      "msg": "amount value spender is not in the amount's subject set"
+    },
+    {
+      "code": 6020,
       "name": "TotalSupplyAuthorityMismatch",
       "msg": "total supply authority does not match mint"
     },
     {
-      "code": 6020,
+      "code": 6021,
       "name": "InvalidKmsCertificate",
       "msg": "KMS public-decrypt certificate is invalid"
     },
     {
-      "code": 6021,
+      "code": 6022,
       "name": "PublicDecryptProofInvalid",
       "msg": "public-decrypt MMR proof is invalid for this lineage"
     },
     {
-      "code": 6022,
+      "code": 6023,
       "name": "GatewayVerifierConfigUnset",
       "msg": "gateway verifier config is not set"
     },
     {
-      "code": 6023,
+      "code": 6024,
       "name": "InvalidKmsContext",
       "msg": "KMS context is not valid for this request"
     },
     {
-      "code": 6024,
+      "code": 6025,
       "name": "RequestWitnessMismatch",
       "msg": "request witness does not match"
     },
     {
-      "code": 6025,
+      "code": 6026,
       "name": "RequestWitnessUnavailable",
       "msg": "request witness is expired or already consumed"
     },
     {
-      "code": 6026,
+      "code": 6027,
       "name": "MaterialCommitmentMismatch",
       "msg": "material commitment witness does not match"
     },
     {
-      "code": 6027,
+      "code": 6028,
       "name": "PublicDecryptNotReleased",
       "msg": "handle is not released for public decrypt"
     },
     {
-      "code": 6028,
+      "code": 6029,
       "name": "InvalidFheEvalPlan",
       "msg": "FHE eval plan is invalid"
     },
     {
-      "code": 6029,
+      "code": 6030,
       "name": "DuplicateFheEvalAccount",
       "msg": "FHE eval account list contains a duplicate account"
     },
     {
-      "code": 6030,
+      "code": 6031,
       "name": "UnexpectedFheEvalAccount",
       "msg": "FHE eval account list contains an unexpected account"
     },
     {
-      "code": 6031,
+      "code": 6032,
       "name": "MissingFheEvalAccount",
       "msg": "FHE eval plan is missing a required dynamic account"
     },
     {
-      "code": 6032,
+      "code": 6033,
       "name": "FheEvalAccountNotWritable",
       "msg": "FHE eval dynamic account must be writable"
     },
     {
-      "code": 6033,
+      "code": 6034,
       "name": "DuplicateFheOutputAuthority",
       "msg": "FHE eval output authority list contains a duplicate authority"
     },
     {
-      "code": 6034,
+      "code": 6035,
       "name": "UnexpectedFheOutputAuthority",
       "msg": "FHE eval output authority list contains an unexpected authority"
     },
     {
-      "code": 6035,
+      "code": 6036,
       "name": "MissingFheOutputAuthority",
       "msg": "FHE eval plan is missing a required output authority"
     },
     {
-      "code": 6036,
+      "code": 6037,
       "name": "VerifierReturnDataInvalid",
       "msg": "public-decrypt verifier return data is invalid"
     },
     {
-      "code": 6037,
+      "code": 6038,
       "name": "DisclosedHandleMismatch",
       "msg": "disclosed handle does not match the pinned handle"
     }

--- a/coprocessor/fhevm-engine/host-listener/idl/solana_abi_golden.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/solana_abi_golden.json
@@ -137,6 +137,14 @@
     },
     {
       "category": "instruction_args",
+      "fixture_hex": "6ba834e88599b9bf",
+      "fixture_len": 8,
+      "name": "confidential_transfer_from_value",
+      "program": "confidential_token",
+      "schema_hash": "f4c6c620bd3f755628a2ec0c008d47bdc76c46e849bd12edd6e909469b93d56d"
+    },
+    {
+      "category": "instruction_args",
       "fixture_hex": "9787bb455c9f88800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202101000000030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f4041424303000000040506450000000000000001000000060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425",
       "fixture_len": 192,
       "name": "disclose_secp",
@@ -353,6 +361,30 @@
     },
     {
       "category": "instruction_args",
+      "fixture_hex": "66e95717aebae95741000000000000000100000002030405060708090a0b0c0d0e0f10111213141503040506",
+      "fixture_len": 44,
+      "name": "define_kms_context",
+      "program": "zama_host",
+      "schema_hash": "8076dd7013b952401ea25d0ce52328a825ec5b4cca97d9d3c2749af854c3f88d"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "f0f8d7586df40167010101010101010101010101010101010101010101010101010101010101010102020202020202020202020202020202020202020202020202020202020202024300000000000000",
+      "fixture_len": 80,
+      "name": "delegate_for_user_decryption",
+      "program": "zama_host",
+      "schema_hash": "8b8752ab947784a48026351ff483ba0ee1e253799cf8c4cb461c4d2bea9007e0"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "2cb818ea5939e8fb4100000000000000",
+      "fixture_len": 16,
+      "name": "destroy_kms_context",
+      "program": "zama_host",
+      "schema_hash": "18447ba3d01d021ce89c1f243a4b740b66bca8c28ae8d29de8cad49327616a24"
+    },
+    {
+      "category": "instruction_args",
       "fixture_hex": "b02a3fb1f4a7786d0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2001000000000000030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2021221400000405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2021222315000500",
       "fixture_len": 118,
       "name": "fhe_eval",
@@ -385,11 +417,91 @@
     },
     {
       "category": "instruction_args",
+      "fixture_hex": "931b7e35412576e1",
+      "fixture_len": 8,
+      "name": "revoke_delegation_for_user_decryption",
+      "program": "zama_host",
+      "schema_hash": "9b48ee4eb11b0d1a4256db2068925f3c4dd510f8a16cd0138084bb3216e6ae7e"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "261e3b2ce901c2b1010000000102030405060708090a0b0c0d0e0f101112131402",
+      "fixture_len": 33,
+      "name": "set_coprocessor_signers",
+      "program": "zama_host",
+      "schema_hash": "363dfb6c5951d4abebe64e2a3cf9f1684247940f47e9be1b28ca92c3c15e79a0"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "8aca8edcf62bd3a0010101010101010101010101010101010101010101010101010101010101010101",
+      "fixture_len": 41,
+      "name": "set_deny_subject",
+      "program": "zama_host",
+      "schema_hash": "fd2d92bd1e96bda8efc441ab7cf5f5c6b6565a4391fb9fa76f6d85c5da1c9346"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "d0cbb13345e10b1801",
+      "fixture_len": 9,
+      "name": "set_grant_deny_list_enabled",
+      "program": "zama_host",
+      "schema_hash": "ea88ca1b750d828eaf1a6436b7cff1927a98d9bb5ef28470381538c69d681ae4"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "423afa56a47dfc8d010101010101010101010101010101010101010101010101010101010101010101",
+      "fixture_len": 41,
+      "name": "set_hcu_app_trusted",
+      "program": "zama_host",
+      "schema_hash": "e635ef68bbc3094760ba078a663f336aade556ac3f6818cc67fd6abdf13b14bf"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "36993a52321006cf4100000000000000",
+      "fixture_len": 16,
+      "name": "set_hcu_block_cap_per_app",
+      "program": "zama_host",
+      "schema_hash": "4c62df1838aaada72fb420dbc25d30bc7459dff34a2f6b708580190936494743"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "773b29834a3a596101",
+      "fixture_len": 9,
+      "name": "set_host_pause",
+      "program": "zama_host",
+      "schema_hash": "00d019ec36c7282cfc505252517aa3c8391e6c89711683a8deada2d02f5febc0"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "5b2c1564b83ee9eb4100000000000000",
+      "fixture_len": 16,
+      "name": "set_max_hcu_depth_per_tx",
+      "program": "zama_host",
+      "schema_hash": "15e4024ae517586e051f1474041cdba04cdd181f97d3ba38e714cf6498a78358"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "8e24ec79aa43d4764100000000000000",
+      "fixture_len": 16,
+      "name": "set_max_hcu_per_tx",
+      "program": "zama_host",
+      "schema_hash": "2d5d2c8a78afbf325972f3dd5abe964b90eaab618211724e5a26203b2b4a813a"
+    },
+    {
+      "category": "instruction_args",
       "fixture_hex": "86070cf7e95023d70102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2021010000000303030303030303030303030303030303030303030303030303030303030303",
       "fixture_len": 108,
       "name": "update_encrypted_value",
       "program": "zama_host",
       "schema_hash": "82af334cd0b5150a9094cf49e1bcf9f4d52fbae6375b527c88c771cbc433a976"
+    },
+    {
+      "category": "instruction_args",
+      "fixture_hex": "80c44c625a03f5770102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202101000000030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f4041424303000000040506450000000000000001000000060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425",
+      "fixture_len": 192,
+      "name": "verify_public_decrypt",
+      "program": "zama_host",
+      "schema_hash": "b1375cd85c8c9a8151f2d2740f42be9273663fa9d016877ed8545ccd9a8a9f7c"
     },
     {
       "category": "type",

--- a/solana/programs/confidential-token/src/errors.rs
+++ b/solana/programs/confidential-token/src/errors.rs
@@ -62,6 +62,10 @@ pub enum ConfidentialTokenError {
     /// The attested input's contract is not the mint compute-signer PDA.
     #[msg("attested input contract does not match compute signer")]
     AttestationContractMismatch,
+    /// The signer spending an existing amount value is not in that value's subject set.
+    /// Token-level spend gate mirroring EVM's `FHE.isAllowed(amount, msg.sender)`.
+    #[msg("amount value spender is not in the amount's subject set")]
+    AmountSpendSubjectMismatch,
     /// Total-supply authority PDA did not match the mint.
     #[msg("total supply authority does not match mint")]
     TotalSupplyAuthorityMismatch,

--- a/solana/programs/confidential-token/src/instructions/common.rs
+++ b/solana/programs/confidential-token/src/instructions/common.rs
@@ -40,6 +40,43 @@ pub(crate) struct TransferAccounts<'a, 'info> {
     pub(crate) hcu_trusted_app_record: Option<AccountInfo<'info>>,
 }
 
+/// Where a transfer's amount comes from. The `ge -> sub -> select` debit and `add` credit that
+/// move the two balance lineages are identical for both arms; only how the amount operand enters
+/// the eval frame differs.
+pub(crate) enum TransferAmountSource<'info> {
+    /// EVM `FHE.fromExternal` parity: a coprocessor-attested fresh client-side encryption,
+    /// verified in-frame and transient-allowed for this eval (no durable amount account).
+    Attested(zama_host::CoprocessorInputAttestation),
+    /// EVM computed/received `euint64` parity: an existing on-chain `EncryptedValue` lineage,
+    /// spent as a read-only durable operand at its current handle. It is never superseded and
+    /// never consumed — only the two balance lineages change. The token's spend gate (signing
+    /// owner in the value's subject set) and euint64 type check run in the instruction handler
+    /// before this reaches the eval builder; the host re-checks the handle is current and that the
+    /// mint's compute subject is allowed on the value, in-frame.
+    ExistingValue {
+        amount_value: AccountInfo<'info>,
+        amount_handle: [u8; 32],
+    },
+}
+
+impl TransferAmountSource<'_> {
+    fn amount_handle(&self) -> [u8; 32] {
+        match self {
+            Self::Attested(attestation) => attestation.input_handle,
+            Self::ExistingValue { amount_handle, .. } => *amount_handle,
+        }
+    }
+
+    /// Domain-separates the eval context id per arm so the two amount sources never derive
+    /// colliding handles for the same (mint, from, to, amount handle) tuple.
+    fn context_tag(&self) -> &'static [u8] {
+        match self {
+            Self::Attested(_) => b"combined",
+            Self::ExistingValue { .. } => b"from-value",
+        }
+    }
+}
+
 pub(crate) struct TransferOutcome {
     pub(crate) mint: Pubkey,
     pub(crate) from_owner: Pubkey,
@@ -59,7 +96,7 @@ pub(crate) struct TransferOutcome {
 pub(crate) fn execute_transfer<'info>(
     accounts: TransferAccounts<'_, 'info>,
     compute_signer_bump: u8,
-    amount_attestation: zama_host::CoprocessorInputAttestation,
+    amount_source: TransferAmountSource<'info>,
 ) -> Result<Option<TransferOutcome>> {
     assert_confidential_mint_shape(accounts.mint)?;
     let mint_key = accounts.mint.key();
@@ -67,14 +104,18 @@ pub(crate) fn execute_transfer<'info>(
     let from = accounts.from_account;
     let to = accounts.to_account;
 
-    // EVM `fromExternal` parity for the amount: the attested input must be authored by the sender
-    // (user) and bound to this mint's compute-signer PDA (the `msg.sender`/contract analog the host
-    // re-checks against `compute_subject`). The coprocessor signature over both is verified in-frame.
-    assert_amount_attestation_binding(
-        &amount_attestation,
-        accounts.transfer_authority,
-        compute_signer,
-    )?;
+    if let TransferAmountSource::Attested(amount_attestation) = &amount_source {
+        // EVM `fromExternal` parity for the amount: the attested input must be authored by the
+        // sender (user) and bound to this mint's compute-signer PDA (the `msg.sender`/contract
+        // analog the host re-checks against `compute_subject`). The coprocessor signature over both
+        // is verified in-frame. The `ExistingValue` arm is gated instead by the token spend gate and
+        // euint64 type check in its instruction handler.
+        assert_amount_attestation_binding(
+            amount_attestation,
+            accounts.transfer_authority,
+            compute_signer,
+        )?;
+    }
     require_keys_eq!(from.mint, mint_key, ConfidentialTokenError::MintMismatch);
     require_keys_eq!(to.mint, mint_key, ConfidentialTokenError::MintMismatch);
     assert_confidential_token_account_shape(from, mint_key, from.owner)?;
@@ -111,7 +152,7 @@ pub(crate) fn execute_transfer<'info>(
     let (new_from_handle, transferred_handle, new_to_handle) = execute_transfer_eval(
         &accounts,
         compute_signer_bump,
-        amount_attestation,
+        &amount_source,
         mint_key,
         old_from_handle,
         old_to_handle,
@@ -140,7 +181,7 @@ pub(crate) fn execute_transfer<'info>(
 fn execute_transfer_eval<'info>(
     accounts: &TransferAccounts<'_, 'info>,
     compute_signer_bump: u8,
-    amount_attestation: zama_host::CoprocessorInputAttestation,
+    amount_source: &TransferAmountSource<'info>,
     mint_key: Pubkey,
     old_from_handle: [u8; 32],
     old_to_handle: [u8; 32],
@@ -150,11 +191,11 @@ fn execute_transfer_eval<'info>(
     let from_owner = accounts.from_account.owner;
     let to_owner = accounts.to_account.owner;
     let context_id = transfer_eval_context(
-        b"combined",
+        amount_source.context_tag(),
         mint_key,
         from_key,
         to_key,
-        amount_attestation.input_handle,
+        amount_source.amount_handle(),
     )?;
     let from_balance = uint64_from_value(old_from_handle, mint_key, from_key, balance_label())?;
     let to_balance = uint64_from_value(old_to_handle, mint_key, to_key, balance_label())?;
@@ -185,11 +226,25 @@ fn execute_transfer_eval<'info>(
     )?;
     let mut builder =
         zama_fhe::EvalBuilder::new(context_id, zama_fhe::EvalAppAuthority::new(from_key));
-    // fromExternal: the amount is a coprocessor-attested external input, verified in-frame and
-    // transient-allowed for this eval (no durable amount handle / ACL account).
-    let amount: zama_fhe::Uint64Handle = builder
-        .verified_input(amount_attestation)
-        .map_err(invalid_eval_plan)?;
+    let amount: zama_fhe::Uint64Handle = match amount_source {
+        // fromExternal: the amount is a coprocessor-attested external input, verified in-frame and
+        // transient-allowed for this eval (no durable amount handle / ACL account).
+        TransferAmountSource::Attested(amount_attestation) => builder
+            .verified_input(amount_attestation.clone())
+            .map_err(invalid_eval_plan)?,
+        // Existing value: the amount is an on-chain lineage's current handle, read as a durable
+        // operand. The slot is derived from the value's own canonical fields, so its PDA equals the
+        // passed account; the host re-checks handle-is-current and compute-subject membership.
+        TransferAmountSource::ExistingValue { amount_value, .. } => {
+            let value = fhe::read_encrypted_value(amount_value)?;
+            uint64_from_value(
+                value.current_handle,
+                value.acl_domain_key,
+                value.app_account,
+                value.encrypted_value_label,
+            )?
+        }
+    };
     let success = builder
         .ge(from_balance, amount, zama_fhe::Output::transient())
         .map_err(invalid_eval_plan)?;
@@ -208,13 +263,19 @@ fn execute_transfer_eval<'info>(
     let plan = builder.finish().map_err(invalid_eval_plan)?;
     let compute_authority =
         fhe::ComputeAuthority::for_mint(accounts.compute_signer, mint_key, compute_signer_bump)?;
+    // Durable output accounts are the same for both arms; the existing-value arm adds the amount
+    // lineage as a read-only durable input operand the plan now requires.
+    let mut dynamic_accounts = vec![
+        from_output.account_info(),
+        transferred_output.account_info(),
+        to_output.account_info(),
+    ];
+    if let TransferAmountSource::ExistingValue { amount_value, .. } = amount_source {
+        dynamic_accounts.push(amount_value.clone());
+    }
     let eval_accounts = fhe::EvalAccountSet::for_plan(
         &plan,
-        [
-            from_output.account_info(),
-            transferred_output.account_info(),
-            to_output.account_info(),
-        ],
+        dynamic_accounts,
         [
             fhe::OutputAuthority::token_account(accounts.from_account)?,
             fhe::OutputAuthority::token_account(accounts.to_account)?,

--- a/solana/programs/confidential-token/src/instructions/common.rs
+++ b/solana/programs/confidential-token/src/instructions/common.rs
@@ -271,7 +271,15 @@ fn execute_transfer_eval<'info>(
         to_output.account_info(),
     ];
     if let TransferAmountSource::ExistingValue { amount_value, .. } = amount_source {
-        dynamic_accounts.push(amount_value.clone());
+        // The amount lineage can legitimately alias one of the output accounts (spending the entire
+        // balance, or re-sending a transferred_amount that is also this frame's output). The plan
+        // already merges those into one slot, so only add the amount when it is a distinct account.
+        if !dynamic_accounts
+            .iter()
+            .any(|account| account.key() == amount_value.key())
+        {
+            dynamic_accounts.push(amount_value.clone());
+        }
     }
     let eval_accounts = fhe::EvalAccountSet::for_plan(
         &plan,

--- a/solana/programs/confidential-token/src/instructions/confidential_transfer.rs
+++ b/solana/programs/confidential-token/src/instructions/confidential_transfer.rs
@@ -97,7 +97,170 @@ pub fn confidential_transfer<'info>(
     let outcome = execute_transfer(
         ctx.accounts.as_transfer_accounts(ctx.remaining_accounts),
         ctx.bumps.compute_signer,
-        amount_attestation,
+        TransferAmountSource::Attested(amount_attestation),
+    )?;
+    if let Some(outcome) = outcome {
+        emit_cpi!(ConfidentialTransferEvent {
+            version: APP_EVENT_VERSION,
+            mint: outcome.mint,
+            from_owner: outcome.from_owner,
+            from_token_account: outcome.from_token_account,
+            to_owner: outcome.to_owner,
+            to_token_account: outcome.to_token_account,
+            transferred_handle: outcome.transferred_handle,
+            transferred_encrypted_value: outcome.transferred_encrypted_value,
+        });
+        emit_cpi!(BalanceHandleUpdatedEvent {
+            version: APP_EVENT_VERSION,
+            mint: outcome.mint,
+            owner: outcome.from_owner,
+            token_account: outcome.from_token_account,
+            old_handle: outcome.old_from_handle,
+            old_encrypted_value: outcome.from_encrypted_value,
+            new_handle: outcome.new_from_handle,
+            new_encrypted_value: outcome.from_encrypted_value,
+            reason: BalanceHandleUpdateReason::TransferDebit,
+        });
+        emit_cpi!(BalanceHandleUpdatedEvent {
+            version: APP_EVENT_VERSION,
+            mint: outcome.mint,
+            owner: outcome.to_owner,
+            token_account: outcome.to_token_account,
+            old_handle: outcome.old_to_handle,
+            old_encrypted_value: outcome.to_encrypted_value,
+            new_handle: outcome.new_to_handle,
+            new_encrypted_value: outcome.to_encrypted_value,
+            reason: BalanceHandleUpdateReason::TransferCredit,
+        });
+    }
+    Ok(())
+}
+
+/// Accounts for a confidential transfer that spends an existing on-chain `EncryptedValue` as the
+/// amount, instead of a freshly attested client-side encryption.
+///
+/// Identical to [`ConfidentialTransfer`] except the 190-byte attestation argument is gone and one
+/// account is added: `amount_value`, the encrypted amount to spend. It is read-only — the durable
+/// operand the eval reads — and is never superseded or consumed; only the two balance lineages
+/// change through the same `ge -> sub -> select` debit and `add` credit.
+#[derive(Accounts)]
+#[event_cpi]
+pub struct ConfidentialTransferFromValue<'info> {
+    /// Sender and transfer authority. Must be in `amount_value`'s subject set (the spend gate).
+    pub owner: Signer<'info>,
+    /// Pays rent for the transferred-amount lineage on its first bind.
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    /// Confidential mint.
+    pub mint: Box<Account<'info, ConfidentialMint>>,
+    /// Sender token account.
+    #[account(mut)]
+    pub from_account: Box<Account<'info, ConfidentialTokenAccount>>,
+    // Anchor 1 rejects duplicate mutable Account<T> values unless the account opts in.
+    // A self-transfer is a supported no-op, so from_account and to_account may be equal.
+    #[account(mut, dup)]
+    pub to_account: Box<Account<'info, ConfidentialTokenAccount>>,
+    /// CHECK: Program-controlled compute signer PDA.
+    #[account(seeds = [b"fhe-compute", mint.key().as_ref()], bump)]
+    pub compute_signer: UncheckedAccount<'info>,
+    /// Sender's stable balance `EncryptedValue` lineage; read for the current
+    /// handle and superseded in place by this eval's CPI.
+    #[account(mut, address = from_account.balance_encrypted_value)]
+    pub from_balance_value: Box<Account<'info, zama_host::EncryptedValue>>,
+    /// Recipient's stable balance `EncryptedValue` lineage.
+    #[account(mut, dup, address = to_account.balance_encrypted_value)]
+    pub to_balance_value: Box<Account<'info, zama_host::EncryptedValue>>,
+    /// CHECK: stable `transferred_amount` lineage for `from_account`; created on
+    /// the sender's first transfer, superseded thereafter.
+    #[account(mut, address = encrypted_value_address(mint.key(), from_account.key(), transferred_amount_label()).0)]
+    pub transferred_amount_value: UncheckedAccount<'info>,
+    /// The existing encrypted amount to spend: a computed or received `euint64` handle. Read-only
+    /// durable operand — never superseded, never consumed. Its address is the canonical PDA of its
+    /// own `(acl_domain_key, app_account, encrypted_value_label)` fields, so a lineage from any app
+    /// may be passed here once its owner has granted the mint's compute subject via `allow_subjects`.
+    pub amount_value: Box<Account<'info, zama_host::EncryptedValue>>,
+    /// CHECK: Anchor event CPI authority for the Zama host program.
+    pub zama_event_authority: UncheckedAccount<'info>,
+    /// ZamaHost program used for FHE operations.
+    pub zama_program: Program<'info, ZamaHost>,
+    /// ZamaHost config used for handle derivation.
+    pub host_config: Box<Account<'info, zama_host::HostConfig>>,
+    /// System program used for ACL account creation.
+    pub system_program: Program<'info, System>,
+    /// CHECK: forwarded verbatim into the ZamaHost `fhe_eval` CPI, which validates it against the
+    /// canonical `["hcu-block-meter", compute_signer]` PDA. The per-mint HCU block meter — supplied
+    /// by an untrusted mint under a metering-band cap, omitted otherwise.
+    #[account(mut)]
+    pub hcu_block_meter: Option<UncheckedAccount<'info>>,
+    /// CHECK: forwarded verbatim into the ZamaHost `fhe_eval` CPI, which validates it. The HCU
+    /// trust witness — present + valid bypasses the cap; absent means untrusted (metered).
+    pub hcu_trusted_app_record: Option<UncheckedAccount<'info>>,
+}
+
+impl<'info> ConfidentialTransferFromValue<'info> {
+    pub(crate) fn as_transfer_accounts<'a>(
+        &'a self,
+        remaining_accounts: &'a [AccountInfo<'info>],
+    ) -> TransferAccounts<'a, 'info> {
+        TransferAccounts {
+            payer: &self.payer,
+            transfer_authority: self.owner.key(),
+            mint: &self.mint,
+            from_account: &self.from_account,
+            to_account: &self.to_account,
+            compute_signer: &self.compute_signer,
+            from_balance_value: self.from_balance_value.to_account_info(),
+            to_balance_value: self.to_balance_value.to_account_info(),
+            transferred_amount_value: self.transferred_amount_value.to_account_info(),
+            zama_event_authority: &self.zama_event_authority,
+            zama_program: &self.zama_program,
+            host_config: &self.host_config,
+            deny_subject_records: remaining_accounts,
+            system_program: &self.system_program,
+            hcu_block_meter: self
+                .hcu_block_meter
+                .as_ref()
+                .map(|account| account.to_account_info()),
+            hcu_trusted_app_record: self
+                .hcu_trusted_app_record
+                .as_ref()
+                .map(|account| account.to_account_info()),
+        }
+    }
+}
+
+/// Transfers an encrypted amount taken from an existing on-chain `EncryptedValue`, rotating the
+/// sender and recipient balance handles. The amount value is spent read-only.
+pub fn confidential_transfer_from_value<'info>(
+    ctx: Context<'info, ConfidentialTransferFromValue<'info>>,
+) -> Result<()> {
+    require_keys_eq!(
+        ctx.accounts.from_account.owner,
+        ctx.accounts.owner.key(),
+        ConfidentialTokenError::OwnerMismatch
+    );
+    let amount_value = &ctx.accounts.amount_value;
+    // Reject a non-euint64 amount early for a clear error, before the eval builder / host would
+    // reject the same handle deeper in the CPI (the host's binary type validation still covers it).
+    require!(
+        zama_host::handle_fhe_type(amount_value.current_handle) == BALANCE_FHE_TYPE,
+        ConfidentialTokenError::AmountHandleTypeMismatch
+    );
+    // Token-level spend gate — EVM `FHE.isAllowed(amount, msg.sender)` parity: the signing owner
+    // must be in the amount value's subject set. App-level by design; the host stays role-blind.
+    require!(
+        amount_value.has_subject(ctx.accounts.owner.key()),
+        ConfidentialTokenError::AmountSpendSubjectMismatch
+    );
+    let amount_handle = amount_value.current_handle;
+    let amount_value_info = amount_value.to_account_info();
+    let outcome = execute_transfer(
+        ctx.accounts.as_transfer_accounts(ctx.remaining_accounts),
+        ctx.bumps.compute_signer,
+        TransferAmountSource::ExistingValue {
+            amount_value: amount_value_info,
+            amount_handle,
+        },
     )?;
     if let Some(outcome) = outcome {
         emit_cpi!(ConfidentialTransferEvent {

--- a/solana/programs/confidential-token/src/lib.rs
+++ b/solana/programs/confidential-token/src/lib.rs
@@ -38,8 +38,8 @@ use instructions::*;
 /// Re-export instruction account contexts for compatibility with existing tests.
 pub use instructions::{
     CloseConsumedBurnRedemptionRequest, CloseExpiredBurnRedemptionRequest, ConfidentialBurn,
-    ConfidentialTransfer, DiscloseSecp, InitializeMint, InitializeTokenAccount,
-    RedeemBurnedAmountSecp, RequestBurnRedemption, WrapUsdc,
+    ConfidentialTransfer, ConfidentialTransferFromValue, DiscloseSecp, InitializeMint,
+    InitializeTokenAccount, RedeemBurnedAmountSecp, RequestBurnRedemption, WrapUsdc,
 };
 /// Re-export account layouts and helper functions used by clients and tests.
 pub use state::*;
@@ -105,6 +105,16 @@ pub mod confidential_token {
         amount_attestation: zama_host::CoprocessorInputAttestation,
     ) -> Result<()> {
         instructions::confidential_transfer(ctx, amount_attestation)
+    }
+
+    /// Transfers an encrypted amount taken from an existing on-chain `EncryptedValue` (a computed or
+    /// received handle) instead of a freshly attested client-side encryption — the path that lets a
+    /// contract be the sender of a computed amount (fhevm-internal#1680). The signing owner must be
+    /// in the amount value's subject set (the token spend gate); the amount is spent read-only.
+    pub fn confidential_transfer_from_value<'info>(
+        ctx: Context<'info, ConfidentialTransferFromValue<'info>>,
+    ) -> Result<()> {
+        instructions::confidential_transfer_from_value(ctx)
     }
 
     /// Requests KMS certification for redeeming a burned encrypted amount.

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 1559
   },
   "confidential_transfer_from_value/direct": {
-    "compute_units": 303659,
+    "compute_units": 303721,
     "unique_accounts": 15,
     "instruction_data_bytes": 8,
     "cpi_instructions": 7,

--- a/solana/runtime-tests/cost-snapshots/token_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/token_mollusk.json
@@ -1,6 +1,6 @@
 {
   "confidential_transfer/direct": {
-    "compute_units": 330602,
+    "compute_units": 331007,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 7,
@@ -8,15 +8,23 @@
     "max_cpi_instruction_data_bytes": 1427
   },
   "confidential_transfer/steady_state": {
-    "compute_units": 348278,
+    "compute_units": 348683,
     "unique_accounts": 14,
     "instruction_data_bytes": 223,
     "cpi_instructions": 5,
     "total_cpi_instruction_data_bytes": 2296,
     "max_cpi_instruction_data_bytes": 1559
   },
+  "confidential_transfer_from_value/direct": {
+    "compute_units": 303659,
+    "unique_accounts": 15,
+    "instruction_data_bytes": 8,
+    "cpi_instructions": 7,
+    "total_cpi_instruction_data_bytes": 1850,
+    "max_cpi_instruction_data_bytes": 1065
+  },
   "initialize_token_account": {
-    "compute_units": 62879,
+    "compute_units": 62882,
     "unique_accounts": 11,
     "instruction_data_bytes": 16,
     "cpi_instructions": 6,

--- a/solana/runtime-tests/tests/plan_contracts.rs
+++ b/solana/runtime-tests/tests/plan_contracts.rs
@@ -176,11 +176,25 @@ fn token_idl_removed_operator_surface_and_splits_payer_from_owner() {
         "CloseOperator",
         "ConfidentialOperator",
     ] {
+        // Whole-identifier match: the new `ConfidentialTransferFromValue` (fhevm-internal#1680) must
+        // not be mistaken for the removed operator struct `ConfidentialTransferFrom`.
         assert!(
-            !source.contains(removed),
+            !contains_symbol(&source, removed),
             "operator symbol `{removed}` must be removed from production token source"
         );
     }
+}
+
+/// True when `symbol` appears in `source` as a standalone Rust identifier, not as a prefix or
+/// suffix of a longer one (so `ConfidentialTransferFrom` does not match inside
+/// `ConfidentialTransferFromValue`).
+fn contains_symbol(source: &str, symbol: &str) -> bool {
+    let is_ident_char = |c: char| c.is_alphanumeric() || c == '_';
+    source.match_indices(symbol).any(|(index, _)| {
+        let before = source[..index].chars().next_back();
+        let after = source[index + symbol.len()..].chars().next();
+        !before.is_some_and(is_ident_char) && !after.is_some_and(is_ident_char)
+    })
 }
 
 #[test]

--- a/solana/runtime-tests/tests/token_mollusk.rs
+++ b/solana/runtime-tests/tests/token_mollusk.rs
@@ -838,6 +838,87 @@ fn confidential_transfer_ix_with_block_cap_accounts(
     ix
 }
 
+/// Builds a `confidential_transfer_from_value` instruction: the amount is taken from the existing
+/// on-chain `EncryptedValue` at `amount_value` (a computed or received handle) rather than a fresh
+/// attestation. `signer_owner` signs and pays; it must own `from_token` and be in the amount
+/// value's subject set.
+#[allow(clippy::too_many_arguments)]
+fn confidential_transfer_from_value_ix(
+    fixture: &TokenFixture,
+    signer_owner: Pubkey,
+    from_token: Pubkey,
+    to_token: Pubkey,
+    from_balance_value: Pubkey,
+    to_balance_value: Pubkey,
+    amount_value: Pubkey,
+) -> Instruction {
+    anchor_ix(
+        token::id(),
+        token::accounts::ConfidentialTransferFromValue {
+            owner: signer_owner,
+            payer: signer_owner,
+            mint: fixture.mint,
+            from_account: from_token,
+            to_account: to_token,
+            compute_signer: fixture.compute_signer,
+            from_balance_value,
+            to_balance_value,
+            transferred_amount_value: fixture.transferred_amount_value_address(from_token),
+            amount_value,
+            zama_event_authority: event_authority(host::id()),
+            zama_program: host::id(),
+            host_config: fixture.host_config,
+            system_program: system_program::ID,
+            hcu_block_meter: None,
+            hcu_trusted_app_record: None,
+            event_authority: event_authority(token::id()),
+            program: token::id(),
+        },
+        token::instruction::ConfidentialTransferFromValue {},
+    )
+}
+
+/// Seeds a spendable amount lineage (a stand-in for a computed/received `euint64` handle) at the
+/// canonical PDA `(mint, app_account, label)` with the given subjects and current handle, and
+/// returns its address.
+fn seed_amount_value(
+    fixture: &TokenFixture,
+    accounts: &mut HashMap<Pubkey, Account>,
+    app_account: Pubkey,
+    label: [u8; 32],
+    handle: [u8; 32],
+    subjects: &[Pubkey],
+) -> Pubkey {
+    let (address, value) = new_encrypted_value(fixture.mint, app_account, label, handle, subjects);
+    accounts.insert(address, encrypted_value_account(&value));
+    address
+}
+
+/// Host `allow_subjects` instruction granting `subject` on `encrypted_value`, authorized by a
+/// current subject `authority`. Mirrors the cross-app grant of the mint's compute subject.
+fn allow_subject_ix(
+    payer: Pubkey,
+    authority: Pubkey,
+    encrypted_value: Pubkey,
+    host_config: Pubkey,
+    subject: Pubkey,
+) -> Instruction {
+    anchor_ix(
+        host::id(),
+        host::accounts::AllowEncryptedValueSubjects {
+            payer,
+            authority,
+            encrypted_value,
+            host_config,
+            deny_subject_record: None,
+            system_program: system_program::ID,
+        },
+        host::instruction::AllowSubjects {
+            subjects: vec![host::instructions::EncryptedValueSubjectGrant { subject }],
+        },
+    )
+}
+
 fn deny_enabled_transfer_accounts(
     fixture: &TokenFixture,
     denied_authority: Option<Pubkey>,
@@ -3471,6 +3552,360 @@ fn mollusk_confidential_transfer_metering_band_charges_meter_through_cpi() {
 }
 
 // ---------------------------------------------------------------------------
+// confidential_transfer_from_value (spend an existing encrypted amount, fhevm-internal#1680)
+// ---------------------------------------------------------------------------
+
+/// Done-when 1: a transfer spends a computed handle produced under the same mint, with no
+/// attestation attached. Here the amount is an existing lineage carrying the sender + compute
+/// subjects; the balances move through the same `ge -> sub -> select` debit and `add` credit, and
+/// the amount value itself is read-only (never superseded, never consumed).
+#[test]
+fn mollusk_transfer_from_value_spends_existing_amount() {
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    let amount_handle = handle_for_chain(41, BALANCE_FHE_TYPE);
+    let amount_value = seed_amount_value(
+        &fixture,
+        &mut accounts,
+        fixture.alice_token,
+        token::transfer_amount_label(),
+        amount_handle,
+        &[fixture.owner, fixture.compute_signer],
+    );
+    let context = mollusk().with_context(accounts);
+
+    let mut cleartext = CleartextLedger::default();
+    cleartext.seed_amount(fixture.alice_initial, 1_000);
+    cleartext.seed_amount(fixture.bob_initial, 100);
+    cleartext.seed_amount(amount_handle, 250);
+
+    let transfer = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_value,
+    );
+
+    let result = context.process_and_validate_instruction(&transfer, &[Check::success()]);
+    let durable_outputs = cleartext.evaluate_fhe_cpi(&context, &result);
+
+    // Only the two balance lineages and the sender's transferred_amount rotate — the amount is not
+    // an output.
+    assert_eq!(durable_outputs, 3);
+    assert_eq!(cleartext.balance(&context, fixture.alice_token), 750);
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 350);
+
+    // The amount value is read-only: current handle, subjects, and history all unchanged.
+    let amount_after = read_encrypted_value(&context, amount_value);
+    assert_eq!(amount_after.current_handle, amount_handle);
+    assert_eq!(amount_after.leaf_count, 0);
+    assert_eq!(
+        amount_after.subjects,
+        vec![fixture.owner, fixture.compute_signer]
+    );
+}
+
+/// Done-when 1 (follow-up): the RECIPIENT of a transfer spends the received `transferred_amount`
+/// into a transfer to a third party — the exact forwarding flow — with no decryption anywhere.
+#[test]
+fn mollusk_transfer_from_value_recipient_forwards_received_amount() {
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    let carol_initial = handle_for_chain(3, BALANCE_FHE_TYPE);
+    let (_carol_owner, carol_token, carol_balance_value) =
+        seed_third_account(&fixture, &mut accounts, carol_initial);
+    let context = mollusk().with_context(accounts);
+
+    let mut cleartext = CleartextLedger::default();
+    cleartext.seed_amount(fixture.alice_initial, 1_000);
+    cleartext.seed_amount(fixture.bob_initial, 0);
+    cleartext.seed_amount(carol_initial, 0);
+
+    // Alice -> Bob (fresh attested): produces Alice's transferred_amount lineage whose subjects
+    // include Bob, so Bob may now spend that received handle.
+    let alice_amount = handle_for_chain(50, BALANCE_FHE_TYPE);
+    cleartext.seed_amount(alice_amount, 300);
+    let first = confidential_transfer_ix(
+        &fixture,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_attestation_for(alice_amount, fixture.owner, fixture.compute_signer),
+    );
+    let first_result = context.process_and_validate_instruction(&first, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &first_result);
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 300);
+
+    let received = fixture.transferred_amount_value_address(fixture.alice_token);
+    let received_before = read_encrypted_value(&context, received);
+    assert!(received_before.has_subject(fixture.bob_owner));
+
+    // Bob -> Carol, spending the received transferred_amount handle directly (no attestation, no
+    // decryption). Bob is a subject of the received amount, so the spend gate passes.
+    let forward = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.bob_owner,
+        fixture.bob_token,
+        carol_token,
+        fixture.bob_balance_value,
+        carol_balance_value,
+        received,
+    );
+    let forward_result = context.process_and_validate_instruction(&forward, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &forward_result);
+
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 0);
+    assert_eq!(cleartext.balance(&context, carol_token), 300);
+
+    // Alice's transferred_amount lineage — the forwarded amount — is untouched by Bob's spend.
+    let received_after = read_encrypted_value(&context, received);
+    assert_eq!(
+        received_after.current_handle,
+        received_before.current_handle
+    );
+    assert_eq!(received_after.leaf_count, received_before.leaf_count);
+    assert_eq!(received_after.subjects, received_before.subjects);
+}
+
+/// Done-when 5: the RFQ settlement shape — an amount computed via a `select(...)` eval producing a
+/// durable output, then transferred — proven end to end. A transfer's `transferred_amount` is
+/// exactly `sub(from_balance, if_then_else(ge, debit, from_balance))`, i.e. a select-computed
+/// durable `euint64`; spending it is the RFQ `eMoved` settlement move.
+#[test]
+fn mollusk_transfer_from_value_settles_select_computed_amount() {
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    let carol_initial = handle_for_chain(4, BALANCE_FHE_TYPE);
+    let (_carol_owner, carol_token, carol_balance_value) =
+        seed_third_account(&fixture, &mut accounts, carol_initial);
+    let context = mollusk().with_context(accounts);
+
+    let mut cleartext = CleartextLedger::default();
+    cleartext.seed_amount(fixture.alice_initial, 900);
+    cleartext.seed_amount(fixture.bob_initial, 50);
+    cleartext.seed_amount(carol_initial, 0);
+
+    // Compute the amount: Alice -> Bob transfers 400. The select picks the full 400 (balance
+    // sufficient), yielding a durable transferred_amount = 400.
+    let alice_amount = handle_for_chain(51, BALANCE_FHE_TYPE);
+    cleartext.seed_amount(alice_amount, 400);
+    let compute = confidential_transfer_ix(
+        &fixture,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_attestation_for(alice_amount, fixture.owner, fixture.compute_signer),
+    );
+    let compute_result = context.process_and_validate_instruction(&compute, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &compute_result);
+
+    let computed_amount = fixture.transferred_amount_value_address(fixture.alice_token);
+    assert_eq!(
+        cleartext.transferred_amount(&context, fixture.mint, fixture.alice_token),
+        400
+    );
+
+    // Settle: Bob transfers the select-computed 400 to Carol.
+    let settle = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.bob_owner,
+        fixture.bob_token,
+        carol_token,
+        fixture.bob_balance_value,
+        carol_balance_value,
+        computed_amount,
+    );
+    let settle_result = context.process_and_validate_instruction(&settle, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &settle_result);
+
+    // Bob had 50 + 400 = 450; settling 400 leaves 50; Carol receives 400.
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 50);
+    assert_eq!(cleartext.balance(&context, carol_token), 400);
+}
+
+/// Done-when 2: a handle whose subjects lack the mint's compute subject fails at the host's
+/// compute-read check; after a single `allow_subjects` grant of the compute subject it succeeds
+/// (the cross-app shape — EVM `FHE.allow(handle, token)`).
+#[test]
+fn mollusk_transfer_from_value_cross_app_requires_compute_subject_grant() {
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    let amount_handle = handle_for_chain(60, BALANCE_FHE_TYPE);
+    // A handle from another app: Alice is a subject (she may spend it), but the mint's compute
+    // subject is not yet allowed.
+    let amount_value = seed_amount_value(
+        &fixture,
+        &mut accounts,
+        fixture.alice_token,
+        token::transfer_amount_label(),
+        amount_handle,
+        &[fixture.owner],
+    );
+    let context = mollusk().with_context(accounts);
+
+    let transfer = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_value,
+    );
+    // Without the grant, the host rejects the durable operand at its compute-read check.
+    context.process_and_validate_instruction(
+        &transfer,
+        &[host_error(host::errors::ZamaHostError::SubjectNotFound)],
+    );
+
+    // The handle's owner grants the mint's compute subject.
+    let grant = allow_subject_ix(
+        fixture.owner,
+        fixture.owner,
+        amount_value,
+        fixture.host_config,
+        fixture.compute_signer,
+    );
+    context.process_and_validate_instruction(&grant, &[Check::success()]);
+
+    // The same transfer now succeeds.
+    let mut cleartext = CleartextLedger::default();
+    cleartext.seed_amount(fixture.alice_initial, 1_000);
+    cleartext.seed_amount(fixture.bob_initial, 100);
+    cleartext.seed_amount(amount_handle, 200);
+    let transfer_again = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_value,
+    );
+    let result = context.process_and_validate_instruction(&transfer_again, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &result);
+    assert_eq!(cleartext.balance(&context, fixture.alice_token), 800);
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 300);
+}
+
+/// Done-when 3: a signer outside the amount handle's subject set is rejected by the token's spend
+/// gate with its own distinct error, before any host CPI.
+#[test]
+fn mollusk_transfer_from_value_rejects_non_subject_signer() {
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    let amount_handle = handle_for_chain(61, BALANCE_FHE_TYPE);
+    // The amount's subjects are Bob + compute; Alice (the from-account owner and signer) is NOT a
+    // subject, so she may not spend it even though she owns the debited balance.
+    let amount_value = seed_amount_value(
+        &fixture,
+        &mut accounts,
+        fixture.alice_token,
+        token::transfer_amount_label(),
+        amount_handle,
+        &[fixture.bob_owner, fixture.compute_signer],
+    );
+    let context = mollusk().with_context(accounts);
+
+    let transfer = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_value,
+    );
+    context.process_and_validate_instruction(
+        &transfer,
+        &[token_error(
+            token::ConfidentialTokenError::AmountSpendSubjectMismatch,
+        )],
+    );
+
+    // Balances untouched.
+    let alice_balance = read_encrypted_value(&context, fixture.alice_balance_value);
+    assert_eq!(alice_balance.current_handle, fixture.alice_initial);
+}
+
+/// The amount handle must be euint64. A non-balance-typed amount is rejected early by the token for
+/// a clear error, before the host's binary type validation would reject the same handle deeper.
+#[test]
+fn mollusk_transfer_from_value_rejects_non_euint64_amount() {
+    let fixture = TokenFixture::new();
+    let mut accounts = fixture.base_accounts();
+    // FHE type 0 (ebool), not euint64.
+    let amount_handle = handle_for_chain(62, 0);
+    let amount_value = seed_amount_value(
+        &fixture,
+        &mut accounts,
+        fixture.alice_token,
+        token::transfer_amount_label(),
+        amount_handle,
+        &[fixture.owner, fixture.compute_signer],
+    );
+    let context = mollusk().with_context(accounts);
+
+    let transfer = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_value,
+    );
+    context.process_and_validate_instruction(
+        &transfer,
+        &[token_error(
+            token::ConfidentialTokenError::AmountHandleTypeMismatch,
+        )],
+    );
+}
+
+/// Done-when 4 (tx-size half): the new arm carries no 190-byte attestation, so its instruction data
+/// is strictly SMALLER than the fresh-attested arm's. This is the measured wire-size win that lets a
+/// contract-driven settlement pack more into a packet.
+#[test]
+fn transfer_from_value_instruction_is_smaller_than_attested_arm() {
+    let fixture = TokenFixture::new();
+    let amount_handle = handle_for_chain(70, BALANCE_FHE_TYPE);
+    let attested = confidential_transfer_ix(
+        &fixture,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_attestation_for(amount_handle, fixture.owner, fixture.compute_signer),
+    );
+    let from_value = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        Pubkey::new_unique(),
+    );
+    eprintln!(
+        "confidential_transfer ix data: {} bytes; confidential_transfer_from_value ix data: {} bytes",
+        attested.data.len(),
+        from_value.data.len(),
+    );
+    assert!(
+        from_value.data.len() < attested.data.len(),
+        "from_value arm ({} bytes) must be smaller than the attested arm ({} bytes)",
+        from_value.data.len(),
+        attested.data.len(),
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Cost snapshots (tests/support/cost_snapshot.rs). Dedicated tests so cost
 // drift never fails a behavior test; regenerate with
 // `bash scripts/update-cost-snapshots.sh`.
@@ -3532,6 +3967,44 @@ fn cost_snapshot_confidential_transfer_direct() {
         "confidential_transfer/steady_state",
         &second_transfer,
         &second_result,
+    );
+}
+
+#[test]
+fn cost_snapshot_confidential_transfer_from_value() {
+    let fixture = TokenFixture::with_keys(
+        Pubkey::new_from_array([0x11; 32]),
+        Pubkey::new_from_array([0x12; 32]),
+        Pubkey::new_from_array([0x13; 32]),
+    );
+    let mut accounts = fixture.base_accounts();
+    let amount_handle = handle_for_chain(21, BALANCE_FHE_TYPE);
+    let amount_value = seed_amount_value(
+        &fixture,
+        &mut accounts,
+        fixture.alice_token,
+        token::transfer_amount_label(),
+        amount_handle,
+        &[fixture.owner, fixture.compute_signer],
+    );
+    let context = mollusk().with_context(accounts);
+    let transfer = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_value,
+    );
+
+    let result = context.process_and_validate_instruction(&transfer, &[Check::success()]);
+
+    cost_snapshot::assert_cost_snapshot(
+        "token_mollusk",
+        "confidential_transfer_from_value/direct",
+        &transfer,
+        &result,
     );
 }
 

--- a/solana/runtime-tests/tests/token_mollusk.rs
+++ b/solana/runtime-tests/tests/token_mollusk.rs
@@ -3868,6 +3868,84 @@ fn mollusk_transfer_from_value_rejects_non_euint64_amount() {
     );
 }
 
+/// Spending the entire balance: the amount lineage is the sender's own balance value, so
+/// `amount_value` aliases the `from_balance` output account. The eval plan merges them into one
+/// account slot, and the transfer debits the whole balance without tripping duplicate-account
+/// resolution.
+#[test]
+fn mollusk_transfer_from_value_spends_full_balance_with_balance_lineage_as_amount() {
+    let fixture = TokenFixture::new();
+    let accounts = fixture.base_accounts();
+    let context = mollusk().with_context(accounts);
+
+    let mut cleartext = CleartextLedger::default();
+    cleartext.seed_amount(fixture.alice_initial, 1_000);
+    cleartext.seed_amount(fixture.bob_initial, 100);
+
+    let transfer = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        // Amount aliased to the sender's own balance lineage: transfer the whole balance.
+        fixture.alice_balance_value,
+    );
+    let result = context.process_and_validate_instruction(&transfer, &[Check::success()]);
+    let durable_outputs = cleartext.evaluate_fhe_cpi(&context, &result);
+
+    assert_eq!(durable_outputs, 3);
+    assert_eq!(cleartext.balance(&context, fixture.alice_token), 0);
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 1_100);
+}
+
+/// Re-sending a received amount: the sender spends their own `transferred_amount` lineage, which is
+/// also this transfer's `transferred_amount` output account. `amount_value` aliases an output the
+/// eval frame writes, and the merged account slot lets the transfer settle.
+#[test]
+fn mollusk_transfer_from_value_resends_transferred_amount_that_is_also_this_output() {
+    let fixture = TokenFixture::new();
+    let accounts = fixture.base_accounts();
+    let context = mollusk().with_context(accounts);
+
+    let mut cleartext = CleartextLedger::default();
+    cleartext.seed_amount(fixture.alice_initial, 1_000);
+    cleartext.seed_amount(fixture.bob_initial, 0);
+
+    // First transfer (attested, 300) creates Alice's transferred_amount lineage.
+    let alice_amount = handle_for_chain(90, BALANCE_FHE_TYPE);
+    cleartext.seed_amount(alice_amount, 300);
+    let first = confidential_transfer_ix(
+        &fixture,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        amount_attestation_for(alice_amount, fixture.owner, fixture.compute_signer),
+    );
+    let first_result = context.process_and_validate_instruction(&first, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &first_result);
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 300);
+
+    // Alice sends the same amount again by spending her own transferred_amount lineage, which is
+    // also this transfer's transferred_amount output account.
+    let own_transferred = fixture.transferred_amount_value_address(fixture.alice_token);
+    let again = confidential_transfer_from_value_ix(
+        &fixture,
+        fixture.owner,
+        fixture.alice_token,
+        fixture.bob_token,
+        fixture.alice_balance_value,
+        fixture.bob_balance_value,
+        own_transferred,
+    );
+    let again_result = context.process_and_validate_instruction(&again, &[Check::success()]);
+    cleartext.evaluate_fhe_cpi(&context, &again_result);
+    assert_eq!(cleartext.balance(&context, fixture.alice_token), 400);
+    assert_eq!(cleartext.balance(&context, fixture.bob_token), 600);
+}
+
 /// Done-when 4 (tx-size half): the new arm carries no 190-byte attestation, so its instruction data
 /// is strictly SMALLER than the fresh-attested arm's. This is the measured wire-size win that lets a
 /// contract-driven settlement pack more into a packet.

--- a/solana/scripts/check_solana_abi.py
+++ b/solana/scripts/check_solana_abi.py
@@ -62,6 +62,19 @@ PINNED_SCHEMAS = [
     ("zama_host", "instruction_args", "remove_subject", True),
     ("zama_host", "instruction_args", "update_encrypted_value", True),
     ("zama_host", "instruction_args", "make_handle_public", True),
+    ("zama_host", "instruction_args", "define_kms_context", True),
+    ("zama_host", "instruction_args", "delegate_for_user_decryption", True),
+    ("zama_host", "instruction_args", "destroy_kms_context", True),
+    ("zama_host", "instruction_args", "revoke_delegation_for_user_decryption", True),
+    ("zama_host", "instruction_args", "set_coprocessor_signers", True),
+    ("zama_host", "instruction_args", "set_deny_subject", True),
+    ("zama_host", "instruction_args", "set_grant_deny_list_enabled", True),
+    ("zama_host", "instruction_args", "set_hcu_app_trusted", True),
+    ("zama_host", "instruction_args", "set_hcu_block_cap_per_app", True),
+    ("zama_host", "instruction_args", "set_host_pause", True),
+    ("zama_host", "instruction_args", "set_max_hcu_depth_per_tx", True),
+    ("zama_host", "instruction_args", "set_max_hcu_per_tx", True),
+    ("zama_host", "instruction_args", "verify_public_decrypt", True),
     ("confidential_token", "account", "ConfidentialMint", True),
     ("confidential_token", "account", "ConfidentialTokenAccount", True),
     # The DisclosureRequest account and its request/disclose/close instruction lifecycle were
@@ -73,6 +86,7 @@ PINNED_SCHEMAS = [
     ("confidential_token", "instruction_args", "close_expired_burn_redemption_request", True),
     ("confidential_token", "instruction_args", "confidential_burn", True),
     ("confidential_token", "instruction_args", "confidential_transfer", True),
+    ("confidential_token", "instruction_args", "confidential_transfer_from_value", True),
     # create_random_amount / create_random_bounded_amount are `poc`-gated demo helpers and are
     # intentionally absent from the production IDL, so they are not pinned here.
     ("confidential_token", "instruction_args", "disclose_secp", True),
@@ -170,6 +184,24 @@ def build_manifest(root: pathlib.Path) -> dict[str, Any]:
     for program, idl in idls.items():
         for event in idl.get("events", []):
             requested.append((program, "event", event["name"], True))
+
+    # Every production instruction must be pinned in PINNED_SCHEMAS. Report any IDL instruction
+    # that has no "instruction_args" entry through the pending channel so it surfaces as an error.
+    pinned_instructions: dict[str, set[str]] = {program: set() for program in idls}
+    for program, category, name, _ in PINNED_SCHEMAS:
+        if category == "instruction_args":
+            pinned_instructions[program].add(name)
+    for program, idl in idls.items():
+        for instruction in idl.get("instructions", []):
+            if instruction["name"] not in pinned_instructions[program]:
+                pending.append(
+                    {
+                        "program": program,
+                        "category": "instruction_args",
+                        "name": instruction["name"],
+                        "reason": "production instruction is not pinned in PINNED_SCHEMAS",
+                    }
+                )
 
     seen: set[tuple[str, str, str]] = set()
     for program, category, name, needs_fixture in requested:


### PR DESCRIPTION
## Overview

Closes zama-ai/fhevm-internal#1680. A confidential transfer can now take its amount from an existing on-chain `EncryptedValue` — a computed or received handle — not only from a freshly attested client-side encryption. This is what lets a **contract be the sender**: RFQ settlement transferring a `select(...)`-computed `eMoved`, a recipient forwarding exactly what they received without decrypting it, vault payouts of computed shares. On EVM this was never restricted (ERC-7984 takes an `euint64` from any source, gated by `FHE.isAllowed(amount, msg.sender)`); this closes the gap.

## What

- New sibling instruction `confidential_transfer_from_value` — the attested `confidential_transfer` stays byte-for-byte unchanged (instruction data still 223B; asserted by test). Both arms share one `execute_transfer` via a `TransferAmountSource` enum; the debit/credit plan is identical.
- **Token spend gate** (the one new rule, EVM `isAllowed` parity): the signing owner must be in the amount value's subject set → `AmountSpendSubjectMismatch`. Early euint64 type check for a clear error.
- **Host side unchanged**: the amount enters the eval frame as a durable input, so the existing compute-subject gate enforces that cross-app handles need one explicit `allow_subjects` grant of the mint's compute subject — the mirror of EVM's `FHE.allow(handle, token)`.
- The amount is strictly read-only: never superseded, never consumed. Only the two balance lineages change, through the unchanged `ge → sub → select` / `add` arithmetic. An amount is a number, not a claim ticket — no allowance mechanism is introduced (#1692 stays deferred).
- Output-handle domain separation between the two arms via distinct eval context tags.

## Design point (stated, not stumbled into)

Using subject-set membership as the spend gate couples "may decrypt" with "may spend". This is deliberate EVM parity and grants nothing beyond what decryption already gives — a subject could decrypt the number and re-encrypt it fresh. It is the first use of subjecthood for authorization beyond decryption on this branch. Transfer rights themselves are not a right on the amount: they are the write right on the balances, which is untouched — no amount-source change can move anyone's funds but the signer's own.

## Measured

New arm instruction data: **8 bytes** (vs 223 attested — no 190-byte attestation), one extra account, ~27k fewer CU (no secp recovery). Cost snapshot profile added.

## Tests

8 new Mollusk tests covering the issue's done-when list verbatim: computed-handle spend, received-`transferred_amount` forwarding to a third party with zero decryption, the RFQ select-computed settlement shape end to end, cross-app grant-absent-fails/grant-present-succeeds, non-subject signer rejected, non-euint64 rejected, wire-size assertion. Full gate green (546 tests), IDL/golden in sync, `-D warnings` and fmt clean. Independent review traced the amount-account identity chain (Anchor owner+discriminator, token re-check, host canonical-PDA re-derivation — the token's gated account and the host's operand are the same single read-only account) and found no incorrect-accept.

## Deferred (follow-up)

The SDK builder (`confidentialTransferFromValue`) — the codegen allowlist entry, builder, and vitest are specified in fhevm-internal#1680; program, IDL, and tests here are complete without it.