### PR TITLE
refactor(host-contracts): clean post-merge disclose and signer-set seams

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/idl/confidential_token.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/confidential_token.json
@@ -1725,12 +1725,12 @@
     {
       "code": 6027,
       "name": "MaterialCommitmentMismatch",
-      "msg": "material commitment witness does not match"
+      "msg": "material commitment witness does not match (retired)"
     },
     {
       "code": 6028,
       "name": "PublicDecryptNotReleased",
-      "msg": "handle is not released for public decrypt"
+      "msg": "handle is not released for public decrypt (retired)"
     },
     {
       "code": 6029,
@@ -1791,6 +1791,11 @@
       "code": 6040,
       "name": "RedemptionDenyRecordInvalid",
       "msg": "redemption deny-list record is invalid"
+    },
+    {
+      "code": 6041,
+      "name": "CleartextExceedsEuint64",
+      "msg": "certified cleartext exceeds euint64 width"
     }
   ],
   "types": [

--- a/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
+++ b/coprocessor/fhevm-engine/host-listener/idl/zama_host.json
@@ -2205,6 +2205,11 @@
       "code": 6078,
       "name": "ZeroCoprocessorSigner",
       "msg": "coprocessor signer set contains the zero address"
+    },
+    {
+      "code": 6079,
+      "name": "ZeroKmsSigner",
+      "msg": "KMS signer set contains the zero address"
     }
   ],
   "types": [

--- a/sdk/js-sdk/src/solana/actions/discloseSecp.test.ts
+++ b/sdk/js-sdk/src/solana/actions/discloseSecp.test.ts
@@ -4,14 +4,9 @@ import { base58 } from '@scure/base';
 
 import type { MmrProof } from '../proof.js';
 import type { SolanaPublicDecryptCertificateClaim } from './publicDecryptCertificate.js';
-import {
-  buildDiscloseSecpInstruction,
-  buildVerifyPublicDecryptInstruction,
-  verifyPublicDecryptArgsFromClaim,
-} from './discloseSecp.js';
+import { buildDiscloseSecpInstruction } from './discloseSecp.js';
 import { getDiscloseSecpInstructionDataDecoder } from '../internal/generated/confidentialToken/instructions/discloseSecp.js';
 import { CONFIDENTIAL_TOKEN_PROGRAM_ADDRESS } from '../internal/generated/confidentialToken/programAddress.js';
-import { getVerifyPublicDecryptInstructionDataDecoder } from '../internal/generated/zamaHost/instructions/verifyPublicDecrypt.js';
 import { ZAMA_HOST_PROGRAM_ADDRESS } from '../internal/generated/zamaHost/programAddress.js';
 
 function addr(fill: number): Address {
@@ -42,55 +37,6 @@ function claim(overrides: Partial<SolanaPublicDecryptCertificateClaim> = {}): So
     ...overrides,
   };
 }
-
-describe('verifyPublicDecryptArgsFromClaim', () => {
-  it('decodes every claim field into the verifier wire types', () => {
-    const args = verifyPublicDecryptArgsFromClaim(claim());
-    expect(Array.from(args.handle)).toEqual(Array.from(handleBytes));
-    expect(Array.from(args.cleartext)).toEqual(Array.from(cleartextBytes));
-    expect(args.signatures).toHaveLength(1);
-    expect(Array.from(args.signatures[0]!)).toEqual(Array.from(signatureBytes));
-    expect(Array.from(args.extraData)).toEqual(Array.from(extraDataBytes));
-    expect(args.leafIndex).toBe(3n);
-    expect(args.siblings.map((s) => Array.from(s))).toEqual([Array.from(sibling)]);
-  });
-
-  it('rejects a non-32-byte handle', () => {
-    expect(() => verifyPublicDecryptArgsFromClaim(claim({ handle: '0xabcd' }))).toThrow(/handle must be 32 bytes/);
-  });
-
-  it('rejects a non-32-byte cleartext', () => {
-    expect(() => verifyPublicDecryptArgsFromClaim(claim({ abiEncodedCleartext: '2a' }))).toThrow(
-      /cleartext must be a 32-byte uint256/,
-    );
-  });
-
-  it('rejects a non-65-byte signature', () => {
-    expect(() => verifyPublicDecryptArgsFromClaim(claim({ signatures: ['1122'] }))).toThrow(
-      /signature\[0\] must be 65 bytes/,
-    );
-  });
-});
-
-describe('buildVerifyPublicDecryptInstruction', () => {
-  it('maps a claim onto the raw host verify_public_decrypt instruction', async () => {
-    const kmsContext = addr(2);
-    const encryptedValue = addr(3);
-    const hostConfig = addr(4);
-    const instruction = await buildVerifyPublicDecryptInstruction({ hostConfig, kmsContext, encryptedValue }, claim());
-
-    expect(instruction.programAddress).toBe(ZAMA_HOST_PROGRAM_ADDRESS);
-    expect(instruction.accounts?.map((a: { readonly address: Address }) => a.address)).toEqual([hostConfig, kmsContext, encryptedValue]);
-
-    const decoded = getVerifyPublicDecryptInstructionDataDecoder().decode(instruction.data!);
-    expect(Array.from(decoded.handle)).toEqual(Array.from(handleBytes));
-    expect(Array.from(decoded.cleartext)).toEqual(Array.from(cleartextBytes));
-    expect(decoded.signatures.map((s) => Array.from(s))).toEqual([Array.from(signatureBytes)]);
-    expect(Array.from(decoded.extraData)).toEqual(Array.from(extraDataBytes));
-    expect(decoded.leafIndex).toBe(3n);
-    expect(decoded.siblings.map((s) => Array.from(s))).toEqual([Array.from(sibling)]);
-  });
-});
 
 describe('buildDiscloseSecpInstruction', () => {
   it('maps a claim onto the token disclose_secp instruction with the right accounts', async () => {

--- a/sdk/js-sdk/src/solana/actions/discloseSecp.ts
+++ b/sdk/js-sdk/src/solana/actions/discloseSecp.ts
@@ -1,91 +1,11 @@
 import { getProgramDerivedAddress, type Address, type Instruction } from '@solana/kit';
 
-import { hexToBytes } from '../../core/base/bytes.js';
 import type { SolanaPublicDecryptCertificateClaim } from './publicDecryptCertificate.js';
+import { verifyPublicDecryptArgsFromClaim } from './verifyPublicDecrypt.js';
 import { getDiscloseSecpInstructionAsync } from '../internal/generated/confidentialToken/instructions/discloseSecp.js';
 import { CONFIDENTIAL_TOKEN_PROGRAM_ADDRESS } from '../internal/generated/confidentialToken/programAddress.js';
-import { getVerifyPublicDecryptInstructionAsync } from '../internal/generated/zamaHost/instructions/verifyPublicDecrypt.js';
 
 const EVENT_AUTHORITY_SEED = new TextEncoder().encode('__event_authority');
-
-/**
- * The certificate + inclusion-proof payload the stateless host verifier consumes, decoded from a
- * relayer [`SolanaPublicDecryptCertificateClaim`] into the exact wire types the generated
- * `verify_public_decrypt` / `disclose_secp` instruction builders expect.
- */
-export type SolanaVerifyPublicDecryptArgs = {
-  readonly handle: Uint8Array;
-  readonly cleartext: Uint8Array;
-  readonly signatures: readonly Uint8Array[];
-  readonly extraData: Uint8Array;
-  readonly leafIndex: bigint;
-  readonly siblings: readonly Uint8Array[];
-};
-
-/**
- * Decodes a relayer public-decrypt certificate claim into the verifier instruction args, validating
- * the fixed-size fields. `handle` and `cleartext` are the 32-byte handle and 32-byte big-endian
- * `uint256` cleartext the KMS signed over; each signature is a 65-byte secp256k1 recoverable
- * signature; the proof is the MMR public-leaf inclusion path for `handle`.
- */
-export function verifyPublicDecryptArgsFromClaim(
-  claim: SolanaPublicDecryptCertificateClaim,
-): SolanaVerifyPublicDecryptArgs {
-  const handle = hexToBytes(claim.handle);
-  if (handle.length !== 32) throw new Error(`public-decrypt handle must be 32 bytes, got ${handle.length}`);
-  const cleartext = hexToBytes(claim.abiEncodedCleartext);
-  if (cleartext.length !== 32) {
-    throw new Error(`public-decrypt cleartext must be a 32-byte uint256, got ${cleartext.length} bytes`);
-  }
-  const signatures = claim.signatures.map((signature, index) => {
-    const bytes = hexToBytes(signature);
-    if (bytes.length !== 65) throw new Error(`public-decrypt signature[${index}] must be 65 bytes, got ${bytes.length}`);
-    return bytes;
-  });
-  return {
-    handle,
-    cleartext,
-    signatures,
-    extraData: hexToBytes(claim.extraData),
-    leafIndex: claim.inclusionProof.leafIndex,
-    siblings: [...claim.inclusionProof.siblings],
-  };
-}
-
-/** Accounts for the generic, program-agnostic host `verify_public_decrypt` instruction. */
-export type SolanaVerifyPublicDecryptAccounts = {
-  /** Canonical singleton host config; defaults to the host config PDA when omitted. */
-  readonly hostConfig?: Address | undefined;
-  /** KMS context PDA for the host's current context id. */
-  readonly kmsContext: Address;
-  /** The `EncryptedValue` lineage the inclusion proof is checked against. */
-  readonly encryptedValue: Address;
-};
-
-/**
- * Builds the raw, stateless `zama_host::verify_public_decrypt` instruction from a certificate claim.
- * The verifier reads state and returns `(handle, cleartext)` via `return_data`; it creates and
- * mutates nothing. Use this when consuming the verifier from a non-token program (the token wrapper
- * is [`buildDiscloseSecpInstruction`]). Async because the host config account defaults to its PDA
- * when omitted.
- */
-export async function buildVerifyPublicDecryptInstruction(
-  accounts: SolanaVerifyPublicDecryptAccounts,
-  claim: SolanaPublicDecryptCertificateClaim,
-): Promise<Instruction> {
-  const args = verifyPublicDecryptArgsFromClaim(claim);
-  return getVerifyPublicDecryptInstructionAsync({
-    ...(accounts.hostConfig !== undefined ? { hostConfig: accounts.hostConfig } : {}),
-    kmsContext: accounts.kmsContext,
-    encryptedValue: accounts.encryptedValue,
-    handle: args.handle,
-    cleartext: args.cleartext,
-    signatures: [...args.signatures],
-    extraData: args.extraData,
-    leafIndex: args.leafIndex,
-    siblings: [...args.siblings],
-  });
-}
 
 /** Accounts for the confidential-token `disclose_secp` consume instruction. */
 export type SolanaDiscloseSecpAccounts = {

--- a/sdk/js-sdk/src/solana/actions/verifyPublicDecrypt.test.ts
+++ b/sdk/js-sdk/src/solana/actions/verifyPublicDecrypt.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { address, type Address } from '@solana/kit';
+import { base58 } from '@scure/base';
+
+import type { MmrProof } from '../proof.js';
+import type { SolanaPublicDecryptCertificateClaim } from './publicDecryptCertificate.js';
+import {
+  buildVerifyPublicDecryptInstruction,
+  verifyPublicDecryptArgsFromClaim,
+} from './verifyPublicDecrypt.js';
+import { getVerifyPublicDecryptInstructionDataDecoder } from '../internal/generated/zamaHost/instructions/verifyPublicDecrypt.js';
+import { ZAMA_HOST_PROGRAM_ADDRESS } from '../internal/generated/zamaHost/programAddress.js';
+
+function addr(fill: number): Address {
+  return address(base58.encode(new Uint8Array(32).fill(fill)));
+}
+
+const handleBytes = new Uint8Array(32).fill(0xab);
+const cleartextBytes = new Uint8Array(32);
+cleartextBytes[31] = 0x2a; // 42 as a uint256 low byte
+const signatureBytes = new Uint8Array(65).fill(0x11);
+const extraDataBytes = new Uint8Array([0x00]);
+const sibling = new Uint8Array(32).fill(0x07);
+const inclusionProof: MmrProof = { leafIndex: 3n, siblings: [sibling] };
+
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function claim(overrides: Partial<SolanaPublicDecryptCertificateClaim> = {}): SolanaPublicDecryptCertificateClaim {
+  return {
+    handle: `0x${hex(handleBytes)}`,
+    abiEncodedCleartext: hex(cleartextBytes),
+    signatures: [hex(signatureBytes)],
+    extraData: `0x${hex(extraDataBytes)}`,
+    inclusionProof,
+    ...overrides,
+  };
+}
+
+describe('verifyPublicDecryptArgsFromClaim', () => {
+  it('decodes every claim field into the verifier wire types', () => {
+    const args = verifyPublicDecryptArgsFromClaim(claim());
+    expect(Array.from(args.handle)).toEqual(Array.from(handleBytes));
+    expect(Array.from(args.cleartext)).toEqual(Array.from(cleartextBytes));
+    expect(args.signatures).toHaveLength(1);
+    expect(Array.from(args.signatures[0]!)).toEqual(Array.from(signatureBytes));
+    expect(Array.from(args.extraData)).toEqual(Array.from(extraDataBytes));
+    expect(args.leafIndex).toBe(3n);
+    expect(args.siblings.map((s) => Array.from(s))).toEqual([Array.from(sibling)]);
+  });
+
+  it('rejects a non-32-byte handle', () => {
+    expect(() => verifyPublicDecryptArgsFromClaim(claim({ handle: '0xabcd' }))).toThrow(/handle must be 32 bytes/);
+  });
+
+  it('rejects a non-32-byte cleartext', () => {
+    expect(() => verifyPublicDecryptArgsFromClaim(claim({ abiEncodedCleartext: '2a' }))).toThrow(
+      /cleartext must be a 32-byte uint256/,
+    );
+  });
+
+  it('rejects a non-65-byte signature', () => {
+    expect(() => verifyPublicDecryptArgsFromClaim(claim({ signatures: ['1122'] }))).toThrow(
+      /signature\[0\] must be 65 bytes/,
+    );
+  });
+});
+
+describe('buildVerifyPublicDecryptInstruction', () => {
+  it('maps a claim onto the raw host verify_public_decrypt instruction', async () => {
+    const kmsContext = addr(2);
+    const encryptedValue = addr(3);
+    const hostConfig = addr(4);
+    const instruction = await buildVerifyPublicDecryptInstruction({ hostConfig, kmsContext, encryptedValue }, claim());
+
+    expect(instruction.programAddress).toBe(ZAMA_HOST_PROGRAM_ADDRESS);
+    expect(instruction.accounts?.map((a: { readonly address: Address }) => a.address)).toEqual([
+      hostConfig,
+      kmsContext,
+      encryptedValue,
+    ]);
+
+    const decoded = getVerifyPublicDecryptInstructionDataDecoder().decode(instruction.data!);
+    expect(Array.from(decoded.handle)).toEqual(Array.from(handleBytes));
+    expect(Array.from(decoded.cleartext)).toEqual(Array.from(cleartextBytes));
+    expect(decoded.signatures.map((s) => Array.from(s))).toEqual([Array.from(signatureBytes)]);
+    expect(Array.from(decoded.extraData)).toEqual(Array.from(extraDataBytes));
+    expect(decoded.leafIndex).toBe(3n);
+    expect(decoded.siblings.map((s) => Array.from(s))).toEqual([Array.from(sibling)]);
+  });
+});

--- a/sdk/js-sdk/src/solana/actions/verifyPublicDecrypt.ts
+++ b/sdk/js-sdk/src/solana/actions/verifyPublicDecrypt.ts
@@ -1,0 +1,84 @@
+import type { Address, Instruction } from '@solana/kit';
+
+import { hexToBytes } from '../../core/base/bytes.js';
+import type { SolanaPublicDecryptCertificateClaim } from './publicDecryptCertificate.js';
+import { getVerifyPublicDecryptInstructionAsync } from '../internal/generated/zamaHost/instructions/verifyPublicDecrypt.js';
+
+/**
+ * The certificate + inclusion-proof payload the stateless host verifier consumes, decoded from a
+ * relayer [`SolanaPublicDecryptCertificateClaim`] into the exact wire types the generated
+ * `verify_public_decrypt` instruction builder expects.
+ */
+export type SolanaVerifyPublicDecryptArgs = {
+  readonly handle: Uint8Array;
+  readonly cleartext: Uint8Array;
+  readonly signatures: readonly Uint8Array[];
+  readonly extraData: Uint8Array;
+  readonly leafIndex: bigint;
+  readonly siblings: readonly Uint8Array[];
+};
+
+/**
+ * Decodes a relayer public-decrypt certificate claim into the verifier instruction args, validating
+ * the fixed-size fields. `handle` and `cleartext` are the 32-byte handle and 32-byte big-endian
+ * `uint256` cleartext the KMS signed over; each signature is a 65-byte secp256k1 recoverable
+ * signature; the proof is the MMR public-leaf inclusion path for `handle`.
+ */
+export function verifyPublicDecryptArgsFromClaim(
+  claim: SolanaPublicDecryptCertificateClaim,
+): SolanaVerifyPublicDecryptArgs {
+  const handle = hexToBytes(claim.handle);
+  if (handle.length !== 32) throw new Error(`public-decrypt handle must be 32 bytes, got ${handle.length}`);
+  const cleartext = hexToBytes(claim.abiEncodedCleartext);
+  if (cleartext.length !== 32) {
+    throw new Error(`public-decrypt cleartext must be a 32-byte uint256, got ${cleartext.length} bytes`);
+  }
+  const signatures = claim.signatures.map((signature, index) => {
+    const bytes = hexToBytes(signature);
+    if (bytes.length !== 65) throw new Error(`public-decrypt signature[${index}] must be 65 bytes, got ${bytes.length}`);
+    return bytes;
+  });
+  return {
+    handle,
+    cleartext,
+    signatures,
+    extraData: hexToBytes(claim.extraData),
+    leafIndex: claim.inclusionProof.leafIndex,
+    siblings: [...claim.inclusionProof.siblings],
+  };
+}
+
+/** Accounts for the generic, program-agnostic host `verify_public_decrypt` instruction. */
+export type SolanaVerifyPublicDecryptAccounts = {
+  /** Canonical singleton host config; defaults to the host config PDA when omitted. */
+  readonly hostConfig?: Address | undefined;
+  /** KMS context PDA for the host's current context id. */
+  readonly kmsContext: Address;
+  /** The `EncryptedValue` lineage the inclusion proof is checked against. */
+  readonly encryptedValue: Address;
+};
+
+/**
+ * Builds the raw, stateless `zama_host::verify_public_decrypt` instruction from a certificate claim.
+ * The verifier reads state and returns `(handle, cleartext)` via `return_data`; it creates and
+ * mutates nothing. Use this when consuming the verifier from a non-token program (the token wrapper
+ * is `buildDiscloseSecpInstruction`). Async because the host config account defaults to its PDA
+ * when omitted.
+ */
+export async function buildVerifyPublicDecryptInstruction(
+  accounts: SolanaVerifyPublicDecryptAccounts,
+  claim: SolanaPublicDecryptCertificateClaim,
+): Promise<Instruction> {
+  const args = verifyPublicDecryptArgsFromClaim(claim);
+  return getVerifyPublicDecryptInstructionAsync({
+    ...(accounts.hostConfig !== undefined ? { hostConfig: accounts.hostConfig } : {}),
+    kmsContext: accounts.kmsContext,
+    encryptedValue: accounts.encryptedValue,
+    handle: args.handle,
+    cleartext: args.cleartext,
+    signatures: [...args.signatures],
+    extraData: args.extraData,
+    leafIndex: args.leafIndex,
+    siblings: [...args.siblings],
+  });
+}

--- a/sdk/js-sdk/src/solana/clients/decorators/publicDecrypt.ts
+++ b/sdk/js-sdk/src/solana/clients/decorators/publicDecrypt.ts
@@ -8,7 +8,7 @@ import type {
 import { publicDecryptCertificate } from '../../actions/publicDecryptCertificate.js';
 
 export type SolanaPublicDecryptActions = {
-  /** Returns a certificate claim that must still be verified by `disclose_*_secp` on-chain. */
+  /** Returns a certificate claim that must still be verified on-chain (`disclose_secp` or host `verify_public_decrypt`). */
   readonly publicDecryptCertificate: (
     parameters: SolanaPublicDecryptCertificateParameters,
   ) => Promise<SolanaPublicDecryptCertificateClaim>;

--- a/sdk/js-sdk/src/solana/index.ts
+++ b/sdk/js-sdk/src/solana/index.ts
@@ -23,16 +23,16 @@ export type {
   SolanaPublicDecryptCertificateClaim,
   SolanaPublicDecryptCertificateParameters,
 } from './actions/publicDecryptCertificate.js';
+export { buildDiscloseSecpInstruction } from './actions/discloseSecp.js';
+export type { SolanaDiscloseSecpAccounts } from './actions/discloseSecp.js';
 export {
-  buildDiscloseSecpInstruction,
   buildVerifyPublicDecryptInstruction,
   verifyPublicDecryptArgsFromClaim,
-} from './actions/discloseSecp.js';
+} from './actions/verifyPublicDecrypt.js';
 export type {
-  SolanaDiscloseSecpAccounts,
   SolanaVerifyPublicDecryptAccounts,
   SolanaVerifyPublicDecryptArgs,
-} from './actions/discloseSecp.js';
+} from './actions/verifyPublicDecrypt.js';
 export type { SolanaDecryptActions } from './clients/decorators/decrypt.js';
 export type { SolanaPublicDecryptActions } from './clients/decorators/publicDecrypt.js';
 

--- a/solana/programs/confidential-token/src/errors.rs
+++ b/solana/programs/confidential-token/src/errors.rs
@@ -88,11 +88,13 @@ pub enum ConfidentialTokenError {
     /// Account-backed request witness is expired or already consumed.
     #[msg("request witness is expired or already consumed")]
     RequestWitnessUnavailable,
-    /// Material commitment witness did not match the disclosed handle.
-    #[msg("material commitment witness does not match")]
+    /// Tombstoned: disclosure material-commitment witness was removed with the
+    /// `DisclosureRequest` lifecycle (fhevm#3231). Kept so Anchor error ordinals stay stable.
+    #[msg("material commitment witness does not match (retired)")]
     MaterialCommitmentMismatch,
-    /// The disclosed handle has not been released for public decrypt.
-    #[msg("handle is not released for public decrypt")]
+    /// Tombstoned: public-decrypt release gate lived on the deleted disclosure request path.
+    /// Kept so Anchor error ordinals stay stable.
+    #[msg("handle is not released for public decrypt (retired)")]
     PublicDecryptNotReleased,
     /// Internal FHE eval plan construction failed before the host CPI.
     #[msg("FHE eval plan is invalid")]
@@ -119,8 +121,7 @@ pub enum ConfidentialTokenError {
     #[msg("FHE eval plan is missing a required output authority")]
     MissingFheOutputAuthority,
     /// The host public-decrypt verifier CPI did not return well-formed `(handle, cleartext)`
-    /// data, was not produced by the ZamaHost program, or certified a cleartext that does not fit
-    /// the token's euint64 width (nonzero high bytes in the 32-byte `uint256`).
+    /// data, or the return was not produced by the ZamaHost program.
     #[msg("public-decrypt verifier return data is invalid")]
     VerifierReturnDataInvalid,
     /// The handle proven public by the host verifier did not equal the caller-pinned handle.
@@ -133,4 +134,7 @@ pub enum ConfidentialTokenError {
     /// or one was supplied while the host grant deny-list is disabled.
     #[msg("redemption deny-list record is invalid")]
     RedemptionDenyRecordInvalid,
+    /// The certified `uint256` cleartext does not fit the token's euint64 width (nonzero high bytes).
+    #[msg("certified cleartext exceeds euint64 width")]
+    CleartextExceedsEuint64,
 }

--- a/solana/programs/confidential-token/src/fhe/mod.rs
+++ b/solana/programs/confidential-token/src/fhe/mod.rs
@@ -4,13 +4,16 @@
 //! so business logic can build typed eval frames and receive host-verified
 //! output handles.
 
-use anchor_lang::{prelude::*, solana_program::program::get_return_data, AccountDeserialize};
-use zama_host::{cpi, program::ZamaHost, EncryptedValue, HostConfig};
+use anchor_lang::{prelude::*, AccountDeserialize};
+use zama_host::{program::ZamaHost, EncryptedValue, HostConfig};
 
 use crate::{
     compute_signer_address, token_account_address, total_supply_authority_address,
     ConfidentialTokenAccount, ConfidentialTokenError,
 };
+
+mod verify_public_decrypt;
+pub(crate) use verify_public_decrypt::*;
 
 /// Audience for a confidential-token durable output.
 ///
@@ -116,7 +119,7 @@ impl<'info> DurableOutput<'info> {
         require_keys_eq!(
             encrypted_value.key(),
             slot.address(),
-            ConfidentialTokenError::AmountAclMismatch
+            ConfidentialTokenError::CurrentEncryptedValueMismatch
         );
         let access = audience.into_policy().map_err(|error| {
             msg!("invalid durable FHE output audience: {:?}", error);
@@ -125,7 +128,7 @@ impl<'info> DurableOutput<'info> {
         let output = if *encrypted_value.owner == System::id() {
             require!(
                 encrypted_value.data_is_empty() && !encrypted_value.executable,
-                ConfidentialTokenError::AmountAclMismatch
+                ConfidentialTokenError::InvalidFheEvalPlan
             );
             zama_fhe::DurableOutput::create(slot, access)
         } else {
@@ -578,73 +581,6 @@ fn validate_deny_subject_records_for_grant_subjects<'info>(
 
 fn is_deny_record_for_authority(record: Pubkey, authority: Pubkey) -> bool {
     zama_host::deny_subject_address(authority).0 == record
-}
-
-/// Inputs required to consume the stateless host public-decrypt verifier.
-pub struct VerifyPublicDecrypt<'a, 'info> {
-    /// Handle the caller pinned; the handle the host proves public must equal this.
-    pub expected_handle: [u8; 32],
-    /// 32-byte big-endian `uint256` cleartext the KMS certificate signs over.
-    pub cleartext: [u8; 32],
-    /// KMS threshold signatures over the `PublicDecryptVerification` certificate.
-    pub signatures: Vec<[u8; 65]>,
-    /// Signed `extra_data` committing the KMS context id (EVM `_extractContextId` parity).
-    pub extra_data: Vec<u8>,
-    /// MMR public-leaf inclusion proof for `expected_handle` against the lineage's current peaks.
-    pub proof: zama_host::instructions::MmrInclusionProof,
-    /// Lineage whose peaks the inclusion proof is checked against.
-    pub encrypted_value: AccountInfo<'info>,
-    /// Host config carrying the current KMS context id and gateway EIP-712 domain.
-    pub host_config: &'a Account<'info, HostConfig>,
-    /// KMS context PDA for the host's current context id.
-    pub kms_context: AccountInfo<'info>,
-    /// ZamaHost program account.
-    pub zama_program: &'a Program<'info, ZamaHost>,
-}
-
-/// CPIs the stateless host `verify_public_decrypt`, then reads the `(handle, cleartext)` it wrote to
-/// `return_data`, asserting the return came from ZamaHost and that the proven handle equals the
-/// caller-pinned `expected_handle`. Returns the certified 32-byte cleartext. The host verifies the
-/// KMS certificate against the CURRENT KMS context and the MMR proof against the lineage's peaks;
-/// this wrapper adds only the return-data integrity + pinned-handle checks.
-pub(crate) fn verify_public_decrypt(request: VerifyPublicDecrypt<'_, '_>) -> Result<[u8; 32]> {
-    let expected_handle = request.expected_handle;
-    cpi::verify_public_decrypt(
-        CpiContext::new(
-            request.zama_program.key(),
-            cpi::accounts::VerifyPublicDecrypt {
-                host_config: request.host_config.to_account_info(),
-                kms_context: request.kms_context,
-                encrypted_value: request.encrypted_value,
-            },
-        ),
-        expected_handle,
-        request.cleartext,
-        request.signatures,
-        request.extra_data,
-        request.proof,
-    )?;
-
-    let (program_id, data) =
-        get_return_data().ok_or(ConfidentialTokenError::VerifierReturnDataInvalid)?;
-    require_keys_eq!(
-        program_id,
-        zama_host::ID,
-        ConfidentialTokenError::VerifierReturnDataInvalid
-    );
-    require!(
-        data.len() == 64,
-        ConfidentialTokenError::VerifierReturnDataInvalid
-    );
-    let mut returned_handle = [0u8; 32];
-    returned_handle.copy_from_slice(&data[..32]);
-    require!(
-        returned_handle == expected_handle,
-        ConfidentialTokenError::DisclosedHandleMismatch
-    );
-    let mut returned_cleartext = [0u8; 32];
-    returned_cleartext.copy_from_slice(&data[32..]);
-    Ok(returned_cleartext)
 }
 
 #[cfg(test)]

--- a/solana/programs/confidential-token/src/fhe/verify_public_decrypt.rs
+++ b/solana/programs/confidential-token/src/fhe/verify_public_decrypt.rs
@@ -1,0 +1,73 @@
+//! CPI wrapper around the host `verify_public_decrypt` instruction.
+
+use anchor_lang::{prelude::*, solana_program::program::get_return_data};
+use zama_host::{cpi, program::ZamaHost, HostConfig};
+
+use crate::ConfidentialTokenError;
+
+/// Inputs required to consume the stateless host public-decrypt verifier.
+pub struct VerifyPublicDecrypt<'a, 'info> {
+    /// Handle the caller pinned; the handle the host proves public must equal this.
+    pub expected_handle: [u8; 32],
+    /// 32-byte big-endian `uint256` cleartext the KMS certificate signs over.
+    pub cleartext: [u8; 32],
+    /// KMS threshold signatures over the `PublicDecryptVerification` certificate.
+    pub signatures: Vec<[u8; 65]>,
+    /// Signed `extra_data` committing the KMS context id (EVM `_extractContextId` parity).
+    pub extra_data: Vec<u8>,
+    /// MMR public-leaf inclusion proof for `expected_handle` against the lineage's current peaks.
+    pub proof: zama_host::instructions::MmrInclusionProof,
+    /// Lineage whose peaks the inclusion proof is checked against.
+    pub encrypted_value: AccountInfo<'info>,
+    /// Host config carrying the current KMS context id and gateway EIP-712 domain.
+    pub host_config: &'a Account<'info, HostConfig>,
+    /// KMS context PDA for the host's current context id.
+    pub kms_context: AccountInfo<'info>,
+    /// ZamaHost program account.
+    pub zama_program: &'a Program<'info, ZamaHost>,
+}
+
+/// CPIs the stateless host `verify_public_decrypt`, then reads the `(handle, cleartext)` it wrote to
+/// `return_data`, asserting the return came from ZamaHost and that the proven handle equals the
+/// caller-pinned `expected_handle`. Returns the certified 32-byte cleartext. The host verifies the
+/// KMS certificate against the CURRENT KMS context and the MMR proof against the lineage's peaks;
+/// this wrapper adds only the return-data integrity + pinned-handle checks.
+pub(crate) fn verify_public_decrypt(request: VerifyPublicDecrypt<'_, '_>) -> Result<[u8; 32]> {
+    let expected_handle = request.expected_handle;
+    cpi::verify_public_decrypt(
+        CpiContext::new(
+            request.zama_program.key(),
+            cpi::accounts::VerifyPublicDecrypt {
+                host_config: request.host_config.to_account_info(),
+                kms_context: request.kms_context,
+                encrypted_value: request.encrypted_value,
+            },
+        ),
+        expected_handle,
+        request.cleartext,
+        request.signatures,
+        request.extra_data,
+        request.proof,
+    )?;
+
+    let (program_id, data) =
+        get_return_data().ok_or(ConfidentialTokenError::VerifierReturnDataInvalid)?;
+    require_keys_eq!(
+        program_id,
+        zama_host::ID,
+        ConfidentialTokenError::VerifierReturnDataInvalid
+    );
+    require!(
+        data.len() == 64,
+        ConfidentialTokenError::VerifierReturnDataInvalid
+    );
+    let mut returned_handle = [0u8; 32];
+    returned_handle.copy_from_slice(&data[..32]);
+    require!(
+        returned_handle == expected_handle,
+        ConfidentialTokenError::DisclosedHandleMismatch
+    );
+    let mut returned_cleartext = [0u8; 32];
+    returned_cleartext.copy_from_slice(&data[32..]);
+    Ok(returned_cleartext)
+}

--- a/solana/programs/confidential-token/src/instructions/common.rs
+++ b/solana/programs/confidential-token/src/instructions/common.rs
@@ -411,7 +411,7 @@ pub(crate) fn assert_burned_amount_lineage(
     require_keys_eq!(
         amount_value.acl_domain_key,
         mint,
-        ConfidentialTokenError::AmountAclMismatch
+        ConfidentialTokenError::AclDomainKeyMismatch
     );
     require_keys_eq!(
         amount_value.app_account,

--- a/solana/programs/confidential-token/src/instructions/disclose_secp.rs
+++ b/solana/programs/confidential-token/src/instructions/disclose_secp.rs
@@ -71,7 +71,7 @@ pub fn disclose_secp(
     require_keys_eq!(
         value.acl_domain_key,
         mint_key,
-        ConfidentialTokenError::AmountAclMismatch
+        ConfidentialTokenError::AclDomainKeyMismatch
     );
 
     let certified_cleartext = fhe::verify_public_decrypt(fhe::VerifyPublicDecrypt {
@@ -91,7 +91,7 @@ pub fn disclose_secp(
     // wider rather than silently discarding high bits.
     require!(
         certified_cleartext[..24].iter().all(|byte| *byte == 0),
-        ConfidentialTokenError::VerifierReturnDataInvalid
+        ConfidentialTokenError::CleartextExceedsEuint64
     );
 
     emit_cpi!(HandleDisclosedEvent {

--- a/solana/programs/zama-host/src/errors.rs
+++ b/solana/programs/zama-host/src/errors.rs
@@ -278,4 +278,7 @@ pub enum ZamaHostError {
     /// EVM signer.
     #[msg("coprocessor signer set contains the zero address")]
     ZeroCoprocessorSigner,
+    /// The KMS signer set contains the zero address, which can never be a valid recovered EVM signer.
+    #[msg("KMS signer set contains the zero address")]
+    ZeroKmsSigner,
 }

--- a/solana/programs/zama-host/src/instructions/common.rs
+++ b/solana/programs/zama-host/src/instructions/common.rs
@@ -17,39 +17,77 @@ use crate::{
 #[cfg(any(feature = "emit-events", test))]
 use crate::{events::HostConfigUpdatedEvent, state::EVENT_VERSION};
 
+/// Error mapping for the shared EVM signer-address checks used by KMS contexts and the
+/// coprocessor signer set.
+pub(super) struct EvmSignerSetErrors {
+    pub empty: ZamaHostError,
+    pub too_many: ZamaHostError,
+    pub duplicate: ZamaHostError,
+    pub zero: ZamaHostError,
+}
+
+/// Shared registration invariants for an EVM secp256k1 signer set: non-empty, within `max`,
+/// no zero address, no duplicates. Threshold checks stay at the call site (KMS has several).
+pub(super) fn assert_evm_signer_set(
+    signers: &[[u8; 20]],
+    max: usize,
+    errors: EvmSignerSetErrors,
+) -> Result<()> {
+    if signers.is_empty() {
+        return Err(errors.empty.into());
+    }
+    if signers.len() > max {
+        return Err(errors.too_many.into());
+    }
+    if signers.contains(&[0u8; 20]) {
+        return Err(errors.zero.into());
+    }
+    for i in 0..signers.len() {
+        for j in (i + 1)..signers.len() {
+            if signers[i] == signers[j] {
+                return Err(errors.duplicate.into());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A verification threshold must be at least one and at most the signer count.
+pub(super) fn assert_quorum_threshold(
+    threshold: u8,
+    signer_count: usize,
+    error: ZamaHostError,
+) -> Result<()> {
+    if threshold >= 1 && (threshold as usize) <= signer_count {
+        Ok(())
+    } else {
+        Err(error.into())
+    }
+}
+
 /// Validates a coprocessor signer set + threshold and packs it into the fixed-capacity array
-/// stored in `HostConfig`. Enforces the EVM `InputVerifier`-parity invariants: non-empty set,
-/// within the capacity bound, `1 <= threshold <= len`, no zero-address signer, and no duplicate
-/// signer (threshold verification counts DISTINCT recovered addresses, so a duplicate would
-/// silently raise the effective quorum). Shared by `initialize_host_config` and the admin setter.
+/// stored in `HostConfig`. Shared by `initialize_host_config` and the admin setter.
+/// Address checks run before the threshold check so a multi-violation input surfaces the
+/// registration shape error first (empty / too-many / zero / duplicate), then threshold.
 pub(super) fn validate_and_pack_coprocessor_signers(
     signers: &[[u8; 20]],
     threshold: u8,
 ) -> Result<([[u8; 20]; HostConfig::MAX_COPROCESSOR_SIGNERS], u8)> {
-    require!(
-        !signers.is_empty(),
-        ZamaHostError::EmptyCoprocessorSignerSet
-    );
-    require!(
-        signers.len() <= HostConfig::MAX_COPROCESSOR_SIGNERS,
-        ZamaHostError::TooManyCoprocessorSigners
-    );
-    require!(
-        threshold >= 1 && threshold as usize <= signers.len(),
-        ZamaHostError::InvalidCoprocessorThreshold
-    );
-    require!(
-        signers.iter().all(|signer| *signer != [0u8; 20]),
-        ZamaHostError::ZeroCoprocessorSigner
-    );
-    for i in 0..signers.len() {
-        for j in (i + 1)..signers.len() {
-            require!(
-                signers[i] != signers[j],
-                ZamaHostError::DuplicateCoprocessorSigner
-            );
-        }
-    }
+    assert_evm_signer_set(
+        signers,
+        HostConfig::MAX_COPROCESSOR_SIGNERS,
+        EvmSignerSetErrors {
+            empty: ZamaHostError::EmptyCoprocessorSignerSet,
+            too_many: ZamaHostError::TooManyCoprocessorSigners,
+            duplicate: ZamaHostError::DuplicateCoprocessorSigner,
+            zero: ZamaHostError::ZeroCoprocessorSigner,
+        },
+    )?;
+    assert_quorum_threshold(
+        threshold,
+        signers.len(),
+        ZamaHostError::InvalidCoprocessorThreshold,
+    )?;
     Ok((
         crate::state::pack_coprocessor_signers(signers),
         signers.len() as u8,

--- a/solana/programs/zama-host/src/instructions/define_kms_context.rs
+++ b/solana/programs/zama-host/src/instructions/define_kms_context.rs
@@ -7,7 +7,10 @@
 
 use anchor_lang::prelude::*;
 
-use super::common::{assert_admin, assert_no_remaining_accounts};
+use super::common::{
+    assert_admin, assert_evm_signer_set, assert_no_remaining_accounts, assert_quorum_threshold,
+    EvmSignerSetErrors,
+};
 #[cfg(feature = "emit-events")]
 use crate::events::NewKmsContextEvent;
 use crate::{errors::ZamaHostError, state::*};
@@ -48,26 +51,32 @@ pub fn define_kms_context(
         context_id == ctx.accounts.host_config.current_kms_context_id + 1,
         ZamaHostError::InvalidKmsContextId
     );
-    require!(!signers.is_empty(), ZamaHostError::EmptyKmsContext);
-    require!(
-        signers.len() <= KmsContext::MAX_SIGNERS,
-        ZamaHostError::TooManyKmsSigners
-    );
+    assert_evm_signer_set(
+        &signers,
+        KmsContext::MAX_SIGNERS,
+        EvmSignerSetErrors {
+            empty: ZamaHostError::EmptyKmsContext,
+            too_many: ZamaHostError::TooManyKmsSigners,
+            duplicate: ZamaHostError::DuplicateKmsSigner,
+            zero: ZamaHostError::ZeroKmsSigner,
+        },
+    )?;
     let signer_count = signers.len();
-    assert_quorum_threshold(thresholds.public_decryption, signer_count)?;
-    assert_quorum_threshold(thresholds.user_decryption, signer_count)?;
+    assert_quorum_threshold(
+        thresholds.public_decryption,
+        signer_count,
+        ZamaHostError::InvalidKmsThreshold,
+    )?;
+    assert_quorum_threshold(
+        thresholds.user_decryption,
+        signer_count,
+        ZamaHostError::InvalidKmsThreshold,
+    )?;
+    // `kms_gen` / `mpc` are stored for fidelity and may be zero; only an upper bound applies.
     require!(
         thresholds.kms_gen as usize <= signer_count && thresholds.mpc as usize <= signer_count,
         ZamaHostError::InvalidKmsThreshold
     );
-    // Reject duplicate signers: threshold verification counts DISTINCT recovered addresses,
-    // so a duplicate would silently raise the effective quorum (a 2-of-[A,A,B] set cannot be
-    // satisfied by A+B). EVM KMS signer sets are distinct; enforce the same here.
-    for i in 0..signer_count {
-        for j in (i + 1)..signer_count {
-            require!(signers[i] != signers[j], ZamaHostError::DuplicateKmsSigner);
-        }
-    }
 
     let kms_context = &mut ctx.accounts.kms_context;
     kms_context.context_id = context_id;
@@ -85,14 +94,5 @@ pub fn define_kms_context(
         public_decryption_threshold: thresholds.public_decryption,
         user_decryption_threshold: thresholds.user_decryption,
     });
-    Ok(())
-}
-
-/// A verification threshold must be at least one and at most the signer count.
-fn assert_quorum_threshold(threshold: u8, signer_count: usize) -> Result<()> {
-    require!(
-        threshold >= 1 && threshold as usize <= signer_count,
-        ZamaHostError::InvalidKmsThreshold
-    );
     Ok(())
 }

--- a/solana/programs/zama-host/src/instructions/input_verification.rs
+++ b/solana/programs/zama-host/src/instructions/input_verification.rs
@@ -44,8 +44,11 @@ impl InputVerifierParams {
     }
 
     /// Active coprocessor signer set (the first `coprocessor_signer_count` entries).
+    /// Count is write-validated (`≤ MAX`); clamp defends a corrupted singleton without panicking.
     fn active_signers(&self) -> &[[u8; 20]] {
-        &self.coprocessor_signers[..self.coprocessor_signer_count as usize]
+        let count =
+            (self.coprocessor_signer_count as usize).min(HostConfig::MAX_COPROCESSOR_SIGNERS);
+        &self.coprocessor_signers[..count]
     }
 }
 

--- a/solana/programs/zama-host/src/state/host_config.rs
+++ b/solana/programs/zama-host/src/state/host_config.rs
@@ -74,16 +74,23 @@ impl HostConfig {
         + 1;
 
     /// Active coprocessor signer set (the first `coprocessor_signer_count` entries).
+    /// Count is write-validated (`≤ MAX`); clamp defends a corrupted singleton without panicking.
     pub fn active_coprocessor_signers(&self) -> &[[u8; 20]] {
-        &self.coprocessor_signers[..self.coprocessor_signer_count as usize]
+        let count = (self.coprocessor_signer_count as usize).min(Self::MAX_COPROCESSOR_SIGNERS);
+        &self.coprocessor_signers[..count]
     }
 }
 
 /// Zero-pads a coprocessor signer slice into the fixed-capacity array stored in `HostConfig`.
-/// Entries beyond `MAX_COPROCESSOR_SIGNERS` are ignored; callers validate the length first.
+/// Panics if `signers.len()` exceeds [`HostConfig::MAX_COPROCESSOR_SIGNERS`] — callers must
+/// validate first (`validate_and_pack_coprocessor_signers`); test fixtures must pass a legal set.
 pub fn pack_coprocessor_signers(
     signers: &[[u8; 20]],
 ) -> [[u8; 20]; HostConfig::MAX_COPROCESSOR_SIGNERS] {
+    assert!(
+        signers.len() <= HostConfig::MAX_COPROCESSOR_SIGNERS,
+        "coprocessor signer set exceeds HostConfig::MAX_COPROCESSOR_SIGNERS"
+    );
     let mut out = [[0u8; 20]; HostConfig::MAX_COPROCESSOR_SIGNERS];
     for (slot, signer) in out.iter_mut().zip(signers.iter()) {
         *slot = *signer;

--- a/solana/runtime-tests/tests/disclose_packet_fit.rs
+++ b/solana/runtime-tests/tests/disclose_packet_fit.rs
@@ -1,0 +1,192 @@
+//! Packet-size envelope for `disclose_secp` under high KMS threshold × deep MMR proofs.
+//!
+//! Kept out of `token_mollusk.rs` so wire-size measurements do not grow the behavioral suite.
+//! Validity is irrelevant here: only bincode-serialized legacy transaction length vs
+//! `PACKET_DATA_SIZE` is asserted.
+
+use anchor_lang::{prelude::Pubkey, InstructionData, ToAccountMetas};
+use confidential_token as token;
+use solana_sdk::{instruction::Instruction, message::Message, transaction::Transaction};
+use zama_host as host;
+
+fn anchor_ix<A, D>(program_id: Pubkey, accounts: A, args: D) -> Instruction
+where
+    A: ToAccountMetas,
+    D: InstructionData,
+{
+    Instruction {
+        program_id,
+        accounts: accounts.to_account_metas(None),
+        data: args.data(),
+    }
+}
+
+fn event_authority(program_id: Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"__event_authority"], &program_id).0
+}
+
+/// Builds a `disclose_secp` legacy transaction carrying `sig_count` signatures and an MMR proof of
+/// `sibling_count` siblings over the real account layout, and returns its bincode-serialized wire
+/// size.
+fn disclose_secp_tx_size(sig_count: usize, sibling_count: usize) -> usize {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let encrypted_value = Pubkey::new_unique();
+    let host_config = host::host_config_address().0;
+    let kms_context = host::kms_context_address(1).0;
+    let proof = host::instructions::MmrInclusionProof {
+        leaf_index: 0,
+        siblings: vec![[0u8; 32]; sibling_count],
+    };
+    let ix = anchor_ix(
+        token::id(),
+        token::accounts::DiscloseSecp {
+            mint,
+            encrypted_value,
+            host_config,
+            kms_context,
+            zama_program: host::id(),
+            event_authority: event_authority(token::id()),
+            program: token::id(),
+        },
+        token::instruction::DiscloseSecp {
+            handle: [0u8; 32],
+            cleartext: [0u8; 32],
+            signatures: vec![[0u8; 65]; sig_count],
+            extra_data: vec![0x00u8],
+            proof,
+        },
+    );
+    let message = Message::new(&[ix], Some(&owner));
+    let tx = Transaction::new_unsigned(message);
+    bincode::serialize(&tx)
+        .expect("serialize transaction")
+        .len()
+}
+
+/// Builds a `redeem_burned_amount` legacy transaction carrying `sig_count` signatures and an MMR
+/// proof of `sibling_count` siblings over the real account layout, and returns its
+/// bincode-serialized wire size. Redeem carries the same cert + MMR proof payload as `disclose_secp`
+/// but over the larger burn-redemption account list (vault, destination, replay marker, ...), so its
+/// single-packet envelope is the binding one for the shared verifier path.
+fn redeem_burned_amount_tx_size(sig_count: usize, sibling_count: usize) -> usize {
+    let owner = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let host_config = host::host_config_address().0;
+    let kms_context = host::kms_context_address(1).0;
+    let proof = host::instructions::MmrInclusionProof {
+        leaf_index: 0,
+        siblings: vec![[0u8; 32]; sibling_count],
+    };
+    let ix = anchor_ix(
+        token::id(),
+        token::accounts::RedeemBurnedAmount {
+            owner,
+            mint,
+            token_account: Pubkey::new_unique(),
+            underlying_mint: Pubkey::new_unique(),
+            vault_usdc: Pubkey::new_unique(),
+            destination_usdc: Pubkey::new_unique(),
+            vault_authority: Pubkey::new_unique(),
+            burned_amount_value: Pubkey::new_unique(),
+            redemption_record: Pubkey::new_unique(),
+            host_config,
+            kms_context,
+            deny_subject_record: None,
+            zama_program: host::id(),
+            token_program: Pubkey::new_unique(),
+            system_program: Pubkey::new_unique(),
+            event_authority: event_authority(token::id()),
+            program: token::id(),
+        },
+        token::instruction::RedeemBurnedAmount {
+            burned_handle: [0u8; 32],
+            cleartext_amount: 0,
+            signatures: vec![[0u8; 65]; sig_count],
+            extra_data: vec![0x00u8],
+            proof,
+        },
+    );
+    let message = Message::new(&[ix], Some(&owner));
+    let tx = Transaction::new_unsigned(message);
+    bincode::serialize(&tx)
+        .expect("serialize transaction")
+        .len()
+}
+
+#[test]
+fn redeem_burned_amount_threshold_fit_table() {
+    // Companion to `disclose_secp_threshold_fit_table` for the burn-redemption path introduced by
+    // #3243, which reuses the same stateless-verifier cert + MMR proof payload. Redeem carries a
+    // larger fixed account list than disclose (vault, destination, replay marker, deny-record slot),
+    // so at the same (t, depth) it is ~242B larger and its single-packet envelope is strictly
+    // tighter. Measured fitting corner: t=7 at depth 0 (1159B); t=7/depth-10 already overflows
+    // (1479B, over by 247), and t>=9 overflows before the proof. Same qualitative boundary as
+    // disclose, so the deep-lineage × high-threshold redeem is the binding corner for the shared
+    // verifier path and needs the #1704 two-tx fallback when it overflows.
+    let cases = [
+        (7usize, 0usize, true),
+        (7, 10, false),
+        (7, 20, false),
+        (9, 10, false),
+        (13, 10, false),
+    ];
+    let limit = solana_packet::PACKET_DATA_SIZE;
+    eprintln!("redeem_burned_amount threshold fit table (packet limit = {limit} bytes):");
+    for (t, depth, expected_fits) in cases {
+        let size = redeem_burned_amount_tx_size(t, depth);
+        let fits = size <= limit;
+        eprintln!(
+            "  t={t:>2} sigs, depth={depth:>2} siblings -> {size:>4} bytes  ({}{})",
+            if fits { "FITS" } else { "OVER" },
+            if fits {
+                String::new()
+            } else {
+                format!(" by {}", size - limit)
+            },
+        );
+        assert_eq!(
+            fits, expected_fits,
+            "t={t}, depth={depth} measured {size} bytes (fits={fits}); table expected fits={expected_fits}. \
+             The single-packet envelope moved — update the table and revisit the #1704 two-tx fallback."
+        );
+    }
+}
+
+#[test]
+fn disclose_secp_threshold_fit_table() {
+    // Corner table: (threshold t, MMR proof sibling depth, expected-to-fit). Measured wire sizes for
+    // the full `disclose_secp` legacy transaction against the 1232-byte packet limit.
+    //
+    // Re-measured against the thin consume path (fhevm-internal#1704). Dropping the DisclosureRequest
+    // witness did NOT shrink the tx enough to keep t=7/depth-10 inside the packet: disclose_secp is
+    // ~24B larger than the old disclose_amount_secp at the same (t, depth). Fitting corner today:
+    // t=7 at depth 0 only. Deep-lineage × high-threshold consumes need the #1704 two-tx fallback.
+    let cases = [
+        (7usize, 0usize, true),
+        (7, 10, false),
+        (7, 20, false),
+        (9, 10, false),
+        (13, 10, false),
+    ];
+    let limit = solana_packet::PACKET_DATA_SIZE;
+    eprintln!("disclose_secp threshold fit table (packet limit = {limit} bytes):");
+    for (t, depth, expected_fits) in cases {
+        let size = disclose_secp_tx_size(t, depth);
+        let fits = size <= limit;
+        eprintln!(
+            "  t={t:>2} sigs, depth={depth:>2} siblings -> {size:>4} bytes  ({}{})",
+            if fits { "FITS" } else { "OVER" },
+            if fits {
+                String::new()
+            } else {
+                format!(" by {}", size - limit)
+            },
+        );
+        assert_eq!(
+            fits, expected_fits,
+            "t={t}, depth={depth} measured {size} bytes (fits={fits}); table expected fits={expected_fits}. \
+             The single-packet envelope moved — update the table and revisit the #1704 two-tx fallback."
+        );
+    }
+}

--- a/solana/runtime-tests/tests/host_mollusk.rs
+++ b/solana/runtime-tests/tests/host_mollusk.rs
@@ -3425,6 +3425,41 @@ fn mollusk_initialize_host_config_rejects_empty_coprocessor_set() {
 }
 
 #[test]
+fn mollusk_initialize_host_config_rejects_zero_coprocessor_signer() {
+    let program_id = host::id();
+    let payer = Pubkey::new_unique();
+    let admin = Pubkey::new_unique();
+    let (host_config, _) = host::host_config_address();
+    let args = init_args_with_coprocessor_set(vec![[0u8; 20]], 1);
+    let context = mollusk_eval_context(payer, vec![(host_config, system_account(0))]);
+
+    context.process_and_validate_instruction(
+        &initialize_host_config_ix(program_id, payer, admin, host_config, args),
+        &[custom_error(
+            host::errors::ZamaHostError::ZeroCoprocessorSigner,
+        )],
+    );
+}
+
+#[test]
+fn mollusk_initialize_host_config_rejects_too_many_coprocessor_signers() {
+    let program_id = host::id();
+    let payer = Pubkey::new_unique();
+    let admin = Pubkey::new_unique();
+    let (host_config, _) = host::host_config_address();
+    let signers: Vec<[u8; 20]> = (1..=9).map(|i| [i; 20]).collect();
+    let args = init_args_with_coprocessor_set(signers, 1);
+    let context = mollusk_eval_context(payer, vec![(host_config, system_account(0))]);
+
+    context.process_and_validate_instruction(
+        &initialize_host_config_ix(program_id, payer, admin, host_config, args),
+        &[custom_error(
+            host::errors::ZamaHostError::TooManyCoprocessorSigners,
+        )],
+    );
+}
+
+#[test]
 fn mollusk_set_coprocessor_signers_rotates_the_set_and_threshold() {
     // The admin setter replaces the registered set + threshold in place.
     let program_id = host::id();
@@ -3517,6 +3552,71 @@ fn mollusk_define_kms_context_at_realistic_signer_count() {
     let stored = read_kms_context(&context, kms_context).expect("kms context");
     assert_eq!(stored.signers, signers);
     assert_eq!(stored.thresholds.public_decryption, 7);
+}
+
+fn default_kms_thresholds() -> host::KmsThresholds {
+    host::KmsThresholds {
+        public_decryption: 1,
+        user_decryption: 1,
+        kms_gen: 1,
+        mpc: 1,
+    }
+}
+
+fn run_define_kms_context_expecting(signers: Vec<[u8; 20]>, expected: Check<'static>) {
+    let program_id = host::id();
+    let admin = Pubkey::new_unique();
+    let (host_config, account) = host_config_account_with_flags(admin, false, false);
+    let context_id = 1;
+    let kms_context = host::kms_context_address(context_id).0;
+    let context = mollusk_eval_context(
+        admin,
+        vec![(host_config, account), (kms_context, system_account(0))],
+    );
+    context.process_and_validate_instruction(
+        &define_kms_context_ix(
+            program_id,
+            admin,
+            host_config,
+            context_id,
+            signers,
+            default_kms_thresholds(),
+        ),
+        &[expected],
+    );
+}
+
+#[test]
+fn mollusk_define_kms_context_rejects_empty_signer_set() {
+    run_define_kms_context_expecting(
+        vec![],
+        custom_error(host::errors::ZamaHostError::EmptyKmsContext),
+    );
+}
+
+#[test]
+fn mollusk_define_kms_context_rejects_too_many_signers() {
+    let signers: Vec<[u8; 20]> = (1..=17).map(|i| [i; 20]).collect();
+    run_define_kms_context_expecting(
+        signers,
+        custom_error(host::errors::ZamaHostError::TooManyKmsSigners),
+    );
+}
+
+#[test]
+fn mollusk_define_kms_context_rejects_duplicate_signer() {
+    run_define_kms_context_expecting(
+        vec![[0xAAu8; 20], [0xAAu8; 20]],
+        custom_error(host::errors::ZamaHostError::DuplicateKmsSigner),
+    );
+}
+
+#[test]
+fn mollusk_define_kms_context_rejects_zero_signer() {
+    run_define_kms_context_expecting(
+        vec![[0u8; 20]],
+        custom_error(host::errors::ZamaHostError::ZeroKmsSigner),
+    );
 }
 
 // ---- EvalFixture: a durable-output frame for block-cap enforcement ----

--- a/solana/runtime-tests/tests/token_mollusk.rs
+++ b/solana/runtime-tests/tests/token_mollusk.rs
@@ -3661,7 +3661,7 @@ fn mollusk_disclose_secp_rejects_foreign_mint_domain() {
             proof,
         ),
         &[token_error(
-            token::ConfidentialTokenError::AmountAclMismatch,
+            token::ConfidentialTokenError::AclDomainKeyMismatch,
         )],
     );
 }
@@ -3709,7 +3709,7 @@ fn mollusk_disclose_secp_rejects_cleartext_wider_than_u64() {
             proof,
         ),
         &[token_error(
-            token::ConfidentialTokenError::VerifierReturnDataInvalid,
+            token::ConfidentialTokenError::CleartextExceedsEuint64,
         )],
     );
 }
@@ -4420,90 +4420,6 @@ fn cost_snapshot_initialize_token_account() {
     let result = context.process_and_validate_instruction(&ix, &[Check::success()]);
 
     cost_snapshot::assert_cost_snapshot("token_mollusk", "initialize_token_account", &ix, &result);
-}
-
-// ---------------------------------------------------------------------------
-// KMS public-decrypt threshold fit table (EVM KMSVerifier parity)
-//
-// Public-decrypt certificates carry t signatures (t = the context's public-decryption threshold)
-// and the consume transaction also carries an MMR inclusion proof whose size scales with the
-// lineage depth. Both grow the serialized `disclose_secp` transaction. This table pins the
-// wire-size corner where high threshold meets deep lineage against the Solana packet limit.
-// ---------------------------------------------------------------------------
-
-/// Builds a `disclose_secp` legacy transaction carrying `sig_count` signatures and an MMR proof of
-/// `sibling_count` siblings over the real disclose account list, and returns its bincode-serialized
-/// wire size. Validity is irrelevant: this measures serialization only.
-fn disclose_secp_tx_size(sig_count: usize, sibling_count: usize) -> usize {
-    use solana_sdk::message::Message;
-    use solana_sdk::transaction::Transaction;
-
-    let fixture = DiscloseFixture::new();
-    let proof = host::instructions::MmrInclusionProof {
-        leaf_index: 0,
-        siblings: vec![[0u8; 32]; sibling_count],
-    };
-    let ix = disclose_secp_ix(
-        &fixture,
-        fixture.amount_value,
-        handle_for_chain(80, BALANCE_FHE_TYPE),
-        cleartext_u256(500),
-        vec![[0u8; 65]; sig_count],
-        vec![0x00u8],
-        proof,
-    );
-    let message = Message::new(&[ix], Some(&fixture.owner));
-    let tx = Transaction::new_unsigned(message);
-    bincode::serialize(&tx)
-        .expect("serialize transaction")
-        .len()
-}
-
-#[test]
-fn disclose_secp_threshold_fit_table() {
-    // Corner table: (threshold t, MMR proof sibling depth, expected-to-fit). Measured wire sizes for
-    // the full `disclose_secp` legacy transaction against the 1232-byte packet limit.
-    //
-    // This table lives on the thin consume path introduced by fhevm-internal#1704, and the booleans
-    // are RE-MEASURED against it, not carried over from the old disclose_amount_secp table. Dropping
-    // the DisclosureRequest witness account did NOT shrink the transaction: it is offset by the added
-    // zama_program account (for the verifier CPI), and the cleartext widened from a u64 (8B) to the
-    // raw 32-byte uint256 the host verifier signs over (+24B). Net, disclose_secp is ~24B LARGER than
-    // disclose_amount_secp at the same (t, depth), so the single-packet envelope NARROWED: the only
-    // fitting corner is t=7 at depth 0 (917B); any MMR proof depth at t=7 already overflows
-    // (t=7/depth-10 = 1237B, over by 5), and t>=9 overflows even before the proof.
-    //
-    // The carried payload scales with the threshold t (t x 65B) plus the proof depth (depth x 32B),
-    // so deep-lineage x high-threshold consumes are the binding corner; anything that overflows needs
-    // the scratch-account two-tx fallback reserved in #1704. The `expected_fits` column pins the
-    // measured boundary so a regression (or a size shrink that widens the envelope) is caught here.
-    let cases = [
-        (7usize, 0usize, true),
-        (7, 10, false),
-        (7, 20, false),
-        (9, 10, false),
-        (13, 10, false),
-    ];
-    let limit = solana_packet::PACKET_DATA_SIZE;
-    eprintln!("disclose_secp threshold fit table (packet limit = {limit} bytes):");
-    for (t, depth, expected_fits) in cases {
-        let size = disclose_secp_tx_size(t, depth);
-        let fits = size <= limit;
-        eprintln!(
-            "  t={t:>2} sigs, depth={depth:>2} siblings -> {size:>4} bytes  ({}{})",
-            if fits { "FITS" } else { "OVER" },
-            if fits {
-                String::new()
-            } else {
-                format!(" by {}", size - limit)
-            },
-        );
-        assert_eq!(
-            fits, expected_fits,
-            "t={t}, depth={depth} measured {size} bytes (fits={fits}); table expected fits={expected_fits}. \
-             The single-packet envelope moved — update the table and revisit the #1704 two-tx fallback."
-        );
-    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Closes the dual-stack leftovers tracked in [fhevm-internal#1752](https://github.com/zama-ai/fhevm-internal/issues/1752) after merged [#3231](https://github.com/zama-ai/fhevm/pull/3231) / [#3230](https://github.com/zama-ai/fhevm/pull/3230).
- Split host-generic `verifyPublicDecrypt` SDK builders out of `discloseSecp`; collapse token `MmrInclusionProof` onto the host type; fix mint-domain / euint64 width error contracts; tombstone retired disclose errors.
- Share EVM signer-set validation between KMS and coprocessor paths; harden `pack_coprocessor_signers`; extract token CPI verify helper and packet-fit suite.

## Test plan
- [x] `cargo test -p zama-host --lib`
- [x] `cargo test -p confidential-token --lib`
- [x] `cargo test -p zama-solana-runtime-tests --test disclose_packet_fit`
- [x] host mollusk: zero / too-many / empty / duplicate coprocessor registration rejects
- [x] token mollusk: `rejects_foreign_mint_domain` → `AclDomainKeyMismatch`; `rejects_cleartext_wider_than_u64` → `CleartextExceedsEuint64`
- [x] `bash scripts/sync-zama-host-idl.sh` (IDL + ABI golden updated)
- [ ] SDK unit tests for `verifyPublicDecrypt` / `discloseSecp` (needs local `npm i` in `sdk/js-sdk`)