### PR TITLE
ci(common): move solana e2e and tests onto AWS runs-on runners

### DIFF
--- a/.github/workflows/solana-e2e.yml
+++ b/.github/workflows/solana-e2e.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   solana-e2e:
     name: solana-e2e/full-vertical${{ matrix.reconstruct && '-reconstruct' || '' }}
-    runs-on: large_ubuntu_32
+    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=80gb
     timeout-minutes: 120
     strategy:
       matrix:

--- a/.github/workflows/solana-e2e.yml
+++ b/.github/workflows/solana-e2e.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   solana-e2e:
     name: solana-e2e/full-vertical${{ matrix.reconstruct && '-reconstruct' || '' }}
-    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=80gb
+    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=160gb
     timeout-minutes: 120
     strategy:
       matrix:

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
     permissions:
       contents: 'read'
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
     defaults:
       run:
         working-directory: solana
@@ -108,7 +108,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
     permissions:
       contents: 'read'
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
     defaults:
       run:
         working-directory: solana
@@ -196,7 +196,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
     permissions:
       contents: 'read'
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
     permissions:
       contents: 'read'
-    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/volume=80gb
     defaults:
       run:
         working-directory: solana
@@ -108,7 +108,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
     permissions:
       contents: 'read'
-    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/volume=80gb
     defaults:
       run:
         working-directory: solana
@@ -196,7 +196,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.changes-solana == 'true' }}
     permissions:
       contents: 'read'
-    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/volume=80gb
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Summary
- Move `solana-e2e` from `large_ubuntu_32` to AWS `32cpu-linux-x64/volume=80gb`.
- Move Solana `build-and-test` / `native-coverage` to AWS `16cpu`, and `host-listener-reconstruct` to AWS `4cpu`.
- Leave `check-changes` on `ubuntu-latest` (tiny paths-filter gate).

Follows the AWS runner policy from the CI cost thread: build/test/e2e on AWS; only very small jobs stay on GitHub-hosted.

## Test plan
- [ ] Confirm workflow YAML validates on PR open
- [ ] Trigger `solana-tests` on this PR and verify jobs schedule on `runs-on` AWS runners
- [ ] Optionally dispatch `solana-e2e` and confirm the 32cpu runner comes up