### PR TITLE
feat(host-contracts): add demo-vault, a minimal public share-mint vault

### DIFF
--- a/.github/workflows/solana-tests.yml
+++ b/.github/workflows/solana-tests.yml
@@ -161,7 +161,8 @@ jobs:
                 {label: "zama-fhe", path: "/crates/zama-fhe/"},
                 {label: "zama-host", path: "/programs/zama-host/"},
                 {label: "confidential-token", path: "/programs/confidential-token/"},
-                {label: "confidential-deposit-app", path: "/programs/confidential-deposit-app/"}
+                {label: "confidential-deposit-app", path: "/programs/confidential-deposit-app/"},
+                {label: "demo-vault", path: "/programs/demo-vault/"}
               ];
               def line_parts($report; $path):
                 [$report.data[0].files[] | select(.filename | contains($path)) | .summary.lines];

--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -8,6 +8,7 @@ skip-lint = false
 [programs.localnet]
 confidential_deposit_app = "8JdZ2wLbRJtc969bcY6rqSRUKFovxHeKhWPmQaLhHojd"
 confidential_token = "pS2gMMq6PNZKpjxiANeoN5XxJgwaFsUR6xaJkpUHcDg"
+demo_vault = "C6TBzPBWPJYY3fbsDV63nnT3s9vEjaWQAqdeAZpzowH7"
 zama_host = "6AtbvED1rfX68aCT1tYgU1aeu4kFksPDxZG9gtB1Fgtu"
 
 [provider]

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -346,8 +346,11 @@ checksum = "0b8005eef3a48a9a8cb21b126ae3bb252647e353afe6ef7f19e545177801c841"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account-interface",
+ "spl-pod",
  "spl-token-2022-interface",
+ "spl-token-group-interface",
  "spl-token-interface",
+ "spl-token-metadata-interface",
 ]
 
 [[package]]
@@ -1174,6 +1177,14 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "demo-vault"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
 ]
 
 [[package]]
@@ -4960,6 +4971,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "confidential-token",
+ "demo-vault",
  "k256",
  "mollusk-svm",
  "mollusk-svm-programs-token",

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/zama-solana-acl",
     "programs/confidential-deposit-app",
     "programs/confidential-token",
+    "programs/demo-vault",
     "programs/zama-host",
     "runtime-tests",
 ]

--- a/solana/programs/demo-vault/Cargo.toml
+++ b/solana/programs/demo-vault/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "demo-vault"
+version = "0.1.0"
+description = "Solana PoC public share-mint vault fronted by the confidential batcher"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "demo_vault"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+
+[dependencies]
+anchor-lang = "1.0.2"
+anchor-spl = { version = "1.0.2", default-features = false, features = ["associated_token", "mint", "token", "token_2022", "token_2022_extensions"] }

--- a/solana/programs/demo-vault/src/constants.rs
+++ b/solana/programs/demo-vault/src/constants.rs
@@ -1,0 +1,29 @@
+//! Shared constants and PDA seed bytes for the demo-vault program.
+
+/// App event schema version. This vault is not ingested by the coprocessor
+/// host-listener; the field exists so app/demo indexers can version their reads
+/// the same way the other PoC programs do.
+pub const APP_EVENT_VERSION: u8 = 1;
+
+/// Virtual assets added to the denominator of every share-price computation.
+///
+/// Together with [`VIRTUAL_SHARES`] this is the ERC-4626 virtual-offset defense
+/// carried over to Solana: an empty vault prices shares 1:1, and a first
+/// depositor can no longer inflate the share price by donating directly into
+/// the vault, because the `+1/+1` offset keeps the price finite and leaves a
+/// later victim with a non-zero, non-trivial share balance.
+pub const VIRTUAL_ASSETS: u128 = 1;
+
+/// Virtual shares added to the numerator of every share-price computation. See
+/// [`VIRTUAL_ASSETS`].
+pub const VIRTUAL_SHARES: u128 = 1;
+
+/// PDA seed for the vault authority that owns the underlying token account and
+/// mints/holds authority over the share mint.
+pub const VAULT_AUTHORITY_SEED: &[u8] = b"authority";
+
+/// PDA seed for the share mint owned by the vault authority.
+pub const SHARE_MINT_SEED: &[u8] = b"shares";
+
+/// PDA seed for the vault's underlying token account.
+pub const VAULT_TOKEN_ACCOUNT_SEED: &[u8] = b"underlying";

--- a/solana/programs/demo-vault/src/errors.rs
+++ b/solana/programs/demo-vault/src/errors.rs
@@ -1,0 +1,38 @@
+//! Program-specific errors returned by demo-vault instructions.
+
+use anchor_lang::prelude::*;
+
+/// Errors returned by the demo-vault PoC.
+#[error_code]
+pub enum DemoVaultError {
+    /// A deposit, withdraw, or harvest was called with a zero amount.
+    #[msg("amount must be greater than zero")]
+    ZeroAmount,
+    /// A deposit rounded down to zero shares (deposit too small for the current price).
+    #[msg("deposit is too small to mint any shares")]
+    ZeroShares,
+    /// A withdraw rounded down to zero underlying assets (redeem too small for the current price).
+    #[msg("redeem is too small to return any assets")]
+    ZeroAssets,
+    /// A withdraw requested more shares than the owner holds.
+    #[msg("insufficient share balance for this withdraw")]
+    InsufficientShares,
+    /// A share-price computation overflowed the u128 intermediate or the u64 result.
+    #[msg("share-price arithmetic overflowed")]
+    MathOverflow,
+    /// The supplied underlying mint did not match the vault's recorded underlying mint.
+    #[msg("underlying mint does not match the vault")]
+    UnderlyingMintMismatch,
+    /// The supplied share mint did not match the vault's recorded share mint.
+    #[msg("share mint does not match the vault")]
+    ShareMintMismatch,
+    /// The supplied vault token account did not match the vault's recorded token account.
+    #[msg("vault token account does not match the vault")]
+    VaultTokenAccountMismatch,
+    /// A user token account was not owned by the expected signer.
+    #[msg("token account owner does not match signer")]
+    OwnerMismatch,
+    /// A user token account was for the wrong mint.
+    #[msg("token account mint does not match")]
+    MintMismatch,
+}

--- a/solana/programs/demo-vault/src/events.rs
+++ b/solana/programs/demo-vault/src/events.rs
@@ -1,0 +1,71 @@
+//! App-local events for demo-vault.
+//!
+//! These events are for frontend/demo indexers. The generic coprocessor
+//! host-listener does not consume them: the vault is the public half of the
+//! confidential-vault design and emits no Zama host protocol events.
+
+use anchor_lang::prelude::*;
+
+/// Emitted when a vault is created.
+#[event]
+pub struct VaultInitialized {
+    /// Event schema version.
+    pub version: u8,
+    /// Vault state account.
+    pub vault: Pubkey,
+    /// Underlying token mint the vault accepts.
+    pub underlying_mint: Pubkey,
+    /// Share mint the vault issues.
+    pub share_mint: Pubkey,
+    /// Token account holding the vault's underlying assets.
+    pub vault_token_account: Pubkey,
+    /// PDA authority owning the underlying token account and the share mint.
+    pub vault_authority: Pubkey,
+}
+
+/// Emitted when underlying assets are deposited for freshly minted shares.
+#[event]
+pub struct Deposited {
+    /// Event schema version.
+    pub version: u8,
+    /// Vault state account.
+    pub vault: Pubkey,
+    /// Depositor and transfer authority.
+    pub depositor: Pubkey,
+    /// Underlying assets moved into the vault.
+    pub assets: u64,
+    /// Shares minted to the depositor.
+    pub shares: u64,
+}
+
+/// Emitted when shares are burned for underlying assets.
+#[event]
+pub struct Withdrawn {
+    /// Event schema version.
+    pub version: u8,
+    /// Vault state account.
+    pub vault: Pubkey,
+    /// Share owner and burn authority.
+    pub owner: Pubkey,
+    /// Shares burned.
+    pub shares: u64,
+    /// Underlying assets returned to the owner.
+    pub assets: u64,
+}
+
+/// Emitted when underlying assets are donated to the vault without minting shares.
+///
+/// This is the demo's simulated yield: the donation raises the share price for
+/// every existing holder. A real vault would gate this behind a keeper/strategy
+/// role; here it is permissionless.
+#[event]
+pub struct Harvested {
+    /// Event schema version.
+    pub version: u8,
+    /// Vault state account.
+    pub vault: Pubkey,
+    /// Donor and transfer authority.
+    pub donor: Pubkey,
+    /// Underlying assets donated to the vault.
+    pub assets: u64,
+}

--- a/solana/programs/demo-vault/src/instructions/deposit.rs
+++ b/solana/programs/demo-vault/src/instructions/deposit.rs
@@ -1,0 +1,96 @@
+//! Deposits underlying assets and mints shares at the current on-the-fly price.
+
+use super::*;
+
+/// Accounts for a deposit.
+#[derive(Accounts)]
+pub struct Deposit<'info> {
+    /// Depositor and transfer authority over `depositor_underlying`.
+    #[account(mut)]
+    pub depositor: Signer<'info>,
+    /// Vault whose share price the deposit is measured against.
+    #[account(
+        has_one = underlying_mint @ DemoVaultError::UnderlyingMintMismatch,
+        has_one = share_mint @ DemoVaultError::ShareMintMismatch,
+        has_one = vault_token_account @ DemoVaultError::VaultTokenAccountMismatch,
+    )]
+    pub vault: Box<Account<'info, Vault>>,
+    /// CHECK: PDA authority that mints shares; validated by seeds + stored bump.
+    #[account(seeds = [VAULT_AUTHORITY_SEED, vault.key().as_ref()], bump = vault.authority_bump)]
+    pub vault_authority: UncheckedAccount<'info>,
+    /// Underlying SPL mint, read for its decimals.
+    pub underlying_mint: Box<Account<'info, Mint>>,
+    /// Share mint, whose supply is the total shares outstanding.
+    #[account(mut)]
+    pub share_mint: Box<Account<'info, Mint>>,
+    /// Depositor's underlying token account (source).
+    #[account(
+        mut,
+        constraint = depositor_underlying.mint == underlying_mint.key() @ DemoVaultError::MintMismatch,
+        constraint = depositor_underlying.owner == depositor.key() @ DemoVaultError::OwnerMismatch,
+    )]
+    pub depositor_underlying: Box<Account<'info, TokenAccount>>,
+    /// Vault token account whose balance is the total assets under management.
+    #[account(mut)]
+    pub vault_token_account: Box<Account<'info, TokenAccount>>,
+    /// Depositor's share token account (destination for minted shares).
+    #[account(
+        mut,
+        constraint = depositor_shares.mint == share_mint.key() @ DemoVaultError::MintMismatch,
+    )]
+    pub depositor_shares: Box<Account<'info, TokenAccount>>,
+    /// SPL token program.
+    pub token_program: Program<'info, Token>,
+}
+
+/// Pulls `amount` underlying in and mints the corresponding shares.
+pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {
+    require!(amount > 0, DemoVaultError::ZeroAmount);
+
+    // Price against the balances *before* this deposit moves any tokens.
+    let total_assets = ctx.accounts.vault_token_account.amount;
+    let total_shares = ctx.accounts.share_mint.supply;
+    let shares = assets_to_shares(amount, total_assets, total_shares)?;
+    require!(shares > 0, DemoVaultError::ZeroShares);
+
+    // Pull the underlying in under the depositor's own signature.
+    spl_token::transfer_checked(
+        CpiContext::new(
+            ctx.accounts.token_program.key(),
+            TransferChecked {
+                from: ctx.accounts.depositor_underlying.to_account_info(),
+                mint: ctx.accounts.underlying_mint.to_account_info(),
+                to: ctx.accounts.vault_token_account.to_account_info(),
+                authority: ctx.accounts.depositor.to_account_info(),
+            },
+        ),
+        amount,
+        ctx.accounts.underlying_mint.decimals,
+    )?;
+
+    // Mint shares under the vault authority PDA.
+    let vault_key = ctx.accounts.vault.key();
+    let authority_bump = [ctx.accounts.vault.authority_bump];
+    let authority_seeds: &[&[u8]] = &[VAULT_AUTHORITY_SEED, vault_key.as_ref(), &authority_bump];
+    spl_token::mint_to(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.key(),
+            MintTo {
+                mint: ctx.accounts.share_mint.to_account_info(),
+                to: ctx.accounts.depositor_shares.to_account_info(),
+                authority: ctx.accounts.vault_authority.to_account_info(),
+            },
+            &[authority_seeds],
+        ),
+        shares,
+    )?;
+
+    emit!(Deposited {
+        version: APP_EVENT_VERSION,
+        vault: vault_key,
+        depositor: ctx.accounts.depositor.key(),
+        assets: amount,
+        shares,
+    });
+    Ok(())
+}

--- a/solana/programs/demo-vault/src/instructions/harvest.rs
+++ b/solana/programs/demo-vault/src/instructions/harvest.rs
@@ -1,0 +1,59 @@
+//! Donates underlying assets to the vault without minting shares — the demo's
+//! simulated yield. The donation raises the share price for existing holders.
+
+use super::*;
+
+/// Accounts for a harvest (donation).
+#[derive(Accounts)]
+pub struct Harvest<'info> {
+    /// Donor and transfer authority over `donor_underlying`.
+    #[account(mut)]
+    pub donor: Signer<'info>,
+    /// Vault receiving the donation.
+    #[account(
+        has_one = underlying_mint @ DemoVaultError::UnderlyingMintMismatch,
+        has_one = vault_token_account @ DemoVaultError::VaultTokenAccountMismatch,
+    )]
+    pub vault: Box<Account<'info, Vault>>,
+    /// Underlying SPL mint, read for its decimals.
+    pub underlying_mint: Box<Account<'info, Mint>>,
+    /// Donor's underlying token account (source).
+    #[account(
+        mut,
+        constraint = donor_underlying.mint == underlying_mint.key() @ DemoVaultError::MintMismatch,
+        constraint = donor_underlying.owner == donor.key() @ DemoVaultError::OwnerMismatch,
+    )]
+    pub donor_underlying: Box<Account<'info, TokenAccount>>,
+    /// Vault token account whose balance is increased by the donation.
+    #[account(mut)]
+    pub vault_token_account: Box<Account<'info, TokenAccount>>,
+    /// SPL token program.
+    pub token_program: Program<'info, Token>,
+}
+
+/// Moves `amount` underlying into the vault without minting shares.
+pub fn harvest(ctx: Context<Harvest>, amount: u64) -> Result<()> {
+    require!(amount > 0, DemoVaultError::ZeroAmount);
+
+    spl_token::transfer_checked(
+        CpiContext::new(
+            ctx.accounts.token_program.key(),
+            TransferChecked {
+                from: ctx.accounts.donor_underlying.to_account_info(),
+                mint: ctx.accounts.underlying_mint.to_account_info(),
+                to: ctx.accounts.vault_token_account.to_account_info(),
+                authority: ctx.accounts.donor.to_account_info(),
+            },
+        ),
+        amount,
+        ctx.accounts.underlying_mint.decimals,
+    )?;
+
+    emit!(Harvested {
+        version: APP_EVENT_VERSION,
+        vault: ctx.accounts.vault.key(),
+        donor: ctx.accounts.donor.key(),
+        assets: amount,
+    });
+    Ok(())
+}

--- a/solana/programs/demo-vault/src/instructions/initialize_vault.rs
+++ b/solana/programs/demo-vault/src/instructions/initialize_vault.rs
@@ -1,0 +1,71 @@
+//! Creates a vault: its state account, the PDA-owned share mint, and the
+//! PDA-owned underlying token account.
+
+use super::*;
+
+/// Accounts for initializing a vault.
+#[derive(Accounts)]
+pub struct InitializeVault<'info> {
+    /// Rent payer and the account that submits the initialization.
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    /// Vault state account, created here. A fresh keypair signs its own creation.
+    #[account(init, payer = payer, space = 8 + Vault::SPACE)]
+    pub vault: Box<Account<'info, Vault>>,
+    /// Underlying SPL mint the vault accepts.
+    pub underlying_mint: Box<Account<'info, Mint>>,
+    /// CHECK: PDA that owns the vault token account and the share mint. Only a
+    /// signing authority, never deserialized.
+    #[account(seeds = [VAULT_AUTHORITY_SEED, vault.key().as_ref()], bump)]
+    pub vault_authority: UncheckedAccount<'info>,
+    /// Share mint created here, with the same decimals as the underlying and the
+    /// vault authority PDA as its mint authority.
+    #[account(
+        init,
+        payer = payer,
+        seeds = [SHARE_MINT_SEED, vault.key().as_ref()],
+        bump,
+        mint::decimals = underlying_mint.decimals,
+        mint::authority = vault_authority,
+    )]
+    pub share_mint: Box<Account<'info, Mint>>,
+    /// Vault token account created here, owned by the vault authority PDA.
+    #[account(
+        init,
+        payer = payer,
+        seeds = [VAULT_TOKEN_ACCOUNT_SEED, vault.key().as_ref()],
+        bump,
+        token::mint = underlying_mint,
+        token::authority = vault_authority,
+    )]
+    pub vault_token_account: Box<Account<'info, TokenAccount>>,
+    /// SPL token program.
+    pub token_program: Program<'info, Token>,
+    /// System program used for account creation.
+    pub system_program: Program<'info, System>,
+}
+
+/// Records vault state and emits [`VaultInitialized`]. The share mint and vault
+/// token account are created by the Anchor `init` constraints above.
+pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {
+    let vault_authority = ctx.accounts.vault_authority.key();
+    let underlying_mint = ctx.accounts.underlying_mint.key();
+    let share_mint = ctx.accounts.share_mint.key();
+    let vault_token_account = ctx.accounts.vault_token_account.key();
+
+    let vault = &mut ctx.accounts.vault;
+    vault.underlying_mint = underlying_mint;
+    vault.share_mint = share_mint;
+    vault.vault_token_account = vault_token_account;
+    vault.authority_bump = ctx.bumps.vault_authority;
+
+    emit!(VaultInitialized {
+        version: APP_EVENT_VERSION,
+        vault: vault.key(),
+        underlying_mint,
+        share_mint,
+        vault_token_account,
+        vault_authority,
+    });
+    Ok(())
+}

--- a/solana/programs/demo-vault/src/instructions/mod.rs
+++ b/solana/programs/demo-vault/src/instructions/mod.rs
@@ -1,0 +1,24 @@
+//! Instruction account contexts and handlers for the demo-vault program.
+//!
+//! The public Anchor entrypoints in `lib.rs` delegate into these modules so
+//! account contexts, validation, and handler logic stay out of the crate root.
+
+pub mod deposit;
+pub mod harvest;
+pub mod initialize_vault;
+pub mod withdraw;
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{
+    self as spl_token, Burn, Mint, MintTo, Token, TokenAccount, TransferChecked,
+};
+
+use crate::constants::*;
+use crate::errors::*;
+use crate::events::*;
+use crate::state::*;
+
+pub use deposit::*;
+pub use harvest::*;
+pub use initialize_vault::*;
+pub use withdraw::*;

--- a/solana/programs/demo-vault/src/instructions/withdraw.rs
+++ b/solana/programs/demo-vault/src/instructions/withdraw.rs
@@ -1,0 +1,100 @@
+//! Burns shares and returns underlying assets at the current on-the-fly price.
+
+use super::*;
+
+/// Accounts for a withdraw.
+#[derive(Accounts)]
+pub struct Withdraw<'info> {
+    /// Share owner and burn authority over `owner_shares`.
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    /// Vault whose share price the withdraw is measured against.
+    #[account(
+        has_one = underlying_mint @ DemoVaultError::UnderlyingMintMismatch,
+        has_one = share_mint @ DemoVaultError::ShareMintMismatch,
+        has_one = vault_token_account @ DemoVaultError::VaultTokenAccountMismatch,
+    )]
+    pub vault: Box<Account<'info, Vault>>,
+    /// CHECK: PDA authority that owns the vault token account; validated by seeds + stored bump.
+    #[account(seeds = [VAULT_AUTHORITY_SEED, vault.key().as_ref()], bump = vault.authority_bump)]
+    pub vault_authority: UncheckedAccount<'info>,
+    /// Underlying SPL mint, read for its decimals.
+    pub underlying_mint: Box<Account<'info, Mint>>,
+    /// Share mint, whose supply is the total shares outstanding.
+    #[account(mut)]
+    pub share_mint: Box<Account<'info, Mint>>,
+    /// Owner's share token account (burn source).
+    #[account(
+        mut,
+        constraint = owner_shares.mint == share_mint.key() @ DemoVaultError::MintMismatch,
+        constraint = owner_shares.owner == owner.key() @ DemoVaultError::OwnerMismatch,
+    )]
+    pub owner_shares: Box<Account<'info, TokenAccount>>,
+    /// Vault token account whose balance is the total assets under management.
+    #[account(mut)]
+    pub vault_token_account: Box<Account<'info, TokenAccount>>,
+    /// Owner's underlying token account (destination for returned assets).
+    #[account(
+        mut,
+        constraint = owner_underlying.mint == underlying_mint.key() @ DemoVaultError::MintMismatch,
+    )]
+    pub owner_underlying: Box<Account<'info, TokenAccount>>,
+    /// SPL token program.
+    pub token_program: Program<'info, Token>,
+}
+
+/// Burns `shares` and returns the corresponding underlying assets.
+pub fn withdraw(ctx: Context<Withdraw>, shares: u64) -> Result<()> {
+    require!(shares > 0, DemoVaultError::ZeroAmount);
+    require!(
+        ctx.accounts.owner_shares.amount >= shares,
+        DemoVaultError::InsufficientShares
+    );
+
+    // Price against the balances *before* this withdraw burns or moves anything.
+    let total_assets = ctx.accounts.vault_token_account.amount;
+    let total_shares = ctx.accounts.share_mint.supply;
+    let assets = shares_to_assets(shares, total_assets, total_shares)?;
+    require!(assets > 0, DemoVaultError::ZeroAssets);
+
+    // Burn the owner's shares under their own signature.
+    spl_token::burn(
+        CpiContext::new(
+            ctx.accounts.token_program.key(),
+            Burn {
+                mint: ctx.accounts.share_mint.to_account_info(),
+                from: ctx.accounts.owner_shares.to_account_info(),
+                authority: ctx.accounts.owner.to_account_info(),
+            },
+        ),
+        shares,
+    )?;
+
+    // Pay out the underlying under the vault authority PDA.
+    let vault_key = ctx.accounts.vault.key();
+    let authority_bump = [ctx.accounts.vault.authority_bump];
+    let authority_seeds: &[&[u8]] = &[VAULT_AUTHORITY_SEED, vault_key.as_ref(), &authority_bump];
+    spl_token::transfer_checked(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.key(),
+            TransferChecked {
+                from: ctx.accounts.vault_token_account.to_account_info(),
+                mint: ctx.accounts.underlying_mint.to_account_info(),
+                to: ctx.accounts.owner_underlying.to_account_info(),
+                authority: ctx.accounts.vault_authority.to_account_info(),
+            },
+            &[authority_seeds],
+        ),
+        assets,
+        ctx.accounts.underlying_mint.decimals,
+    )?;
+
+    emit!(Withdrawn {
+        version: APP_EVENT_VERSION,
+        vault: vault_key,
+        owner: ctx.accounts.owner.key(),
+        shares,
+        assets,
+    });
+    Ok(())
+}

--- a/solana/programs/demo-vault/src/lib.rs
+++ b/solana/programs/demo-vault/src/lib.rs
@@ -1,0 +1,81 @@
+//! Minimal public share-mint vault for the Solana FHEVM PoC.
+//!
+//! This is the public half of the confidential-vault design (see
+//! `solana/docs/CONFIDENTIAL_VAULTS.md` and DD-042): tokens in, shares out,
+//! share price computed on the fly as `assets / shares`, and yield delivered as
+//! share-price appreciation (never rebasing). The confidential batcher fronts
+//! this vault; its instruction interface deliberately mirrors Jupiter Earn's
+//! (deposit/withdraw taking amounts, asset/share duality, a PDA authority that
+//! owns the assets and the share mint) so the batcher can be retargeted to a
+//! real venue later.
+//!
+//! It is standalone: plain SPL Token only, no dependency on `zama-host` or
+//! `confidential-token`, and it emits no Zama host protocol events (the
+//! coprocessor host-listener never ingests this program).
+
+// Anchor macros generate framework-shaped code that trips rustc/Clippy checks.
+#![allow(unexpected_cfgs)]
+#![allow(
+    clippy::diverging_sub_expression,
+    clippy::too_many_arguments,
+    clippy::result_large_err
+)]
+
+/// Shared constants, seed bytes, and virtual-offset parameters.
+pub mod constants;
+/// Program-specific errors returned by demo-vault instructions.
+pub mod errors;
+/// App-local events.
+pub mod events;
+/// Instruction account contexts and handlers.
+pub mod instructions;
+/// Vault account layout and share-price math.
+pub mod state;
+
+use anchor_lang::prelude::*;
+
+/// Re-export constants for generated clients and tests.
+pub use constants::*;
+/// Re-export errors for generated clients and tests.
+pub use errors::*;
+/// Re-export events for generated clients and tests.
+pub use events::*;
+use instructions::*;
+/// Re-export instruction account contexts for tests.
+pub use instructions::{Deposit, Harvest, InitializeVault, Withdraw};
+/// Re-export the vault layout and share-price helpers.
+pub use state::*;
+
+declare_id!("C6TBzPBWPJYY3fbsDV63nnT3s9vEjaWQAqdeAZpzowH7");
+
+/// Anchor entrypoint module for the demo vault.
+#[program]
+pub mod demo_vault {
+    use super::*;
+
+    /// Creates the vault state account, its PDA-owned share mint, and its
+    /// PDA-owned underlying token account. Permissionless; no admin role beyond
+    /// this one-time setup.
+    pub fn initialize_vault(ctx: Context<InitializeVault>) -> Result<()> {
+        instructions::initialize_vault(ctx)
+    }
+
+    /// Deposits `amount` underlying assets and mints shares at the current price
+    /// (rounded down). Permissionless.
+    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {
+        instructions::deposit(ctx, amount)
+    }
+
+    /// Burns `shares` and returns underlying assets at the current price
+    /// (rounded down). Permissionless.
+    pub fn withdraw(ctx: Context<Withdraw>, shares: u64) -> Result<()> {
+        instructions::withdraw(ctx, shares)
+    }
+
+    /// Donates `amount` underlying to the vault without minting shares, raising
+    /// the share price for existing holders. Permissionless (demo-only; a real
+    /// vault gates this behind a keeper/strategy role).
+    pub fn harvest(ctx: Context<Harvest>, amount: u64) -> Result<()> {
+        instructions::harvest(ctx, amount)
+    }
+}

--- a/solana/programs/demo-vault/src/state.rs
+++ b/solana/programs/demo-vault/src/state.rs
@@ -1,0 +1,128 @@
+//! Vault account layout and the on-the-fly share-price math.
+
+use anchor_lang::prelude::*;
+
+use crate::constants::{VIRTUAL_ASSETS, VIRTUAL_SHARES};
+use crate::errors::DemoVaultError;
+
+/// Public share-mint vault state.
+///
+/// Deliberately minimal: totals are never mirrored here. Total assets are read
+/// live from the vault token account balance and total shares from the share
+/// mint supply, so a permissionless `harvest` (a plain donation transfer) is
+/// accounted for by construction — the donation just increases the token
+/// account balance, and every share-price read picks it up.
+#[account]
+#[derive(InitSpace)]
+pub struct Vault {
+    /// Underlying token mint the vault accepts.
+    pub underlying_mint: Pubkey,
+    /// Share mint issued 1:1 in decimals with the underlying.
+    pub share_mint: Pubkey,
+    /// Token account holding the vault's underlying assets, owned by the authority PDA.
+    pub vault_token_account: Pubkey,
+    /// Bump for the vault authority PDA that owns assets and the share mint.
+    pub authority_bump: u8,
+}
+
+impl Vault {
+    /// Serialized size of the account body, excluding the Anchor discriminator.
+    pub const SPACE: usize = 32 + 32 + 32 + 1;
+}
+
+/// Shares minted for a deposit of `assets`, rounded DOWN (protocol-favoring).
+///
+/// `shares = assets * (total_shares + VIRTUAL_SHARES) / (total_assets + VIRTUAL_ASSETS)`
+///
+/// `total_assets` / `total_shares` are the balances *before* this deposit. The
+/// virtual offset makes the denominator always positive, so an empty vault
+/// prices 1:1 and there is no division by zero.
+pub fn assets_to_shares(assets: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
+    let numerator = (assets as u128)
+        .checked_mul((total_shares as u128).saturating_add(VIRTUAL_SHARES))
+        .ok_or(DemoVaultError::MathOverflow)?;
+    let denominator = (total_assets as u128).saturating_add(VIRTUAL_ASSETS);
+    let shares = numerator / denominator;
+    u64::try_from(shares).map_err(|_| DemoVaultError::MathOverflow.into())
+}
+
+/// Underlying assets returned for a redeem of `shares`, rounded DOWN (protocol-favoring).
+///
+/// `assets = shares * (total_assets + VIRTUAL_ASSETS) / (total_shares + VIRTUAL_SHARES)`
+///
+/// `total_assets` / `total_shares` are the balances *before* this withdraw.
+pub fn shares_to_assets(shares: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
+    let numerator = (shares as u128)
+        .checked_mul((total_assets as u128).saturating_add(VIRTUAL_ASSETS))
+        .ok_or(DemoVaultError::MathOverflow)?;
+    let denominator = (total_shares as u128).saturating_add(VIRTUAL_SHARES);
+    let assets = numerator / denominator;
+    u64::try_from(assets).map_err(|_| DemoVaultError::MathOverflow.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_vault_prices_one_to_one() {
+        assert_eq!(assets_to_shares(1_000, 0, 0).unwrap(), 1_000);
+    }
+
+    #[test]
+    fn deposit_and_withdraw_round_trip_without_yield() {
+        let shares = assets_to_shares(1_000, 0, 0).unwrap();
+        // Same price back out: shares -> assets returns the original deposit.
+        let assets = shares_to_assets(shares, 1_000, shares).unwrap();
+        assert_eq!(assets, 1_000);
+    }
+
+    #[test]
+    fn second_depositor_after_yield_gets_fewer_shares() {
+        // First depositor: 1_000 assets -> 1_000 shares (1:1).
+        let first = assets_to_shares(1_000, 0, 0).unwrap();
+        assert_eq!(first, 1_000);
+        // Yield doubles the assets (harvest of 1_000) with supply unchanged.
+        let second = assets_to_shares(1_000, 2_000, 1_000).unwrap();
+        // Price is ~2 assets/share now, so the same deposit buys ~half the shares.
+        assert!(second < first);
+        assert_eq!(second, 500);
+    }
+
+    #[test]
+    fn rounding_is_down_on_both_sides() {
+        // shares = 5 * (1 + 1) / (2 + 1) = 10 / 3 = 3.33... -> floor 3.
+        assert_eq!(assets_to_shares(5, 2, 1).unwrap(), 3);
+        // assets = 1 * (4 + 1) / (1 + 1) = 5 / 2 = 2.5 -> floor 2.
+        assert_eq!(shares_to_assets(1, 4, 1).unwrap(), 2);
+    }
+
+    #[test]
+    fn inflation_attack_leaves_victim_with_shares_and_no_attacker_profit() {
+        const DONATION: u64 = 100_000_000;
+        const VICTIM_DEPOSIT: u64 = 100_000_000;
+
+        // Attacker seeds 1 asset -> 1 share (empty vault, 1:1).
+        let attacker_shares = assets_to_shares(1, 0, 0).unwrap();
+        assert_eq!(attacker_shares, 1);
+        // Attacker donates a large amount directly (harvest); supply stays 1.
+        let assets_after_donation = 1 + DONATION;
+        // Victim deposits; without the virtual offset it would round to zero shares and be wiped.
+        let victim_shares =
+            assets_to_shares(VICTIM_DEPOSIT, assets_after_donation, attacker_shares).unwrap();
+        assert!(victim_shares > 0, "virtual offset must protect the victim");
+
+        // Attacker redeems their single share against the post-victim state. The donation is
+        // shared with the victim, so the attacker cannot recover the 1 + DONATION they spent —
+        // the attack is uneconomical.
+        let assets_after_victim = assets_after_donation + VICTIM_DEPOSIT;
+        let shares_after_victim = attacker_shares + victim_shares;
+        let attacker_payout =
+            shares_to_assets(attacker_shares, assets_after_victim, shares_after_victim).unwrap();
+        assert!(
+            attacker_payout < 1 + DONATION,
+            "attacker must exit at a loss; spent {} and recovered {attacker_payout}",
+            1 + DONATION
+        );
+    }
+}

--- a/solana/runtime-tests/Cargo.toml
+++ b/solana/runtime-tests/Cargo.toml
@@ -10,6 +10,7 @@ anchor-lang = "1.0.2"
 anchor-spl = { version = "1.0.2", default-features = false, features = ["associated_token", "token", "token_2022"] }
 base64 = "0.22.1"
 confidential-token = { path = "../programs/confidential-token", features = ["no-entrypoint", "poc"] }
+demo-vault = { path = "../programs/demo-vault", features = ["no-entrypoint"] }
 mollusk-svm = { version = "0.12.1-agave-4.0", features = ["inner-instructions", "precompiles"] }
 mollusk-svm-programs-token = { version = "0.12.1-agave-4.0", default-features = false, features = ["token"] }
 solana-program = "3.0.0"

--- a/solana/runtime-tests/cost-snapshots/vault_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/vault_mollusk.json
@@ -1,0 +1,26 @@
+{
+  "deposit": {
+    "compute_units": 14814,
+    "unique_accounts": 10,
+    "instruction_data_bytes": 16,
+    "cpi_instructions": 2,
+    "total_cpi_instruction_data_bytes": 19,
+    "max_cpi_instruction_data_bytes": 10
+  },
+  "harvest": {
+    "compute_units": 7070,
+    "unique_accounts": 7,
+    "instruction_data_bytes": 16,
+    "cpi_instructions": 1,
+    "total_cpi_instruction_data_bytes": 10,
+    "max_cpi_instruction_data_bytes": 10
+  },
+  "withdraw": {
+    "compute_units": 14836,
+    "unique_accounts": 10,
+    "instruction_data_bytes": 16,
+    "cpi_instructions": 2,
+    "total_cpi_instruction_data_bytes": 19,
+    "max_cpi_instruction_data_bytes": 10
+  }
+}

--- a/solana/runtime-tests/tests/vault_mollusk.rs
+++ b/solana/runtime-tests/tests/vault_mollusk.rs
@@ -1,0 +1,847 @@
+//! Mollusk-based runtime tests for the `demo-vault` public share-mint vault.
+//!
+//! The vault is standalone plain-SPL code (no `zama-host` / `confidential-token`
+//! involvement), so this harness only registers the SPL Token program alongside
+//! `demo_vault` — no host program, no FHE fixtures.
+//!
+//! Coverage: initialization (state + PDA-owned share mint and token account),
+//! the first-deposit 1:1 price, a full deposit/withdraw round trip, that
+//! `harvest` raises the share price so a later depositor gets fewer shares, the
+//! ERC-4626 first-depositor inflation-attack regression (victim keeps shares and
+//! the attacker cannot profit), and the input-validation rejects (zero amount,
+//! withdraw more than owned, empty-vault withdraw). Rounding direction is
+//! asserted in the deposit/withdraw math both here and in the program's own unit
+//! tests.
+
+// Deliberate `#[path]` include (not `mod support;`): pull in only the shared
+// cost-snapshot helper, not the FHE support modules that `support/mod.rs`
+// declares (this vault has no host/FHE dependency).
+#[path = "support/cost_snapshot.rs"]
+mod cost_snapshot;
+
+use anchor_lang::{
+    prelude::system_program, AccountDeserialize, AccountSerialize, InstructionData, ToAccountMetas,
+};
+use anchor_spl::token::spl_token;
+use demo_vault as vault;
+use mollusk_svm::{
+    result::{Check, InstructionResult},
+    Mollusk,
+};
+use solana_sdk::{
+    account::Account, instruction::Instruction, program_error::ProgramError,
+    program_option::COption, program_pack::Pack, pubkey::Pubkey,
+};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+const DECIMALS: u8 = 6;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+fn mollusk() -> Mollusk {
+    let deploy_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../target/deploy");
+    unsafe {
+        std::env::set_var("SBF_OUT_DIR", deploy_dir);
+    }
+    let mut mollusk = Mollusk::new(&vault::id(), "demo_vault");
+    mollusk_svm_programs_token::token::add_program(&mut mollusk);
+    // A deposit/withdraw issues two token CPIs; give it headroom over the 200k default.
+    mollusk.compute_budget.compute_unit_limit = 400_000;
+    mollusk
+}
+
+fn anchor_ix<A, D>(accounts: A, args: D) -> Instruction
+where
+    A: ToAccountMetas,
+    D: InstructionData,
+{
+    Instruction {
+        program_id: vault::id(),
+        accounts: accounts.to_account_metas(None),
+        data: args.data(),
+    }
+}
+
+fn vault_error(error: vault::DemoVaultError) -> Check<'static> {
+    Check::err(ProgramError::Custom(
+        anchor_lang::error::ERROR_CODE_OFFSET + error as u32,
+    ))
+}
+
+fn system_account(lamports: u64) -> Account {
+    Account {
+        lamports,
+        data: vec![],
+        owner: system_program::ID,
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+fn spl_mint_account(mint_authority: Option<Pubkey>, supply: u64) -> Account {
+    let mut data = vec![0u8; spl_token::state::Mint::LEN];
+    spl_token::state::Mint::pack(
+        spl_token::state::Mint {
+            mint_authority: mint_authority.map(COption::Some).unwrap_or(COption::None),
+            supply,
+            decimals: DECIMALS,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        },
+        &mut data,
+    )
+    .unwrap();
+    Account {
+        lamports: 1_000_000_000,
+        data,
+        owner: spl_token::id(),
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+fn spl_token_account(mint: Pubkey, owner: Pubkey, amount: u64) -> Account {
+    let mut data = vec![0u8; spl_token::state::Account::LEN];
+    spl_token::state::Account::pack(
+        spl_token::state::Account {
+            mint,
+            owner,
+            amount,
+            delegate: COption::None,
+            state: spl_token::state::AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::None,
+        },
+        &mut data,
+    )
+    .unwrap();
+    Account {
+        lamports: 1_000_000_000,
+        data,
+        owner: spl_token::id(),
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+fn read_spl_amount(
+    context: &mollusk_svm::MolluskContext<HashMap<Pubkey, Account>>,
+    address: Pubkey,
+) -> u64 {
+    let store = context.account_store.borrow();
+    let account = store.get(&address).expect("missing spl token account");
+    spl_token::state::Account::unpack(&account.data)
+        .expect("valid spl token account")
+        .amount
+}
+
+fn read_mint_supply(
+    context: &mollusk_svm::MolluskContext<HashMap<Pubkey, Account>>,
+    address: Pubkey,
+) -> u64 {
+    let store = context.account_store.borrow();
+    let account = store.get(&address).expect("missing spl mint");
+    spl_token::state::Mint::unpack(&account.data)
+        .expect("valid spl mint")
+        .supply
+}
+
+fn read_vault(
+    context: &mollusk_svm::MolluskContext<HashMap<Pubkey, Account>>,
+    address: Pubkey,
+) -> vault::Vault {
+    let store = context.account_store.borrow();
+    let account = store.get(&address).expect("missing vault");
+    vault::Vault::try_deserialize(&mut account.data.as_slice()).expect("valid vault")
+}
+
+// ---------------------------------------------------------------------------
+// Fixture for an already-initialized vault with a chosen assets/shares state
+// ---------------------------------------------------------------------------
+
+struct VaultFixture {
+    vault: Pubkey,
+    vault_authority: Pubkey,
+    authority_bump: u8,
+    underlying_mint: Pubkey,
+    share_mint: Pubkey,
+    vault_token_account: Pubkey,
+}
+
+impl VaultFixture {
+    fn new() -> Self {
+        Self::from_keys(Pubkey::new_unique(), Pubkey::new_unique())
+    }
+
+    /// Fixture with fully fixed keys. Used by the cost-snapshot tests: the
+    /// on-chain PDA bump search is part of the measured compute, so the vault
+    /// key (and therefore the bumps) must be stable across runs — `new_unique`
+    /// is a global counter whose value depends on test ordering.
+    fn fixed(seed: u8) -> Self {
+        Self::from_keys(
+            Pubkey::new_from_array([seed; 32]),
+            Pubkey::new_from_array([seed.wrapping_add(1); 32]),
+        )
+    }
+
+    fn from_keys(vault: Pubkey, underlying_mint: Pubkey) -> Self {
+        let (vault_authority, authority_bump) =
+            Pubkey::find_program_address(&[b"authority", vault.as_ref()], &vault::id());
+        let share_mint = Pubkey::find_program_address(&[b"shares", vault.as_ref()], &vault::id()).0;
+        let vault_token_account =
+            Pubkey::find_program_address(&[b"underlying", vault.as_ref()], &vault::id()).0;
+        Self {
+            vault,
+            vault_authority,
+            authority_bump,
+            underlying_mint,
+            share_mint,
+            vault_token_account,
+        }
+    }
+
+    fn vault_account(&self) -> Account {
+        let mut data = Vec::new();
+        vault::Vault {
+            underlying_mint: self.underlying_mint,
+            share_mint: self.share_mint,
+            vault_token_account: self.vault_token_account,
+            authority_bump: self.authority_bump,
+        }
+        .try_serialize(&mut data)
+        .unwrap();
+        Account {
+            lamports: 1_000_000_000,
+            data,
+            owner: vault::id(),
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    /// Base account set for a vault holding `total_assets` underlying and having
+    /// `total_shares` shares outstanding. Callers add the user token accounts.
+    fn accounts(&self, total_assets: u64, total_shares: u64) -> HashMap<Pubkey, Account> {
+        HashMap::from([
+            (self.vault, self.vault_account()),
+            (self.vault_authority, system_account(0)),
+            (self.underlying_mint, spl_mint_account(None, 0)),
+            (
+                self.share_mint,
+                spl_mint_account(Some(self.vault_authority), total_shares),
+            ),
+            (
+                self.vault_token_account,
+                spl_token_account(self.underlying_mint, self.vault_authority, total_assets),
+            ),
+        ])
+    }
+}
+
+fn deposit_ix(
+    fixture: &VaultFixture,
+    depositor: Pubkey,
+    depositor_underlying: Pubkey,
+    depositor_shares: Pubkey,
+    amount: u64,
+) -> Instruction {
+    anchor_ix(
+        vault::accounts::Deposit {
+            depositor,
+            vault: fixture.vault,
+            vault_authority: fixture.vault_authority,
+            underlying_mint: fixture.underlying_mint,
+            share_mint: fixture.share_mint,
+            depositor_underlying,
+            vault_token_account: fixture.vault_token_account,
+            depositor_shares,
+            token_program: spl_token::id(),
+        },
+        vault::instruction::Deposit { amount },
+    )
+}
+
+fn withdraw_ix(
+    fixture: &VaultFixture,
+    owner: Pubkey,
+    owner_shares: Pubkey,
+    owner_underlying: Pubkey,
+    shares: u64,
+) -> Instruction {
+    anchor_ix(
+        vault::accounts::Withdraw {
+            owner,
+            vault: fixture.vault,
+            vault_authority: fixture.vault_authority,
+            underlying_mint: fixture.underlying_mint,
+            share_mint: fixture.share_mint,
+            owner_shares,
+            vault_token_account: fixture.vault_token_account,
+            owner_underlying,
+            token_program: spl_token::id(),
+        },
+        vault::instruction::Withdraw { shares },
+    )
+}
+
+fn harvest_ix(
+    fixture: &VaultFixture,
+    donor: Pubkey,
+    donor_underlying: Pubkey,
+    amount: u64,
+) -> Instruction {
+    anchor_ix(
+        vault::accounts::Harvest {
+            donor,
+            vault: fixture.vault,
+            underlying_mint: fixture.underlying_mint,
+            donor_underlying,
+            vault_token_account: fixture.vault_token_account,
+            token_program: spl_token::id(),
+        },
+        vault::instruction::Harvest { amount },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// initialize_vault
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mollusk_initialize_vault_creates_state_share_mint_and_token_account() {
+    let payer = Pubkey::new_unique();
+    let vault_key = Pubkey::new_unique();
+    let underlying_mint = Pubkey::new_unique();
+    let (vault_authority, _) =
+        Pubkey::find_program_address(&[b"authority", vault_key.as_ref()], &vault::id());
+    let share_mint = Pubkey::find_program_address(&[b"shares", vault_key.as_ref()], &vault::id()).0;
+    let vault_token_account =
+        Pubkey::find_program_address(&[b"underlying", vault_key.as_ref()], &vault::id()).0;
+
+    let context = mollusk().with_context(HashMap::from([
+        (payer, system_account(5_000_000_000)),
+        (vault_key, system_account(0)),
+        (underlying_mint, spl_mint_account(Some(payer), 0)),
+        (vault_authority, system_account(0)),
+        (share_mint, system_account(0)),
+        (vault_token_account, system_account(0)),
+    ]));
+
+    let ix = anchor_ix(
+        vault::accounts::InitializeVault {
+            payer,
+            vault: vault_key,
+            underlying_mint,
+            vault_authority,
+            share_mint,
+            vault_token_account,
+            token_program: spl_token::id(),
+            system_program: system_program::ID,
+        },
+        vault::instruction::InitializeVault {},
+    );
+
+    context.process_and_validate_instruction(&ix, &[Check::success()]);
+
+    let stored = read_vault(&context, vault_key);
+    assert_eq!(stored.underlying_mint, underlying_mint);
+    assert_eq!(stored.share_mint, share_mint);
+    assert_eq!(stored.vault_token_account, vault_token_account);
+
+    // Share mint created with the vault authority as mint authority, matching decimals, zero supply.
+    let store = context.account_store.borrow();
+    let share = spl_token::state::Mint::unpack(&store.get(&share_mint).unwrap().data).unwrap();
+    assert_eq!(share.mint_authority, COption::Some(vault_authority));
+    assert_eq!(share.decimals, DECIMALS);
+    assert_eq!(share.supply, 0);
+    // Vault token account owned by the authority PDA, for the underlying mint, empty.
+    let token =
+        spl_token::state::Account::unpack(&store.get(&vault_token_account).unwrap().data).unwrap();
+    assert_eq!(token.owner, vault_authority);
+    assert_eq!(token.mint, underlying_mint);
+    assert_eq!(token.amount, 0);
+}
+
+// ---------------------------------------------------------------------------
+// deposit / withdraw math
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mollusk_first_deposit_is_one_to_one() {
+    let fixture = VaultFixture::new();
+    let depositor = Pubkey::new_unique();
+    let depositor_underlying = Pubkey::new_unique();
+    let depositor_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(depositor, system_account(1_000_000_000));
+    accounts.insert(
+        depositor_underlying,
+        spl_token_account(fixture.underlying_mint, depositor, 1_000),
+    );
+    accounts.insert(
+        depositor_shares,
+        spl_token_account(fixture.share_mint, depositor, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = deposit_ix(
+        &fixture,
+        depositor,
+        depositor_underlying,
+        depositor_shares,
+        1_000,
+    );
+    context.process_and_validate_instruction(&ix, &[Check::success()]);
+
+    // Empty vault prices 1:1: 1_000 assets -> 1_000 shares.
+    assert_eq!(read_spl_amount(&context, depositor_shares), 1_000);
+    assert_eq!(read_spl_amount(&context, depositor_underlying), 0);
+    assert_eq!(
+        read_spl_amount(&context, fixture.vault_token_account),
+        1_000
+    );
+    assert_eq!(read_mint_supply(&context, fixture.share_mint), 1_000);
+}
+
+#[test]
+fn mollusk_deposit_withdraw_round_trip_returns_principal() {
+    let fixture = VaultFixture::new();
+    let owner = Pubkey::new_unique();
+    let owner_underlying = Pubkey::new_unique();
+    let owner_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_underlying,
+        spl_token_account(fixture.underlying_mint, owner, 1_000),
+    );
+    accounts.insert(
+        owner_shares,
+        spl_token_account(fixture.share_mint, owner, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let deposit = deposit_ix(&fixture, owner, owner_underlying, owner_shares, 1_000);
+    context.process_and_validate_instruction(&deposit, &[Check::success()]);
+    assert_eq!(read_spl_amount(&context, owner_shares), 1_000);
+
+    // Redeem every share; with no yield the round trip returns the full principal.
+    let withdraw = withdraw_ix(&fixture, owner, owner_shares, owner_underlying, 1_000);
+    context.process_and_validate_instruction(&withdraw, &[Check::success()]);
+
+    assert_eq!(read_spl_amount(&context, owner_shares), 0);
+    assert_eq!(read_spl_amount(&context, owner_underlying), 1_000);
+    assert_eq!(read_spl_amount(&context, fixture.vault_token_account), 0);
+    assert_eq!(read_mint_supply(&context, fixture.share_mint), 0);
+}
+
+#[test]
+fn mollusk_harvest_raises_price_so_later_depositor_gets_fewer_shares() {
+    // Vault already at 1:1 with 1_000 assets and 1_000 shares outstanding.
+    let fixture = VaultFixture::new();
+    let donor = Pubkey::new_unique();
+    let donor_underlying = Pubkey::new_unique();
+    let depositor = Pubkey::new_unique();
+    let depositor_underlying = Pubkey::new_unique();
+    let depositor_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    accounts.insert(donor, system_account(1_000_000_000));
+    accounts.insert(
+        donor_underlying,
+        spl_token_account(fixture.underlying_mint, donor, 1_000),
+    );
+    accounts.insert(depositor, system_account(1_000_000_000));
+    accounts.insert(
+        depositor_underlying,
+        spl_token_account(fixture.underlying_mint, depositor, 1_000),
+    );
+    accounts.insert(
+        depositor_shares,
+        spl_token_account(fixture.share_mint, depositor, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    // Harvest doubles the assets without minting shares: price becomes ~2 assets/share.
+    let harvest = harvest_ix(&fixture, donor, donor_underlying, 1_000);
+    context.process_and_validate_instruction(&harvest, &[Check::success()]);
+    assert_eq!(
+        read_spl_amount(&context, fixture.vault_token_account),
+        2_000
+    );
+    assert_eq!(read_mint_supply(&context, fixture.share_mint), 1_000);
+
+    // A 1_000 deposit now buys shares = 1_000 * (1_000 + 1) / (2_000 + 1) = 500 (floor).
+    let deposit = deposit_ix(
+        &fixture,
+        depositor,
+        depositor_underlying,
+        depositor_shares,
+        1_000,
+    );
+    context.process_and_validate_instruction(&deposit, &[Check::success()]);
+    assert_eq!(read_spl_amount(&context, depositor_shares), 500);
+}
+
+#[test]
+fn mollusk_inflation_attack_leaves_victim_with_shares_and_no_attacker_profit() {
+    let fixture = VaultFixture::new();
+    let attacker = Pubkey::new_unique();
+    let attacker_underlying = Pubkey::new_unique();
+    let attacker_shares = Pubkey::new_unique();
+    let victim = Pubkey::new_unique();
+    let victim_underlying = Pubkey::new_unique();
+    let victim_shares = Pubkey::new_unique();
+
+    const DONATION: u64 = 1_000_000;
+    const VICTIM_DEPOSIT: u64 = 1_000_000;
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(attacker, system_account(1_000_000_000));
+    // 1 to seed the vault + DONATION to inflate it.
+    accounts.insert(
+        attacker_underlying,
+        spl_token_account(fixture.underlying_mint, attacker, 1 + DONATION),
+    );
+    accounts.insert(
+        attacker_shares,
+        spl_token_account(fixture.share_mint, attacker, 0),
+    );
+    accounts.insert(victim, system_account(1_000_000_000));
+    accounts.insert(
+        victim_underlying,
+        spl_token_account(fixture.underlying_mint, victim, VICTIM_DEPOSIT),
+    );
+    accounts.insert(
+        victim_shares,
+        spl_token_account(fixture.share_mint, victim, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    // Attacker seeds 1 asset -> 1 share (empty vault, 1:1).
+    let seed = deposit_ix(&fixture, attacker, attacker_underlying, attacker_shares, 1);
+    context.process_and_validate_instruction(&seed, &[Check::success()]);
+    assert_eq!(read_spl_amount(&context, attacker_shares), 1);
+
+    // Attacker donates directly via harvest to inflate the price.
+    let donate = harvest_ix(&fixture, attacker, attacker_underlying, DONATION);
+    context.process_and_validate_instruction(&donate, &[Check::success()]);
+
+    // Victim deposits; the virtual offset keeps them from being rounded to zero shares.
+    let victim_deposit = deposit_ix(
+        &fixture,
+        victim,
+        victim_underlying,
+        victim_shares,
+        VICTIM_DEPOSIT,
+    );
+    context.process_and_validate_instruction(&victim_deposit, &[Check::success()]);
+    let victim_share_balance = read_spl_amount(&context, victim_shares);
+    assert!(
+        victim_share_balance > 0,
+        "virtual offset must leave the victim with shares, got {victim_share_balance}"
+    );
+
+    // Attacker redeems their single share; the donation is shared with the victim, so the
+    // attacker cannot recover what they spent (1 seed + DONATION) — the attack is uneconomical.
+    let attacker_exit = withdraw_ix(&fixture, attacker, attacker_shares, attacker_underlying, 1);
+    context.process_and_validate_instruction(&attacker_exit, &[Check::success()]);
+    let attacker_final = read_spl_amount(&context, attacker_underlying);
+    assert!(
+        attacker_final < 1 + DONATION,
+        "attacker must not profit; started with {} and ended with {attacker_final}",
+        1 + DONATION
+    );
+}
+
+// ---------------------------------------------------------------------------
+// rejects
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mollusk_deposit_zero_amount_rejects() {
+    let fixture = VaultFixture::new();
+    let depositor = Pubkey::new_unique();
+    let depositor_underlying = Pubkey::new_unique();
+    let depositor_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(depositor, system_account(1_000_000_000));
+    accounts.insert(
+        depositor_underlying,
+        spl_token_account(fixture.underlying_mint, depositor, 1_000),
+    );
+    accounts.insert(
+        depositor_shares,
+        spl_token_account(fixture.share_mint, depositor, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = deposit_ix(
+        &fixture,
+        depositor,
+        depositor_underlying,
+        depositor_shares,
+        0,
+    );
+    context
+        .process_and_validate_instruction(&ix, &[vault_error(vault::DemoVaultError::ZeroAmount)]);
+}
+
+#[test]
+fn mollusk_withdraw_more_than_owned_rejects() {
+    let fixture = VaultFixture::new();
+    let owner = Pubkey::new_unique();
+    let owner_underlying = Pubkey::new_unique();
+    let owner_shares = Pubkey::new_unique();
+
+    // Vault holds 1_000 assets / 1_000 shares; owner holds only 10 shares.
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_underlying,
+        spl_token_account(fixture.underlying_mint, owner, 0),
+    );
+    accounts.insert(
+        owner_shares,
+        spl_token_account(fixture.share_mint, owner, 10),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = withdraw_ix(&fixture, owner, owner_shares, owner_underlying, 11);
+    context.process_and_validate_instruction(
+        &ix,
+        &[vault_error(vault::DemoVaultError::InsufficientShares)],
+    );
+}
+
+#[test]
+fn mollusk_withdraw_from_empty_vault_rejects() {
+    // Empty vault: supply is 0, so nobody can own shares; a withdraw of 1 fails
+    // the ownership check before any burn/transfer.
+    let fixture = VaultFixture::new();
+    let owner = Pubkey::new_unique();
+    let owner_underlying = Pubkey::new_unique();
+    let owner_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_underlying,
+        spl_token_account(fixture.underlying_mint, owner, 0),
+    );
+    accounts.insert(
+        owner_shares,
+        spl_token_account(fixture.share_mint, owner, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = withdraw_ix(&fixture, owner, owner_shares, owner_underlying, 1);
+    context.process_and_validate_instruction(
+        &ix,
+        &[vault_error(vault::DemoVaultError::InsufficientShares)],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// account-constraint rejects (has_one / token-account constraints)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mollusk_deposit_wrong_mint_token_account_rejects() {
+    let fixture = VaultFixture::new();
+    let other_mint = Pubkey::new_unique();
+    let depositor = Pubkey::new_unique();
+    let depositor_underlying = Pubkey::new_unique();
+    let depositor_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(depositor, system_account(1_000_000_000));
+    accounts.insert(other_mint, spl_mint_account(None, 0));
+    // Source token account is for a different mint than the vault's underlying.
+    accounts.insert(
+        depositor_underlying,
+        spl_token_account(other_mint, depositor, 1_000),
+    );
+    accounts.insert(
+        depositor_shares,
+        spl_token_account(fixture.share_mint, depositor, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = deposit_ix(
+        &fixture,
+        depositor,
+        depositor_underlying,
+        depositor_shares,
+        1_000,
+    );
+    context
+        .process_and_validate_instruction(&ix, &[vault_error(vault::DemoVaultError::MintMismatch)]);
+}
+
+#[test]
+fn mollusk_withdraw_foreign_share_mint_rejects() {
+    let fixture = VaultFixture::new();
+    let foreign = VaultFixture::new();
+    let owner = Pubkey::new_unique();
+    let owner_underlying = Pubkey::new_unique();
+    let owner_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    // Bring in a foreign vault's share mint and a matching owner share account.
+    accounts.insert(
+        foreign.share_mint,
+        spl_mint_account(Some(foreign.vault_authority), 1_000),
+    );
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_underlying,
+        spl_token_account(fixture.underlying_mint, owner, 0),
+    );
+    accounts.insert(
+        owner_shares,
+        spl_token_account(foreign.share_mint, owner, 1_000),
+    );
+    let context = mollusk().with_context(accounts);
+
+    // Pass the foreign share mint where the vault expects its own -> has_one fails.
+    let ix = anchor_ix(
+        vault::accounts::Withdraw {
+            owner,
+            vault: fixture.vault,
+            vault_authority: fixture.vault_authority,
+            underlying_mint: fixture.underlying_mint,
+            share_mint: foreign.share_mint,
+            owner_shares,
+            vault_token_account: fixture.vault_token_account,
+            owner_underlying,
+            token_program: spl_token::id(),
+        },
+        vault::instruction::Withdraw { shares: 100 },
+    );
+    context.process_and_validate_instruction(
+        &ix,
+        &[vault_error(vault::DemoVaultError::ShareMintMismatch)],
+    );
+}
+
+#[test]
+fn mollusk_harvest_wrong_vault_token_account_rejects() {
+    let fixture = VaultFixture::new();
+    let foreign = VaultFixture::new();
+    let donor = Pubkey::new_unique();
+    let donor_underlying = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    // A valid token account for the right mint/authority but NOT the vault's recorded one.
+    accounts.insert(
+        foreign.vault_token_account,
+        spl_token_account(fixture.underlying_mint, fixture.vault_authority, 0),
+    );
+    accounts.insert(donor, system_account(1_000_000_000));
+    accounts.insert(
+        donor_underlying,
+        spl_token_account(fixture.underlying_mint, donor, 1_000),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = anchor_ix(
+        vault::accounts::Harvest {
+            donor,
+            vault: fixture.vault,
+            underlying_mint: fixture.underlying_mint,
+            donor_underlying,
+            vault_token_account: foreign.vault_token_account,
+            token_program: spl_token::id(),
+        },
+        vault::instruction::Harvest { amount: 1_000 },
+    );
+    context.process_and_validate_instruction(
+        &ix,
+        &[vault_error(
+            vault::DemoVaultError::VaultTokenAccountMismatch,
+        )],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cost snapshots
+// ---------------------------------------------------------------------------
+
+fn assert_deposit_cost(profile: &str, result: &InstructionResult, ix: &Instruction) {
+    cost_snapshot::assert_cost_snapshot("vault_mollusk", profile, ix, result);
+}
+
+#[test]
+fn cost_snapshot_deposit() {
+    let fixture = VaultFixture::fixed(0x11);
+    let depositor = Pubkey::new_from_array([0x21; 32]);
+    let depositor_underlying = Pubkey::new_from_array([0x22; 32]);
+    let depositor_shares = Pubkey::new_from_array([0x23; 32]);
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(depositor, system_account(1_000_000_000));
+    accounts.insert(
+        depositor_underlying,
+        spl_token_account(fixture.underlying_mint, depositor, 1_000),
+    );
+    accounts.insert(
+        depositor_shares,
+        spl_token_account(fixture.share_mint, depositor, 0),
+    );
+    let context = mollusk().with_context(accounts);
+    let ix = deposit_ix(
+        &fixture,
+        depositor,
+        depositor_underlying,
+        depositor_shares,
+        1_000,
+    );
+    let result = context.process_and_validate_instruction(&ix, &[Check::success()]);
+    assert_deposit_cost("deposit", &result, &ix);
+}
+
+#[test]
+fn cost_snapshot_withdraw() {
+    let fixture = VaultFixture::fixed(0x31);
+    let owner = Pubkey::new_from_array([0x41; 32]);
+    let owner_underlying = Pubkey::new_from_array([0x42; 32]);
+    let owner_shares = Pubkey::new_from_array([0x43; 32]);
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_underlying,
+        spl_token_account(fixture.underlying_mint, owner, 0),
+    );
+    accounts.insert(
+        owner_shares,
+        spl_token_account(fixture.share_mint, owner, 1_000),
+    );
+    let context = mollusk().with_context(accounts);
+    let ix = withdraw_ix(&fixture, owner, owner_shares, owner_underlying, 500);
+    let result = context.process_and_validate_instruction(&ix, &[Check::success()]);
+    assert_deposit_cost("withdraw", &result, &ix);
+}
+
+#[test]
+fn cost_snapshot_harvest() {
+    let fixture = VaultFixture::fixed(0x51);
+    let donor = Pubkey::new_from_array([0x61; 32]);
+    let donor_underlying = Pubkey::new_from_array([0x62; 32]);
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    accounts.insert(donor, system_account(1_000_000_000));
+    accounts.insert(
+        donor_underlying,
+        spl_token_account(fixture.underlying_mint, donor, 1_000),
+    );
+    let context = mollusk().with_context(accounts);
+    let ix = harvest_ix(&fixture, donor, donor_underlying, 1_000);
+    let result = context.process_and_validate_instruction(&ix, &[Check::success()]);
+    assert_deposit_cost("harvest", &result, &ix);
+}


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1756. Part of the confidential-vault demo epic (fhevm-internal#1754).

## What

A new `demo-vault` program: the smallest honest version of the vault shape every major Solana venue uses. One state account, a PDA authority that owns the underlying token account and the share mint, and four permissionless instructions:

- `initialize_vault` — one-time setup; share mint, vault token account, and authority are all PDAs seeded from the vault key (deterministic addresses, no fresh keypairs — this makes the batcher CPI integration trivial).
- `deposit(amount)` — transfer underlying in, mint shares at the current price.
- `withdraw(shares)` — burn shares, pay underlying out at the current price.
- `harvest(amount)` — donate underlying with no shares minted, so the share price rises. This is the demo's simulated yield.

The instruction interface mirrors Jupiter Earn's shape (asset/share duality, share mint + PDA authority), so the confidential batcher integrates against a realistic ABI and can be retargeted at a real venue later.

## Design

- **Balance-based accounting.** Total assets are read live from the vault token account and total shares from the mint supply — nothing is mirrored in state. This makes permissionless `harvest` correct by construction: a donation is just a transfer, and any raw SPL transfer into the vault account is equivalent to one (a harmless price rise).
- **Share price computed on the fly, never stored.** Both instructions read balances before any CPI, so shares are always priced on pre-transfer state.
- **Rounding floors in both directions** (protocol-favoring), u128 intermediates, checked math with explicit errors; deposits or withdrawals that round to zero are rejected rather than confiscated.
- **+1/+1 virtual offset** against the first-depositor inflation attack, with a regression test asserting the attacker exits at a loss. Known limit (accepted for the PoC, as specified in the issue): the minimal offset makes the attack unprofitable for the attacker but does not bound the victim's loss to dust under extreme donations.
- **Standalone.** Depends on anchor-lang + anchor-spl only — no zama-host, no confidential-token. The host-listener never ingests demo-vault events, so the program is (correctly) outside the ABI-pinning gate's scope.

## Tests

`vault_mollusk.rs` (14 tests) + 6 in-program math unit tests: init, first-deposit 1:1, deposit/withdraw round-trip returns exactly the principal, harvest raises the price for later depositors, inflation-attack regression (victim keeps shares AND attacker exits at a loss), zero-amount/insufficient-shares/empty-vault rejects, wrong-mint / foreign-share-mint / wrong-vault-token-account constraint rejects, and three cost snapshots (with fixed fixture keys so PDA-bump search cost is deterministic).

Full suite: 738 passed, 0 failed. Clippy zero warnings, fmt clean, ABI/IDL checks in sync, program_autofixer clean.
