### PR TITLE
fix(test-suite): bump e2e runner volume to 160gb

### DIFF
--- a/.github/workflows/test-suite-e2e-tests.yml
+++ b/.github/workflows/test-suite-e2e-tests.yml
@@ -176,7 +176,7 @@ jobs:
       ORCHESTRATED: ${{ inputs.orchestrated && 'true' || 'false' }}
       SCENARIO: ${{ inputs.scenario || 'two-of-three-multi-chain' }}
       TEST_PROFILE: ${{ inputs.test-profile || 'standard' }}
-    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=80gb
+    runs-on: runs-on=${{ github.run_id }}/runner=32cpu-linux-x64/volume=160gb
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### Summary

E2E test have been failing with `No space left on device`: https://github.com/zama-ai/fhevm/actions/runs/29768546859
This pr bumps the e2e runner volume to 160gb.