### PR TITLE
fix(test-suite): drop --seed-start-block for legacy host-listener pollers

### DIFF
--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -131,6 +131,38 @@ describe("compat", () => {
     expect(policy.coprocessorDropFlags["host-listener-poller"]).toContain("--kms-generation-address");
   });
 
+  test("drops seed-start-block for host listener images below v0.13.2", () => {
+    const policy = compatPolicyForState({
+      versions: {
+        target: "latest-supported",
+        lockName: "latest-supported.json",
+        env: {
+          COPROCESSOR_HOST_LISTENER_VERSION: "v0.11.0",
+        } as Record<string, string>,
+        sources: [],
+      },
+      overrides: [],
+      scenario: testDefaultScenario(),
+    });
+    expect(policy.coprocessorDropFlags["host-listener-poller"]).toContain("--seed-start-block");
+  });
+
+  test("keeps seed-start-block for host listener images at v0.13.2", () => {
+    const policy = compatPolicyForState({
+      versions: {
+        target: "latest-main",
+        lockName: "latest-main.json",
+        env: {
+          COPROCESSOR_HOST_LISTENER_VERSION: "v0.13.2-0",
+        } as Record<string, string>,
+        sources: [],
+      },
+      overrides: [],
+      scenario: testDefaultScenario(),
+    });
+    expect(policy.coprocessorDropFlags["host-listener-poller"] ?? []).not.toContain("--seed-start-block");
+  });
+
   test("treats sha-style gateway bundles as modern kms-generation sourcing", () => {
     expect(
       requiresLegacyGatewayKmsGenerationAddress({

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -34,6 +34,7 @@ export const COMPAT_MATRIX = {
   legacyShims: [
     { key: "COPROCESSOR_GW_LISTENER_VERSION", below: [0, 12, 0] as CompatSemver, profile: "legacy-gw-listener-no-drift-addresses", unparsed: "modern" as const },
     { key: "COPROCESSOR_GW_LISTENER_VERSION", below: [0, 13, 0] as CompatSemver, profile: "legacy-gw-listener-kms-generation-address", unparsed: "modern" as const },
+    { key: "COPROCESSOR_HOST_LISTENER_VERSION", below: [0, 13, 2] as CompatSemver, profile: "legacy-host-listener-poller-no-seed-start-block", unparsed: "modern" as const },
     { key: "COPROCESSOR_HOST_LISTENER_VERSION", below: [0, 13, 0] as CompatSemver, profile: "legacy-host-listener-no-kms-generation-address", unparsed: "modern" as const },
     { key: "COPROCESSOR_HOST_LISTENER_VERSION", below: [0, 12, 0] as CompatSemver, profile: "legacy-coprocessor-api-keys", unparsed: "modern" as const },
     { key: "COPROCESSOR_TX_SENDER_VERSION", below: [0, 12, 0] as CompatSemver, profile: "legacy-tx-sender-gateway-flags", unparsed: "modern" as const },
@@ -72,6 +73,14 @@ const SHIM_PROFILES = {
     coprocessorDropFlags: {
       "host-listener": ["--kms-generation-address"],
       "host-listener-poller": ["--kms-generation-address"],
+    },
+    connectorEnv: {},
+    composeEnv: {},
+  },
+  "legacy-host-listener-poller-no-seed-start-block": {
+    coprocessorArgs: {},
+    coprocessorDropFlags: {
+      "host-listener-poller": ["--seed-start-block"],
     },
     connectorEnv: {},
     composeEnv: {},


### PR DESCRIPTION
Related to this failure: https://github.com/zama-ai/fhevm/actions/runs/29862794296/job/88776253910?pr=3271