### PR TITLE
ci(common): skip unchanged solana-e2e component builds via branch-published images

### DIFF
--- a/.github/workflows/solana-e2e.yml
+++ b/.github/workflows/solana-e2e.yml
@@ -51,6 +51,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: "false"
+          # Depth 2 so the pull_request merge commit's parents are available: HEAD^1 is the base
+          # branch commit the PR is applied onto, which the override selection below diffs against
+          # and whose branch-published images (:feature-solana-<sha>) it uses for untouched groups.
+          fetch-depth: 2
 
       - name: Setup Node
         # full-vertical.sh runs the @fhevm/sdk clients under `node`. node 24 realpath-resolves the
@@ -108,6 +112,16 @@ jobs:
           username: ${{ secrets.CGR_USERNAME }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as test-suite-e2e workflows
           password: ${{ secrets.CGR_PASSWORD }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as test-suite-e2e workflows
 
+      - name: Select source-built overrides (skip components this PR does not touch)
+        # #1766 step 3: build from source only the component groups whose docker-image inputs the
+        # PR changes; the rest run the branch-published images from solana-images-publish.yml.
+        # Runs after the ghcr.io login (the script probes image existence with docker manifest
+        # inspect) and only on PRs: workflow_dispatch runs keep the build-everything default in
+        # clean-e2e.sh (the selection step is skipped, so both outputs stay empty).
+        id: select-overrides
+        if: github.event_name == 'pull_request'
+        run: bash solana/scripts/e2e/select-overrides.sh "$(git rev-parse HEAD^1)"
+
       - name: Build the @fhevm/sdk ESM (full-vertical's node clients import it)
         # build:esm emits src/_esm (gitignored) + copies the TKMS WASM into it; the @fhevm/sdk
         # `./solana` export resolves there. npm ci also populates the SDK's own node_modules.
@@ -153,6 +167,10 @@ jobs:
           SCCACHE_S3_PREFIX: sccache/fhevm-coprocessor
           AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }} # zizmor: ignore[secrets-outside-env] sccache S3 cache creds scoped to this step's env, same pattern as the registry logins above
           AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }} # zizmor: ignore[secrets-outside-env] sccache S3 cache creds scoped to this step's env, same pattern as the registry logins above
+          # Override selection computed above (empty on workflow_dispatch or if the step was
+          # skipped, in which case clean-e2e.sh keeps its build-everything default).
+          SOLANA_E2E_OVERRIDES: ${{ steps.select-overrides.outputs.overrides }}
+          SOLANA_E2E_LOCK_PINS: ${{ steps.select-overrides.outputs.lock_pins }}
         run: bash solana/scripts/e2e/clean-e2e.sh
 
       - name: Ensure @fhevm/sdk runtime deps resolve for full-vertical

--- a/.github/workflows/solana-images-publish.yml
+++ b/.github/workflows/solana-images-publish.yml
@@ -1,0 +1,200 @@
+name: solana-images-publish
+
+# Publishes branch-scoped images for the five component groups that solana-e2e otherwise builds
+# from source on every PR (#1766 step 3). Each image is built with the SAME Dockerfile, target,
+# build args, and sccache wiring that fhevm-cli's --override compose builds use (the
+# COMPONENT_BUILD_SPECS table in test-suite/fhevm/src/generate/compose.ts), so a pulled image is
+# interchangeable with a source build of the same commit.
+#
+# Tags per image:
+#   ghcr.io/zama-ai/<image>:feature-solana                  floating, tracks the branch tip
+#   ghcr.io/zama-ai/<image>:feature-solana-<full-sha>       immutable, per pushed commit
+#
+# solana-e2e.yml's select-overrides step consumes ONLY the immutable tags: PRs that leave a
+# component group's source untouched pull the base commit's image instead of rebuilding it.
+# The floating tag is published for humans (manual debugging / docker pull convenience) and is
+# never consumed by selection — with fail-fast:false one failed matrix leg can leave a floating
+# tag one push behind its siblings, so consuming it could mix components across branch commits.
+on:
+  push:
+    branches: [feature/solana]
+  workflow_dispatch:
+
+permissions: {}
+
+# Queue pushes instead of racing: the floating tag must end on the newest commit. GitHub keeps
+# only the latest pending run per group, so intermediate commits may publish no immutable tag;
+# select-overrides falls back to building from source when a base-commit tag set is incomplete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish/${{ matrix.name }}
+    # extras=s3-cache provisions the sccache S3 bucket access (same as solana-e2e.yml); the Rust
+    # workspace images share main's sccache cache so rebuilds are mostly cache hits.
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/volume=100gb/extras=s3-cache
+    timeout-minutes: 90
+    permissions:
+      contents: "read" # checkout
+      packages: "write" # push repo-owned images to ghcr.io
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors COMPONENT_BUILD_SPECS in test-suite/fhevm/src/generate/compose.ts: same
+        # dockerfile/context/target/args as the --override source builds. `sccache: true` marks
+        # the specs fhevm-cli routes through withSccacheBuild (coprocessor + kms-connector).
+        include:
+          - name: gateway-contracts
+            image: fhevm/gateway-contracts
+            dockerfile: gateway-contracts/Dockerfile
+            context: gateway-contracts
+          - name: host-contracts
+            image: fhevm/host-contracts
+            dockerfile: host-contracts/Dockerfile
+            context: .
+          - name: coprocessor-db-migration
+            image: fhevm/coprocessor/db-migration
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: db-migration
+            sccache: true
+          - name: coprocessor-host-listener
+            image: fhevm/coprocessor/host-listener
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: host-listener
+            sccache: true
+          - name: coprocessor-gw-listener
+            image: fhevm/coprocessor/gw-listener
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: gw-listener
+            sccache: true
+          - name: coprocessor-tfhe-worker
+            image: fhevm/coprocessor/tfhe-worker
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: tfhe-worker
+            sccache: true
+          - name: coprocessor-zkproof-worker
+            image: fhevm/coprocessor/zkproof-worker
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: zkproof-worker
+            sccache: true
+          - name: coprocessor-sns-worker
+            image: fhevm/coprocessor/sns-worker
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: sns-worker
+            sccache: true
+          - name: coprocessor-tx-sender
+            image: fhevm/coprocessor/tx-sender
+            dockerfile: coprocessor/fhevm-engine/Dockerfile.workspace
+            context: .
+            target: transaction-sender
+            sccache: true
+          - name: relayer
+            image: fhevm/relayer
+            dockerfile: relayer/docker/relayer/Dockerfile
+            context: .
+          - name: relayer-migrate
+            image: fhevm/relayer-migrate
+            dockerfile: relayer/docker/relayer-migrate/Dockerfile
+            context: .
+          - name: kms-connector-db-migration
+            image: fhevm/kms-connector/db-migration
+            dockerfile: kms-connector/connector-db/Dockerfile
+            context: .
+            build_args: "RUST_IMAGE_VERSION=1.91.0"
+            sccache: true
+          - name: kms-connector-gw-listener
+            image: fhevm/kms-connector/gw-listener
+            dockerfile: kms-connector/Dockerfile.workspace
+            context: .
+            target: gw-listener
+            build_args: "RUST_IMAGE_VERSION=1.91.0"
+            sccache: true
+          - name: kms-connector-kms-worker
+            image: fhevm/kms-connector/kms-worker
+            dockerfile: kms-connector/Dockerfile.workspace
+            context: .
+            target: kms-worker
+            build_args: "RUST_IMAGE_VERSION=1.91.0"
+            sccache: true
+          - name: kms-connector-tx-sender
+            image: fhevm/kms-connector/tx-sender
+            dockerfile: kms-connector/Dockerfile.workspace
+            context: .
+            target: tx-sender
+            build_args: "RUST_IMAGE_VERSION=1.91.0"
+            sccache: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: "false"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Login to ghcr.io
+        # GITHUB_TOKEN with packages:write pushes repo-owned fhevm/* images (same pattern as
+        # re-tag-docker-image.yml). Also covers pulling the gci base images.
+        uses: zama-ai/ci-templates/.github/actions/retry@542103e14b9ae6a9aea27787b8724b3b35bb3918 # v1.0.9
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          command: |
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+      - name: Login to cgr.dev
+        # Chainguard base images (glibc-dynamic, postgres, rust) used by every runtime stage.
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CGR_USERNAME }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as solana-e2e.yml
+          password: ${{ secrets.CGR_PASSWORD }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as solana-e2e.yml
+
+      - name: Build and push
+        env:
+          IMAGE: ${{ matrix.image }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+          CONTEXT: ${{ matrix.context }}
+          TARGET: ${{ matrix.target || '' }}
+          EXTRA_BUILD_ARGS: ${{ matrix.build_args || '' }}
+          USE_SCCACHE: ${{ matrix.sccache && 'true' || 'false' }}
+          # Same gating as solana-e2e.yml: activate sccache only when BOTH S3 creds are present,
+          # so a fork/misconfigured run degrades to a plain (slower) build instead of failing.
+          SCCACHE_BUCKET: ${{ secrets.AWS_ACCESS_KEY_S3_USER != '' && secrets.AWS_SECRET_KEY_S3_USER != '' && 'gh-actions-cache-eu-west-3' || '' }} # zizmor: ignore[secrets-outside-env] gates the bucket on both creds being present, same pattern as solana-e2e.yml
+          SCCACHE_REGION: eu-west-3
+          SCCACHE_S3_PREFIX: sccache/fhevm-coprocessor
+          AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }} # zizmor: ignore[secrets-outside-env] sccache S3 creds scoped to this step's env, same pattern as solana-e2e.yml
+          AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }} # zizmor: ignore[secrets-outside-env] sccache S3 creds scoped to this step's env, same pattern as solana-e2e.yml
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          args=(--file "$DOCKERFILE")
+          if [ -n "$TARGET" ]; then
+            args+=(--target "$TARGET")
+          fi
+          for arg in $EXTRA_BUILD_ARGS; do
+            args+=(--build-arg "$arg")
+          done
+          if [ "$USE_SCCACHE" = "true" ] && [ -n "$SCCACHE_BUCKET" ]; then
+            # Same build args + BuildKit secret ids as test-suite/fhevm/src/utils/sccache.ts.
+            args+=(
+              --build-arg "SCCACHE_BUCKET=$SCCACHE_BUCKET"
+              --build-arg "SCCACHE_REGION=$SCCACHE_REGION"
+              --build-arg "SCCACHE_S3_PREFIX=$SCCACHE_S3_PREFIX"
+              --secret "id=sccache_aws_access_key_id,env=AWS_ACCESS_KEY_S3_USER"
+              --secret "id=sccache_aws_secret_access_key,env=AWS_SECRET_KEY_S3_USER"
+            )
+          fi
+          docker buildx build "${args[@]}" \
+            --tag "ghcr.io/zama-ai/$IMAGE:feature-solana" \
+            --tag "ghcr.io/zama-ai/$IMAGE:feature-solana-$SHA" \
+            --push "$CONTEXT"

--- a/solana/scripts/e2e/clean-e2e.sh
+++ b/solana/scripts/e2e/clean-e2e.sh
@@ -15,7 +15,8 @@
 # The kms-core image carrying `compute_link_solana` is pinned in the lock; its tag is the
 # single source of truth in test-suite/fhevm/solana-images.env (kms-core is not an fhevm
 # override group). The five source-built groups are passed as --override so they build from
-# THIS worktree:
+# THIS worktree (by default — CI narrows the set via SOLANA_E2E_OVERRIDES/SOLANA_E2E_LOCK_PINS,
+# substituting branch-published images for groups the PR does not touch, see select-overrides.sh):
 #   - gateway-contracts : userDecryptionRequestSolana + verifyProofRequestSolana
 #   - host-contracts    : must track HEAD because the source-built kms-connector's gw-listener
 #                         reads ProtocolConfig.getCurrentKmsContextAndEpoch() at startup (the
@@ -36,6 +37,24 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 FHEVM="$ROOT/test-suite/fhevm"
+
+# CI seam (#1766): which of the five source-built groups build from THIS worktree (--override),
+# and optional KEY=TAG lock-env pins pointing the remaining groups at branch-published images
+# (select-overrides.sh computes both in CI). Local runs keep the build-everything default; set
+# SOLANA_E2E_OVERRIDES to "none" for an explicit empty override list.
+SOLANA_E2E_OVERRIDES="${SOLANA_E2E_OVERRIDES:-gateway-contracts host-contracts coprocessor relayer kms-connector}"
+SOLANA_E2E_LOCK_PINS="${SOLANA_E2E_LOCK_PINS:-}"
+if [ "$SOLANA_E2E_OVERRIDES" = "none" ]; then
+  SOLANA_E2E_OVERRIDES=""
+fi
+OVERRIDE_ARGS=()
+for group in $SOLANA_E2E_OVERRIDES; do
+  OVERRIDE_ARGS+=(--override "$group")
+done
+echo "[clean-e2e] source-built overrides: ${SOLANA_E2E_OVERRIDES:-<none>}"
+if [ -n "$SOLANA_E2E_LOCK_PINS" ]; then
+  echo "[clean-e2e] lock pins for published images: $SOLANA_E2E_LOCK_PINS"
+fi
 # Pin the EVM stack to the main SHA this PoC was validated against. RFC-021 / Solana host support
 # is not yet on a release bundle, so we resolve a specific main commit explicitly.
 BASE_SHA="feaf86e"
@@ -47,15 +66,20 @@ LOCK="$ROOT/.fhevm/state/locks/sha-$BASE_SHA.json"
 
 # 1. Pin the Solana-capable kms-core image in the lock (idempotent).
 #    CORE_VERSION comes from the single source of truth so it cannot drift from the TS call sites.
+#    SOLANA_E2E_LOCK_PINS additionally repoints non-overridden groups at branch-published image
+#    tags (space-separated KEY=TAG entries, see select-overrides.sh).
 # shellcheck source=/dev/null
 source "$FHEVM/solana-images.env"
-python3 - "$LOCK" "$CORE_VERSION" <<'PY'
+# shellcheck disable=SC2086 # SOLANA_E2E_LOCK_PINS is a space-separated KEY=TAG list, one arg each
+python3 - "$LOCK" "CORE_VERSION=$CORE_VERSION" $SOLANA_E2E_LOCK_PINS <<'PY'
 import json, sys
-p, core = sys.argv[1], sys.argv[2]
+p = sys.argv[1]
 d = json.load(open(p))
-d["env"]["CORE_VERSION"] = core
+for pin in sys.argv[2:]:
+    key, _, tag = pin.partition("=")
+    d["env"][key] = tag
+    print(f"[clean-e2e] pinned {key}={tag} in {p}")
 json.dump(d, open(p, "w"), indent=2)
-print(f"[clean-e2e] pinned CORE_VERSION={core} in {p}")
 PY
 
 # 2. Clean rebuild of the whole EVM stack with the Solana code baked in from bootstrap.
@@ -65,16 +89,13 @@ PY
 ( cd "$FHEVM" && ./fhevm-cli up \
     --scenario solana \
     --lock-file "$LOCK" \
-    --override gateway-contracts \
-    --override host-contracts \
-    --override coprocessor \
-    --override relayer \
-    --override kms-connector \
+    ${OVERRIDE_ARGS[@]+"${OVERRIDE_ARGS[@]}"} \
     --allow-schema-mismatch )
-# NOTE: relayer + kms-connector must be built from source, NOT pulled from the pinned 4f42734
+# NOTE: relayer + kms-connector must run feature/solana code, NOT the pinned 4f42734 baseline
 # images: the prebuilt kms-connector at that tag rejects the generated Solana host_chains config
 # ("missing field acl_address") — its config schema predates the optional-acl_address change the
-# config generator (src/generate/solana.ts) assumes. Dropping these --overrides breaks clean-e2e.
+# config generator (src/generate/solana.ts) assumes. Dropping these --overrides breaks clean-e2e
+# unless SOLANA_E2E_LOCK_PINS points them at branch-published feature/solana images instead.
 
 # 3. Bring the Solana side-stack online against the freshly-deployed live backend.
 #    Reads gateway addresses + KMS/coprocessor signer set live, so it tracks the new signer.

--- a/solana/scripts/e2e/select-overrides.sh
+++ b/solana/scripts/e2e/select-overrides.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# select-overrides.sh — decide which of the five source-built solana-e2e component groups must be
+# built from this worktree (fhevm-cli --override) and which can run the branch-published images
+# that solana-images-publish.yml pushes on every push to feature/solana.
+#
+# Usage (from CI, after `docker login ghcr.io`):
+#   solana/scripts/e2e/select-overrides.sh <base-sha>
+#     <base-sha>: full SHA of the commit the PR is applied onto (parent 1 of the pull_request
+#                 merge commit that actions/checkout checks out).
+#
+# Selection rule:
+#   1. Diff <base-sha>..HEAD and map changed paths to the five groups (see path map below).
+#      Paths that affect the build recipe itself (this script, the e2e/publish workflows,
+#      test-suite/fhevm, clean-e2e.sh) force building everything.
+#   2. Groups whose image inputs changed are built from source (--override), exactly as before.
+#   3. The untouched groups run the immutable base-commit images
+#      `ghcr.io/zama-ai/fhevm/<image>:feature-solana-<base-sha>` (bit-for-bit the code the PR is
+#      rebased onto) — but only if EVERY such image exists. If any is missing (first run ever,
+#      publish still running, or the base commit was skipped by the publish queue), fall back to
+#      building everything from source — never a broken run. The floating `:feature-solana` tag
+#      is deliberately NOT consumed here: the publish matrix is fail-fast:false, so one failed
+#      image job can leave that tag pointing at a previous push while sibling images advance,
+#      and consuming it could silently mix components from different branch commits.
+#
+# Outputs (printed as key=value; appended to $GITHUB_OUTPUT when set):
+#   overrides  space-separated group list to pass as --override, or "none" when every group
+#              runs published images (SOLANA_E2E_OVERRIDES in clean-e2e.sh uses the same encoding)
+#   lock_pins  space-separated KEY=TAG lock-env pins for the non-overridden groups (may be empty)
+#
+# Test seams:
+#   CHANGED_FILES     newline-separated changed-file list; skips the git diff when set
+#   MANIFEST_INSPECT  command probing image existence (default: docker manifest inspect)
+set -euo pipefail
+
+BASE_SHA="${1:?usage: select-overrides.sh <base-sha>}"
+BASE_TAG="feature-solana-$BASE_SHA"
+
+GROUPS_ALL=(gateway-contracts host-contracts coprocessor relayer kms-connector)
+
+# Lock env keys per group (test-suite/fhevm/src/resolve/target.ts REPO_PACKAGES): pinning these in
+# the lock makes the non-overridden compose services pull the branch image instead of the pinned
+# main baseline. RELAYER_IMAGE_REPOSITORY is derived from RELAYER_VERSION by fhevm-cli (unparsed
+# tags resolve to the modern ghcr.io/zama-ai/fhevm/relayer repository), so only versions are pinned.
+lock_keys_for() {
+  case "$1" in
+    gateway-contracts) echo "GATEWAY_VERSION" ;;
+    host-contracts) echo "HOST_VERSION" ;;
+    coprocessor) echo "COPROCESSOR_DB_MIGRATION_VERSION COPROCESSOR_HOST_LISTENER_VERSION COPROCESSOR_GW_LISTENER_VERSION COPROCESSOR_TFHE_WORKER_VERSION COPROCESSOR_ZKPROOF_WORKER_VERSION COPROCESSOR_SNS_WORKER_VERSION COPROCESSOR_TX_SENDER_VERSION" ;;
+    relayer) echo "RELAYER_VERSION RELAYER_MIGRATE_VERSION" ;;
+    kms-connector) echo "CONNECTOR_DB_MIGRATION_VERSION CONNECTOR_GW_LISTENER_VERSION CONNECTOR_KMS_WORKER_VERSION CONNECTOR_TX_SENDER_VERSION" ;;
+    *) echo "unknown group $1" >&2; return 1 ;;
+  esac
+}
+
+# ghcr.io/zama-ai/<image> repositories per group; must stay in sync with solana-images-publish.yml.
+images_for() {
+  case "$1" in
+    gateway-contracts) echo "fhevm/gateway-contracts" ;;
+    host-contracts) echo "fhevm/host-contracts" ;;
+    coprocessor) echo "fhevm/coprocessor/db-migration fhevm/coprocessor/host-listener fhevm/coprocessor/gw-listener fhevm/coprocessor/tfhe-worker fhevm/coprocessor/zkproof-worker fhevm/coprocessor/sns-worker fhevm/coprocessor/tx-sender" ;;
+    relayer) echo "fhevm/relayer fhevm/relayer-migrate" ;;
+    kms-connector) echo "fhevm/kms-connector/db-migration fhevm/kms-connector/gw-listener fhevm/kms-connector/kms-worker fhevm/kms-connector/tx-sender" ;;
+    *) echo "unknown group $1" >&2; return 1 ;;
+  esac
+}
+
+# Path -> groups map. Derived from the docker build inputs of each image:
+#   - coprocessor (coprocessor/fhevm-engine/Dockerfile.workspace COPY lines): coprocessor/,
+#     listener/, gateway-contracts/, host-contracts/, shared/ciphertext-attestation, solana Rust
+#     tree, root package files. The solana crates/programs reach the binaries through
+#     host-listener/Cargo.toml (zama-host, zama-solana-acl, zama-solana-transaction) and
+#     tfhe-worker/Cargo.toml (confidential-token, zama-host, zama-fhe).
+#   - kms-connector (kms-connector/Dockerfile.workspace + connector-db/Dockerfile COPY lines):
+#     kms-connector/, both rust_bindings, shared/, and ONLY solana/crates/zama-solana-acl of the
+#     solana tree (its Cargo.toml deliberately avoids workspace inheritance), hence the dedicated
+#     zama-solana-acl rule below instead of the general solana fan-out.
+#   - relayer (relayer/docker/relayer[-migrate]/Dockerfile bind mounts): relayer/, both
+#     rust_bindings, shared/user-decryption-signature, whole solana Rust tree (zama-host +
+#     transitive path deps via relayer/Cargo.toml).
+#   - gateway-contracts / host-contracts images: their own trees + root package files.
+# Non-Rust solana/ paths (scripts, geyser, docs, runtime-tests, test-fixtures) are copied into
+# builder stages at most but never reach the runtime images, so they trigger no rebuild. Programs
+# that no image consumes (demo-vault, confidential-deposit-app) are none-ruled explicitly; any
+# FUTURE program falls into the general solana/programs/* rule and is over-built by default.
+groups_for_path() {
+  local path="$1"
+  case "$path" in
+    # Build-recipe changes: rebuild everything (a stale published image could mask the change).
+    solana/scripts/e2e/select-overrides.sh|solana/scripts/e2e/clean-e2e.sh|.github/workflows/solana-e2e.yml|.github/workflows/solana-images-publish.yml|test-suite/fhevm/*|package.json|package-lock.json)
+      echo "all" ;;
+    coprocessor/*) echo "coprocessor" ;;
+    listener/*) echo "coprocessor" ;;
+    kms-connector/*) echo "kms-connector" ;;
+    relayer/*) echo "relayer" ;;
+    gateway-contracts/*) echo "gateway-contracts coprocessor kms-connector relayer" ;;
+    host-contracts/*) echo "host-contracts coprocessor kms-connector relayer" ;;
+    shared/*) echo "coprocessor kms-connector relayer" ;;
+    # On-chain-only demo programs: no docker image compiles them (checked against the Cargo.tomls
+    # and Dockerfile COPY lines cited above).
+    solana/programs/demo-vault/*|solana/programs/confidential-deposit-app/*) echo "" ;;
+    # The one solana crate the kms-connector image consumes (Dockerfile.workspace line ~72).
+    solana/crates/zama-solana-acl/*) echo "coprocessor kms-connector relayer" ;;
+    solana/programs/*|solana/crates/*|solana/Cargo.toml|solana/Cargo.lock) echo "coprocessor relayer" ;;
+    *) echo "" ;;
+  esac
+}
+
+if [ -z "${CHANGED_FILES+x}" ]; then
+  # --no-renames is load-bearing: with rename detection, a pure move is listed only under its NEW
+  # path, so moving a file OUT of a mapped tree (e.g. coprocessor/ -> sdk/) would change the image
+  # contents without touching a mapped path and the stale published image would test false-green.
+  # Disabling detection lists a move as delete(old)+add(new), so both sides hit the map.
+  CHANGED_FILES="$(git diff --name-only --no-renames "$BASE_SHA" HEAD)"
+fi
+
+touched=""
+build_all=false
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  groups="$(groups_for_path "$file")"
+  if [ "$groups" = "all" ]; then
+    echo "[select-overrides] $file changes the build recipe -> building all groups from source"
+    build_all=true
+    break
+  fi
+  for group in $groups; do
+    case " $touched " in *" $group "*) ;; *) touched="$touched $group" ;; esac
+  done
+done <<< "$CHANGED_FILES"
+
+untouched=""
+if [ "$build_all" = true ]; then
+  touched="${GROUPS_ALL[*]}"
+else
+  touched="${touched# }"
+  for group in "${GROUPS_ALL[@]}"; do
+    case " $touched " in *" $group "*) ;; *) untouched="$untouched $group" ;; esac
+  done
+  untouched="${untouched# }"
+fi
+echo "[select-overrides] source-changed groups: ${touched:-<none>}"
+echo "[select-overrides] unchanged groups:      ${untouched:-<none>}"
+
+manifest_exists() {
+  ${MANIFEST_INSPECT:-docker manifest inspect} "$1" > /dev/null 2>&1
+}
+
+# All published images for the unchanged groups must exist at one tag; mixing tags across groups
+# could pair components from different base commits.
+all_images_exist_at() {
+  local tag="$1" group image
+  for group in $untouched; do
+    for image in $(images_for "$group"); do
+      if ! manifest_exists "ghcr.io/zama-ai/$image:$tag"; then
+        echo "[select-overrides] missing ghcr.io/zama-ai/$image:$tag"
+        return 1
+      fi
+    done
+  done
+}
+
+selected_tag=""
+if [ -n "$untouched" ]; then
+  if all_images_exist_at "$BASE_TAG"; then
+    selected_tag="$BASE_TAG"
+    echo "[select-overrides] using base-commit images :$BASE_TAG for unchanged groups"
+  else
+    # No complete base-commit image set (first run ever, publish still running, or the base
+    # commit was skipped by the publish queue). The floating :feature-solana tag is NOT a
+    # fallback (see the header: a partial publish failure can leave it mixing branch commits),
+    # so build everything from source — the pre-#1766 behavior.
+    echo "[select-overrides] WARNING: no complete :$BASE_TAG image set published;" \
+      "falling back to building all groups from source (pre-#1766 behavior)." \
+      "Rerun once solana-images-publish.yml has finished for $BASE_SHA to get the skip."
+    touched="${GROUPS_ALL[*]}"
+    untouched=""
+  fi
+fi
+
+lock_pins=""
+for group in $untouched; do
+  for key in $(lock_keys_for "$group"); do
+    lock_pins="$lock_pins $key=$selected_tag"
+  done
+done
+lock_pins="${lock_pins# }"
+
+overrides="${touched:-none}"
+echo "overrides=$overrides"
+echo "lock_pins=$lock_pins"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "overrides=$overrides"
+    echo "lock_pins=$lock_pins"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/solana/scripts/e2e/select-overrides.test.sh
+++ b/solana/scripts/e2e/select-overrides.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Offline tests for select-overrides.sh: injects CHANGED_FILES and a stubbed image-existence
+# probe (MANIFEST_INSPECT), then asserts the computed override set and lock pins.
+#
+# Run: bash solana/scripts/e2e/select-overrides.test.sh
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/select-overrides.sh"
+BASE_SHA="0123456789abcdef0123456789abcdef01234567"
+failures=0
+tests_run=0
+
+# Stub manifest probes. "true" pretends every image exists; the stubs below simulate publish
+# gaps to exercise the build-everything fallback.
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+cat > "$STUB_DIR/missing-all" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+# One group's base-tag image missing (relayer) while every other image exists: a partial publish
+# must never mix a stale group in — the whole run falls back to source builds.
+cat > "$STUB_DIR/missing-relayer" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in ghcr.io/zama-ai/fhevm/relayer:*) exit 1 ;; *) exit 0 ;; esac
+EOF
+chmod +x "$STUB_DIR/missing-all" "$STUB_DIR/missing-relayer"
+
+check() {
+  local name="$1" changed="$2" probe="$3" want_overrides="$4" want_pins="$5"
+  local out overrides pins
+  tests_run=$((tests_run + 1))
+  out="$(CHANGED_FILES="$changed" MANIFEST_INSPECT="$probe" GITHUB_OUTPUT="" bash "$SCRIPT" "$BASE_SHA")"
+  overrides="$(printf '%s\n' "$out" | sed -n 's/^overrides=//p')"
+  pins="$(printf '%s\n' "$out" | sed -n 's/^lock_pins=//p')"
+  if [ "$overrides" = "$want_overrides" ] && [ "$pins" = "$want_pins" ]; then
+    echo "ok   $name"
+  else
+    echo "FAIL $name"
+    echo "  want overrides: $want_overrides"
+    echo "  got  overrides: $overrides"
+    echo "  want lock_pins: $want_pins"
+    echo "  got  lock_pins: $pins"
+    failures=$((failures + 1))
+  fi
+}
+
+ALL="gateway-contracts host-contracts coprocessor relayer kms-connector"
+T="feature-solana-$BASE_SHA"
+PINS_GATEWAY="GATEWAY_VERSION=$T"
+PINS_HOST="HOST_VERSION=$T"
+PINS_COPRO="COPROCESSOR_DB_MIGRATION_VERSION=$T COPROCESSOR_HOST_LISTENER_VERSION=$T COPROCESSOR_GW_LISTENER_VERSION=$T COPROCESSOR_TFHE_WORKER_VERSION=$T COPROCESSOR_ZKPROOF_WORKER_VERSION=$T COPROCESSOR_SNS_WORKER_VERSION=$T COPROCESSOR_TX_SENDER_VERSION=$T"
+PINS_RELAYER="RELAYER_VERSION=$T RELAYER_MIGRATE_VERSION=$T"
+PINS_CONNECTOR="CONNECTOR_DB_MIGRATION_VERSION=$T CONNECTOR_GW_LISTENER_VERSION=$T CONNECTOR_KMS_WORKER_VERSION=$T CONNECTOR_TX_SENDER_VERSION=$T"
+
+# Solana-only script/geyser/docs change: nothing is built, everything pinned to the base tag.
+check "solana scripts only -> no overrides" \
+  $'solana/scripts/e2e/full-vertical.sh\nsolana/geyser/src/lib.rs\nsolana/docs/notes.md' \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
+# zama-host is compiled into the coprocessor and relayer binaries, but NOT the kms-connector's
+# (its image copies only solana/crates/zama-solana-acl).
+check "solana program change -> coprocessor + relayer" \
+  "solana/programs/zama-host/src/lib.rs" \
+  "true" \
+  "coprocessor relayer" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_CONNECTOR"
+
+# zama-solana-acl is the one solana crate the kms-connector image consumes.
+check "zama-solana-acl change -> all rust consumers" \
+  "solana/crates/zama-solana-acl/src/lib.rs" \
+  "true" \
+  "coprocessor kms-connector relayer" \
+  "$PINS_GATEWAY $PINS_HOST"
+
+check "other solana crate change -> coprocessor + relayer" \
+  "solana/crates/zama-fhe/src/lib.rs" \
+  "true" \
+  "coprocessor relayer" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_CONNECTOR"
+
+check "solana Cargo.lock change -> coprocessor + relayer" \
+  "solana/Cargo.lock" \
+  "true" \
+  "coprocessor relayer" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_CONNECTOR"
+
+# On-chain-only demo programs are compiled into no docker image.
+check "demo-vault change -> no overrides" \
+  "solana/programs/demo-vault/src/lib.rs" \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
+check "confidential-deposit-app change -> no overrides" \
+  "solana/programs/confidential-deposit-app/src/lib.rs" \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
+check "coprocessor change -> coprocessor only" \
+  "coprocessor/fhevm-engine/tfhe-worker/src/main.rs" \
+  "true" \
+  "coprocessor" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_RELAYER $PINS_CONNECTOR"
+
+check "kms-connector change -> kms-connector only" \
+  "kms-connector/crates/gw-listener/src/lib.rs" \
+  "true" \
+  "kms-connector" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER"
+
+# Contracts are compiled into the Rust images (bindings/artifacts), so they fan out.
+check "host-contracts change -> contracts + rust consumers" \
+  "host-contracts/contracts/FHEVMExecutor.sol" \
+  "true" \
+  "host-contracts coprocessor kms-connector relayer" \
+  "$PINS_GATEWAY"
+
+check "gateway-contracts change -> contracts + rust consumers" \
+  "gateway-contracts/contracts/Decryption.sol" \
+  "true" \
+  "gateway-contracts coprocessor kms-connector relayer" \
+  "$PINS_HOST"
+
+check "sdk-only change -> no overrides" \
+  "sdk/js-sdk/src/solana/index.ts" \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
+# Build-recipe changes force full source builds regardless of published images.
+check "workflow change -> build all" \
+  ".github/workflows/solana-e2e.yml" \
+  "true" \
+  "$ALL" \
+  ""
+
+check "test-suite/fhevm change -> build all" \
+  "test-suite/fhevm/src/generate/compose.ts" \
+  "true" \
+  "$ALL" \
+  ""
+
+check "clean-e2e.sh change -> build all" \
+  "solana/scripts/e2e/clean-e2e.sh" \
+  "true" \
+  "$ALL" \
+  ""
+
+# Fail-safe: an incomplete base-commit image set means build everything — the floating tag is
+# never consumed (a partial publish could leave it mixing branch commits).
+check "no published images -> build all" \
+  "solana/docs/notes.md" \
+  "$STUB_DIR/missing-all" \
+  "$ALL" \
+  ""
+
+check "one group's image missing -> build all (no tag mixing)" \
+  "solana/docs/notes.md" \
+  "$STUB_DIR/missing-relayer" \
+  "$ALL" \
+  ""
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures of $tests_run select-overrides test(s) failed"
+  exit 1
+fi
+echo "all $tests_run select-overrides tests passed"


### PR DESCRIPTION
Step 3 of zama-ai/fhevm-internal#1766.

## What

The `solana-e2e` job now skips source-building docker component groups whose build inputs a PR doesn't touch, pulling `feature/solana`-published images instead. Measured motivation (recorded on #1766): bring-up is ~41–44 min, of which ~22 min is `docker compose build` of five component groups on every PR, while the actual vertical tests take 3.6 min. The sccache measurement showed compilation was never the bottleneck — not building at all is.

## How

- **New `solana-images-publish.yml`**: on every push to `feature/solana` (+ manual dispatch), builds the 15 images that `fhevm-cli`'s `COMPONENT_BUILD_SPECS` defines — same Dockerfiles, contexts, targets, build args, and sccache wiring as the compose path — and pushes two tags per image to ghcr.io: `:feature-solana-<sha>` (immutable, what CI consumes) and `:feature-solana` (floating, for humans only — deliberately never consumed by selection, because a partial matrix failure could leave it mixing images from different commits).
- **New `solana/scripts/e2e/select-overrides.sh`**: diffs the PR against its base (`--no-renames`, so file moves list both sides — a pure rename out of a mapped tree must still trigger its group), maps changed paths to component groups, and probes ghcr for the base-SHA tags. Selection rule: images at `:feature-solana-<base-sha>` must exist for **all** untouched groups — otherwise build everything from source (today's behavior, with a logged reason). No cross-commit tag mixing is possible.
- **Path → group map** derived from the actual build graph (each rule cites its Dockerfile COPY lines / consuming Cargo.tomls in the script): coprocessor and relayer genuinely link the Solana program crates (`host-listener`/`tfhe-worker` depend on `zama-host` + `confidential-token`), so program PRs still rebuild those two; kms-connector's image copies only `solana/crates/zama-solana-acl`, so program PRs skip it; demo programs (`demo-vault`, `confidential-deposit-app`) feed no image and map to none — but only via explicit none-rules, so any future program is over-built by default. Changes to the build recipe itself (these scripts, both workflows, `test-suite/fhevm/`, root package files) force build-everything.
- **`clean-e2e.sh` seam is ~20 lines** (`SOLANA_E2E_OVERRIDES` + `SOLANA_E2E_LOCK_PINS` riding the existing lock-file version-pin mechanism, generalized to N pins): unset env → byte-identical previous behavior, local dev unchanged. No fhevm-cli changes were needed — the non-override compose path already pulls `ghcr.io/zama-ai/fhevm/<image>:${<KEY>_VERSION}` from the lock env, and branch tags parse as "modern" throughout the compat machinery.

## What each PR type gets

| PR touches | Built from source | Saved |
|---|---|---|
| solana scripts / geyser / docs / sdk | nothing | ~22 min |
| solana programs / crates | coprocessor + relayer | contracts + kms-connector builds |
| one component (e.g. coprocessor) | that component | the other four groups |
| build recipe | everything | — (fail-safe) |

Fail-safes: first run before any publish, a partially failed publish, fork PRs, registry auth failures, and transient probe errors all degrade to build-everything — a wrong skip would mean false-green e2e on stale binaries, so every ambiguity resolves toward building.

## Verification

- `select-overrides.test.sh`: 17/17 offline tests (fan-outs, none-rules, recipe→build-all, missing-tag and mixed-tag fallbacks).
- `bun test src`: 248 pass / 0 fail (fhevm-cli untouched; degradation structural).
- zizmor (default + `--persona pedantic`), actionlint, shellcheck: all clean.
- Independently reviewed; the review's build-graph findings (kms-connector narrowing, demo-program none-rules, `--no-renames`, floating-tag consumption removal) are folded in.

## Notes

- The first e2e run after this merges will build everything (no published tags exist yet); the publish workflow must succeed on `feature/solana` once before skips activate.
- kms-core (`CORE_VERSION`) is built from the kms repo and stays pinned via `solana-images.env`, unchanged.
- Step 2 of #1766 (dropping `Dockerfile.workspace`, per-component layer caching) remains, and is where the residual program-PR cost (coprocessor+relayer rebuilds) shrinks further.
