### PR TITLE
docs(host-contracts): fix stale batcher claim formula in overview and README

### DIFF
--- a/solana/README.md
+++ b/solana/README.md
@@ -20,7 +20,7 @@ programs/confidential-token     App program. Minimal confidential-token / cUSDC 
                                 spirit): wrap, transfer, burn, redeem, disclose. Drives zama-host by CPI.
 programs/confidential-batcher   Confidential batcher (DD-042): aggregates encrypted deposits per
                                 batch, reveals only each batch's KMS-certified total to the public
-                                demo-vault, and pays encrypted shares at the batch's public rate.
+                                demo-vault, and pays each user their exact proportional cut, encrypted.
                                 Its `join` keeps the app-driven composition pattern: it CPIs
                                 `confidential_transfer` with the user as sole signer — the
                                 replacement for EVM transfer-and-call callbacks.

--- a/solana/docs/CONFIDENTIAL_VAULTS.md
+++ b/solana/docs/CONFIDENTIAL_VAULTS.md
@@ -40,7 +40,7 @@ everything below uses Solana-native building blocks.
    └────┘ └────┘ └────┘            (adds while                     mint shares
                                     encrypted)                        │
    ┌────────────────────────◄──────────────────────────────────────┘
-   │  each user gets encrypted shares: e(amount) × public share rate
+   │  each user's encrypted cut: e(amount) × batch shares ÷ batch total
 ```
 
 ## How a deposit works, step by step


### PR DESCRIPTION
Small follow-up to #3263 (review finding, non-blocking).

#3263 changed batcher claims to the exact proportional floor `joined × payout_received / total_joined` and made the stored `payout_rate` informational only. Two doc spots still described the old `e(amount) × public rate` formula:

- `solana/docs/CONFIDENTIAL_VAULTS.md` — the overview ASCII diagram
- `solana/README.md` — the `confidential-batcher` component blurb

Both updated to the proportional description so integrators don't reproduce the superseded double-rounding calculation. The step-by-step (step 5) and the redeem paragraph already described the proportional math correctly — only the overview and README lagged. Docs only, no code change.