### PR TITLE
fix(coprocessor): guard green-stack writes against dry-run rollback reset

### DIFF
--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -42,7 +42,7 @@ use alloy::providers::Provider;
 use fhevm_engine_common::database::GCS_SCHEMA_QUOTED;
 use fhevm_engine_common::utils::DatabaseURL;
 use serde::{Deserialize, Serialize};
-use sqlx::{postgres::PgListener, Pool, Postgres};
+use sqlx::{postgres::PgListener, Executor, Pool, Postgres};
 use thiserror::Error;
 use tokio::select;
 use tokio::sync::RwLock;
@@ -241,14 +241,15 @@ fn all_slots_filled(slots: &[Option<Vec<u8>>]) -> bool {
 /// Returns `(start_block, end_block)` for the GCS dry-run when it's active.
 /// `None` otherwise. Scoped to `stack_role = 'GCS'` because BCS also stays
 /// `status='in_progress'` during the upgrade and doesn't own the replay window.
-pub(crate) async fn active_upgrade_window(
-    pool: &Pool<Postgres>,
-) -> Result<Option<(i64, i64)>, Error> {
+pub(crate) async fn active_upgrade_window<'e, E>(executor: E) -> Result<Option<(i64, i64)>, Error>
+where
+    E: Executor<'e, Database = Postgres>,
+{
     let row: Option<(String, Option<i64>, Option<i64>)> = sqlx::query_as(
         "SELECT state, start_block, end_block FROM upgrade_state
           WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?;
 
     let Some((state, start_block, end_block)) = row else {

--- a/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use aws_sdk_s3::primitives::ByteStream;
 use fhevm_engine_common::database::{GCS_SCHEMA, GCS_SCHEMA_QUOTED};
 use fhevm_engine_common::gcs_activation::EVENT_GW_NEW_BLOCK;
-use sqlx::{postgres::PgListener, Pool, Postgres, Row};
+use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
+use sqlx::{postgres::PgListener, Pool, Postgres, Row, Transaction};
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -27,12 +28,44 @@ pub fn state_hash_key(chain_id: i64, block_number: i64) -> String {
     format!("state_hash/chain={chain_id}/block={block_number}.bin")
 }
 
+/// Outcome of a guarded state-hash insert.
+enum HashInsert {
+    /// Inserted a new row.
+    Wrote,
+    /// The row already exists.
+    Noop,
+}
+
+/// Inserts a state hash in the guarded transaction.
+async fn insert_state_hash(
+    tx: &mut Transaction<'_, Postgres>,
+    chain_id: i64,
+    block_number: i64,
+    hash: &str,
+) -> Result<HashInsert, sqlx::Error> {
+    let affected = sqlx::query(&format!(
+        "INSERT INTO {GCS_SCHEMA_QUOTED}.state_hash (chain_id, block_number, state_hash)
+         VALUES ($1, $2, $3) ON CONFLICT (chain_id, block_number) DO NOTHING"
+    ))
+    .bind(chain_id)
+    .bind(block_number)
+    .bind(hash)
+    .execute(&mut **tx)
+    .await?
+    .rows_affected();
+    Ok(if affected > 0 {
+        HashInsert::Wrote
+    } else {
+        HashInsert::Noop
+    })
+}
+
 /// GCS path: stamp the GCS `state_hash` for blocks in `[start, end]` that don't
 /// already have an entry. Empty blocks (`fhe_event_count = 0`) get
 /// [`EMPTY_BLOCK_STATE_HASH`]; non-empty blocks get the SHA-256 over their
 /// GCS `ciphertexts`.
 async fn compute_and_insert_gcs(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     start: i64,
     end: i64,
     batch_limit: i64,
@@ -73,14 +106,9 @@ async fn compute_and_insert_gcs(
         .bind(start)
         .bind(end)
         .bind(batch_limit)
-        .fetch_all(pool)
+        .fetch_all(&mut **tx)
         .await?;
 
-    let insert_sql = format!(
-        "INSERT INTO {GCS_SCHEMA_QUOTED}.state_hash (chain_id, block_number, state_hash)
-         VALUES ($1, $2, $3)
-         ON CONFLICT (chain_id, block_number) DO NOTHING"
-    );
     for row in pending {
         let chain_id: i64 = row.try_get("chain_id")?;
         let block_number: i64 = row.try_get("block_number")?;
@@ -88,18 +116,12 @@ async fn compute_and_insert_gcs(
         let hash = if is_empty {
             Some(EMPTY_BLOCK_STATE_HASH.to_string())
         } else {
-            compute_gcs_hash(pool, chain_id, block_number).await?
+            compute_gcs_hash(tx, chain_id, block_number).await?
         };
         let Some(hash) = hash else { continue };
-        let affected = sqlx::query(&insert_sql)
-            .bind(chain_id)
-            .bind(block_number)
-            .bind(&hash)
-            .execute(pool)
-            .await?
-            .rows_affected();
-        if affected > 0 {
-            info!(chain_id, block_number, "gcs.state_hash inserted");
+        match insert_state_hash(tx, chain_id, block_number, &hash).await? {
+            HashInsert::Wrote => info!(chain_id, block_number, "gcs.state_hash inserted"),
+            HashInsert::Noop => {}
         }
     }
     Ok(())
@@ -115,7 +137,7 @@ async fn compute_and_insert_gcs(
 /// read public. Runtime `sqlx::query` because the schema name is only known at
 /// runtime.
 async fn compute_gcs_hash(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     chain_id: i64,
     block_number: i64,
 ) -> anyhow::Result<Option<String>> {
@@ -140,7 +162,7 @@ async fn compute_gcs_hash(
     let Some(row) = sqlx::query(&sql)
         .bind(chain_id)
         .bind(block_number)
-        .fetch_optional(pool)
+        .fetch_optional(&mut **tx)
         .await?
     else {
         return Ok(None);
@@ -165,7 +187,7 @@ async fn compute_gcs_hash(
 /// Like [`compute_and_insert_gcs`], every table is explicitly qualified with the
 /// versioned GCS schema and never falls back to `public`.
 async fn compute_and_insert_gw_input_hashes(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     gw_chain_id: i64,
     gw_start_block: i64,
     gw_tip: i64,
@@ -192,33 +214,24 @@ async fn compute_and_insert_gw_input_hashes(
         .bind(gw_tip)
         .bind(gw_chain_id)
         .bind(batch_limit)
-        .fetch_all(pool)
+        .fetch_all(&mut **tx)
         .await?;
 
-    let insert_sql = format!(
-        "INSERT INTO {GCS_SCHEMA_QUOTED}.state_hash (chain_id, block_number, state_hash)
-         VALUES ($1, $2, $3)
-         ON CONFLICT (chain_id, block_number) DO NOTHING"
-    );
     for row in pending {
         let block_number: i64 = row.try_get("block_number")?;
         // `None` when the input ciphertexts aren't all present yet (handle exists
         // in input_handles but its ciphertext row hasn't landed) — retry later.
-        let Some(hash) = compute_gw_input_hash(pool, block_number).await? else {
+        let Some(hash) = compute_gw_input_hash(tx, block_number).await? else {
             continue;
         };
-        let affected = sqlx::query(&insert_sql)
-            .bind(gw_chain_id)
-            .bind(block_number)
-            .bind(&hash)
-            .execute(pool)
-            .await?
-            .rows_affected();
-        if affected > 0 {
-            info!(
-                gw_chain_id,
-                block_number, "gcs.state_hash (gw inputs) inserted"
-            );
+        match insert_state_hash(tx, gw_chain_id, block_number, &hash).await? {
+            HashInsert::Wrote => {
+                info!(
+                    gw_chain_id,
+                    block_number, "gcs.state_hash (gw inputs) inserted"
+                )
+            }
+            HashInsert::Noop => {}
         }
     }
     Ok(())
@@ -231,7 +244,7 @@ async fn compute_and_insert_gw_input_hashes(
 /// two tracks are byte-compatible, but the source is `input_handles` joined to
 /// `is_input` ciphertexts rather than `computations` outputs.
 async fn compute_gw_input_hash(
-    pool: &Pool<Postgres>,
+    tx: &mut Transaction<'_, Postgres>,
     block_number: i64,
 ) -> anyhow::Result<Option<String>> {
     let sql = format!(
@@ -249,7 +262,7 @@ async fn compute_gw_input_hash(
     );
     let Some(row) = sqlx::query(&sql)
         .bind(block_number)
-        .fetch_optional(pool)
+        .fetch_optional(&mut **tx)
         .await?
     else {
         return Ok(None);
@@ -261,22 +274,28 @@ async fn compute_gw_input_hash(
 /// The Gateway tip = the GCS gw-listener watermark. `None` when the watermark
 /// row is absent/NULL (listener hasn't ingested any Gateway block yet), which
 /// disables Gateway hashing until it does.
-pub(crate) async fn gw_listener_tip(pool: &Pool<Postgres>) -> Result<Option<i64>, sqlx::Error> {
+pub(crate) async fn gw_listener_tip<'e, E>(executor: E) -> Result<Option<i64>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
     let sql = format!(
         "SELECT last_block_num FROM {GCS_SCHEMA_QUOTED}.gw_listener_last_block
           WHERE dummy_id = true"
     );
-    let row: Option<(Option<i64>,)> = sqlx::query_as(&sql).fetch_optional(pool).await?;
+    let row: Option<(Option<i64>,)> = sqlx::query_as(&sql).fetch_optional(executor).await?;
     Ok(row.and_then(|(v,)| v))
 }
 
 /// `gw_start_block` of the active GCS upgrade row, or `None` when unset.
-pub(crate) async fn gw_start_block(pool: &Pool<Postgres>) -> Result<Option<i64>, sqlx::Error> {
+pub(crate) async fn gw_start_block<'e, E>(executor: E) -> Result<Option<i64>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
     let row: Option<(Option<i64>,)> = sqlx::query_as(
         "SELECT gw_start_block FROM upgrade_state
           WHERE stack_role = 'GCS' AND status = 'in_progress'",
     )
-    .fetch_optional(pool)
+    .fetch_optional(executor)
     .await?;
     Ok(row.and_then(|(v,)| v))
 }
@@ -429,12 +448,12 @@ async fn upload_pending_gw_state_hashes(
 /// Checked against `information_schema.schemata` by exact (unquoted) name, so the
 /// hyphen/dots in the schema name need no identifier quoting. See
 /// [`compute_and_upload_state_hashes`] for why the pass is gated on this.
-async fn gcs_schema_exists(pool: &Pool<Postgres>) -> anyhow::Result<bool> {
+async fn gcs_schema_exists(tx: &mut Transaction<'_, Postgres>) -> anyhow::Result<bool> {
     let (exists,): (bool,) = sqlx::query_as(
         "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)",
     )
     .bind(GCS_SCHEMA)
-    .fetch_one(pool)
+    .fetch_one(&mut **tx)
     .await?;
     Ok(exists)
 }
@@ -450,6 +469,11 @@ async fn compute_and_upload_state_hashes(
     batch_limit: i64,
     gw_chain_id: i64,
 ) -> anyhow::Result<()> {
+    let mut tx = match begin_write_guarded(pool, true, GcsRollbackPolicy::Skip).await? {
+        WriteGuard::Proceed(tx) => tx,
+        WriteGuard::Stop | WriteGuard::Skip => return Ok(()),
+    };
+
     // Every branch below touches the versioned GCS schema — the compute paths and
     // the GW-inputs upload explicitly via GCS_SCHEMA_QUOTED, the host-chain upload
     // implicitly through the gcs-first search_path. That schema is created by the
@@ -459,28 +483,31 @@ async fn compute_and_upload_state_hashes(
     // schema is absent, and the hard-qualified GW upload would fail every pass with
     // `relation "gcs-<ver>.state_hash" does not exist`. There is nothing to compute
     // or upload without the schema, so skip the whole pass cleanly.
-    if !gcs_schema_exists(pool).await? {
+    if !gcs_schema_exists(&mut tx).await? {
         debug!(
             schema = GCS_SCHEMA,
             "GCS schema absent — skipping state_hash pass"
         );
+        tx.rollback().await?;
         return Ok(());
     }
 
     // GCS hashes are only produced during an active upgrade window; BCS hashes
     // are not produced because they would never be uploaded or consumed.
-    if let Some((start, end)) = crate::active_upgrade_window(pool).await? {
-        compute_and_insert_gcs(pool, start, end, batch_limit).await?;
+    if let Some((start, end)) = crate::active_upgrade_window(&mut *tx).await? {
+        compute_and_insert_gcs(&mut tx, start, end, batch_limit).await?;
 
         // Gateway-inputs track: only once the GCS gw-listener has a watermark and
         // gw_start_block is set. Bounded to sealed blocks (< gw_tip).
-        if let (Some(gw_start), Some(gw_tip)) =
-            (gw_start_block(pool).await?, gw_listener_tip(pool).await?)
-        {
-            compute_and_insert_gw_input_hashes(pool, gw_chain_id, gw_start, gw_tip, batch_limit)
+        if let (Some(gw_start), Some(gw_tip)) = (
+            gw_start_block(&mut *tx).await?,
+            gw_listener_tip(&mut *tx).await?,
+        ) {
+            compute_and_insert_gw_input_hashes(&mut tx, gw_chain_id, gw_start, gw_tip, batch_limit)
                 .await?;
         }
     }
+    tx.commit().await?;
 
     // S3 upload: drains pending rows; runs every pass so failed PUTs retry.
     if let Some(s3) = s3 {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -310,19 +310,51 @@ pub async fn begin_guarded_conn(
     Ok(tx)
 }
 
-/// PostgreSQL advisory-lock key serializing BCS writes against `execute_cutover`.
-/// `execute_cutover` (upgrade-controller) takes the **exclusive** form; every BCS
-/// write transaction takes the **shared** form via [`cutover_gate`]. Chosen to be
+/// PostgreSQL advisory-lock key serializing writes against cutover and rollback.
+/// The upgrade-controller takes the **exclusive** form; every guarded write
+/// transaction takes the **shared** form via [`cutover_gate`]. Chosen to be
 /// recognizable in logs (`0x4648_4556_4355_5456` ~ ASCII "FHEVCUTV").
 pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 
-/// Cutover safety gate for a BCS write transaction.
+/// Result of opening a guarded write transaction.
+pub enum WriteGuard<'a> {
+    Proceed(Transaction<'a, Postgres>),
+    Stop,
+    Skip,
+}
+
+impl<'a> WriteGuard<'a> {
+    /// Returns the transaction when the write can proceed.
+    pub fn into_tx(self) -> Option<Transaction<'a, Postgres>> {
+        match self {
+            WriteGuard::Proceed(tx) => Some(tx),
+            WriteGuard::Stop | WriteGuard::Skip => None,
+        }
+    }
+}
+
+/// Controls GCS writes after a rollback.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GcsRollbackPolicy {
+    /// Used by raw chain ingestion.
+    Continue,
+    /// Used by derived output workers.
+    Skip,
+}
+
+#[derive(Clone, Copy)]
+enum GateBlock {
+    Stop,
+    Skip,
+}
+
+/// Cutover and rollback safety gate for a write transaction.
 ///
-/// Takes the **shared** cutover advisory lock on `tx`, then re-checks the
-/// retirement fence ([`is_retired`]) now that this transaction is ordered
-/// against `execute_cutover` (which holds the **exclusive** form). Returns `true`
-/// if a committed cutover has retired this stack — the caller must roll back and
-/// stop, having written nothing into the now-live tables.
+/// Takes the **shared** advisory lock on `tx`, then checks the stack state while
+/// ordered against controller changes, which take the **exclusive** form.
+/// Returns `Stop` when cutover has retired a BCS writer and `Skip` when rollback
+/// has paused derived GCS writes. The caller rolls back either blocked
+/// transaction before returning it.
 ///
 /// Why the lock, not just [`begin_guarded_pool`]'s BEGIN-time check:
 /// `assert_not_retired` runs only at BEGIN, so a transaction opened before
@@ -334,49 +366,64 @@ pub const CUTOVER_LOCK_ID: i64 = 0x4648_4556_4355_5456;
 /// compatible, so this does **not** serialize BCS worker replicas against each
 /// other — only against the one-shot cutover.
 ///
-/// GCS-mode (green) workers also take the shared lock: their writes land in the
-/// `gcs` schema, which `execute_cutover` merges into the live tables and then
-/// drops. Without the lock a green write committing between cutover's merge read
-/// and its `DROP SCHEMA gcs CASCADE` would be neither merged nor preserved (a
-/// silent-loss window); holding the shared lock makes cutover's exclusive request
-/// block until the write commits, so it is merged before the drop. They skip only
-/// the [`is_retired`] re-check: a green binary is strictly newer than the live
-/// stack, so it can never be retired (`is_retired` is always `false` for it).
-pub async fn cutover_gate(
+/// GCS-mode (green) writers also take the shared lock: their writes land in the
+/// `gcs` schema, which cutover merges and rollback resets. Without the lock a
+/// green write could be lost during cutover or land in the recreated schema after
+/// rollback. Holding the shared lock makes either exclusive request wait until
+/// the write commits. Raw ingestion continues after rollback, while derived
+/// workers skip when the GCS row is `PAUSED`. GCS writers skip only the
+/// [`is_retired`] re-check because a green binary is newer than the live stack
+/// and cannot be retired.
+async fn cutover_gate(
     tx: &mut Transaction<'_, Postgres>,
     gcs_mode: bool,
-) -> Result<bool, sqlx::Error> {
+    rollback_policy: GcsRollbackPolicy,
+) -> Result<Option<GateBlock>, sqlx::Error> {
     sqlx::query("SELECT pg_advisory_xact_lock_shared($1)")
         .bind(CUTOVER_LOCK_ID)
         .execute(&mut **tx)
         .await?;
     if gcs_mode {
-        return Ok(false);
+        if rollback_policy == GcsRollbackPolicy::Skip {
+            let paused: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM upgrade_state WHERE stack_role = 'GCS' AND state = 'PAUSED')",
+            )
+            .fetch_one(&mut **tx)
+            .await?;
+            return Ok(paused.then_some(GateBlock::Skip));
+        }
+        return Ok(None);
     }
-    is_retired(tx).await
+    Ok(is_retired(tx).await?.then_some(GateBlock::Stop))
 }
 
-/// Begin a **write** transaction fenced against cutover, in one call.
+/// Begin a **write** transaction fenced against cutover and rollback, in one call.
 ///
 /// Combines [`begin_guarded_pool`] (BEGIN-time `assert_not_retired`) with
-/// [`cutover_gate`] (shared cutover lock + retirement re-check). Returns
-/// `Ok(None)` if a committed cutover has retired this stack — the caller should
-/// skip the write and stop cleanly, having written nothing.
+/// [`cutover_gate`] (shared advisory lock plus the relevant state check). Returns
+/// [`WriteGuard::Stop`] for a retired BCS stack and [`WriteGuard::Skip`] for a
+/// derived GCS write after rollback.
 ///
-/// Use this for every BCS write transaction. Keep [`begin_guarded_pool`] for
-/// **read-only** transactions: reads cannot corrupt merged state, so they should
-/// not take the shared cutover lock (which would make `execute_cutover` block
-/// behind every in-flight read).
+/// Use this for every BCS or GCS write transaction. Keep [`begin_guarded_pool`]
+/// for **read-only** transactions: reads cannot corrupt merged or reset state,
+/// so they should not take the shared lock, which would delay cutover or
+/// rollback behind every in-flight read.
 pub async fn begin_write_guarded(
     pool: &Pool<Postgres>,
     gcs_mode: bool,
-) -> Result<Option<Transaction<'static, Postgres>>, sqlx::Error> {
+    rollback_policy: GcsRollbackPolicy,
+) -> Result<WriteGuard<'static>, sqlx::Error> {
     let mut tx = begin_guarded_pool(pool).await?;
-    if cutover_gate(&mut tx, gcs_mode).await? {
-        tx.rollback().await?;
-        return Ok(None);
+    match cutover_gate(&mut tx, gcs_mode, rollback_policy).await? {
+        None => Ok(WriteGuard::Proceed(tx)),
+        Some(block) => {
+            tx.rollback().await?;
+            Ok(match block {
+                GateBlock::Stop => WriteGuard::Stop,
+                GateBlock::Skip => WriteGuard::Skip,
+            })
+        }
     }
-    Ok(Some(tx))
 }
 
 /// Like [`begin_write_guarded`] but begins on an already-acquired connection
@@ -384,13 +431,19 @@ pub async fn begin_write_guarded(
 pub async fn begin_write_guarded_conn(
     conn: &mut PgConnection,
     gcs_mode: bool,
-) -> Result<Option<Transaction<'_, Postgres>>, sqlx::Error> {
+    rollback_policy: GcsRollbackPolicy,
+) -> Result<WriteGuard<'_>, sqlx::Error> {
     let mut tx = begin_guarded_conn(conn).await?;
-    if cutover_gate(&mut tx, gcs_mode).await? {
-        tx.rollback().await?;
-        return Ok(None);
+    match cutover_gate(&mut tx, gcs_mode, rollback_policy).await? {
+        None => Ok(WriteGuard::Proceed(tx)),
+        Some(block) => {
+            tx.rollback().await?;
+            Ok(match block {
+                GateBlock::Stop => WriteGuard::Stop,
+                GateBlock::Skip => WriteGuard::Skip,
+            })
+        }
     }
-    Ok(Some(tx))
 }
 
 #[cfg(test)]

--- a/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -481,17 +481,18 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             .transpose()
             .map_err(|err| anyhow::anyhow!("block_number does not fit in i64: {err}"))?;
 
-        // Cutover safety: fence this write behind the shared cutover lock +
-        // retirement re-check. `verify_proofs` is not a merge target, but this
-        // makes every BCS write uniformly stop the instant a cutover retires the
-        // stack. GCS-mode listeners skip the gate (they write the gcs schema).
+        // Fence this write against cutover and schema reset. Retired BCS
+        // listeners stop, while GCS raw ingestion continues after rollback.
+        // `verify_proofs` is not merged, but follows the same write boundary as
+        // the other listener tables.
         let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
             db_pool,
             self.stack_mode.gcs_mode(),
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
         )
         .await?
-        else {
-            info!("Cutover completed — gw-listener skipping verify_proofs insert (retired stack)");
+        .into_tx() else {
+            info!("Cutover completed — gw-listener skipping verify_proofs insert on retired stack");
             return Ok(());
         };
         // TODO: check if we can avoid the cast from u256 to i64
@@ -567,16 +568,17 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             .earliest_open_ct_commits_block
             .map(i64::try_from)
             .transpose()?;
-        // Cutover safety: gate the watermark write (+ its notify) behind the
-        // shared cutover lock + retirement re-check, so a retired BCS listener
-        // stops advancing the watermark the instant a cutover flips the stack.
+        // Fence the watermark and notification against cutover and schema reset.
+        // Retired BCS listeners stop; GCS raw ingestion continues after rollback.
+        // This keeps the stored progress aligned with the listener's writes.
         let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
             db_pool,
             self.stack_mode.gcs_mode(),
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
         )
         .await?
-        else {
-            info!("Cutover completed — gw-listener skipping watermark update (retired stack)");
+        .into_tx() else {
+            info!("Cutover completed — gw-listener skipping watermark update on retired stack");
             return Ok(());
         };
         sqlx::query(

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -603,21 +603,22 @@ impl Database {
     }
 
     /// Begin a write transaction fenced against cutover. Runs `assert_not_retired`
-    /// at BEGIN (via `begin_guarded_pool`), then takes the shared cutover advisory
-    /// lock and re-checks retirement. Returns `Ok(None)` if a committed cutover has
-    /// retired this stack — the caller must skip the write. GCS-mode connections
-    /// (`self.gcs_mode`) still take the shared lock (their gcs-schema writes are
-    /// merged into the cutover target) but skip the retirement re-check, since a
-    /// green stack can never be retired. See `versioning::cutover_gate`.
+    /// at BEGIN (via `begin_guarded_pool`), then takes the shared advisory lock and
+    /// re-checks retirement. Returns `Ok(None)` if a committed cutover retired
+    /// this stack. GCS-mode connections (`self.gcs_mode`) take the same lock so
+    /// their raw writes cannot overlap cutover or schema reset, but continue after
+    /// rollback to refill the GCS schema. See `versioning::begin_write_guarded`.
     pub async fn new_transaction(
         &self,
     ) -> Result<Option<Transaction<'_>>, SqlxError> {
         let pool = self.pool().await;
-        fhevm_engine_common::versioning::begin_write_guarded(
+        Ok(fhevm_engine_common::versioning::begin_write_guarded(
             &pool,
             self.gcs_mode,
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
         )
-        .await
+        .await?
+        .into_tx())
     }
 
     pub async fn pool(&self) -> sqlx::Pool<Postgres> {

--- a/coprocessor/fhevm-engine/sns-worker/src/executor.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/executor.rs
@@ -23,6 +23,7 @@ use fhevm_engine_common::telemetry;
 use fhevm_engine_common::types::{get_ct_type, SupportedFheCiphertexts};
 use fhevm_engine_common::utils::to_hex;
 use fhevm_engine_common::versioning::StackMode;
+use fhevm_engine_common::versioning::{GcsRollbackPolicy, WriteGuard};
 use opentelemetry::trace::{Status, TraceContextExt};
 use rayon::prelude::*;
 use sqlx::postgres::PgListener;
@@ -363,7 +364,12 @@ pub async fn garbage_collect(pool: &PgPool, limit: u32) -> Result<(), ExecutionE
     // shared lock + retirement re-check make that airtight instead of relying on
     // the digest-NULL predicate alone. GC only runs for the live (non-GCS) stack,
     // so gcs_mode is false here.
-    let Some(mut trx) = fhevm_engine_common::versioning::begin_write_guarded(pool, false).await?
+    let WriteGuard::Proceed(mut trx) = fhevm_engine_common::versioning::begin_write_guarded(
+        pool,
+        false,
+        GcsRollbackPolicy::Continue,
+    )
+    .await?
     else {
         info!("Cutover completed — skipping ciphertexts128 GC on retired stack");
         return Ok(());
@@ -440,22 +446,31 @@ async fn fetch_and_execute_sns_tasks(
     uploads_enabled: bool,
     gcs_mode: bool,
 ) -> Result<Option<(bool, usize)>, ExecutionError> {
-    // Cutover safety (BCS only): begin a write tx fenced against cutover before
-    // writing any ct128 / digest rows into the tables execute_cutover merges.
-    // `None` means a committed cutover retired this stack. See
+    // Begin the write tx under the shared controller lock before changing any
+    // ct128 or digest rows. A retired BCS stack stops here; a GCS worker skips
+    // while the dry-run is PAUSED after rollback. See
     // versioning::begin_write_guarded.
-    let mut db_txn =
-        match fhevm_engine_common::versioning::begin_write_guarded(pool, gcs_mode).await {
-            Ok(Some(txn)) => txn,
-            Ok(None) => {
-                info!("Cutover completed — SnS BCS worker stopping");
-                return Ok(None);
-            }
-            Err(err) => {
-                error!(error = %err, "Failed to begin transaction");
-                return Err(err.into());
-            }
-        };
+    let mut db_txn = match fhevm_engine_common::versioning::begin_write_guarded(
+        pool,
+        gcs_mode,
+        GcsRollbackPolicy::Skip,
+    )
+    .await
+    {
+        Ok(WriteGuard::Proceed(txn)) => txn,
+        Ok(WriteGuard::Stop) => {
+            info!("Cutover completed — SnS BCS worker stopping");
+            return Ok(None);
+        }
+        Ok(WriteGuard::Skip) => {
+            debug!("GCS dry-run rolled back — SnS worker skipping cycle");
+            return Ok(Some((false, 0)));
+        }
+        Err(err) => {
+            error!(error = %err, "Failed to begin transaction");
+            return Err(err.into());
+        }
+    };
 
     let order = if conf.db.lifo {
         Order::Desc

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -9,6 +9,7 @@ use fhevm_engine_common::gcs_activation::{run_gcs_activation_watcher, GCS_NOT_AC
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::tfhe_ops::check_fhe_operand_types;
 use fhevm_engine_common::types::{FhevmError, Handle, SupportedFheCiphertexts};
+use fhevm_engine_common::versioning::{GcsRollbackPolicy, WriteGuard};
 use fhevm_engine_common::{tfhe_ops::current_ciphertext_version, types::SupportedFheOperations};
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -232,20 +233,31 @@ async fn tfhe_worker_cycle(
             "acquire_connection"
         );
         let mut conn = pool.acquire().instrument(acq_span).await?;
-        // Cutover safety (BCS only): begin a write tx fenced against cutover —
-        // BEGIN-time retirement fence + shared cutover lock + retirement re-check.
-        // `None` means a committed cutover retired this stack: exit the cycle
-        // cleanly without writing. GCS workers write the gcs schema (not the
-        // cutover target), so the gate is a no-op for them. See
-        // versioning::begin_write_guarded.
+        // Begin a write tx under the shared controller lock. A retired BCS stack
+        // stops here; a GCS worker skips while a rolled-back dry-run is PAUSED.
+        // Holding the lock for the transaction keeps cutover and schema reset
+        // from overlapping its reads and writes. Shared locks still allow worker
+        // replicas to run concurrently. The state check runs after taking the
+        // lock. See versioning::begin_write_guarded.
         let txn_span = tracing::info_span!(parent: &loop_span, "begin_transaction");
-        let Some(mut trx) =
-            fhevm_engine_common::versioning::begin_write_guarded_conn(&mut conn, gcs_mode)
-                .instrument(txn_span)
-                .await?
-        else {
-            info!(target: "tfhe_worker", "Cutover completed — BCS worker exiting cycle");
-            return Ok(());
+        let mut trx = match fhevm_engine_common::versioning::begin_write_guarded_conn(
+            &mut conn,
+            gcs_mode,
+            GcsRollbackPolicy::Skip,
+        )
+        .instrument(txn_span)
+        .await?
+        {
+            WriteGuard::Proceed(trx) => trx,
+            WriteGuard::Stop => {
+                info!(target: "tfhe_worker", "Cutover completed — BCS worker exiting cycle");
+                return Ok(());
+            }
+            WriteGuard::Skip => {
+                debug!(target: "tfhe_worker", "GCS dry-run rolled back — skipping cycle");
+                immediately_poll_more_work = false;
+                continue;
+            }
         };
 
         // Query for transactions to execute

--- a/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/coprocessor/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -186,16 +186,20 @@ where
         txn_block_number: Option<i64>,
         src_transaction_id: Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        // Cutover safety: both writes below target tables execute_cutover merges
-        // into `public` (ciphertext_digest, ciphertexts128). Gate them behind the
-        // shared cutover lock + retirement re-check so a retired BCS sender cannot
-        // clobber a re-armed digest or delete the merged green ct128. These run
-        // AFTER the on-chain send as plain DB writes, so no advisory lock is held
-        // across the on-chain call. See versioning::cutover_gate.
-        let Some(mut tx) =
-            fhevm_engine_common::versioning::begin_write_guarded(&self.db_pool, self.conf.gcs_mode)
-                .await?
-        else {
+        // Both writes below target tables execute_cutover merges into `public`.
+        // Operations start only after this sender is live, even when it started
+        // as GCS, so the guard must always apply the live-stack retirement check.
+        // These writes run after the on-chain send as plain database writes, so
+        // the lock is not held across the network call. A blocked write leaves
+        // the database unchanged. See
+        // versioning::begin_write_guarded.
+        let Some(mut tx) = fhevm_engine_common::versioning::begin_write_guarded(
+            &self.db_pool,
+            false,
+            fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
+        )
+        .await?
+        .into_tx() else {
             info!("Cutover completed — skipping post-send digest/ct128 writes on retired stack");
             return Ok(());
         };

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -58,11 +58,11 @@ pub use fhevm_engine_common::versioning::EVENT_STACK_VERSION_UPGRADED;
 /// for now; expected to become configurable.
 const READINESS_CONFIRMATIONS: i64 = 100;
 
-/// PostgreSQL advisory-lock key used to serialize cutover against in-flight
-/// BCS writes. `execute_cutover` takes the exclusive form; every BCS-mode
-/// compute worker takes the shared form inside its write tx via
-/// [`fhevm_engine_common::versioning::cutover_gate`]. Re-exported from the common
-/// crate so the controller and all workers agree on one canonical value.
+/// PostgreSQL advisory-lock key used to serialize controller changes against
+/// writes. Cutover and rollback take the exclusive form; write transactions take
+/// the shared form through [`fhevm_engine_common::versioning::begin_write_guarded`].
+/// Re-exported from the common crate so the controller and all writers agree on
+/// one canonical value.
 pub use fhevm_engine_common::versioning::CUTOVER_LOCK_ID;
 
 /// Returns the `upgrade_state.stack_role` value for a given `gcs_mode` flag:
@@ -1036,10 +1036,19 @@ async fn try_cutover_if_consensus(pool: &Pool<Postgres>) -> Result<(), Error> {
     execute_cutover(pool).await
 }
 
-/// Roll back a dry-run: PAUSED/failed, reset schema, wake workers. Scoped to the
-/// `end_block` window so a stale re-emitted timeout can't reset a newer attempt. Returns whether it acted.
+/// Roll back a dry-run under the write lock: PAUSED/failed, reset schema, wake workers.
+/// Scoped to `end_block` so a stale timeout cannot reset a newer attempt. Returns whether it acted.
 async fn rollback_dry_run(pool: &Pool<Postgres>, end_block: i64) -> Result<bool, Error> {
     let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(CUTOVER_LOCK_ID)
+        .execute(&mut *tx)
+        .await?;
+    info!(
+        lock_id = CUTOVER_LOCK_ID,
+        "rollback acquired exclusive advisory lock"
+    );
+
     let claimed = sqlx::query(
         r#"
         UPDATE upgrade_state
@@ -1951,5 +1960,90 @@ mod tests {
             .await
             .expect("gw transition");
         assert!(gw_flag(pool.clone()).await, "matching proposal releases gw");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gcs_rollback_policy_distinguishes_derived_and_raw_writes() {
+        use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        assert!(
+            matches!(
+                begin_write_guarded(&pool, true, GcsRollbackPolicy::Skip)
+                    .await
+                    .expect("guard"),
+                WriteGuard::Proceed(_)
+            ),
+            "write proceeds while dry-running"
+        );
+
+        seed_gcs_row(&pool, "PAUSED", "failed").await;
+        assert!(
+            matches!(
+                begin_write_guarded(&pool, true, GcsRollbackPolicy::Skip)
+                    .await
+                    .expect("guard"),
+                WriteGuard::Skip
+            ),
+            "derived output is skipped after rollback"
+        );
+        assert!(
+            matches!(
+                begin_write_guarded(&pool, true, GcsRollbackPolicy::Continue)
+                    .await
+                    .expect("guard"),
+                WriteGuard::Proceed(_)
+            ),
+            "raw ingestion continues after rollback"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rollback_waits_for_in_flight_guarded_write() {
+        use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
+        use tokio::time::{timeout, Duration};
+
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+
+        let guarded_tx = match begin_write_guarded(&pool, true, GcsRollbackPolicy::Continue)
+            .await
+            .expect("guard")
+        {
+            WriteGuard::Proceed(tx) => tx,
+            WriteGuard::Stop | WriteGuard::Skip => panic!("write unexpectedly blocked"),
+        };
+
+        let rollback_pool = pool.clone();
+        let mut rollback = tokio::spawn(async move { rollback_dry_run(&rollback_pool, 200).await });
+
+        assert!(
+            timeout(Duration::from_millis(200), &mut rollback)
+                .await
+                .is_err(),
+            "rollback must block while a writer holds the shared advisory lock"
+        );
+        assert!(
+            marker_exists(&pool).await,
+            "schema must not reset while the guarded write is in flight"
+        );
+
+        guarded_tx.commit().await.expect("release write guard");
+        assert!(
+            timeout(Duration::from_secs(10), rollback)
+                .await
+                .expect("rollback remained blocked")
+                .expect("rollback task panicked")
+                .expect("rollback failed"),
+            "rollback should claim the active dry-run"
+        );
+        assert!(
+            !marker_exists(&pool).await,
+            "schema should reset after the guarded write commits"
+        );
+        assert_eq!(gcs_state(&pool).await, ("PAUSED".into(), "failed".into()));
     }
 }

--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -9,6 +9,7 @@ use fhevm_engine_common::host_chains::HostChainsCache;
 use fhevm_engine_common::pg_pool::{PostgresPoolManager, ServiceError};
 use fhevm_engine_common::tfhe_ops::{current_ciphertext_version, extract_ct_list};
 use fhevm_engine_common::types::{FhevmError, SupportedFheCiphertexts};
+use fhevm_engine_common::versioning::{GcsRollbackPolicy, WriteGuard};
 use fhevm_engine_common::{telemetry, HANDLE_VERSION};
 
 use fhevm_engine_common::utils::safe_deserialize_conformant;
@@ -369,15 +370,26 @@ async fn execute_verify_proof_routine(
     // failure. Enforces the invariant: "one unknown chain on the queue must
     // not stop processing for known chains" — workers simply don't see those
     // rows.
-    // Cutover safety (BCS only): begin a write tx fenced against cutover before
-    // inserting verified input ciphertexts into the `ciphertexts` table
-    // execute_cutover merges. `None` means a committed cutover retired this stack.
+    // Begin the write tx under the shared controller lock before inserting
+    // verified ciphertexts into a table cutover merges. A retired BCS stack
+    // stops; a GCS worker skips while the dry-run is PAUSED after rollback.
     // See versioning::begin_write_guarded.
-    let Some(mut txn) =
-        fhevm_engine_common::versioning::begin_write_guarded(pool, conf.gcs_mode).await?
-    else {
-        info!("Cutover completed — zkproof BCS worker skipping cycle");
-        return Ok(());
+    let mut txn = match fhevm_engine_common::versioning::begin_write_guarded(
+        pool,
+        conf.gcs_mode,
+        GcsRollbackPolicy::Skip,
+    )
+    .await?
+    {
+        WriteGuard::Proceed(txn) => txn,
+        WriteGuard::Stop => {
+            info!("Cutover completed — zkproof BCS worker skipping cycle");
+            return Ok(());
+        }
+        WriteGuard::Skip => {
+            debug!("GCS dry-run rolled back — zkproof skipping cycle");
+            return Ok(());
+        }
     };
 
     if let Ok(row) = sqlx::query!(


### PR DESCRIPTION
### Problem

When a GCS dry-run is rolled back, the controller wipes the `gcs` schema and notifies the workers to pause. Workers learn about the pause from an in-memory flag that a background task flips when the notification arrives, so there's a window where the rollback has already committed (schema reset) but a worker hasn't seen the flag yet. A worker mid-computation can then finish its old batch and write stale rows into the freshly reset schema, which can poison the next upgrade attempt.

### Fix

Order every green write against the reset, and have each write re-check the durable state in its own transaction, so there's no window to race:

- The rollback runs in one transaction holding the **exclusive** advisory lock: it marks the upgrade row `PAUSED`, wipes and recreates the schema, and notifies the workers.
- Every guarded write takes the **shared** form of the same lock. A write therefore either commits before the reset (and is dropped by it) or runs after the reset — it can never interleave with the wipe.
- A write that runs after the reset re-reads the paused state inside its own transaction, so a worker that missed the flag still sees `PAUSED` and holds off. Raw chain ingestion (host-listener, gw-listener) keeps tailing after a rollback; derived-output workers (tfhe, sns, zkproof, `state_hash`, tx-sender digest/ct128) skip while the row is `PAUSED`.

Because the write path itself re-checks and is ordered against the reset, the protection holds for every writer without depending on the in-memory flag arriving in time.

### Options considered

- **In-memory flag check before writing**: cheap, but only narrows the window; the flag lags the durable rollback, so stale writes still go through.
- **Rely on the timeout**: the stale row is from the *old* window, so it never enters the new comparison, yet cutover still merges it into live data (whole-table merge, overwrite on conflict). Nothing catches it, so this isn't a safe fallback.
- **Restart + wait before reset**: reset the schema only while all workers are stopped and waiting. Race-free, but it restarts every green worker on each rollback and needs extra machinery (durable reset flag + self-restart +
  startup barrier).
- **Durable check in each write transaction (this PR)**: each write re-checks the paused state in its own transaction, ordered against the reset by a shared/exclusive advisory lock. Race-free with no worker restart; costs a stack-specific check (raw vs derived) on the write paths.
