### PR TITLE
fix(test-suite): resolve sha baselines against published image tags

### DIFF
--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -15,7 +15,9 @@ import {
   SIMPLE_ACL_MIN_SHA,
   SHA_RUNTIME_COMPAT_MIN_SHA,
   applyVersionEnvOverrides,
+  findPublishedAncestorTag,
   presetBundle,
+  resolveMissingRepoTagFallbacks,
   selectSupportedMainSha,
   shaRuntimeCompatFloor,
   simpleAclFloor,
@@ -111,6 +113,50 @@ describe("resolve", () => {
     expect("COPROCESSOR_CONSENSUS_DETECTOR_VERSION" in bundle.env).toBe(false);
     const next = applyVersionEnvOverrides(bundle, { COPROCESSOR_CONSENSUS_DETECTOR_VERSION: "v0.14.0" });
     expect(next.env.COPROCESSOR_CONSENSUS_DETECTOR_VERSION).toBe("v0.14.0");
+  });
+
+  test("finds the nearest ancestor with a published image tag", () => {
+    const commits = [
+      "d77a0417aa5d928063181454756ebb73cdbadc24",
+      "2cde6c960c24405015ab03959a2d9053cde31f23",
+      "8e2f724d4000000000000000000000000000000",
+    ];
+    expect(findPublishedAncestorTag(commits, new Set(["2cde6c9", "8e2f724"]))).toBe("2cde6c9");
+    expect(findPublishedAncestorTag(commits, new Set(["fffffff"]))).toBeUndefined();
+    expect(findPublishedAncestorTag([], new Set(["2cde6c9"]))).toBeUndefined();
+  });
+
+  test("falls back to the newest published ancestor tag for missing images", () => {
+    const { overrides, sources } = resolveMissingRepoTagFallbacks({
+      requestedTag: "d77a041",
+      missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+      commitShas: ["d77a0417aa5d928063181454756ebb73cdbadc24", "2cde6c960c24405015ab03959a2d9053cde31f23"],
+      packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set(["2cde6c9"]) },
+    });
+    expect(overrides).toEqual({ CONNECTOR_GW_LISTENER_VERSION: "2cde6c9" });
+    expect(sources).toEqual(["CONNECTOR_GW_LISTENER_VERSION=2cde6c9 (fallback: d77a041 unpublished)"]);
+  });
+
+  test("keeps the unverified pin when no published ancestor is reachable", () => {
+    const { overrides, sources } = resolveMissingRepoTagFallbacks({
+      requestedTag: "d77a041",
+      missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+      commitShas: ["d77a0417aa5d928063181454756ebb73cdbadc24"],
+      packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set<string>() },
+    });
+    expect(overrides).toEqual({});
+    expect(sources).toEqual([
+      "CONNECTOR_GW_LISTENER_VERSION=d77a041 (unverified: no published tag within 1 commits)",
+    ]);
+  });
+
+  test("applies per-component fallback overrides to a sha preset bundle", () => {
+    const bundle = presetBundle("sha", "d77a041", "sha-d77a041.json", [], new Set(), {
+      CONNECTOR_GW_LISTENER_VERSION: "2cde6c9",
+    });
+    expect(bundle.env.CONNECTOR_GW_LISTENER_VERSION).toBe("2cde6c9");
+    expect(bundle.env.CONNECTOR_TX_SENDER_VERSION).toBe("d77a041");
+    expect(bundle.env.COPROCESSOR_HOST_LISTENER_VERSION).toBe("d77a041");
   });
 
   test("only caches immutable sha targets", () => {

--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -12,10 +12,11 @@ import {
   shouldStopPackageTagScan,
 } from "./resolve/github";
 import {
+  MAX_FALLBACK_COMMIT_DEPTH,
   SIMPLE_ACL_MIN_SHA,
   SHA_RUNTIME_COMPAT_MIN_SHA,
   applyVersionEnvOverrides,
-  findPublishedAncestorTag,
+  findPublishedAncestorIndex,
   presetBundle,
   resolveMissingRepoTagFallbacks,
   selectSupportedMainSha,
@@ -121,9 +122,9 @@ describe("resolve", () => {
       "2cde6c960c24405015ab03959a2d9053cde31f23",
       "8e2f724d4000000000000000000000000000000",
     ];
-    expect(findPublishedAncestorTag(commits, new Set(["2cde6c9", "8e2f724"]))).toBe("2cde6c9");
-    expect(findPublishedAncestorTag(commits, new Set(["fffffff"]))).toBeUndefined();
-    expect(findPublishedAncestorTag([], new Set(["2cde6c9"]))).toBeUndefined();
+    expect(findPublishedAncestorIndex(commits, new Set(["2cde6c9", "8e2f724"]))).toBe(1);
+    expect(findPublishedAncestorIndex(commits, new Set(["fffffff"]))).toBe(-1);
+    expect(findPublishedAncestorIndex([], new Set(["2cde6c9"]))).toBe(-1);
   });
 
   test("falls back to the newest published ancestor tag for missing images", () => {
@@ -135,6 +136,21 @@ describe("resolve", () => {
     });
     expect(overrides).toEqual({ CONNECTOR_GW_LISTENER_VERSION: "2cde6c9" });
     expect(sources).toEqual(["CONNECTOR_GW_LISTENER_VERSION=2cde6c9 (fallback: d77a041 unpublished)"]);
+  });
+
+  test("fails resolution when the newest published image lags beyond the fallback limit", () => {
+    const commits = Array.from(
+      { length: MAX_FALLBACK_COMMIT_DEPTH + 2 },
+      (_, index) => index.toString(16).padEnd(40, "f"),
+    );
+    expect(() =>
+      resolveMissingRepoTagFallbacks({
+        requestedTag: commits[0].slice(0, 7),
+        missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+        commitShas: commits,
+        packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set([commits.at(-1)!.slice(0, 7)]) },
+      }),
+    ).toThrow("beyond the 50-commit fallback limit");
   });
 
   test("keeps the unverified pin when no published ancestor is reachable", () => {

--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -153,7 +153,7 @@ describe("resolve", () => {
     ).toThrow("beyond the 50-commit fallback limit");
   });
 
-  test("keeps the unverified pin when no published ancestor is reachable", () => {
+  test("keeps the unverified pin when the package has no visible published tags", () => {
     const { overrides, sources } = resolveMissingRepoTagFallbacks({
       requestedTag: "d77a041",
       missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
@@ -162,8 +162,19 @@ describe("resolve", () => {
     });
     expect(overrides).toEqual({});
     expect(sources).toEqual([
-      "CONNECTOR_GW_LISTENER_VERSION=d77a041 (unverified: no published tag within 1 commits)",
+      "CONNECTOR_GW_LISTENER_VERSION=d77a041 (unverified: package has no visible published tags)",
     ]);
+  });
+
+  test("fails resolution when a published package has no tag anywhere on the ancestry", () => {
+    expect(() =>
+      resolveMissingRepoTagFallbacks({
+        requestedTag: "d77a041",
+        missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+        commitShas: ["d77a0417aa5d928063181454756ebb73cdbadc24"],
+        packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set(["0000000"]) },
+      }),
+    ).toThrow("nor for any of the 1 commits behind it");
   });
 
   test("applies per-component fallback overrides to a sha preset bundle", () => {

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -173,11 +173,14 @@ export const shouldStopPackageTagScan = (
   targetTag?: string,
 ) => (targetTag && tags.has(targetTag)) || payload.length < 100;
 
-/** Returns recent main-branch commit SHAs for fhevm. */
-export const mainCommits = async (limit = 200) => {
-  const commits = await ghPages<{ sha: string }>(`repos/${FHEVM_REPO}/commits?sha=main`, limit);
+/** Returns recent fhevm commit SHAs reachable from a ref (branch, tag, or sha), newest first. */
+export const commitsFrom = async (ref: string, limit = 200) => {
+  const commits = await ghPages<{ sha: string }>(`repos/${FHEVM_REPO}/commits?sha=${ref}`, limit);
   return commits.map((item) => item.sha);
 };
+
+/** Returns recent main-branch commit SHAs for fhevm. */
+export const mainCommits = async (limit = 200) => commitsFrom("main", limit);
 
 /** Returns the published tag set for one GHCR package. A missing (404) package
  * yields an empty set so newly added images without CI builds yet don't block

--- a/test-suite/fhevm/src/resolve/target.ts
+++ b/test-suite/fhevm/src/resolve/target.ts
@@ -212,10 +212,20 @@ export const resolveMissingRepoTagFallbacks = (options: {
   for (const key of options.missingKeys) {
     const ancestorIndex = findPublishedAncestorIndex(options.commitShas, options.packageTagsMap[key] ?? new Set());
     if (ancestorIndex < 0) {
-      sources.push(
-        `${key}=${options.requestedTag} (unverified: no published tag within ${options.commitShas.length} commits)`,
+      // An empty tag set can mean the GitHub token simply cannot see the package (the versions
+      // API 404s on inaccessible packages), so the registry pull may still succeed with the
+      // runtime's own credentials; keep the pin and record that it is unverified.
+      if (!options.packageTagsMap[key]?.size) {
+        sources.push(`${key}=${options.requestedTag} (unverified: package has no visible published tags)`);
+        continue;
+      }
+      // A non-empty tag set with no tag anywhere on the ancestry proves the lock would be
+      // unpullable; failing here beats the guaranteed `manifest unknown` at e2e time.
+      throw new GitHubApiError(
+        `${key} has no published image for ${options.requestedTag} nor for any of the ` +
+          `${options.commitShas.length} commits behind it. Its docker builds look broken; fix or re-run them ` +
+          `before resolving this baseline, or pin ${key} explicitly to a published tag.`,
       );
-      continue;
     }
     if (ancestorIndex > MAX_FALLBACK_COMMIT_DEPTH) {
       throw new GitHubApiError(
@@ -445,7 +455,19 @@ export const resolveTarget = async (
     console.log(
       `[resolve] sha ${tag}: no published image for ${missingKeys.join(", ")}; looking for published ancestor tags`,
     );
-    const commitShas = await commitsFrom(requested, SHA_FALLBACK_COMMIT_WINDOW);
+    // Unlike the tag fetch above, an ancestry failure here is not skippable: missingKeys proves
+    // the unverified pin would produce an unpullable lock, so resolution must not fall back to it.
+    let commitShas: string[];
+    try {
+      commitShas = await commitsFrom(requested, SHA_FALLBACK_COMMIT_WINDOW);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message.split("\n")[0] : String(error);
+      throw new GitHubApiError(
+        `${missingKeys.join(", ")} have no published image for ${tag}, and the ancestry lookup for ` +
+          `fallback tags failed (${reason}). Retry once GitHub is reachable, or pin the affected ` +
+          `versions explicitly.`,
+      );
+    }
     const { overrides, sources } = resolveMissingRepoTagFallbacks({
       requestedTag: tag,
       missingKeys,

--- a/test-suite/fhevm/src/resolve/target.ts
+++ b/test-suite/fhevm/src/resolve/target.ts
@@ -11,7 +11,7 @@ import {
   MODERN_RELAYER_MIGRATE_IMAGE_REPOSITORY,
 } from "../compat/compat";
 import { GitHubApiError } from "../errors";
-import { gitopsFile, mainCommits, packageTags } from "./github";
+import { commitsFrom, gitopsFile, mainCommits, packageTags } from "./github";
 import { NON_NETWORK_COMPANIONS } from "./presets";
 import { LATEST_SUPPORTED_PROFILE } from "../layout";
 import type { VersionBundle, VersionTarget } from "../types";
@@ -114,6 +114,8 @@ const PACKAGE_REPOSITORY_CANDIDATES: Partial<Record<keyof typeof PACKAGE_TO_REPO
   RELAYER_MIGRATE_VERSION: [MODERN_RELAYER_MIGRATE_IMAGE_REPOSITORY, LEGACY_RELAYER_MIGRATE_IMAGE_REPOSITORY],
 };
 
+const SHA_FALLBACK_COMMIT_WINDOW = 500;
+
 export const REPO_TAG = /^[0-9a-f]{7}$/;
 export const SHA_REF = /^(?:[0-9a-f]{7}|[0-9a-f]{40})$/i;
 export const SIMPLE_ACL_MIN_SHA = COMPAT_MATRIX.anchors.SIMPLE_ACL_MIN_SHA;
@@ -174,6 +176,44 @@ const findImageTag = (
 /** Normalizes a full SHA into the short tag form used by repo-owned images. */
 export const shortSha = (value: string) => value.toLowerCase().slice(0, 7);
 
+/** Finds the newest commit in an ancestry walk (newest first) that has a published image tag. */
+export const findPublishedAncestorTag = (commitShas: string[], publishedTags: Set<string>) =>
+  commitShas.map(shortSha).find((sha) => publishedTags.has(sha));
+
+/**
+ * Resolves per-component fallback tags for repo-owned images with no published image at the
+ * requested sha.
+ *
+ * A missing tag is an exceptional state: on every push the docker-build workflows either build a
+ * changed component or re-tag the previous image with the new sha, so a gap means one of those
+ * jobs failed or has not finished. Each affected component independently falls back to its
+ * newest published tag on the requested sha's ancestry, and the substitution is recorded in
+ * `sources`. Components with no published tag in the walked window (brand-new or
+ * feature-branch-only packages) keep the requested sha, matching how latest-main skips gating
+ * on such packages.
+ */
+export const resolveMissingRepoTagFallbacks = (options: {
+  requestedTag: string;
+  missingKeys: string[];
+  commitShas: string[];
+  packageTagsMap: Record<string, Set<string>>;
+}): { overrides: Record<string, string>; sources: string[] } => {
+  const overrides: Record<string, string> = {};
+  const sources: string[] = [];
+  for (const key of options.missingKeys) {
+    const ancestor = findPublishedAncestorTag(options.commitShas, options.packageTagsMap[key] ?? new Set());
+    if (!ancestor) {
+      sources.push(
+        `${key}=${options.requestedTag} (unverified: no published tag within ${options.commitShas.length} commits)`,
+      );
+      continue;
+    }
+    overrides[key] = ancestor;
+    sources.push(`${key}=${ancestor} (fallback: ${options.requestedTag} unpublished)`);
+  }
+  return { overrides, sources };
+};
+
 /** Locates the simple-ACL support floor in fetched main history. */
 export const simpleAclFloor = (commits: string[]) => {
   const floor = commits.indexOf(SIMPLE_ACL_MIN_SHA);
@@ -203,6 +243,7 @@ export const presetBundle = (
   lockName: string,
   sources: string[] = [],
   publishedOptionalKeys?: ReadonlySet<string>,
+  repoKeyOverrides?: Record<string, string>,
 ): VersionBundle => ({
   target,
   lockName,
@@ -213,7 +254,7 @@ export const presetBundle = (
         return [];
       }
       const version = REPO_KEYS.has(key)
-        ? repoVersion
+        ? repoKeyOverrides?.[key] ?? repoVersion
         : NON_NETWORK_COMPANIONS[target][key as keyof (typeof NON_NETWORK_COMPANIONS)[typeof target]];
       if (!version) {
         throw new Error(`Missing ${target} preset for ${key}`);
@@ -362,7 +403,42 @@ export const resolveTarget = async (
       throw new GitHubApiError(`Invalid sha ${requested}; expected 7 or 40 hex characters`);
     }
     const tag = shortSha(requested);
-    return presetBundle(target, tag, `sha-${tag}.json`, [`requested-sha=${requested.toLowerCase()}`], new Set());
+    const lockName = `sha-${tag}.json`;
+    const baseSources = [`requested-sha=${requested.toLowerCase()}`];
+
+    // The docker-build workflows re-tag unchanged components on every push, so normally every
+    // repo-owned image is published at the requested sha. Verify that instead of trusting it: a
+    // flaked re-tag or failed build otherwise only surfaces as `manifest unknown` at pull time.
+    let packageTagsMap: Record<string, Set<string>>;
+    try {
+      packageTagsMap = await repoPackageTags(tag);
+    } catch (error) {
+      // GitHub metadata is unavailable (offline, missing scopes): keep the historical unverified
+      // pin so `--target sha` still resolves, and record that the check was skipped.
+      const reason = error instanceof Error ? error.message.split("\n")[0] : String(error);
+      console.log(`[resolve] sha ${tag}: skipping published-image check (${reason})`);
+      return presetBundle(target, tag, lockName, [...baseSources, "published-image-check=skipped"], new Set());
+    }
+    const missingKeys = Object.keys(REPO_PACKAGES).filter(
+      (key) => !OPTIONAL_REPO_KEYS.has(key) && !packageTagsMap[key]?.has(tag),
+    );
+    if (!missingKeys.length) {
+      return presetBundle(target, tag, lockName, baseSources, new Set());
+    }
+    console.log(
+      `[resolve] sha ${tag}: no published image for ${missingKeys.join(", ")}; looking for published ancestor tags`,
+    );
+    const commitShas = await commitsFrom(requested, SHA_FALLBACK_COMMIT_WINDOW);
+    const { overrides, sources } = resolveMissingRepoTagFallbacks({
+      requestedTag: tag,
+      missingKeys,
+      commitShas,
+      packageTagsMap,
+    });
+    for (const source of sources) {
+      console.log(`[resolve] ${source}`);
+    }
+    return presetBundle(target, tag, lockName, [...baseSources, ...sources], new Set(), overrides);
   }
 
   const [packageTagsMap, commits] = await Promise.all([repoPackageTags(), mainCommits(5000)]);

--- a/test-suite/fhevm/src/resolve/target.ts
+++ b/test-suite/fhevm/src/resolve/target.ts
@@ -115,6 +115,11 @@ const PACKAGE_REPOSITORY_CANDIDATES: Partial<Record<keyof typeof PACKAGE_TO_REPO
 };
 
 const SHA_FALLBACK_COMMIT_WINDOW = 500;
+// A missing tag from a flaked re-tag, an in-flight push pipeline, or an is-latest-commit skip
+// sits a handful of commits behind the requested sha (a merge train at most). A published image
+// lagging further than this means the component's publishing is genuinely broken, which a
+// fallback must not paper over.
+export const MAX_FALLBACK_COMMIT_DEPTH = 50;
 
 export const REPO_TAG = /^[0-9a-f]{7}$/;
 export const SHA_REF = /^(?:[0-9a-f]{7}|[0-9a-f]{40})$/i;
@@ -176,9 +181,11 @@ const findImageTag = (
 /** Normalizes a full SHA into the short tag form used by repo-owned images. */
 export const shortSha = (value: string) => value.toLowerCase().slice(0, 7);
 
-/** Finds the newest commit in an ancestry walk (newest first) that has a published image tag. */
-export const findPublishedAncestorTag = (commitShas: string[], publishedTags: Set<string>) =>
-  commitShas.map(shortSha).find((sha) => publishedTags.has(sha));
+/** Finds the position of the newest commit in an ancestry walk (newest first) that has a
+ * published image tag; -1 when none does. The position is the commit distance behind the walk's
+ * starting sha. */
+export const findPublishedAncestorIndex = (commitShas: string[], publishedTags: Set<string>) =>
+  commitShas.findIndex((sha) => publishedTags.has(shortSha(sha)));
 
 /**
  * Resolves per-component fallback tags for repo-owned images with no published image at the
@@ -186,9 +193,11 @@ export const findPublishedAncestorTag = (commitShas: string[], publishedTags: Se
  *
  * A missing tag is an exceptional state: on every push the docker-build workflows either build a
  * changed component or re-tag the previous image with the new sha, so a gap means one of those
- * jobs failed or has not finished. Each affected component independently falls back to its
- * newest published tag on the requested sha's ancestry, and the substitution is recorded in
- * `sources`. Components with no published tag in the walked window (brand-new or
+ * jobs failed, has not finished, or was skipped for a superseded branch tip. Each affected
+ * component independently falls back to its newest published tag on the requested sha's
+ * ancestry, and the substitution is recorded in `sources`. A fallback deeper than
+ * MAX_FALLBACK_COMMIT_DEPTH fails resolution instead — that lag means the component's publishing
+ * is broken, not flaked. Components with no published tag in the walked window (brand-new or
  * feature-branch-only packages) keep the requested sha, matching how latest-main skips gating
  * on such packages.
  */
@@ -201,13 +210,21 @@ export const resolveMissingRepoTagFallbacks = (options: {
   const overrides: Record<string, string> = {};
   const sources: string[] = [];
   for (const key of options.missingKeys) {
-    const ancestor = findPublishedAncestorTag(options.commitShas, options.packageTagsMap[key] ?? new Set());
-    if (!ancestor) {
+    const ancestorIndex = findPublishedAncestorIndex(options.commitShas, options.packageTagsMap[key] ?? new Set());
+    if (ancestorIndex < 0) {
       sources.push(
         `${key}=${options.requestedTag} (unverified: no published tag within ${options.commitShas.length} commits)`,
       );
       continue;
     }
+    if (ancestorIndex > MAX_FALLBACK_COMMIT_DEPTH) {
+      throw new GitHubApiError(
+        `${key} has no published image for ${options.requestedTag}, and its newest published image is ` +
+          `${ancestorIndex} commits behind — beyond the ${MAX_FALLBACK_COMMIT_DEPTH}-commit fallback limit. ` +
+          `Its docker builds look broken rather than flaked; fix or re-run them before resolving this baseline.`,
+      );
+    }
+    const ancestor = shortSha(options.commitShas[ancestorIndex]);
     overrides[key] = ancestor;
     sources.push(`${key}=${ancestor} (fallback: ${options.requestedTag} unpublished)`);
   }


### PR DESCRIPTION
## Problem

The orchestrated e2e workflow generates its baseline lock with `resolve --target sha --sha $BASE_SHA`, which pins every repo-owned image to the base sha without checking that the tag actually exists in GHCR.

The docker-build workflows normally guarantee it does: on every push, each component is either rebuilt or its previous image is re-tagged with the new sha. But that invariant can break — on `release/0.13.x`, the `re-tag-gw-listener-image` job of [kms-connector-docker-build run 29908109541](https://github.com/zama-ai/fhevm/actions/runs/29908109541) hit a transient DNS timeout during `docker login ghcr.io`, so `kms-connector/gw-listener:d77a041` was never published. Every e2e run whose baseline landed on `d77a041` then failed ~20 minutes in with `manifest unknown`, on PRs unrelated to the flake (#3273).

Beyond flakes, two normal behaviors also leave base shas without a complete tag set: a baseline resolved while the base push's builds are still running, and `is-latest-commit` gating skipping docker builds entirely for commits superseded before their workflows ran.

## Fix

`--target sha` now resolves against observed registry state instead of trusting the invariant:

- fetch the published GHCR tag set for each repo-owned package (same primitive the `latest-main` target already uses);
- any component missing a tag at the requested sha independently falls back to its newest published tag on the requested sha's ancestry (`commitsFrom` generalizes `mainCommits` to walk from any ref);
- each substitution is recorded in the lock's `sources` and printed by the resolve step, e.g. `CONNECTOR_GW_LISTENER_VERSION=2cde6c9 (fallback: d77a041 unpublished)`;
- a fallback deeper than **50 commits** fails resolution instead: that lag means the component's publishing is broken rather than flaked, and a fallback must not paper over it;
- components with no published tag in the walked window (brand-new images, feature-branch-only packages) keep the requested sha, matching how `latest-main` skips gating on them;
- if GitHub metadata is unavailable (offline, missing `read:packages`), resolution keeps the previous unverified behavior and records `published-image-check=skipped`.

The fallback can never skip a published feature: if a component changed at some commit at-or-before the base sha and its build succeeded, that tag exists and the ancestry walk stops there first. Since re-tags publish byte-identical images under new names, a flake-induced fallback points at exactly the image the re-tag would have produced (verified on the incident: both `gw-listener` tags share digest `sha256:c71f99b2…`).

## Trade-off

If a component's image is missing because a *real build* of changed code failed on the base branch, a shallow fallback substitutes the previous image instead of failing resolution — visible in the resolve log and lock sources, but not fatal. Detecting that case precisely would require duplicating the per-component path filters from the docker-build workflows, which would drift; the build failure itself is already loud on the base branch, and the 50-commit cap bounds how stale a substitution can silently get. Chosen behavior: keep unrelated PRs unblocked, keep substitutions visible, fail on structural lag.

## Follow-ups

- Backport to `release/0.14.x` and `release/0.13.x` after review (the resolver has drifted between branches, so these are adaptations, not cherry-picks).
- Separately, the re-tag jobs could retry `docker login`/push so a single DNS blip can't strand a branch tip in the first place.

## Test plan

- `bun run check` (tsc) clean
- `bun test src`: 307 pass, including new coverage for `findPublishedAncestorIndex`, `resolveMissingRepoTagFallbacks` (fallback, depth-cap failure, unverified-pin cases), and per-component overrides in `presetBundle`
- `compat-smoke` runs in CI (requires a Docker daemon locally)