### PR TITLE
fix(solana-proof-service): retry RPC recovery with backoff instead of dying when the endpoint is unreachable

### DIFF
--- a/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
+++ b/solana-proof-service/crates/solana-proof-source/src/rpc_recovery.rs
@@ -71,16 +71,60 @@ pub struct RpcRecoveryConfig {
 
 #[derive(thiserror::Error, Clone, Debug, PartialEq, Eq)]
 pub enum RecoveryError {
+    /// Transport-layer failure reaching the RPC endpoint: connection refused,
+    /// DNS failure, connect/request timeout on `send()`, or a body that dropped
+    /// mid-read or exceeded the body timeout. The endpoint may simply not exist
+    /// yet (startup bring-up) or be flapping, so callers retry with backoff
+    /// rather than failing closed. Born only from a `reqwest` `send()`/body-read
+    /// error — never from a body the endpoint fully returned.
     #[error("RPC transport error: {0}")]
     Transport(String),
+    /// The endpoint responded but returned a JSON-RPC `error` object that is not
+    /// a known history-unavailable code. A reachable node rejecting the call is
+    /// a logical/protocol failure, not unreachability — fail closed.
+    #[error("RPC returned an error: {0}")]
+    RpcError(String),
     #[error("RPC history unavailable: {0}")]
     HistoryUnavailable(String),
+    /// A fully-read body that failed to parse, or a well-formed response missing
+    /// its `result` field: the node answered with garbage. Terminal.
     #[error("invalid RPC block or configuration: {0}")]
     Invalid(String),
     #[error("recovery cancelled")]
     Cancelled,
     #[error("recovery bound exhausted: {0}")]
     BoundExhausted(String),
+}
+
+/// Solana archive nodes signal pruned/absent history with these codes/messages.
+fn is_history_unavailable(message: &str) -> bool {
+    message.contains("Block cleaned up")
+        || message.contains("Block not available")
+        || message.contains("Slot skipped")
+        || message.contains("-32007")
+        || message.contains("-32009")
+}
+
+/// Interpret an already-parsed JSON-RPC response into its `result` field, or a
+/// typed error. Only reached once the body was fully read and parsed, so it
+/// never sees a transport failure.
+///
+/// A present `error` object means the endpoint is reachable but rejected the
+/// call: it is either typed history-unavailability or a logical
+/// [`RecoveryError::RpcError`] — never [`RecoveryError::Transport`], so a node
+/// that answers with an error is not mistaken for an unreachable endpoint.
+fn interpret_rpc_response(value: serde_json::Value) -> Result<serde_json::Value, RecoveryError> {
+    if let Some(error) = value.get("error") {
+        let message = error.to_string();
+        if is_history_unavailable(&message) {
+            return Err(RecoveryError::HistoryUnavailable(message));
+        }
+        return Err(RecoveryError::RpcError(message));
+    }
+    value
+        .get("result")
+        .cloned()
+        .ok_or_else(|| RecoveryError::Invalid("missing result field".to_owned()))
 }
 
 pub struct RpcRecoveryClient {
@@ -301,29 +345,21 @@ impl RpcRecoveryClient {
                 result.map_err(|err| RecoveryError::Transport(err.to_string()))?
             }
         };
-        let value: serde_json::Value = tokio::select! {
+        // Split the body read from the parse. `reqwest::Response::json` folds a
+        // dropped-mid-body / body-timeout failure into `is_decode()`, which would
+        // misclassify those transport conditions as terminal. Read raw bytes
+        // (any error here is transport/IO/timeout — retryable) then parse the
+        // buffered bytes (a parse error is a node that answered with garbage —
+        // terminal `Invalid`).
+        let bytes = tokio::select! {
             _ = cancel.cancelled() => return Err(RecoveryError::Cancelled),
-            result = response.json() => {
+            result = response.bytes() => {
                 result.map_err(|err| RecoveryError::Transport(err.to_string()))?
             }
         };
-        if let Some(error) = value.get("error") {
-            let message = error.to_string();
-            // Solana archive nodes often use -32007 / BlockCleanedUp / SlotSkipped.
-            if message.contains("Block cleaned up")
-                || message.contains("Block not available")
-                || message.contains("Slot skipped")
-                || message.contains("-32007")
-                || message.contains("-32009")
-            {
-                return Err(RecoveryError::HistoryUnavailable(message));
-            }
-            return Err(RecoveryError::Transport(message));
-        }
-        value
-            .get("result")
-            .cloned()
-            .ok_or_else(|| RecoveryError::Invalid("missing result field".to_owned()))
+        let value: serde_json::Value = serde_json::from_slice(&bytes)
+            .map_err(|err| RecoveryError::Invalid(format!("malformed RPC response body: {err}")))?;
+        interpret_rpc_response(value)
     }
 }
 
@@ -1090,6 +1126,116 @@ mod tests {
             Some(&single),
             10
         ));
+    }
+
+    #[test]
+    fn rpc_error_object_is_logical_not_transport() {
+        // A reachable node that answers with a JSON-RPC error object must never
+        // be classified as an unreachable transport failure (which would retry
+        // forever): it is a terminal logical/protocol failure.
+        let err = interpret_rpc_response(json!({
+            "error": { "code": -32601, "message": "Method not found" }
+        }))
+        .unwrap_err();
+        assert!(matches!(err, RecoveryError::RpcError(_)));
+    }
+
+    #[test]
+    fn history_unavailable_codes_stay_typed() {
+        for value in [
+            json!({ "error": { "code": -32007, "message": "Block cleaned up" } }),
+            json!({ "error": { "code": -32009, "message": "Slot skipped" } }),
+        ] {
+            let err = interpret_rpc_response(value).unwrap_err();
+            assert!(matches!(err, RecoveryError::HistoryUnavailable(_)));
+        }
+    }
+
+    #[test]
+    fn missing_result_field_is_invalid() {
+        let err = interpret_rpc_response(json!({ "jsonrpc": "2.0", "id": 1 })).unwrap_err();
+        assert!(matches!(err, RecoveryError::Invalid(_)));
+    }
+
+    /// Accept exactly one connection on an ephemeral port, read the request,
+    /// then write `response` verbatim and close. Blocking `std::net` keeps this
+    /// self-contained without pulling extra tokio features into the workspace.
+    fn spawn_one_shot_server(response: &'static [u8]) -> u16 {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            if let Ok((mut socket, _)) = listener.accept() {
+                let mut buf = [0u8; 2048];
+                let _ = socket.read(&mut buf);
+                let _ = socket.write_all(response);
+                let _ = socket.flush();
+                // socket dropped here: the connection closes.
+            }
+        });
+        port
+    }
+
+    fn client_for_port(port: u16) -> RpcRecoveryClient {
+        RpcRecoveryClient::new(RpcRecoveryConfig {
+            rpc_url: format!("http://127.0.0.1:{port}"),
+            program_id: b58(&program()),
+            bounds: RecoveryBounds::default(),
+            bootstrap_slot: None,
+        })
+        .expect("valid recovery client")
+    }
+
+    #[tokio::test]
+    async fn body_dropped_mid_read_is_transport() {
+        // Server promises 100 bytes then sends 5 and closes: the body read fails
+        // partway through. reqwest folds this into `is_decode()`, so it must be
+        // classified from the raw body-read error, not the parse — Transport,
+        // retryable. (A large getBlock body on a busy node hits this same path
+        // via the body timeout.)
+        let port = spawn_one_shot_server(b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort");
+        let client = client_for_port(port);
+        let cancel = CancellationToken::new();
+        let err = client.get_confirmed_slot(&cancel).await.unwrap_err();
+        assert!(
+            matches!(err, RecoveryError::Transport(_)),
+            "dropped-mid-body must be retryable Transport, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fully_read_non_json_body_is_invalid() {
+        // Server returns a complete 200 whose body is not JSON: the node
+        // answered, so this is a terminal parse failure, never Transport.
+        let port =
+            spawn_one_shot_server(b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\n\r\nnot-json-at-all");
+        let client = client_for_port(port);
+        let cancel = CancellationToken::new();
+        let err = client.get_confirmed_slot(&cancel).await.unwrap_err();
+        assert!(
+            matches!(err, RecoveryError::Invalid(_)),
+            "garbage body from a responding node must be terminal Invalid, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_refused_tip_read_is_transport() {
+        // Reproduces the e2e bring-up window: the validator/RPC does not exist
+        // yet, so the request itself is refused. That must surface as the
+        // retryable `Transport` class, never a terminal error.
+        let client = RpcRecoveryClient::new(RpcRecoveryConfig {
+            rpc_url: "http://127.0.0.1:1".to_owned(),
+            program_id: b58(&program()),
+            bounds: RecoveryBounds::default(),
+            bootstrap_slot: None,
+        })
+        .expect("valid recovery client");
+        let cancel = CancellationToken::new();
+        let err = client.get_confirmed_slot(&cancel).await.unwrap_err();
+        assert!(
+            matches!(err, RecoveryError::Transport(_)),
+            "expected Transport, got {err:?}"
+        );
     }
 
     #[test]

--- a/solana-proof-service/crates/solana-proof-store/src/runner.rs
+++ b/solana-proof-service/crates/solana-proof-store/src/runner.rs
@@ -16,6 +16,13 @@ use tracing::{info, warn};
 
 use crate::store::{ApplyOutcome, SqlProofStore, StoreError};
 
+/// Backoff floor for the ingest loop: Yellowstone reconnects, and now RPC
+/// recovery retries when the endpoint is unreachable, share this schedule.
+const INGEST_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
+/// Backoff ceiling. An unreachable RPC endpoint is retried indefinitely at this
+/// cadence, so the WARN log fires at most this often — not once per second.
+const INGEST_MAX_BACKOFF: Duration = Duration::from_secs(5);
+
 #[derive(thiserror::Error, Debug)]
 pub enum RunnerError {
     #[error(transparent)]
@@ -81,8 +88,7 @@ pub async fn run_sequential_ingest(
     cancel: CancellationToken,
     hooks: IngestHooks<'_>,
 ) -> Result<(), RunnerError> {
-    let mut backoff = Duration::from_millis(200);
-    const MAX_BACKOFF: Duration = Duration::from_secs(5);
+    let mut backoff = INGEST_INITIAL_BACKOFF;
 
     loop {
         if cancel.is_cancelled() {
@@ -118,9 +124,19 @@ pub async fn run_sequential_ingest(
                     {
                         Ok(Recovered::Filled { confirmed_tip }) => {
                             maybe_mark_history_complete(client, store, confirmed_tip).await?;
+                            // Successful fill is meaningful progress: collapse the
+                            // backoff so a recovery-only cadence does not stay at
+                            // the ceiling between fills.
+                            backoff = INGEST_INITIAL_BACKOFF;
                             continue;
                         }
                         Ok(Recovered::Cancelled) => return Ok(()),
+                        Ok(Recovered::Unreachable(message)) => {
+                            if !back_off_after_unreachable(&message, &cancel, &mut backoff).await {
+                                return Ok(());
+                            }
+                            continue;
+                        }
                         Err(error) => return Err(error),
                     }
                 }
@@ -140,7 +156,7 @@ pub async fn run_sequential_ingest(
                         _ = cancel.cancelled() => return Ok(()),
                         _ = tokio::time::sleep(backoff) => {}
                     }
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    backoff = (backoff * 2).min(INGEST_MAX_BACKOFF);
                     continue;
                 }
                 Err(YellowstoneSourceError::ReplayUnsupported(message)) => {
@@ -169,9 +185,16 @@ pub async fn run_sequential_ingest(
                             if let Some(client) = recovery {
                                 maybe_mark_history_complete(client, store, confirmed_tip).await?;
                             }
+                            backoff = INGEST_INITIAL_BACKOFF;
                             continue;
                         }
                         Recovered::Cancelled => return Ok(()),
+                        Recovered::Unreachable(message) => {
+                            if !back_off_after_unreachable(&message, &cancel, &mut backoff).await {
+                                return Ok(());
+                            }
+                            continue;
+                        }
                     }
                 }
                 Err(error) => return Err(RunnerError::Source(error)),
@@ -189,7 +212,7 @@ pub async fn run_sequential_ingest(
                     _ = cancel.cancelled() => return Ok(()),
                     _ = tokio::time::sleep(backoff) => {}
                 }
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                backoff = (backoff * 2).min(INGEST_MAX_BACKOFF);
             }
             Err(RunnerError::Source(YellowstoneSourceError::ReplayUnsupported(message))) => {
                 return Err(RunnerError::Source(
@@ -217,9 +240,16 @@ pub async fn run_sequential_ingest(
                         if let Some(client) = recovery {
                             maybe_mark_history_complete(client, store, confirmed_tip).await?;
                         }
+                        backoff = INGEST_INITIAL_BACKOFF;
                         continue;
                     }
                     Recovered::Cancelled => return Ok(()),
+                    Recovered::Unreachable(message) => {
+                        if !back_off_after_unreachable(&message, &cancel, &mut backoff).await {
+                            return Ok(());
+                        }
+                        continue;
+                    }
                 }
             }
             Err(RunnerError::RecoveryRequired {
@@ -243,10 +273,17 @@ pub async fn run_sequential_ingest(
                         if let Some(client) = recovery {
                             maybe_mark_history_complete(client, store, confirmed_tip).await?;
                         }
+                        backoff = INGEST_INITIAL_BACKOFF;
                         // Resubscribe from durable checkpoint (inclusive replay).
                         continue;
                     }
                     Recovered::Cancelled => return Ok(()),
+                    Recovered::Unreachable(message) => {
+                        if !back_off_after_unreachable(&message, &cancel, &mut backoff).await {
+                            return Ok(());
+                        }
+                        continue;
+                    }
                 }
             }
             Err(error) => return Err(error),
@@ -270,6 +307,42 @@ enum Recovered {
         confirmed_tip: u64,
     },
     Cancelled,
+    /// The RPC recovery endpoint was unreachable (transport-level). The endpoint
+    /// may not exist yet (e2e bring-up) or be flapping; the caller backs off and
+    /// retries the loop instead of failing the writer closed.
+    Unreachable(String),
+}
+
+/// Confirmed-tip read outcome, separating a retryable unreachable endpoint from
+/// a terminal read failure so a connection-refused tip read never crashes the
+/// writer at startup.
+enum TipRead {
+    Tip(u64),
+    Unreachable(String),
+    Cancelled,
+}
+
+/// Back off after an unreachable RPC recovery endpoint, growing the delay toward
+/// [`INGEST_MAX_BACKOFF`]. Returns `false` when cancelled during the wait so the
+/// caller can stop; `true` to retry the ingest loop. Logs at WARN once per
+/// backoff interval (not once per failed request).
+async fn back_off_after_unreachable(
+    message: &str,
+    cancel: &CancellationToken,
+    backoff: &mut Duration,
+) -> bool {
+    warn!(
+        %message,
+        ?backoff,
+        "RPC recovery endpoint unreachable; staying unready and retrying with backoff"
+    );
+    tokio::select! {
+        _ = cancel.cancelled() => false,
+        _ = tokio::time::sleep(*backoff) => {
+            *backoff = (*backoff * 2).min(INGEST_MAX_BACKOFF);
+            true
+        }
+    }
 }
 
 struct RecoveryGate<'a> {
@@ -323,7 +396,11 @@ async fn attempt_recovery(
 
     let (to_slot, confirmed_tip) = match hint {
         GapHint::UntilExclusive(Some(gap_end)) if gap_end > checkpoint.slot + 1 => {
-            let confirmed_tip = read_confirmed_tip(client, cancel).await?;
+            let confirmed_tip = match read_confirmed_tip(client, cancel).await? {
+                TipRead::Tip(tip) => tip,
+                TipRead::Unreachable(message) => return Ok(Recovered::Unreachable(message)),
+                TipRead::Cancelled => return Ok(Recovered::Cancelled),
+            };
             (gap_end - 1, confirmed_tip)
         }
         GapHint::UntilExclusive(Some(gap_end)) if gap_end <= checkpoint.slot + 1 => {
@@ -333,7 +410,11 @@ async fn attempt_recovery(
             )));
         }
         GapHint::FromCheckpointForward => {
-            let tip = read_confirmed_tip(client, cancel).await?;
+            let tip = match read_confirmed_tip(client, cancel).await? {
+                TipRead::Tip(tip) => tip,
+                TipRead::Unreachable(message) => return Ok(Recovered::Unreachable(message)),
+                TipRead::Cancelled => return Ok(Recovered::Cancelled),
+            };
             if tip <= checkpoint.slot {
                 return Err(recovery_required(format!(
                     "confirmed tip {tip} is not ahead of checkpoint {}; cannot catch up after replay-unavailable",
@@ -376,18 +457,20 @@ async fn attempt_recovery(
     .await
 }
 
+/// Read the confirmed tip, mapping a transport-unreachable endpoint to a
+/// retryable [`TipRead::Unreachable`] and cancellation to [`TipRead::Cancelled`].
+/// Only integrity/logical read failures (RPC error, invalid, bound, history
+/// unavailable) stay terminal — the boundary the fix pins.
 async fn read_confirmed_tip(
     client: &RpcRecoveryClient,
     cancel: &CancellationToken,
-) -> Result<u64, RunnerError> {
+) -> Result<TipRead, RunnerError> {
     match client.get_confirmed_slot(cancel).await {
-        Ok(tip) => Ok(tip),
-        Err(RecoveryError::Transport(message)) => Err(recovery_required(format!(
-            "RPC recovery transport failure while reading tip: {message}"
+        Ok(tip) => Ok(TipRead::Tip(tip)),
+        Err(RecoveryError::Transport(message)) => Ok(TipRead::Unreachable(format!(
+            "RPC recovery endpoint unreachable while reading tip: {message}"
         ))),
-        Err(RecoveryError::Cancelled) => Err(recovery_required(
-            "RPC recovery cancelled while reading tip".to_owned(),
-        )),
+        Err(RecoveryError::Cancelled) => Ok(TipRead::Cancelled),
         Err(err) => Err(recovery_required(format!(
             "failed to read confirmed tip for recovery: {err}"
         ))),
@@ -404,7 +487,11 @@ async fn recover_bootstrap_from_start(
     if cancel.is_cancelled() {
         return Ok(Recovered::Cancelled);
     }
-    let confirmed_tip = read_confirmed_tip(client, cancel).await?;
+    let confirmed_tip = match read_confirmed_tip(client, cancel).await? {
+        TipRead::Tip(tip) => tip,
+        TipRead::Unreachable(message) => return Ok(Recovered::Unreachable(message)),
+        TipRead::Cancelled => return Ok(Recovered::Cancelled),
+    };
     if confirmed_tip < bootstrap_slot {
         return Err(recovery_required(format!(
             "confirmed tip {confirmed_tip} is behind bootstrap slot {bootstrap_slot}"
@@ -425,17 +512,25 @@ async fn recover_bootstrap_from_start(
     .await
 }
 
+/// Split a recovery list/fetch error along the transport-vs-integrity boundary:
+/// an unreachable endpoint ([`RecoveryError::Transport`]) is a retryable
+/// [`Recovered::Unreachable`], while every integrity/logical class (RPC error,
+/// history unavailable, bound exhausted, invalid data) stays a terminal
+/// [`RunnerError::RecoveryRequired`].
 fn map_recovery_list_error(err: RecoveryError, context: &str) -> Result<Recovered, RunnerError> {
     match err {
         RecoveryError::Cancelled => Ok(Recovered::Cancelled),
+        RecoveryError::Transport(message) => Ok(Recovered::Unreachable(format!(
+            "{context} RPC endpoint unreachable: {message}"
+        ))),
+        RecoveryError::RpcError(message) => Err(recovery_required(format!(
+            "{context} RPC returned an error: {message}"
+        ))),
         RecoveryError::BoundExhausted(message) => Err(recovery_required(format!(
             "{context} bound exhausted: {message}"
         ))),
         RecoveryError::HistoryUnavailable(message) => Err(recovery_required(format!(
             "{context} RPC history unavailable: {message}"
-        ))),
-        RecoveryError::Transport(message) => Err(recovery_required(format!(
-            "{context} RPC transport failure: {message}"
         ))),
         RecoveryError::Invalid(message) => Err(recovery_required(format!(
             "{context} invalid RPC data: {message}"
@@ -504,6 +599,9 @@ async fn recover_range_incremental(range: RecoverRange<'_>) -> Result<Recovered,
         .await?
         {
             Recovered::Cancelled => return Ok(Recovered::Cancelled),
+            // Applying to the store touches no RPC, so it never reports the
+            // endpoint unreachable; propagate defensively rather than panic.
+            unreachable @ Recovered::Unreachable(_) => return Ok(unreachable),
             Recovered::Filled { .. } => {}
         }
     }
@@ -593,7 +691,6 @@ async fn drive_subscription(
     backoff: &mut Duration,
     hooks: &IngestHooks<'_>,
 ) -> Result<(), RunnerError> {
-    const INITIAL_BACKOFF: Duration = Duration::from_millis(200);
     loop {
         let block = tokio::select! {
             _ = cancel.cancelled() => {
@@ -630,14 +727,14 @@ async fn drive_subscription(
         match store.apply_completed_block(&block).await? {
             ApplyOutcome::Applied => {
                 // Meaningful stream progress — safe to collapse reconnect delay.
-                *backoff = INITIAL_BACKOFF;
+                *backoff = INGEST_INITIAL_BACKOFF;
                 info!(slot = block.slot, "applied completed block");
                 if let Some(on_progress) = hooks.on_progress {
                     on_progress(block.slot);
                 }
             }
             ApplyOutcome::AlreadyApplied => {
-                *backoff = INITIAL_BACKOFF;
+                *backoff = INGEST_INITIAL_BACKOFF;
                 info!(slot = block.slot, "exact replay no-op");
                 if let Some(on_progress) = hooks.on_progress {
                     on_progress(block.slot);
@@ -659,12 +756,85 @@ async fn drive_subscription(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_proof_source::{history_complete_justified, BlockCheckpoint, CompletedBlock};
+    use solana_proof_source::{
+        history_complete_justified, BlockCheckpoint, CompletedBlock, RecoveryBounds,
+        RpcRecoveryConfig,
+    };
 
     fn cp(slot: u64) -> BlockCheckpoint {
         BlockCheckpoint {
             slot,
             block_hash: [slot as u8; 32],
+        }
+    }
+
+    /// System program id: 32 base58 `1`s decode to 32 zero bytes, so this needs
+    /// no bs58 dev-dependency to build a valid `RpcRecoveryClient`.
+    const VALID_PROGRAM_ID: &str = "11111111111111111111111111111111";
+
+    fn unreachable_recovery_client() -> RpcRecoveryClient {
+        // Port 1 is not listening: `send()` fails with connection-refused, the
+        // exact e2e bring-up condition before the validator exists.
+        RpcRecoveryClient::new(RpcRecoveryConfig {
+            rpc_url: "http://127.0.0.1:1".to_owned(),
+            program_id: VALID_PROGRAM_ID.to_owned(),
+            bounds: RecoveryBounds::default(),
+            bootstrap_slot: None,
+        })
+        .expect("valid recovery client")
+    }
+
+    #[tokio::test]
+    async fn tip_read_when_endpoint_unreachable_is_retryable_not_terminal() {
+        // The startup failure mode: reading the confirmed tip against an RPC
+        // that does not exist yet must yield a retryable Unreachable, never a
+        // terminal RunnerError that would exit the writer and kill the process.
+        let client = unreachable_recovery_client();
+        let cancel = CancellationToken::new();
+        let outcome = read_confirmed_tip(&client, &cancel)
+            .await
+            .expect("transport failure must not be a terminal RunnerError");
+        assert!(
+            matches!(outcome, TipRead::Unreachable(_)),
+            "expected TipRead::Unreachable, got a different outcome"
+        );
+    }
+
+    #[tokio::test]
+    async fn tip_read_respects_cancellation() {
+        let client = unreachable_recovery_client();
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let outcome = read_confirmed_tip(&client, &cancel).await.unwrap();
+        assert!(matches!(outcome, TipRead::Cancelled));
+    }
+
+    #[test]
+    fn recovery_error_boundary_transport_retries_integrity_terminates() {
+        // Transport-class unreachability is retryable (stays alive)...
+        assert!(matches!(
+            map_recovery_list_error(RecoveryError::Transport("refused".into()), "recovery"),
+            Ok(Recovered::Unreachable(_))
+        ));
+        // ...cancellation stops cleanly...
+        assert!(matches!(
+            map_recovery_list_error(RecoveryError::Cancelled, "recovery"),
+            Ok(Recovered::Cancelled)
+        ));
+        // ...and every integrity/logical class stays terminal (fail-closed).
+        for terminal in [
+            RecoveryError::RpcError("method not found".into()),
+            RecoveryError::HistoryUnavailable("Block cleaned up".into()),
+            RecoveryError::BoundExhausted("span too wide".into()),
+            RecoveryError::Invalid("malformed block".into()),
+        ] {
+            assert!(
+                matches!(
+                    map_recovery_list_error(terminal.clone(), "recovery"),
+                    Err(RunnerError::RecoveryRequired { .. })
+                ),
+                "expected {terminal:?} to stay terminal"
+            );
         }
     }
 


### PR DESCRIPTION
Fixes the deterministic post-#3215 `solana-e2e/full-vertical-reconstruct` failure (run 29930166216): the e2e bring-up starts the proof service before the Solana validator exists — by design, the documented contract for that window is "stay unready, reconnect with backoff" — but the ingest task's first RPC tip read classified connection-refused as terminal `RecoveryRequired`, the writer exited, and the (correct, untouched) lifecycle invariant killed the container at `15:22:21`, one second after start. Every e2e on the branch failed at bring-up. The Yellowstone path already survived this window; the RPC-recovery path did not.

## WHAT

Error classification in `RpcRecoveryClient::call` is now strictly by phase, split at the source:

| Condition | Class | Outcome |
|---|---|---|
| `send()` fails (connection refused / DNS / connect timeout) | `Transport` | retry with backoff, writer stays alive, readiness stays false |
| body dropped mid-read / body-read timeout | `Transport` | retry with backoff |
| body fully read but not valid JSON | `Invalid` | terminal |
| JSON-RPC `error` object (incl. pruned-history codes → `HistoryUnavailable`) | `RpcError` / `HistoryUnavailable` | terminal |
| bound exhausted / integrity failures (ancestry, corruption) | unchanged | terminal |
| cancellation (incl. during tip read — previously a spurious terminal on shutdown) | `Cancelled` | clean stop |

- Retry reuses the existing Yellowstone reconnect schedule (`INGEST_INITIAL_BACKOFF` 200 ms → `INGEST_MAX_BACKOFF` 5 s, hoisted and shared — no parallel constants); WARN at most once per backoff interval; backoff resets on live progress AND on every successful recovery fill.
- The fail-closed lifecycle invariant ("ingest writer exited while HTTP server was still running" → process exit) is byte-identical — the fix is that the writer no longer exits on retryable conditions, not that its exit is tolerated.

## Review trail

Independent adversarial review round 1 verified the over-retry direction is fully guarded (no logical/integrity error can reach the retry loop) but caught a real P1 in the first version: `reqwest` wraps body-phase transport failures (mid-body drop, body-read timeout under the client's 10 s budget) as `is_decode()`, which the first version classified terminal — recreating the writer-death class under routine slow-RPC conditions. Fixed by splitting `response.bytes()` (IO error → `Transport`) from `serde_json::from_slice` (parse error → `Invalid`); the previously-buggy cell is now pinned from both sides by real-socket tests (`body_dropped_mid_read_is_transport`, `fully_read_non_json_body_is_invalid`).

## Test plan

- [x] `make check && make fmt && make clippy && make test` from `solana-proof-service/` — all clean; 6 rpc_recovery classification tests + 3 runner boundary tests green (`connection_refused_tip_read_is_transport` reproduces the CI condition; `recovery_error_boundary_transport_retries_integrity_terminates` pins the boundary from both sides)
- [ ] `solana-e2e/full-vertical-reconstruct` on this PR — the end-to-end proof that bring-up now survives the validator-less window