### PR TITLE
fix(test-suite): resolve sha baselines against published image tags (backport 0.14.x)

### DIFF
--- a/test-suite/fhevm/src/resolve.test.ts
+++ b/test-suite/fhevm/src/resolve.test.ts
@@ -12,10 +12,13 @@ import {
   shouldStopPackageTagScan,
 } from "./resolve/github";
 import {
+  MAX_FALLBACK_COMMIT_DEPTH,
   SIMPLE_ACL_MIN_SHA,
   SHA_RUNTIME_COMPAT_MIN_SHA,
   applyVersionEnvOverrides,
+  findPublishedAncestorIndex,
   presetBundle,
+  resolveMissingRepoTagFallbacks,
   shaRuntimeCompatFloor,
   simpleAclFloor,
 } from "./resolve/target";
@@ -49,6 +52,76 @@ describe("resolve", () => {
     expect(bundle.env.RELAYER_VERSION).toBe("abcdef0");
     expect(bundle.env.RELAYER_MIGRATE_VERSION).toBe("abcdef0");
     expect(bundle.env.CORE_VERSION).not.toBe("abcdef0");
+  });
+
+  test("finds the nearest ancestor with a published image tag", () => {
+    const commits = [
+      "d77a0417aa5d928063181454756ebb73cdbadc24",
+      "2cde6c960c24405015ab03959a2d9053cde31f23",
+      "8e2f724d4000000000000000000000000000000",
+    ];
+    expect(findPublishedAncestorIndex(commits, new Set(["2cde6c9", "8e2f724"]))).toBe(1);
+    expect(findPublishedAncestorIndex(commits, new Set(["fffffff"]))).toBe(-1);
+    expect(findPublishedAncestorIndex([], new Set(["2cde6c9"]))).toBe(-1);
+  });
+
+  test("falls back to the newest published ancestor tag for missing images", () => {
+    const { overrides, sources } = resolveMissingRepoTagFallbacks({
+      requestedTag: "d77a041",
+      missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+      commitShas: ["d77a0417aa5d928063181454756ebb73cdbadc24", "2cde6c960c24405015ab03959a2d9053cde31f23"],
+      packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set(["2cde6c9"]) },
+    });
+    expect(overrides).toEqual({ CONNECTOR_GW_LISTENER_VERSION: "2cde6c9" });
+    expect(sources).toEqual(["CONNECTOR_GW_LISTENER_VERSION=2cde6c9 (fallback: d77a041 unpublished)"]);
+  });
+
+  test("fails resolution when the newest published image lags beyond the fallback limit", () => {
+    const commits = Array.from(
+      { length: MAX_FALLBACK_COMMIT_DEPTH + 2 },
+      (_, index) => index.toString(16).padEnd(40, "f"),
+    );
+    expect(() =>
+      resolveMissingRepoTagFallbacks({
+        requestedTag: commits[0].slice(0, 7),
+        missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+        commitShas: commits,
+        packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set([commits.at(-1)!.slice(0, 7)]) },
+      }),
+    ).toThrow("beyond the 50-commit fallback limit");
+  });
+
+  test("keeps the unverified pin when the package has no visible published tags", () => {
+    const { overrides, sources } = resolveMissingRepoTagFallbacks({
+      requestedTag: "d77a041",
+      missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+      commitShas: ["d77a0417aa5d928063181454756ebb73cdbadc24"],
+      packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set<string>() },
+    });
+    expect(overrides).toEqual({});
+    expect(sources).toEqual([
+      "CONNECTOR_GW_LISTENER_VERSION=d77a041 (unverified: package has no visible published tags)",
+    ]);
+  });
+
+  test("fails resolution when a published package has no tag anywhere on the ancestry", () => {
+    expect(() =>
+      resolveMissingRepoTagFallbacks({
+        requestedTag: "d77a041",
+        missingKeys: ["CONNECTOR_GW_LISTENER_VERSION"],
+        commitShas: ["d77a0417aa5d928063181454756ebb73cdbadc24"],
+        packageTagsMap: { CONNECTOR_GW_LISTENER_VERSION: new Set(["0000000"]) },
+      }),
+    ).toThrow("nor for any of the 1 commits behind it");
+  });
+
+  test("applies per-component fallback overrides to a sha preset bundle", () => {
+    const bundle = presetBundle("sha", "d77a041", "sha-d77a041.json", [], {
+      CONNECTOR_GW_LISTENER_VERSION: "2cde6c9",
+    });
+    expect(bundle.env.CONNECTOR_GW_LISTENER_VERSION).toBe("2cde6c9");
+    expect(bundle.env.CONNECTOR_TX_SENDER_VERSION).toBe("d77a041");
+    expect(bundle.env.COPROCESSOR_HOST_LISTENER_VERSION).toBe("d77a041");
   });
 
   test("only caches immutable sha targets", () => {

--- a/test-suite/fhevm/src/resolve/github.ts
+++ b/test-suite/fhevm/src/resolve/github.ts
@@ -170,11 +170,14 @@ export const shouldStopPackageTagScan = (
   targetTag?: string,
 ) => (targetTag && tags.has(targetTag)) || payload.length < 100;
 
-/** Returns recent main-branch commit SHAs for fhevm. */
-export const mainCommits = async (limit = 200) => {
-  const commits = await ghPages<{ sha: string }>(`repos/${FHEVM_REPO}/commits?sha=main`, limit);
+/** Returns recent fhevm commit SHAs reachable from a ref (branch, tag, or sha), newest first. */
+export const commitsFrom = async (ref: string, limit = 200) => {
+  const commits = await ghPages<{ sha: string }>(`repos/${FHEVM_REPO}/commits?sha=${ref}`, limit);
   return commits.map((item) => item.sha);
 };
+
+/** Returns recent main-branch commit SHAs for fhevm. */
+export const mainCommits = async (limit = 200) => commitsFrom("main", limit);
 
 /** Returns the published tag set for one GHCR package. */
 export const packageTags = async (pkg: string, targetTag?: string) => {

--- a/test-suite/fhevm/src/resolve/target.ts
+++ b/test-suite/fhevm/src/resolve/target.ts
@@ -11,7 +11,7 @@ import {
   MODERN_RELAYER_MIGRATE_IMAGE_REPOSITORY,
 } from "../compat/compat";
 import { GitHubApiError } from "../errors";
-import { gitopsFile, mainCommits, packageTags } from "./github";
+import { commitsFrom, gitopsFile, mainCommits, packageTags } from "./github";
 import { NON_NETWORK_COMPANIONS } from "./presets";
 import { LATEST_SUPPORTED_PROFILE } from "../layout";
 import type { VersionBundle, VersionTarget } from "../types";
@@ -104,6 +104,13 @@ const PACKAGE_REPOSITORY_CANDIDATES: Partial<Record<keyof typeof PACKAGE_TO_REPO
   RELAYER_MIGRATE_VERSION: [MODERN_RELAYER_MIGRATE_IMAGE_REPOSITORY, LEGACY_RELAYER_MIGRATE_IMAGE_REPOSITORY],
 };
 
+const SHA_FALLBACK_COMMIT_WINDOW = 500;
+// A missing tag from a flaked re-tag, an in-flight push pipeline, or an is-latest-commit skip
+// sits a handful of commits behind the requested sha (a merge train at most). A published image
+// lagging further than this means the component's publishing is genuinely broken, which a
+// fallback must not paper over.
+export const MAX_FALLBACK_COMMIT_DEPTH = 50;
+
 export const REPO_TAG = /^[0-9a-f]{7}$/;
 export const SHA_REF = /^(?:[0-9a-f]{7}|[0-9a-f]{40})$/i;
 export const SIMPLE_ACL_MIN_SHA = COMPAT_MATRIX.anchors.SIMPLE_ACL_MIN_SHA;
@@ -164,6 +171,64 @@ const findImageTag = (
 /** Normalizes a full SHA into the short tag form used by repo-owned images. */
 const shortSha = (value: string) => value.toLowerCase().slice(0, 7);
 
+/** Finds the position of the newest commit in an ancestry walk (newest first) that has a
+ * published image tag; -1 when none does. The position is the commit distance behind the walk's
+ * starting sha. */
+export const findPublishedAncestorIndex = (commitShas: string[], publishedTags: Set<string>) =>
+  commitShas.findIndex((sha) => publishedTags.has(shortSha(sha)));
+
+/**
+ * Resolves per-component fallback tags for repo-owned images with no published image at the
+ * requested sha.
+ *
+ * A missing tag is an exceptional state: on every push the docker-build workflows either build a
+ * changed component or re-tag the previous image with the new sha, so a gap means one of those
+ * jobs failed, has not finished, or was skipped for a superseded branch tip. Each affected
+ * component independently falls back to its newest published tag on the requested sha's
+ * ancestry, and the substitution is recorded in `sources`. A fallback deeper than
+ * MAX_FALLBACK_COMMIT_DEPTH fails resolution instead — that lag means the component's publishing
+ * is broken, not flaked.
+ */
+export const resolveMissingRepoTagFallbacks = (options: {
+  requestedTag: string;
+  missingKeys: string[];
+  commitShas: string[];
+  packageTagsMap: Record<string, Set<string>>;
+}): { overrides: Record<string, string>; sources: string[] } => {
+  const overrides: Record<string, string> = {};
+  const sources: string[] = [];
+  for (const key of options.missingKeys) {
+    const ancestorIndex = findPublishedAncestorIndex(options.commitShas, options.packageTagsMap[key] ?? new Set());
+    if (ancestorIndex < 0) {
+      // An empty tag set can mean the GitHub token simply cannot see the package (the versions
+      // API 404s on inaccessible packages), so the registry pull may still succeed with the
+      // runtime's own credentials; keep the pin and record that it is unverified.
+      if (!options.packageTagsMap[key]?.size) {
+        sources.push(`${key}=${options.requestedTag} (unverified: package has no visible published tags)`);
+        continue;
+      }
+      // A non-empty tag set with no tag anywhere on the ancestry proves the lock would be
+      // unpullable; failing here beats the guaranteed `manifest unknown` at e2e time.
+      throw new GitHubApiError(
+        `${key} has no published image for ${options.requestedTag} nor for any of the ` +
+          `${options.commitShas.length} commits behind it. Its docker builds look broken; fix or re-run them ` +
+          `before resolving this baseline, or pin ${key} explicitly to a published tag.`,
+      );
+    }
+    if (ancestorIndex > MAX_FALLBACK_COMMIT_DEPTH) {
+      throw new GitHubApiError(
+        `${key} has no published image for ${options.requestedTag}, and its newest published image is ` +
+          `${ancestorIndex} commits behind — beyond the ${MAX_FALLBACK_COMMIT_DEPTH}-commit fallback limit. ` +
+          `Its docker builds look broken rather than flaked; fix or re-run them before resolving this baseline.`,
+      );
+    }
+    const ancestor = shortSha(options.commitShas[ancestorIndex]);
+    overrides[key] = ancestor;
+    sources.push(`${key}=${ancestor} (fallback: ${options.requestedTag} unpublished)`);
+  }
+  return { overrides, sources };
+};
+
 /** Locates the simple-ACL support floor in fetched main history. */
 export const simpleAclFloor = (commits: string[]) => {
   const floor = commits.indexOf(SIMPLE_ACL_MIN_SHA);
@@ -192,13 +257,14 @@ export const presetBundle = (
   repoVersion: string,
   lockName: string,
   sources: string[] = [],
+  repoKeyOverrides?: Record<string, string>,
 ): VersionBundle => ({
   target,
   lockName,
   env: Object.fromEntries(
     Object.keys(PACKAGE_TO_REPOSITORY).map((key) => {
       const version = REPO_KEYS.has(key)
-        ? repoVersion
+        ? repoKeyOverrides?.[key] ?? repoVersion
         : NON_NETWORK_COMPANIONS[target][key as keyof (typeof NON_NETWORK_COMPANIONS)[typeof target]];
       if (!version) {
         throw new Error(`Missing ${target} preset for ${key}`);
@@ -317,7 +383,52 @@ export const resolveTarget = async (
       throw new GitHubApiError(`Invalid sha ${requested}; expected 7 or 40 hex characters`);
     }
     const tag = shortSha(requested);
-    return presetBundle(target, tag, `sha-${tag}.json`, [`requested-sha=${requested.toLowerCase()}`]);
+    const lockName = `sha-${tag}.json`;
+    const baseSources = [`requested-sha=${requested.toLowerCase()}`];
+
+    // The docker-build workflows re-tag unchanged components on every push, so normally every
+    // repo-owned image is published at the requested sha. Verify that instead of trusting it: a
+    // flaked re-tag or failed build otherwise only surfaces as `manifest unknown` at pull time.
+    let packageTagsMap: Record<string, Set<string>>;
+    try {
+      packageTagsMap = await repoPackageTags(tag);
+    } catch (error) {
+      // GitHub metadata is unavailable (offline, missing scopes): keep the historical unverified
+      // pin so `--target sha` still resolves, and record that the check was skipped.
+      const reason = error instanceof Error ? error.message.split("\n")[0] : String(error);
+      console.log(`[resolve] sha ${tag}: skipping published-image check (${reason})`);
+      return presetBundle(target, tag, lockName, [...baseSources, "published-image-check=skipped"]);
+    }
+    const missingKeys = Object.keys(REPO_PACKAGES).filter((key) => !packageTagsMap[key]?.has(tag));
+    if (!missingKeys.length) {
+      return presetBundle(target, tag, lockName, baseSources);
+    }
+    console.log(
+      `[resolve] sha ${tag}: no published image for ${missingKeys.join(", ")}; looking for published ancestor tags`,
+    );
+    // Unlike the tag fetch above, an ancestry failure here is not skippable: missingKeys proves
+    // the unverified pin would produce an unpullable lock, so resolution must not fall back to it.
+    let commitShas: string[];
+    try {
+      commitShas = await commitsFrom(requested, SHA_FALLBACK_COMMIT_WINDOW);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message.split("\n")[0] : String(error);
+      throw new GitHubApiError(
+        `${missingKeys.join(", ")} have no published image for ${tag}, and the ancestry lookup for ` +
+          `fallback tags failed (${reason}). Retry once GitHub is reachable, or pin the affected ` +
+          `versions explicitly.`,
+      );
+    }
+    const { overrides, sources } = resolveMissingRepoTagFallbacks({
+      requestedTag: tag,
+      missingKeys,
+      commitShas,
+      packageTagsMap,
+    });
+    for (const source of sources) {
+      console.log(`[resolve] ${source}`);
+    }
+    return presetBundle(target, tag, lockName, [...baseSources, ...sources], overrides);
   }
 
   const [packageTagsMap, commits] = await Promise.all([repoPackageTags(), mainCommits(5000)]);


### PR DESCRIPTION
Backport of #3285 (approved on main) to `release/0.14.x`.

Same fix, hand-adapted because the resolver drifted between branches: this branch has no `OPTIONAL_REPO_KEYS`/`publishedOptionalKeys` machinery, so `presetBundle` takes the per-component fallback overrides as its fifth parameter and the missing-key scan covers all repo-owned packages.

See #3285 for the full problem statement, design rationale, and trade-offs. Summary: `resolve --target sha` (used to generate orchestrated e2e baseline locks) now verifies each repo-owned image against published GHCR tags instead of blindly pinning the base sha; missing components independently fall back to their newest published ancestor tag (≤50 commits of lag, else resolution fails loudly), substitutions are recorded in lock `sources` and resolve logs, and provably-unpullable locks fail at resolve time instead of `manifest unknown` twenty minutes into e2e. This is the class of failure that broke Compat Smoke / e2e on `release/0.13.x` this week (missing `kms-connector/gw-listener:d77a041` after a flaked re-tag job).

Test plan: `bun run check` clean; `bun test src` 245/245 pass on this branch.