### PR TITLE
ci(common): route solana-e2e compose builds through branch-local workspace Dockerfiles

### DIFF
--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -1,0 +1,315 @@
+# =============================================================================
+# BRANCH-LOCAL (feature/solana) E2E BUILD FILE — DELETE AT MERGE-BACK TO MAIN.
+# Main's release CI builds each image from its per-binary Dockerfile
+# (coprocessor/fhevm-engine/*/Dockerfile), and so does this branch's
+# solana-images-publish.yml. This file exists only so the e2e stack's
+# `--override` compose builds compile all coprocessor binaries in ONE cargo
+# pass instead of eight sequential full-workspace compilations (measured:
+# ~41 min of cargo, 71 min run vs 44 min baseline).
+# =============================================================================
+# =============================================================================
+# UNIFIED COPROCESSOR DOCKERFILE (LOCAL BUILDS)
+# =============================================================================
+# This Dockerfile builds ALL coprocessor workspace binaries in a single builder
+# stage, ensuring dependencies (especially tfhe-rs) are compiled exactly ONCE.
+# Individual runtime images are produced via multi-stage targets.
+#
+# LOCAL vs CI BUILDS:
+#   - LOCAL: Uses this Dockerfile.workspace via docker-compose for faster builds
+#            (shared builder stage, single tfhe-rs compilation)
+#   - CI:    Uses individual Dockerfiles (coprocessor/*/Dockerfile) for granular
+#            caching and independent service builds
+#
+# Usage (standalone):
+#   docker build --target tfhe-worker -t tfhe-worker:latest .
+#   docker build --target host-listener -t host-listener:latest .
+#   docker build --target gw-listener -t gw-listener:latest .
+#   docker build --target sns-worker -t sns-worker:latest .
+#   docker build --target transaction-sender -t transaction-sender:latest .
+#   docker build --target zkproof-worker -t zkproof-worker:latest .
+#   docker build --target db-migration -t db-migration:latest .
+#
+# Usage (via docker-compose, recommended for local dev):
+#   cd test-suite/fhevm
+#   ./fhevm-cli deploy --build --local
+#
+# =============================================================================
+
+# =============================================================================
+# Stage 0: Build Solidity contracts (required for host-listener, gw-listener)
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
+
+USER root
+WORKDIR /app
+
+# Copy root lockfile for workspace resolution
+COPY package.json package-lock.json ./
+
+# Copy host-contracts for host-listener
+COPY host-contracts ./host-contracts
+
+# Compile host-contracts
+RUN cp host-contracts/.env.example host-contracts/.env && \
+    npm ci --workspace=host-contracts --include-workspace-root=false && \
+    cd host-contracts && \
+    HARDHAT_NETWORK=hardhat npm run deploy:emptyProxies && \
+    npx hardhat compile
+
+# Copy gateway-contracts for gw-listener
+WORKDIR /app
+COPY gateway-contracts ./gateway-contracts
+
+# Compile gateway-contracts
+WORKDIR /app/gateway-contracts
+RUN npm ci && \
+    DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
+
+# =============================================================================
+# Stage 1: Build ALL Rust workspace binaries
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
+
+ARG CARGO_PROFILE=release
+ARG BUILD_ID=unknown
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION=eu-west-3
+ARG SCCACHE_S3_PREFIX
+ARG SCCACHE_VERSION=v0.15.0
+ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_REGION=${SCCACHE_REGION}
+ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
+ENV AWS_REGION=${SCCACHE_REGION}
+
+USER root
+WORKDIR /app
+
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
+RUN set -eux; \
+    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-musl ;; \
+        aarch64) triple=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
+    chmod +x /usr/local/bin/sccache; \
+    sccache --version
+
+# Copy contract artifacts from contract_builder stage
+COPY --from=contract_builder /app/host-contracts/artifacts/contracts /app/host-contracts/artifacts/contracts
+COPY --from=contract_builder /app/gateway-contracts/artifacts/contracts /app/gateway-contracts/artifacts/contracts
+
+# Copy Rust sources and dependencies
+# TODO fix
+COPY listener ./listener
+COPY coprocessor/fhevm-engine ./coprocessor/fhevm-engine
+COPY coprocessor/proto ./coprocessor/proto
+COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
+COPY gateway-contracts/contracts ./gateway-contracts/contracts
+COPY host-contracts/contracts ./host-contracts/contracts
+# The Solana branch adds tfhe-worker dev-deps on solana/programs/{zama-host,
+# confidential-token}; the whole-workspace build must resolve their manifests, so
+# the Solana sources must be present. .dockerignore excludes solana/target.
+COPY solana ./solana
+COPY shared/ciphertext-attestation ./shared/ciphertext-attestation
+
+WORKDIR /app/coprocessor/fhevm-engine
+
+# Build entire workspace - tfhe compiles ONCE here
+# NOTE: We use cache mounts for incremental compilation. Because cache mounts
+# are NOT committed to the image layer, we must copy binaries to /out during
+# the same RUN instruction for COPY --from to work in later stages.
+#
+# gw-listener, transaction-sender, and host-listener each call Solc::find_or_install(0.8.28) in
+# their build script. Under the parallel `cargo build --workspace` they race on svm's shared solc
+# binary (one writes it while another execs it -> ETXTBSY, "Text file busy"). So build gw-listener
+# first, serially, to install solc 0.8.28 once; the workspace build then finds it already present
+# instead of re-downloading. gw-listener does not depend on tfhe, so this serial step stays small.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
+    --mount=type=secret,id=sccache_aws_access_key_id \
+    --mount=type=secret,id=sccache_aws_secret_access_key \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
+      export RUSTC_WRAPPER=sccache; \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
+      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
+    fi && \
+    cargo fetch && \
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p gw-listener && \
+    SQLX_OFFLINE=true BUILD_ID=${BUILD_ID} cargo build --profile=${CARGO_PROFILE} --workspace && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
+    mkdir -p /out && \
+    cp target/${CARGO_PROFILE}/tfhe_worker /out/ && \
+    cp target/${CARGO_PROFILE}/host_listener /out/ && \
+    cp target/${CARGO_PROFILE}/host_listener_poller /out/ && \
+    cp target/${CARGO_PROFILE}/host_listener_consumer /out/ && \
+    cp target/${CARGO_PROFILE}/gw_listener /out/ && \
+    cp target/${CARGO_PROFILE}/sns_worker /out/ && \
+    cp target/${CARGO_PROFILE}/transaction_sender /out/ && \
+    cp target/${CARGO_PROFILE}/zkproof_worker /out/ && \
+    cp target/${CARGO_PROFILE}/resolve_database_url /out/
+
+# =============================================================================
+# Stage 1b: Build sqlx-cli for db-migration
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS sqlx_builder
+
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION=eu-west-3
+ARG SCCACHE_S3_PREFIX
+ARG SCCACHE_VERSION=v0.15.0
+ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_REGION=${SCCACHE_REGION}
+ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
+ENV AWS_REGION=${SCCACHE_REGION}
+
+USER root
+WORKDIR /app
+
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
+RUN set -eux; \
+    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-musl ;; \
+        aarch64) triple=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
+    chmod +x /usr/local/bin/sccache; \
+    sccache --version
+
+# Install sqlx-cli
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=secret,id=sccache_aws_access_key_id \
+    --mount=type=secret,id=sccache_aws_secret_access_key \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
+      export RUSTC_WRAPPER=sccache; \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
+      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
+    fi && \
+    cargo install sqlx-cli --version 0.7.2 \
+    --no-default-features --features postgres,rustls --locked && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi
+
+# =============================================================================
+# Stage 2a: tfhe-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS tfhe-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/tfhe_worker /usr/local/bin/tfhe_worker
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/tfhe_worker"]
+
+# =============================================================================
+# Stage 2b: host-listener runtime (includes both host_listener and host_listener_poller)
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS host-listener
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/host_listener /usr/local/bin/host_listener
+COPY --from=builder --chown=fhevm:fhevm /out/host_listener_poller /usr/local/bin/host_listener_poller
+COPY --from=builder --chown=fhevm:fhevm /out/host_listener_consumer /usr/local/bin/host_listener_consumer
+
+USER fhevm:fhevm
+
+# No CMD - compose specifies the command (host_listener or host_listener_poller)
+
+# =============================================================================
+# Stage 2c: gw-listener runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS gw-listener
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/gw_listener /usr/local/bin/gw_listener
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/gw_listener"]
+
+# =============================================================================
+# Stage 2d: sns-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS sns-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/sns_worker /usr/local/bin/sns_worker
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/sns_worker"]
+
+# =============================================================================
+# Stage 2e: transaction-sender runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS transaction-sender
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/transaction_sender /usr/local/bin/transaction_sender
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/transaction_sender"]
+
+# =============================================================================
+# Stage 2f: zkproof-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS zkproof-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/zkproof_worker /usr/local/bin/zkproof_worker
+
+USER fhevm:fhevm
+
+CMD ["/usr/local/bin/zkproof_worker"]
+
+# =============================================================================
+# Stage 2g: db-migration runtime (special: Postgres-based image)
+# =============================================================================
+FROM cgr.dev/zama.ai/postgres:17 AS db-migration
+
+# Copy sqlx-cli from sqlx_builder
+COPY --from=sqlx_builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+COPY --from=builder /out/resolve_database_url /usr/local/bin/resolve_database_url
+
+# Copy migrations and initialization script from source
+COPY coprocessor/fhevm-engine/db-migration/initialize_db.sh /initialize_db.sh
+COPY coprocessor/fhevm-engine/db-migration/prepare_database_url.sh /prepare_database_url.sh
+COPY coprocessor/fhevm-engine/db-migration/migrations /migrations
+COPY coprocessor/fhevm-engine/db-migration/db-scripts /db-scripts
+COPY coprocessor/fhevm-engine/db-migration/revert_coprocessor_db_state.sh /revert_coprocessor_db_state.sh
+
+# Copy user/group from builder for consistency
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+
+# Set ownership
+RUN chown -R fhevm:fhevm /initialize_db.sh /prepare_database_url.sh /migrations /db-scripts /revert_coprocessor_db_state.sh
+
+USER fhevm:fhevm
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD psql --version || exit 1
+
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/kms-connector/Dockerfile.workspace
+++ b/kms-connector/Dockerfile.workspace
@@ -1,0 +1,159 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# BRANCH-LOCAL (feature/solana) E2E BUILD FILE — DELETE AT MERGE-BACK TO MAIN.
+# Main's release CI builds each image from its per-binary Dockerfile
+# (kms-connector/crates/*/Dockerfile), and so does this branch's
+# solana-images-publish.yml. This file exists only so the e2e stack's
+# `--override` compose builds compile all kms-connector binaries in ONE cargo
+# pass instead of one full-workspace compilation per image.
+# =============================================================================
+# =============================================================================
+# UNIFIED KMS-CONNECTOR DOCKERFILE (LOCAL BUILDS)
+# =============================================================================
+# This Dockerfile builds ALL kms-connector workspace binaries in a single
+# builder stage, ensuring dependencies (tfhe-rs, alloy, sqlx) are compiled
+# exactly ONCE. Individual runtime images are produced via multi-stage targets.
+#
+# LOCAL vs CI BUILDS:
+#   - LOCAL: Uses this Dockerfile.workspace via docker-compose for faster builds
+#            (shared builder stage, single dependency compilation)
+#   - CI:    Uses individual Dockerfiles (kms-connector/crates/*/Dockerfile) for
+#            granular caching and independent service builds
+#
+# Usage (standalone):
+#   docker build --target gw-listener -t gw-listener:latest .
+#   docker build --target kms-worker -t kms-worker:latest .
+#   docker build --target tx-sender -t tx-sender:latest .
+#
+# Usage (via docker-compose, recommended for local dev):
+#   cd test-suite/fhevm
+#   ./fhevm-cli deploy --build --local
+#
+# =============================================================================
+
+ARG RUST_IMAGE_VERSION=1.91.0
+
+# =============================================================================
+# Stage 1: Build ALL workspace binaries
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+
+ARG CARGO_PROFILE=release
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION=eu-west-3
+ARG SCCACHE_S3_PREFIX
+ARG SCCACHE_VERSION=v0.15.0
+ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
+ENV SCCACHE_REGION=${SCCACHE_REGION}
+ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
+ENV AWS_REGION=${SCCACHE_REGION}
+
+USER root
+WORKDIR /app
+
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
+RUN set -eux; \
+    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  triple=x86_64-unknown-linux-musl ;; \
+        aarch64) triple=aarch64-unknown-linux-musl ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
+        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
+    chmod +x /usr/local/bin/sccache; \
+    sccache --version
+
+COPY .git ./.git
+COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
+COPY host-contracts/rust_bindings ./host-contracts/rust_bindings
+COPY shared ./shared
+COPY kms-connector ./kms-connector
+# kms-worker depends on zama-solana-acl via `../solana/crates/zama-solana-acl`
+# (see kms-connector/Cargo.toml). The crate is standalone (no workspace
+# inheritance), so copying just it satisfies the path dependency.
+COPY solana/crates/zama-solana-acl ./solana/crates/zama-solana-acl
+
+WORKDIR /app/kms-connector
+
+# Build entire workspace - shared deps compile ONCE here
+# NOTE: Cache mounts are NOT committed to image layers, so we copy binaries
+# to /tmp in the same RUN instruction for COPY --from to work in later stages.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/app/kms-connector/target,sharing=locked \
+    --mount=type=secret,id=sccache_aws_access_key_id \
+    --mount=type=secret,id=sccache_aws_secret_access_key \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
+      export RUSTC_WRAPPER=sccache; \
+      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
+      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
+    fi && \
+    if [ -f /app/.git ]; then rm -f /app/.git; fi && \
+    git config --global --add safe.directory '*' && \
+    git config --global user.email build@local && \
+    git config --global user.name build && \
+    if [ ! -e /app/.git ]; then \
+      git init -q /app && \
+      git -C /app commit --allow-empty -q -m build && \
+      git -C /app tag -a v0.0.0-build -m build; \
+    fi && \
+    cargo fetch && \
+    cargo build --profile=${CARGO_PROFILE} --workspace && \
+    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
+    mkdir -p /out && \
+    cp target/${CARGO_PROFILE}/gw-listener /out/ && \
+    cp target/${CARGO_PROFILE}/kms-worker /out/ && \
+    cp target/${CARGO_PROFILE}/tx-sender /out/
+
+# =============================================================================
+# Stage 2a: gw-listener runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS gw-listener
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/gw-listener /app/kms-connector/bin/gw-listener
+
+USER fhevm:fhevm
+
+ENTRYPOINT ["/app/kms-connector/bin/gw-listener", "start"]
+
+HEALTHCHECK --start-period=5s --interval=1m --timeout=3s --retries=3 \
+    CMD ["/app/kms-connector/bin/gw-listener", "health", "--endpoint", "http://127.0.0.1:9100/healthz"]
+
+# =============================================================================
+# Stage 2b: kms-worker runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS kms-worker
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/kms-worker /app/kms-connector/bin/kms-worker
+
+USER fhevm:fhevm
+
+ENTRYPOINT ["/app/kms-connector/bin/kms-worker", "start"]
+
+HEALTHCHECK --start-period=5s --interval=1m --timeout=3s --retries=3 \
+    CMD ["/app/kms-connector/bin/kms-worker", "health", "--endpoint", "http://127.0.0.1:9100/healthz"]
+
+# =============================================================================
+# Stage 2c: tx-sender runtime
+# =============================================================================
+FROM cgr.dev/zama.ai/glibc-dynamic:15.2.0 AS tx-sender
+
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder --chown=fhevm:fhevm /out/tx-sender /app/kms-connector/bin/tx-sender
+
+USER fhevm:fhevm
+
+ENTRYPOINT ["/app/kms-connector/bin/tx-sender", "start"]
+
+HEALTHCHECK --start-period=5s --interval=1m --timeout=3s --retries=3 \
+    CMD ["/app/kms-connector/bin/tx-sender", "health", "--endpoint", "http://127.0.0.1:9100/healthz"]

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -88,55 +88,63 @@ const buildSpec = (context: string, dockerfile: string, extra: Record<string, un
   dockerfile: resolveComposePath(dockerfile),
   ...extra,
 });
-// Each image builds from its own per-binary Dockerfile (the same recipes main's docker-build
-// workflows publish from), not a shared Dockerfile.workspace: a per-image build compiles only
-// what that image needs, and identical COPY/RUN prefixes across images are deduplicated by
-// BuildKit content-addressing within a run and by the registry layer cache across runs.
+// The Rust images build from the BRANCH-LOCAL workspace Dockerfiles so one cargo pass compiles
+// every binary of a workspace (a per-binary Dockerfile per image ran a full workspace-sized cargo
+// build eight times sequentially; measured ~41 min of cargo, 71 min run vs the 44 min baseline).
+// The publish workflow (solana-images-publish.yml) still builds from the per-binary Dockerfiles,
+// like main's release CI. Pulled images (unchanged groups) are therefore per-binary `-p` builds
+// while locally rebuilt groups are `--workspace` builds: these stay functionally interchangeable.
+// Verified with `cargo tree -e normal,build` (dev-deps excluded; both workspaces use
+// resolver = "2"): kms-connector resolves identically under `-p` and `--workspace`; for
+// fhevm-engine the `--workspace` resolution is a strict additive superset per binary — every
+// feature of the `-p` build is present, siblings only ADD features on shared deps, none removed.
 const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknown>>> = {
   coprocessor: {
-    "coprocessor-db-migration": buildSpec("../../..", "coprocessor/fhevm-engine/db-migration/Dockerfile", {
-      target: "prod",
+    "coprocessor-db-migration": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "db-migration",
     }),
-    "coprocessor-host-listener": buildSpec("../../..", "coprocessor/fhevm-engine/host-listener/Dockerfile", {
-      target: "prod",
+    "coprocessor-host-listener": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "host-listener",
     }),
-    "coprocessor-host-listener-poller": buildSpec("../../..", "coprocessor/fhevm-engine/host-listener/Dockerfile", {
-      target: "prod",
+    "coprocessor-host-listener-poller": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "host-listener",
     }),
-    "coprocessor-host-listener-consumer": buildSpec("../../..", "coprocessor/fhevm-engine/host-listener/Dockerfile", {
-      target: "prod",
+    "coprocessor-host-listener-consumer": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "host-listener",
     }),
-    "coprocessor-gw-listener": buildSpec("../../..", "coprocessor/fhevm-engine/gw-listener/Dockerfile", {
-      target: "prod",
+    "coprocessor-gw-listener": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "gw-listener",
     }),
-    "coprocessor-tfhe-worker": buildSpec("../../..", "coprocessor/fhevm-engine/tfhe-worker/Dockerfile", {
-      target: "prod",
+    "coprocessor-tfhe-worker": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "tfhe-worker",
     }),
-    "coprocessor-zkproof-worker": buildSpec("../../..", "coprocessor/fhevm-engine/zkproof-worker/Dockerfile", {
-      target: "prod",
+    "coprocessor-zkproof-worker": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "zkproof-worker",
     }),
-    "coprocessor-sns-worker": buildSpec("../../..", "coprocessor/fhevm-engine/sns-worker/Dockerfile", {
-      target: "prod",
+    "coprocessor-sns-worker": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "sns-worker",
     }),
-    "coprocessor-transaction-sender": buildSpec("../../..", "coprocessor/fhevm-engine/transaction-sender/Dockerfile", {
-      target: "prod",
+    "coprocessor-transaction-sender": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
+      target: "transaction-sender",
     }),
   },
   "kms-connector": {
+    // connector-db was never workspace-built (sqlx-cli install, not a workspace member); it keeps
+    // its own per-binary Dockerfile.
     "kms-connector-db-migration": buildSpec("../../..", "kms-connector/connector-db/Dockerfile", {
       target: "prod",
       args: { RUST_IMAGE_VERSION: "1.91.0" },
     }),
-    "kms-connector-gw-listener": buildSpec("../../..", "kms-connector/crates/gw-listener/Dockerfile", {
-      target: "prod",
+    "kms-connector-gw-listener": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
+      target: "gw-listener",
       args: { RUST_IMAGE_VERSION: "1.91.0" },
     }),
-    "kms-connector-kms-worker": buildSpec("../../..", "kms-connector/crates/kms-worker/Dockerfile", {
-      target: "prod",
+    "kms-connector-kms-worker": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
+      target: "kms-worker",
       args: { RUST_IMAGE_VERSION: "1.91.0" },
     }),
-    "kms-connector-tx-sender": buildSpec("../../..", "kms-connector/crates/tx-sender/Dockerfile", {
-      target: "prod",
+    "kms-connector-tx-sender": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
+      target: "tx-sender",
       args: { RUST_IMAGE_VERSION: "1.91.0" },
     }),
   },
@@ -206,11 +214,17 @@ const withSccacheBuild = (component: string, build: Record<string, unknown> | un
  * solana-images-publish.yml exports) when FHEVM_BUILDCACHE_TAG is set. The cache ref is the
  * service's own image repository at the cache tag, so the compose reader and the publish-workflow
  * writer stay aligned without a name map. Scoped to the same Rust components as sccache (the
- * builds the publish workflow exports caches for). A no-op otherwise, so the generated compose is
- * byte-identical when FHEVM_BUILDCACHE_TAG is unset.
+ * builds the publish workflow exports caches for), and within those to the specs that still build
+ * from a per-binary Dockerfile: the publish workflow's caches are per-binary build graphs, so
+ * they cannot hit against the branch-local workspace Dockerfiles — injecting them there would
+ * only add a guaranteed cache miss (harmless but pointless). A no-op otherwise, so the generated
+ * compose is byte-identical when FHEVM_BUILDCACHE_TAG is unset.
  */
 const withRegistryBuildCache = (component: string, image: unknown, build: Record<string, unknown> | undefined) => {
   if (!build || !buildCacheEnabled() || !SCCACHE_BUILD_COMPONENTS.has(component) || typeof image !== "string") {
+    return build;
+  }
+  if (typeof build.dockerfile === "string" && build.dockerfile.endsWith("Dockerfile.workspace")) {
     return build;
   }
   const next = structuredClone(build);

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -343,7 +343,7 @@ describe("render-compose", () => {
     });
   });
 
-  test("builds every coprocessor and kms-connector image from its own per-image Dockerfile", async () => {
+  test("builds coprocessor and kms-connector images from the branch-local workspace Dockerfiles", async () => {
     await withTempStateDir(async () => {
       await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
       await writeFile(envPath("coprocessor"), "\n");
@@ -353,44 +353,52 @@ describe("render-compose", () => {
       type BuildDoc = { services: Record<string, { build?: { dockerfile?: string; target?: string } }> };
       const coprocessor = YAML.parse(await readFile(composePath("coprocessor"), "utf8")) as BuildDoc;
       const connector = YAML.parse(await readFile(composePath("kms-connector"), "utf8")) as BuildDoc;
-      const dockerfileFor = (doc: BuildDoc, service: string) => doc.services[service]?.build?.dockerfile ?? "";
-      expect(dockerfileFor(coprocessor, "coprocessor-host-listener")).toContain(
-        "coprocessor/fhevm-engine/host-listener/Dockerfile",
-      );
-      expect(dockerfileFor(coprocessor, "coprocessor-host-listener-poller")).toContain(
-        "coprocessor/fhevm-engine/host-listener/Dockerfile",
-      );
-      expect(dockerfileFor(coprocessor, "coprocessor-tfhe-worker")).toContain(
-        "coprocessor/fhevm-engine/tfhe-worker/Dockerfile",
-      );
-      expect(dockerfileFor(coprocessor, "coprocessor-transaction-sender")).toContain(
-        "coprocessor/fhevm-engine/transaction-sender/Dockerfile",
-      );
-      expect(dockerfileFor(coprocessor, "coprocessor-db-migration")).toContain(
-        "coprocessor/fhevm-engine/db-migration/Dockerfile",
-      );
-      expect(dockerfileFor(connector, "kms-connector-kms-worker")).toContain(
-        "kms-connector/crates/kms-worker/Dockerfile",
-      );
-      expect(dockerfileFor(connector, "kms-connector-db-migration")).toContain("kms-connector/connector-db/Dockerfile");
-      // No spec points at the deleted Dockerfile.workspace files, and every Rust image builds the
-      // canonical `prod` runtime stage.
-      for (const doc of [coprocessor, connector]) {
-        for (const service of Object.values(doc.services)) {
-          if (!service.build) continue;
-          expect(service.build.dockerfile ?? "").not.toContain("Dockerfile.workspace");
-          expect(service.build.target).toBe("prod");
-        }
+      const buildFor = (doc: BuildDoc, service: string) => doc.services[service]?.build ?? {};
+      // Every coprocessor image builds from the shared workspace Dockerfile (one cargo pass for
+      // all binaries) with a per-image runtime target.
+      const coprocessorTargets: Record<string, string> = {
+        "coprocessor-db-migration": "db-migration",
+        "coprocessor-host-listener": "host-listener",
+        "coprocessor-host-listener-poller": "host-listener",
+        "coprocessor-host-listener-consumer": "host-listener",
+        "coprocessor-gw-listener": "gw-listener",
+        "coprocessor-tfhe-worker": "tfhe-worker",
+        "coprocessor-zkproof-worker": "zkproof-worker",
+        "coprocessor-sns-worker": "sns-worker",
+        "coprocessor-transaction-sender": "transaction-sender",
+      };
+      for (const [service, target] of Object.entries(coprocessorTargets)) {
+        const build = buildFor(coprocessor, service);
+        expect(build.dockerfile).toContain("coprocessor/fhevm-engine/Dockerfile.workspace");
+        expect(build.target).toBe(target);
       }
+      // The kms-connector worker images build from their shared workspace Dockerfile; connector-db
+      // was never workspace-built (sqlx-cli install, not a workspace member) and keeps its own
+      // per-image Dockerfile.
+      const connectorTargets: Record<string, string> = {
+        "kms-connector-gw-listener": "gw-listener",
+        "kms-connector-kms-worker": "kms-worker",
+        "kms-connector-tx-sender": "tx-sender",
+      };
+      for (const [service, target] of Object.entries(connectorTargets)) {
+        const build = buildFor(connector, service);
+        expect(build.dockerfile).toContain("kms-connector/Dockerfile.workspace");
+        expect(build.target).toBe(target);
+      }
+      const connectorDb = buildFor(connector, "kms-connector-db-migration");
+      expect(connectorDb.dockerfile).toContain("kms-connector/connector-db/Dockerfile");
+      expect(connectorDb.target).toBe("prod");
     });
   });
 
   describe("registry build-cache wiring", () => {
     const BUILDCACHE_ENV = { FHEVM_BUILDCACHE_TAG: "buildcache-test" } as const;
 
-    // Renders the coprocessor override with the given env applied for the duration of the
-    // generation (same harness shape as the sccache tests below).
-    const renderCoprocessor = async (env: Record<string, string>) => {
+    const buildCacheState: State = { ...state, overrides: [{ group: "coprocessor" }, { group: "kms-connector" }] };
+
+    // Renders the coprocessor + kms-connector overrides with the given env applied for the
+    // duration of the generation (same harness shape as the sccache tests below).
+    const renderOverrides = async (env: Record<string, string>) => {
       const saved = new Map<string, string | undefined>();
       for (const key of Object.keys({ ...BUILDCACHE_ENV })) {
         saved.set(key, process.env[key]);
@@ -400,8 +408,11 @@ describe("render-compose", () => {
         process.env[key] = value;
       }
       try {
-        await generateComposeOverrides(inheritedScenarioState, stackSpecForState(inheritedScenarioState));
-        return await readFile(composePath("coprocessor"), "utf8");
+        await generateComposeOverrides(buildCacheState, stackSpecForState(buildCacheState));
+        return {
+          coprocessor: await readFile(composePath("coprocessor"), "utf8"),
+          connector: await readFile(composePath("kms-connector"), "utf8"),
+        };
       } finally {
         for (const [key, value] of saved) {
           if (value === undefined) {
@@ -418,41 +429,52 @@ describe("render-compose", () => {
         await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
         await writeFile(envPath("coprocessor"), "\n");
         await writeFile(envPath("coprocessor.1"), "\n");
-        const raw = await renderCoprocessor({});
-        expect(raw).not.toContain("cache_from");
-        expect(raw).not.toContain("buildcache");
+        const rendered = await renderOverrides({});
+        for (const raw of [rendered.coprocessor, rendered.connector]) {
+          expect(raw).not.toContain("cache_from");
+          expect(raw).not.toContain("buildcache");
+        }
       });
     });
 
-    test("adds only a per-image registry cache_from when FHEVM_BUILDCACHE_TAG is set", async () => {
+    test("adds a per-image registry cache_from only for per-image Dockerfile builds", async () => {
       await withTempStateDir(async () => {
         await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
         await writeFile(envPath("coprocessor"), "\n");
         await writeFile(envPath("coprocessor.1"), "\n");
-        const withoutEnv = await renderCoprocessor({});
-        const withEnv = await renderCoprocessor({ ...BUILDCACHE_ENV });
+        const withoutEnv = await renderOverrides({});
+        const withEnv = await renderOverrides({ ...BUILDCACHE_ENV });
 
         type BuildDoc = { services: Record<string, { build?: { cache_from?: string[] } }> };
-        const enabled = YAML.parse(withEnv) as BuildDoc;
+        const connector = YAML.parse(withEnv.connector) as BuildDoc;
 
-        // The cache ref is the service's own image repository at the cache tag, matching what
+        // The publish workflow exports per-image build caches; those cannot hit against the
+        // branch-local workspace Dockerfiles, so workspace-built services get no cache_from and
+        // a set FHEVM_BUILDCACHE_TAG stays harmless.
+        expect(withEnv.coprocessor).not.toContain("cache_from");
+        expect(connector.services["kms-connector-kms-worker"]?.build?.cache_from).toBeUndefined();
+
+        // connector-db still builds from its per-image Dockerfile, so its cache ref is the
+        // service's own image repository at the cache tag, matching what
         // solana-images-publish.yml exports.
-        expect(enabled.services["coprocessor-host-listener"]?.build?.cache_from).toEqual([
-          "ghcr.io/zama-ai/fhevm/coprocessor/host-listener:buildcache-test",
-        ]);
-        expect(enabled.services["coprocessor-tfhe-worker"]?.build?.cache_from).toEqual([
-          "ghcr.io/zama-ai/fhevm/coprocessor/tfhe-worker:buildcache-test",
+        expect(connector.services["kms-connector-db-migration"]?.build?.cache_from).toEqual([
+          "ghcr.io/zama-ai/fhevm/kms-connector/db-migration:buildcache-test",
         ]);
 
         // Structural proof of graceful degradation: strip the cache_from additions from the
-        // enabled document and it is identical to the disabled one.
-        const stripped = YAML.parse(withEnv) as BuildDoc;
-        for (const service of Object.values(stripped.services)) {
-          if (service.build) {
-            delete service.build.cache_from;
+        // enabled documents and they are identical to the disabled ones.
+        for (const [enabledRaw, disabledRaw] of [
+          [withEnv.coprocessor, withoutEnv.coprocessor],
+          [withEnv.connector, withoutEnv.connector],
+        ] as const) {
+          const stripped = YAML.parse(enabledRaw) as BuildDoc;
+          for (const service of Object.values(stripped.services)) {
+            if (service.build) {
+              delete service.build.cache_from;
+            }
           }
+          expect(stripped).toEqual(YAML.parse(disabledRaw) as BuildDoc);
         }
-        expect(stripped).toEqual(YAML.parse(withoutEnv) as BuildDoc);
       });
     });
   });


### PR DESCRIPTION
Part of zama-ai/fhevm-internal#1766. Follow-up to #3259, driven by a measurement.

## Why

#3259 routed the e2e `--override` compose builds through the per-binary Dockerfiles (same as main's release CI). The first program-touching PR (#3263) then measured the cost of that on the e2e job: a `solana/programs/` change invalidates the source `COPY` layer of every coprocessor image, so the job compiled the fhevm-engine workspace **eight times sequentially** — ~41 min of cargo, **71 min total run vs the ~44 min baseline**. The old workspace Dockerfile compiled all binaries in one ~14-min pass; the registry layer cache can't help once a layer's inputs genuinely change, and cargo cache mounts are local to the ephemeral runner.

## What

- **Restore both `Dockerfile.workspace` files byte-exact** from `a0628116f` (they already carry the gated sccache hooks and the solana path-dep COPY blocks), each with a header marking it **BRANCH-LOCAL — delete at merge-back** (main's release CI and this branch's `solana-images-publish.yml` both use the per-binary Dockerfiles; these exist only so the e2e stack compiles a workspace in one cargo pass).
- **Re-point the e2e compose specs** (`COMPONENT_BUILD_SPECS` in `test-suite/fhevm/src/generate/compose.ts`) for the coprocessor and kms-connector Rust images back at the workspace files with per-image `target`. Relayer/contract images unchanged (never workspace-built); kms-connector `connector-db` keeps its per-binary Dockerfile.
- **Buildcache coherence**: the publish workflow exports *per-image* build-cache manifests, which cannot hit against a workspace build graph, so `withRegistryBuildCache` now skips any spec whose dockerfile ends in `Dockerfile.workspace` (avoids a guaranteed-miss `cache_from`). A set `FHEVM_BUILDCACHE_TAG` stays harmless; the utility + its degradation tests survive for the per-binary specs.

**Untouched on purpose:** the per-binary Dockerfiles, `solana-images-publish.yml`, and `select-overrides.sh` / the skip machinery. Group *selection* is orthogonal to how a rebuilt group is *built*.

## Interchangeability of pulled vs rebuilt images (reviewed)

In a single e2e run, unchanged groups are **pulled** as per-binary (`-p`) images published by the workflow, while a changed group is **rebuilt** from the workspace (`--workspace`) Dockerfile — so a mixed run must have interchangeable images. Verified with `cargo tree -e normal,build` across **both** workspaces: no feature is *removed* under `--workspace` for any shipped binary — it's a strict **additive superset** (this corrects #3259's "identical feature set" framing; kms-connector is a superset too, e.g. `k256` + `serde`/`pkcs8` pulled in by the `kms-worker` sibling).

The superset is **not strictly runtime-invisible**, but is benign for this POC. Two features unify onto shipped binaries from the non-shipped `stress-test-generator`/`test-harness` members:
- `serde_json/preserve_order` — JSON map key order becomes insertion order for the fhevm-engine `gw-listener`/`transaction-sender`/`tfhe-worker`/`zkproof-worker` rebuilds;
- `reqwest` `gzip`/`br`/`deflate` + `rustls-tls-native-roots` — transparent HTTP decompression and OS-root trust.

Both are semantically equivalent for the consumers in play — these binaries sign over alloy RLP/EIP-712, not canonical serde_json, and HTTP bodies are identical after decompression — so a mixed pulled+rebuilt run stays consistent, and #3263's e2e passed green on exactly this setup. **Caveat for future work** (this file is delete-at-merge-back): if any service ever hashes or signs over canonical serde_json output, a pulled vs rebuilt image could diverge on key order.

## Expected effect

- **Program-touching PRs**: e2e cargo returns to one ~14-min pass instead of ~41 min → back around the ~44 min baseline (regression cancelled, not beaten).
- **Docs/SDK-only PRs**: unaffected — still full-skip (nothing builds).
- Going *below* baseline needs a shared dependency cache (cargo-chef); that rewrites team-owned Dockerfiles and is deliberately left to the owning teams, with the measurement and proposal in fhevm-internal#1775.

## Verification

- `bun test src`: 251 pass / 0 fail; `tsc --noEmit` clean.
- `select-overrides.test.sh`: 17/17 (untouched).
- Workspace Dockerfiles `diff` clean vs `a0628116f` apart from the added header block.
- Independent review: **no P1/P2 findings.** Confirmed byte-exactness (header-only delta), every re-pointed `target:` maps to a real workspace stage (incl. the poller/consumer variants sharing the `host-listener` stage), runtime-stage fidelity vs the per-binary `prod` stages (base image, binary paths, user, entrypoint, healthcheck), buildcache no-op for workspace specs, and the feature-superset analysis above. The two P3 nits (commit-message precision on kms-connector; the runtime-visibility caveat) are folded into the commit message and this body.

