### PR TITLE
fix(coprocessor): run cargo tests and clippy on AWS runners

### DIFF
--- a/.github/workflows/coprocessor-cargo-clippy.yml
+++ b/.github/workflows/coprocessor-cargo-clippy.yml
@@ -38,7 +38,7 @@ jobs:
       contents: 'read' # Required to checkout repository code
       checks: 'write' # Required to create GitHub checks for test results
       packages: 'read' # Required to read GitHub packages/container registry
-    runs-on: large_ubuntu_16
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -50,37 +50,37 @@ jobs:
             package: tfhe-worker
             needs_localstack: false
             needs_foundry: false
-            runner: large_ubuntu_16
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
           - service: sns-worker
             package: sns-worker
             needs_localstack: true
             needs_foundry: false
-            runner: large_ubuntu_16
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
           - service: zkproof-worker
             package: zkproof-worker
             needs_localstack: false
             needs_foundry: false
-            runner: large_ubuntu_16
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
           - service: transaction-sender
             package: transaction-sender
             needs_localstack: true
             needs_foundry: true
-            runner: large_ubuntu_16
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
           - service: gw-listener
             package: gw-listener
             needs_localstack: false
             needs_foundry: true
-            runner: large_ubuntu_16
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
           - service: host-listener
             package: host-listener
             needs_localstack: false
             needs_foundry: true
-            runner: large_ubuntu_16
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
           - service: common
             package: fhevm-engine-common
             needs_localstack: false
             needs_foundry: false
-            runner: ubuntu-latest
+            runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Summary

Moves the `coprocessor cargo-test` matrix and `coprocessor-cargo-clippy` jobs off GitHub-hosted runners (ubuntu-latest, large_ubuntu_16) onto AWS runners. Tiny path-filter jobs stay GitHub-hosted.