### PR TITLE
chore(kms-connector): destroy epoch tied to context

### DIFF
--- a/kms-connector/.sqlx/query-2c49f3c558d5e89b8824638fde6163aef18678061cac5425f845175039c04874.json
+++ b/kms-connector/.sqlx/query-2c49f3c558d5e89b8824638fde6163aef18678061cac5425f845175039c04874.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT is_valid FROM kms_epoch WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_valid",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2c49f3c558d5e89b8824638fde6163aef18678061cac5425f845175039c04874"
+}

--- a/kms-connector/.sqlx/query-3bcf70ac1e0569fd64faeece681f828f090a6cc03510c5fd2a842bb461431c6c.json
+++ b/kms-connector/.sqlx/query-3bcf70ac1e0569fd64faeece681f828f090a6cc03510c5fd2a842bb461431c6c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM kms_epoch WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3bcf70ac1e0569fd64faeece681f828f090a6cc03510c5fd2a842bb461431c6c"
+}

--- a/kms-connector/.sqlx/query-64eaca4589792a8aba4523df31c5fe5d188de85bf598f1f7dbb049b77a885b5a.json
+++ b/kms-connector/.sqlx/query-64eaca4589792a8aba4523df31c5fe5d188de85bf598f1f7dbb049b77a885b5a.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO kms_epoch(id, context_id, is_valid, created_at, updated_at)\n            VALUES ($1, NULL, TRUE, $2, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "64eaca4589792a8aba4523df31c5fe5d188de85bf598f1f7dbb049b77a885b5a"
+}

--- a/kms-connector/.sqlx/query-abc15fc887e4fc66b8e45d17f33638d1acddbbb38f1bfbfecbd2fbed4097e26d.json
+++ b/kms-connector/.sqlx/query-abc15fc887e4fc66b8e45d17f33638d1acddbbb38f1bfbfecbd2fbed4097e26d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM kms_epoch WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "abc15fc887e4fc66b8e45d17f33638d1acddbbb38f1bfbfecbd2fbed4097e26d"
+}

--- a/kms-connector/.sqlx/query-b7a0ac06ac11ddfbf3132ba6bb4e88330a91c6b7b21ff966bfab0916e1c9d8c6.json
+++ b/kms-connector/.sqlx/query-b7a0ac06ac11ddfbf3132ba6bb4e88330a91c6b7b21ff966bfab0916e1c9d8c6.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, context_id FROM kms_epoch WHERE is_valid = TRUE ORDER BY id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "context_id",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "b7a0ac06ac11ddfbf3132ba6bb4e88330a91c6b7b21ff966bfab0916e1c9d8c6"
+}

--- a/kms-connector/.sqlx/query-d661e2f54ba11bb4f233be6694a3ed7a5b6d5eb70d991bc03f052a3c85ff8c21.json
+++ b/kms-connector/.sqlx/query-d661e2f54ba11bb4f233be6694a3ed7a5b6d5eb70d991bc03f052a3c85ff8c21.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM kms_context WHERE is_valid = TRUE ORDER BY id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d661e2f54ba11bb4f233be6694a3ed7a5b6d5eb70d991bc03f052a3c85ff8c21"
+}

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -300,7 +300,7 @@ checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bc2wrap"
 version = "2.0.1"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+source = "git+https://github.com/zama-ai/kms.git?rev=d27c3b52aa292f6e06c03c668223d0aac9be22e4#d27c3b52aa292f6e06c03c668223d0aac9be22e4"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "connector-utils"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "actix-web",
  "alloy",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "gw-listener"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "actix-web",
  "alloy",
@@ -4114,8 +4114,8 @@ dependencies = [
 
 [[package]]
 name = "kms-grpc"
-version = "0.14.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+version = "0.15.0-0"
+source = "git+https://github.com/zama-ai/kms.git?rev=d27c3b52aa292f6e06c03c668223d0aac9be22e4#d27c3b52aa292f6e06c03c668223d0aac9be22e4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4127,8 +4127,8 @@ dependencies = [
  "prost 0.14.4",
  "rand 0.8.6",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "tfhe",
  "tfhe-versionable",
  "thiserror 2.0.18",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "kms-worker"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "actix-web",
  "alloy",
@@ -6534,8 +6534,14 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
 ]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -6547,6 +6553,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -6678,7 +6696,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha3 0.10.8",
- "strum",
+ "strum 0.27.1",
  "tfhe-csprng",
  "tfhe-fft",
  "tfhe-ntt",
@@ -6843,8 +6861,8 @@ dependencies = [
 
 [[package]]
 name = "threshold-hashing"
-version = "0.14.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+version = "0.15.0-0"
+source = "git+https://github.com/zama-ai/kms.git?rev=d27c3b52aa292f6e06c03c668223d0aac9be22e4#d27c3b52aa292f6e06c03c668223d0aac9be22e4"
 dependencies = [
  "anyhow",
  "bc2wrap",
@@ -6856,8 +6874,8 @@ dependencies = [
 
 [[package]]
 name = "threshold-types"
-version = "0.14.0-0"
-source = "git+https://github.com/zama-ai/kms.git?rev=b9087af025de26cd6ada5033e8044b05a518cf22#b9087af025de26cd6ada5033e8044b05a518cf22"
+version = "0.15.0-0"
+source = "git+https://github.com/zama-ai/kms.git?rev=d27c3b52aa292f6e06c03c668223d0aac9be22e4#d27c3b52aa292f6e06c03c668223d0aac9be22e4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7351,7 +7369,7 @@ dependencies = [
 
 [[package]]
 name = "tx-sender"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "actix-web",
  "alloy",

--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Zama"]
 edition = "2024"
 license = "BSD-3-Clause-Clear"
 publish = true
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies]
 
@@ -20,8 +20,8 @@ tx-sender.path = "crates/tx-sender"
 connector-utils.path = "crates/utils"
 fhevm_gateway_bindings = { path = "../gateway-contracts/rust_bindings", default-features = false }
 fhevm_host_bindings = { path = "../host-contracts/rust_bindings", default-features = false }
-kms-grpc = { git = "https://github.com/zama-ai/kms.git", rev = "b9087af025de26cd6ada5033e8044b05a518cf22", default-features = true }
-bc2wrap = { git = "https://github.com/zama-ai/kms.git", rev = "b9087af025de26cd6ada5033e8044b05a518cf22", default-features = true }
+kms-grpc = { git = "https://github.com/zama-ai/kms.git", rev = "d27c3b52aa292f6e06c03c668223d0aac9be22e4", default-features = true }
+bc2wrap = { git = "https://github.com/zama-ai/kms.git", rev = "d27c3b52aa292f6e06c03c668223d0aac9be22e4", default-features = true }
 tfhe = { version = "=1.6.2", default-features = false }
 user-decryption-signature = { path = "../shared/user-decryption-signature", default-features = false }
 ciphertext-attestation = { path = "../shared/ciphertext-attestation" }

--- a/kms-connector/crates/gw-listener/src/core/ethereum.rs
+++ b/kms-connector/crates/gw-listener/src/core/ethereum.rs
@@ -415,6 +415,7 @@ mod tests {
         let db = test_instance.db();
         clear_context_cache(db).await;
 
+        // Arbitrary context/epoch IDs chosen to test the revalidation logic.
         let destroyed_context = U256::from(1_u64);
         let destroyed_context_epoch = U256::from(10_u64);
         let valid_context = U256::from(2_u64);
@@ -426,9 +427,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Rows are audited in `ORDER BY id` order: `isValidKmsContext(#1)` -> false,
-        // `isValidKmsContext(#2)` -> true, then `isValidEpochForContext(#2, #20)` -> true.
-        // Epoch #10 must not trigger a call, as its context is already known destroyed.
+        // The `Asserter` replies to each on-chain `.call()` with the next queued response, in
+        // order. `revalidate_context_cache` audits contexts first (both are cached as valid, so
+        // both are checked), then epochs, each `ORDER BY id`. So the calls happen in this order:
+        //   1. `isValidKmsContext(#1)`         -> false: context #1 is destroyed on-chain
+        //   2. `isValidKmsContext(#2)`         -> true:  context #2 is still valid on-chain
+        //   3. `isValidEpochForContext(#2,#20)`-> true:  epoch #20 (of valid ctx #2) still valid
+        // Note there is no call for epoch #10: its context (#1) was just found destroyed, so the
+        // audit invalidates the epoch without an on-chain check.
         let asserter = Asserter::new();
         asserter.push_success(&false.abi_encode());
         asserter.push_success(&true.abi_encode());
@@ -457,7 +463,10 @@ mod tests {
             .await
             .unwrap();
 
-        // `isValidKmsContext(#1)` -> true, `isValidEpochForContext(#1, #10)` -> false
+        // The `Asserter` replies to each on-chain `.call()` with the next queued response, in
+        // order. In this scenario, the context is still valid but its epoch has been destroyed:
+        //   1. `isValidKmsContext(#1)`          -> true:  context #1 is still valid
+        //   2. `isValidEpochForContext(#1,#10)` -> false: epoch #10 is destroyed, so invalidated
         let asserter = Asserter::new();
         asserter.push_success(&true.abi_encode());
         asserter.push_success(&false.abi_encode());

--- a/kms-connector/crates/gw-listener/src/core/ethereum.rs
+++ b/kms-connector/crates/gw-listener/src/core/ethereum.rs
@@ -158,7 +158,7 @@ where
             let Some(context_id) = epoch.context_id.map(|i| U256::from_le_slice(&i)) else {
                 // A valid epoch row always carries its context association; without it the epoch
                 // cannot be checked on-chain. This should be unreachable, but we delete the row
-                // just in case so the kms-worker's on-chain is able to fix the cache.
+                // just in case so the kms-worker's on-chain check is able to fix the cache.
                 warn!("KMS epoch #{epoch_id} was cached as valid without any context. Deleting...");
                 sqlx::query!("DELETE FROM kms_epoch WHERE id = $1", epoch.id)
                     .execute(&self.db_pool)

--- a/kms-connector/crates/gw-listener/src/core/ethereum.rs
+++ b/kms-connector/crates/gw-listener/src/core/ethereum.rs
@@ -6,7 +6,7 @@ use crate::{
     monitoring::metrics::{EVENT_LISTENING_ERRORS, EVENT_RECEIVED_COUNTER},
 };
 use alloy::{
-    eips::BlockNumberOrTag,
+    eips::{BlockId, BlockNumberOrTag},
     network::Ethereum,
     primitives::{B256, U256},
     providers::Provider,
@@ -114,6 +114,7 @@ where
         let active = self
             .protocol_config_contract
             .getCurrentKmsContextAndEpoch()
+            .block(BlockId::finalized())
             .call()
             .await?;
 
@@ -138,6 +139,7 @@ where
             let is_valid_context = self
                 .protocol_config_contract
                 .isValidKmsContext(context_id)
+                .block(BlockId::finalized())
                 .call()
                 .await?;
             if !is_valid_context {
@@ -169,6 +171,7 @@ where
                 && self
                     .protocol_config_contract
                     .isValidEpochForContext(context_id, epoch_id)
+                    .block(BlockId::finalized())
                     .call()
                     .await?;
             if !epoch_valid {

--- a/kms-connector/crates/gw-listener/src/core/ethereum.rs
+++ b/kms-connector/crates/gw-listener/src/core/ethereum.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy::{
     eips::BlockNumberOrTag,
     network::Ethereum,
-    primitives::B256,
+    primitives::{B256, U256},
     providers::Provider,
     rpc::types::{Filter, Log},
     sol_types::{SolEvent, SolEventInterface},
@@ -16,7 +16,10 @@ use alloy::{
 use anyhow::anyhow;
 use connector_utils::{
     monitoring::otlp::PropagationContext,
-    types::{KMS_CONTEXT_COUNTER_BASE, ProtocolEvent, db::EventType},
+    types::{
+        KMS_CONTEXT_COUNTER_BASE, ProtocolEvent,
+        db::{EventType, invalidate_kms_context, invalidate_kms_epoch},
+    },
 };
 use fhevm_host_bindings::{
     kms_generation::KMSGeneration::{
@@ -29,6 +32,7 @@ use fhevm_host_bindings::{
     },
 };
 use sqlx::{Pool, Postgres};
+use std::collections::HashSet;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, info_span, warn};
@@ -114,6 +118,69 @@ where
             .await?;
 
         publish_context_and_epoch(&self.db_pool, active.contextId, active.epochId).await
+    }
+
+    /// Re-validates the cached-valid KMS contexts and epochs against `ProtocolConfig`.
+    ///
+    /// Used in case of:
+    /// * a missed event and a failing catchup mechanism
+    /// * if KMS Core is unable to return the full list of destroyed epochs tied to a given
+    ///   context. This can happen if a context destruction is retried multiple times, and KMS
+    ///   Core is restarted in the middle of the process as full list of epochs lives in RAM
+    pub async fn revalidate_context_cache(&self) -> anyhow::Result<()> {
+        let mut destroyed_contexts = HashSet::new();
+        let context_ids =
+            sqlx::query_scalar!("SELECT id FROM kms_context WHERE is_valid = TRUE ORDER BY id")
+                .fetch_all(&self.db_pool)
+                .await?;
+        for id in context_ids {
+            let context_id = U256::from_le_slice(&id);
+            let is_valid_context = self
+                .protocol_config_contract
+                .isValidKmsContext(context_id)
+                .call()
+                .await?;
+            if !is_valid_context {
+                warn!("KMS context #{context_id} is no longer valid. Invalidating...");
+                invalidate_kms_context(&self.db_pool, context_id).await?;
+                destroyed_contexts.insert(context_id);
+            }
+        }
+
+        let epochs =
+            sqlx::query!("SELECT id, context_id FROM kms_epoch WHERE is_valid = TRUE ORDER BY id")
+                .fetch_all(&self.db_pool)
+                .await?;
+        for epoch in epochs {
+            let epoch_id = U256::from_le_slice(&epoch.id);
+            let Some(context_id) = epoch.context_id.map(|i| U256::from_le_slice(&i)) else {
+                // A valid epoch row always carries its context association; without it the epoch
+                // cannot be checked on-chain. This should be unreachable, but we delete the row
+                // just in case so the kms-worker's on-chain is able to fix the cache.
+                warn!("KMS epoch #{epoch_id} was cached as valid without any context. Deleting...");
+                sqlx::query!("DELETE FROM kms_epoch WHERE id = $1", epoch.id)
+                    .execute(&self.db_pool)
+                    .await?;
+                continue;
+            };
+
+            // Epochs of a destroyed context are destroyed with it: no need to check on-chain
+            let epoch_valid = !destroyed_contexts.contains(&context_id)
+                && self
+                    .protocol_config_contract
+                    .isValidEpochForContext(context_id, epoch_id)
+                    .call()
+                    .await?;
+            if !epoch_valid {
+                warn!(
+                    "KMS epoch #{epoch_id} (context #{context_id}) is no longer valid. Invalidating..."
+                );
+                invalidate_kms_epoch(&self.db_pool, epoch_id).await?;
+            }
+        }
+
+        info!("KMS context cache successfully revalidated against ProtocolConfig");
+        Ok(())
     }
 
     /// Polling loop to listen to [`KMSGeneration`] and [`ProtocolConfig`] events on Ethereum.
@@ -299,6 +366,7 @@ mod tests {
         tests::setup::{TestInstance, TestInstanceBuilder},
         types::ProtocolEventKind,
     };
+    use sqlx::types::chrono::Utc;
     use std::time::Duration;
 
     #[rstest::rstest]
@@ -310,21 +378,10 @@ mod tests {
         let epoch_id = U256::from(3_u64);
 
         let asserter = Asserter::new();
-        // `getActiveKmsContextAndEpoch()` returns the tuple `(contextId, epochId)`.
+        // `getCurrentKmsContextAndEpoch()` returns the tuple `(contextId, epochId)`.
         asserter.push_success(&(context_id, epoch_id).abi_encode_sequence());
 
-        let mock_provider = ProviderBuilder::new()
-            .disable_recommended_fillers()
-            .connect_mocked_client(asserter);
-
-        let config = Config::default();
-        let listener = EthereumListener::new(
-            test_instance.db().clone(),
-            mock_provider,
-            &config,
-            CancellationToken::new(),
-        );
-
+        let listener = new_listener_with_mocked_calls(test_instance.db().clone(), asserter);
         listener.store_on_chain_context().await.unwrap();
 
         let context_valid: bool = sqlx::query_scalar!(
@@ -345,6 +402,107 @@ mod tests {
         .unwrap();
         assert!(epoch_row.is_valid);
         assert_eq!(epoch_row.context_id, Some(context_id.to_le_bytes_vec()));
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_revalidate_context_cache_invalidates_destroyed_context_and_its_epochs() {
+        let test_instance = TestInstanceBuilder::db_setup().await.unwrap();
+        let db = test_instance.db();
+        clear_context_cache(db).await;
+
+        let destroyed_context = U256::from(1_u64);
+        let destroyed_context_epoch = U256::from(10_u64);
+        let valid_context = U256::from(2_u64);
+        let valid_epoch = U256::from(20_u64);
+        publish_context_and_epoch(db, destroyed_context, destroyed_context_epoch)
+            .await
+            .unwrap();
+        publish_context_and_epoch(db, valid_context, valid_epoch)
+            .await
+            .unwrap();
+
+        // Rows are audited in `ORDER BY id` order: `isValidKmsContext(#1)` -> false,
+        // `isValidKmsContext(#2)` -> true, then `isValidEpochForContext(#2, #20)` -> true.
+        // Epoch #10 must not trigger a call, as its context is already known destroyed.
+        let asserter = Asserter::new();
+        asserter.push_success(&false.abi_encode());
+        asserter.push_success(&true.abi_encode());
+        asserter.push_success(&true.abi_encode());
+
+        let listener = new_listener_with_mocked_calls(db.clone(), asserter);
+        listener.revalidate_context_cache().await.unwrap();
+
+        assert!(!context_is_valid(db, destroyed_context).await);
+        assert!(context_is_valid(db, valid_context).await);
+        assert!(!epoch_is_valid(db, destroyed_context_epoch).await);
+        assert!(epoch_is_valid(db, valid_epoch).await);
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_revalidate_context_cache_invalidates_destroyed_epoch() {
+        let test_instance = TestInstanceBuilder::db_setup().await.unwrap();
+        let db = test_instance.db();
+        clear_context_cache(db).await;
+
+        let context_id = U256::from(1_u64);
+        let epoch_id = U256::from(10_u64);
+        publish_context_and_epoch(db, context_id, epoch_id)
+            .await
+            .unwrap();
+
+        // `isValidKmsContext(#1)` -> true, `isValidEpochForContext(#1, #10)` -> false
+        let asserter = Asserter::new();
+        asserter.push_success(&true.abi_encode());
+        asserter.push_success(&false.abi_encode());
+
+        let listener = new_listener_with_mocked_calls(db.clone(), asserter);
+        listener.revalidate_context_cache().await.unwrap();
+
+        assert!(context_is_valid(db, context_id).await);
+        assert!(!epoch_is_valid(db, epoch_id).await);
+    }
+
+    #[rstest::rstest]
+    #[timeout(Duration::from_secs(90))]
+    #[tokio::test]
+    async fn test_revalidate_context_cache_deletes_valid_epoch_without_context() {
+        let test_instance = TestInstanceBuilder::db_setup().await.unwrap();
+        let db = test_instance.db();
+        clear_context_cache(db).await;
+
+        // A valid epoch row without context association should never exist (only invalidations
+        // are written without one), but if it does it cannot be checked on-chain.
+        let epoch_id = U256::from(10_u64);
+        let now = Utc::now();
+        sqlx::query!(
+            "INSERT INTO kms_epoch(id, context_id, is_valid, created_at, updated_at)
+            VALUES ($1, NULL, TRUE, $2, $2)",
+            epoch_id.as_le_slice(),
+            now,
+        )
+        .execute(db)
+        .await
+        .unwrap();
+
+        // The empty asserter ensures the audit performs no on-chain call for this row
+        let listener = new_listener_with_mocked_calls(db.clone(), Asserter::new());
+        listener.revalidate_context_cache().await.unwrap();
+
+        let row = sqlx::query!(
+            "SELECT id FROM kms_epoch WHERE id = $1",
+            epoch_id.as_le_slice()
+        )
+        .fetch_optional(db)
+        .await
+        .unwrap();
+        assert!(
+            row.is_none(),
+            "the orphan epoch row should have been deleted"
+        );
     }
 
     #[rstest::rstest]
@@ -472,6 +630,60 @@ mod tests {
             CancellationToken::new(),
         );
         (test_instance, asserter, listener)
+    }
+
+    /// Creates an `EthereumListener` over a mocked provider replaying the asserter's responses.
+    fn new_listener_with_mocked_calls(
+        db_pool: Pool<Postgres>,
+        asserter: Asserter,
+    ) -> EthereumListener<impl Provider<Ethereum> + Clone + 'static> {
+        let mock_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_mocked_client(asserter);
+        EthereumListener::new(
+            db_pool,
+            mock_provider,
+            &Config::default(),
+            CancellationToken::new(),
+        )
+    }
+
+    /// Empties the `kms_context` and `kms_epoch` tables.
+    ///
+    /// `db_setup` seeds a valid `TESTING_KMS_CONTEXT`/`DEFAULT_EPOCH_ID` pair, but the
+    /// `revalidate_context_cache` tests audit the full content of these tables, so they
+    /// require full control over the cached rows.
+    async fn clear_context_cache(db: &Pool<Postgres>) {
+        sqlx::query("DELETE FROM kms_epoch")
+            .execute(db)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM kms_context")
+            .execute(db)
+            .await
+            .unwrap();
+    }
+
+    /// Fetches the cached validity of a KMS context from the DB.
+    async fn context_is_valid(db: &Pool<Postgres>, context_id: U256) -> bool {
+        sqlx::query_scalar!(
+            "SELECT is_valid FROM kms_context WHERE id = $1",
+            context_id.as_le_slice()
+        )
+        .fetch_one(db)
+        .await
+        .unwrap()
+    }
+
+    /// Fetches the cached validity of a KMS epoch from the DB.
+    async fn epoch_is_valid(db: &Pool<Postgres>, epoch_id: U256) -> bool {
+        sqlx::query_scalar!(
+            "SELECT is_valid FROM kms_epoch WHERE id = $1",
+            epoch_id.as_le_slice()
+        )
+        .fetch_one(db)
+        .await
+        .unwrap()
     }
 
     /// Pushes a mock finalized block response onto the asserter.

--- a/kms-connector/crates/gw-listener/src/core/gw_listener.rs
+++ b/kms-connector/crates/gw-listener/src/core/gw_listener.rs
@@ -44,6 +44,12 @@ where
             .await
             .map_err(|e| anyhow!("Failed to store current context: {e}"))?;
 
+        // Invalidate cached-valid contexts/epochs
+        self.ethereum_listener
+            .revalidate_context_cache()
+            .await
+            .map_err(|e| anyhow!("Failed to revalidate the KMS context cache: {e}"))?;
+
         join!(
             self.gateway_listener.start(),
             self.ethereum_listener.start()

--- a/kms-connector/crates/gw-listener/src/core/publish.rs
+++ b/kms-connector/crates/gw-listener/src/core/publish.rs
@@ -411,7 +411,7 @@ pub async fn update_last_block_polled<'e>(
 }
 
 /// Persists the `(context_id, epoch_id)` pair fetched at startup via
-/// `ProtocolConfig::getActiveKmsContextAndEpoch()`.
+/// `ProtocolConfig::getCurrentKmsContextAndEpoch()`.
 pub async fn publish_context_and_epoch(
     db_pool: &Pool<Postgres>,
     context_id: U256,

--- a/kms-connector/crates/gw-listener/src/core/publish.rs
+++ b/kms-connector/crates/gw-listener/src/core/publish.rs
@@ -5,7 +5,10 @@ use alloy::{
 use anyhow::anyhow;
 use connector_utils::{
     monitoring::otlp::PropagationContext,
-    types::{ProtocolEvent, ProtocolEventKind, db::ParamsTypeDb},
+    types::{
+        ProtocolEvent, ProtocolEventKind,
+        db::{ParamsTypeDb, invalidate_kms_context, invalidate_kms_epoch},
+    },
 };
 // Handle-only overloaded decryption events (authoritative ct-commits verifier, v0.15).
 use fhevm_gateway_bindings::decryption::Decryption::{
@@ -550,49 +553,4 @@ async fn publish_kms_epoch_destroyed<'e>(
     .execute(executor)
     .await
     .map_err(anyhow::Error::from)
-}
-
-/// Marks a destroyed KMS context as invalid in the `kms_context` validation cache.
-///
-/// The invalidation is upserted so the destruction is recorded even if the context was not cached.
-async fn invalidate_kms_context<'e>(
-    executor: impl PgExecutor<'e>,
-    context_id: U256,
-) -> anyhow::Result<()> {
-    let now = Utc::now();
-    sqlx::query!(
-        "INSERT INTO kms_context(id, is_valid, created_at, updated_at)
-        VALUES ($1, FALSE, $2, $2)
-        ON CONFLICT (id) DO UPDATE SET is_valid = FALSE, updated_at = $2",
-        context_id.as_le_slice(),
-        now,
-    )
-    .execute(executor)
-    .await?;
-
-    info!("KMS context #{context_id} marked as destroyed in DB");
-    Ok(())
-}
-
-/// Marks a destroyed KMS epoch as invalid in the `kms_epoch` validation cache.
-///
-/// The invalidation is upserted so the destruction is recorded even if the epoch was never cached;
-/// `context_id` stays NULL in that case, as the event does not carry it.
-async fn invalidate_kms_epoch<'e>(
-    executor: impl PgExecutor<'e>,
-    epoch_id: U256,
-) -> anyhow::Result<()> {
-    let now = Utc::now();
-    sqlx::query!(
-        "INSERT INTO kms_epoch(id, is_valid, created_at, updated_at)
-        VALUES ($1, FALSE, $2, $2)
-        ON CONFLICT (id) DO UPDATE SET is_valid = FALSE, updated_at = $2",
-        epoch_id.as_le_slice(),
-        now,
-    )
-    .execute(executor)
-    .await?;
-
-    info!("KMS epoch #{epoch_id} marked as destroyed in DB");
-    Ok(())
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/context.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/context.rs
@@ -2,7 +2,7 @@ use crate::core::{
     config::Config,
     event_processor::{RequestCheckError, RequestCheckKind},
 };
-use alloy::{primitives::U256, providers::Provider};
+use alloy::{eips::BlockId, primitives::U256, providers::Provider};
 use anyhow::anyhow;
 use connector_utils::types::extra_data::ExtraData;
 use fhevm_host_bindings::protocol_config::ProtocolConfig::{self, ProtocolConfigInstance};
@@ -132,6 +132,7 @@ impl<P: Provider> DbContextManager<P> {
         let context_valid = self
             .protocol_config_contract
             .isValidKmsContext(context_id)
+            .block(BlockId::finalized())
             .call()
             .await
             .map_err(|e| {
@@ -154,6 +155,7 @@ impl<P: Provider> DbContextManager<P> {
         let epoch_valid = self
             .protocol_config_contract
             .isValidEpochForContext(context_id, epoch_id)
+            .block(BlockId::finalized())
             .call()
             .await
             .map_err(|e| {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/kms_client.rs
@@ -9,13 +9,16 @@ use alloy::primitives::U256;
 use anyhow::anyhow;
 use connector_utils::{
     conn::{CONNECTION_RETRY_DELAY, CONNECTION_RETRY_NUMBER},
-    types::{KmsGrpcRequest, KmsGrpcResponse, db::EventType, request_id_to_u256, u256_to_u32},
+    types::{
+        KmsGrpcRequest, KmsGrpcResponse, SendResponse, db::EventType, request_id_to_u256,
+        u256_to_u32,
+    },
 };
 use kms_grpc::{
     kms::v1::{
-        CrsGenRequest, DestroyMpcContextRequest, DestroyMpcEpochRequest, KeyGenPreprocRequest,
-        KeyGenRequest, NewMpcContextRequest, NewMpcEpochRequest, PublicDecryptionRequest,
-        RequestId, UserDecryptionRequest,
+        CrsGenRequest, DestroyMpcContextRequest, DestroyMpcContextResponse, DestroyMpcEpochRequest,
+        KeyGenPreprocRequest, KeyGenRequest, NewMpcContextRequest, NewMpcEpochRequest,
+        PublicDecryptionRequest, RequestId, UserDecryptionRequest,
     },
     kms_service::v1::core_service_endpoint_client::CoreServiceEndpointClient,
 };
@@ -92,7 +95,7 @@ impl KmsClient {
     pub async fn send_request(
         &self,
         request: &KmsGrpcRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         match request {
             KmsGrpcRequest::PublicDecryption(req) => self.request_public_decryption(req).await,
             KmsGrpcRequest::UserDecryption(req) => self.request_user_decryption(req).await,
@@ -155,7 +158,7 @@ impl KmsClient {
     async fn request_public_decryption(
         &self,
         request: &PublicDecryptionRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(request_id) = request.request_id.clone() else {
             return irrecoverable_error(anyhow!("Missing request ID"));
         };
@@ -169,6 +172,7 @@ impl KmsClient {
                 async move { client.public_decrypt(request).await }
             },
             EventType::PublicDecryptionRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -176,7 +180,7 @@ impl KmsClient {
     async fn request_user_decryption(
         &self,
         request: &UserDecryptionRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(request_id) = request.request_id.clone() else {
             return irrecoverable_error(anyhow!("Missing request ID"));
         };
@@ -189,6 +193,7 @@ impl KmsClient {
                 async move { client.user_decrypt(request).await }
             },
             EventType::UserDecryptionRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -196,7 +201,7 @@ impl KmsClient {
     async fn request_prep_keygen(
         &self,
         request: &KeyGenPreprocRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(request_id) = request.request_id.clone() else {
             return irrecoverable_error(anyhow!("Missing request ID"));
         };
@@ -210,11 +215,15 @@ impl KmsClient {
                 async move { client.key_gen_preproc(request).await }
             },
             EventType::PrepKeygenRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
 
-    async fn request_keygen(&self, request: &KeyGenRequest) -> (i16, Result<(), ProcessingError>) {
+    async fn request_keygen(
+        &self,
+        request: &KeyGenRequest,
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         // Route to the shard holding this keygen's preprocessing material (keyed by the
         // preprocessing ID), so prep-keygen, keygen and abort-keygen all target the same shard.
         let Some(preproc_id) = request.preproc_id.clone() else {
@@ -230,11 +239,15 @@ impl KmsClient {
                 async move { client.key_gen(request).await }
             },
             EventType::KeygenRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
 
-    async fn request_crsgen(&self, request: &CrsGenRequest) -> (i16, Result<(), ProcessingError>) {
+    async fn request_crsgen(
+        &self,
+        request: &CrsGenRequest,
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(request_id) = request.request_id.clone() else {
             return irrecoverable_error(anyhow!("Missing request ID"));
         };
@@ -248,6 +261,7 @@ impl KmsClient {
                 async move { client.crs_gen(request).await }
             },
             EventType::CrsgenRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -255,7 +269,7 @@ impl KmsClient {
     async fn request_abort_keygen(
         &self,
         request_id: &RequestId,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let inner_client = self.choose_client(request_id.clone());
 
         send_request_with_retries(
@@ -266,6 +280,7 @@ impl KmsClient {
                 async move { client.abort_key_gen(request_id).await }
             },
             EventType::AbortKeygenRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -273,7 +288,7 @@ impl KmsClient {
     async fn request_abort_crsgen(
         &self,
         request_id: &RequestId,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let inner_client = self.choose_client(request_id.clone());
 
         send_request_with_retries(
@@ -284,6 +299,7 @@ impl KmsClient {
                 async move { client.abort_crs_gen(request_id).await }
             },
             EventType::AbortCrsgenRequest,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -452,7 +468,7 @@ impl KmsClient {
     async fn request_new_mpc_context(
         &self,
         request: &NewMpcContextRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(context_id) = request
             .new_context
             .as_ref()
@@ -471,6 +487,7 @@ impl KmsClient {
                 async move { client.new_mpc_context(request).await }
             },
             EventType::NewKmsContext,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -478,7 +495,7 @@ impl KmsClient {
     async fn request_destroy_mpc_context(
         &self,
         request: &DestroyMpcContextRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(context_id) = request.context_id.clone() else {
             return irrecoverable_error(anyhow!("Missing context_id in DestroyMpcContextRequest"));
         };
@@ -492,6 +509,7 @@ impl KmsClient {
                 async move { client.destroy_mpc_context(request).await }
             },
             EventType::KmsContextDestroyed,
+            map_destroyed_epochs,
         )
         .await
     }
@@ -499,7 +517,7 @@ impl KmsClient {
     async fn request_destroy_mpc_epoch(
         &self,
         request: &DestroyMpcEpochRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(epoch_id) = request.epoch_id.clone() else {
             return irrecoverable_error(anyhow!("Missing epoch_id in DestroyMpcEpochRequest"));
         };
@@ -513,6 +531,7 @@ impl KmsClient {
                 async move { client.destroy_mpc_epoch(request).await }
             },
             EventType::KmsEpochDestroyed,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -520,7 +539,7 @@ impl KmsClient {
     async fn request_new_mpc_epoch(
         &self,
         request: &NewMpcEpochRequest,
-    ) -> (i16, Result<(), ProcessingError>) {
+    ) -> (i16, Result<SendResponse, ProcessingError>) {
         let Some(epoch_id) = request.epoch_id.clone() else {
             return irrecoverable_error(anyhow!("Missing epoch_id in NewMpcEpochRequest"));
         };
@@ -534,6 +553,7 @@ impl KmsClient {
                 async move { client.new_mpc_epoch(request).await }
             },
             EventType::NewKmsEpoch,
+            |_| Ok(SendResponse::Empty),
         )
         .await
     }
@@ -625,6 +645,23 @@ fn irrecoverable_error<T>(err: anyhow::Error) -> (i16, Result<T, ProcessingError
     (0, Err(ProcessingError::Irrecoverable(err)))
 }
 
+/// Converts a `DestroyMpcContextResponse` into the list of destroyed epoch IDs to invalidate.
+fn map_destroyed_epochs(
+    response: DestroyMpcContextResponse,
+) -> Result<SendResponse, ProcessingError> {
+    response
+        .epoch_ids
+        .into_iter()
+        .map(request_id_to_u256)
+        .collect::<Result<Vec<_>, _>>()
+        .map(SendResponse::DestroyedEpochs)
+        .map_err(|e| {
+            ProcessingError::Irrecoverable(anyhow!(
+                "Invalid epoch_id in DestroyMpcContextResponse: {e}"
+            ))
+        })
+}
+
 const RETRYABLE_GRPC_CODE: [Code; 4] = [
     Code::DeadlineExceeded,
     Code::ResourceExhausted,
@@ -635,40 +672,41 @@ const RETRYABLE_GRPC_CODE: [Code; 4] = [
 /// Sends a given GRPC request to the KMS with retries.
 ///
 /// Returns the number of errors and the result of the request.
-async fn send_request_with_retries<F, Fut, R>(
+async fn send_request_with_retries<F, Fut, R, M>(
     retries: u8,
     mut request_fn: F,
     event_type: EventType,
-) -> (i16, Result<(), ProcessingError>)
+    map_response: M,
+) -> (i16, Result<SendResponse, ProcessingError>)
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<Response<R>, Status>>,
+    M: Fn(R) -> Result<SendResponse, ProcessingError>,
 {
     for i in 1..=retries as i16 {
-        match request_fn().await {
-            Ok(_) => {
+        // Don't count last successful attempt
+        let error = match request_fn().await {
+            Ok(response) => {
                 GRPC_REQUEST_SENT_COUNTER
                     .with_label_values(&[event_type.as_str()])
                     .inc();
                 info!("GRPC request successfully sent to the KMS!");
-                return (i - 1, Ok(())); // Don't count last successful attempt
+                return (i - 1, map_response(response.into_inner()));
             }
             Err(e) if e.code() == Code::AlreadyExists => {
                 info!("GRPC already sent to the KMS!");
-                return (i - 1, Ok(())); // Don't count last successful attempt
+                return (i - 1, Ok(SendResponse::Empty));
             }
-            Err(e) if RETRYABLE_GRPC_CODE.contains(&e.code()) => {
-                GRPC_REQUEST_SENT_ERRORS
-                    .with_label_values(&[event_type.as_str()])
-                    .inc();
-                warn!("#{i}/{retries} GRPC request attempt failed: {e}");
-            }
-            Err(e) => {
-                GRPC_REQUEST_SENT_ERRORS
-                    .with_label_values(&[event_type.as_str()])
-                    .inc();
-                return (i, Err(ProcessingError::Irrecoverable(e.into())));
-            }
+            Err(e) => e,
+        };
+
+        GRPC_REQUEST_SENT_ERRORS
+            .with_label_values(&[event_type.as_str()])
+            .inc();
+        if RETRYABLE_GRPC_CODE.contains(&error.code()) {
+            warn!("#{i}/{retries} GRPC request attempt failed: {error}");
+        } else {
+            return (i, Err(ProcessingError::Irrecoverable(error.into())));
         }
     }
     (

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -263,7 +263,7 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
 
             // Invalidate epochs associated to destroyed context returned by the KMS Core.
             // A failure must not prevent the event from completing, as retrying would result in an
-            // `AlreadyExists` from KMS Core with no epoch IDs.
+            // `NotFound` from KMS Core with no epoch IDs.
             if let SendResponse::DestroyedEpochs(epoch_ids) = send_response {
                 for epoch_id in epoch_ids {
                     if let Err(e) = invalidate_kms_epoch(&self.db_pool, epoch_id).await {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/processor.rs
@@ -9,7 +9,7 @@ use alloy::{primitives::B256, providers::Provider};
 use anyhow::anyhow;
 use connector_utils::types::{
     KmsGrpcRequest, KmsGrpcResponse, KmsResponseKind, ProtocolEvent, ProtocolEventKind,
-    u256_to_request_id,
+    SendResponse, db::invalidate_kms_epoch, u256_to_request_id,
 };
 use kms_grpc::kms::v1::{DestroyMpcContextRequest, DestroyMpcEpochRequest};
 use sqlx::{Pool, Postgres};
@@ -232,17 +232,11 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
                     .prepare_new_kms_epoch_request(req)
                     .await
             }
-            ProtocolEventKind::KmsContextDestroyed(req) => {
-                // TODO: the `epoch_ids` field is left empty for now, as the gRPC interface of
-                // the KMS Core for context/epoch destruction is about to change.
-                // Remove once https://github.com/zama-ai/kms-internal/issues/3079 is done.
-                Ok(KmsGrpcRequest::DestroyMpcContext(
-                    DestroyMpcContextRequest {
-                        context_id: Some(u256_to_request_id(req.kmsContextId)),
-                        epoch_ids: vec![],
-                    },
-                ))
-            }
+            ProtocolEventKind::KmsContextDestroyed(req) => Ok(KmsGrpcRequest::DestroyMpcContext(
+                DestroyMpcContextRequest {
+                    context_id: Some(u256_to_request_id(req.kmsContextId)),
+                },
+            )),
             ProtocolEventKind::KmsEpochDestroyed(req) => {
                 Ok(KmsGrpcRequest::DestroyMpcEpoch(DestroyMpcEpochRequest {
                     epoch_id: Some(u256_to_request_id(req.epochId)),
@@ -264,8 +258,19 @@ impl<GP: Provider + Clone + 'static, HP: Provider, C: ContextManager> DbEventPro
         if !event.already_sent {
             let (error_count, result) = self.kms_client.send_request(&request).await;
             event.error_counter += error_count;
-            result?;
+            let send_response = result?;
             event.already_sent = true;
+
+            // Invalidate epochs associated to destroyed context returned by the KMS Core.
+            // A failure must not prevent the event from completing, as retrying would result in an
+            // `AlreadyExists` from KMS Core with no epoch IDs.
+            if let SendResponse::DestroyedEpochs(epoch_ids) = send_response {
+                for epoch_id in epoch_ids {
+                    if let Err(e) = invalidate_kms_epoch(&self.db_pool, epoch_id).await {
+                        warn!("Failed to invalidate destroyed KMS epoch #{epoch_id}: {e}");
+                    }
+                }
+            }
         }
 
         let (error_count, grpc_result) = self.kms_client.poll_result(request).await;

--- a/kms-connector/crates/kms-worker/tests/context.rs
+++ b/kms-connector/crates/kms-worker/tests/context.rs
@@ -21,13 +21,14 @@ use connector_utils::{
             init_host_chains_acl_contracts_mock,
         },
     },
-    types::{DEFAULT_EPOCH_ID, TESTING_KMS_CONTEXT, extra_data::ExtraData},
+    types::{DEFAULT_EPOCH_ID, TESTING_KMS_CONTEXT, extra_data::ExtraData, u256_to_request_id},
 };
+use kms_grpc::kms::v1::DestroyMpcContextResponse;
 use kms_worker::core::{
     Config,
     event_processor::{ContextManager, DbContextManager, ProcessingError, RequestCheckError},
 };
-use mocktail::server::MockServer;
+use mocktail::{MockSet, server::MockServer};
 use rstest::rstest;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -242,6 +243,105 @@ async fn test_decryption_context_invalid(#[case] event_type: TestEventType) -> a
 
     // Verify no pending requests remain
     check_no_uncompleted_request_in_db(test_instance.db(), event_type).await?;
+
+    cancel_token.cancel();
+    kms_worker_task.await.unwrap();
+    Ok(())
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(60))]
+#[tokio::test]
+async fn test_context_destruction_invalidates_returned_epochs() -> anyhow::Result<()> {
+    let test_instance = TestInstanceBuilder::default()
+        .with_db(DbInstance::setup_external().await?)
+        .build();
+
+    // The registry mocks are only consumed by its initial load — the destruction flow involves
+    // no ciphertext nor ACL interaction.
+    let asserter = Asserter::new();
+    mock_copro_registry_load(&asserter, "http://unused-bucket-url");
+    let mock_provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .connect_mocked_client(asserter);
+    let acl_contracts_mock = init_host_chains_acl_contracts_mock(rand_handle(), vec![]);
+
+    // Two epochs cached as valid under the testing context, to be reported destroyed by the Core
+    let destroyed_epoch_ids = [U256::from(41), U256::from(42)];
+    for epoch_id in destroyed_epoch_ids {
+        sqlx::query(
+            "INSERT INTO kms_epoch(id, context_id, is_valid, created_at, updated_at)
+            VALUES ($1, $2, TRUE, NOW(), NOW())",
+        )
+        .bind(epoch_id.as_le_slice())
+        .bind(TESTING_KMS_CONTEXT.as_le_slice())
+        .execute(test_instance.db())
+        .await?;
+    }
+
+    // Destruction request targeting `TESTING_KMS_CONTEXT`
+    insert_rand_request(
+        test_instance.db(),
+        TestEventType::KmsContextDestroyed,
+        InsertRequestOptions::new().with_id(TESTING_KMS_CONTEXT),
+    )
+    .await?;
+
+    // Mock the KMS Core's response to the destruction request
+    let mut kms_mocks = MockSet::new();
+    kms_mocks.mock(|when, then| {
+        when.path("/kms_service.v1.CoreServiceEndpoint/DestroyMpcContext");
+        then.pb(DestroyMpcContextResponse {
+            epoch_ids: destroyed_epoch_ids.map(u256_to_request_id).to_vec(),
+        });
+    });
+    let kms_mock_server =
+        MockServer::new_grpc("kms_service.v1.CoreServiceEndpoint").with_mocks(kms_mocks);
+    kms_mock_server.start().await?;
+    info!("KMS mock server started!");
+
+    let config = Config {
+        kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
+        ct_attestation: testing_ct_attestation_config(),
+        ..Default::default()
+    };
+    let kms_worker = init_kms_worker(
+        config,
+        mock_provider,
+        acl_contracts_mock,
+        test_instance.db(),
+    )
+    .await?;
+    let cancel_token = CancellationToken::new();
+    let kms_worker_task = tokio::spawn(kms_worker.start(cancel_token.clone()));
+    info!("KmsWorker started!");
+
+    // Waiting for the destruction request to reach a terminal status.
+    while let Err(e) =
+        check_no_uncompleted_request_in_db(test_instance.db(), TestEventType::KmsContextDestroyed)
+            .await
+    {
+        warn!("Request not yet processed: {e}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Both epochs reported by the Core must be invalidated...
+    for epoch_id in destroyed_epoch_ids {
+        let is_valid: bool = sqlx::query_scalar("SELECT is_valid FROM kms_epoch WHERE id = $1")
+            .bind(epoch_id.as_le_slice())
+            .fetch_one(test_instance.db())
+            .await?;
+        assert!(!is_valid, "epoch #{epoch_id} should have been invalidated");
+    }
+    // ...while the epoch not reported (seeded by `DbInstance::setup`) must remain valid.
+    let sibling_valid: bool = sqlx::query_scalar("SELECT is_valid FROM kms_epoch WHERE id = $1")
+        .bind(DEFAULT_EPOCH_ID.as_le_slice())
+        .fetch_one(test_instance.db())
+        .await?;
+    assert!(
+        sibling_valid,
+        "an epoch not reported by the Core should remain valid"
+    );
 
     cancel_token.cancel();
     kms_worker_task.await.unwrap();

--- a/kms-connector/crates/utils/src/tests/setup/blockchain.rs
+++ b/kms-connector/crates/utils/src/tests/setup/blockchain.rs
@@ -4,9 +4,10 @@ use crate::{
     provider::{FillersWithoutNonceManagement, NonceManagedProvider},
 };
 use alloy::{
+    eips::BlockNumberOrTag,
     node_bindings::{Anvil, AnvilInstance},
     primitives::{Address, ChainId},
-    providers::ProviderBuilder,
+    providers::{Provider, ProviderBuilder},
     transports::http::reqwest::Url,
 };
 use anyhow::anyhow;
@@ -130,6 +131,9 @@ impl BlockchainInstance {
         info!("KMSGenerationMock deployed at: {}", kms_generation_addr);
         info!("ProtocolConfigMock deployed at: {}", protocol_config_addr);
 
+        // Connector's view calls target finalized block, so we wait to avoid reverts in tests
+        wait_for_deployments_finalized(&provider).await?;
+
         Ok(BlockchainInstance::new(
             anvil,
             provider,
@@ -156,6 +160,22 @@ impl BlockchainInstance {
     /// Resumes a previously paused Anvil process via `SIGCONT`.
     pub fn unpause_anvil(&self) -> anyhow::Result<()> {
         signal_anvil(&self.anvil, "-CONT")
+    }
+}
+
+/// Waits until the deployed mock contracts are visible to `finalized`-pinned view calls.
+async fn wait_for_deployments_finalized(provider: &WalletProvider) -> anyhow::Result<()> {
+    let contracts_deployed_at = provider.get_block_number().await?;
+    loop {
+        let finalized = provider
+            .get_block_by_number(BlockNumberOrTag::Finalized)
+            .await?
+            .map(|block| block.header.number)
+            .unwrap_or_default();
+        if finalized >= contracts_deployed_at {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
     }
 }
 

--- a/kms-connector/crates/utils/src/tests/setup/kms.rs
+++ b/kms-connector/crates/utils/src/tests/setup/kms.rs
@@ -25,11 +25,9 @@ impl KmsInstance {
         // between parallel tests.
         let s3_port: u16 = s3_url.split(":").nth(2).unwrap().parse()?;
         let s3_internal_url = format!("http://host.docker.internal:{s3_port}");
-        let cmd = format!(
-            "kms-gen-keys --public-storage s3 --public-s3-bucket '{KMS_PUBLIC_VAULT_URL}' \\
-            --aws-s3-endpoint '{s3_internal_url}' --private-storage file --private-file-path \\
-            '{KMS_PRIVATE_VAULT_URL}' centralized && kms-server --config-file config/config.toml"
-        );
+
+        let cmd = "kms-gen-keys --config-file config/gen-keys-config.toml && \
+            kms-server --config-file config/config.toml";
         let version = ROOT_CARGO_TOML.get_kms_grpc_version();
         let container = GenericImage::new("ghcr.io/zama-ai/kms/core-service", &version)
             .with_exposed_port(ContainerPort::Tcp(50051))
@@ -57,7 +55,15 @@ impl KmsInstance {
                 ))
                 .unwrap(),
             )
-            .with_cmd(["-c", &cmd])
+            .with_copy_to(
+                "/app/kms/core/service/config/gen-keys-config.toml".to_string(),
+                PathBuf::from_str(&format!(
+                    "{}/tests/data/gen-keys-config.toml",
+                    env!("CARGO_MANIFEST_DIR"),
+                ))
+                .unwrap(),
+            )
+            .with_cmd(["-c", cmd])
             .with_startup_timeout(Duration::from_secs(180))
             .start()
             .await?;

--- a/kms-connector/crates/utils/src/types/db.rs
+++ b/kms-connector/crates/utils/src/types/db.rs
@@ -1,5 +1,8 @@
 use crate::types::ProtocolEventKind;
-use alloy::{primitives::B256, sol_types::SolEvent};
+use alloy::{
+    primitives::{B256, U256},
+    sol_types::SolEvent,
+};
 use anyhow::anyhow;
 // Handle-only overloaded decryption events
 use fhevm_gateway_bindings::decryption::Decryption::{
@@ -18,8 +21,9 @@ use fhevm_host_bindings::{
         KmsContextDestroyed, KmsEpochDestroyed, NewKmsContext, NewKmsEpoch,
     },
 };
-use sqlx::postgres::PgNotification;
+use sqlx::{PgExecutor, postgres::PgNotification, types::chrono::Utc};
 use std::{fmt::Display, str::FromStr};
+use tracing::info;
 
 /// Struct representing the `ParamsType` enum in the database.
 #[derive(sqlx::Type, Copy, Clone, Debug, PartialEq)]
@@ -271,4 +275,49 @@ impl std::fmt::Display for OperationStatus {
             Self::Aborted => "aborted",
         })
     }
+}
+
+/// Marks a destroyed KMS context as invalid in the `kms_context` validation cache.
+///
+/// The invalidation is upserted so the destruction is recorded even if the context was not cached.
+pub async fn invalidate_kms_context<'e>(
+    executor: impl PgExecutor<'e>,
+    context_id: U256,
+) -> anyhow::Result<()> {
+    let now = Utc::now();
+    sqlx::query!(
+        "INSERT INTO kms_context(id, is_valid, created_at, updated_at)
+        VALUES ($1, FALSE, $2, $2)
+        ON CONFLICT (id) DO UPDATE SET is_valid = FALSE, updated_at = $2",
+        context_id.as_le_slice(),
+        now,
+    )
+    .execute(executor)
+    .await?;
+
+    info!("KMS context #{context_id} marked as destroyed in DB");
+    Ok(())
+}
+
+/// Marks a destroyed KMS epoch as invalid in the `kms_epoch` validation cache.
+///
+/// The invalidation is upserted so the destruction is recorded even if the epoch was never cached;
+/// `context_id` stays NULL in that case, as the event does not carry it.
+pub async fn invalidate_kms_epoch<'e>(
+    executor: impl PgExecutor<'e>,
+    epoch_id: U256,
+) -> anyhow::Result<()> {
+    let now = Utc::now();
+    sqlx::query!(
+        "INSERT INTO kms_epoch(id, is_valid, created_at, updated_at)
+        VALUES ($1, FALSE, $2, $2)
+        ON CONFLICT (id) DO UPDATE SET is_valid = FALSE, updated_at = $2",
+        epoch_id.as_le_slice(),
+        now,
+    )
+    .execute(executor)
+    .await?;
+
+    info!("KMS epoch #{epoch_id} marked as destroyed in DB");
+    Ok(())
 }

--- a/kms-connector/crates/utils/src/types/grpc.rs
+++ b/kms-connector/crates/utils/src/types/grpc.rs
@@ -28,6 +28,18 @@ pub enum KmsGrpcRequest {
     DestroyMpcEpoch(DestroyMpcEpochRequest),
 }
 
+/// The outcome of sending a GRPC request to the KMS Core.
+///
+/// Most requests only yield an acknowledgement (`Empty`). Context destruction additionally
+/// returns the list of epochs destroyed as a side effect, which the caller invalidates locally.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SendResponse {
+    /// The send was acknowledged, with no meaningful payload to act on.
+    Empty,
+    /// Epoch IDs destroyed as part of a context destruction, to be invalidated locally.
+    DestroyedEpochs(Vec<U256>),
+}
+
 impl From<PublicDecryptionRequest> for KmsGrpcRequest {
     fn from(value: PublicDecryptionRequest) -> Self {
         Self::PublicDecryption(value)

--- a/kms-connector/crates/utils/src/types/grpc.rs
+++ b/kms-connector/crates/utils/src/types/grpc.rs
@@ -28,18 +28,6 @@ pub enum KmsGrpcRequest {
     DestroyMpcEpoch(DestroyMpcEpochRequest),
 }
 
-/// The outcome of sending a GRPC request to the KMS Core.
-///
-/// Most requests only yield an acknowledgement (`Empty`). Context destruction additionally
-/// returns the list of epochs destroyed as a side effect, which the caller invalidates locally.
-#[derive(Clone, Debug, PartialEq)]
-pub enum SendResponse {
-    /// The send was acknowledged, with no meaningful payload to act on.
-    Empty,
-    /// Epoch IDs destroyed as part of a context destruction, to be invalidated locally.
-    DestroyedEpochs(Vec<U256>),
-}
-
 impl From<PublicDecryptionRequest> for KmsGrpcRequest {
     fn from(value: PublicDecryptionRequest) -> Self {
         Self::PublicDecryption(value)
@@ -105,4 +93,16 @@ impl TryFrom<(RequestId, Response<UserDecryptionResponse>)> for KmsGrpcResponse 
             grpc_response: value.1.into_inner(),
         })
     }
+}
+
+/// The outcome of sending a GRPC request to the KMS Core.
+///
+/// Most requests only yield an acknowledgement (`Empty`). Context destruction additionally
+/// returns the list of epochs destroyed as a side effect, which the caller invalidates locally.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SendResponse {
+    /// The send was acknowledged, with no meaningful payload to act on.
+    Empty,
+    /// Epoch IDs destroyed as part of a context destruction, to be invalidated locally.
+    DestroyedEpochs(Vec<U256>),
 }

--- a/kms-connector/crates/utils/src/types/mod.rs
+++ b/kms-connector/crates/utils/src/types/mod.rs
@@ -6,7 +6,7 @@ pub mod handle;
 pub mod kms_response;
 
 pub use event::{ProtocolEvent, ProtocolEventKind};
-pub use grpc::{KmsGrpcRequest, KmsGrpcResponse};
+pub use grpc::{KmsGrpcRequest, KmsGrpcResponse, SendResponse};
 pub use kms_response::{
     CrsgenResponse, EpochResultResponse, KeygenResponse, KmsResponse, KmsResponseKind,
     NewKmsContextResponse, PrepKeygenResponse, PublicDecryptionResponse, UserDecryptionResponse,

--- a/kms-connector/crates/utils/tests/data/gen-keys-config.toml
+++ b/kms-connector/crates/utils/tests/data/gen-keys-config.toml
@@ -1,0 +1,20 @@
+# Config for the `kms-gen-keys` step that runs before `kms-server` in the KMS Core test
+# container. Its schema rejects unknown fields, so it can't reuse `core-service-config.toml`.
+# The vault sections mirror `core-service-config.toml` so the generated keys land where
+# `kms-server` reads them. `aws.s3_endpoint` is a placeholder overridden at runtime by the
+# `KMS_CORE__AWS__S3_ENDPOINT` env var (dynamic host port), like the server config.
+
+[keygen]
+overwrite = false
+show_existing = false
+
+[aws]
+region = "eu-west-1"
+s3_endpoint = "http://minio:9000"
+
+[public_vault.storage.s3]
+bucket = "kms-public"
+prefix = "PUB"
+
+[private_vault.storage.file]
+path = "./keys"

--- a/kms-connector/tests/contracts/ProtocolConfigMock.sol
+++ b/kms-connector/tests/contracts/ProtocolConfigMock.sol
@@ -129,4 +129,12 @@ contract ProtocolConfigMock {
     function getCurrentKmsContextAndEpoch() external pure returns (uint256, uint256) {
         return (1, 1);
     }
+
+    function isValidKmsContext(uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function isValidEpochForContext(uint256, uint256) external pure returns (bool) {
+        return true;
+    }
 }


### PR DESCRIPTION
### Summary

Follow-up of #3073.

Aligns the kms-connector with the new KMS Core gRPC contract for context/epoch destruction, where destroyed epochs are now reported back in the gRPC response.
Also adds a startup cache-reconciliation for `gw-listener` and pins all context/epoch validity view calls to finalized blocks.

Bumps `kms-grpc` (`b9087af` → `d27c3b52`, `0.14.0` → `0.15.0`).

### What changed

1. **Destroyed epochs flow back via the response.**
   - `DestroyMpcContextRequest` drops its `epoch_ids` field; `DestroyMpcContextResponse` now returns the epoch IDs destroyed alongside a context.
   - New `SendResponse` enum (`Empty` | `DestroyedEpochs(Vec<U256>)`) carries this through the send path; `send_request_with_retries` gains a `map_response` closure.
   - The connector invalidates the returned epochs locally in the processor.

2. **Startup cache reconciliation.** New `EthereumListener::revalidate_context_cache()` re-checks every cached-valid context/epoch against on-chain `ProtocolConfig` and invalidates stale rows. Wired into gw-listener startup as a backstop for missed events or a KMS-Core restart mid-destruction.

3. **View calls pinned to `BlockId::finalized()`** across all five context/epoch validity call sites, plus a test-setup helper that waits for deployments to finalize.