### PR TITLE
fix(solana-proof-service): bind MMR proof DTO to chain context

### DIFF
--- a/solana-proof-service/README.md
+++ b/solana-proof-service/README.md
@@ -24,17 +24,40 @@ vertical. Multi-replica / prod auth remain later slices.
 | `GET /internal/solana/mmr-proof?encrypted_value=<base58>&leaf_index=<u64>` | Verified MMR proof |
 | `GET /swagger-ui` / `GET /api-docs/openapi.json` | Generated OpenAPI |
 
-Success proof DTO (preserved until #1721):
+Success proof DTO:
 
 ```json
 {
   "mmr_proof": { "leaf_index": 0, "siblings": ["<hex>", "..."] },
   "leaf_count": 1,
-  "proof_slot": 1,
+  "rpc_context_slot": 1234,
+  "lineage_last_slot": 1230,
+  "commitment": "confirmed",
+  "proof_format_version": "v1",
   "verified": true,
   "status": "verified"
 }
 ```
+
+Chain-context fields bind the served proof to observed state so a consumer can
+reason about staleness when the store and the RPC provider see different
+confirmed tips:
+
+- `leaf_count` — lineage leaf count the proof was built against.
+- `rpc_context_slot` — confirmed Solana RPC context slot of the on-chain peak
+  comparison that produced `verified`.
+- `lineage_last_slot` — per-lineage durable ingest slot at which this lineage's
+  served leaves were last written (`solana_proof_lineages.last_slot`). Omitted
+  when no snapshot backed the response (store has not ingested the lineage yet).
+  This is deliberately distinct from the store's GLOBAL durable ingest checkpoint
+  (`solana_proof_progress.checkpoint_slot`); surfacing that global checkpoint on
+  the proof DTO remains a possible follow-up.
+- `commitment` — commitment level of the on-chain authorization reads.
+- `proof_format_version` — response wire-format marker (`v1`).
+
+The `lagging` (503) and `corrupt_cache` (500) envelopes reuse this shape and
+carry `leaf_count` + `rpc_context_slot` (the two tips being compared);
+`lineage_last_slot` appears only when a snapshot was in hand.
 
 The proof path is **read-only**: SQL `proof_snapshot` + confirmed on-chain peak
 check; no request-triggered catch-up writer.
@@ -43,8 +66,7 @@ Invalid `leaf_index` (≥ on-chain `leaf_count`) → HTTP 400 with typed
 `ErrorResponse` (`code: leaf_index_out_of_range`). Lagging store (behind **or
 briefly ahead of** a different confirmed RPC) → HTTP 503 with
 `status: "lagging"`. Equal-count peak divergence or snapshot inconsistency →
-HTTP 500 with `status: "corrupt_cache"` (fail closed; wire name preserved for
-relayer DTO parity until #1721). Other client/server failures use the same
+HTTP 500 with `status: "corrupt_cache"` (fail closed). Other client/server failures use the same
 `ErrorResponse` JSON envelope. Proof routes get an `x-request-id`, a 30s typed
 timeout (`code: timeout`), and a shed-on-saturate concurrency limit sized to
 `max_connections - 2` so ingest and readiness keep reserved DB pool slots

--- a/solana-proof-service/crates/solana-proof-service/src/chain.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/chain.rs
@@ -13,7 +13,10 @@ use async_trait::async_trait;
 use base64::Engine;
 use serde_json::json;
 
-const SOLANA_PROOF_COMMITMENT: &str = "confirmed";
+/// Commitment level of the on-chain authorization reads (peak comparison).
+/// Surfaced on proof responses so a consumer knows which confirmed tip the
+/// served proof was validated against.
+pub const SOLANA_PROOF_COMMITMENT: &str = "confirmed";
 const EXPECTED_DATA_ENCODING: &str = "base64";
 
 #[derive(thiserror::Error, Debug)]
@@ -33,6 +36,9 @@ pub enum ChainError {
 pub struct OnChainLineageState {
     pub peaks: Vec<[u8; 32]>,
     pub leaf_count: u64,
+    /// Solana RPC context slot from the `getAccountInfo` response that produced
+    /// this read — the confirmed tip the peak comparison was made against.
+    pub rpc_context_slot: u64,
 }
 
 #[async_trait]
@@ -125,6 +131,7 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, String> {
 fn parse_account_value(
     value: &serde_json::Value,
     expected_program_id: &[u8; 32],
+    rpc_context_slot: u64,
 ) -> Result<OnChainLineageState, ChainError> {
     let owner = value
         .get("owner")
@@ -168,7 +175,21 @@ fn parse_account_value(
     Ok(OnChainLineageState {
         peaks: decoded.peaks,
         leaf_count: decoded.leaf_count,
+        rpc_context_slot,
     })
+}
+
+/// The confirmed slot the RPC node evaluated `getAccountInfo` at. Required:
+/// binding the served proof to a chain tip is the point of the read, so a
+/// response without it is malformed rather than defaulted.
+fn parse_context_slot(result: &serde_json::Value) -> Result<u64, ChainError> {
+    result
+        .get("context")
+        .and_then(|context| context.get("slot"))
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            ChainError::Rpc("malformed getAccountInfo result: missing context slot".to_string())
+        })
 }
 
 /// Interprets `getAccountInfo` `result`: only explicit `"value": null` means absent.
@@ -179,12 +200,17 @@ fn lineage_from_rpc_result(
     if result.is_null() {
         return Err(ChainError::Rpc("null getAccountInfo result".to_string()));
     }
+    let rpc_context_slot = parse_context_slot(result)?;
     match result.get("value") {
         None => Err(ChainError::Rpc(
             "malformed getAccountInfo result: missing value field".to_string(),
         )),
         Some(value) if value.is_null() => Ok(None),
-        Some(value) => Ok(Some(parse_account_value(value, expected_program_id)?)),
+        Some(value) => Ok(Some(parse_account_value(
+            value,
+            expected_program_id,
+            rpc_context_slot,
+        )?)),
     }
 }
 
@@ -267,7 +293,7 @@ mod tests {
         let owner = base58_encode(&program_id());
         let payload = base64::engine::general_purpose::STANDARD.encode(minimal_account_body());
         let value = account_json(&owner, &payload, "base58");
-        let err = parse_account_value(&value, &program_id()).unwrap_err();
+        let err = parse_account_value(&value, &program_id(), 4242).unwrap_err();
         assert!(matches!(err, ChainError::Encoding(_)));
         assert!(err.to_string().contains("unexpected account encoding"));
     }
@@ -276,7 +302,7 @@ mod tests {
     fn parse_rejects_malformed_base64_payload() {
         let owner = base58_encode(&program_id());
         let value = account_json(&owner, "not-base64!!!", "base64");
-        let err = parse_account_value(&value, &program_id()).unwrap_err();
+        let err = parse_account_value(&value, &program_id(), 4242).unwrap_err();
         assert!(matches!(err, ChainError::Encoding(_)));
     }
 
@@ -288,7 +314,7 @@ mod tests {
             &payload,
             "base64",
         );
-        let err = parse_account_value(&value, &program_id()).unwrap_err();
+        let err = parse_account_value(&value, &program_id(), 4242).unwrap_err();
         assert!(matches!(err, ChainError::WrongOwner { .. }));
     }
 
@@ -299,7 +325,7 @@ mod tests {
             "owner": owner,
             "data": "aGVsbG8=",
         });
-        let err = parse_account_value(&value, &program_id()).unwrap_err();
+        let err = parse_account_value(&value, &program_id(), 4242).unwrap_err();
         assert!(matches!(err, ChainError::Encoding(_)));
     }
 
@@ -308,9 +334,34 @@ mod tests {
         let owner = base58_encode(&program_id());
         let payload = base64::engine::general_purpose::STANDARD.encode(minimal_account_body());
         let value = account_json(&owner, &payload, "base64");
-        let state = parse_account_value(&value, &program_id()).unwrap();
+        let state = parse_account_value(&value, &program_id(), 4242).unwrap();
         assert_eq!(state.leaf_count, 0);
         assert!(state.peaks.is_empty());
+        assert_eq!(state.rpc_context_slot, 4242);
+    }
+
+    #[test]
+    fn valid_account_threads_rpc_context_slot() {
+        let owner = base58_encode(&program_id());
+        let payload = base64::engine::general_purpose::STANDARD.encode(minimal_account_body());
+        let result = json!({
+            "context": { "slot": 918_273 },
+            "value": account_json(&owner, &payload, "base64"),
+        });
+        let state = lineage_from_rpc_result(&result, &program_id())
+            .unwrap()
+            .expect("account present");
+        assert_eq!(state.rpc_context_slot, 918_273);
+    }
+
+    #[test]
+    fn missing_context_slot_is_malformed_rpc() {
+        let owner = base58_encode(&program_id());
+        let payload = base64::engine::general_purpose::STANDARD.encode(minimal_account_body());
+        let result = json!({ "value": account_json(&owner, &payload, "base64") });
+        let err = lineage_from_rpc_result(&result, &program_id()).unwrap_err();
+        assert!(matches!(err, ChainError::Rpc(_)));
+        assert!(err.to_string().contains("missing context slot"));
     }
 
     #[test]
@@ -320,7 +371,7 @@ mod tests {
         raw[0] ^= 0xff;
         let payload = base64::engine::general_purpose::STANDARD.encode(raw);
         let value = account_json(&owner, &payload, "base64");
-        let err = parse_account_value(&value, &program_id()).unwrap_err();
+        let err = parse_account_value(&value, &program_id(), 4242).unwrap_err();
         assert!(matches!(err, ChainError::Encoding(_)));
     }
 

--- a/solana-proof-service/crates/solana-proof-service/src/http.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/http.rs
@@ -28,6 +28,10 @@ use crate::readiness::{evaluate_readiness, ReadinessClass, ReadinessQueryable, R
 /// Hard ceiling for a single proof HTTP request (includes RPC peak check).
 const PROOF_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Proof response wire-format marker. Bump on a breaking DTO change; there is no
+/// negotiation machinery in this PoC — consumers assert the version they expect.
+const PROOF_FORMAT_VERSION: &str = "v1";
+
 /// Shared application state. Generic over the chain fetcher and snapshot source
 /// so handler tests can inject fakes without a live RPC node or Postgres.
 pub struct AppState<C: ChainFetcher, S: ProofSnapshotSource> {
@@ -65,8 +69,18 @@ impl From<&zama_solana_acl::mmr::MmrProof> for MmrProofDto {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct MmrProofResponse {
     pub mmr_proof: Option<MmrProofDto>,
+    /// Lineage leaf count the proof was built against.
     pub leaf_count: u64,
-    pub proof_slot: u64,
+    /// Confirmed Solana RPC context slot of the on-chain peak comparison.
+    pub rpc_context_slot: u64,
+    /// Durable ingest slot at which this lineage's served leaves were last written.
+    /// Omitted when no snapshot backed the response (e.g. store not yet ingested).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lineage_last_slot: Option<u64>,
+    /// Commitment level of the on-chain authorization reads.
+    pub commitment: &'static str,
+    /// Proof response wire-format version.
+    pub proof_format_version: &'static str,
     pub verified: bool,
     pub status: &'static str,
 }
@@ -111,29 +125,42 @@ pub enum HttpError {
 impl IntoResponse for HttpError {
     fn into_response(self) -> Response {
         match self {
-            HttpError::Proof(ProofError::Lagging { leaf_count }) => {
+            HttpError::Proof(ProofError::Lagging {
+                leaf_count,
+                rpc_context_slot,
+                lineage_last_slot,
+            }) => {
                 metrics::record_proof("lagging");
                 (
                     StatusCode::SERVICE_UNAVAILABLE,
                     Json(MmrProofResponse {
                         mmr_proof: None,
                         leaf_count,
-                        proof_slot: leaf_count,
+                        rpc_context_slot,
+                        lineage_last_slot,
+                        commitment: crate::chain::SOLANA_PROOF_COMMITMENT,
+                        proof_format_version: PROOF_FORMAT_VERSION,
                         verified: false,
                         status: "lagging",
                     }),
                 )
                     .into_response()
             }
-            HttpError::Proof(ProofError::CorruptStore { leaf_count }) => {
-                // Wire name preserved for relayer DTO parity until #1721.
+            HttpError::Proof(ProofError::CorruptStore {
+                leaf_count,
+                rpc_context_slot,
+                lineage_last_slot,
+            }) => {
                 metrics::record_proof("corrupt_cache");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(MmrProofResponse {
                         mmr_proof: None,
                         leaf_count,
-                        proof_slot: leaf_count,
+                        rpc_context_slot,
+                        lineage_last_slot,
+                        commitment: crate::chain::SOLANA_PROOF_COMMITMENT,
+                        proof_format_version: PROOF_FORMAT_VERSION,
                         verified: false,
                         status: "corrupt_cache",
                     }),
@@ -234,7 +261,10 @@ pub async fn mmr_proof_handler<C: ChainFetcher, S: ProofSnapshotSource>(
     Ok(Json(MmrProofResponse {
         mmr_proof: result.mmr_proof.as_ref().map(MmrProofDto::from),
         leaf_count: result.leaf_count,
-        proof_slot: result.proof_slot,
+        rpc_context_slot: result.rpc_context_slot,
+        lineage_last_slot: result.lineage_last_slot,
+        commitment: crate::chain::SOLANA_PROOF_COMMITMENT,
+        proof_format_version: PROOF_FORMAT_VERSION,
         verified: result.verified,
         status: "verified",
     }))
@@ -566,7 +596,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 4242,
+            },
+        );
         let store = FakeStore::new();
         store.insert(snapshot_with_leaves(lineage, vec![leaf]));
 
@@ -585,7 +622,12 @@ mod tests {
         assert_eq!(json["status"], "verified");
         assert_eq!(json["verified"], true);
         assert_eq!(json["leaf_count"], 1);
-        assert_eq!(json["proof_slot"], 1);
+        assert_eq!(json["rpc_context_slot"], 4242);
+        // snapshot_with_leaves pins last_slot = 1.
+        assert_eq!(json["lineage_last_slot"], 1);
+        assert_eq!(json["commitment"], "confirmed");
+        assert_eq!(json["proof_format_version"], "v1");
+        assert!(json.get("proof_slot").is_none());
         assert!(json["mmr_proof"].is_object());
     }
 
@@ -600,7 +642,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf1).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 4242,
+            },
+        );
         let store = FakeStore::new();
         store.insert(snapshot_with_leaves(lineage, vec![leaf0]));
 
@@ -632,7 +681,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, other).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 4242,
+            },
+        );
         let store = FakeStore::new();
         store.insert(snapshot_with_leaves(lineage, vec![leaf]));
 
@@ -663,7 +719,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 4242,
+            },
+        );
         let store = FakeStore::new();
         store.mark_inconsistent(lineage, 1, 0);
 
@@ -715,7 +778,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 4242,
+            },
+        );
         let store = FakeStore::new();
         store.insert(snapshot_with_leaves(lineage, vec![leaf]));
 
@@ -745,7 +815,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 4242,
+            },
+        );
         let store = FakeStore::new();
         store.insert(snapshot_with_leaves(lineage, vec![leaf]));
 
@@ -767,22 +844,39 @@ mod tests {
 
     #[tokio::test]
     async fn lagging_maps_to_503_json_body() {
-        let response = HttpError::Proof(ProofError::Lagging { leaf_count: 3 }).into_response();
+        let response = HttpError::Proof(ProofError::Lagging {
+            leaf_count: 3,
+            rpc_context_slot: 77,
+            lineage_last_slot: Some(9),
+        })
+        .into_response();
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = json_body(response).await;
         assert_eq!(body["status"], "lagging");
         assert_eq!(body["verified"], false);
         assert_eq!(body["leaf_count"], 3);
+        assert_eq!(body["rpc_context_slot"], 77);
+        assert_eq!(body["lineage_last_slot"], 9);
+        assert_eq!(body["commitment"], "confirmed");
+        assert_eq!(body["proof_format_version"], "v1");
     }
 
     #[tokio::test]
     async fn corrupt_store_maps_to_500_corrupt_cache_json_body() {
-        let response = HttpError::Proof(ProofError::CorruptStore { leaf_count: 3 }).into_response();
+        let response = HttpError::Proof(ProofError::CorruptStore {
+            leaf_count: 3,
+            rpc_context_slot: 77,
+            lineage_last_slot: None,
+        })
+        .into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         let body = json_body(response).await;
         assert_eq!(body["status"], "corrupt_cache");
         assert_eq!(body["verified"], false);
         assert_eq!(body["leaf_count"], 3);
+        assert_eq!(body["rpc_context_slot"], 77);
+        // lineage_last_slot omitted when no snapshot backed the error.
+        assert!(body.get("lineage_last_slot").is_none());
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-service/src/proof.rs
+++ b/solana-proof-service/crates/solana-proof-service/src/proof.rs
@@ -26,9 +26,13 @@ impl ProofSnapshotSource for SqlProofStore {
 #[derive(Debug, Clone, PartialEq)]
 pub struct MmrProofResult {
     pub mmr_proof: Option<MmrProof>,
+    /// Lineage leaf count the proof was built against (matches the confirmed chain read).
     pub leaf_count: u64,
-    /// Backwards-compatible wire name for the lineage `leaf_count` the proof was built against.
-    pub proof_slot: u64,
+    /// Confirmed RPC context slot of the on-chain peak comparison that produced `verified`.
+    pub rpc_context_slot: u64,
+    /// Durable ingest slot at which this lineage's served leaves were last written
+    /// (`solana_proof_lineages.last_slot`). `None` when no snapshot backed the result.
+    pub lineage_last_slot: Option<u64>,
     pub verified: bool,
 }
 
@@ -41,11 +45,19 @@ pub enum ProofError {
     #[error("no on-chain account found for lineage")]
     LineageNotFound,
     #[error("lineage proof data is lagging chain state (leaf_count {leaf_count})")]
-    Lagging { leaf_count: u64 },
+    Lagging {
+        leaf_count: u64,
+        rpc_context_slot: u64,
+        lineage_last_slot: Option<u64>,
+    },
     #[error(
         "lineage proof store diverged from chain (leaf_count {leaf_count}); integrity rebuild required"
     )]
-    CorruptStore { leaf_count: u64 },
+    CorruptStore {
+        leaf_count: u64,
+        rpc_context_slot: u64,
+        lineage_last_slot: Option<u64>,
+    },
     #[error("leaf index {leaf_index} out of range for leaf_count {leaf_count}")]
     LeafIndexOutOfRange { leaf_index: u64, leaf_count: u64 },
 }
@@ -75,17 +87,23 @@ pub async fn build_proof<C: ChainFetcher, S: ProofSnapshotSource>(
     let snapshot = match store.proof_snapshot(lineage).await {
         Ok(snapshot) => snapshot,
         Err(StoreError::SnapshotInconsistent { .. }) => {
-            // Fail closed with the same wire envelope as peak divergence.
+            // Fail closed with the same wire envelope as peak divergence. The torn
+            // snapshot never surfaced a durable slot, so there is no checkpoint to report.
             return Err(ProofError::CorruptStore {
                 leaf_count: on_chain.leaf_count,
+                rpc_context_slot: on_chain.rpc_context_slot,
+                lineage_last_slot: None,
             });
         }
         Err(err) => return Err(ProofError::Store(err)),
     };
     let Some(snapshot) = snapshot else {
-        // Chain has the lineage but the store has not ingested it yet.
+        // Chain has the lineage but the store has not ingested it yet, so this
+        // lineage has no durable slot to report.
         return Err(ProofError::Lagging {
             leaf_count: on_chain.leaf_count,
+            rpc_context_slot: on_chain.rpc_context_slot,
+            lineage_last_slot: None,
         });
     };
 
@@ -97,11 +115,16 @@ fn try_build_from_snapshot(
     on_chain: &OnChainLineageState,
     leaf_index: u64,
 ) -> Result<MmrProofResult, ProofError> {
+    // The snapshot is in hand, so its durable slot is the honest checkpoint for
+    // every result (success or divergence) built from it.
+    let lineage_last_slot = Some(snapshot.last_slot);
     // Internal consistency: recomputed peaks must match the persisted peaks.
     let recomputed = mmr_peaks_from_leaves(&snapshot.leaves);
     if recomputed != snapshot.peaks || snapshot.leaf_count != snapshot.leaves.len() as u64 {
         return Err(ProofError::CorruptStore {
             leaf_count: on_chain.leaf_count,
+            rpc_context_slot: on_chain.rpc_context_slot,
+            lineage_last_slot,
         });
     }
 
@@ -109,6 +132,8 @@ fn try_build_from_snapshot(
         std::cmp::Ordering::Less => {
             return Err(ProofError::Lagging {
                 leaf_count: on_chain.leaf_count,
+                rpc_context_slot: on_chain.rpc_context_slot,
+                lineage_last_slot,
             });
         }
         std::cmp::Ordering::Greater => {
@@ -116,6 +141,8 @@ fn try_build_from_snapshot(
             // Treat as retryable lag, not integrity failure.
             return Err(ProofError::Lagging {
                 leaf_count: on_chain.leaf_count,
+                rpc_context_slot: on_chain.rpc_context_slot,
+                lineage_last_slot,
             });
         }
         std::cmp::Ordering::Equal => {}
@@ -124,6 +151,8 @@ fn try_build_from_snapshot(
     if snapshot.peaks != on_chain.peaks {
         return Err(ProofError::CorruptStore {
             leaf_count: on_chain.leaf_count,
+            rpc_context_slot: on_chain.rpc_context_slot,
+            lineage_last_slot,
         });
     }
 
@@ -136,7 +165,8 @@ fn try_build_from_snapshot(
     Ok(MmrProofResult {
         mmr_proof: Some(proof),
         leaf_count: on_chain.leaf_count,
-        proof_slot: on_chain.leaf_count,
+        rpc_context_slot: on_chain.rpc_context_slot,
+        lineage_last_slot,
         verified: true,
     })
 }
@@ -257,10 +287,17 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let snapshot = snapshot_with_leaves(lineage, vec![leaf]);
-        let on_chain = OnChainLineageState { peaks, leaf_count };
+        let on_chain = OnChainLineageState {
+            peaks,
+            leaf_count,
+            rpc_context_slot: 55,
+        };
         let result = try_build_from_snapshot(&snapshot, &on_chain, 0).unwrap();
         assert!(result.verified);
         assert_eq!(result.leaf_count, 1);
+        assert_eq!(result.rpc_context_slot, 55);
+        // snapshot_with_leaves pins last_slot = 1.
+        assert_eq!(result.lineage_last_slot, Some(1));
         assert!(result.mmr_proof.is_some());
     }
 
@@ -273,7 +310,14 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 55,
+            },
+        );
         let store = FakeStore::new();
 
         let err = build_proof(&chain, &store, lineage, 100).await.unwrap_err();
@@ -299,9 +343,13 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf1).unwrap();
 
         let snapshot = snapshot_with_leaves(lineage, vec![leaf0]);
-        let on_chain = OnChainLineageState { peaks, leaf_count };
+        let on_chain = OnChainLineageState {
+            peaks,
+            leaf_count,
+            rpc_context_slot: 55,
+        };
         let err = try_build_from_snapshot(&snapshot, &on_chain, 0).unwrap_err();
-        assert!(matches!(err, ProofError::Lagging { leaf_count: 2 }));
+        assert!(matches!(err, ProofError::Lagging { leaf_count: 2, .. }));
     }
 
     #[test]
@@ -322,9 +370,10 @@ mod tests {
         let on_chain = OnChainLineageState {
             peaks: chain_peaks,
             leaf_count: chain_count,
+            rpc_context_slot: 55,
         };
         let err = try_build_from_snapshot(&snapshot, &on_chain, 0).unwrap_err();
-        assert!(matches!(err, ProofError::Lagging { leaf_count: 1 }));
+        assert!(matches!(err, ProofError::Lagging { leaf_count: 1, .. }));
     }
 
     #[test]
@@ -337,9 +386,16 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, other).unwrap();
 
         let snapshot = snapshot_with_leaves(lineage, vec![leaf]);
-        let on_chain = OnChainLineageState { peaks, leaf_count };
+        let on_chain = OnChainLineageState {
+            peaks,
+            leaf_count,
+            rpc_context_slot: 55,
+        };
         let err = try_build_from_snapshot(&snapshot, &on_chain, 0).unwrap_err();
-        assert!(matches!(err, ProofError::CorruptStore { leaf_count: 1 }));
+        assert!(matches!(
+            err,
+            ProofError::CorruptStore { leaf_count: 1, .. }
+        ));
     }
 
     #[test]
@@ -355,9 +411,13 @@ mod tests {
         let on_chain = OnChainLineageState {
             peaks: peaks.clone(),
             leaf_count,
+            rpc_context_slot: 55,
         };
         let err = try_build_from_snapshot(&snapshot, &on_chain, 0).unwrap_err();
-        assert!(matches!(err, ProofError::CorruptStore { leaf_count: 1 }));
+        assert!(matches!(
+            err,
+            ProofError::CorruptStore { leaf_count: 1, .. }
+        ));
     }
 
     #[tokio::test]
@@ -369,12 +429,22 @@ mod tests {
         mmr_append(&mut peaks, &mut leaf_count, leaf).unwrap();
 
         let chain = FakeChain::new();
-        chain.set(lineage, OnChainLineageState { peaks, leaf_count });
+        chain.set(
+            lineage,
+            OnChainLineageState {
+                peaks,
+                leaf_count,
+                rpc_context_slot: 55,
+            },
+        );
         let store = FakeStore::new();
         store.mark_inconsistent(lineage, 1, 0);
 
         let err = build_proof(&chain, &store, lineage, 0).await.unwrap_err();
-        assert!(matches!(err, ProofError::CorruptStore { leaf_count: 1 }));
+        assert!(matches!(
+            err,
+            ProofError::CorruptStore { leaf_count: 1, .. }
+        ));
         assert_eq!(store.reads.load(Ordering::SeqCst), 1);
         assert_eq!(chain.fetches.load(Ordering::SeqCst), 1);
     }
@@ -393,6 +463,7 @@ mod tests {
             OnChainLineageState {
                 peaks: peaks.clone(),
                 leaf_count,
+                rpc_context_slot: 55,
             },
         );
         let store = FakeStore::new();

--- a/solana/scripts/e2e/live-client/main.rs
+++ b/solana/scripts/e2e/live-client/main.rs
@@ -765,13 +765,13 @@ fn proof_service_url() -> String {
     std::env::var("PROOF_SERVICE_URL").unwrap_or_else(|_| "http://127.0.0.1:8088".to_string())
 }
 
-/// JSON mirror of `solana_proof_service::http::MmrProofResponse` (DTO preserved until #1721).
+/// JSON mirror of `solana_proof_service::http::MmrProofResponse`. Only the fields
+/// this client consumes are declared; the response also carries `rpc_context_slot`,
+/// `lineage_last_slot`, `commitment`, and `proof_format_version` (ignored here).
 #[derive(Deserialize)]
 struct ProofServiceMmrProofResponse {
     mmr_proof: Option<ProofServiceMmrProofDto>,
     leaf_count: u64,
-    #[allow(dead_code)]
-    proof_slot: u64,
     verified: bool,
     status: String,
 }
@@ -2763,7 +2763,7 @@ mod tests {
 
     #[test]
     fn retries_only_structured_lagging_response() {
-        let lagging = br#"{"mmr_proof":null,"leaf_count":7,"proof_slot":42,"verified":false,"status":"lagging"}"#;
+        let lagging = br#"{"mmr_proof":null,"leaf_count":7,"rpc_context_slot":42,"commitment":"confirmed","proof_format_version":"v1","verified":false,"status":"lagging"}"#;
         let lagging_error = proof_service_http_error(503, lagging);
         assert_eq!(
             lagging_error,
@@ -2771,7 +2771,7 @@ mod tests {
         );
         assert!(is_proof_service_lagging(&lagging_error));
 
-        let wrong_status = br#"{"mmr_proof":null,"leaf_count":7,"proof_slot":42,"verified":false,"status":"corrupt_cache"}"#;
+        let wrong_status = br#"{"mmr_proof":null,"leaf_count":7,"rpc_context_slot":42,"commitment":"confirmed","proof_format_version":"v1","verified":false,"status":"corrupt_cache"}"#;
         let fatal_error = proof_service_http_error(503, wrong_status);
         assert_eq!(
             fatal_error,


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1828. From the proof-service architecture review (2026-07-22): the historical proof DTO called a leaf count `proof_slot` (the error paths literally set `proof_slot: leaf_count`), and responses carried no chain context, leaving served proofs ambiguous when the store and the RPC provider observe different confirmed tips.

## WHAT

`MmrProofResponse` drops `proof_slot` entirely (POC branch — no compat alias) and gains honest chain context:

| Field | Source (threaded, never re-read in the HTTP layer) |
|---|---|
| `leaf_count` | unchanged — the lineage leaf count, now the only field carrying it |
| `rpc_context_slot` | `result.context.slot` of the SAME `getAccountInfo` read whose peaks feed the `verified` comparison |
| `lineage_last_slot` (optional) | `solana_proof_lineages.last_slot` — the durable block slot at which this lineage's served leaves/peaks were last written; omitted on the two pre-snapshot failure paths where no durable slot exists |
| `commitment` | `SOLANA_PROOF_COMMITMENT` — the same constant used in the actual RPC request params, so response and read cannot drift |
| `proof_format_version` | `"v1"` marker, no negotiation machinery |

`lagging` (503) and `corrupt_cache` (500) carry the same context (they occur after the chain read — they ARE the store-vs-RPC-tip mismatch cases); errors that fire before any chain read get no fabricated context. The e2e live-client mirror and fixtures updated; its lagging-retry behavior unchanged.

Deliberately named `lineage_last_slot`, not `checkpoint_slot`: the store already owns that term for the GLOBAL ingest checkpoint (`solana_proof_progress.checkpoint_slot`). Surfacing the global checkpoint at the proof-snapshot boundary would require a sqlx offline-metadata regeneration (needs a live DB) and is noted in the README as a possible follow-up.

Scope boundary held: the user-decrypt extraData transport blob and its `proofSlot` naming (decrypt-spec route, fhevm-internal#1689) are untouched, as is the SDK.

## Test plan

- [x] `make check && make fmt && make clippy && make test` from `solana-proof-service/` — service 60/60, store 41, source 27 (DB-gated integration tests `ignored`, as in CI without DATABASE_URL)
- [x] live client: `NO_DNA=1 cargo check --tests` + `NO_DNA=1 cargo test` (2/2)
- [x] Independent adversarial review: provenance audit on every new field (all traced to true origins, no fabrication), scope/blast-radius check, README/consumer parity — APPROVE-WITH-NITS; the one P2 (naming collision) folded in
- [x] Full e2e vertical: not runnable locally; covered by the `solana-e2e` job on this PR