### PR TITLE
feat(host-contracts): confidential-batcher redeem direction (join, dispatch, settle, claim)

### DIFF
--- a/solana/docs/CONFIDENTIAL_VAULTS.md
+++ b/solana/docs/CONFIDENTIAL_VAULTS.md
@@ -60,13 +60,18 @@ everything below uses Solana-native building blocks.
    share tokens, and wraps them into **confidential shares**. It fixes one
    public exchange rate for the whole batch: shares received ÷ total
    deposited.
-5. **Claim.** Each user collects their shares. Their encrypted deposit is
-   multiplied by the public rate — an encrypted number times a public number,
-   which FHE does cheaply. No one ever divides encrypted by encrypted.
+5. **Claim.** Each user collects their shares: their encrypted deposit's
+   exact proportional part of the batch's shares — an encrypted number times
+   a public number, divided by a public number, which FHE does cheaply. No
+   one ever divides encrypted by encrypted, and the floor rounding means the
+   claims can never add up to more than the batch received.
 
-Withdrawing works the same way in mirror: join a redeem batch with encrypted
-shares, the batch total of shares is revealed and redeemed from the vault,
-and users claim encrypted tokens back at the batch's rate.
+Withdrawing works the same way in mirror, in the same program: a *redeem*
+batcher's batches are joined with encrypted shares, the batch total of shares
+is revealed and withdrawn from the vault, and users claim their exact
+proportional part of the returned tokens, encrypted. Deposit and redeem
+batchers run side by side — one pending batch each — so exits never wait on
+entries.
 
 ## What is public and what is private
 

--- a/solana/docs/DESIGN_DECISIONS.md
+++ b/solana/docs/DESIGN_DECISIONS.md
@@ -1825,3 +1825,45 @@ the loss per batch is bounded below one share's worth. Behavior is pinned by
 cancel-and-refund settle branch: wrap the redeemed underlying back into the batch's confidential
 account and refund each user's encrypted deposit via `confidential_transfer_from_value` (quit's
 mechanism) — not implemented in the deposit-path PR.
+
+Redeem path implemented (fhevm-internal#1758), as an addendum to the deposit path above. **One
+program serves both directions, with the direction on the `Batcher` config** — each config is a
+Deposit or a Redeem instance, mirroring the EVM's two batcher deployments: a pending deposit batch
+never blocks a redeem batch (each batcher serializes only its own batches), yet every account
+layout and every instruction is shared. The vocabulary is direction-neutral — a JOIN confidential
+mint (what users batch in: cUnderlying for deposits, cShares for redeems) and a PAYOUT confidential
+mint (what claims pay: cShares for deposits, cUnderlying for redeems) — and the batch lifecycle's
+only direction branch is settle's vault leg (`demo_vault::deposit` vs `demo_vault::withdraw`);
+`initialize_batcher` additionally validates the mint wiring per direction at setup, and join, quit,
+dispatch, claim, and open_batch are direction-free. The
+alternative (a duplicated instruction set) was rejected because the two flows differ in exactly one
+CPI: duplicating fourteen account structs to encode one branch would double the review surface for
+zero clarity.
+
+Claim math changed for BOTH directions (fixes fhevm-internal#1774 item 1): a claim is the exact
+proportional floor `encrypted(joined) x payout_received / total_joined` in one MulDiv — same FHE op
+count as before — instead of `encrypted(joined) x rate / RATE_SCALE` on a pre-floored rate. The
+double rounding stranded up to RATE_SCALE-scale dust per batch (6,148,914,726 raw units measured at
+a u64-scale two-user batch, vs at most one unit per claim now; pinned by
+`exact_division_strands_less_than_the_rate_would`). Sum-of-claims <= payout still holds:
+`sum(floor(j_i * P / T)) <= floor(sum(j_i) * P / T) = P`. The MulDiv intermediate
+`joined * payout_received < 2^128` stays inside the coprocessor's widened MulDiv and the result is
+at most `payout_received`, so it fits euint64; `total_joined > 0` because zero-total batches
+cancel. The frozen `payout_rate` remains on the batch and in `BatchSettled`, but is informational
+only and SATURATES at u64::MAX instead of failing settle (a redeem batch of few shares against a
+large payout can legitimately exceed the u64 rate domain — a display number must not brick funds).
+
+Settle's delta accounting is preserved as a security invariant on the redeem direction's
+underlying-received leg: the payout is the batch payout account's SPL balance DELTA across the
+vault CPI, never its raw balance, so preloaded tokens (which SPL destinations cannot refuse) stay
+inert (pinned by `mollusk_redeem_preloaded_underlying_stays_inert` alongside the deposit-side
+test). The dust-brick limitation above is deposit-only: the vault's share price never drops below
+1:1 (floor rounding favors the vault; `harvest` only raises the price), so withdrawing any non-zero
+share total always returns at least that many underlying units and `ZeroAssets` is unreachable from
+a redeem batch (pinned by `mollusk_redeem_one_share_dust_settles_at_extreme_price`). Exit rules are
+symmetric too: `quit` returns the exact encrypted share amount while pending; there is NO exit
+between dispatch and settle in either direction — the deadline-cancel path stays out of demo scope
+(fhevm-internal#1773). Operational assumption, both directions (fhevm-internal#1774 item 2): every
+token/host CPI passes deny-list records and HCU accounts (`deny_subject_record`,
+`hcu_block_meter`, `hcu_trusted_app_record`) as hardcoded `None` — the program assumes
+`grant_deny_list_enabled = false` and no binding HCU cap, which is how the PoC host fixtures run.

--- a/solana/programs/confidential-batcher/src/constants.rs
+++ b/solana/programs/confidential-batcher/src/constants.rs
@@ -3,20 +3,21 @@
 /// App event schema version, following the demo-vault pattern. The batcher is
 /// not ingested by the coprocessor host-listener (host protocol events are
 /// emitted by the ZamaHost CPIs it composes); this versions app/demo indexer
-/// reads.
-pub const APP_EVENT_VERSION: u8 = 1;
+/// reads. Version 2: direction-neutral join/payout field names and the
+/// `direction` field on `BatcherInitialized`.
+pub const APP_EVENT_VERSION: u8 = 2;
 
-/// Fixed-point scale of a batch's public share rate:
-/// `share_rate = shares_received * RATE_SCALE / total_deposited`, and each
-/// claim is `encrypted(deposit) * share_rate / RATE_SCALE` in one MulDiv eval.
+/// Fixed-point scale of a batch's public payout rate:
+/// `payout_rate = payout_received * RATE_SCALE / total_joined`.
 ///
-/// Domain bound: `share_rate <= RATE_SCALE * shares / total`, and the demo
-/// vault's share price never drops below ~1 (no loss path, donations only
-/// raise it), so `shares <= total` and the rate fits u64 with room to spare;
-/// `freeze_share_rate` still checks the u64 fit and fails closed. The MulDiv
-/// intermediate is `deposit * rate <= total * rate <= shares * RATE_SCALE
-/// < 2^64 * 10^9 < 2^128`, inside the coprocessor's widened MulDiv, and the
-/// result is at most `shares_received`, so it fits euint64.
+/// The rate is event-facing and informational only. Claims do NOT multiply by
+/// it: each claim is the exact proportional floor
+/// `encrypted(joined) * payout_received / total_joined` in one MulDiv eval,
+/// which strands strictly less than the rate's double rounding would (the
+/// intermediate `joined * payout_received < 2^128` stays inside the
+/// coprocessor's widened MulDiv, and the result is at most `payout_received`,
+/// so it fits euint64). On the redeem direction the rate itself can exceed
+/// u64 at extreme share prices, so it saturates instead of failing settle.
 pub const RATE_SCALE: u64 = 1_000_000_000;
 
 /// PDA seed for a batch, keyed by batcher and batch index.
@@ -26,13 +27,15 @@ pub const BATCH_SEED: &[u8] = b"batch";
 /// SPL token accounts, signs its FHE evals, and authorizes its token CPIs.
 pub const BATCH_AUTHORITY_SEED: &[u8] = b"batch-authority";
 
-/// PDA seed for a user's per-batch deposit record.
-pub const DEPOSIT_RECORD_SEED: &[u8] = b"deposit-record";
+/// PDA seed for a user's per-batch join record.
+pub const JOIN_RECORD_SEED: &[u8] = b"join-record";
 
-/// PDA seed for the batch's plain SPL account holding redeemed underlying
-/// tokens between settle's redeem and vault-deposit legs.
-pub const BATCH_UNDERLYING_SEED: &[u8] = b"batch-underlying";
+/// PDA seed for the batch's plain SPL account in the JOIN mint's underlying
+/// (vault underlying for deposit batchers, vault shares for redeem batchers),
+/// holding the redeemed batch total between settle's redeem and vault legs.
+pub const BATCH_JOIN_UNDERLYING_SEED: &[u8] = b"batch-join-underlying";
 
-/// PDA seed for the batch's plain SPL account holding vault shares between
-/// settle's vault-deposit and wrap legs.
-pub const BATCH_SHARE_TOKENS_SEED: &[u8] = b"batch-share-tokens";
+/// PDA seed for the batch's plain SPL account in the PAYOUT mint's underlying
+/// (vault shares for deposit batchers, vault underlying for redeem batchers),
+/// holding the vault leg's output between settle's vault and wrap legs.
+pub const BATCH_PAYOUT_UNDERLYING_SEED: &[u8] = b"batch-payout-underlying";

--- a/solana/programs/confidential-batcher/src/errors.rs
+++ b/solana/programs/confidential-batcher/src/errors.rs
@@ -7,10 +7,10 @@ use anchor_lang::prelude::*;
 /// Errors returned by the confidential batcher.
 #[error_code]
 pub enum BatcherError {
-    /// The deposit confidential mint does not wrap the vault's underlying mint.
+    /// Legacy (unused since the join/payout refactor; kept for code stability).
     #[msg("deposit confidential mint does not wrap the vault underlying mint")]
     DepositMintVaultMismatch,
-    /// The shares confidential mint does not wrap the vault's share mint.
+    /// Legacy (unused since the join/payout refactor; kept for code stability).
     #[msg("shares confidential mint does not wrap the vault share mint")]
     SharesMintVaultMismatch,
     /// The supplied confidential mint does not match the batcher config.
@@ -49,18 +49,29 @@ pub enum BatcherError {
     /// The batcher produced an invalid FHE eval plan (internal invariant).
     #[msg("invalid FHE eval plan")]
     InvalidFheEvalPlan,
-    /// The deposit record's shares were already claimed.
-    #[msg("shares already claimed for this deposit record")]
+    /// The join record's payout was already claimed.
+    #[msg("payout already claimed for this join record")]
     AlreadyClaimed,
-    /// The frozen share rate overflowed u64 (vault share price below the
-    /// supported domain).
+    /// Legacy (unused since the informational rate saturates; kept for code
+    /// stability).
     #[msg("share rate does not fit u64")]
     ShareRateOverflow,
     /// A batch index computation overflowed.
     #[msg("batch index overflowed")]
     BatchIndexOverflow,
-    /// The batch share account's balance decreased across the vault deposit
-    /// (unreachable; guards the delta computation).
+    /// Legacy (unused since the join/payout refactor; kept for code stability).
     #[msg("batch share balance decreased across the vault deposit")]
     ShareBalanceUnderflow,
+    /// The join confidential mint does not wrap the vault mint the direction
+    /// requires (underlying for deposit batchers, shares for redeem batchers).
+    #[msg("join confidential mint does not wrap the vault mint this direction requires")]
+    JoinMintVaultMismatch,
+    /// The payout confidential mint does not wrap the vault mint the direction
+    /// requires (shares for deposit batchers, underlying for redeem batchers).
+    #[msg("payout confidential mint does not wrap the vault mint this direction requires")]
+    PayoutMintVaultMismatch,
+    /// The batch payout account's balance decreased across the vault leg
+    /// (unreachable; guards the delta computation).
+    #[msg("batch payout balance decreased across the vault leg")]
+    PayoutBalanceUnderflow,
 }

--- a/solana/programs/confidential-batcher/src/events.rs
+++ b/solana/programs/confidential-batcher/src/events.rs
@@ -2,9 +2,12 @@
 //!
 //! For frontend/demo indexers. The generic coprocessor host-listener does not
 //! consume these: the FHE-protocol events are emitted by the ZamaHost CPIs the
-//! batcher composes.
+//! batcher composes. Only settled events carry amounts — everything else stays
+//! encrypted.
 
 use anchor_lang::prelude::*;
+
+use crate::state::BatchDirection;
 
 /// Emitted when a batcher config is created.
 #[event]
@@ -13,10 +16,12 @@ pub struct BatcherInitialized {
     pub version: u8,
     /// Batcher config account.
     pub batcher: Pubkey,
-    /// Confidential mint users deposit through the batcher.
-    pub deposit_confidential_mint: Pubkey,
-    /// Confidential mint wrapping the vault's share mint.
-    pub shares_confidential_mint: Pubkey,
+    /// Direction of this batcher instance.
+    pub direction: BatchDirection,
+    /// Confidential mint users join batches with.
+    pub join_confidential_mint: Pubkey,
+    /// Confidential mint claims pay out in.
+    pub payout_confidential_mint: Pubkey,
     /// Public vault the batcher fronts.
     pub vault: Pubkey,
     /// Minimum slots a batch must stay open before dispatch.
@@ -48,16 +53,16 @@ pub struct JoinedBatch {
     pub version: u8,
     /// Batch account.
     pub batch: Pubkey,
-    /// Joining user (deposit owner).
+    /// Joining user.
     pub user: Pubkey,
-    /// `EncryptedValue` lineage holding the user's accumulated batch deposit.
-    pub deposit_encrypted_value: Pubkey,
-    /// Current handle of the deposit lineage after this join.
-    pub deposit_handle: [u8; 32],
+    /// `EncryptedValue` lineage holding the user's accumulated joined amount.
+    pub joined_encrypted_value: Pubkey,
+    /// Current handle of the joined lineage after this join.
+    pub joined_handle: [u8; 32],
 }
 
-/// Emitted when a user quits a pending batch: the exact recorded deposit was
-/// transferred back and the deposit lineage reset to zero.
+/// Emitted when a user quits a pending batch: the exact recorded amount was
+/// transferred back and the joined lineage reset to zero.
 #[event]
 pub struct QuitBatch {
     /// Event schema version.
@@ -80,24 +85,26 @@ pub struct BatchDispatched {
     pub burned_total_handle: [u8; 32],
 }
 
-/// Emitted when a batch settles: the certified total went into the vault and
-/// the batch's public share rate is frozen.
+/// Emitted when a batch settles: the certified total went through the vault
+/// and the batch's public settle results are frozen. The amounts here are the
+/// batch aggregates, intentionally public.
 #[event]
 pub struct BatchSettled {
     /// Event schema version.
     pub version: u8,
     /// Batch account.
     pub batch: Pubkey,
-    /// KMS-certified batch total (public by design).
-    pub total_deposited: u64,
-    /// Vault shares received for the batch total.
-    pub shares_received: u64,
-    /// Frozen share rate: `shares_received * RATE_SCALE / total_deposited`.
-    pub share_rate: u64,
+    /// KMS-certified batch join total (public by design).
+    pub total_joined: u64,
+    /// Payout units the vault leg produced for the batch total.
+    pub payout_received: u64,
+    /// Informational rate `payout_received * RATE_SCALE / total_joined`,
+    /// saturating at u64::MAX. Claims use exact proportional division.
+    pub payout_rate: u64,
 }
 
 /// Emitted when a zero-total batch is canceled at settle time (nothing to
-/// deposit, no rate to freeze — the division never happens).
+/// move through the vault, no rate to freeze — the division never happens).
 #[event]
 pub struct BatchCanceled {
     /// Event schema version.
@@ -106,15 +113,15 @@ pub struct BatchCanceled {
     pub batch: Pubkey,
 }
 
-/// Emitted when a user's confidential shares are claimed from a settled batch.
+/// Emitted when a user's confidential payout is claimed from a settled batch.
 #[event]
-pub struct SharesClaimed {
+pub struct PayoutClaimed {
     /// Event schema version.
     pub version: u8,
     /// Batch account.
     pub batch: Pubkey,
-    /// User the shares were transferred to.
+    /// User the payout was transferred to.
     pub user: Pubkey,
-    /// `EncryptedValue` lineage holding the claimed share amount.
+    /// `EncryptedValue` lineage holding the claimed payout amount.
     pub claim_encrypted_value: Pubkey,
 }

--- a/solana/programs/confidential-batcher/src/instructions/claim.rs
+++ b/solana/programs/confidential-batcher/src/instructions/claim.rs
@@ -1,23 +1,36 @@
-//! Claims a user's confidential shares from a settled batch.
+//! Claims a user's confidential payout from a settled batch. Direction-free:
+//! the payout mint is confidential shares for deposit batchers, confidential
+//! underlying for redeem batchers.
 //!
-//! One MulDiv eval frame — `encrypted(deposit) x share_rate / RATE_SCALE` —
-//! then a confidential transfer of the resulting handle from the batch's
-//! shares account to the user. Permissionless pull: anyone can trigger a
-//! user's claim; the shares can only land in the user's own account.
+//! One MulDiv eval frame — the exact proportional floor
+//! `encrypted(joined) x payout_received / total_joined` — then a confidential
+//! transfer of the resulting handle from the batch's payout account to the
+//! user. Permissionless pull: anyone can trigger a user's claim; the payout
+//! can only land in the user's own account.
 //!
-//! Rounding guarantees delivery: the rate and every claim round down, so the
-//! sum of all claims never exceeds the wrapped shares and the all-or-zero
-//! transfer always moves the full claim.
+//! Rounding guarantees delivery: every claim floors its exact share of the
+//! aggregate, so the sum of all claims never exceeds the wrapped payout and
+//! the all-or-zero transfer always moves the full claim. Exact division (not
+//! the informational `payout_rate`) avoids the double rounding that stranded
+//! up to `RATE_SCALE`-scale dust per batch at u64 amounts. The MulDiv's
+//! intermediate `joined * payout_received < 2^128` stays inside the
+//! coprocessor's widened MulDiv, and the result is at most `payout_received`,
+//! so it fits euint64. `total_joined > 0` because zero-total batches cancel.
+//!
+//! The eval and transfer assume `grant_deny_list_enabled = false` and no
+//! binding HCU cap: `hcu_block_meter` and `hcu_trusted_app_record` are
+//! hardcoded `None` (the PoC host fixtures never enable them), and deny-list
+//! records ride in as the (empty) remaining accounts.
 
 use super::*;
 
-/// Accounts for claiming shares.
+/// Accounts for claiming a payout.
 #[derive(Accounts)]
 pub struct Claim<'info> {
     /// Pays the claim lineage and transfer output rent. Anyone.
     #[account(mut)]
     pub payer: Signer<'info>,
-    /// CHECK: the user being claimed for; pinned by the deposit record's PDA
+    /// CHECK: the user being claimed for; pinned by the join record's PDA
     /// seeds. Not a signer — claims are permissionless pulls.
     pub user: UncheckedAccount<'info>,
     /// Batcher config.
@@ -26,45 +39,45 @@ pub struct Claim<'info> {
     #[account(constraint = batch.batcher == batcher.key() @ BatcherError::BatchBatcherMismatch)]
     pub batch: Box<Account<'info, Batch>>,
     /// CHECK: per-batch authority PDA; the claim eval's compute subject + app
-    /// authority and the share transfer's authority via invoke_signed.
+    /// authority and the payout transfer's authority via invoke_signed.
     #[account(seeds = [BATCH_AUTHORITY_SEED, batch.key().as_ref()], bump = batch.authority_bump)]
     pub batch_authority: UncheckedAccount<'info>,
-    /// The user's deposit record; marked claimed here.
+    /// The user's join record; marked claimed here.
     #[account(
         mut,
-        seeds = [DEPOSIT_RECORD_SEED, batch.key().as_ref(), user.key().as_ref()],
-        bump = deposit_record.bump,
+        seeds = [JOIN_RECORD_SEED, batch.key().as_ref(), user.key().as_ref()],
+        bump = join_record.bump,
     )]
-    pub deposit_record: Box<Account<'info, DepositRecord>>,
-    /// CHECK: the user's batch deposit lineage; read as the MulDiv operand.
-    pub pending_deposit_value: UncheckedAccount<'info>,
+    pub join_record: Box<Account<'info, JoinRecord>>,
+    /// CHECK: the user's joined lineage; read as the MulDiv operand.
+    pub pending_join_value: UncheckedAccount<'info>,
     /// CHECK: the user's claim lineage; created by the claim eval and spent as
     /// the transfer amount.
     #[account(mut)]
     pub claim_amount_value: UncheckedAccount<'info>,
-    /// Confidential mint wrapping the vault's share mint.
-    pub shares_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: shares mint compute-signer PDA; validated by the token CPI.
-    pub shares_compute_signer: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential shares token account (transfer source);
+    /// Confidential mint claims pay out in.
+    pub payout_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: payout mint compute-signer PDA; validated by the token CPI.
+    pub payout_compute_signer: UncheckedAccount<'info>,
+    /// CHECK: batch's confidential payout token account (transfer source);
     /// validated by the token CPI and pinned below.
     #[account(mut)]
-    pub batch_shares_token_account: UncheckedAccount<'info>,
-    /// CHECK: user's confidential shares token account (transfer destination);
+    pub batch_payout_token_account: UncheckedAccount<'info>,
+    /// CHECK: user's confidential payout token account (transfer destination);
     /// must already exist — the user initializes it once. Validated by the
     /// token CPI and pinned below.
     #[account(mut)]
-    pub user_shares_token_account: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential shares balance lineage; superseded by the token CPI.
+    pub user_payout_token_account: UncheckedAccount<'info>,
+    /// CHECK: batch's confidential payout balance lineage; superseded by the token CPI.
     #[account(mut)]
-    pub batch_shares_balance_value: UncheckedAccount<'info>,
-    /// CHECK: user's confidential shares balance lineage; superseded by the token CPI.
+    pub batch_payout_balance_value: UncheckedAccount<'info>,
+    /// CHECK: user's confidential payout balance lineage; superseded by the token CPI.
     #[account(mut)]
-    pub user_shares_balance_value: UncheckedAccount<'info>,
-    /// CHECK: batch shares account's transferred-amount lineage; superseded by
+    pub user_payout_balance_value: UncheckedAccount<'info>,
+    /// CHECK: batch payout account's transferred-amount lineage; superseded by
     /// the token CPI.
     #[account(mut)]
-    pub batch_shares_transferred_value: UncheckedAccount<'info>,
+    pub batch_payout_transferred_value: UncheckedAccount<'info>,
     /// CHECK: ZamaHost event-CPI authority; validated by the host program.
     pub zama_event_authority: UncheckedAccount<'info>,
     /// ZamaHost program (FHE compute + ACL).
@@ -79,44 +92,45 @@ pub struct Claim<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// Computes the user's encrypted share amount and transfers it to them.
+/// Computes the user's encrypted payout amount and transfers it to them.
 pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
     require!(
         ctx.accounts.batch.status == BatchStatus::Settled,
         BatcherError::BatchNotSettled
     );
     require!(
-        !ctx.accounts.deposit_record.claimed,
+        !ctx.accounts.join_record.claimed,
         BatcherError::AlreadyClaimed
     );
     require_keys_eq!(
-        ctx.accounts.shares_confidential_mint.key(),
-        ctx.accounts.batcher.shares_confidential_mint,
+        ctx.accounts.payout_confidential_mint.key(),
+        ctx.accounts.batcher.payout_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     require_keys_eq!(
-        ctx.accounts.pending_deposit_value.key(),
-        ctx.accounts.deposit_record.deposit_encrypted_value,
+        ctx.accounts.pending_join_value.key(),
+        ctx.accounts.join_record.joined_encrypted_value,
         BatcherError::DerivedAccountMismatch
     );
-    let shares_mint_key = ctx.accounts.shares_confidential_mint.key();
+    let payout_mint_key = ctx.accounts.payout_confidential_mint.key();
     let batch_key = ctx.accounts.batch.key();
     let user = ctx.accounts.user.key();
     let batch_authority = ctx.accounts.batch_authority.key();
     require_keys_eq!(
-        ctx.accounts.batch_shares_token_account.key(),
-        ct::token_account_address(shares_mint_key, batch_authority).0,
+        ctx.accounts.batch_payout_token_account.key(),
+        ct::token_account_address(payout_mint_key, batch_authority).0,
         BatcherError::DerivedAccountMismatch
     );
     require_keys_eq!(
-        ctx.accounts.user_shares_token_account.key(),
-        ct::token_account_address(shares_mint_key, user).0,
+        ctx.accounts.user_payout_token_account.key(),
+        ct::token_account_address(payout_mint_key, user).0,
         BatcherError::DerivedAccountMismatch
     );
 
-    // Leg 1: the one MulDiv frame — encrypted deposit times the public rate.
-    let deposit_value = fhe::read_encrypted_value(&ctx.accounts.pending_deposit_value)?;
-    let deposit = fhe::uint64_operand(&deposit_value)?;
+    // Leg 1: the one MulDiv frame — the encrypted joined amount's exact
+    // proportional share of the public aggregate payout.
+    let joined_value = fhe::read_encrypted_value(&ctx.accounts.pending_join_value)?;
+    let joined = fhe::uint64_operand(&joined_value)?;
     let claim_binding = fhe::DurableBinding::bind(
         ctx.accounts.claim_amount_value.to_account_info(),
         zama_fhe::DurableSlot::new(
@@ -125,12 +139,12 @@ pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
             zama_fhe::DurableLabel::new(claim_amount_label(user)),
         ),
         // The user decrypts their claimed amount; the batch authority spends
-        // it as the transfer amount; the shares mint's compute signer lets the
+        // it as the transfer amount; the payout mint's compute signer lets the
         // transfer eval read it.
         zama_fhe::AccessPolicy::from_subjects(vec![
             zama_fhe::AccessSubject::owner(user),
             zama_fhe::AccessSubject::compute(batch_authority),
-            zama_fhe::AccessSubject::compute(ctx.accounts.shares_confidential_mint.compute_signer),
+            zama_fhe::AccessSubject::compute(ctx.accounts.payout_confidential_mint.compute_signer),
         ])
         .map_err(fhe::invalid_eval_plan)?,
     )?;
@@ -139,12 +153,13 @@ pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
             b"confidential-batcher-claim-v1",
             batch_key.as_ref(),
             user.as_ref(),
-            &deposit_value.current_handle,
+            &joined_value.current_handle,
         ])
         .to_bytes(),
     )
     .map_err(fhe::invalid_eval_plan)?;
-    let share_rate = ctx.accounts.batch.share_rate;
+    let payout_received = ctx.accounts.batch.payout_received;
+    let total_joined = ctx.accounts.batch.total_joined;
     fhe::eval_as_batch_authority(
         fhe::BatchAuthorityEval {
             batch: batch_key,
@@ -160,13 +175,13 @@ pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
         context_id,
         vec![
             claim_binding.account_info(),
-            ctx.accounts.pending_deposit_value.to_account_info(),
+            ctx.accounts.pending_join_value.to_account_info(),
         ],
         |builder| {
             builder.mul_div(
-                deposit,
-                zama_fhe::Scalar::<zama_fhe::Uint<64>>::u64(share_rate),
-                zama_fhe::Scalar::<zama_fhe::Uint<64>>::u64(RATE_SCALE),
+                joined,
+                zama_fhe::Scalar::<zama_fhe::Uint<64>>::u64(payout_received),
+                zama_fhe::Scalar::<zama_fhe::Uint<64>>::u64(total_joined),
                 claim_binding.output(),
             )
         },
@@ -180,15 +195,15 @@ pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
         ct::cpi::accounts::ConfidentialTransferFromValue {
             owner: ctx.accounts.batch_authority.to_account_info(),
             payer: ctx.accounts.payer.to_account_info(),
-            mint: ctx.accounts.shares_confidential_mint.to_account_info(),
-            from_account: ctx.accounts.batch_shares_token_account.to_account_info(),
-            to_account: ctx.accounts.user_shares_token_account.to_account_info(),
-            compute_signer: ctx.accounts.shares_compute_signer.to_account_info(),
-            from_balance_value: ctx.accounts.batch_shares_balance_value.to_account_info(),
-            to_balance_value: ctx.accounts.user_shares_balance_value.to_account_info(),
+            mint: ctx.accounts.payout_confidential_mint.to_account_info(),
+            from_account: ctx.accounts.batch_payout_token_account.to_account_info(),
+            to_account: ctx.accounts.user_payout_token_account.to_account_info(),
+            compute_signer: ctx.accounts.payout_compute_signer.to_account_info(),
+            from_balance_value: ctx.accounts.batch_payout_balance_value.to_account_info(),
+            to_balance_value: ctx.accounts.user_payout_balance_value.to_account_info(),
             transferred_amount_value: ctx
                 .accounts
-                .batch_shares_transferred_value
+                .batch_payout_transferred_value
                 .to_account_info(),
             amount_value: ctx.accounts.claim_amount_value.to_account_info(),
             zama_event_authority: ctx.accounts.zama_event_authority.to_account_info(),
@@ -206,9 +221,9 @@ pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
         &[&authority_seeds],
     ))?;
 
-    ctx.accounts.deposit_record.claimed = true;
+    ctx.accounts.join_record.claimed = true;
 
-    emit!(SharesClaimed {
+    emit!(PayoutClaimed {
         version: APP_EVENT_VERSION,
         batch: batch_key,
         user,

--- a/solana/programs/confidential-batcher/src/instructions/dispatch.rs
+++ b/solana/programs/confidential-batcher/src/instructions/dispatch.rs
@@ -1,4 +1,6 @@
 //! Dispatches a batch: burns its full encrypted balance for KMS certification.
+//! Direction-free — the burn is always on the join mint (confidential
+//! underlying for deposit batchers, confidential shares for redeem batchers).
 //!
 //! Permissionless after `min_batch_age_slots`. The batch account's own balance
 //! lineage IS the burn amount (`confidential_burn_from_value`'s whole-balance
@@ -23,15 +25,15 @@ pub struct Dispatch<'info> {
     pub batch_authority: UncheckedAccount<'info>,
     /// Confidential mint whose encrypted total supply the burn decreases.
     #[account(mut)]
-    pub deposit_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: deposit mint compute-signer PDA; validated by the token CPI.
-    pub deposit_compute_signer: UncheckedAccount<'info>,
+    pub join_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: join mint compute-signer PDA; validated by the token CPI.
+    pub join_compute_signer: UncheckedAccount<'info>,
     /// CHECK: mint-scoped total-supply authority PDA; validated by the token CPI.
     pub total_supply_authority: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential deposit token account; validated by the
+    /// CHECK: batch's confidential join token account; validated by the
     /// token CPI and pinned below.
     #[account(mut)]
-    pub batch_deposit_token_account: UncheckedAccount<'info>,
+    pub batch_join_token_account: UncheckedAccount<'info>,
     /// CHECK: batch's stable balance lineage — read as the burn amount AND
     /// superseded as the burn's balance output (the whole-balance alias).
     #[account(mut)]
@@ -64,8 +66,8 @@ pub fn dispatch(ctx: Context<Dispatch>) -> Result<()> {
         BatcherError::BatchNotPending
     );
     require_keys_eq!(
-        ctx.accounts.deposit_confidential_mint.key(),
-        ctx.accounts.batcher.deposit_confidential_mint,
+        ctx.accounts.join_confidential_mint.key(),
+        ctx.accounts.batcher.join_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     let now = Clock::get()?.slot;
@@ -77,11 +79,11 @@ pub fn dispatch(ctx: Context<Dispatch>) -> Result<()> {
             .saturating_add(ctx.accounts.batcher.min_batch_age_slots),
         BatcherError::BatchTooYoung
     );
-    let mint_key = ctx.accounts.deposit_confidential_mint.key();
+    let mint_key = ctx.accounts.join_confidential_mint.key();
     let batch_key = ctx.accounts.batch.key();
     let batch_authority = ctx.accounts.batch_authority.key();
     require_keys_eq!(
-        ctx.accounts.batch_deposit_token_account.key(),
+        ctx.accounts.batch_join_token_account.key(),
         ct::token_account_address(mint_key, batch_authority).0,
         BatcherError::DerivedAccountMismatch
     );
@@ -93,9 +95,9 @@ pub fn dispatch(ctx: Context<Dispatch>) -> Result<()> {
         ct::cpi::accounts::ConfidentialBurnFromValue {
             owner: ctx.accounts.batch_authority.to_account_info(),
             payer: ctx.accounts.payer.to_account_info(),
-            mint: ctx.accounts.deposit_confidential_mint.to_account_info(),
-            token_account: ctx.accounts.batch_deposit_token_account.to_account_info(),
-            compute_signer: ctx.accounts.deposit_compute_signer.to_account_info(),
+            mint: ctx.accounts.join_confidential_mint.to_account_info(),
+            token_account: ctx.accounts.batch_join_token_account.to_account_info(),
+            compute_signer: ctx.accounts.join_compute_signer.to_account_info(),
             total_supply_authority: ctx.accounts.total_supply_authority.to_account_info(),
             balance_value: ctx.accounts.batch_balance_value.to_account_info(),
             total_supply_value: ctx.accounts.total_supply_value.to_account_info(),

--- a/solana/programs/confidential-batcher/src/instructions/initialize_batcher.rs
+++ b/solana/programs/confidential-batcher/src/instructions/initialize_batcher.rs
@@ -1,4 +1,5 @@
-//! Creates the batcher config wiring the two confidential mints and the vault.
+//! Creates the batcher config wiring the two confidential mints and the vault
+//! for one direction.
 
 use super::*;
 
@@ -12,32 +13,49 @@ pub struct InitializeBatcher<'info> {
     /// creation (the demo-vault `Vault` pattern).
     #[account(init, payer = payer, space = 8 + Batcher::SPACE)]
     pub batcher: Box<Account<'info, Batcher>>,
-    /// Confidential mint users deposit through the batcher.
-    pub deposit_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// Confidential mint wrapping the vault's share mint.
-    pub shares_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// Confidential mint users join batches with.
+    pub join_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// Confidential mint claims pay out in.
+    pub payout_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
     /// Public vault the batcher fronts.
     pub vault: Box<Account<'info, demo_vault::Vault>>,
     /// System program used for account creation.
     pub system_program: Program<'info, System>,
 }
 
-/// Validates the mint/vault wiring and records the batcher config.
-pub fn initialize_batcher(ctx: Context<InitializeBatcher>, min_batch_age_slots: u64) -> Result<()> {
+/// Validates the direction's mint/vault wiring and records the batcher config.
+pub fn initialize_batcher(
+    ctx: Context<InitializeBatcher>,
+    min_batch_age_slots: u64,
+    direction: BatchDirection,
+) -> Result<()> {
+    // The join mint must wrap what the batch total goes INTO the vault as,
+    // and the payout mint what comes back OUT.
+    let (join_vault_mint, payout_vault_mint) = match direction {
+        BatchDirection::Deposit => (
+            ctx.accounts.vault.underlying_mint,
+            ctx.accounts.vault.share_mint,
+        ),
+        BatchDirection::Redeem => (
+            ctx.accounts.vault.share_mint,
+            ctx.accounts.vault.underlying_mint,
+        ),
+    };
     require_keys_eq!(
-        ctx.accounts.deposit_confidential_mint.underlying_mint,
-        ctx.accounts.vault.underlying_mint,
-        BatcherError::DepositMintVaultMismatch
+        ctx.accounts.join_confidential_mint.underlying_mint,
+        join_vault_mint,
+        BatcherError::JoinMintVaultMismatch
     );
     require_keys_eq!(
-        ctx.accounts.shares_confidential_mint.underlying_mint,
-        ctx.accounts.vault.share_mint,
-        BatcherError::SharesMintVaultMismatch
+        ctx.accounts.payout_confidential_mint.underlying_mint,
+        payout_vault_mint,
+        BatcherError::PayoutMintVaultMismatch
     );
 
     let batcher = &mut ctx.accounts.batcher;
-    batcher.deposit_confidential_mint = ctx.accounts.deposit_confidential_mint.key();
-    batcher.shares_confidential_mint = ctx.accounts.shares_confidential_mint.key();
+    batcher.direction = direction;
+    batcher.join_confidential_mint = ctx.accounts.join_confidential_mint.key();
+    batcher.payout_confidential_mint = ctx.accounts.payout_confidential_mint.key();
     batcher.vault = ctx.accounts.vault.key();
     batcher.min_batch_age_slots = min_batch_age_slots;
     batcher.next_batch_index = 0;
@@ -45,8 +63,9 @@ pub fn initialize_batcher(ctx: Context<InitializeBatcher>, min_batch_age_slots: 
     emit!(BatcherInitialized {
         version: APP_EVENT_VERSION,
         batcher: batcher.key(),
-        deposit_confidential_mint: batcher.deposit_confidential_mint,
-        shares_confidential_mint: batcher.shares_confidential_mint,
+        direction,
+        join_confidential_mint: batcher.join_confidential_mint,
+        payout_confidential_mint: batcher.payout_confidential_mint,
         vault: batcher.vault,
         min_batch_age_slots,
     });

--- a/solana/programs/confidential-batcher/src/instructions/join.rs
+++ b/solana/programs/confidential-batcher/src/instructions/join.rs
@@ -1,9 +1,11 @@
-//! Joins the pending batch with a coprocessor-attested encrypted amount.
+//! Joins the pending batch with a coprocessor-attested encrypted amount of the
+//! batcher's join token (confidential underlying for deposit batchers,
+//! confidential shares for redeem batchers — the code is direction-free).
 //!
 //! One user-signed transaction: the user's signature propagates through the
 //! `confidential_transfer` CPI into the batch's own token account, and the
 //! batcher's own eval re-materializes the transferred amount into the user's
-//! batch deposit lineage **in the same transaction**. Same-transaction is
+//! joined lineage **in the same transaction**. Same-transaction is
 //! load-bearing: the transfer's recipient rule places the batch authority in
 //! the `transferred_amount` output audience by construction, but that lineage
 //! is superseded by the user's next transfer and input admission pins the
@@ -17,7 +19,7 @@ use super::*;
 pub struct Join<'info> {
     /// Joining user; transfer authority over their confidential balance.
     pub user: Signer<'info>,
-    /// Pays deposit-record rent, transfer output rent, and the batcher eval's
+    /// Pays join-record rent, transfer output rent, and the batcher eval's
     /// ACL rent.
     #[account(mut)]
     pub payer: Signer<'info>,
@@ -30,27 +32,27 @@ pub struct Join<'info> {
     /// batcher eval's compute subject + app authority.
     #[account(seeds = [BATCH_AUTHORITY_SEED, batch.key().as_ref()], bump = batch.authority_bump)]
     pub batch_authority: UncheckedAccount<'info>,
-    /// The user's deposit record for this batch; created on first join.
+    /// The user's join record for this batch; created on first join.
     #[account(
         init_if_needed,
         payer = payer,
-        space = 8 + DepositRecord::SPACE,
-        seeds = [DEPOSIT_RECORD_SEED, batch.key().as_ref(), user.key().as_ref()],
+        space = 8 + JoinRecord::SPACE,
+        seeds = [JOIN_RECORD_SEED, batch.key().as_ref(), user.key().as_ref()],
         bump,
     )]
-    pub deposit_record: Box<Account<'info, DepositRecord>>,
-    /// Confidential mint users deposit through the batcher.
-    pub deposit_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: deposit mint compute-signer PDA; validated by the token CPI.
-    pub deposit_compute_signer: UncheckedAccount<'info>,
+    pub join_record: Box<Account<'info, JoinRecord>>,
+    /// Confidential mint users join batches with.
+    pub join_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: join mint compute-signer PDA; validated by the token CPI.
+    pub join_compute_signer: UncheckedAccount<'info>,
     /// CHECK: user's confidential token account (transfer source); validated
     /// by the token CPI.
     #[account(mut)]
     pub user_token_account: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential deposit token account (transfer
-    /// destination); validated by the token CPI and pinned below.
+    /// CHECK: batch's confidential join token account (transfer destination);
+    /// validated by the token CPI and pinned below.
     #[account(mut)]
-    pub batch_deposit_token_account: UncheckedAccount<'info>,
+    pub batch_join_token_account: UncheckedAccount<'info>,
     /// CHECK: user's stable balance lineage; superseded by the token CPI.
     #[account(mut)]
     pub user_balance_value: UncheckedAccount<'info>,
@@ -61,10 +63,10 @@ pub struct Join<'info> {
     /// token CPI, then read as the batcher eval's operand.
     #[account(mut)]
     pub user_transferred_value: UncheckedAccount<'info>,
-    /// CHECK: the user's batch deposit lineage; created on first join,
-    /// superseded (accumulated) on repeat joins by the batcher eval.
+    /// CHECK: the user's joined lineage; created on first join, superseded
+    /// (accumulated) on repeat joins by the batcher eval.
     #[account(mut)]
-    pub pending_deposit_value: UncheckedAccount<'info>,
+    pub pending_join_value: UncheckedAccount<'info>,
     /// CHECK: ZamaHost event-CPI authority; validated by the host program.
     pub zama_event_authority: UncheckedAccount<'info>,
     /// ZamaHost program (FHE compute + ACL).
@@ -80,7 +82,7 @@ pub struct Join<'info> {
 }
 
 /// Transfers the attested amount into the batch account and accumulates it
-/// into the user's deposit lineage, atomically.
+/// into the user's joined lineage, atomically.
 pub fn join<'info>(
     ctx: Context<'info, Join<'info>>,
     amount_attestation: zama_host::CoprocessorInputAttestation,
@@ -90,16 +92,16 @@ pub fn join<'info>(
         BatcherError::BatchNotPending
     );
     require_keys_eq!(
-        ctx.accounts.deposit_confidential_mint.key(),
-        ctx.accounts.batcher.deposit_confidential_mint,
+        ctx.accounts.join_confidential_mint.key(),
+        ctx.accounts.batcher.join_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
-    let mint_key = ctx.accounts.deposit_confidential_mint.key();
+    let mint_key = ctx.accounts.join_confidential_mint.key();
     let batch_key = ctx.accounts.batch.key();
     let user = ctx.accounts.user.key();
     let batch_authority = ctx.accounts.batch_authority.key();
     require_keys_eq!(
-        ctx.accounts.batch_deposit_token_account.key(),
+        ctx.accounts.batch_join_token_account.key(),
         ct::token_account_address(mint_key, batch_authority).0,
         BatcherError::DerivedAccountMismatch
     );
@@ -113,10 +115,10 @@ pub fn join<'info>(
             ct::cpi::accounts::ConfidentialTransfer {
                 owner: ctx.accounts.user.to_account_info(),
                 payer: ctx.accounts.payer.to_account_info(),
-                mint: ctx.accounts.deposit_confidential_mint.to_account_info(),
+                mint: ctx.accounts.join_confidential_mint.to_account_info(),
                 from_account: ctx.accounts.user_token_account.to_account_info(),
-                to_account: ctx.accounts.batch_deposit_token_account.to_account_info(),
-                compute_signer: ctx.accounts.deposit_compute_signer.to_account_info(),
+                to_account: ctx.accounts.batch_join_token_account.to_account_info(),
+                compute_signer: ctx.accounts.join_compute_signer.to_account_info(),
                 from_balance_value: ctx.accounts.user_balance_value.to_account_info(),
                 to_balance_value: ctx.accounts.batch_balance_value.to_account_info(),
                 transferred_amount_value: ctx.accounts.user_transferred_value.to_account_info(),
@@ -136,33 +138,33 @@ pub fn join<'info>(
         amount_attestation,
     )?;
 
-    // Leg 2: re-materialize the just-transferred amount into the user's batch
-    // deposit lineage. The batch authority reads the transferred lineage (it
-    // is in its audience as the recipient owner) and accumulates:
-    // first join creates `deposit = transferred + 0`, repeats supersede to
-    // `deposit = deposit + transferred`.
+    // Leg 2: re-materialize the just-transferred amount into the user's joined
+    // lineage. The batch authority reads the transferred lineage (it is in its
+    // audience as the recipient owner) and accumulates: first join creates
+    // `joined = transferred + 0`, repeats supersede to
+    // `joined = joined + transferred`.
     let transferred_value = fhe::read_encrypted_value(&ctx.accounts.user_transferred_value)?;
     let transferred = fhe::uint64_operand(&transferred_value)?;
-    let deposit_binding = fhe::DurableBinding::bind(
-        ctx.accounts.pending_deposit_value.to_account_info(),
+    let joined_binding = fhe::DurableBinding::bind(
+        ctx.accounts.pending_join_value.to_account_info(),
         zama_fhe::DurableSlot::new(
             batch_key,
             batch_authority,
-            zama_fhe::DurableLabel::new(pending_deposit_label(user)),
+            zama_fhe::DurableLabel::new(pending_join_label(user)),
         ),
-        // The user decrypts their pending deposit; the batch authority computes
-        // refunds and claims from it; the deposit mint's compute signer lets
+        // The user decrypts their pending amount; the batch authority computes
+        // refunds and claims from it; the join mint's compute signer lets
         // quit's transfer eval read it as the refund amount.
         zama_fhe::AccessPolicy::from_subjects(vec![
             zama_fhe::AccessSubject::owner(user),
             zama_fhe::AccessSubject::compute(batch_authority),
-            zama_fhe::AccessSubject::compute(ctx.accounts.deposit_confidential_mint.compute_signer),
+            zama_fhe::AccessSubject::compute(ctx.accounts.join_confidential_mint.compute_signer),
         ])
         .map_err(fhe::invalid_eval_plan)?,
     )?;
-    let previous_deposit = match deposit_binding.previous_handle() {
+    let previous_joined = match joined_binding.previous_handle() {
         Some(_) => Some(fhe::uint64_operand(&fhe::read_encrypted_value(
-            &ctx.accounts.pending_deposit_value,
+            &ctx.accounts.pending_join_value,
         )?)?),
         None => None,
     };
@@ -176,9 +178,9 @@ pub fn join<'info>(
         .to_bytes(),
     )
     .map_err(fhe::invalid_eval_plan)?;
-    // The deposit and transferred lineages live in different ACL domains (the
+    // The joined and transferred lineages live in different ACL domains (the
     // batch vs the mint), so their PDAs are distinct by construction; the only
-    // alias in this frame is the deposit lineage as both operand and output on
+    // alias in this frame is the joined lineage as both operand and output on
     // repeat joins, which is the standard same-slot supersede.
     fhe::eval_as_batch_authority(
         fhe::BatchAuthorityEval {
@@ -194,25 +196,25 @@ pub fn join<'info>(
         },
         context_id,
         vec![
-            deposit_binding.account_info(),
+            joined_binding.account_info(),
             ctx.accounts.user_transferred_value.to_account_info(),
         ],
-        |builder| match previous_deposit {
-            Some(deposit) => builder.add(deposit, transferred, deposit_binding.output()),
+        |builder| match previous_joined {
+            Some(joined) => builder.add(joined, transferred, joined_binding.output()),
             None => builder.add(
                 transferred,
                 zama_fhe::Scalar::<zama_fhe::Uint<64>>::u64(0),
-                deposit_binding.output(),
+                joined_binding.output(),
             ),
         },
     )?;
 
-    let deposit_handle = deposit_binding.handle_after_eval()?;
-    let record = &mut ctx.accounts.deposit_record;
+    let joined_handle = joined_binding.handle_after_eval()?;
+    let record = &mut ctx.accounts.join_record;
     record.batch = batch_key;
     record.user = user;
-    record.deposit_encrypted_value = ctx.accounts.pending_deposit_value.key();
-    record.bump = ctx.bumps.deposit_record;
+    record.joined_encrypted_value = ctx.accounts.pending_join_value.key();
+    record.bump = ctx.bumps.join_record;
 
     let batch = &mut ctx.accounts.batch;
     batch.join_count = batch.join_count.saturating_add(1);
@@ -221,8 +223,8 @@ pub fn join<'info>(
         version: APP_EVENT_VERSION,
         batch: batch_key,
         user,
-        deposit_encrypted_value: ctx.accounts.pending_deposit_value.key(),
-        deposit_handle,
+        joined_encrypted_value: ctx.accounts.pending_join_value.key(),
+        joined_handle,
     });
     Ok(())
 }

--- a/solana/programs/confidential-batcher/src/instructions/open_batch.rs
+++ b/solana/programs/confidential-batcher/src/instructions/open_batch.rs
@@ -1,10 +1,13 @@
 //! Opens the next batch: the `Batch` account, its per-batch authority, its own
-//! confidential token accounts (deposit and shares side), and its plain SPL
-//! accounts for settle's redeem/deposit/wrap legs.
+//! confidential token accounts (join and payout side), and its plain SPL
+//! accounts for settle's redeem/vault/wrap legs.
 //!
 //! One batch, one token account: the burned/revealed total is exactly this
 //! batch's sum, so dust from an earlier batch can never leak into it (the EVM
 //! batcher documents the inter-batch dust leak this prevents).
+//!
+//! Direction-free: the join/payout roles are fixed by the batcher config, so
+//! deposit and redeem batches open identically.
 
 use super::*;
 
@@ -34,50 +37,52 @@ pub struct OpenBatch<'info> {
     /// the funding it receives here.
     #[account(mut, seeds = [BATCH_AUTHORITY_SEED, batch.key().as_ref()], bump)]
     pub batch_authority: UncheckedAccount<'info>,
-    /// Confidential mint users deposit through the batcher.
-    pub deposit_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: deposit mint compute-signer PDA; validated by the token CPI.
-    pub deposit_compute_signer: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential deposit token account; created by the token CPI.
+    /// Confidential mint users join batches with.
+    pub join_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: join mint compute-signer PDA; validated by the token CPI.
+    pub join_compute_signer: UncheckedAccount<'info>,
+    /// CHECK: batch's confidential join token account; created by the token CPI.
     #[account(mut)]
-    pub batch_deposit_token_account: UncheckedAccount<'info>,
-    /// CHECK: batch deposit balance lineage; created by the host CPI.
+    pub batch_join_token_account: UncheckedAccount<'info>,
+    /// CHECK: batch join balance lineage; created by the host CPI.
     #[account(mut)]
-    pub batch_deposit_balance_value: UncheckedAccount<'info>,
-    /// Confidential mint wrapping the vault's share mint.
-    pub shares_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: shares mint compute-signer PDA; validated by the token CPI.
-    pub shares_compute_signer: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential shares token account; created by the token CPI.
+    pub batch_join_balance_value: UncheckedAccount<'info>,
+    /// Confidential mint claims pay out in.
+    pub payout_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: payout mint compute-signer PDA; validated by the token CPI.
+    pub payout_compute_signer: UncheckedAccount<'info>,
+    /// CHECK: batch's confidential payout token account; created by the token CPI.
     #[account(mut)]
-    pub batch_shares_token_account: UncheckedAccount<'info>,
-    /// CHECK: batch shares balance lineage; created by the host CPI.
+    pub batch_payout_token_account: UncheckedAccount<'info>,
+    /// CHECK: batch payout balance lineage; created by the host CPI.
     #[account(mut)]
-    pub batch_shares_balance_value: UncheckedAccount<'info>,
-    /// Vault underlying SPL mint (the deposit confidential mint's underlying).
-    pub underlying_mint: Box<Account<'info, SplMint>>,
-    /// Vault share SPL mint (the shares confidential mint's underlying).
-    pub share_mint: Box<Account<'info, SplMint>>,
-    /// Batch's plain SPL account for redeemed underlying tokens at settle.
+    pub batch_payout_balance_value: UncheckedAccount<'info>,
+    /// SPL mint the join confidential mint wraps (vault underlying for deposit
+    /// batchers, vault shares for redeem batchers).
+    pub join_underlying_mint: Box<Account<'info, SplMint>>,
+    /// SPL mint the payout confidential mint wraps (vault shares for deposit
+    /// batchers, vault underlying for redeem batchers).
+    pub payout_underlying_mint: Box<Account<'info, SplMint>>,
+    /// Batch's plain SPL account receiving the redeemed batch total at settle.
     #[account(
         init,
         payer = payer,
-        seeds = [BATCH_UNDERLYING_SEED, batch.key().as_ref()],
+        seeds = [BATCH_JOIN_UNDERLYING_SEED, batch.key().as_ref()],
         bump,
-        token::mint = underlying_mint,
+        token::mint = join_underlying_mint,
         token::authority = batch_authority,
     )]
-    pub batch_underlying_tokens: Box<Account<'info, TokenAccount>>,
-    /// Batch's plain SPL account for received vault shares at settle.
+    pub batch_join_underlying: Box<Account<'info, TokenAccount>>,
+    /// Batch's plain SPL account receiving the vault leg's output at settle.
     #[account(
         init,
         payer = payer,
-        seeds = [BATCH_SHARE_TOKENS_SEED, batch.key().as_ref()],
+        seeds = [BATCH_PAYOUT_UNDERLYING_SEED, batch.key().as_ref()],
         bump,
-        token::mint = share_mint,
+        token::mint = payout_underlying_mint,
         token::authority = batch_authority,
     )]
-    pub batch_share_tokens: Box<Account<'info, TokenAccount>>,
+    pub batch_payout_underlying: Box<Account<'info, TokenAccount>>,
     /// CHECK: ZamaHost event-CPI authority; validated by the host program.
     pub zama_event_authority: UncheckedAccount<'info>,
     /// ZamaHost program (FHE compute + ACL).
@@ -98,24 +103,24 @@ pub struct OpenBatch<'info> {
 pub fn open_batch(ctx: Context<OpenBatch>, authority_funding_lamports: u64) -> Result<()> {
     let index = ctx.accounts.batcher.next_batch_index;
     require_keys_eq!(
-        ctx.accounts.deposit_confidential_mint.key(),
-        ctx.accounts.batcher.deposit_confidential_mint,
+        ctx.accounts.join_confidential_mint.key(),
+        ctx.accounts.batcher.join_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     require_keys_eq!(
-        ctx.accounts.shares_confidential_mint.key(),
-        ctx.accounts.batcher.shares_confidential_mint,
+        ctx.accounts.payout_confidential_mint.key(),
+        ctx.accounts.batcher.payout_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     require_keys_eq!(
-        ctx.accounts.underlying_mint.key(),
-        ctx.accounts.deposit_confidential_mint.underlying_mint,
-        BatcherError::DepositMintVaultMismatch
+        ctx.accounts.join_underlying_mint.key(),
+        ctx.accounts.join_confidential_mint.underlying_mint,
+        BatcherError::JoinMintVaultMismatch
     );
     require_keys_eq!(
-        ctx.accounts.share_mint.key(),
-        ctx.accounts.shares_confidential_mint.underlying_mint,
-        BatcherError::SharesMintVaultMismatch
+        ctx.accounts.payout_underlying_mint.key(),
+        ctx.accounts.payout_confidential_mint.underlying_mint,
+        BatcherError::PayoutMintVaultMismatch
     );
     match (&ctx.accounts.previous_batch, index) {
         (None, 0) => {}
@@ -146,16 +151,16 @@ pub fn open_batch(ctx: Context<OpenBatch>, authority_funding_lamports: u64) -> R
     let authority_seeds = authority.seeds();
     for (mint, compute_signer, token_account, balance_value) in [
         (
-            &ctx.accounts.deposit_confidential_mint,
-            &ctx.accounts.deposit_compute_signer,
-            &ctx.accounts.batch_deposit_token_account,
-            &ctx.accounts.batch_deposit_balance_value,
+            &ctx.accounts.join_confidential_mint,
+            &ctx.accounts.join_compute_signer,
+            &ctx.accounts.batch_join_token_account,
+            &ctx.accounts.batch_join_balance_value,
         ),
         (
-            &ctx.accounts.shares_confidential_mint,
-            &ctx.accounts.shares_compute_signer,
-            &ctx.accounts.batch_shares_token_account,
-            &ctx.accounts.batch_shares_balance_value,
+            &ctx.accounts.payout_confidential_mint,
+            &ctx.accounts.payout_compute_signer,
+            &ctx.accounts.batch_payout_token_account,
+            &ctx.accounts.batch_payout_balance_value,
         ),
     ] {
         ct::cpi::initialize_token_account(
@@ -195,9 +200,9 @@ pub fn open_batch(ctx: Context<OpenBatch>, authority_funding_lamports: u64) -> R
     batch.authority_bump = ctx.bumps.batch_authority;
     batch.bump = ctx.bumps.batch;
     batch.burned_total_handle = [0; 32];
-    batch.total_deposited = 0;
-    batch.shares_received = 0;
-    batch.share_rate = 0;
+    batch.total_joined = 0;
+    batch.payout_received = 0;
+    batch.payout_rate = 0;
 
     let batcher = &mut ctx.accounts.batcher;
     batcher.next_batch_index = index

--- a/solana/programs/confidential-batcher/src/instructions/quit.rs
+++ b/solana/programs/confidential-batcher/src/instructions/quit.rs
@@ -1,10 +1,13 @@
-//! Leaves a pending batch: exact refund of the recorded deposit, all-or-nothing.
+//! Leaves a pending batch: exact refund of the recorded joined amount,
+//! all-or-nothing. Direction-free, and the demo's only exit before claims:
+//! quit-before-dispatch is in scope; a deadline-cancel path for batches stuck
+//! after dispatch is out of scope (tracked in fhevm-internal#1773).
 //!
-//! The batch authority spends the user's deposit lineage as the transfer
+//! The batch authority spends the user's joined lineage as the transfer
 //! amount (`confidential_transfer_from_value` back to the user), then resets
 //! the lineage to an encrypted zero so a later re-join accumulates from zero.
 //! The refund can never partially fail: the batch account's balance is the sum
-//! of all recorded deposits, so `ge(balance, deposit)` always holds pending.
+//! of all recorded joins, so `ge(balance, joined)` always holds pending.
 
 use super::*;
 
@@ -25,20 +28,20 @@ pub struct Quit<'info> {
     /// the reset eval's compute subject + app authority.
     #[account(seeds = [BATCH_AUTHORITY_SEED, batch.key().as_ref()], bump = batch.authority_bump)]
     pub batch_authority: UncheckedAccount<'info>,
-    /// The user's deposit record for this batch.
+    /// The user's join record for this batch.
     #[account(
-        seeds = [DEPOSIT_RECORD_SEED, batch.key().as_ref(), user.key().as_ref()],
-        bump = deposit_record.bump,
+        seeds = [JOIN_RECORD_SEED, batch.key().as_ref(), user.key().as_ref()],
+        bump = join_record.bump,
     )]
-    pub deposit_record: Box<Account<'info, DepositRecord>>,
-    /// Confidential mint users deposit through the batcher.
-    pub deposit_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: deposit mint compute-signer PDA; validated by the token CPI.
-    pub deposit_compute_signer: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential deposit token account (refund source);
+    pub join_record: Box<Account<'info, JoinRecord>>,
+    /// Confidential mint users join batches with.
+    pub join_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: join mint compute-signer PDA; validated by the token CPI.
+    pub join_compute_signer: UncheckedAccount<'info>,
+    /// CHECK: batch's confidential join token account (refund source);
     /// validated by the token CPI and pinned below.
     #[account(mut)]
-    pub batch_deposit_token_account: UncheckedAccount<'info>,
+    pub batch_join_token_account: UncheckedAccount<'info>,
     /// CHECK: user's confidential token account (refund destination);
     /// validated by the token CPI.
     #[account(mut)]
@@ -53,10 +56,10 @@ pub struct Quit<'info> {
     /// a transfer FROM the batch account); superseded by the token CPI.
     #[account(mut)]
     pub batch_transferred_value: UncheckedAccount<'info>,
-    /// CHECK: the user's batch deposit lineage; spent read-only as the refund
+    /// CHECK: the user's joined lineage; spent read-only as the refund
     /// amount, then reset to an encrypted zero by the batcher eval.
     #[account(mut)]
-    pub pending_deposit_value: UncheckedAccount<'info>,
+    pub pending_join_value: UncheckedAccount<'info>,
     /// CHECK: ZamaHost event-CPI authority; validated by the host program.
     pub zama_event_authority: UncheckedAccount<'info>,
     /// ZamaHost program (FHE compute + ACL).
@@ -71,35 +74,35 @@ pub struct Quit<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// Refunds the exact recorded deposit and resets the deposit lineage to zero.
+/// Refunds the exact recorded amount and resets the joined lineage to zero.
 pub fn quit<'info>(ctx: Context<'info, Quit<'info>>) -> Result<()> {
     require!(
         ctx.accounts.batch.status == BatchStatus::Pending,
         BatcherError::BatchNotPending
     );
     require_keys_eq!(
-        ctx.accounts.deposit_confidential_mint.key(),
-        ctx.accounts.batcher.deposit_confidential_mint,
+        ctx.accounts.join_confidential_mint.key(),
+        ctx.accounts.batcher.join_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     require_keys_eq!(
-        ctx.accounts.pending_deposit_value.key(),
-        ctx.accounts.deposit_record.deposit_encrypted_value,
+        ctx.accounts.pending_join_value.key(),
+        ctx.accounts.join_record.joined_encrypted_value,
         BatcherError::DerivedAccountMismatch
     );
-    let mint_key = ctx.accounts.deposit_confidential_mint.key();
+    let mint_key = ctx.accounts.join_confidential_mint.key();
     let batch_key = ctx.accounts.batch.key();
     let user = ctx.accounts.user.key();
     let batch_authority = ctx.accounts.batch_authority.key();
     require_keys_eq!(
-        ctx.accounts.batch_deposit_token_account.key(),
+        ctx.accounts.batch_join_token_account.key(),
         ct::token_account_address(mint_key, batch_authority).0,
         BatcherError::DerivedAccountMismatch
     );
 
-    // Leg 1: exact refund — the deposit lineage IS the transfer amount. The
+    // Leg 1: exact refund — the joined lineage IS the transfer amount. The
     // batch authority signs via invoke_signed; the token's spend gate accepts
-    // it because every deposit lineage carries the batch authority in its
+    // it because every joined lineage carries the batch authority in its
     // audience from birth.
     let authority = BatchAuthoritySeeds::new(batch_key, ctx.accounts.batch.authority_bump);
     let authority_seeds = authority.seeds();
@@ -108,14 +111,14 @@ pub fn quit<'info>(ctx: Context<'info, Quit<'info>>) -> Result<()> {
         ct::cpi::accounts::ConfidentialTransferFromValue {
             owner: ctx.accounts.batch_authority.to_account_info(),
             payer: ctx.accounts.payer.to_account_info(),
-            mint: ctx.accounts.deposit_confidential_mint.to_account_info(),
-            from_account: ctx.accounts.batch_deposit_token_account.to_account_info(),
+            mint: ctx.accounts.join_confidential_mint.to_account_info(),
+            from_account: ctx.accounts.batch_join_token_account.to_account_info(),
             to_account: ctx.accounts.user_token_account.to_account_info(),
-            compute_signer: ctx.accounts.deposit_compute_signer.to_account_info(),
+            compute_signer: ctx.accounts.join_compute_signer.to_account_info(),
             from_balance_value: ctx.accounts.batch_balance_value.to_account_info(),
             to_balance_value: ctx.accounts.user_balance_value.to_account_info(),
             transferred_amount_value: ctx.accounts.batch_transferred_value.to_account_info(),
-            amount_value: ctx.accounts.pending_deposit_value.to_account_info(),
+            amount_value: ctx.accounts.pending_join_value.to_account_info(),
             zama_event_authority: ctx.accounts.zama_event_authority.to_account_info(),
             zama_program: ctx.accounts.zama_program.to_account_info(),
             host_config: ctx.accounts.host_config.to_account_info(),
@@ -131,21 +134,21 @@ pub fn quit<'info>(ctx: Context<'info, Quit<'info>>) -> Result<()> {
         &[&authority_seeds],
     ))?;
 
-    // Leg 2: reset the deposit lineage to an encrypted zero (supersede in
+    // Leg 2: reset the joined lineage to an encrypted zero (supersede in
     // place), so a later re-join of the same batch accumulates from zero.
-    let deposit_value = fhe::read_encrypted_value(&ctx.accounts.pending_deposit_value)?;
-    let old_handle = deposit_value.current_handle;
+    let joined_value = fhe::read_encrypted_value(&ctx.accounts.pending_join_value)?;
+    let old_handle = joined_value.current_handle;
     let reset_binding = fhe::DurableBinding::bind(
-        ctx.accounts.pending_deposit_value.to_account_info(),
+        ctx.accounts.pending_join_value.to_account_info(),
         zama_fhe::DurableSlot::new(
             batch_key,
             batch_authority,
-            zama_fhe::DurableLabel::new(pending_deposit_label(user)),
+            zama_fhe::DurableLabel::new(pending_join_label(user)),
         ),
         zama_fhe::AccessPolicy::from_subjects(vec![
             zama_fhe::AccessSubject::owner(user),
             zama_fhe::AccessSubject::compute(batch_authority),
-            zama_fhe::AccessSubject::compute(ctx.accounts.deposit_confidential_mint.compute_signer),
+            zama_fhe::AccessSubject::compute(ctx.accounts.join_confidential_mint.compute_signer),
         ])
         .map_err(fhe::invalid_eval_plan)?,
     )?;

--- a/solana/programs/confidential-batcher/src/instructions/settle.rs
+++ b/solana/programs/confidential-batcher/src/instructions/settle.rs
@@ -1,37 +1,53 @@
 //! Settles a dispatched batch with the KMS certificate for its burned total.
 //!
-//! Four legs, one instruction, all permissionless:
+//! Four legs, one instruction, all permissionless — and the batch lifecycle's
+//! only direction branch (the vault CPI; `initialize_batcher` additionally
+//! validates the mint wiring per direction at setup):
 //! 1. `redeem_burned_amount` — the host verifies the KMS certificate on-chain
 //!    (current context + exact-handle MMR public-decrypt proof) and releases
-//!    the certified plain tokens to the batch authority.
-//! 2. `demo_vault::deposit` — the one public number goes into the vault.
-//! 3. `wrap_usdc` on the shares mint — the received shares become confidential
-//!    (the wrapped amount is the already-public aggregate, nothing new leaks).
-//!    "Received" is the vault-minted balance DELTA across leg 2, never the
-//!    account's raw balance: SPL destinations cannot refuse transfers, so a
-//!    preloaded share balance must stay unpriced and unwrapped (inert).
-//! 4. Freeze `share_rate = shares_received * RATE_SCALE / total` — the single
-//!    plaintext division of the whole flow.
+//!    the certified plain tokens (vault underlying for deposit batchers,
+//!    vault shares for redeem batchers) to the batch authority.
+//! 2. The vault leg — `demo_vault::deposit` for deposit batchers,
+//!    `demo_vault::withdraw` for redeem batchers. The one public number goes
+//!    through the vault; the payout units come back.
+//! 3. `wrap_usdc` on the payout mint — the received payout becomes
+//!    confidential (the wrapped amount is the already-public aggregate,
+//!    nothing new leaks). "Received" is the balance DELTA across leg 2, never
+//!    the account's raw balance: SPL destinations cannot refuse transfers, so
+//!    a preloaded balance must stay unpriced and unwrapped (inert).
+//! 4. Record `payout_rate = payout_received * RATE_SCALE / total_joined`
+//!    (informational, saturating). Claims use exact proportional division —
+//!    `joined * payout_received / total_joined` — never this rate.
 //!
 //! A zero-total batch cancels after leg 1: the certificate still proves the
 //! total (so cancellation is trustless), and the division never happens.
 //!
-//! ## Known limitation: a dust-total batch is stuck Dispatched forever
+//! The wrap and rate legs assume `grant_deny_list_enabled = false` and no
+//! binding HCU cap: every token/host CPI passes `deny_subject_record`,
+//! `hcu_block_meter`, and `hcu_trusted_app_record` as hardcoded `None` (the
+//! PoC host fixtures never enable them).
 //!
-//! If the certified total is small enough that the vault floors it to zero
-//! shares (`total < ~1 share's worth` at the current price), leg 2 reverts
-//! with the vault's `ZeroShares` and the whole settle reverts atomically —
-//! retryable, but never to success: the demo vault's share price only rises
-//! (floor rounding favors the vault, `harvest` only donates, there is no loss
-//! path), so the batch stays Dispatched with its deposits burned and
-//! unrecoverable. The grief is cheap for an attacker holding ~all vault
+//! ## Known limitation (deposit direction only): a dust-total batch is stuck
+//! Dispatched forever
+//!
+//! If a DEPOSIT batch's certified total is small enough that the vault floors
+//! it to zero shares (`total < ~1 share's worth` at the current price), leg 2
+//! reverts with the vault's `ZeroShares` and the whole settle reverts
+//! atomically — retryable, but never to success: the demo vault's share price
+//! only rises (floor rounding favors the vault, `harvest` only donates, there
+//! is no loss path), so the batch stays Dispatched with its deposits burned
+//! and unrecoverable. The grief is cheap for an attacker holding ~all vault
 //! shares: `harvest`-donating pumps the price P (the donation accrues to
 //! their own shares), bricking any batch whose total is below P. The loss is
 //! bounded below one share's worth per batch. Pinned by
 //! `mollusk_dust_total_settle_reverts_and_batch_stays_dispatched`; the future
-//! fix is a cancel-and-refund path (wrap the redeemed underlying back into
-//! the batch's confidential account and refund each user's encrypted deposit
-//! via `confidential_transfer_from_value`, quit's mechanism).
+//! fix is a cancel-and-refund path (tracked in fhevm-internal#1773).
+//!
+//! REDEEM batches have no analog: the vault's share price never drops below
+//! 1:1 (floor rounding favors the vault; `harvest` only raises the price), so
+//! `withdraw` of any non-zero share total always returns at least that many
+//! underlying units and `ZeroAssets` is unreachable. Pinned by
+//! `mollusk_redeem_one_share_dust_settles_at_extreme_price`.
 
 use super::*;
 
@@ -41,33 +57,37 @@ pub struct Settle<'info> {
     /// Pays the batch authority funding. Anyone.
     #[account(mut)]
     pub payer: Signer<'info>,
-    /// Batcher config.
+    /// Batcher config (carries the direction).
     pub batcher: Box<Account<'info, Batcher>>,
     /// The dispatched batch being settled.
     #[account(mut, constraint = batch.batcher == batcher.key() @ BatcherError::BatchBatcherMismatch)]
     pub batch: Box<Account<'info, Batch>>,
-    /// CHECK: per-batch authority PDA; redemption recipient, vault depositor,
-    /// and wrap owner via invoke_signed. Receives funding for the rent the
-    /// redeem marker and wrap eval charge to the owner.
+    /// CHECK: per-batch authority PDA; redemption recipient, vault
+    /// depositor/withdrawer, and wrap owner via invoke_signed. Receives
+    /// funding for the rent the redeem marker and wrap eval charge to the
+    /// owner.
     #[account(mut, seeds = [BATCH_AUTHORITY_SEED, batch.key().as_ref()], bump = batch.authority_bump)]
     pub batch_authority: UncheckedAccount<'info>,
 
     // --- leg 1: redeem the KMS-certified burned total ---
     /// Confidential mint the batch total was burned on.
-    pub deposit_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: batch's confidential deposit token account; validated by the token CPI.
-    pub batch_deposit_token_account: UncheckedAccount<'info>,
-    /// Vault underlying SPL mint.
-    pub underlying_mint: Box<Account<'info, SplMint>>,
-    /// CHECK: deposit mint's underlying-token vault (canonical ATA); validated
+    pub join_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// CHECK: batch's confidential join token account; validated by the token CPI.
+    pub batch_join_token_account: UncheckedAccount<'info>,
+    /// SPL mint the join confidential mint wraps (vault underlying for deposit
+    /// batchers, vault shares for redeem batchers). Mutable because it is the
+    /// vault share mint on the redeem direction (leg 2 burns from it).
+    #[account(mut)]
+    pub join_underlying_mint: Box<Account<'info, SplMint>>,
+    /// CHECK: join mint's underlying-token vault (canonical ATA); validated
     /// by the token CPI.
     #[account(mut)]
-    pub deposit_vault_underlying: UncheckedAccount<'info>,
-    /// CHECK: deposit mint's vault authority PDA; validated by the token CPI.
-    pub deposit_vault_authority: UncheckedAccount<'info>,
-    /// Batch's plain SPL account receiving the redeemed underlying tokens.
-    #[account(mut, seeds = [BATCH_UNDERLYING_SEED, batch.key().as_ref()], bump)]
-    pub batch_underlying_tokens: Box<Account<'info, TokenAccount>>,
+    pub join_mint_vault_underlying: UncheckedAccount<'info>,
+    /// CHECK: join mint's vault authority PDA; validated by the token CPI.
+    pub join_mint_vault_authority: UncheckedAccount<'info>,
+    /// Batch's plain SPL account receiving the redeemed batch total.
+    #[account(mut, seeds = [BATCH_JOIN_UNDERLYING_SEED, batch.key().as_ref()], bump)]
+    pub batch_join_underlying: Box<Account<'info, TokenAccount>>,
     /// CHECK: batch's burned-amount lineage; validated by the token CPI.
     pub batch_burned_amount_value: UncheckedAccount<'info>,
     /// CHECK: per-handle redemption replay marker; created by the token CPI.
@@ -79,44 +99,46 @@ pub struct Settle<'info> {
     /// verifier CPI.
     pub kms_context: UncheckedAccount<'info>,
 
-    // --- leg 2: deposit the public total into the vault ---
+    // --- leg 2: move the public total through the vault ---
     /// Public vault the batcher fronts.
     pub vault: Box<Account<'info, demo_vault::Vault>>,
     /// CHECK: demo-vault authority PDA; validated by the vault CPI.
     pub vault_authority: UncheckedAccount<'info>,
-    /// Vault share SPL mint.
-    #[account(mut)]
-    pub share_mint: Box<Account<'info, SplMint>>,
     /// CHECK: vault's underlying token account; validated by the vault CPI.
     #[account(mut)]
     pub vault_token_account: UncheckedAccount<'info>,
-    /// Batch's plain SPL account receiving the minted vault shares.
-    #[account(mut, seeds = [BATCH_SHARE_TOKENS_SEED, batch.key().as_ref()], bump)]
-    pub batch_share_tokens: Box<Account<'info, TokenAccount>>,
+    /// Batch's plain SPL account receiving the vault leg's output.
+    #[account(mut, seeds = [BATCH_PAYOUT_UNDERLYING_SEED, batch.key().as_ref()], bump)]
+    pub batch_payout_underlying: Box<Account<'info, TokenAccount>>,
 
-    // --- leg 3: wrap the received shares into confidential shares ---
-    /// Confidential mint wrapping the vault's share mint.
+    // --- leg 3: wrap the received payout into confidential payout tokens ---
+    /// Confidential mint claims pay out in.
     #[account(mut)]
-    pub shares_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
-    /// CHECK: batch's confidential shares token account; validated by the token CPI.
+    pub payout_confidential_mint: Box<Account<'info, ct::ConfidentialMint>>,
+    /// SPL mint the payout confidential mint wraps (vault shares for deposit
+    /// batchers, vault underlying for redeem batchers). Mutable because it is
+    /// the vault share mint on the deposit direction (leg 2 mints to it).
     #[account(mut)]
-    pub batch_shares_token_account: UncheckedAccount<'info>,
-    /// CHECK: shares mint's underlying-token vault (canonical ATA of the share
-    /// mint); validated by the token CPI.
+    pub payout_underlying_mint: Box<Account<'info, SplMint>>,
+    /// CHECK: batch's confidential payout token account; validated by the token CPI.
     #[account(mut)]
-    pub shares_vault_underlying: UncheckedAccount<'info>,
-    /// CHECK: shares mint's vault authority PDA; validated by the token CPI.
-    pub shares_vault_authority: UncheckedAccount<'info>,
-    /// CHECK: shares mint compute-signer PDA; validated by the token CPI.
-    pub shares_compute_signer: UncheckedAccount<'info>,
-    /// CHECK: shares mint total-supply authority PDA; validated by the token CPI.
-    pub shares_total_supply_authority: UncheckedAccount<'info>,
-    /// CHECK: batch's confidential shares balance lineage; superseded by the wrap.
+    pub batch_payout_token_account: UncheckedAccount<'info>,
+    /// CHECK: payout mint's underlying-token vault (canonical ATA); validated
+    /// by the token CPI.
     #[account(mut)]
-    pub batch_shares_balance_value: UncheckedAccount<'info>,
-    /// CHECK: shares mint's total-supply lineage; superseded by the wrap.
+    pub payout_mint_vault_underlying: UncheckedAccount<'info>,
+    /// CHECK: payout mint's vault authority PDA; validated by the token CPI.
+    pub payout_mint_vault_authority: UncheckedAccount<'info>,
+    /// CHECK: payout mint compute-signer PDA; validated by the token CPI.
+    pub payout_compute_signer: UncheckedAccount<'info>,
+    /// CHECK: payout mint total-supply authority PDA; validated by the token CPI.
+    pub payout_total_supply_authority: UncheckedAccount<'info>,
+    /// CHECK: batch's confidential payout balance lineage; superseded by the wrap.
     #[account(mut)]
-    pub shares_total_supply_value: UncheckedAccount<'info>,
+    pub batch_payout_balance_value: UncheckedAccount<'info>,
+    /// CHECK: payout mint's total-supply lineage; superseded by the wrap.
+    #[account(mut)]
+    pub payout_total_supply_value: UncheckedAccount<'info>,
 
     /// CHECK: ZamaHost event-CPI authority; validated by the host program.
     pub zama_event_authority: UncheckedAccount<'info>,
@@ -134,7 +156,8 @@ pub struct Settle<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// Redeems, deposits, wraps, and freezes the rate — or cancels on zero total.
+/// Redeems, moves the total through the vault, wraps, and records the rate —
+/// or cancels on zero total.
 pub fn settle(
     ctx: Context<Settle>,
     cleartext_total: u64,
@@ -148,19 +171,29 @@ pub fn settle(
         BatcherError::BatchNotDispatched
     );
     require_keys_eq!(
-        ctx.accounts.deposit_confidential_mint.key(),
-        ctx.accounts.batcher.deposit_confidential_mint,
+        ctx.accounts.join_confidential_mint.key(),
+        ctx.accounts.batcher.join_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     require_keys_eq!(
-        ctx.accounts.shares_confidential_mint.key(),
-        ctx.accounts.batcher.shares_confidential_mint,
+        ctx.accounts.payout_confidential_mint.key(),
+        ctx.accounts.batcher.payout_confidential_mint,
         BatcherError::ConfidentialMintMismatch
     );
     require_keys_eq!(
         ctx.accounts.vault.key(),
         ctx.accounts.batcher.vault,
         BatcherError::VaultMismatch
+    );
+    require_keys_eq!(
+        ctx.accounts.join_underlying_mint.key(),
+        ctx.accounts.join_confidential_mint.underlying_mint,
+        BatcherError::JoinMintVaultMismatch
+    );
+    require_keys_eq!(
+        ctx.accounts.payout_underlying_mint.key(),
+        ctx.accounts.payout_confidential_mint.underlying_mint,
+        BatcherError::PayoutMintVaultMismatch
     );
     let batch_key = ctx.accounts.batch.key();
     let burned_total_handle = ctx.accounts.batch.burned_total_handle;
@@ -182,12 +215,12 @@ pub fn settle(
             ctx.accounts.confidential_token_program.key(),
             ct::cpi::accounts::RedeemBurnedAmount {
                 owner: ctx.accounts.batch_authority.to_account_info(),
-                mint: ctx.accounts.deposit_confidential_mint.to_account_info(),
-                token_account: ctx.accounts.batch_deposit_token_account.to_account_info(),
-                underlying_mint: ctx.accounts.underlying_mint.to_account_info(),
-                vault_usdc: ctx.accounts.deposit_vault_underlying.to_account_info(),
-                destination_usdc: ctx.accounts.batch_underlying_tokens.to_account_info(),
-                vault_authority: ctx.accounts.deposit_vault_authority.to_account_info(),
+                mint: ctx.accounts.join_confidential_mint.to_account_info(),
+                token_account: ctx.accounts.batch_join_token_account.to_account_info(),
+                underlying_mint: ctx.accounts.join_underlying_mint.to_account_info(),
+                vault_usdc: ctx.accounts.join_mint_vault_underlying.to_account_info(),
+                destination_usdc: ctx.accounts.batch_join_underlying.to_account_info(),
+                vault_authority: ctx.accounts.join_mint_vault_authority.to_account_info(),
                 burned_amount_value: ctx.accounts.batch_burned_amount_value.to_account_info(),
                 redemption_record: ctx.accounts.redemption_record.to_account_info(),
                 host_config: ctx.accounts.host_config.to_account_info(),
@@ -211,10 +244,10 @@ pub fn settle(
         proof,
     )?;
 
-    // Zero-total batch: nothing to deposit, no rate to freeze — cancel. The
-    // certificate above still proved the total, so this branch is trustless
-    // and public (it branches on the certified cleartext, never on encrypted
-    // state).
+    // Zero-total batch: nothing to move through the vault, no rate to record —
+    // cancel. The certificate above still proved the total, so this branch is
+    // trustless and public (it branches on the certified cleartext, never on
+    // encrypted state). The only branch the redeem direction shares verbatim.
     if cleartext_total == 0 {
         ctx.accounts.batch.status = BatchStatus::Canceled;
         emit!(BatchCanceled {
@@ -224,61 +257,81 @@ pub fn settle(
         return Ok(());
     }
 
-    // Leg 2: the one public number goes into the vault; shares come back.
-    // The received shares are the vault-minted DELTA across this CPI, never
-    // the account's raw balance: SPL token destinations cannot refuse
-    // incoming transfers, so anyone can preload `batch_share_tokens` with
-    // shares — pricing a preloaded balance would let an attacker inflate the
-    // rate past u64 and brick the batch. Preloaded shares stay in the
-    // account, unwrapped and unpriced (inert).
-    let share_balance_before_deposit = ctx.accounts.batch_share_tokens.amount;
-    demo_vault::cpi::deposit(
-        CpiContext::new_with_signer(
-            ctx.accounts.demo_vault_program.key(),
-            demo_vault::cpi::accounts::Deposit {
-                depositor: ctx.accounts.batch_authority.to_account_info(),
-                vault: ctx.accounts.vault.to_account_info(),
-                vault_authority: ctx.accounts.vault_authority.to_account_info(),
-                underlying_mint: ctx.accounts.underlying_mint.to_account_info(),
-                share_mint: ctx.accounts.share_mint.to_account_info(),
-                depositor_underlying: ctx.accounts.batch_underlying_tokens.to_account_info(),
-                vault_token_account: ctx.accounts.vault_token_account.to_account_info(),
-                depositor_shares: ctx.accounts.batch_share_tokens.to_account_info(),
-                token_program: ctx.accounts.token_program.to_account_info(),
-            },
-            &[&authority_seeds],
-        ),
-        cleartext_total,
-    )?;
-    ctx.accounts.batch_share_tokens.reload()?;
-    let shares_received = ctx
+    // Leg 2: the one public number goes through the vault; the payout comes
+    // back. The received payout is the batch payout account's balance DELTA
+    // across this CPI, never its raw balance: SPL token destinations cannot
+    // refuse incoming transfers, so anyone can preload `batch_payout_underlying`
+    // — pricing a preloaded balance would let an attacker distort the batch
+    // accounting. Preloaded tokens stay in the account, unwrapped and unpriced
+    // (inert).
+    let payout_balance_before = ctx.accounts.batch_payout_underlying.amount;
+    match ctx.accounts.batcher.direction {
+        BatchDirection::Deposit => demo_vault::cpi::deposit(
+            CpiContext::new_with_signer(
+                ctx.accounts.demo_vault_program.key(),
+                demo_vault::cpi::accounts::Deposit {
+                    depositor: ctx.accounts.batch_authority.to_account_info(),
+                    vault: ctx.accounts.vault.to_account_info(),
+                    vault_authority: ctx.accounts.vault_authority.to_account_info(),
+                    underlying_mint: ctx.accounts.join_underlying_mint.to_account_info(),
+                    share_mint: ctx.accounts.payout_underlying_mint.to_account_info(),
+                    depositor_underlying: ctx.accounts.batch_join_underlying.to_account_info(),
+                    vault_token_account: ctx.accounts.vault_token_account.to_account_info(),
+                    depositor_shares: ctx.accounts.batch_payout_underlying.to_account_info(),
+                    token_program: ctx.accounts.token_program.to_account_info(),
+                },
+                &[&authority_seeds],
+            ),
+            cleartext_total,
+        )?,
+        BatchDirection::Redeem => demo_vault::cpi::withdraw(
+            CpiContext::new_with_signer(
+                ctx.accounts.demo_vault_program.key(),
+                demo_vault::cpi::accounts::Withdraw {
+                    owner: ctx.accounts.batch_authority.to_account_info(),
+                    vault: ctx.accounts.vault.to_account_info(),
+                    vault_authority: ctx.accounts.vault_authority.to_account_info(),
+                    underlying_mint: ctx.accounts.payout_underlying_mint.to_account_info(),
+                    share_mint: ctx.accounts.join_underlying_mint.to_account_info(),
+                    owner_shares: ctx.accounts.batch_join_underlying.to_account_info(),
+                    vault_token_account: ctx.accounts.vault_token_account.to_account_info(),
+                    owner_underlying: ctx.accounts.batch_payout_underlying.to_account_info(),
+                    token_program: ctx.accounts.token_program.to_account_info(),
+                },
+                &[&authority_seeds],
+            ),
+            cleartext_total,
+        )?,
+    }
+    ctx.accounts.batch_payout_underlying.reload()?;
+    let payout_received = ctx
         .accounts
-        .batch_share_tokens
+        .batch_payout_underlying
         .amount
-        .checked_sub(share_balance_before_deposit)
-        .ok_or(BatcherError::ShareBalanceUnderflow)?;
+        .checked_sub(payout_balance_before)
+        .ok_or(BatcherError::PayoutBalanceUnderflow)?;
 
-    // Leg 3: wrap only the vault-minted share delta into the batch's
-    // confidential shares account. The wrapped amount is the already-public
-    // aggregate's share value; any preloaded balance stays behind.
+    // Leg 3: wrap only the vault-produced payout delta into the batch's
+    // confidential payout account. The wrapped amount is the already-public
+    // aggregate's payout value; any preloaded balance stays behind.
     ct::cpi::wrap_usdc(
         CpiContext::new_with_signer(
             ctx.accounts.confidential_token_program.key(),
             ct::cpi::accounts::WrapUsdc {
                 owner: ctx.accounts.batch_authority.to_account_info(),
-                mint: ctx.accounts.shares_confidential_mint.to_account_info(),
-                token_account: ctx.accounts.batch_shares_token_account.to_account_info(),
-                underlying_mint: ctx.accounts.share_mint.to_account_info(),
-                user_usdc: ctx.accounts.batch_share_tokens.to_account_info(),
-                vault_usdc: ctx.accounts.shares_vault_underlying.to_account_info(),
-                vault_authority: ctx.accounts.shares_vault_authority.to_account_info(),
-                compute_signer: ctx.accounts.shares_compute_signer.to_account_info(),
+                mint: ctx.accounts.payout_confidential_mint.to_account_info(),
+                token_account: ctx.accounts.batch_payout_token_account.to_account_info(),
+                underlying_mint: ctx.accounts.payout_underlying_mint.to_account_info(),
+                user_usdc: ctx.accounts.batch_payout_underlying.to_account_info(),
+                vault_usdc: ctx.accounts.payout_mint_vault_underlying.to_account_info(),
+                vault_authority: ctx.accounts.payout_mint_vault_authority.to_account_info(),
+                compute_signer: ctx.accounts.payout_compute_signer.to_account_info(),
                 total_supply_authority: ctx
                     .accounts
-                    .shares_total_supply_authority
+                    .payout_total_supply_authority
                     .to_account_info(),
-                balance_value: ctx.accounts.batch_shares_balance_value.to_account_info(),
-                total_supply_value: ctx.accounts.shares_total_supply_value.to_account_info(),
+                balance_value: ctx.accounts.batch_payout_balance_value.to_account_info(),
+                total_supply_value: ctx.accounts.payout_total_supply_value.to_account_info(),
                 zama_event_authority: ctx.accounts.zama_event_authority.to_account_info(),
                 zama_program: ctx.accounts.zama_program.to_account_info(),
                 host_config: ctx.accounts.host_config.to_account_info(),
@@ -294,23 +347,24 @@ pub fn settle(
             },
             &[&authority_seeds],
         ),
-        shares_received,
+        payout_received,
     )?;
 
-    // Leg 4: freeze the batch's public rate — the one plaintext division.
-    let share_rate = freeze_share_rate(shares_received, cleartext_total)?;
+    // Leg 4: record the batch's informational public rate (saturating) — the
+    // one plaintext division of the whole flow, display-only.
+    let payout_rate = payout_rate(payout_received, cleartext_total)?;
     let batch = &mut ctx.accounts.batch;
     batch.status = BatchStatus::Settled;
-    batch.total_deposited = cleartext_total;
-    batch.shares_received = shares_received;
-    batch.share_rate = share_rate;
+    batch.total_joined = cleartext_total;
+    batch.payout_received = payout_received;
+    batch.payout_rate = payout_rate;
 
     emit!(BatchSettled {
         version: APP_EVENT_VERSION,
         batch: batch_key,
-        total_deposited: cleartext_total,
-        shares_received,
-        share_rate,
+        total_joined: cleartext_total,
+        payout_received,
+        payout_rate,
     });
     Ok(())
 }

--- a/solana/programs/confidential-batcher/src/lib.rs
+++ b/solana/programs/confidential-batcher/src/lib.rs
@@ -1,14 +1,22 @@
-//! Confidential batcher for the Solana FHEVM PoC — the deposit path of the
+//! Confidential batcher for the Solana FHEVM PoC — both directions of the
 //! confidential-vault design (DD-042, `solana/docs/CONFIDENTIAL_VAULTS.md`).
+//!
+//! One program serves deposits and redemptions: each `Batcher` config is one
+//! DIRECTION instance (the EVM design's two batcher deployments), wiring a
+//! join confidential mint (what users batch in) and a payout confidential
+//! mint (what claims pay) around one public `demo-vault`. Deposit batchers
+//! join with confidential underlying and pay confidential shares; redeem
+//! batchers join with confidential shares and pay confidential underlying.
 //!
 //! Users join a batch with encrypted amounts; the batch's own confidential
 //! token account accumulates them while encrypted; dispatch burns the batch
-//! total and the KMS certifies the one public number; settle deposits that
-//! number into the public `demo-vault`, wraps the received shares into
-//! confidential shares, and freezes the batch's public share rate; claim pays
-//! each user `encrypted(deposit) x rate / RATE_SCALE` in confidential shares.
-//! Individual amounts stay encrypted end to end — only each batch's total is
-//! ever revealed.
+//! total and the KMS certifies the one public number; settle moves that
+//! number through the vault (deposit or withdraw), wraps what comes back into
+//! the payout confidential mint, and records the batch's informational public
+//! rate; claim pays each user the exact proportional floor
+//! `encrypted(joined) x payout_received / total_joined` in confidential
+//! payout tokens. Individual amounts stay encrypted end to end — only each
+//! batch's total is ever revealed.
 //!
 //! This program evolves the earlier `confidential-deposit-app` reference: the
 //! app-driven join (one user signature propagating through the transfer CPI)
@@ -27,7 +35,7 @@ pub mod events;
 mod fhe;
 /// Instruction account contexts and handlers.
 pub mod instructions;
-/// Account layouts, PDA helpers, encrypted-value labels, and the rate math.
+/// Account layouts, PDA helpers, encrypted-value labels, and the payout math.
 pub mod state;
 
 use anchor_lang::prelude::*;
@@ -41,7 +49,7 @@ pub use events::*;
 use instructions::*;
 /// Re-export instruction account contexts for tests.
 pub use instructions::{Claim, Dispatch, InitializeBatcher, Join, OpenBatch, Quit, Settle};
-/// Re-export account layouts, PDA helpers, and rate math.
+/// Re-export account layouts, PDA helpers, and payout math.
 pub use state::*;
 
 declare_id!("415fK9iaJJzMHbwkGD4pWgAmDkMvp7Wbd9TTPUtyRX1g");
@@ -51,33 +59,38 @@ declare_id!("415fK9iaJJzMHbwkGD4pWgAmDkMvp7Wbd9TTPUtyRX1g");
 pub mod confidential_batcher {
     use super::*;
 
-    /// Creates the batcher config wiring one deposit confidential mint, one
-    /// confidential-shares mint, and one public vault together. Permissionless
-    /// one-time setup; the batcher holds no admin role afterwards.
+    /// Creates a batcher config for one direction, wiring a join confidential
+    /// mint, a payout confidential mint, and one public vault together.
+    /// Deposit batchers join with confidential underlying and pay confidential
+    /// shares; redeem batchers join with confidential shares and pay
+    /// confidential underlying. Permissionless one-time setup; the batcher
+    /// holds no admin role afterwards.
     pub fn initialize_batcher(
         ctx: Context<InitializeBatcher>,
         min_batch_age_slots: u64,
+        direction: BatchDirection,
     ) -> Result<()> {
-        instructions::initialize_batcher(ctx, min_batch_age_slots)
+        instructions::initialize_batcher(ctx, min_batch_age_slots, direction)
     }
 
     /// Opens the next batch: creates the `Batch` account, its per-batch
-    /// authority PDA, its own confidential deposit and shares token accounts,
-    /// and its plain SPL underlying/share accounts. Permissionless; requires
-    /// the previous batch to have been dispatched (batches never overlap while
-    /// pending). `authority_funding_lamports` is moved from the payer to the
-    /// batch authority PDA, which pays the rent the token CPIs charge to the
-    /// account owner. Unspent funding stays on the PDA and is unrecoverable
-    /// by design in this PoC (no sweep instruction).
+    /// authority PDA, its own confidential join and payout token accounts,
+    /// and its plain SPL accounts for settle's legs. Permissionless; requires
+    /// the previous batch of the same batcher to have been dispatched (a
+    /// batcher's batches never overlap while pending; the other direction's
+    /// batcher is independent). `authority_funding_lamports` is moved from
+    /// the payer to the batch authority PDA, which pays the rent the token
+    /// CPIs charge to the account owner. Unspent funding stays on the PDA and
+    /// is unrecoverable by design in this PoC (no sweep instruction).
     pub fn open_batch(ctx: Context<OpenBatch>, authority_funding_lamports: u64) -> Result<()> {
         instructions::open_batch(ctx, authority_funding_lamports)
     }
 
-    /// Joins the pending batch: one user-signed transaction that CPIs the
-    /// coprocessor-attested confidential transfer into the batch's own token
-    /// account, then re-materializes the transferred amount into the user's
-    /// batch deposit lineage (audience: user + batch authority) in the same
-    /// transaction. Repeated joins accumulate.
+    /// Joins the pending batch with the batcher's join token: one user-signed
+    /// transaction that CPIs the coprocessor-attested confidential transfer
+    /// into the batch's own token account, then re-materializes the
+    /// transferred amount into the user's joined lineage (audience: user +
+    /// batch authority) in the same transaction. Repeated joins accumulate.
     pub fn join<'info>(
         ctx: Context<'info, Join<'info>>,
         amount_attestation: zama_host::CoprocessorInputAttestation,
@@ -86,8 +99,9 @@ pub mod confidential_batcher {
     }
 
     /// Leaves the pending batch before dispatch: transfers the user's exact
-    /// recorded deposit back from the batch account (all-or-nothing) and
-    /// resets the deposit lineage to zero. Always available while pending.
+    /// recorded amount back from the batch account (all-or-nothing) and
+    /// resets the joined lineage to zero. Always available while pending;
+    /// there is no exit between dispatch and settle (fhevm-internal#1773).
     pub fn quit<'info>(ctx: Context<'info, Quit<'info>>) -> Result<()> {
         instructions::quit(ctx)
     }
@@ -100,10 +114,11 @@ pub mod confidential_batcher {
     }
 
     /// Settles a dispatched batch with the KMS certificate for its burned
-    /// total: redeems the plain tokens, deposits them into the public vault,
-    /// wraps the received shares into confidential shares, and freezes the
-    /// batch's public share rate. A zero-total batch is canceled instead.
-    /// Permissionless.
+    /// total: redeems the plain tokens, moves them through the vault
+    /// (deposit for deposit batchers, withdraw for redeem batchers), wraps
+    /// the received payout into confidential payout tokens, and records the
+    /// batch's informational public rate. A zero-total batch is canceled
+    /// instead. Permissionless.
     pub fn settle(
         ctx: Context<Settle>,
         cleartext_total: u64,
@@ -122,9 +137,10 @@ pub mod confidential_batcher {
         )
     }
 
-    /// Claims a user's confidential shares from a settled batch: one MulDiv
-    /// eval frame (`encrypted(deposit) x rate / RATE_SCALE`) then a
-    /// confidential transfer of the resulting handle to the user's shares
+    /// Claims a user's confidential payout from a settled batch: one MulDiv
+    /// eval frame — the exact proportional floor
+    /// `encrypted(joined) x payout_received / total_joined` — then a
+    /// confidential transfer of the resulting handle to the user's payout
     /// account. Permissionless pull — anyone can trigger a user's claim.
     pub fn claim<'info>(ctx: Context<'info, Claim<'info>>) -> Result<()> {
         instructions::claim(ctx)

--- a/solana/programs/confidential-batcher/src/state.rs
+++ b/solana/programs/confidential-batcher/src/state.rs
@@ -1,20 +1,35 @@
-//! Account layouts, PDA helpers, encrypted-value labels, and the rate math.
+//! Account layouts, PDA helpers, encrypted-value labels, and the payout math.
 
 use anchor_lang::prelude::*;
 
 use crate::constants::*;
 use crate::errors::BatcherError;
 
-/// Batcher config wiring one deposit confidential mint, one confidential
-/// shares mint, and one public vault together.
+/// Which way through the vault a batcher instance moves value. Direction lives
+/// on the `Batcher` config — one instance per direction, mirroring the EVM's
+/// two batcher deployments — so a pending deposit batch never blocks a redeem
+/// batch, and every batch inherits its batcher's direction.
+#[derive(AnchorSerialize, AnchorDeserialize, InitSpace, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BatchDirection {
+    /// Users join with confidential underlying; claims pay confidential shares.
+    Deposit,
+    /// Users join with confidential shares; claims pay confidential underlying.
+    Redeem,
+}
+
+/// Batcher config wiring a join confidential mint, a payout confidential mint,
+/// and one public vault together for one direction.
 #[account]
 #[derive(InitSpace)]
 pub struct Batcher {
-    /// Confidential mint users deposit through the batcher; wraps the vault's
-    /// underlying mint.
-    pub deposit_confidential_mint: Pubkey,
-    /// Confidential mint wrapping the vault's share mint.
-    pub shares_confidential_mint: Pubkey,
+    /// Direction of this batcher instance.
+    pub direction: BatchDirection,
+    /// Confidential mint users join batches with. Wraps the vault's underlying
+    /// mint for deposit batchers, the vault's share mint for redeem batchers.
+    pub join_confidential_mint: Pubkey,
+    /// Confidential mint claims pay out in. Wraps the vault's share mint for
+    /// deposit batchers, the vault's underlying mint for redeem batchers.
+    pub payout_confidential_mint: Pubkey,
     /// Public `demo_vault::Vault` the batcher fronts.
     pub vault: Pubkey,
     /// Minimum slots a batch must stay open before dispatch.
@@ -25,7 +40,7 @@ pub struct Batcher {
 
 impl Batcher {
     /// Serialized size of the account body, excluding the Anchor discriminator.
-    pub const SPACE: usize = 32 + 32 + 32 + 8 + 8;
+    pub const SPACE: usize = 1 + 32 + 32 + 32 + 8 + 8;
 }
 
 /// Lifecycle of a batch.
@@ -35,7 +50,7 @@ pub enum BatchStatus {
     Pending,
     /// Total burned; awaiting the KMS certificate.
     Dispatched,
-    /// Rate frozen; claims open.
+    /// Payout received; claims open.
     Settled,
     /// Certified total was zero; nothing to claim.
     Canceled,
@@ -46,7 +61,7 @@ pub enum BatchStatus {
 #[account]
 #[derive(InitSpace)]
 pub struct Batch {
-    /// Batcher config this batch belongs to.
+    /// Batcher config this batch belongs to (carries the direction).
     pub batcher: Pubkey,
     /// Zero-based index within the batcher.
     pub index: u64,
@@ -62,12 +77,14 @@ pub struct Batch {
     pub bump: u8,
     /// Born-public handle of the burned batch total (set at dispatch).
     pub burned_total_handle: [u8; 32],
-    /// KMS-certified batch total (set at settle; public by design).
-    pub total_deposited: u64,
-    /// Vault shares received for the batch total (set at settle).
-    pub shares_received: u64,
-    /// Frozen rate `shares_received * RATE_SCALE / total_deposited` (settle).
-    pub share_rate: u64,
+    /// KMS-certified batch join total (set at settle; public by design).
+    pub total_joined: u64,
+    /// Payout units the vault leg produced for the batch total (set at settle).
+    pub payout_received: u64,
+    /// Informational rate `payout_received * RATE_SCALE / total_joined`,
+    /// saturating at u64::MAX (settle). Claims use exact proportional division
+    /// instead — never this field.
+    pub payout_rate: u64,
 }
 
 impl Batch {
@@ -75,26 +92,26 @@ impl Batch {
     pub const SPACE: usize = 32 + 8 + 1 + 8 + 8 + 1 + 1 + 32 + 8 + 8 + 8;
 }
 
-/// Per-(batch, user) deposit record. The encrypted amount itself lives in the
-/// batcher-owned `EncryptedValue` lineage at `deposit_encrypted_value`
-/// (audience: the user, who can decrypt their pending deposit, and the batch
+/// Per-(batch, user) join record. The encrypted amount itself lives in the
+/// batcher-owned `EncryptedValue` lineage at `joined_encrypted_value`
+/// (audience: the user, who can decrypt their pending amount, and the batch
 /// authority, which computes refunds and claims from it).
 #[account]
 #[derive(InitSpace)]
-pub struct DepositRecord {
+pub struct JoinRecord {
     /// Batch this record belongs to.
     pub batch: Pubkey,
-    /// Depositing user.
+    /// Joining user.
     pub user: Pubkey,
-    /// `EncryptedValue` lineage holding the user's accumulated batch deposit.
-    pub deposit_encrypted_value: Pubkey,
-    /// Whether the user's shares were claimed.
+    /// `EncryptedValue` lineage holding the user's accumulated joined amount.
+    pub joined_encrypted_value: Pubkey,
+    /// Whether the user's payout was claimed.
     pub claimed: bool,
     /// PDA bump for `(batch, user)`.
     pub bump: u8,
 }
 
-impl DepositRecord {
+impl JoinRecord {
     /// Serialized size of the account body, excluding the Anchor discriminator.
     pub const SPACE: usize = 32 + 32 + 32 + 1 + 1;
 }
@@ -112,30 +129,30 @@ pub fn batch_authority_address(batch: Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[BATCH_AUTHORITY_SEED, batch.as_ref()], &crate::ID)
 }
 
-/// Returns the deposit record PDA for a batch and user.
-pub fn deposit_record_address(batch: Pubkey, user: Pubkey) -> (Pubkey, u8) {
+/// Returns the join record PDA for a batch and user.
+pub fn join_record_address(batch: Pubkey, user: Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(
-        &[DEPOSIT_RECORD_SEED, batch.as_ref(), user.as_ref()],
+        &[JOIN_RECORD_SEED, batch.as_ref(), user.as_ref()],
         &crate::ID,
     )
 }
 
-/// Returns the batch's plain SPL account for redeemed underlying tokens.
-pub fn batch_underlying_address(batch: Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[BATCH_UNDERLYING_SEED, batch.as_ref()], &crate::ID)
+/// Returns the batch's plain SPL account in the join mint's underlying.
+pub fn batch_join_underlying_address(batch: Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[BATCH_JOIN_UNDERLYING_SEED, batch.as_ref()], &crate::ID)
 }
 
-/// Returns the batch's plain SPL account for received vault shares.
-pub fn batch_share_tokens_address(batch: Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[BATCH_SHARE_TOKENS_SEED, batch.as_ref()], &crate::ID)
+/// Returns the batch's plain SPL account in the payout mint's underlying.
+pub fn batch_payout_underlying_address(batch: Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[BATCH_PAYOUT_UNDERLYING_SEED, batch.as_ref()], &crate::ID)
 }
 
-/// Encrypted-value label for a user's accumulated batch deposit.
-pub fn pending_deposit_label(user: Pubkey) -> [u8; 32] {
-    solana_sha256_hasher::hashv(&[b"batcher-pending-deposit", user.as_ref()]).to_bytes()
+/// Encrypted-value label for a user's accumulated joined batch amount.
+pub fn pending_join_label(user: Pubkey) -> [u8; 32] {
+    solana_sha256_hasher::hashv(&[b"batcher-pending-join", user.as_ref()]).to_bytes()
 }
 
-/// Encrypted-value label for a user's claimed share amount.
+/// Encrypted-value label for a user's claimed payout amount.
 pub fn claim_amount_label(user: Pubkey) -> [u8; 32] {
     solana_sha256_hasher::hashv(&[b"batcher-claim-amount", user.as_ref()]).to_bytes()
 }
@@ -166,83 +183,126 @@ fn zama_solana_acl_value_key(
     .value_key()
 }
 
-/// Freezes a settled batch's public share rate, rounded DOWN so the sum of all
-/// claims can never exceed the wrapped shares:
-/// `rate = shares_received * RATE_SCALE / total_deposited`.
+/// Computes the informational payout rate of a settled batch, rounded DOWN
+/// and saturating at u64::MAX:
+/// `rate = payout_received * RATE_SCALE / total_joined`.
 ///
-/// The one plaintext division of the whole flow. `total_deposited` must be
-/// non-zero (zero-total batches cancel instead). The u64 fit check fails
-/// closed if the vault's share price ever left the supported domain.
-pub fn freeze_share_rate(shares_received: u64, total_deposited: u64) -> Result<u64> {
-    require!(total_deposited > 0, BatcherError::InvalidFheEvalPlan);
-    let rate = (shares_received as u128) * (RATE_SCALE as u128) / (total_deposited as u128);
-    u64::try_from(rate).map_err(|_| BatcherError::ShareRateOverflow.into())
+/// Event-facing only — claims never multiply by it (they use exact
+/// proportional division), so a redeem batch whose per-unit payout exceeds
+/// the u64 rate domain (extreme share price) must not fail settle over a
+/// display number. `total_joined` must be non-zero (zero-total batches cancel
+/// instead).
+pub fn payout_rate(payout_received: u64, total_joined: u64) -> Result<u64> {
+    require!(total_joined > 0, BatcherError::InvalidFheEvalPlan);
+    let rate = (payout_received as u128) * (RATE_SCALE as u128) / (total_joined as u128);
+    Ok(u64::try_from(rate).unwrap_or(u64::MAX))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The cleartext mirror of the claim MulDiv: `deposit * rate / RATE_SCALE`.
-    fn claim_shares(deposit: u64, rate: u64) -> u64 {
-        ((deposit as u128) * (rate as u128) / (RATE_SCALE as u128)) as u64
+    /// The cleartext mirror of the claim MulDiv: the exact proportional floor
+    /// `joined * payout_received / total_joined`.
+    fn claim_payout(joined: u64, payout_received: u64, total_joined: u64) -> u64 {
+        ((joined as u128) * (payout_received as u128) / (total_joined as u128)) as u64
+    }
+
+    /// The superseded double-rounding claim math (`joined * rate / RATE_SCALE`
+    /// on a floored rate), kept only to prove the exact division strands less.
+    fn claim_payout_via_rate(joined: u64, rate: u64) -> u64 {
+        ((joined as u128) * (rate as u128) / (RATE_SCALE as u128)) as u64
     }
 
     #[test]
     fn manual_space_matches_derived_init_space() {
         assert_eq!(Batcher::SPACE, Batcher::INIT_SPACE);
         assert_eq!(Batch::SPACE, Batch::INIT_SPACE);
-        assert_eq!(DepositRecord::SPACE, DepositRecord::INIT_SPACE);
+        assert_eq!(JoinRecord::SPACE, JoinRecord::INIT_SPACE);
     }
 
     #[test]
-    fn one_to_one_price_rate_is_the_scale() {
-        assert_eq!(freeze_share_rate(1_000, 1_000).unwrap(), RATE_SCALE);
+    fn one_to_one_payout_rate_is_the_scale() {
+        assert_eq!(payout_rate(1_000, 1_000).unwrap(), RATE_SCALE);
     }
 
     #[test]
     fn rate_rounds_down() {
-        // 2 shares for 3 deposited: rate = 2 * 1e9 / 3 = 666_666_666 (floor).
-        assert_eq!(freeze_share_rate(2, 3).unwrap(), 666_666_666);
+        // 2 payout units for 3 joined: rate = 2 * 1e9 / 3 = 666_666_666 (floor).
+        assert_eq!(payout_rate(2, 3).unwrap(), 666_666_666);
     }
 
     #[test]
-    fn claims_never_exceed_received_shares() {
-        // Adversarially rounded batch: floor(rate) then floor(claims) must
-        // never over-distribute what was wrapped.
+    fn rate_saturates_instead_of_failing_settle() {
+        // A redeem batch of 1 share paying out u64::MAX underlying: the true
+        // rate is above u64; the informational field saturates.
+        assert_eq!(payout_rate(u64::MAX, 1).unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn claims_never_exceed_received_payout() {
+        // Adversarially rounded batches, including the u64-scale case where
+        // the old rate-based double rounding stranded ~6.1e9 raw units:
+        // sum(floor(joined_i * payout / total)) <= floor(payout) always.
         let cases: &[(&[u64], u64)] = &[
             (&[300, 500], 799),
             (&[1, 1, 1], 2),
             (&[7, 11, 13], 17),
             (&[u64::MAX / 2, u64::MAX / 2 - 100], u64::MAX / 3),
+            (&[u64::MAX / 3, u64::MAX / 3, u64::MAX / 3], u64::MAX - 5),
         ];
-        for (deposits, shares) in cases {
-            let total: u64 = deposits
+        for (joins, payout) in cases {
+            let total: u64 = joins
                 .iter()
                 .copied()
-                .fold(0, |acc, d| acc.checked_add(d).unwrap());
-            let rate = freeze_share_rate(*shares, total).unwrap();
-            let distributed: u128 = deposits
+                .fold(0, |acc, j| acc.checked_add(j).unwrap());
+            let distributed: u128 = joins
                 .iter()
-                .map(|deposit| claim_shares(*deposit, rate) as u128)
+                .map(|joined| claim_payout(*joined, *payout, total) as u128)
                 .sum();
             assert!(
-                distributed <= *shares as u128,
-                "distributed {distributed} > shares {shares} for deposits {deposits:?}"
+                distributed <= *payout as u128,
+                "distributed {distributed} > payout {payout} for joins {joins:?}"
             );
         }
     }
 
     #[test]
+    fn exact_division_strands_less_than_the_rate_would() {
+        // The fhevm-internal#1774 case: at u64 scale the floored rate loses
+        // precision that every claim then re-multiplies. Exact proportional
+        // division recovers those units.
+        let joins = [u64::MAX / 2, u64::MAX / 2 - 100];
+        let payout = u64::MAX / 3;
+        let total: u64 = joins.iter().sum();
+        let rate = payout_rate(payout, total).unwrap();
+        let via_rate: u128 = joins
+            .iter()
+            .map(|j| claim_payout_via_rate(*j, rate) as u128)
+            .sum();
+        let exact: u128 = joins
+            .iter()
+            .map(|j| claim_payout(*j, payout, total) as u128)
+            .sum();
+        let stranded_via_rate = payout as u128 - via_rate;
+        let stranded_exact = payout as u128 - exact;
+        // The historical measurement: 6_148_914_726 raw units stranded by the
+        // double rounding; exact division strands at most one unit per claim.
+        assert_eq!(stranded_via_rate, 6_148_914_726);
+        assert!(stranded_exact <= joins.len() as u128);
+        assert!(stranded_exact < stranded_via_rate);
+    }
+
+    #[test]
     fn zero_total_rate_is_rejected() {
-        assert!(freeze_share_rate(10, 0).is_err());
+        assert!(payout_rate(10, 0).is_err());
     }
 
     #[test]
     fn labels_are_distinct_per_user_and_per_purpose() {
         let alice = Pubkey::new_unique();
         let bob = Pubkey::new_unique();
-        assert_ne!(pending_deposit_label(alice), pending_deposit_label(bob));
-        assert_ne!(pending_deposit_label(alice), claim_amount_label(alice));
+        assert_ne!(pending_join_label(alice), pending_join_label(bob));
+        assert_ne!(pending_join_label(alice), claim_amount_label(alice));
     }
 }

--- a/solana/runtime-tests/cost-snapshots/batcher_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/batcher_mollusk.json
@@ -1,6 +1,6 @@
 {
   "claim": {
-    "compute_units": 327538,
+    "compute_units": 327616,
     "unique_accounts": 22,
     "instruction_data_bytes": 8,
     "cpi_instructions": 12,
@@ -8,7 +8,7 @@
     "max_cpi_instruction_data_bytes": 1065
   },
   "dispatch": {
-    "compute_units": 470073,
+    "compute_units": 470091,
     "unique_accounts": 18,
     "instruction_data_bytes": 8,
     "cpi_instructions": 9,
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 969
   },
   "join": {
-    "compute_units": 429421,
+    "compute_units": 432449,
     "unique_accounts": 20,
     "instruction_data_bytes": 223,
     "cpi_instructions": 14,
@@ -24,7 +24,39 @@
     "max_cpi_instruction_data_bytes": 1427
   },
   "open_batch": {
-    "compute_units": 250964,
+    "compute_units": 249528,
+    "unique_accounts": 24,
+    "instruction_data_bytes": 16,
+    "cpi_instructions": 20,
+    "total_cpi_instruction_data_bytes": 1472,
+    "max_cpi_instruction_data_bytes": 249
+  },
+  "redeem_claim": {
+    "compute_units": 432617,
+    "unique_accounts": 22,
+    "instruction_data_bytes": 8,
+    "cpi_instructions": 12,
+    "total_cpi_instruction_data_bytes": 2267,
+    "max_cpi_instruction_data_bytes": 1065
+  },
+  "redeem_dispatch": {
+    "compute_units": 288560,
+    "unique_accounts": 18,
+    "instruction_data_bytes": 8,
+    "cpi_instructions": 9,
+    "total_cpi_instruction_data_bytes": 1721,
+    "max_cpi_instruction_data_bytes": 969
+  },
+  "redeem_join": {
+    "compute_units": 375450,
+    "unique_accounts": 20,
+    "instruction_data_bytes": 223,
+    "cpi_instructions": 14,
+    "total_cpi_instruction_data_bytes": 2877,
+    "max_cpi_instruction_data_bytes": 1427
+  },
+  "redeem_open_batch": {
+    "compute_units": 242029,
     "unique_accounts": 24,
     "instruction_data_bytes": 16,
     "cpi_instructions": 20,

--- a/solana/runtime-tests/tests/batcher_mollusk.rs
+++ b/solana/runtime-tests/tests/batcher_mollusk.rs
@@ -1,4 +1,5 @@
-//! Mollusk-based runtime tests for the `confidential-batcher` deposit path.
+//! Mollusk-based runtime tests for the `confidential-batcher` — both the
+//! deposit and the redeem direction.
 //!
 //! The batcher composes four programs — zama-host (FHE compute + ACL),
 //! confidential-token (transfers, burn, redeem, wrap), demo-vault (public
@@ -6,13 +7,19 @@
 //! drives the REAL batcher instructions end to end. Every CPI the batcher
 //! issues under its per-batch authority PDA is therefore exercised through a
 //! genuine `invoke_signed` (init token account, attested transfer, transfer
-//! from value, whole-balance burn, redeem, vault deposit, wrap), not through
-//! the marked-signer stand-in used by the token suite's PDA-owner test.
+//! from value, whole-balance burn, redeem, vault deposit/withdraw, wrap), not
+//! through the marked-signer stand-in used by the token suite's PDA-owner
+//! test.
 //!
 //! Encrypted state is checked with the cleartext ledger: each instruction's
 //! `fhe_eval` CPIs (there can be several — a token CPI's eval plus the
 //! batcher's own) are decoded from the inner instructions and replayed in
 //! cleartext, binding results to the handles the host persisted.
+//!
+//! The fixture is direction-parametric: the same two confidential mints (one
+//! wrapping the vault's underlying, one wrapping its share mint) serve a
+//! deposit batcher (join = underlying, payout = shares) or a redeem batcher
+//! (join = shares, payout = underlying).
 
 mod support;
 
@@ -246,15 +253,14 @@ fn read_batch(context: &Ctx, address: Pubkey) -> batcher::Batch {
     batcher::Batch::try_deserialize(&mut account.data.as_slice()).expect("valid batch account")
 }
 
-fn read_deposit_record(context: &Ctx, address: Pubkey) -> batcher::DepositRecord {
+fn read_join_record(context: &Ctx, address: Pubkey) -> batcher::JoinRecord {
     let account = context
         .account_store
         .borrow()
         .get(&address)
-        .expect("missing deposit record")
+        .expect("missing join record")
         .clone();
-    batcher::DepositRecord::try_deserialize(&mut account.data.as_slice())
-        .expect("valid deposit record")
+    batcher::JoinRecord::try_deserialize(&mut account.data.as_slice()).expect("valid join record")
 }
 
 fn read_spl_amount(context: &Ctx, address: Pubkey) -> u64 {
@@ -370,7 +376,7 @@ fn coprocessor_signing_key() -> k256::ecdsa::SigningKey {
 }
 
 /// Coprocessor-signed `fromExternal` attestation over `amount_handle`, bound
-/// to (`user`, the deposit mint's compute-signer PDA).
+/// to (`user`, the join mint's compute-signer PDA).
 fn amount_attestation_for(
     amount_handle: [u8; 32],
     user: Pubkey,
@@ -491,16 +497,42 @@ impl ConfidentialMintKeys {
     }
 }
 
+/// One user's accounts on one confidential mint.
+struct UserMintKeys {
+    token_account: Pubkey,
+    balance_value: Pubkey,
+    transferred_value: Pubkey,
+    initial_balance: [u8; 32],
+}
+
+impl UserMintKeys {
+    fn new(user: Pubkey, mint: &ConfidentialMintKeys, seed: u8) -> Self {
+        let token_account = token::token_account_address(mint.mint, user).0;
+        Self {
+            token_account,
+            balance_value: token::balance_encrypted_value_address(mint.mint, token_account).0,
+            transferred_value: token::encrypted_value_address(
+                mint.mint,
+                token_account,
+                token::transferred_amount_label(),
+            )
+            .0,
+            initial_balance: handle_for_chain(seed, BALANCE_FHE_TYPE),
+        }
+    }
+}
+
 /// One user with token accounts on both confidential mints.
 struct UserKeys {
     user: Pubkey,
-    deposit_token_account: Pubkey,
-    deposit_balance_value: Pubkey,
-    deposit_transferred_value: Pubkey,
-    shares_token_account: Pubkey,
-    shares_balance_value: Pubkey,
-    initial_deposit_balance: [u8; 32],
-    initial_shares_balance: [u8; 32],
+    /// The user's accounts on the confidential mint wrapping the vault's
+    /// underlying (the join side of deposit batchers, the payout side of
+    /// redeem batchers).
+    underlying: UserMintKeys,
+    /// The user's accounts on the confidential mint wrapping the vault's
+    /// share mint (the payout side of deposit batchers, the join side of
+    /// redeem batchers).
+    shares: UserMintKeys,
 }
 
 impl UserKeys {
@@ -509,101 +541,82 @@ impl UserKeys {
         fixture_mints: (&ConfidentialMintKeys, &ConfidentialMintKeys),
         seed: u8,
     ) -> Self {
-        let (deposit_mint, shares_mint) = fixture_mints;
-        let deposit_token_account = token::token_account_address(deposit_mint.mint, user).0;
-        let shares_token_account = token::token_account_address(shares_mint.mint, user).0;
+        let (underlying_cmint, shares_cmint) = fixture_mints;
         Self {
             user,
-            deposit_token_account,
-            deposit_balance_value: token::balance_encrypted_value_address(
-                deposit_mint.mint,
-                deposit_token_account,
-            )
-            .0,
-            deposit_transferred_value: token::encrypted_value_address(
-                deposit_mint.mint,
-                deposit_token_account,
-                token::transferred_amount_label(),
-            )
-            .0,
-            shares_token_account,
-            shares_balance_value: token::balance_encrypted_value_address(
-                shares_mint.mint,
-                shares_token_account,
-            )
-            .0,
-            initial_deposit_balance: handle_for_chain(seed, BALANCE_FHE_TYPE),
-            initial_shares_balance: handle_for_chain(seed + 1, BALANCE_FHE_TYPE),
+            underlying: UserMintKeys::new(user, underlying_cmint, seed),
+            shares: UserMintKeys::new(user, shares_cmint, seed + 1),
         }
     }
 }
 
-/// Per-batch derived addresses.
+/// Per-batch derived addresses, resolved for the fixture's direction.
 struct BatchKeys {
     batch: Pubkey,
     batch_authority: Pubkey,
-    deposit_token_account: Pubkey,
-    deposit_balance_value: Pubkey,
-    deposit_transferred_value: Pubkey,
+    join_token_account: Pubkey,
+    join_balance_value: Pubkey,
+    join_transferred_value: Pubkey,
     burned_amount_value: Pubkey,
-    shares_token_account: Pubkey,
-    shares_balance_value: Pubkey,
-    shares_transferred_value: Pubkey,
-    underlying_tokens: Pubkey,
-    share_tokens: Pubkey,
+    payout_token_account: Pubkey,
+    payout_balance_value: Pubkey,
+    payout_transferred_value: Pubkey,
+    join_underlying: Pubkey,
+    payout_underlying: Pubkey,
 }
 
 impl BatchKeys {
     fn new(fixture: &BatcherFixture, index: u64) -> Self {
         let batch = batcher::batch_address(fixture.batcher, index).0;
         let batch_authority = batcher::batch_authority_address(batch).0;
-        let deposit_token_account =
-            token::token_account_address(fixture.deposit_mint.mint, batch_authority).0;
-        let shares_token_account =
-            token::token_account_address(fixture.shares_mint.mint, batch_authority).0;
+        let join_mint = fixture.join_mint();
+        let payout_mint = fixture.payout_mint();
+        let join_token_account = token::token_account_address(join_mint.mint, batch_authority).0;
+        let payout_token_account =
+            token::token_account_address(payout_mint.mint, batch_authority).0;
         Self {
             batch,
             batch_authority,
-            deposit_token_account,
-            deposit_balance_value: token::balance_encrypted_value_address(
-                fixture.deposit_mint.mint,
-                deposit_token_account,
+            join_token_account,
+            join_balance_value: token::balance_encrypted_value_address(
+                join_mint.mint,
+                join_token_account,
             )
             .0,
-            deposit_transferred_value: token::encrypted_value_address(
-                fixture.deposit_mint.mint,
-                deposit_token_account,
+            join_transferred_value: token::encrypted_value_address(
+                join_mint.mint,
+                join_token_account,
                 token::transferred_amount_label(),
             )
             .0,
             burned_amount_value: token::encrypted_value_address(
-                fixture.deposit_mint.mint,
-                deposit_token_account,
+                join_mint.mint,
+                join_token_account,
                 token::burned_amount_label(),
             )
             .0,
-            shares_token_account,
-            shares_balance_value: token::balance_encrypted_value_address(
-                fixture.shares_mint.mint,
-                shares_token_account,
+            payout_token_account,
+            payout_balance_value: token::balance_encrypted_value_address(
+                payout_mint.mint,
+                payout_token_account,
             )
             .0,
-            shares_transferred_value: token::encrypted_value_address(
-                fixture.shares_mint.mint,
-                shares_token_account,
+            payout_transferred_value: token::encrypted_value_address(
+                payout_mint.mint,
+                payout_token_account,
                 token::transferred_amount_label(),
             )
             .0,
-            underlying_tokens: batcher::batch_underlying_address(batch).0,
-            share_tokens: batcher::batch_share_tokens_address(batch).0,
+            join_underlying: batcher::batch_join_underlying_address(batch).0,
+            payout_underlying: batcher::batch_payout_underlying_address(batch).0,
         }
     }
 
-    fn pending_deposit_value(&self, user: Pubkey) -> Pubkey {
+    fn pending_join_value(&self, user: Pubkey) -> Pubkey {
         batcher::batcher_encrypted_value_address(
             self.batch,
             self.batch_authority,
-            batcher::pending_deposit_label(user),
+            batcher::pending_join_label(user),
         )
         .0
     }
@@ -617,16 +630,19 @@ impl BatchKeys {
         .0
     }
 
-    fn deposit_record(&self, user: Pubkey) -> Pubkey {
-        batcher::deposit_record_address(self.batch, user).0
+    fn join_record(&self, user: Pubkey) -> Pubkey {
+        batcher::join_record_address(self.batch, user).0
     }
 }
 
 struct BatcherFixture {
+    direction: batcher::BatchDirection,
     payer: Pubkey,
     batcher: Pubkey,
-    deposit_mint: ConfidentialMintKeys,
-    shares_mint: ConfidentialMintKeys,
+    /// Confidential mint wrapping the vault's underlying mint.
+    underlying_cmint: ConfidentialMintKeys,
+    /// Confidential mint wrapping the vault's share mint.
+    shares_cmint: ConfidentialMintKeys,
     vault: Pubkey,
     vault_authority: Pubkey,
     share_mint: Pubkey,
@@ -639,8 +655,9 @@ struct BatcherFixture {
 }
 
 impl BatcherFixture {
-    fn new() -> Self {
+    fn new(direction: batcher::BatchDirection) -> Self {
         Self::with_keys(
+            direction,
             Pubkey::new_unique(),
             Pubkey::new_unique(),
             Pubkey::new_unique(),
@@ -653,8 +670,9 @@ impl BatcherFixture {
 
     /// Fixed-key variant for cost snapshots: PDA bump searches are part of the
     /// measured compute, so profile addresses must not change between runs.
-    fn fixed(seed: u8) -> Self {
+    fn fixed(direction: batcher::BatchDirection, seed: u8) -> Self {
         Self::with_keys(
+            direction,
             Pubkey::new_from_array([seed; 32]),
             Pubkey::new_from_array([seed.wrapping_add(1); 32]),
             Pubkey::new_from_array([seed.wrapping_add(2); 32]),
@@ -665,11 +683,13 @@ impl BatcherFixture {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn with_keys(
+        direction: batcher::BatchDirection,
         payer: Pubkey,
         batcher_key: Pubkey,
-        deposit_mint: Pubkey,
-        shares_mint: Pubkey,
+        underlying_cmint: Pubkey,
+        shares_cmint: Pubkey,
         underlying_mint: Pubkey,
         vault_key: Pubkey,
         users_seed: Pubkey,
@@ -680,8 +700,8 @@ impl BatcherFixture {
             Pubkey::find_program_address(&[b"shares", vault_key.as_ref()], &vault::id()).0;
         let vault_token_account =
             Pubkey::find_program_address(&[b"underlying", vault_key.as_ref()], &vault::id()).0;
-        let deposit_mint = ConfidentialMintKeys::new(deposit_mint, underlying_mint, 3);
-        let shares_mint = ConfidentialMintKeys::new(shares_mint, share_mint, 4);
+        let underlying_cmint = ConfidentialMintKeys::new(underlying_cmint, underlying_mint, 3);
+        let shares_cmint = ConfidentialMintKeys::new(shares_cmint, share_mint, 4);
         // Derive two deterministic user keys from the seed key so the fixed
         // fixture stays stable across runs.
         let mut alice_bytes = users_seed.to_bytes();
@@ -690,19 +710,20 @@ impl BatcherFixture {
         bob_bytes[31] = bob_bytes[31].wrapping_add(2);
         let alice = UserKeys::new(
             Pubkey::new_from_array(alice_bytes),
-            (&deposit_mint, &shares_mint),
+            (&underlying_cmint, &shares_cmint),
             10,
         );
         let bob = UserKeys::new(
             Pubkey::new_from_array(bob_bytes),
-            (&deposit_mint, &shares_mint),
+            (&underlying_cmint, &shares_cmint),
             20,
         );
         Self {
+            direction,
             payer,
             batcher: batcher_key,
-            deposit_mint,
-            shares_mint,
+            underlying_cmint,
+            shares_cmint,
             vault: vault_key,
             vault_authority,
             share_mint,
@@ -712,6 +733,72 @@ impl BatcherFixture {
             kms_context: host::kms_context_address(KMS_CONTEXT_ID).0,
             alice,
             bob,
+        }
+    }
+
+    /// The confidential mint users join batches with.
+    fn join_mint(&self) -> &ConfidentialMintKeys {
+        match self.direction {
+            batcher::BatchDirection::Deposit => &self.underlying_cmint,
+            batcher::BatchDirection::Redeem => &self.shares_cmint,
+        }
+    }
+
+    /// The confidential mint claims pay out in.
+    fn payout_mint(&self) -> &ConfidentialMintKeys {
+        match self.direction {
+            batcher::BatchDirection::Deposit => &self.shares_cmint,
+            batcher::BatchDirection::Redeem => &self.underlying_cmint,
+        }
+    }
+
+    /// The given user's accounts on the join mint.
+    fn user_join<'a>(&self, user: &'a UserKeys) -> &'a UserMintKeys {
+        match self.direction {
+            batcher::BatchDirection::Deposit => &user.underlying,
+            batcher::BatchDirection::Redeem => &user.shares,
+        }
+    }
+
+    /// The given user's accounts on the payout mint.
+    fn user_payout<'a>(&self, user: &'a UserKeys) -> &'a UserMintKeys {
+        match self.direction {
+            batcher::BatchDirection::Deposit => &user.shares,
+            batcher::BatchDirection::Redeem => &user.underlying,
+        }
+    }
+
+    /// A redeem-direction batcher instance over this fixture's exact world:
+    /// same mints, vault, users, and payer — only the batcher config account
+    /// differs. The two-instance pattern for the concurrency test.
+    fn redeem_twin(&self, batcher_key: Pubkey) -> Self {
+        Self {
+            direction: batcher::BatchDirection::Redeem,
+            payer: self.payer,
+            batcher: batcher_key,
+            underlying_cmint: ConfidentialMintKeys::new(
+                self.underlying_cmint.mint,
+                self.underlying_mint,
+                3,
+            ),
+            shares_cmint: ConfidentialMintKeys::new(self.shares_cmint.mint, self.share_mint, 4),
+            vault: self.vault,
+            vault_authority: self.vault_authority,
+            share_mint: self.share_mint,
+            vault_token_account: self.vault_token_account,
+            underlying_mint: self.underlying_mint,
+            host_config: self.host_config,
+            kms_context: self.kms_context,
+            alice: UserKeys::new(
+                self.alice.user,
+                (&self.underlying_cmint, &self.shares_cmint),
+                10,
+            ),
+            bob: UserKeys::new(
+                self.bob.user,
+                (&self.underlying_cmint, &self.shares_cmint),
+                20,
+            ),
         }
     }
 
@@ -804,13 +891,18 @@ impl BatcherFixture {
         }
     }
 
-    /// Full account set: host + KMS fixtures, both confidential mints with
-    /// funded underlying vaults, the demo vault at `(total_assets,
-    /// total_shares)`, and both users with seeded balance lineages.
-    fn accounts(
+    /// Full account set: host + KMS fixtures, both confidential mints, the
+    /// demo vault at `(total_assets, total_shares)`, and both users with
+    /// seeded balance lineages on both mints. The confidential mints' plain
+    /// escrows hold `underlying_escrow` / `shares_escrow` — deposit tests
+    /// escrow underlying (the users' shielded deposits), redeem tests escrow
+    /// vault shares (the users' shielded share positions).
+    fn accounts_with_escrows(
         &self,
         vault_total_assets: u64,
         vault_total_shares: u64,
+        underlying_escrow: u64,
+        shares_escrow: u64,
     ) -> HashMap<Pubkey, Account> {
         let mut accounts = HashMap::from([
             (self.payer, system_account(50_000_000_000)),
@@ -838,21 +930,17 @@ impl BatcherFixture {
             (event_authority(token::id()), system_account(0)),
             mollusk_svm_programs_token::token::keyed_account(),
         ]);
-        for mint in [&self.deposit_mint, &self.shares_mint] {
+        for (mint, escrow_amount) in [
+            (&self.underlying_cmint, underlying_escrow),
+            (&self.shares_cmint, shares_escrow),
+        ] {
             accounts.insert(mint.mint, mint.mint_account(self.payer));
             accounts.insert(mint.compute_signer, system_account(0));
             accounts.insert(mint.total_supply_authority, system_account(0));
             accounts.insert(mint.vault_authority, system_account(0));
-            // The deposit mint's vault holds the users' escrowed underlying;
-            // the shares mint's vault starts empty and receives the wrap.
-            let vault_amount = if mint.mint == self.deposit_mint.mint {
-                1_000_000
-            } else {
-                0
-            };
             accounts.insert(
                 mint.vault_underlying,
-                spl_token_account(mint.underlying_mint, mint.vault_authority, vault_amount),
+                spl_token_account(mint.underlying_mint, mint.vault_authority, escrow_amount),
             );
             let (_, total_supply) = new_encrypted_value(
                 mint.mint,
@@ -867,56 +955,52 @@ impl BatcherFixture {
             );
         }
         for user in [&self.alice, &self.bob] {
-            accounts.insert(
-                user.deposit_token_account,
-                self.confidential_token_account(
-                    &self.deposit_mint,
-                    user.user,
-                    user.deposit_balance_value,
-                ),
-            );
-            let (_, deposit_balance) = new_encrypted_value(
-                self.deposit_mint.mint,
-                user.deposit_token_account,
-                token::balance_label(),
-                user.initial_deposit_balance,
-                &[user.user, self.deposit_mint.compute_signer],
-            );
-            accounts.insert(
-                user.deposit_balance_value,
-                encrypted_value_account(&deposit_balance),
-            );
-            accounts.insert(
-                user.shares_token_account,
-                self.confidential_token_account(
-                    &self.shares_mint,
-                    user.user,
-                    user.shares_balance_value,
-                ),
-            );
-            let (_, shares_balance) = new_encrypted_value(
-                self.shares_mint.mint,
-                user.shares_token_account,
-                token::balance_label(),
-                user.initial_shares_balance,
-                &[user.user, self.shares_mint.compute_signer],
-            );
-            accounts.insert(
-                user.shares_balance_value,
-                encrypted_value_account(&shares_balance),
-            );
+            for (mint, keys) in [
+                (&self.underlying_cmint, &user.underlying),
+                (&self.shares_cmint, &user.shares),
+            ] {
+                accounts.insert(
+                    keys.token_account,
+                    self.confidential_token_account(mint, user.user, keys.balance_value),
+                );
+                let (_, balance) = new_encrypted_value(
+                    mint.mint,
+                    keys.token_account,
+                    token::balance_label(),
+                    keys.initial_balance,
+                    &[user.user, mint.compute_signer],
+                );
+                accounts.insert(keys.balance_value, encrypted_value_account(&balance));
+            }
         }
         accounts
     }
 
-    /// Seeds ledger values for the fixture's initial handles.
-    fn seed_ledger(&self, ledger: &mut CleartextLedger, alice_balance: u64, bob_balance: u64) {
-        ledger.seed_amount(self.alice.initial_deposit_balance, alice_balance);
-        ledger.seed_amount(self.bob.initial_deposit_balance, bob_balance);
-        ledger.seed_amount(self.alice.initial_shares_balance, 0);
-        ledger.seed_amount(self.bob.initial_shares_balance, 0);
-        ledger.seed_amount(self.deposit_mint.initial_total_supply, 1_000_000);
-        ledger.seed_amount(self.shares_mint.initial_total_supply, 0);
+    /// Deposit-shaped account set: the underlying escrow holds the users'
+    /// shielded deposits, the shares escrow starts empty.
+    fn accounts(
+        &self,
+        vault_total_assets: u64,
+        vault_total_shares: u64,
+    ) -> HashMap<Pubkey, Account> {
+        self.accounts_with_escrows(vault_total_assets, vault_total_shares, 1_000_000, 0)
+    }
+
+    /// Seeds ledger values for the fixture's initial handles:
+    /// per-user `(underlying, shares)` balances and both encrypted supplies.
+    fn seed_ledger(
+        &self,
+        ledger: &mut CleartextLedger,
+        alice: (u64, u64),
+        bob: (u64, u64),
+        supplies: (u64, u64),
+    ) {
+        ledger.seed_amount(self.alice.underlying.initial_balance, alice.0);
+        ledger.seed_amount(self.alice.shares.initial_balance, alice.1);
+        ledger.seed_amount(self.bob.underlying.initial_balance, bob.0);
+        ledger.seed_amount(self.bob.shares.initial_balance, bob.1);
+        ledger.seed_amount(self.underlying_cmint.initial_total_supply, supplies.0);
+        ledger.seed_amount(self.shares_cmint.initial_total_supply, supplies.1);
     }
 }
 
@@ -930,13 +1014,14 @@ fn initialize_batcher_ix(fixture: &BatcherFixture, min_batch_age_slots: u64) -> 
         batcher::accounts::InitializeBatcher {
             payer: fixture.payer,
             batcher: fixture.batcher,
-            deposit_confidential_mint: fixture.deposit_mint.mint,
-            shares_confidential_mint: fixture.shares_mint.mint,
+            join_confidential_mint: fixture.join_mint().mint,
+            payout_confidential_mint: fixture.payout_mint().mint,
             vault: fixture.vault,
             system_program: system_program::ID,
         },
         batcher::instruction::InitializeBatcher {
             min_batch_age_slots,
+            direction: fixture.direction,
         },
     )
 }
@@ -954,18 +1039,18 @@ fn open_batch_ix(
             previous_batch,
             batch: keys.batch,
             batch_authority: keys.batch_authority,
-            deposit_confidential_mint: fixture.deposit_mint.mint,
-            deposit_compute_signer: fixture.deposit_mint.compute_signer,
-            batch_deposit_token_account: keys.deposit_token_account,
-            batch_deposit_balance_value: keys.deposit_balance_value,
-            shares_confidential_mint: fixture.shares_mint.mint,
-            shares_compute_signer: fixture.shares_mint.compute_signer,
-            batch_shares_token_account: keys.shares_token_account,
-            batch_shares_balance_value: keys.shares_balance_value,
-            underlying_mint: fixture.underlying_mint,
-            share_mint: fixture.share_mint,
-            batch_underlying_tokens: keys.underlying_tokens,
-            batch_share_tokens: keys.share_tokens,
+            join_confidential_mint: fixture.join_mint().mint,
+            join_compute_signer: fixture.join_mint().compute_signer,
+            batch_join_token_account: keys.join_token_account,
+            batch_join_balance_value: keys.join_balance_value,
+            payout_confidential_mint: fixture.payout_mint().mint,
+            payout_compute_signer: fixture.payout_mint().compute_signer,
+            batch_payout_token_account: keys.payout_token_account,
+            batch_payout_balance_value: keys.payout_balance_value,
+            join_underlying_mint: fixture.join_mint().underlying_mint,
+            payout_underlying_mint: fixture.payout_mint().underlying_mint,
+            batch_join_underlying: keys.join_underlying,
+            batch_payout_underlying: keys.payout_underlying,
             zama_event_authority: event_authority(host::id()),
             zama_program: host::id(),
             host_config: fixture.host_config,
@@ -986,6 +1071,7 @@ fn join_ix(
     user: &UserKeys,
     amount_attestation: host::CoprocessorInputAttestation,
 ) -> Instruction {
+    let user_join = fixture.user_join(user);
     anchor_ix(
         batcher::id(),
         batcher::accounts::Join {
@@ -994,15 +1080,15 @@ fn join_ix(
             batcher: fixture.batcher,
             batch: keys.batch,
             batch_authority: keys.batch_authority,
-            deposit_record: keys.deposit_record(user.user),
-            deposit_confidential_mint: fixture.deposit_mint.mint,
-            deposit_compute_signer: fixture.deposit_mint.compute_signer,
-            user_token_account: user.deposit_token_account,
-            batch_deposit_token_account: keys.deposit_token_account,
-            user_balance_value: user.deposit_balance_value,
-            batch_balance_value: keys.deposit_balance_value,
-            user_transferred_value: user.deposit_transferred_value,
-            pending_deposit_value: keys.pending_deposit_value(user.user),
+            join_record: keys.join_record(user.user),
+            join_confidential_mint: fixture.join_mint().mint,
+            join_compute_signer: fixture.join_mint().compute_signer,
+            user_token_account: user_join.token_account,
+            batch_join_token_account: keys.join_token_account,
+            user_balance_value: user_join.balance_value,
+            batch_balance_value: keys.join_balance_value,
+            user_transferred_value: user_join.transferred_value,
+            pending_join_value: keys.pending_join_value(user.user),
             zama_event_authority: event_authority(host::id()),
             zama_program: host::id(),
             host_config: fixture.host_config,
@@ -1015,6 +1101,7 @@ fn join_ix(
 }
 
 fn quit_ix(fixture: &BatcherFixture, keys: &BatchKeys, user: &UserKeys) -> Instruction {
+    let user_join = fixture.user_join(user);
     anchor_ix(
         batcher::id(),
         batcher::accounts::Quit {
@@ -1023,15 +1110,15 @@ fn quit_ix(fixture: &BatcherFixture, keys: &BatchKeys, user: &UserKeys) -> Instr
             batcher: fixture.batcher,
             batch: keys.batch,
             batch_authority: keys.batch_authority,
-            deposit_record: keys.deposit_record(user.user),
-            deposit_confidential_mint: fixture.deposit_mint.mint,
-            deposit_compute_signer: fixture.deposit_mint.compute_signer,
-            batch_deposit_token_account: keys.deposit_token_account,
-            user_token_account: user.deposit_token_account,
-            batch_balance_value: keys.deposit_balance_value,
-            user_balance_value: user.deposit_balance_value,
-            batch_transferred_value: keys.deposit_transferred_value,
-            pending_deposit_value: keys.pending_deposit_value(user.user),
+            join_record: keys.join_record(user.user),
+            join_confidential_mint: fixture.join_mint().mint,
+            join_compute_signer: fixture.join_mint().compute_signer,
+            batch_join_token_account: keys.join_token_account,
+            user_token_account: user_join.token_account,
+            batch_balance_value: keys.join_balance_value,
+            user_balance_value: user_join.balance_value,
+            batch_transferred_value: keys.join_transferred_value,
+            pending_join_value: keys.pending_join_value(user.user),
             zama_event_authority: event_authority(host::id()),
             zama_program: host::id(),
             host_config: fixture.host_config,
@@ -1051,12 +1138,12 @@ fn dispatch_ix(fixture: &BatcherFixture, keys: &BatchKeys) -> Instruction {
             batcher: fixture.batcher,
             batch: keys.batch,
             batch_authority: keys.batch_authority,
-            deposit_confidential_mint: fixture.deposit_mint.mint,
-            deposit_compute_signer: fixture.deposit_mint.compute_signer,
-            total_supply_authority: fixture.deposit_mint.total_supply_authority,
-            batch_deposit_token_account: keys.deposit_token_account,
-            batch_balance_value: keys.deposit_balance_value,
-            total_supply_value: fixture.deposit_mint.total_supply_value,
+            join_confidential_mint: fixture.join_mint().mint,
+            join_compute_signer: fixture.join_mint().compute_signer,
+            total_supply_authority: fixture.join_mint().total_supply_authority,
+            batch_join_token_account: keys.join_token_account,
+            batch_balance_value: keys.join_balance_value,
+            total_supply_value: fixture.join_mint().total_supply_value,
             batch_burned_amount_value: keys.burned_amount_value,
             zama_event_authority: event_authority(host::id()),
             zama_program: host::id(),
@@ -1085,29 +1172,29 @@ fn settle_ix(
             batcher: fixture.batcher,
             batch: keys.batch,
             batch_authority: keys.batch_authority,
-            deposit_confidential_mint: fixture.deposit_mint.mint,
-            batch_deposit_token_account: keys.deposit_token_account,
-            underlying_mint: fixture.underlying_mint,
-            deposit_vault_underlying: fixture.deposit_mint.vault_underlying,
-            deposit_vault_authority: fixture.deposit_mint.vault_authority,
-            batch_underlying_tokens: keys.underlying_tokens,
+            join_confidential_mint: fixture.join_mint().mint,
+            batch_join_token_account: keys.join_token_account,
+            join_underlying_mint: fixture.join_mint().underlying_mint,
+            join_mint_vault_underlying: fixture.join_mint().vault_underlying,
+            join_mint_vault_authority: fixture.join_mint().vault_authority,
+            batch_join_underlying: keys.join_underlying,
             batch_burned_amount_value: keys.burned_amount_value,
             redemption_record,
             host_config: fixture.host_config,
             kms_context: fixture.kms_context,
             vault: fixture.vault,
             vault_authority: fixture.vault_authority,
-            share_mint: fixture.share_mint,
             vault_token_account: fixture.vault_token_account,
-            batch_share_tokens: keys.share_tokens,
-            shares_confidential_mint: fixture.shares_mint.mint,
-            batch_shares_token_account: keys.shares_token_account,
-            shares_vault_underlying: fixture.shares_mint.vault_underlying,
-            shares_vault_authority: fixture.shares_mint.vault_authority,
-            shares_compute_signer: fixture.shares_mint.compute_signer,
-            shares_total_supply_authority: fixture.shares_mint.total_supply_authority,
-            batch_shares_balance_value: keys.shares_balance_value,
-            shares_total_supply_value: fixture.shares_mint.total_supply_value,
+            batch_payout_underlying: keys.payout_underlying,
+            payout_confidential_mint: fixture.payout_mint().mint,
+            payout_underlying_mint: fixture.payout_mint().underlying_mint,
+            batch_payout_token_account: keys.payout_token_account,
+            payout_mint_vault_underlying: fixture.payout_mint().vault_underlying,
+            payout_mint_vault_authority: fixture.payout_mint().vault_authority,
+            payout_compute_signer: fixture.payout_mint().compute_signer,
+            payout_total_supply_authority: fixture.payout_mint().total_supply_authority,
+            batch_payout_balance_value: keys.payout_balance_value,
+            payout_total_supply_value: fixture.payout_mint().total_supply_value,
             zama_event_authority: event_authority(host::id()),
             zama_program: host::id(),
             confidential_token_event_authority: event_authority(token::id()),
@@ -1127,6 +1214,7 @@ fn settle_ix(
 }
 
 fn claim_ix(fixture: &BatcherFixture, keys: &BatchKeys, user: &UserKeys) -> Instruction {
+    let user_payout = fixture.user_payout(user);
     anchor_ix(
         batcher::id(),
         batcher::accounts::Claim {
@@ -1135,16 +1223,16 @@ fn claim_ix(fixture: &BatcherFixture, keys: &BatchKeys, user: &UserKeys) -> Inst
             batcher: fixture.batcher,
             batch: keys.batch,
             batch_authority: keys.batch_authority,
-            deposit_record: keys.deposit_record(user.user),
-            pending_deposit_value: keys.pending_deposit_value(user.user),
+            join_record: keys.join_record(user.user),
+            pending_join_value: keys.pending_join_value(user.user),
             claim_amount_value: keys.claim_amount_value(user.user),
-            shares_confidential_mint: fixture.shares_mint.mint,
-            shares_compute_signer: fixture.shares_mint.compute_signer,
-            batch_shares_token_account: keys.shares_token_account,
-            user_shares_token_account: user.shares_token_account,
-            batch_shares_balance_value: keys.shares_balance_value,
-            user_shares_balance_value: user.shares_balance_value,
-            batch_shares_transferred_value: keys.shares_transferred_value,
+            payout_confidential_mint: fixture.payout_mint().mint,
+            payout_compute_signer: fixture.payout_mint().compute_signer,
+            batch_payout_token_account: keys.payout_token_account,
+            user_payout_token_account: user_payout.token_account,
+            batch_payout_balance_value: keys.payout_balance_value,
+            user_payout_balance_value: user_payout.balance_value,
+            batch_payout_transferred_value: keys.payout_transferred_value,
             zama_event_authority: event_authority(host::id()),
             zama_program: host::id(),
             host_config: fixture.host_config,
@@ -1185,13 +1273,25 @@ fn ensure_open_batch_accounts(context: &Ctx, keys: &BatchKeys) {
         &[
             keys.batch,
             keys.batch_authority,
-            keys.deposit_token_account,
-            keys.deposit_balance_value,
-            keys.shares_token_account,
-            keys.shares_balance_value,
-            keys.underlying_tokens,
-            keys.share_tokens,
+            keys.join_token_account,
+            keys.join_balance_value,
+            keys.payout_token_account,
+            keys.payout_balance_value,
+            keys.join_underlying,
+            keys.payout_underlying,
         ],
+    );
+}
+
+/// Seeds the batch's freshly created (encrypted zero) balance lineages.
+fn seed_open_batch_balances(context: &Ctx, keys: &BatchKeys, ledger: &mut CleartextLedger) {
+    ledger.seed_amount(
+        read_encrypted_value(context, keys.join_balance_value).current_handle,
+        0,
+    );
+    ledger.seed_amount(
+        read_encrypted_value(context, keys.payout_balance_value).current_handle,
+        0,
     );
 }
 
@@ -1209,16 +1309,13 @@ fn run_join(
     ensure_system_accounts(
         context,
         &[
-            keys.deposit_record(user.user),
-            user.deposit_transferred_value,
-            keys.pending_deposit_value(user.user),
+            keys.join_record(user.user),
+            fixture.user_join(user).transferred_value,
+            keys.pending_join_value(user.user),
         ],
     );
-    let attestation = amount_attestation_for(
-        amount_handle,
-        user.user,
-        fixture.deposit_mint.compute_signer,
-    );
+    let attestation =
+        amount_attestation_for(amount_handle, user.user, fixture.join_mint().compute_signer);
     let ix = join_ix(fixture, keys, user, attestation);
     let result = context.process_and_validate_instruction(&ix, &[Check::success()]);
     // The join issues the transfer's eval plus the batcher's re-materialization.
@@ -1252,7 +1349,7 @@ fn run_settle(
     let (signatures, extra_data) = kms_public_decrypt_cert(burned_handle, total);
     let proof = single_burn_public_decrypt_proof(keys.burned_amount_value, burned_handle);
     let redemption_record =
-        token::burn_redemption_address(fixture.deposit_mint.mint, burned_handle).0;
+        token::burn_redemption_address(fixture.join_mint().mint, burned_handle).0;
     ensure_system_accounts(context, &[redemption_record]);
     let ix = settle_ix(
         fixture,
@@ -1282,7 +1379,7 @@ fn run_claim(
         context,
         &[
             keys.claim_amount_value(user.user),
-            keys.shares_transferred_value,
+            keys.payout_transferred_value,
         ],
     );
     let ix = claim_ix(fixture, keys, user);
@@ -1292,34 +1389,27 @@ fn run_claim(
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle tests
+// Deposit lifecycle tests
 // ---------------------------------------------------------------------------
 
 /// Full multi-user lifecycle against a fresh (1:1) vault: two users join with
 /// encrypted amounts, only the total (800) is revealed by the burn+redeem, the
-/// vault mints 800 shares, the rate freezes at exactly RATE_SCALE, and each
-/// user claims encrypted shares equal to their deposit. Every batcher CPI is a
-/// real `invoke_signed` by the per-batch authority PDA.
+/// vault mints 800 shares, and each user claims encrypted shares equal to
+/// their exact proportional part. Every batcher CPI is a real `invoke_signed`
+/// by the per-batch authority PDA.
 #[test]
 fn mollusk_lifecycle_two_users_deposit_dispatch_settle_claim() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
 
     // Batch opens with an encrypted zero balance on both sides.
     let open_result = read_batch(&context, keys.batch);
     assert_eq!(open_result.status, batcher::BatchStatus::Pending);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
 
     run_join(
         &context,
@@ -1341,23 +1431,23 @@ fn mollusk_lifecycle_two_users_deposit_dispatch_settle_claim() {
     );
 
     // Encrypted accounting after the joins: user balances debited, the batch
-    // account holds the (still encrypted) sum, each deposit lineage carries
+    // account holds the (still encrypted) sum, each joined lineage carries
     // that user's amount and only that user's amount.
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.deposit_balance_value),
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
         700
     );
     assert_eq!(
-        ledger.u64_at(&context, fixture.bob.deposit_balance_value),
+        ledger.u64_at(&context, fixture.bob.underlying.balance_value),
         1_500
     );
-    assert_eq!(ledger.u64_at(&context, keys.deposit_balance_value), 800);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 800);
     assert_eq!(
-        ledger.u64_at(&context, keys.pending_deposit_value(fixture.alice.user)),
+        ledger.u64_at(&context, keys.pending_join_value(fixture.alice.user)),
         300
     );
     assert_eq!(
-        ledger.u64_at(&context, keys.pending_deposit_value(fixture.bob.user)),
+        ledger.u64_at(&context, keys.pending_join_value(fixture.bob.user)),
         500
     );
     assert_eq!(read_batch(&context, keys.batch).join_count, 2);
@@ -1365,7 +1455,7 @@ fn mollusk_lifecycle_two_users_deposit_dispatch_settle_claim() {
     // Dispatch burns the batch's whole balance; the burned lineage carries the
     // batch total, born publicly decryptable.
     let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
-    assert_eq!(ledger.u64_at(&context, keys.deposit_balance_value), 0);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 0);
     assert_eq!(ledger.u64_at(&context, keys.burned_amount_value), 800);
     assert_eq!(
         read_batch(&context, keys.batch).status,
@@ -1373,60 +1463,53 @@ fn mollusk_lifecycle_two_users_deposit_dispatch_settle_claim() {
     );
 
     // Settle: the KMS certifies 800; the vault (empty, 1:1) mints 800 shares;
-    // the rate freezes at exactly RATE_SCALE.
+    // the informational rate lands at exactly RATE_SCALE.
     run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 800);
     let settled = read_batch(&context, keys.batch);
     assert_eq!(settled.status, batcher::BatchStatus::Settled);
-    assert_eq!(settled.total_deposited, 800);
-    assert_eq!(settled.shares_received, 800);
-    assert_eq!(settled.share_rate, batcher::RATE_SCALE);
+    assert_eq!(settled.total_joined, 800);
+    assert_eq!(settled.payout_received, 800);
+    assert_eq!(settled.payout_rate, batcher::RATE_SCALE);
     assert_eq!(read_spl_amount(&context, fixture.vault_token_account), 800);
-    // The received shares were wrapped: the plain share account drained into
-    // the shares mint's vault, and the batch's confidential shares balance is
+    // The received shares were wrapped: the plain payout account drained into
+    // the shares mint's escrow, and the batch's confidential payout balance is
     // the aggregate.
-    assert_eq!(read_spl_amount(&context, keys.share_tokens), 0);
+    assert_eq!(read_spl_amount(&context, keys.payout_underlying), 0);
     assert_eq!(
-        read_spl_amount(&context, fixture.shares_mint.vault_underlying),
+        read_spl_amount(&context, fixture.shares_cmint.vault_underlying),
         800
     );
-    assert_eq!(ledger.u64_at(&context, keys.shares_balance_value), 800);
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 800);
 
-    // Claims: each user receives encrypted shares equal to deposit x rate.
+    // Claims: each user receives their exact proportional encrypted shares.
     run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
     run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.shares_balance_value),
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
         300
     );
     assert_eq!(
-        ledger.u64_at(&context, fixture.bob.shares_balance_value),
+        ledger.u64_at(&context, fixture.bob.shares.balance_value),
         500
     );
-    assert_eq!(ledger.u64_at(&context, keys.shares_balance_value), 0);
-    assert!(read_deposit_record(&context, keys.deposit_record(fixture.alice.user)).claimed);
-    assert!(read_deposit_record(&context, keys.deposit_record(fixture.bob.user)).claimed);
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 0);
+    assert!(read_join_record(&context, keys.join_record(fixture.alice.user)).claimed);
+    assert!(read_join_record(&context, keys.join_record(fixture.bob.user)).claimed);
 }
 
 /// Lifecycle against a vault with existing yield (2_000 assets / 1_000
-/// shares): the rate rounds down and the floor-rounded claims never exceed the
+/// shares): the floor-rounded exact-proportional claims never exceed the
 /// wrapped shares.
 #[test]
 fn mollusk_lifecycle_with_yield_rate_rounds_down() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     // Share price ~2: 2_000 assets backing 1_000 shares.
     let context = mollusk().with_context(fixture.accounts(2_000, 1_000));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
 
     run_join(
         &context,
@@ -1450,24 +1533,24 @@ fn mollusk_lifecycle_with_yield_rate_rounds_down() {
     run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 800);
 
     // shares = 800 * (1_000 + 1) / (2_000 + 1) = 400 (floor);
-    // rate = 400 * RATE_SCALE / 800 = RATE_SCALE / 2.
+    // informational rate = 400 * RATE_SCALE / 800 = RATE_SCALE / 2.
     let settled = read_batch(&context, keys.batch);
-    assert_eq!(settled.shares_received, 400);
-    assert_eq!(settled.share_rate, batcher::RATE_SCALE / 2);
+    assert_eq!(settled.payout_received, 400);
+    assert_eq!(settled.payout_rate, batcher::RATE_SCALE / 2);
 
     run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
     run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
-    // 300 * rate / RATE_SCALE = 150 and 500 -> 250; the claims sum exactly to
-    // the wrapped 400 here, and can never exceed it by the floor rounding.
+    // 300 * 400 / 800 = 150 and 500 -> 250; the claims sum exactly to the
+    // wrapped 400 here, and can never exceed it by the floor rounding.
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.shares_balance_value),
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
         150
     );
     assert_eq!(
-        ledger.u64_at(&context, fixture.bob.shares_balance_value),
+        ledger.u64_at(&context, fixture.bob.shares.balance_value),
         250
     );
-    assert_eq!(ledger.u64_at(&context, keys.shares_balance_value), 0);
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 0);
 }
 
 /// A single-participant batch settles correctly but reveals that participant's
@@ -1477,20 +1560,13 @@ fn mollusk_lifecycle_with_yield_rate_rounds_down() {
 /// participant count.
 #[test]
 fn mollusk_single_user_batch_reveals_that_users_amount() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
 
     let alice_amount = 777;
     run_join(
@@ -1515,40 +1591,33 @@ fn mollusk_single_user_batch_reveals_that_users_amount() {
     // The amount-reveal caveat: with one participant, the public batch total
     // equals their private deposit exactly.
     let settled = read_batch(&context, keys.batch);
-    assert_eq!(settled.total_deposited, alice_amount);
+    assert_eq!(settled.total_joined, alice_amount);
     assert_eq!(
-        settled.total_deposited,
-        ledger.u64_at(&context, keys.pending_deposit_value(fixture.alice.user))
+        settled.total_joined,
+        ledger.u64_at(&context, keys.pending_join_value(fixture.alice.user))
     );
 
     run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.shares_balance_value),
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
         alice_amount
     );
 }
 
-/// Repeated joins accumulate in the deposit lineage (the operand-aliases-output
-/// supersede), quit refunds the exact accumulated deposit all-or-nothing and
+/// Repeated joins accumulate in the joined lineage (the operand-aliases-output
+/// supersede), quit refunds the exact accumulated amount all-or-nothing and
 /// resets the lineage to zero, and a re-join after quit accumulates from zero.
 #[test]
 fn mollusk_repeat_join_accumulates_and_quit_refunds_exactly() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
 
-    // Two joins accumulate: the second join's eval reads the deposit lineage
+    // Two joins accumulate: the second join's eval reads the joined lineage
     // as an operand AND supersedes it as the output (the #3238 aliasing class
     // for the batcher's own eval — the standard same-slot supersede).
     run_join(
@@ -1569,10 +1638,10 @@ fn mollusk_repeat_join_accumulates_and_quit_refunds_exactly() {
         handle_for_chain(42, BALANCE_FHE_TYPE),
         250,
     );
-    let pending = keys.pending_deposit_value(fixture.alice.user);
+    let pending = keys.pending_join_value(fixture.alice.user);
     assert_eq!(ledger.u64_at(&context, pending), 350);
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.deposit_balance_value),
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
         650
     );
 
@@ -1582,12 +1651,12 @@ fn mollusk_repeat_join_accumulates_and_quit_refunds_exactly() {
     assert_eq!(ledger.evaluate_fhe_cpis(&context, &result), 2);
     assert_eq!(ledger.u64_at(&context, pending), 0);
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.deposit_balance_value),
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
         1_000
     );
-    assert_eq!(ledger.u64_at(&context, keys.deposit_balance_value), 0);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 0);
 
-    // Re-join after quit accumulates from zero, not from the stale deposit.
+    // Re-join after quit accumulates from zero, not from the stale amount.
     run_join(
         &context,
         &fixture,
@@ -1598,7 +1667,7 @@ fn mollusk_repeat_join_accumulates_and_quit_refunds_exactly() {
         40,
     );
     assert_eq!(ledger.u64_at(&context, pending), 40);
-    assert_eq!(ledger.u64_at(&context, keys.deposit_balance_value), 40);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 40);
 }
 
 /// A batch with no joins burns zero, and settle with the KMS-certified zero
@@ -1607,14 +1676,14 @@ fn mollusk_repeat_join_accumulates_and_quit_refunds_exactly() {
 /// construction.
 #[test]
 fn mollusk_zero_total_batch_cancels_at_settle() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
     ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
+        read_encrypted_value(&context, keys.join_balance_value).current_handle,
         0,
     );
 
@@ -1624,7 +1693,7 @@ fn mollusk_zero_total_batch_cancels_at_settle() {
 
     let batch = read_batch(&context, keys.batch);
     assert_eq!(batch.status, batcher::BatchStatus::Canceled);
-    assert_eq!(batch.share_rate, 0);
+    assert_eq!(batch.payout_rate, 0);
     assert_eq!(read_spl_amount(&context, fixture.vault_token_account), 0);
 
     // The next batch opens against the canceled one.
@@ -1638,6 +1707,613 @@ fn mollusk_zero_total_batch_cancels_at_settle() {
 }
 
 // ---------------------------------------------------------------------------
+// Redeem lifecycle tests
+// ---------------------------------------------------------------------------
+
+/// Redeem-shaped account set: users hold confidential shares (backed by plain
+/// vault shares in the shares mint's escrow) and claim underlying back.
+fn redeem_accounts(
+    fixture: &BatcherFixture,
+    vault_total_assets: u64,
+    vault_total_shares: u64,
+    shares_escrow: u64,
+) -> HashMap<Pubkey, Account> {
+    fixture.accounts_with_escrows(vault_total_assets, vault_total_shares, 0, shares_escrow)
+}
+
+/// Full multi-user redeem lifecycle against a 1:1 vault: two users join with
+/// encrypted SHARE amounts, only the share total (700) is revealed by the
+/// burn+redeem, the vault pays 700 underlying for it, and each user claims
+/// encrypted underlying equal to their exact proportional part. The mirror of
+/// the deposit lifecycle with join and payout mints swapped.
+#[test]
+fn mollusk_redeem_lifecycle_two_users_join_dispatch_settle_claim() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    // 1_000 assets backing 1_000 outstanding shares, all of them wrapped as
+    // the users' confidential share positions.
+    let context = mollusk().with_context(redeem_accounts(&fixture, 1_000, 1_000, 1_000));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 600), (0, 400), (0, 1_000));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    assert_eq!(
+        read_batch(&context, keys.batch).status,
+        batcher::BatchStatus::Pending
+    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        300,
+    );
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.bob,
+        &mut ledger,
+        handle_for_chain(42, BALANCE_FHE_TYPE),
+        400,
+    );
+
+    // Encrypted accounting after the joins: confidential SHARE balances
+    // debited, the batch account holds the encrypted share sum.
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
+        300
+    );
+    assert_eq!(ledger.u64_at(&context, fixture.bob.shares.balance_value), 0);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 700);
+    assert_eq!(read_batch(&context, keys.batch).join_count, 2);
+
+    // Dispatch burns the batch's whole confidential-share balance.
+    let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 0);
+    assert_eq!(ledger.u64_at(&context, keys.burned_amount_value), 700);
+
+    // Settle: the KMS certifies 700 shares; the vault (1:1) pays 700
+    // underlying; the underlying is wrapped into the batch's confidential
+    // payout account.
+    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 700);
+    let settled = read_batch(&context, keys.batch);
+    assert_eq!(settled.status, batcher::BatchStatus::Settled);
+    assert_eq!(settled.total_joined, 700);
+    assert_eq!(settled.payout_received, 700);
+    assert_eq!(settled.payout_rate, batcher::RATE_SCALE);
+    // 700 shares burned from the escrowed plain shares; 700 underlying left
+    // the vault and got wrapped into the underlying mint's escrow.
+    assert_eq!(read_spl_amount(&context, fixture.vault_token_account), 300);
+    assert_eq!(read_spl_amount(&context, keys.join_underlying), 0);
+    assert_eq!(read_spl_amount(&context, keys.payout_underlying), 0);
+    assert_eq!(
+        read_spl_amount(&context, fixture.underlying_cmint.vault_underlying),
+        700
+    );
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 700);
+
+    // Claims: each user receives their exact proportional encrypted underlying.
+    run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
+    run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
+        300
+    );
+    assert_eq!(
+        ledger.u64_at(&context, fixture.bob.underlying.balance_value),
+        400
+    );
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 0);
+    assert!(read_join_record(&context, keys.join_record(fixture.alice.user)).claimed);
+    assert!(read_join_record(&context, keys.join_record(fixture.bob.user)).claimed);
+}
+
+/// Redeem lifecycle with yield (2_000 assets / 1_000 shares): 700 shares pay
+/// 700 * 2_001 / 1_001 = 1_399 underlying (floor), and the exact-proportional
+/// floor claims (599 + 799) never exceed the wrapped 1_399 — one dust unit
+/// stays in the batch account instead of over-distributing.
+#[test]
+fn mollusk_redeem_lifecycle_with_yield_rounds_down() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    let context = mollusk().with_context(redeem_accounts(&fixture, 2_000, 1_000, 1_000));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 600), (0, 400), (0, 1_000));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        300,
+    );
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.bob,
+        &mut ledger,
+        handle_for_chain(42, BALANCE_FHE_TYPE),
+        400,
+    );
+    let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
+    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 700);
+
+    // assets = 700 * (2_000 + 1) / (1_000 + 1) = 1_399 (floor).
+    let settled = read_batch(&context, keys.batch);
+    assert_eq!(settled.payout_received, 1_399);
+
+    run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
+    run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
+    // Exact proportional floors: 300 * 1_399 / 700 = 599, 400 * 1_399 / 700
+    // = 799. Sum 1_398 <= 1_399; the one dust unit stays with the batch.
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
+        599
+    );
+    assert_eq!(
+        ledger.u64_at(&context, fixture.bob.underlying.balance_value),
+        799
+    );
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 1);
+}
+
+/// The redeem twin of the deposit repeat-join/quit/re-join test: repeated
+/// SHARE joins accumulate in the joined lineage (the operand-aliases-output
+/// same-slot supersede — the aliasing class this test exists to pin), quit
+/// refunds the exact accumulated shares all-or-nothing and resets the lineage
+/// to zero, and a re-join after quit accumulates from zero.
+#[test]
+fn mollusk_redeem_repeat_join_accumulates_and_quit_refunds_exactly() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    let context = mollusk().with_context(redeem_accounts(&fixture, 1_000, 1_000, 1_000));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 600), (0, 400), (0, 1_000));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+
+    // Two joins accumulate: the second join's eval reads the joined lineage
+    // as an operand AND supersedes it as the output.
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        100,
+    );
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(42, BALANCE_FHE_TYPE),
+        250,
+    );
+    let pending = keys.pending_join_value(fixture.alice.user);
+    assert_eq!(ledger.u64_at(&context, pending), 350);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
+        250
+    );
+
+    // Quit refunds exactly 350 shares (all-or-nothing) and resets the lineage.
+    let quit = quit_ix(&fixture, &keys, &fixture.alice);
+    let result = context.process_and_validate_instruction(&quit, &[Check::success()]);
+    assert_eq!(ledger.evaluate_fhe_cpis(&context, &result), 2);
+    assert_eq!(ledger.u64_at(&context, pending), 0);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
+        600
+    );
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 0);
+
+    // Re-join after quit accumulates from zero, not from the stale amount.
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(43, BALANCE_FHE_TYPE),
+        40,
+    );
+    assert_eq!(ledger.u64_at(&context, pending), 40);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 40);
+}
+
+/// A user who quits before dispatch can still run the (permissionless) claim
+/// after the batch settles on the other participants: their reset lineage
+/// makes the MulDiv produce an encrypted zero, the all-or-zero transfer moves
+/// nothing, and the record is marked claimed. Deposit direction only: quit,
+/// claim, and the lineage reset are direction-free shared code (settle's
+/// vault CPI is the sole direction branch), so one direction pins the class.
+#[test]
+fn mollusk_claim_after_quit_pays_zero() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
+    let context = mollusk().with_context(fixture.accounts(0, 0));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        300,
+    );
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.bob,
+        &mut ledger,
+        handle_for_chain(42, BALANCE_FHE_TYPE),
+        500,
+    );
+
+    // Alice quits; the batch dispatches and settles on bob's 500 alone.
+    let quit = quit_ix(&fixture, &keys, &fixture.alice);
+    let result = context.process_and_validate_instruction(&quit, &[Check::success()]);
+    assert_eq!(ledger.evaluate_fhe_cpis(&context, &result), 2);
+    let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
+    assert_eq!(ledger.u64_at(&context, keys.burned_amount_value), 500);
+    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 500);
+
+    // Alice's claim computes 0 * 500 / 500 = encrypted zero and transfers
+    // nothing; her record still flips to claimed (the record survives quit).
+    run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
+        0
+    );
+    assert_eq!(
+        ledger.u64_at(&context, keys.claim_amount_value(fixture.alice.user)),
+        0
+    );
+    assert!(read_join_record(&context, keys.join_record(fixture.alice.user)).claimed);
+
+    // Bob's claim still pays the full settled batch.
+    run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.bob.shares.balance_value),
+        500
+    );
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 0);
+}
+
+/// A redeem batch with no joins cancels at settle exactly like a deposit
+/// batch: the certified zero cancels trustlessly and the vault is untouched.
+#[test]
+fn mollusk_redeem_zero_total_batch_cancels_at_settle() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    let context = mollusk().with_context(redeem_accounts(&fixture, 1_000, 1_000, 1_000));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 600), (0, 400), (0, 1_000));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    ledger.seed_amount(
+        read_encrypted_value(&context, keys.join_balance_value).current_handle,
+        0,
+    );
+
+    let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
+    assert_eq!(ledger.u64_at(&context, keys.burned_amount_value), 0);
+    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 0);
+
+    let batch = read_batch(&context, keys.batch);
+    assert_eq!(batch.status, batcher::BatchStatus::Canceled);
+    assert_eq!(batch.payout_rate, 0);
+    assert_eq!(
+        read_spl_amount(&context, fixture.vault_token_account),
+        1_000
+    );
+}
+
+/// A dust redeem batch has NO analog of the deposit direction's stuck state:
+/// the vault's share price never drops below 1:1 (floor rounding favors the
+/// vault, harvest only raises the price), so withdrawing any non-zero share
+/// total always returns at least that many underlying units —
+/// `demo_vault::withdraw`'s `ZeroAssets` is unreachable from a batch. One
+/// share redeemed at an extreme (donation-pumped) price settles fine.
+#[test]
+fn mollusk_redeem_one_share_dust_settles_at_extreme_price() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    // Share price ~20_000 underlying per share: 2_000_000 assets backing 100
+    // shares (the price shape that bricks sub-price deposit batches).
+    let context = mollusk().with_context(redeem_accounts(&fixture, 2_000_000, 100, 100));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 60), (0, 40), (0, 100));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        1,
+    );
+    let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
+    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 1);
+
+    // assets = 1 * (2_000_000 + 1) / (100 + 1) = 19_801 (floor) — always
+    // >= 1 per share at any reachable price, so no ZeroAssets, no stuck batch.
+    let settled = read_batch(&context, keys.batch);
+    assert_eq!(settled.status, batcher::BatchStatus::Settled);
+    assert_eq!(settled.total_joined, 1);
+    assert_eq!(settled.payout_received, 19_801);
+
+    run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
+        19_801
+    );
+}
+
+/// SPL destinations cannot refuse incoming transfers, so an attacker can push
+/// plain underlying into the PDA-owned `batch_payout_underlying` account of a
+/// redeem batch before settlement. Settle must price and wrap only the
+/// vault-paid delta across its withdraw leg — the redeem mirror of the
+/// deposit direction's preload invariant. Preloaded tokens stay in the
+/// account, unwrapped and unpriced (inert).
+#[test]
+fn mollusk_redeem_preloaded_underlying_stays_inert() {
+    const PRELOAD: u64 = 15_000_000_000_000;
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    let attacker = Pubkey::new_unique();
+    let attacker_underlying = Pubkey::new_unique();
+
+    let mut accounts = redeem_accounts(&fixture, 1_000, 1_000, 1_000);
+    accounts.insert(attacker, system_account(1_000_000_000));
+    accounts.insert(
+        attacker_underlying,
+        spl_token_account(fixture.underlying_mint, attacker, PRELOAD),
+    );
+    let context = mollusk().with_context(accounts);
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 600), (0, 400), (0, 1_000));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        300,
+    );
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.bob,
+        &mut ledger,
+        handle_for_chain(42, BALANCE_FHE_TYPE),
+        400,
+    );
+
+    // The attacker pushes plain underlying into the batch's payout account.
+    let preload_transfer = spl_token::instruction::transfer(
+        &spl_token::id(),
+        &attacker_underlying,
+        &keys.payout_underlying,
+        &attacker,
+        &[],
+        PRELOAD,
+    )
+    .unwrap();
+    context.process_and_validate_instruction(&preload_transfer, &[Check::success()]);
+    assert_eq!(read_spl_amount(&context, keys.payout_underlying), PRELOAD);
+
+    let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
+    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 700);
+
+    // Settle succeeded and the batch accounting reflects only the vault-paid
+    // delta: 700 shares in, 700 underlying out at the 1:1 price. The preload
+    // sits in the account, unwrapped, inert.
+    let settled = read_batch(&context, keys.batch);
+    assert_eq!(settled.status, batcher::BatchStatus::Settled);
+    assert_eq!(settled.total_joined, 700);
+    assert_eq!(settled.payout_received, 700);
+    assert_eq!(read_spl_amount(&context, keys.payout_underlying), PRELOAD);
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 700);
+
+    run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
+    run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
+    assert_eq!(
+        ledger.u64_at(&context, fixture.alice.underlying.balance_value),
+        300
+    );
+    assert_eq!(
+        ledger.u64_at(&context, fixture.bob.underlying.balance_value),
+        400
+    );
+}
+
+/// One deposit batcher and one redeem batcher run a FULL interleaved
+/// lifecycle concurrently over the same vault, mints, and users — the
+/// two-instance pattern. Cross-direction state confusion (a redeem batch
+/// reading deposit-batch lineages, the shared escrows or the vault mixing
+/// legs) would surface here, not at open: both directions join, dispatch,
+/// settle, and claim against the shared world, and every balance is checked.
+#[test]
+fn mollusk_deposit_and_redeem_batchers_run_concurrently() {
+    let deposit = BatcherFixture::new(batcher::BatchDirection::Deposit);
+    // Same physical world (mints, vault, users, payer); only the batcher
+    // config account differs.
+    let redeem = deposit.redeem_twin(Pubkey::new_unique());
+
+    let mut accounts = deposit.accounts_with_escrows(1_000, 1_000, 1_000_000, 1_000);
+    accounts.insert(redeem.batcher, system_account(0));
+    let context = mollusk().with_context(accounts);
+    let mut ledger = CleartextLedger::default();
+    // Users hold both cUnderlying (to deposit) and cShares (to redeem).
+    deposit.seed_ledger(&mut ledger, (1_000, 600), (2_000, 400), (1_000_000, 1_000));
+
+    let deposit_keys = initialize_and_open_first_batch(&context, &deposit, 0);
+    let redeem_keys = initialize_and_open_first_batch(&context, &redeem, 0);
+    assert_ne!(deposit_keys.batch, redeem_keys.batch);
+    seed_open_batch_balances(&context, &deposit_keys, &mut ledger);
+    seed_open_batch_balances(&context, &redeem_keys, &mut ledger);
+
+    // Interleaved joins: both batches are pending at once, and each user
+    // participates in both directions.
+    run_join(
+        &context,
+        &deposit,
+        &deposit_keys,
+        &deposit.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        300,
+    );
+    run_join(
+        &context,
+        &redeem,
+        &redeem_keys,
+        &redeem.alice,
+        &mut ledger,
+        handle_for_chain(43, BALANCE_FHE_TYPE),
+        200,
+    );
+    run_join(
+        &context,
+        &deposit,
+        &deposit_keys,
+        &deposit.bob,
+        &mut ledger,
+        handle_for_chain(42, BALANCE_FHE_TYPE),
+        500,
+    );
+    run_join(
+        &context,
+        &redeem,
+        &redeem_keys,
+        &redeem.bob,
+        &mut ledger,
+        handle_for_chain(44, BALANCE_FHE_TYPE),
+        300,
+    );
+
+    // Each batch account holds exactly its own direction's encrypted sum.
+    assert_eq!(
+        ledger.u64_at(&context, deposit_keys.join_balance_value),
+        800
+    );
+    assert_eq!(ledger.u64_at(&context, redeem_keys.join_balance_value), 500);
+
+    // Interleaved dispatches: two independent burned handles on two mints.
+    let deposit_burned = run_dispatch(&context, &deposit, &deposit_keys, &mut ledger);
+    let redeem_burned = run_dispatch(&context, &redeem, &redeem_keys, &mut ledger);
+    assert_ne!(deposit_burned, redeem_burned);
+
+    // Settle the redeem batch first: 500 shares withdraw 500 underlying at
+    // the 1:1 price, leaving the vault at (500, 500).
+    run_settle(
+        &context,
+        &redeem,
+        &redeem_keys,
+        &mut ledger,
+        redeem_burned,
+        500,
+    );
+    let redeem_settled = read_batch(&context, redeem_keys.batch);
+    assert_eq!(redeem_settled.status, batcher::BatchStatus::Settled);
+    assert_eq!(redeem_settled.total_joined, 500);
+    assert_eq!(redeem_settled.payout_received, 500);
+    assert_eq!(read_spl_amount(&context, deposit.vault_token_account), 500);
+
+    // Then the deposit batch: 800 underlying at the (still 1:1) price mints
+    // 800 shares; the vault ends at (1_300, 1_300).
+    run_settle(
+        &context,
+        &deposit,
+        &deposit_keys,
+        &mut ledger,
+        deposit_burned,
+        800,
+    );
+    let deposit_settled = read_batch(&context, deposit_keys.batch);
+    assert_eq!(deposit_settled.status, batcher::BatchStatus::Settled);
+    assert_eq!(deposit_settled.total_joined, 800);
+    assert_eq!(deposit_settled.payout_received, 800);
+    assert_eq!(
+        read_spl_amount(&context, deposit.vault_token_account),
+        1_300
+    );
+    // Shared escrows carry both directions without mixing: the shares escrow
+    // lost the 500 redeemed and gained the 800 wrapped; the underlying escrow
+    // lost the 800 redeemed and gained the 500 wrapped.
+    assert_eq!(
+        read_spl_amount(&context, deposit.shares_cmint.vault_underlying),
+        1_000 - 500 + 800
+    );
+    assert_eq!(
+        read_spl_amount(&context, deposit.underlying_cmint.vault_underlying),
+        1_000_000 - 800 + 500
+    );
+
+    // Interleaved claims across both directions.
+    run_claim(
+        &context,
+        &deposit,
+        &deposit_keys,
+        &deposit.alice,
+        &mut ledger,
+    );
+    run_claim(&context, &redeem, &redeem_keys, &redeem.alice, &mut ledger);
+    run_claim(&context, &redeem, &redeem_keys, &redeem.bob, &mut ledger);
+    run_claim(&context, &deposit, &deposit_keys, &deposit.bob, &mut ledger);
+
+    // Final per-user balances: cShares = start - redeem join + deposit claim;
+    // cUnderlying = start - deposit join + redeem claim.
+    assert_eq!(
+        ledger.u64_at(&context, deposit.alice.shares.balance_value),
+        600 - 200 + 300
+    );
+    assert_eq!(
+        ledger.u64_at(&context, deposit.alice.underlying.balance_value),
+        1_000 - 300 + 200
+    );
+    assert_eq!(
+        ledger.u64_at(&context, deposit.bob.shares.balance_value),
+        400 - 300 + 500
+    );
+    assert_eq!(
+        ledger.u64_at(&context, deposit.bob.underlying.balance_value),
+        2_000 - 500 + 300
+    );
+    // Both batch payout accounts fully drained.
+    assert_eq!(
+        ledger.u64_at(&context, deposit_keys.payout_balance_value),
+        0
+    );
+    assert_eq!(ledger.u64_at(&context, redeem_keys.payout_balance_value), 0);
+}
+
+// ---------------------------------------------------------------------------
 // Lifecycle-gate rejects
 // ---------------------------------------------------------------------------
 
@@ -1645,7 +2321,7 @@ fn mollusk_zero_total_batch_cancels_at_settle() {
 /// is the only time gate in the flow.
 #[test]
 fn mollusk_dispatch_before_min_batch_age_rejects() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     // Batch opens at slot 100 and must age 1_000 slots.
     let keys = initialize_and_open_first_batch(&context, &fixture, 1_000);
@@ -1660,14 +2336,14 @@ fn mollusk_dispatch_before_min_batch_age_rejects() {
 /// and a second dispatch rejects. Claims reject until settle.
 #[test]
 fn mollusk_join_quit_and_claim_respect_batch_status() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
     ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
+        read_encrypted_value(&context, keys.join_balance_value).current_handle,
         0,
     );
     run_join(
@@ -1685,7 +2361,7 @@ fn mollusk_join_quit_and_claim_respect_batch_status() {
         &context,
         &[
             keys.claim_amount_value(fixture.alice.user),
-            keys.shares_transferred_value,
+            keys.payout_transferred_value,
         ],
     );
     context.process_and_validate_instruction(
@@ -1699,13 +2375,14 @@ fn mollusk_join_quit_and_claim_respect_batch_status() {
     let attestation = amount_attestation_for(
         handle_for_chain(42, BALANCE_FHE_TYPE),
         fixture.alice.user,
-        fixture.deposit_mint.compute_signer,
+        fixture.join_mint().compute_signer,
     );
     context.process_and_validate_instruction(
         &join_ix(&fixture, &keys, &fixture.alice, attestation),
         &[batcher_error(batcher::BatcherError::BatchNotPending)],
     );
-    // Quit after dispatch rejects — the exit is the claim, at the batch rate.
+    // Quit after dispatch rejects — the exit is the claim, pro rata. There is
+    // no exit between dispatch and settle (fhevm-internal#1773).
     context.process_and_validate_instruction(
         &quit_ix(&fixture, &keys, &fixture.alice),
         &[batcher_error(batcher::BatcherError::BatchNotPending)],
@@ -1721,20 +2398,13 @@ fn mollusk_join_quit_and_claim_respect_batch_status() {
 /// record's claimed flag.
 #[test]
 fn mollusk_double_claim_rejects() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
     run_join(
         &context,
         &fixture,
@@ -1753,7 +2423,7 @@ fn mollusk_double_claim_rejects() {
         &[batcher_error(batcher::BatcherError::AlreadyClaimed)],
     );
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.shares_balance_value),
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
         300
     );
 }
@@ -1763,7 +2433,7 @@ fn mollusk_double_claim_rejects() {
 /// rejects.
 #[test]
 fn mollusk_open_batch_requires_previous_batch_not_pending() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
 
@@ -1781,6 +2451,35 @@ fn mollusk_open_batch_requires_previous_batch_not_pending() {
     );
 }
 
+/// Initializing a batcher with the direction's mint wiring swapped rejects:
+/// a redeem batcher whose join mint wraps the vault underlying (instead of
+/// its shares) is refused at setup.
+#[test]
+fn mollusk_initialize_batcher_rejects_swapped_direction_wiring() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Redeem);
+    let context = mollusk().with_context(redeem_accounts(&fixture, 0, 0, 0));
+    let swapped = anchor_ix(
+        batcher::id(),
+        batcher::accounts::InitializeBatcher {
+            payer: fixture.payer,
+            batcher: fixture.batcher,
+            // Deposit-shaped wiring under a Redeem direction.
+            join_confidential_mint: fixture.underlying_cmint.mint,
+            payout_confidential_mint: fixture.shares_cmint.mint,
+            vault: fixture.vault,
+            system_program: system_program::ID,
+        },
+        batcher::instruction::InitializeBatcher {
+            min_batch_age_slots: 0,
+            direction: batcher::BatchDirection::Redeem,
+        },
+    );
+    context.process_and_validate_instruction(
+        &swapped,
+        &[batcher_error(batcher::BatcherError::JoinMintVaultMismatch)],
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Cost snapshots
 // ---------------------------------------------------------------------------
@@ -1790,101 +2489,115 @@ fn assert_batcher_cost(profile: &str, ix: &Instruction, result: &InstructionResu
 }
 
 /// One fixed-key run through open/join/dispatch/claim, snapshotting each
-/// instruction's cost profile. Fixed fixture keys keep the PDA bump searches —
-/// part of the measured compute — stable across runs.
-#[test]
-fn cost_snapshot_batcher_lifecycle() {
-    let fixture = BatcherFixture::fixed(0x61);
-    let context = mollusk().with_context(fixture.accounts(0, 0));
-    let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
-
+/// instruction's cost profile under `prefix`. Fixed fixture keys keep the PDA
+/// bump searches — part of the measured compute — stable across runs. No
+/// settle snapshot: its redemption-marker PDA seed is runtime-derived (the
+/// burned handle), so its bump search is not key-stable.
+fn snapshot_lifecycle(
+    fixture: &BatcherFixture,
+    context: &Ctx,
+    ledger: &mut CleartextLedger,
+    prefix: &str,
+) {
     context
-        .process_and_validate_instruction(&initialize_batcher_ix(&fixture, 0), &[Check::success()]);
-    let keys = BatchKeys::new(&fixture, 0);
-    ensure_open_batch_accounts(&context, &keys);
-    let open = open_batch_ix(&fixture, &keys, None);
+        .process_and_validate_instruction(&initialize_batcher_ix(fixture, 0), &[Check::success()]);
+    let keys = BatchKeys::new(fixture, 0);
+    ensure_open_batch_accounts(context, &keys);
+    let open = open_batch_ix(fixture, &keys, None);
     let open_result = context.process_and_validate_instruction(&open, &[Check::success()]);
-    assert_batcher_cost("open_batch", &open, &open_result);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    assert_batcher_cost(&format!("{prefix}open_batch"), &open, &open_result);
+    seed_open_batch_balances(context, &keys, ledger);
 
     let amount_handle = handle_for_chain(0x71, BALANCE_FHE_TYPE);
     ledger.seed_amount(amount_handle, 300);
     ensure_system_accounts(
-        &context,
+        context,
         &[
-            keys.deposit_record(fixture.alice.user),
-            fixture.alice.deposit_transferred_value,
-            keys.pending_deposit_value(fixture.alice.user),
+            keys.join_record(fixture.alice.user),
+            fixture.user_join(&fixture.alice).transferred_value,
+            keys.pending_join_value(fixture.alice.user),
         ],
     );
     let join = join_ix(
-        &fixture,
+        fixture,
         &keys,
         &fixture.alice,
         amount_attestation_for(
             amount_handle,
             fixture.alice.user,
-            fixture.deposit_mint.compute_signer,
+            fixture.join_mint().compute_signer,
         ),
     );
     let join_result = context.process_and_validate_instruction(&join, &[Check::success()]);
-    ledger.evaluate_fhe_cpis(&context, &join_result);
-    assert_batcher_cost("join", &join, &join_result);
+    ledger.evaluate_fhe_cpis(context, &join_result);
+    assert_batcher_cost(&format!("{prefix}join"), &join, &join_result);
 
-    ensure_system_accounts(&context, &[keys.burned_amount_value]);
-    let dispatch = dispatch_ix(&fixture, &keys);
+    ensure_system_accounts(context, &[keys.burned_amount_value]);
+    let dispatch = dispatch_ix(fixture, &keys);
     let dispatch_result = context.process_and_validate_instruction(&dispatch, &[Check::success()]);
-    ledger.evaluate_fhe_cpis(&context, &dispatch_result);
-    assert_batcher_cost("dispatch", &dispatch, &dispatch_result);
+    ledger.evaluate_fhe_cpis(context, &dispatch_result);
+    assert_batcher_cost(&format!("{prefix}dispatch"), &dispatch, &dispatch_result);
 
-    let burned_handle = read_batch(&context, keys.batch).burned_total_handle;
-    run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 300);
+    let burned_handle = read_batch(context, keys.batch).burned_total_handle;
+    run_settle(context, fixture, &keys, ledger, burned_handle, 300);
 
     ensure_system_accounts(
-        &context,
+        context,
         &[
             keys.claim_amount_value(fixture.alice.user),
-            keys.shares_transferred_value,
+            keys.payout_transferred_value,
         ],
     );
-    let claim = claim_ix(&fixture, &keys, &fixture.alice);
+    let claim = claim_ix(fixture, &keys, &fixture.alice);
     let claim_result = context.process_and_validate_instruction(&claim, &[Check::success()]);
-    ledger.evaluate_fhe_cpis(&context, &claim_result);
-    assert_batcher_cost("claim", &claim, &claim_result);
+    ledger.evaluate_fhe_cpis(context, &claim_result);
+    assert_batcher_cost(&format!("{prefix}claim"), &claim, &claim_result);
+}
+
+#[test]
+fn cost_snapshot_batcher_lifecycle() {
+    let fixture = BatcherFixture::fixed(batcher::BatchDirection::Deposit, 0x61);
+    let context = mollusk().with_context(fixture.accounts(0, 0));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
+    snapshot_lifecycle(&fixture, &context, &mut ledger, "");
+}
+
+#[test]
+fn cost_snapshot_batcher_redeem_lifecycle() {
+    let fixture = BatcherFixture::fixed(batcher::BatchDirection::Redeem, 0x51);
+    let context = mollusk().with_context(redeem_accounts(&fixture, 1_000, 1_000, 1_000));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (0, 600), (0, 400), (0, 1_000));
+    snapshot_lifecycle(&fixture, &context, &mut ledger, "redeem_");
 }
 
 // ---------------------------------------------------------------------------
-// Known limitation: dust-total batches cannot settle (pinned behavior)
+// Known limitation: dust-total DEPOSIT batches cannot settle (pinned behavior)
 // ---------------------------------------------------------------------------
 
-/// A batch whose certified total floors to zero shares at the vault's price
-/// cannot settle: `demo_vault::deposit` rejects `ZeroShares`, the settle
+/// A deposit batch whose certified total floors to zero shares at the vault's
+/// price cannot settle: `demo_vault::deposit` rejects `ZeroShares`, the settle
 /// reverts atomically (nothing paid out, no marker written), and the batch
 /// stays Dispatched forever — the demo vault's price only rises, so no retry
 /// can ever succeed. An attacker holding ~all vault shares can manufacture
 /// this near-free by `harvest`-donating to pump the price (the donation
 /// accrues to their own shares). This test pins today's behavior so the
-/// future cancel-and-refund settle branch has a failing test to flip.
+/// future cancel-and-refund settle branch (fhevm-internal#1773) has a failing
+/// test to flip. The redeem direction has no analog — see
+/// `mollusk_redeem_one_share_dust_settles_at_extreme_price`.
 #[test]
 fn mollusk_dust_total_settle_reverts_and_batch_stays_dispatched() {
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     // Share price ~20_000 underlying per share (e.g. after an adversarial
     // harvest donation): 2_000_000 assets backing 100 shares.
     let context = mollusk().with_context(fixture.accounts(2_000_000, 100));
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
     ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
+        read_encrypted_value(&context, keys.join_balance_value).current_handle,
         0,
     );
 
@@ -1904,7 +2617,7 @@ fn mollusk_dust_total_settle_reverts_and_batch_stays_dispatched() {
     let (signatures, extra_data) = kms_public_decrypt_cert(burned_handle, 100);
     let proof = single_burn_public_decrypt_proof(keys.burned_amount_value, burned_handle);
     let redemption_record =
-        token::burn_redemption_address(fixture.deposit_mint.mint, burned_handle).0;
+        token::burn_redemption_address(fixture.join_mint().mint, burned_handle).0;
     ensure_system_accounts(&context, &[redemption_record]);
     let ix = settle_ix(
         &fixture,
@@ -1926,8 +2639,8 @@ fn mollusk_dust_total_settle_reverts_and_batch_stays_dispatched() {
     // underlying released, vault untouched.
     let batch = read_batch(&context, keys.batch);
     assert_eq!(batch.status, batcher::BatchStatus::Dispatched);
-    assert_eq!(batch.total_deposited, 0);
-    assert_eq!(read_spl_amount(&context, keys.underlying_tokens), 0);
+    assert_eq!(batch.total_joined, 0);
+    assert_eq!(read_spl_amount(&context, keys.join_underlying), 0);
     assert_eq!(
         read_spl_amount(&context, fixture.vault_token_account),
         2_000_000
@@ -1942,22 +2655,20 @@ fn mollusk_dust_total_settle_reverts_and_batch_stays_dispatched() {
 /// realistically shaped cert/proof data) as (a) a legacy `Transaction` and
 /// (b) a v0 `VersionedTransaction` whose non-payer accounts load through one
 /// address lookup table, across cert thresholds and proof depths. Legacy
-/// settle never fits one packet (the 34-account meta list alone approaches
+/// settle never fits one packet (the ~35-account meta list alone approaches
 /// the limit); v0+ALT fits comfortably at every reachable batcher shape —
 /// the batch's burned lineage always holds exactly one leaf, so its proof
 /// depth is 0 regardless of the KMS threshold. The deep-proof row is the
 /// out-of-domain bound where even v0+ALT would need a split settle.
-#[test]
-fn settle_transaction_size_needs_v0_lookup_table_and_fits() {
-    let fixture = BatcherFixture::fixed(0x91);
-    let keys = BatchKeys::new(&fixture, 0);
+fn assert_settle_wire_sizes(fixture: &BatcherFixture) {
+    let keys = BatchKeys::new(fixture, 0);
     let burned_handle = handle_for_chain(0x92, BALANCE_FHE_TYPE);
     let redemption_record =
-        token::burn_redemption_address(fixture.deposit_mint.mint, burned_handle).0;
+        token::burn_redemption_address(fixture.join_mint().mint, burned_handle).0;
 
     let settle_with = |threshold: usize, proof_depth: usize| -> Instruction {
         settle_ix(
-            &fixture,
+            fixture,
             &keys,
             800,
             vec![[0u8; 65]; threshold],
@@ -2015,8 +2726,9 @@ fn settle_transaction_size_needs_v0_lookup_table_and_fits() {
         let legacy = legacy_size(&ix);
         let v0 = v0_with_lookup_table_size(&ix);
         println!(
-            "settle wire size t={threshold} depth={depth}: legacy={legacy}B v0+ALT={v0}B \
+            "settle wire size ({:?}) t={threshold} depth={depth}: legacy={legacy}B v0+ALT={v0}B \
              (packet limit {})",
+            fixture.direction,
             solana_packet::PACKET_DATA_SIZE
         );
         sizes.push((threshold, depth, legacy, v0));
@@ -2040,24 +2752,40 @@ fn settle_transaction_size_needs_v0_lookup_table_and_fits() {
     }
 }
 
+#[test]
+fn settle_transaction_size_needs_v0_lookup_table_and_fits() {
+    assert_settle_wire_sizes(&BatcherFixture::fixed(
+        batcher::BatchDirection::Deposit,
+        0x91,
+    ));
+}
+
+#[test]
+fn redeem_settle_transaction_size_needs_v0_lookup_table_and_fits() {
+    assert_settle_wire_sizes(&BatcherFixture::fixed(
+        batcher::BatchDirection::Redeem,
+        0x81,
+    ));
+}
+
 // ---------------------------------------------------------------------------
-// Preloaded shares must not poison the rate (settle prices the delta)
+// Preloaded shares must not poison the batch (settle prices the delta)
 // ---------------------------------------------------------------------------
 
 /// SPL destinations cannot refuse incoming transfers, so an attacker can push
-/// vault shares into the PDA-owned `batch_share_tokens` account before
-/// settlement. Settle must price and wrap only the vault-minted delta across
-/// its deposit leg: with balance-based accounting, this preload (~18.75e9 x
-/// the batch total in rate units, above the u64 rate bound of ~18.45e9) would
-/// make `freeze_share_rate` overflow and permanently brick the batch. The
+/// vault shares into the PDA-owned `batch_payout_underlying` account of a
+/// deposit batch before settlement. Settle must price and wrap only the
+/// vault-minted delta across its deposit leg: with balance-based accounting,
+/// this preload would have inflated the batch's payout accounting (and, under
+/// the old rate math, overflowed the u64 rate and bricked the batch). The
 /// attacker acquires the shares through a genuine demo-vault deposit and a
 /// genuine SPL transfer — no seeded shortcuts.
 #[test]
 fn mollusk_preloaded_shares_do_not_poison_the_rate() {
-    // Large enough that (PRELOAD + 800) * RATE_SCALE / 800 > u64::MAX, so the
-    // old balance-based computation would have failed with ShareRateOverflow.
+    // Large enough that (PRELOAD + 800) * RATE_SCALE / 800 > u64::MAX, so a
+    // balance-based rate would have left the u64 domain entirely.
     const PRELOAD: u64 = 15_000_000_000_000;
-    let fixture = BatcherFixture::new();
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let attacker = Pubkey::new_unique();
     let attacker_underlying = Pubkey::new_unique();
     let attacker_shares = Pubkey::new_unique();
@@ -2074,17 +2802,10 @@ fn mollusk_preloaded_shares_do_not_poison_the_rate() {
     );
     let context = mollusk().with_context(accounts);
     let mut ledger = CleartextLedger::default();
-    fixture.seed_ledger(&mut ledger, 1_000, 2_000);
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
 
     let keys = initialize_and_open_first_batch(&context, &fixture, 0);
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.deposit_balance_value).current_handle,
-        0,
-    );
-    ledger.seed_amount(
-        read_encrypted_value(&context, keys.shares_balance_value).current_handle,
-        0,
-    );
+    seed_open_batch_balances(&context, &keys, &mut ledger);
     run_join(
         &context,
         &fixture,
@@ -2123,43 +2844,44 @@ fn mollusk_preloaded_shares_do_not_poison_the_rate() {
     context.process_and_validate_instruction(&attacker_deposit, &[Check::success()]);
     assert_eq!(read_spl_amount(&context, attacker_shares), PRELOAD);
 
-    // ... and pushes the whole share balance into the batch's share account.
+    // ... and pushes the whole share balance into the batch's payout account.
     let preload_transfer = spl_token::instruction::transfer(
         &spl_token::id(),
         &attacker_shares,
-        &keys.share_tokens,
+        &keys.payout_underlying,
         &attacker,
         &[],
         PRELOAD,
     )
     .unwrap();
     context.process_and_validate_instruction(&preload_transfer, &[Check::success()]);
-    assert_eq!(read_spl_amount(&context, keys.share_tokens), PRELOAD);
+    assert_eq!(read_spl_amount(&context, keys.payout_underlying), PRELOAD);
 
     let burned_handle = run_dispatch(&context, &fixture, &keys, &mut ledger);
     run_settle(&context, &fixture, &keys, &mut ledger, burned_handle, 800);
 
-    // Settle succeeded and the frozen rate reflects only the vault-minted
-    // delta: 800 in, 800 shares out at the (still ~1:1) price, rate exactly
-    // RATE_SCALE. The preloaded shares sit in the account, unwrapped, inert.
+    // Settle succeeded and the recorded payout reflects only the vault-minted
+    // delta: 800 in, 800 shares out at the (still ~1:1) price, informational
+    // rate exactly RATE_SCALE. The preloaded shares sit in the account,
+    // unwrapped, inert.
     let settled = read_batch(&context, keys.batch);
     assert_eq!(settled.status, batcher::BatchStatus::Settled);
-    assert_eq!(settled.total_deposited, 800);
-    assert_eq!(settled.shares_received, 800);
-    assert_eq!(settled.share_rate, batcher::RATE_SCALE);
-    assert_eq!(read_spl_amount(&context, keys.share_tokens), PRELOAD);
-    assert_eq!(ledger.u64_at(&context, keys.shares_balance_value), 800);
+    assert_eq!(settled.total_joined, 800);
+    assert_eq!(settled.payout_received, 800);
+    assert_eq!(settled.payout_rate, batcher::RATE_SCALE);
+    assert_eq!(read_spl_amount(&context, keys.payout_underlying), PRELOAD);
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 800);
 
     // Claims pay out exactly as in the clean lifecycle.
     run_claim(&context, &fixture, &keys, &fixture.alice, &mut ledger);
     run_claim(&context, &fixture, &keys, &fixture.bob, &mut ledger);
     assert_eq!(
-        ledger.u64_at(&context, fixture.alice.shares_balance_value),
+        ledger.u64_at(&context, fixture.alice.shares.balance_value),
         300
     );
     assert_eq!(
-        ledger.u64_at(&context, fixture.bob.shares_balance_value),
+        ledger.u64_at(&context, fixture.bob.shares.balance_value),
         500
     );
-    assert_eq!(ledger.u64_at(&context, keys.shares_balance_value), 0);
+    assert_eq!(ledger.u64_at(&context, keys.payout_balance_value), 0);
 }


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1758. Part of the confidential-vault demo epic (fhevm-internal#1754). Also fixes fhevm-internal#1774 items 1–2.

## What

The confidential batcher's **redeem direction**, mirroring deposits: users join a batch with encrypted vault shares; only the batch's share **total** is ever revealed (confidential burn + KMS certificate); settle redeems the certified total via `demo_vault::withdraw`, wraps the received underlying back into confidential tokens, and freezes an informational rate; claims pay each user encrypted underlying proportional to their joined shares. Same privacy property both ways: individual amounts stay encrypted, only the batch total is born public.

## Design

- **One program, direction fixed per `Batcher` instance.** Each batcher is initialized as `Deposit` or `Redeem` — mirroring the EVM's two deployments, so pending batches in one direction never block the other — while all account layouts and instructions are shared under direction-neutral **join/payout** vocabulary (join mint = what users batch in; payout mint = what claims pay). The batch lifecycle's only direction branch is settle's vault CPI (`deposit` vs `withdraw`); `initialize_batcher` additionally validates the mint wiring per direction at setup. Join, quit, dispatch, and claim are literally direction-free shared code. Rationale in the DD-042 addendum: the two flows differ in exactly one CPI, so duplicating every accounts struct to encode one branch would double review surface for zero clarity.
- **Exact proportional claims (fixes #1774 item 1, both directions):** claims now pay `mul_div(joined, payout_received, total_joined)` — the exact proportional floor, same FHE op count, intermediate < 2¹²⁸. The old two-step rate math double-rounded; a pinning unit test verifies it stranded exactly 6,148,914,726 raw units on the u64-scale case vs ≤1 unit per claim now. The frozen `payout_rate` is informational/event-facing only (grep-verified: written, never read by an instruction) and saturates at u64::MAX — a display value must not be able to brick settle.
- **Delta accounting preserved as an invariant:** the settle payout leg in both directions snapshots the SPL balance before the vault CPI, reloads after, and wraps only the `checked_sub` delta — preloading the payout account is inert (adversarial tests in both directions at rate-breaking scale).
- **Dust asymmetry (analyzed, tested):** the deposit-side dust brick (#1773) has **no redeem analog** — the vault price never drops below 1:1, so withdrawing ≥1 share always pays ≥1 underlying; pinned by a test at an extreme share price. Deposit dust behavior unchanged and still pinned.
- **Host-policy envelope documented (#1774 item 2):** settle/claim module docs and DD-042 now state the POC assumption that deny-list records and HCU accounts are hardcoded `None`.
- Cancel-after-dispatch stays out of scope (quit-before-dispatch only), per the issue; deadline-cancel is tracked in fhevm-internal#1773.

## Breaking renames (deliberate, POC — no back-compat)

The direction-neutral vocabulary renames merged deposit-direction identifiers: PDA seeds `deposit-record`→`join-record`, `batch-underlying`→`batch-join-underlying`, `batch-share-tokens`→`batch-payout-underlying`; pending label `batcher-pending-join`; `DepositRecord`→`JoinRecord`; event `SharesClaimed`→`PayoutClaimed`; `Batcher`/`Batch` layout changes. `APP_EVENT_VERSION` bumped to 2. Any batcher deployed from the previous commit is orphaned and old event decoders break — accepted cost on this branch, nothing consumes the old deployment. Error enum strictly append-only (retired variants kept in place, marked legacy).

## Tests

24 batcher Mollusk tests (all genuine `invoke_signed` CPIs with the cleartext-ledger replay asserting exact eval counts): full redeem lifecycle ×2 users, redeem with yield (rounding), redeem repeat-join/quit-rejoin aliasing, redeem zero-total cancel, redeem dust-at-extreme-price (settles, no brick), redeem preload attack (inert), claim-after-quit (pays zero, record closed, others unaffected), deposit+redeem batchers interleaved end-to-end over shared mints (joins/dispatches/settles/claims alternating, escrow/vault/user balances checked at every stage), swapped-wiring reject, redeem settle wire-size (legacy overflows 1232 B; v0 + one lookup table fits at 7-of-13 cert threshold), redeem cost snapshots (fixed fixture keys) — plus all existing deposit tests, updated to the exact-proportional claim math.

Full suite: **796 passed, 0 failed**. Clippy `-D warnings`, fmt, IDL/ABI goldens in sync (no host/token changes), cost snapshots byte-identical on re-run, `program_autofixer` clean. Independently reviewed (privacy audiences, delta accounting, fund safety, state machine, cross-direction substitution, math, docs honesty, wire size): no P1/P2 findings; all review nits folded in.
