### PR TITLE
feat(charts): add optional network.slotsInAnEpoch to anvil-node

### DIFF
--- a/charts/anvil-node/Chart.yaml
+++ b/charts/anvil-node/Chart.yaml
@@ -1,6 +1,6 @@
 name: anvil-node
 description: A helm chart to deploy fhevm anvil node
-version: 0.5.0
+version: 0.6.0
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/anvil-node/templates/anvil-statefulset.yaml
+++ b/charts/anvil-node/templates/anvil-statefulset.yaml
@@ -44,10 +44,6 @@ spec:
             - "--accounts"
             - "{{ .Values.network.accounts }}"
             {{- with .Values.network.slotsInAnEpoch }}
-            # Lower = the `finalized`/`safe` block tags advance sooner (anvil
-            # defaults to 32 slots/epoch, so `finalized` lags ~2 epochs behind
-            # head). Consumers that wait on finalized events (e.g. kms-connector)
-            # otherwise pay that full lag on every cycle.
             - "--slots-in-an-epoch"
             - "{{ . }}"
             {{- end }}

--- a/charts/anvil-node/templates/anvil-statefulset.yaml
+++ b/charts/anvil-node/templates/anvil-statefulset.yaml
@@ -43,6 +43,14 @@ spec:
             - "{{ .Values.network.chainId }}"
             - "--accounts"
             - "{{ .Values.network.accounts }}"
+            {{- with .Values.network.slotsInAnEpoch }}
+            # Lower = the `finalized`/`safe` block tags advance sooner (anvil
+            # defaults to 32 slots/epoch, so `finalized` lags ~2 epochs behind
+            # head). Consumers that wait on finalized events (e.g. kms-connector)
+            # otherwise pay that full lag on every cycle.
+            - "--slots-in-an-epoch"
+            - "{{ . }}"
+            {{- end }}
             - "--mnemonic"
             - "$(MNEMONIC)"
           ports:

--- a/charts/anvil-node/values.yaml
+++ b/charts/anvil-node/values.yaml
@@ -10,6 +10,11 @@ network:
   chainId: "12345"
   accounts: "10"
   mnemonic: ""
+  # Optional. When set, passes --slots-in-an-epoch to anvil, controlling how
+  # quickly the `finalized`/`safe` block tags advance (anvil default: 32).
+  # Set to "1" to make finalization near-instant for test setups whose
+  # consumers wait on finalized events. Omitted -> anvil default.
+  # slotsInAnEpoch: "1"
 
 port: 8545
 


### PR DESCRIPTION
## Summary
- Adds an optional `network.slotsInAnEpoch` value to the `anvil-node` chart. When set, it passes `--slots-in-an-epoch` to anvil; when unset the flag is omitted, so existing chart consumers are unaffected.
- Bumps the chart `0.5.0` → `0.6.0` so it gets published to GHCR on merge.

## Why
anvil defaults to 32 slots/epoch, so the `finalized`/`safe` block tags lag ~2 epochs behind head (~60s+ at a 1s block time). Components that subscribe to **finalized** events — notably the kms-connector — pay that full lag on every keygen/decrypt cycle. Setting `slotsInAnEpoch: "1"` makes finalization near-instant, matching the docker-compose test setup (`test-suite/fhevm/docker-compose/host-node-docker-compose.yml`).

This is the chart prerequisite for wiring `slotsInAnEpoch: "1"` into the per-PR e2e preview environment (PR #3189); that PR bumps the pinned `anvil-node` chart version to `0.6.0` once this publishes.

## Test plan
- [x] `helm lint charts/anvil-node`
- [x] `helm template` with `--set network.slotsInAnEpoch=1` renders `--slots-in-an-epoch 1`
- [x] `helm template` with no value omits the flag (backward-compatible)

Made with [Cursor](https://cursor.com)