### PR TITLE
feat(kms-connector): add generic host chain support to kms-worker chart

### DIFF
--- a/charts/kms-connector/Chart.yaml
+++ b/charts/kms-connector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kms-connector
 description: A helm chart to distribute and deploy the Zama KMS Connector services
-version: 1.5.3
+version: 1.5.4
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/kms-connector/templates/_helpers.tpl
+++ b/charts/kms-connector/templates/_helpers.tpl
@@ -37,15 +37,18 @@ consume with `fromYaml`.
 {{- $gw := .Values.commonConfig.gatewayContractAddresses | default dict -}}
 {{- $eth := .Values.commonConfig.ethereumContractAddresses | default dict -}}
 {{- $pol := .Values.commonConfig.polygonContractAddresses | default dict -}}
+{{- $bnb := .Values.commonConfig.bnbTestnetContractAddresses | default dict -}}
 gatewayChainId: {{ default (index $preset "gateway.chain_id") .Values.commonConfig.gatewayChainId | quote }}
 ethereumChainId: {{ default (index $preset "ethereum.chain_id") .Values.commonConfig.ethereumChainId | quote }}
 polygonChainId: {{ default (index $preset "polygon.chain_id") .Values.commonConfig.polygonChainId | quote }}
+bnbTestnetChainId: {{ default (index $preset "bnb_testnet.chain_id") .Values.commonConfig.bnbTestnetChainId | quote }}
 decryption: {{ default (index $preset "gateway.decryption.address") $gw.decryption | quote }}
 gatewayConfig: {{ default (index $preset "gateway.gateway_config.address") $gw.gatewayConfig | quote }}
 ethereumKmsGeneration: {{ default (index $preset "gateway.kms_generation.address") $eth.kmsGeneration | quote }}
 ethereumAcl: {{ default (index $preset "ethereum.acl.address") $eth.acl | quote }}
 ethereumProtocolConfig: {{ default (index $preset "ethereum.protocol_config.address") $eth.protocolConfig | quote }}
 polygonAcl: {{ default (index $preset "polygon.acl.address") $pol.acl | quote }}
+bnbTestnetAcl: {{ default (index $preset "bnb_testnet.acl.address") $bnb.acl | quote }}
 {{- end -}}
 
 {{/*

--- a/charts/kms-connector/templates/kms-connector-kms-worker-deployment.yaml
+++ b/charts/kms-connector/templates/kms-connector-kms-worker-deployment.yaml
@@ -79,6 +79,14 @@ spec:
               value: {{ $contracts.polygonChainId | quote }}
             - name: KMS_CONNECTOR_POLYGON_ACL_ADDRESS
               value: {{ $contracts.polygonAcl | quote }}
+          {{- if .Values.commonConfig.bnbTestnetUrl }}
+            - name: KMS_CONNECTOR_BNB_TESTNET_URL
+              value: {{ .Values.commonConfig.bnbTestnetUrl | quote }}
+            - name: KMS_CONNECTOR_BNB_TESTNET_CHAIN_ID
+              value: {{ $contracts.bnbTestnetChainId | quote }}
+            - name: KMS_CONNECTOR_BNB_TESTNET_ACL_ADDRESS
+              value: {{ $contracts.bnbTestnetAcl | quote }}
+          {{- end }}
             - name: KMS_CONNECTOR_KMS_GENERATION_CONTRACT__ADDRESS
               value: {{ $contracts.ethereumKmsGeneration | quote }}
             - name: KMS_CONNECTOR_PROTOCOL_CONFIG_CONTRACT__ADDRESS

--- a/charts/kms-connector/values.yaml
+++ b/charts/kms-connector/values.yaml
@@ -51,6 +51,14 @@ commonConfig:
   polygonContractAddresses:
     acl: ""
 
+  # BNB Testnet chain RPC node endpoint (HTTP)
+  bnbTestnetUrl: ""
+  # BNB Testnet chain identifier (override the network preset when set)
+  bnbTestnetChainId: ""
+  # BNB Testnet smart contract addresses (override the network preset when set)
+  bnbTestnetContractAddresses:
+    acl: ""
+
   # Distributed tracing configuration
   tracing:
     enabled: false


### PR DESCRIPTION
## Summary
  - Add `bnbTestnetUrl`, `bnbTestnetChainId`, `bnbTestnetContractAddresses` to `commonConfig`
  - Add `KMS_CONNECTOR_BNB_TESTNET_*` env vars into kms-worker deployment (conditional on `bnbTestnetUrl` being set)
  - Resolve BNB contract addresses via the contracts helper, same pattern as polygon
  - Bump chart version to 1.5.4
  - Backwards compatible: no BNB env vars rendered when `bnbTestnetUrl` is empty

## Test plan
  - [ ] `helm lint charts/kms-connector/` passes
  - [ ] `helm template` with BNB config renders three chains in `KMS_CONNECTOR_HOST_CHAINS`
  - [ ] `helm template` without BNB config renders only ETH + Polygon (backwards compat)
  - [ ] Deploy on zws-dev with BNB values and verify KMS worker processes chain 97 decrypt requests