### PR TITLE
ci(common): route solana-e2e compose builds through sccache

### DIFF
--- a/.github/workflows/solana-e2e.yml
+++ b/.github/workflows/solana-e2e.yml
@@ -31,7 +31,9 @@ concurrency:
 jobs:
   solana-e2e:
     name: solana-e2e/full-vertical${{ matrix.reconstruct && '-reconstruct' || '' }}
-    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=160gb
+    # extras=s3-cache is the RunsOn S3 build-cache extra (same one main's docker-build runners use);
+    # it provisions the runner's access to the sccache S3 bucket wired into clean-e2e.sh below.
+    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=160gb/extras=s3-cache
     timeout-minutes: 120
     strategy:
       matrix:
@@ -118,7 +120,39 @@ jobs:
         # realpath-resolves that link to sdk/js-sdk/src and finds @noble/* by walking up from there.
         run: bun install --frozen-lockfile
 
+      - name: Cache host-side cargo builds (host-listener + live-client)
+        # setup-solana-side.sh compiles the host-listener (coprocessor/fhevm-engine/target) and the
+        # live-client (solana/scripts/e2e/live-client/target) natively on the runner, plus the
+        # shared cargo registry/git. Cache them so a cold runner reuses prior compilation. Same
+        # pinned action + key shape as solana-tests.yml, distinct `-solana-e2e-host-` key.
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            coprocessor/fhevm-engine/target
+            solana/scripts/e2e/live-client/target
+          key: ${{ runner.os }}-cargo-solana-e2e-host-${{ hashFiles('coprocessor/fhevm-engine/Cargo.lock', 'solana/scripts/e2e/live-client/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-solana-e2e-host-
+
       - name: Bring up fresh stack + Solana side (clean-e2e.sh)
+        # sccache S3 cache for the source-built Rust images (coprocessor + kms-connector). The
+        # bucket/region/prefix mirror main's publishing CI (zama-ai/ci-templates common-docker.yml)
+        # so builds share the same cache; the AWS creds reach docker as BuildKit secrets sourced
+        # from these env vars (fhevm-cli wires the compose `secrets:` plumbing). Keeping the creds in
+        # step-level env (not inline) is the zizmor-clean pattern for run steps.
+        env:
+          # Only set the bucket when BOTH S3-cache creds are actually present (they are empty on
+          # fork PRs / Dependabot, and one missing secret would activate sccache with a broken
+          # credential). Empty bucket -> fhevm-cli's sccacheEnabled() gate is false -> compose
+          # is byte-identical and the Dockerfile hook falls back to a plain build, so the whole chain
+          # degrades by design without relying on sccache's own handling of unusable S3 creds. This
+          # mirrors main's common-docker.yml, which passes the bucket only alongside the creds.
+          SCCACHE_BUCKET: ${{ secrets.AWS_ACCESS_KEY_S3_USER != '' && secrets.AWS_SECRET_KEY_S3_USER != '' && 'gh-actions-cache-eu-west-3' || '' }} # zizmor: ignore[secrets-outside-env] gates the bucket on both creds being present, same creds scoped to this step's env below
+          SCCACHE_REGION: eu-west-3
+          SCCACHE_S3_PREFIX: sccache/fhevm-coprocessor
+          AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }} # zizmor: ignore[secrets-outside-env] sccache S3 cache creds scoped to this step's env, same pattern as the registry logins above
+          AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }} # zizmor: ignore[secrets-outside-env] sccache S3 cache creds scoped to this step's env, same pattern as the registry logins above
         run: bash solana/scripts/e2e/clean-e2e.sh
 
       - name: Ensure @fhevm/sdk runtime deps resolve for full-vertical

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -63,9 +63,35 @@ FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
 
 ARG CARGO_PROFILE=release
 ARG BUILD_ID=unknown
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION=eu-west-3
+ARG SCCACHE_S3_PREFIX
+ARG SCCACHE_VERSION=v0.15.0
+ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_REGION=${SCCACHE_REGION}
+ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
+ENV AWS_REGION=${SCCACHE_REGION}
 
 USER root
 WORKDIR /app
+
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
+RUN set -eux; \
+    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-musl ;; \
+        aarch64) triple=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
+    chmod +x /usr/local/bin/sccache; \
+    sccache --version
 
 # Copy contract artifacts from contract_builder stage
 COPY --from=contract_builder /app/host-contracts/artifacts/contracts /app/host-contracts/artifacts/contracts
@@ -99,9 +125,17 @@ WORKDIR /app/coprocessor/fhevm-engine
 # instead of re-downloading. gw-listener does not depend on tfhe, so this serial step stays small.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=sccache_aws_access_key_id \
+    --mount=type=secret,id=sccache_aws_secret_access_key \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
+      export RUSTC_WRAPPER=sccache; \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
+      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
+    fi && \
     cargo fetch && \
     SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p gw-listener && \
     SQLX_OFFLINE=true BUILD_ID=${BUILD_ID} cargo build --profile=${CARGO_PROFILE} --workspace && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     mkdir -p /out && \
     cp target/${CARGO_PROFILE}/tfhe_worker /out/ && \
     cp target/${CARGO_PROFILE}/host_listener /out/ && \
@@ -118,13 +152,48 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # =============================================================================
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS sqlx_builder
 
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION=eu-west-3
+ARG SCCACHE_S3_PREFIX
+ARG SCCACHE_VERSION=v0.15.0
+ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_REGION=${SCCACHE_REGION}
+ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
+ENV AWS_REGION=${SCCACHE_REGION}
+
 USER root
 WORKDIR /app
 
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
+RUN set -eux; \
+    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-musl ;; \
+        aarch64) triple=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
+    chmod +x /usr/local/bin/sccache; \
+    sccache --version
+
 # Install sqlx-cli
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=secret,id=sccache_aws_access_key_id \
+    --mount=type=secret,id=sccache_aws_secret_access_key \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
+      export RUSTC_WRAPPER=sccache; \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
+      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
+    fi && \
     cargo install sqlx-cli --version 0.7.2 \
-    --no-default-features --features postgres,rustls --locked
+    --no-default-features --features postgres,rustls --locked && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi
 
 # =============================================================================
 # Stage 2a: tfhe-worker runtime

--- a/kms-connector/Dockerfile.workspace
+++ b/kms-connector/Dockerfile.workspace
@@ -31,9 +31,35 @@ ARG RUST_IMAGE_VERSION=1.91.0
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION=eu-west-3
+ARG SCCACHE_S3_PREFIX
+ARG SCCACHE_VERSION=v0.15.0
+ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_REGION=${SCCACHE_REGION}
+ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
+ENV AWS_REGION=${SCCACHE_REGION}
 
 USER root
 WORKDIR /app
+
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
+RUN set -eux; \
+    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-musl ;; \
+        aarch64) triple=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
+    chmod +x /usr/local/bin/sccache; \
+    sccache --version
 
 COPY .git ./.git
 COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
@@ -52,6 +78,13 @@ WORKDIR /app/kms-connector
 # to /tmp in the same RUN instruction for COPY --from to work in later stages.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/kms-connector/target,sharing=locked \
+    --mount=type=secret,id=sccache_aws_access_key_id \
+    --mount=type=secret,id=sccache_aws_secret_access_key \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
+      export RUSTC_WRAPPER=sccache; \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
+      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
+    fi && \
     if [ -f /app/.git ]; then rm -f /app/.git; fi && \
     git config --global --add safe.directory '*' && \
     git config --global user.email build@local && \
@@ -63,6 +96,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     fi && \
     cargo fetch && \
     cargo build --profile=${CARGO_PROFILE} --workspace && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     mkdir -p /out && \
     cp target/${CARGO_PROFILE}/gw-listener /out/ && \
     cp target/${CARGO_PROFILE}/kms-worker /out/ && \

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -25,6 +25,12 @@ import { type StackSpec, topologyForState } from "../stack-spec/stack-spec";
 import { buildKmsThresholdOverride, kmsRenderOptionsFor } from "./kms-core";
 import type { HostChainScenario, ResolvedCoprocessorScenarioInstance, State } from "../types";
 import { ensureDir, exists, mergeArgs, readEnvFile, remove, toServiceName } from "../utils/fs";
+import {
+  sccacheBuildArgs,
+  sccacheBuildSecretIds,
+  sccacheComposeSecrets,
+  sccacheEnabled,
+} from "../utils/sccache";
 
 export type ComposeDoc = Record<string, unknown> & {
   services: Record<string, Record<string, unknown>>;
@@ -163,6 +169,40 @@ const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknow
   },
 };
 const localBuildSpecFor = (component: string, service: string) => COMPONENT_BUILD_SPECS[component]?.[service];
+
+/**
+ * Components whose Dockerfiles carry the sccache hook (the Rust workspace builds). Only these get
+ * the S3-cache build args + BuildKit secrets injected; Node/Solidity image builds (gateway/host
+ * contracts, test-suite) are left untouched.
+ */
+const SCCACHE_BUILD_COMPONENTS = new Set(["coprocessor", "kms-connector"]);
+
+/**
+ * Returns a build spec augmented with the sccache build args + secret references when sccache is
+ * enabled and the component's Dockerfile carries the hook. A no-op otherwise, so the generated
+ * compose is byte-identical when SCCACHE_BUCKET is unset. Clones the input so the shared
+ * COMPONENT_BUILD_SPECS entries are never mutated.
+ */
+const withSccacheBuild = (component: string, build: Record<string, unknown> | undefined) => {
+  if (!build || !sccacheEnabled() || !SCCACHE_BUILD_COMPONENTS.has(component)) {
+    return build;
+  }
+  const next = structuredClone(build);
+  const existingArgs = (next.args as Record<string, unknown> | undefined) ?? {};
+  next.args = { ...existingArgs, ...sccacheBuildArgs() };
+  const existingSecrets = Array.isArray(next.secrets) ? (next.secrets as string[]) : [];
+  next.secrets = [...existingSecrets, ...sccacheBuildSecretIds()];
+  return next;
+};
+
+/** Adds the top-level compose `secrets:` block for a Rust component when sccache is enabled. */
+const withSccacheSecrets = <T extends Record<string, unknown>>(component: string, doc: T): T => {
+  if (!sccacheEnabled() || !SCCACHE_BUILD_COMPONENTS.has(component)) {
+    return doc;
+  }
+  const existing = (doc.secrets as Record<string, unknown> | undefined) ?? {};
+  return { ...doc, secrets: { ...existing, ...sccacheComposeSecrets() } };
+};
 const CANONICAL_HOST_ONLY_SERVICES = new Set([
   "host-sc-trigger-keygen",
   "host-sc-trigger-crsgen",
@@ -374,7 +414,7 @@ const applyCoprocessorSource = (
 ) => {
   if (locallyBuilt) {
     service.image = retagLocal(service.image, localInstanceTag(instance.index));
-    service.build = localBuildSpecFor("coprocessor", serviceName);
+    service.build = withSccacheBuild("coprocessor", localBuildSpecFor("coprocessor", serviceName));
     return;
   }
   if (instance.source.mode === "registry") {
@@ -434,7 +474,7 @@ const buildCoprocessorOverride = async (plan: StackSpec) => {
     }
   }
   next.services = services;
-  return next;
+  return withSccacheSecrets("coprocessor", next);
 };
 
 /**
@@ -466,7 +506,7 @@ export const buildKmsConnectorOverride = async (plan: StackSpec) => {
       next.env_file = [envFileValue];
       applyBuildPolicy(next, overridden.has(name));
       if (party === 1 && overridden.has(name)) {
-        const build = localBuildSpecFor("kms-connector", name);
+        const build = withSccacheBuild("kms-connector", localBuildSpecFor("kms-connector", name));
         if (build) {
           next.build = build;
         }
@@ -482,7 +522,7 @@ export const buildKmsConnectorOverride = async (plan: StackSpec) => {
       services[serviceName] = next;
     }
   }
-  return { services };
+  return withSccacheSecrets("kms-connector", { services });
 };
 
 /** Builds the generated compose override for one component. */
@@ -508,13 +548,13 @@ const buildComposeOverride = async (component: string, plan: StackSpec) => {
     }
     const next = structuredClone(service);
     applyBuildPolicy(next, true);
-    const build = localBuildSpecFor(component, name);
+    const build = withSccacheBuild(component, localBuildSpecFor(component, name));
     if (build) {
       next.build = build;
     }
     services[name] = next;
   }
-  return { services };
+  return withSccacheSecrets(component, { services });
 };
 
 /** Builds a host-node compose override for an extra (EVM) host chain. */
@@ -624,7 +664,7 @@ const buildExtraCoprocessorListenerOverride = async (
       services[cloneName] = adjusted;
     }
   }
-  return { services };
+  return withSccacheSecrets("coprocessor", { services });
 };
 
 /** Lists which components need generated compose overrides for a runtime plan. */

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -342,4 +342,98 @@ describe("render-compose", () => {
       );
     });
   });
+
+  describe("sccache build wiring", () => {
+    const SCCACHE_ENV = {
+      SCCACHE_BUCKET: "gh-actions-cache-eu-west-3",
+      SCCACHE_REGION: "eu-west-3",
+      SCCACHE_S3_PREFIX: "sccache/fhevm-coprocessor",
+      AWS_ACCESS_KEY_S3_USER: "test-access-key",
+      AWS_SECRET_KEY_S3_USER: "test-secret-key",
+    } as const;
+
+    // Renders the coprocessor override with the given sccache env applied for the duration of the
+    // generation. Both renders below run inside the SAME temp state dir so the only differences are
+    // the sccache additions (env_file paths embed the temp dir and would otherwise differ).
+    const renderCoprocessor = async (env: Record<string, string>) => {
+      const saved = new Map<string, string | undefined>();
+      for (const key of Object.keys({ ...SCCACHE_ENV })) {
+        saved.set(key, process.env[key]);
+        delete process.env[key];
+      }
+      for (const [key, value] of Object.entries(env)) {
+        process.env[key] = value;
+      }
+      try {
+        await generateComposeOverrides(inheritedScenarioState, stackSpecForState(inheritedScenarioState));
+        return await readFile(composePath("coprocessor"), "utf8");
+      } finally {
+        for (const [key, value] of saved) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+      }
+    };
+
+    test("emits compose with no sccache tokens when SCCACHE_BUCKET is unset", async () => {
+      await withTempStateDir(async () => {
+        await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+        await writeFile(envPath("coprocessor"), "\n");
+        await writeFile(envPath("coprocessor.1"), "\n");
+        const raw = await renderCoprocessor({});
+        expect(raw).not.toContain("SCCACHE");
+        expect(raw).not.toContain("sccache_aws");
+        expect(raw).not.toMatch(/^secrets:/m);
+      });
+    });
+
+    test("adds only the sccache build args + secrets when SCCACHE_BUCKET is set", async () => {
+      await withTempStateDir(async () => {
+        await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+        await writeFile(envPath("coprocessor"), "\n");
+        await writeFile(envPath("coprocessor.1"), "\n");
+        const withoutEnv = await renderCoprocessor({});
+        const withEnv = await renderCoprocessor({ ...SCCACHE_ENV });
+
+        type BuildDoc = {
+          secrets?: Record<string, unknown>;
+          services: Record<string, { build?: { args?: Record<string, string>; secrets?: string[] } }>;
+        };
+        const enabled = YAML.parse(withEnv) as BuildDoc;
+
+        // Top-level secrets map BuildKit ids to the CI credential env vars.
+        expect(enabled.secrets).toEqual({
+          sccache_aws_access_key_id: { environment: "AWS_ACCESS_KEY_S3_USER" },
+          sccache_aws_secret_access_key: { environment: "AWS_SECRET_KEY_S3_USER" },
+        });
+        const hostListener = enabled.services["coprocessor-host-listener"]?.build;
+        expect(hostListener?.args).toMatchObject({
+          SCCACHE_BUCKET: "gh-actions-cache-eu-west-3",
+          SCCACHE_REGION: "eu-west-3",
+          SCCACHE_S3_PREFIX: "sccache/fhevm-coprocessor",
+        });
+        expect(hostListener?.secrets).toEqual(["sccache_aws_access_key_id", "sccache_aws_secret_access_key"]);
+
+        // Structural proof of graceful degradation: strip the sccache additions from the enabled
+        // document and it is identical to the disabled one.
+        const stripped = YAML.parse(withEnv) as BuildDoc;
+        delete stripped.secrets;
+        for (const service of Object.values(stripped.services)) {
+          if (service.build) {
+            for (const key of ["SCCACHE_BUCKET", "SCCACHE_REGION", "SCCACHE_S3_PREFIX"]) {
+              delete service.build.args?.[key];
+            }
+            if (service.build.args && Object.keys(service.build.args).length === 0) {
+              delete service.build.args;
+            }
+            delete service.build.secrets;
+          }
+        }
+        expect(stripped).toEqual(YAML.parse(withoutEnv) as BuildDoc);
+      });
+    });
+  });
 });

--- a/test-suite/fhevm/src/utils/process.ts
+++ b/test-suite/fhevm/src/utils/process.ts
@@ -4,6 +4,7 @@
 import { STATE_DIR, envPath, versionsEnvPath } from "../layout";
 import { exists, readEnvFileIfExists, type RunOptions, type RunResult } from "./fs";
 import { CommandError } from "../errors";
+import { sccacheComposeEnv } from "./sccache";
 
 /** Reads a spawned process pipe into a string when one exists. */
 const readPipe = async (stream: ReadableStream<Uint8Array> | number | null | undefined) =>
@@ -214,5 +215,8 @@ export const composeEnv = async (component: string, extra?: Record<string, strin
   const env = (await exists(versionsEnvPath))
     ? { ...(await readEnvFileIfExists(versionsEnvPath)), COMPOSE_IGNORE_ORPHANS: "true", FHEVM_STATE_DIR: STATE_DIR }
     : { COMPOSE_IGNORE_ORPHANS: "true", FHEVM_STATE_DIR: STATE_DIR };
-  return { ...env, ...(await readEnvFileIfExists(envPath(component))), ...extra };
+  // Forward the sccache S3-cache env (bucket/region/prefix + AWS creds) so `docker compose build`
+  // can resolve the environment-sourced BuildKit secrets. Empty unless SCCACHE_BUCKET is set, so
+  // the local-dev / fork build env is unchanged.
+  return { ...env, ...sccacheComposeEnv(), ...(await readEnvFileIfExists(envPath(component))), ...extra };
 };

--- a/test-suite/fhevm/src/utils/sccache.ts
+++ b/test-suite/fhevm/src/utils/sccache.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared sccache build wiring for the source-built Rust images.
+ *
+ * The coprocessor and kms-connector Dockerfiles (Dockerfile.workspace) activate the sccache
+ * compiler cache ONLY when SCCACHE_BUCKET is set at build time; otherwise they run a plain cargo
+ * build. So every helper here is gated on SCCACHE_BUCKET being present in the environment. With it
+ * unset (local dev, forks) nothing is emitted: the generated compose documents and the resulting
+ * `docker compose build` invocation are byte-for-byte identical to before.
+ *
+ * The names below mirror the publishing CI (zama-ai/ci-templates common-docker.yml @v1.0.11): the
+ * S3 bucket/region/prefix arrive as build args, and the AWS credentials arrive as BuildKit secrets
+ * sourced from the AWS_ACCESS_KEY_S3_USER / AWS_SECRET_KEY_S3_USER environment variables. Sharing
+ * the same names keeps the solana-e2e builds on the same S3 cache as main's per-image builds.
+ */
+
+/** BuildKit secret ids the Rust Dockerfiles mount for sccache S3 authentication. */
+export const SCCACHE_ACCESS_KEY_SECRET_ID = "sccache_aws_access_key_id";
+export const SCCACHE_SECRET_KEY_SECRET_ID = "sccache_aws_secret_access_key";
+
+/** Environment variables that carry the S3-cache AWS credentials (mirrors main's publishing CI). */
+export const SCCACHE_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_S3_USER";
+export const SCCACHE_SECRET_KEY_ENV = "AWS_SECRET_KEY_S3_USER";
+
+/** Build args forwarded to the Rust builder stage, in the order the Dockerfile declares them. */
+const SCCACHE_BUILD_ARG_ENV = ["SCCACHE_BUCKET", "SCCACHE_REGION", "SCCACHE_S3_PREFIX"] as const;
+
+/** True when sccache should be wired into the source builds. */
+export const sccacheEnabled = () => !!process.env.SCCACHE_BUCKET;
+
+/** Build args forwarded to the Rust builder stage (empty map when disabled). */
+export const sccacheBuildArgs = (): Record<string, string> => {
+  if (!sccacheEnabled()) {
+    return {};
+  }
+  const args: Record<string, string> = {};
+  for (const key of SCCACHE_BUILD_ARG_ENV) {
+    const value = process.env[key];
+    if (value !== undefined && value !== "") {
+      args[key] = value;
+    }
+  }
+  return args;
+};
+
+/** BuildKit secret ids a service's `build.secrets` should reference (empty when disabled). */
+export const sccacheBuildSecretIds = (): string[] =>
+  sccacheEnabled() ? [SCCACHE_ACCESS_KEY_SECRET_ID, SCCACHE_SECRET_KEY_SECRET_ID] : [];
+
+/** Top-level compose `secrets:` mapping BuildKit ids to their env sources (empty when disabled). */
+export const sccacheComposeSecrets = (): Record<string, { environment: string }> =>
+  sccacheEnabled()
+    ? {
+        [SCCACHE_ACCESS_KEY_SECRET_ID]: { environment: SCCACHE_ACCESS_KEY_ENV },
+        [SCCACHE_SECRET_KEY_SECRET_ID]: { environment: SCCACHE_SECRET_KEY_ENV },
+      }
+    : {};
+
+/** Env vars the CLI forwards to `docker compose` so environment-sourced secrets resolve (empty when disabled). */
+export const sccacheComposeEnv = (): Record<string, string> => {
+  if (!sccacheEnabled()) {
+    return {};
+  }
+  const env: Record<string, string> = {};
+  for (const key of [...SCCACHE_BUILD_ARG_ENV, SCCACHE_ACCESS_KEY_ENV, SCCACHE_SECRET_KEY_ENV]) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return env;
+};


### PR DESCRIPTION
Step 1 of zama-ai/fhevm-internal#1766.

## What

Route the `solana-e2e` job's `fhevm-cli` compose builds through S3-backed sccache, and cache the host-side cargo builds. Measured on a recent run: `clean-e2e.sh` = **40.2 min** (dominated by `docker compose build` source-compiling the whole fhevm-engine workspace, tfhe-rs included, from scratch every PR) vs **3.6 min** of actual vertical tests.

## How

- **Dockerfile hooks ported from main** (#3071, `1aa36f8cf`): `feature/solana` predates the sccache rollout, so the hooks for the two Dockerfiles the compose path builds (`coprocessor/fhevm-engine/Dockerfile.workspace`, `kms-connector/Dockerfile.workspace`) are hand-applied here — byte-identical to main's sccache hunks, preserving this branch's Solana-specific content (the `COPY solana` lines, the serial gw-listener build). The hook activates only when `SCCACHE_BUCKET` is set; otherwise the build is a plain cargo build, unchanged.
- **`fhevm-cli` forwards the contract** (`src/utils/sccache.ts`, `generate/compose.ts`, `utils/process.ts`): when the sccache env is present, the generated compose for the coprocessor and kms-connector components gains the three build args and the two BuildKit secret refs (environment-sourced, mirroring the exact ids/names main's `common-docker.yml` uses — shared bucket, not a fork). When the env is absent, the generated compose is **byte-identical to today's** — proven by a structural strip-and-compare test, not token grepping.
- **Workflow**: `extras=s3-cache` on the runner, sccache env + creds on the bring-up step, and an `actions/cache` for the host-side cargo builds (`host-listener`, `live-client`) that `setup-solana-side.sh` performs — that part pays off immediately, independent of sccache.
- **Fork safety by construction**: the bucket env is gated on secret presence (`secrets.AWS_ACCESS_KEY_S3_USER != ''`), restoring main's invariant that *bucket set ⟺ creds present*. Fork/Dependabot PRs get an empty bucket → the entire chain (CLI gate → compose generation → Dockerfile gate) degrades to today's behavior, with zero reliance on sccache's S3 error handling.
- Relayer intentionally not plumbed: its compose Dockerfile has no sccache hook even on main (#3071 only touched the relayer Makefile — a different build path). Node/Solidity image builds (gateway-contracts, host-contracts) are out of scope for a Rust compile cache.

## Expectations

The first CI run **populates** the cache (no speedup); the second run is the measurement. Before/after timings will be recorded on #1766.

## Verification

- `tsc --noEmit` clean; `bun test src` 248 pass / 0 fail (includes the two degradation tests).
- zizmor clean under default and `--persona pedantic`.
- Dockerfile port fidelity: `git diff 1aa36f8cf` on both files shows only this branch's pre-existing Solana content — the sccache portions match main exactly.
- No Rust/program/test files touched.
