### PR TITLE
fix(test-suite): inject rust version from toolchain file

### DIFF
--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -1,6 +1,7 @@
 /**
  * Generates compose overrides for local builds, scenario instances, and compatibility-adjusted service commands.
  */
+import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
@@ -19,6 +20,7 @@ import {
   GROUP_BUILD_COMPONENTS,
   GROUP_BUILD_SERVICES,
   GROUP_SERVICE_SUFFIXES,
+  REPO_ROOT,
   TEMPLATE_COMPOSE_DIR,
   composePath,
   envPath,
@@ -86,6 +88,20 @@ const buildSpec = (context: string, dockerfile: string, extra: Record<string, un
   dockerfile: resolveComposePath(dockerfile),
   ...extra,
 });
+
+/**
+ * Reads the Rust toolchain channel from a `rust-toolchain.toml` (relative to the
+ * repo root) and returns it.
+ */
+const rustImageVersion = (toolchainRepoPath: string): string => {
+  const filePath = path.join(REPO_ROOT, toolchainRepoPath);
+  const match = readFileSync(filePath, "utf8").match(/^\s*channel\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error(`Could not read Rust toolchain channel from ${toolchainRepoPath}`);
+  }
+  return match[1];
+};
+
 const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknown>>> = {
   coprocessor: {
     "coprocessor-db-migration": buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
@@ -124,27 +140,31 @@ const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknow
   },
   "kms-connector": {
     "kms-connector-db-migration": buildSpec("../../..", "kms-connector/connector-db/Dockerfile", {
-      args: { RUST_IMAGE_VERSION: "1.91.0" },
+      args: { RUST_IMAGE_VERSION: rustImageVersion("kms-connector/rust-toolchain.toml") },
     }),
     "kms-connector-gw-listener": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
       target: "gw-listener",
-      args: { RUST_IMAGE_VERSION: "1.91.0" },
+      args: { RUST_IMAGE_VERSION: rustImageVersion("kms-connector/rust-toolchain.toml") },
     }),
     "kms-connector-kms-worker": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
       target: "kms-worker",
-      args: { RUST_IMAGE_VERSION: "1.91.0" },
+      args: { RUST_IMAGE_VERSION: rustImageVersion("kms-connector/rust-toolchain.toml") },
     }),
     "kms-connector-tx-sender": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
       target: "tx-sender",
-      args: { RUST_IMAGE_VERSION: "1.91.0" },
+      args: { RUST_IMAGE_VERSION: rustImageVersion("kms-connector/rust-toolchain.toml") },
     }),
   },
   "listener-core": {
     "listener-publisher-for-anvil": buildSpec("../../../listener", "Dockerfile"),
   },
   relayer: {
-    "relayer-db-migration": buildSpec("../../..", "relayer/docker/relayer-migrate/Dockerfile"),
-    relayer: buildSpec("../../..", "relayer/docker/relayer/Dockerfile"),
+    "relayer-db-migration": buildSpec("../../..", "relayer/docker/relayer-migrate/Dockerfile", {
+      args: { RUST_IMAGE_VERSION: rustImageVersion("relayer/rust-toolchain.toml") },
+    }),
+    relayer: buildSpec("../../..", "relayer/docker/relayer/Dockerfile", {
+      args: { RUST_IMAGE_VERSION: rustImageVersion("relayer/rust-toolchain.toml") },
+    }),
   },
   "gateway-mocked-payment": {
     "gateway-deploy-mocked-zama-oft": buildSpec("../../../gateway-contracts", "Dockerfile"),


### PR DESCRIPTION
Follow-up of https://github.com/zama-ai/fhevm/pull/3250

### What this fixes

Local e2e builds (`fhevm-cli up --build`) failed when building the `relayer` from source with invalid reference format. The `relayer` Dockerfiles reference `FROM ...rust-glibc:${RUST_IMAGE_VERSION}`, but that arg was only ever injected by CI's `common-docker.yml`, the test-suite's local-build path never set it, so the tag resolved empty.

###  Change

`compose.ts` now reads the Rust toolchain channel from each component's `rust-toolchain.toml` and injects it as `RUST_IMAGE_VERSION` when building locally:
- `relayer` → `relayer/rust-toolchain.toml` (was unset → the bug)
- `kms-connector` → `kms-connector/rust-toolchain.toml` (was hardcoded 1.91.0, drifted from the actual channel 1.97.1)

This keeps the version single-sourced from `rust-toolchain.toml`, matching how CI derives it, and avoids adding a hardcoded default in the Dockerfiles.

coprocessor and listener-core are untouched (they don't rely on the injected arg, might change with this other [PR](https://github.com/zama-ai/fhevm/pull/3256)).

### E2E test run with the fix

https://github.com/zama-ai/fhevm/actions/runs/29905447520/job/88875663454
https://github.com/zama-ai/fhevm/actions/runs/29906381475/job/88878736719