### PR TITLE
docs(host-contracts): record the confidential-vault batcher-gateway intent

### DIFF
--- a/solana/docs/CONFIDENTIAL_VAULTS.md
+++ b/solana/docs/CONFIDENTIAL_VAULTS.md
@@ -117,4 +117,4 @@ strategy machinery that a demo does not need, and none of them is a standard
   tokens to the vault so the share price rises.
 
 Design record: DD-042 in `DESIGN_DECISIONS.md`. Demo tracking: the
-confidential-vault epic in fhevm-internal.
+confidential-vault epic, fhevm-internal#1754.

--- a/solana/docs/CONFIDENTIAL_VAULTS.md
+++ b/solana/docs/CONFIDENTIAL_VAULTS.md
@@ -1,0 +1,120 @@
+# Confidential Vaults on Solana — What We Are Building and Why
+
+This document explains the confidential vault design in plain language. It is
+the intent behind the `demo-vault` and `confidential-batcher` programs and the
+vault demo. Read this before reading their code.
+
+## The goal
+
+Let people earn yield on tokens **without revealing how much they hold or
+move**. Balances and amounts stay encrypted end to end; the yield source is an
+ordinary, public Solana vault.
+
+## The core idea: keep the vault public, make the doorway confidential
+
+A vault needs to know how much money it manages — that is how it computes the
+price of a share. If every position were encrypted, the vault could not price
+anything without heavy encrypted math (in particular, dividing one encrypted
+number by another, which FHE cannot do efficiently today).
+
+So we split the problem:
+
+- The **vault stays public and ordinary**: tokens in, shares out, share price
+  = assets / shares. Anyone can read its totals. This is exactly how the big
+  Solana vaults (Kamino, Jupiter Earn, Meteora, liquid staking) already work:
+  a program-owned account holds the assets, and a normal SPL token represents
+  shares.
+- The **doorway is confidential**: a *batcher* program collects many encrypted
+  deposits, adds them up while still encrypted, and reveals **only the total**.
+  That single public number goes into the vault. Individual amounts are never
+  revealed — only the sum of everyone in the batch.
+
+This is the same architecture Zama shipped on Ethereum (the confidential
+batcher in front of a Morpho vault). We port the *idea*, not the mechanics:
+everything below uses Solana-native building blocks.
+
+```
+   users (encrypted amounts)          one public number           public vault
+   ┌────┐ ┌────┐ ┌────┐
+   │ e(a)│ │e(b)│ │e(c)│ ──join──►  BATCHER  ──"total = a+b+c"──►  deposit
+   └────┘ └────┘ └────┘            (adds while                     mint shares
+                                    encrypted)                        │
+   ┌────────────────────────◄──────────────────────────────────────┘
+   │  each user gets encrypted shares: e(amount) × public share rate
+```
+
+## How a deposit works, step by step
+
+1. **Shield.** The user wraps public tokens into confidential tokens (their
+   balance becomes an encrypted number only they can decrypt).
+2. **Join.** The user sends an encrypted amount to the current batch. In the
+   same transaction the batcher records a private receipt of the deposit —
+   readable by the user and the batcher, nobody else.
+3. **Dispatch.** After a waiting period, anyone can dispatch the batch. The
+   batcher burns the batch's encrypted total and asks the key-management
+   network (KMS) to certify the burned amount. That certificate is how the
+   one public number is produced — it reveals the batch total and nothing
+   else.
+4. **Settle.** Anyone can submit the certificate. The batcher verifies it
+   on-chain, deposits the now-public total into the vault, receives ordinary
+   share tokens, and wraps them into **confidential shares**. It fixes one
+   public exchange rate for the whole batch: shares received ÷ total
+   deposited.
+5. **Claim.** Each user collects their shares. Their encrypted deposit is
+   multiplied by the public rate — an encrypted number times a public number,
+   which FHE does cheaply. No one ever divides encrypted by encrypted.
+
+Withdrawing works the same way in mirror: join a redeem batch with encrypted
+shares, the batch total of shares is revealed and redeemed from the vault,
+and users claim encrypted tokens back at the batch's rate.
+
+## What is public and what is private
+
+| Always private (encrypted)              | Public by design                    |
+| --------------------------------------- | ----------------------------------- |
+| each user's deposit / withdrawal amount | each batch's total                  |
+| each user's confidential balance        | the vault share price               |
+| each user's share position              | who participated in a batch (addresses) |
+
+Honest limits, learned on the EVM side: a batch with one participant reveals
+that participant's amount (the total *is* their amount), and an attacker who
+joins a batch with known amounts can subtract them from the total. Privacy
+grows with the number of genuine participants per batch. We do not enforce a
+minimum participant count — such gates are trivially defeated by one person
+joining many times with zero — and we say so instead of pretending otherwise.
+
+## Safety rules carried over from the EVM design
+
+- **Deposit and wait, never react.** No user action ever branches on an
+  encrypted value (no "instant exit if the pool is big enough"). Anything
+  that reacts to encrypted state can be probed until the secret leaks.
+- **Self-serve everything.** Dispatch, settle, and claim are permissionless;
+  `quit` returns your exact deposit from a pending batch. No operator can
+  hold user funds hostage.
+- **One batch, one account.** Each batch has its own token account, so the
+  revealed total is exactly that batch's sum — leftover dust from an earlier
+  batch can never leak into it.
+
+## Why the vault itself is new code (and deliberately boring)
+
+The demo vault is ~200 lines and copies the shape every major Solana vault
+uses: a program-owned state account, a program-derived authority that owns the
+assets and mints shares, a share price computed on the fly, and yield delivered
+as share-price appreciation (never rebasing). Its instruction interface mirrors
+Jupiter Earn's, and the batcher talks to it through one small file — so
+pointing the batcher at a real venue later is a one-file change. We did not
+import an existing vault program: real ones drag in oracles, admin roles and
+strategy machinery that a demo does not need, and none of them is a standard
+(Solana has no adopted equivalent of Ethereum's ERC-4626 vault interface).
+
+## What this is not (yet)
+
+- Not a natively confidential vault (one whose *own accounting* is encrypted).
+  That is the long-term direction; the batcher is the pragmatic first step,
+  same as on Ethereum.
+- Not a privacy mixer. Participation is visible; amounts are what is hidden.
+- No incentive/reward machinery. Yield in the demo is simulated by donating
+  tokens to the vault so the share price rises.
+
+Design record: DD-042 in `DESIGN_DECISIONS.md`. Demo tracking: the
+confidential-vault epic in fhevm-internal.

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1692,3 +1692,53 @@ depth (or `t>=9`) needs the scratch-account two-transaction fallback reserved in
 
 Relates to DD-007 (input verification model) and closes the FUTURE_DESIGN §1 / EVM_PARITY "single
 coprocessor signer at threshold 1" fragile item.
+
+## DD-042: Confidential Vaults Are A Batcher-Gateway In Front Of A Public Share-Mint Vault
+
+Confidential yield on Solana is built as a **confidential batcher in front of an ordinary public
+vault**, not as a vault whose own accounting is encrypted. The batcher collects encrypted deposits,
+sums them homomorphically, and reveals **only the batch total**; that one public number is deposited
+into a standard share-mint vault (PDA authority, SPL share mint, share price = assets / shares,
+yield as share-price appreciation — the shape Kamino/Jupiter/Meteora/LSTs all use). Per-user share
+distribution is `encrypted(deposit) x public batch rate` — the share-price division happens once, on
+the plaintext aggregate. Ciphertext-by-ciphertext division is never needed anywhere in the flow.
+
+This mirrors the architecture Zama shipped on Ethereum (confidential batcher over a Morpho ERC-4626
+vault) for the same reason it was chosen there: a natively confidential vault needs encrypted
+division for share pricing, which FHE cannot do efficiently, while an aggregate-only reveal
+preserves individual amount privacy at near-zero encrypted-math cost. Ported as *intent*, not
+mechanics: where the EVM join is a token-side `transferAndCall` hook, Solana inverts control — the
+batcher's `join` CPIs the confidential transfer itself (programs cannot react to incoming
+transfers); where the EVM aggregate reveal is a gateway callback, ours is the existing pull-shaped
+burn-redemption certificate (`confidential_burn` -> `request_burn_redemption` -> KMS-certified
+`redeem_burned_amount_secp`, DD-040 family) — the burn certificate *is* the aggregate decrypt, no
+separate reveal instruction.
+
+Load-bearing mechanics, all pre-existing host semantics (verified, no host changes): the transfer's
+recipient rule already places the receiving account's owner in the `transferred_amount` output
+audience, so the batcher PDA gains read admission on the deposit handle **by construction**; the
+batcher re-materializes each deposit into its own batcher-owned lineage in the same join transaction
+(audience `{user, batcher}`) because input admission pins `current_handle` and the user's
+`transferred_amount` lineage is superseded by their next transfer. Each batch gets its **own token
+account**, so the burned/revealed total is exactly that batch's sum (the EVM code documents the
+inter-batch dust leak this prevents). Lifecycle is Pending -> Dispatched -> Finalized/Canceled with
+permissionless dispatch/settle/claim and an exact-refund `quit` — no operator custody of principal.
+
+Deliberate non-goals, carrying the EVM team's recorded lessons: **no participant-count gates**
+(trivially defeated by one actor joining N times with encrypted zeros; a single-participant batch
+reveals that participant's amount and we document it instead of gating it), **no protocol-level
+noise injection**, **no action that branches on encrypted state** (push-only flow; reactive designs
+are probeable), and **no reward/incentive machinery** (the EVM campaign's dominant operational pain;
+demo yield is simulated by donating underlying to the vault). The demo vault is new, deliberately
+minimal code whose instruction interface mirrors Jupiter Earn's and is isolated behind one CPI
+module in the batcher — Solana has no adopted vault interface standard (no ERC-4626 equivalent), so
+compatibility means matching the prevailing shape, not importing a program.
+
+The only confidential-token addition the flow needs is `confidential_burn_from_value` (burn an
+existing handle; today burn only accepts a fresh coprocessor attestation) — the burn-side analog of
+the existing-handle transfer, with the same aliased-account dedup applied from day one (burning an
+entire balance aliases the amount lineage with the balance lineage).
+
+Didactic companion: `CONFIDENTIAL_VAULTS.md`. Relates to DD-039 (HCU metering identity), DD-040
+(pull-oracle public decrypt), DD-041 (packet envelope — batch transactions stay within the measured
+fit table).

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1710,9 +1710,9 @@ preserves individual amount privacy at near-zero encrypted-math cost. Ported as 
 mechanics: where the EVM join is a token-side `transferAndCall` hook, Solana inverts control — the
 batcher's `join` CPIs the confidential transfer itself (programs cannot react to incoming
 transfers); where the EVM aggregate reveal is a gateway callback, ours is the existing pull-shaped
-burn-redemption certificate (`confidential_burn` -> `request_burn_redemption` -> KMS-certified
-`redeem_burned_amount_secp`, DD-040 family) — the burn certificate *is* the aggregate decrypt, no
-separate reveal instruction.
+burn-redemption certificate (`confidential_burn` -> KMS-certified `redeem_burned_amount` against the
+current context, DD-040 family; the request-witness lifecycle is dissolved by fhevm-internal#1763) —
+the burn certificate *is* the aggregate decrypt, no separate reveal instruction.
 
 Load-bearing mechanics, all pre-existing host semantics (verified, no host changes): the transfer's
 recipient rule already places the receiving account's owner in the `transferred_amount` output


### PR DESCRIPTION
## What

Two documentation additions ahead of the confidential-vault demo work:

- `solana/docs/CONFIDENTIAL_VAULTS.md` — a plain-language explanation of what we are building and why: the vault stays public and ordinary, the doorway is confidential; a batcher sums encrypted deposits and reveals only the batch total; shares are distributed as encrypted deposit × public batch rate, so encrypted-by-encrypted division is never needed.
- `DESIGN_DECISIONS.md` DD-042 — the decision record: EVM lineage (the Ethereum confidential batcher over Morpho), the Solana-idiomatic inversions (join CPIs the transfer instead of a token hook; the burn-redemption certificate is the aggregate reveal instead of a gateway callback), the pre-existing host mechanics it rides (recipient rule for admission, same-tx re-materialization, per-batch accounts), and the deliberate non-goals carried from the EVM team's recorded lessons.

## Why

The vault demo spans several PRs (token instruction, two programs, SDK module, stack, dApp). Recording the intent first gives every implementer and reviewer one didactic reference, and keeps the "why" out of code comments per repo convention.

No code changes. Tracking epic to follow in fhevm-internal.