### PR TITLE
docs(solana): reconcile stale claims with DD-038/DD-039

### DIFF
--- a/solana/docs/EVM_PARITY.md
+++ b/solana/docs/EVM_PARITY.md
@@ -76,7 +76,7 @@ fromExternal** — all implemented. The confidential token is therefore **op-com
 | handle byte-layout (ver/type/chainid/computed-marker) + entropy-seeded derivation | symbolic-exec handle; no per-output nonce (only `fheRand`'s global `counterRand`, folded into the rand seed) | identical layout; `hash(domain, op, operands, programID, chainid, prev_bank_hash, ts, context_id, op_index)`. Durable outputs use the same base handle as local outputs; `value_key` remains only the `EncryptedValue` PDA seed (DD-015). | **MET** (DIVERGENCE: sha256/keccak vs keccak, bankhash vs blockhash → handles not cross-chain-interoperable) |
 | compute identity = `msg.sender` | implicit caller | explicit `compute_subject: Signer` checked `is_signer && is_allowed` | **DIVERGENCE** (no `msg.sender`; RFC 024 compute-signer) |
 | `FHEVMExecutor` op breadth: Mul/Div/Rem/BitAnd/Or/Xor/Shl/Shr/Rotl/Rotr/Eq/Ne/Gt/Lt/Le/Min/Max, Neg/Not, cast, Sum/IsIn, MulDiv | full opcode catalog | implemented in `fhe_eval` as the binary catalog, unary ops, `Sum`, `IsIn`, and `MulDiv`; constrained by the supported `FheType` set below | **MET** for the modeled operator surface; remaining breadth is type support, not dispatch shape |
-| `HCULimit` (per-op/tx/block/depth homomorphic-compute caps) | gas-like metering | `HostConfig::max_hcu_per_tx` / `max_hcu_depth_per_tx` summed over an `fhe_eval` plan (`0` = off), plus Solana compute-budget + op-count/collection caps | **DIVERGENCE** (per-plan cap + compute-budget vs per-block metering) — see fragility #3 |
+| `HCULimit` (per-op/tx/block/depth homomorphic-compute caps) | gas-like metering | `HostConfig::max_hcu_per_tx` / `max_hcu_depth_per_tx` summed over an `fhe_eval` plan (`0` = off), plus per-app per-slot block cap (`hcu_block_cap_per_app`, DD-039), plus Solana compute-budget + op-count/collection caps | **DIVERGENCE** (per-plan + per-app-per-slot cap vs global per-block metering) — see fragility #3 |
 | `KMSVerifier` (on-chain decrypt-sig threshold verify) | verify KMS sigs on-chain | on-chain secp256k1: `eip712::verify_kms_public_decrypt` recovers EVM KMS signers and threshold-checks them against the witness-pinned `KmsContext` (rejects high-s) | **MET** (DD-021: mirrors EVM `KMSVerifier`) |
 | `ProtocolConfig` / `KMSGeneration` / `PauserSet` (role set) | KMS node/threshold registry, keygen, pauser role set | none (subset in `HostConfig`: authorities/chain_id/flags) | **PRODUCT-OPEN** |
 | `FheType` (86 variants) | type enum | supported set Bool/Uint8..Uint256 (covers token + shipped ops) | **MET (partial)** / **SCOPE** (signed/large/string types) |
@@ -165,9 +165,12 @@ connector's canonical-PDA + MMR-proof verification (DD-032; materiality now live
 2. **No host-side test/mock bypass remains.** The former `mock_input_verified_and_bind` input
    short-circuit, admin toggles, zero birth-entropy fallback, and event-only `test_emit_*`
    instructions were removed entirely (DD-014).
-3. **No per-block HCU / complexity metering.** The host caps total and critical-path HCU per
-   `fhe_eval` plan (`HostConfig::max_hcu_per_tx` / `max_hcu_depth_per_tx`, `0` = off) plus the Solana
-   compute budget, but there is no EVM-style per-block `HCULimit` plane. Relevant to DoS/cost-bounding.
+3. **No *global* per-block HCU plane.** The host enforces a per-app, per-slot HCU block cap
+   (`HostConfig::hcu_block_cap_per_app`, DD-039) plus per-plan total and critical-path caps
+   (`max_hcu_per_tx` / `max_hcu_depth_per_tx`, `0` = off) and the Solana compute budget.
+   There is no EVM-style *global* per-block `HCULimit` aggregating across all apps; the per-app
+   cap is the Solana analog. Costs are uncalibrated placeholders and limits ship disabled
+   (`u64::MAX` = unrestricted). Relevant to DoS/cost-bounding.
 4. **On-chain disclosure/redemption uses secp256k1 KMS-cert verification.** Both disclosure and
    burn-redemption are now stateless consumers of the host `verify_public_decrypt` verifier (no
    request-witness accounts): `disclose_secp` (DD-040) and `redeem_burned_amount`

--- a/solana/docs/MMR_ACL_MVP.md
+++ b/solana/docs/MMR_ACL_MVP.md
@@ -172,7 +172,7 @@ sequenceDiagram
 
 ```mermaid
 flowchart TD
-    prog["zama-host fhe_eval"] -->|"emit_cpi! (≤8-event frames only;<br/>no emit! log fallback)"| ev["op-event (self-CPI inner ix):<br/>carries the block-entropy output handle"]
+    prog["zama-host fhe_eval"] -->|"emit_cpi! (single batch CPI, ≤16 records;<br/>DD-038; no emit! log fallback)"| ev["op-event (self-CPI inner ix):<br/>carries the block-entropy output handle"]
     prog -->|"instruction data (args)"| ix["fhe_eval durable-output / make_public args"]
     ev --> proofsvc["solana-proof-service (Yellowstone + Postgres):<br/>resolves born-public handle from op-event,<br/>reconstructs MMR, cross-checks vs confirmed peaks"]
     ix --> listener["host-listener indexer:<br/>Yellowstone gRPC reconstruction-only<br/>(SlotHashes+Clock sysvar streams → block entropy;<br/>never reads events)"]

--- a/solana/docs/TESTING_STRATEGY.md
+++ b/solana/docs/TESTING_STRATEGY.md
@@ -33,8 +33,9 @@ all fail closed (see the `*_rejects_*` mollusk tests).
    rejection surfaced from the host, and mint-domain binding. The verifier's own negatives (destroyed
    context, sub-threshold cert, handle/proof mismatch, non-canonical context, survives-supersede) live
    in `host_mollusk` (#3220). There are no more `request_disclose_*` / `disclose_*_secp` witness-bound
-   disclosure tests. Because Mollusk
-   enforces the 1.4M CU budget, every passing test is also an implicit CU-fits assertion.
+   disclosure tests. The token and batcher Mollusk suites explicitly set `compute_unit_limit = 1_400_000`;
+   the host suite uses Mollusk's default per-instruction budget (stricter than 1.4M). In all cases,
+   every passing test is an implicit CU-fits assertion at the configured budget.
 3. **Handle-derivation / lifecycle transport** (`zama-host` lib unit): the maximum 16-record batch's
     exact 1,077-byte CPI envelope and signer/readonly event-authority metadata, plus handle-derivation
     determinism.

--- a/solana/programs/zama-host/README.md
+++ b/solana/programs/zama-host/README.md
@@ -9,8 +9,10 @@ application programs such as `confidential-token`.
 ```text
 HostConfig
   PDA("host-config")
-  stores chain id, protocol authorities, pause state, HCU limits,
-  and the persistent-grant deny-list policy
+  stores chain id, gateway chain id, protocol authorities (admin, coprocessor signer set +
+  threshold, decryption contract, input verification contract), current KMS context pointer,
+  pause state, HCU limits (per-tx, per-depth, per-app-per-slot block cap), and the
+  persistent-grant deny-list policy
 
 EncryptedValue
   PDA("encrypted-value", value_key)
@@ -46,8 +48,8 @@ this handle" — current membership, or an MMR-proven historical/public-decrypt 
 
 ## Instruction-Local Transients
 
-`fhe_eval` composes mixed FHE steps in one host instruction: **Binary / Ternary / TrivialEncrypt /
-Rand / RandBounded** (no `Input` step — DD-007/DD-023). Binary scratch results can feed ternary
+`fhe_eval` composes mixed FHE steps in one host instruction: **Binary / Ternary / Unary /
+TrivialEncrypt / Rand / RandBounded / Sum / IsIn / MulDiv** (no `Input` step — DD-007/DD-023). Binary scratch results can feed ternary
 `if_then_else`, and trivial-encrypt / random births can participate in the same frame. Outputs
 produced earlier in the eval can be referenced as transient operands by later operations.
 Durable operands must still be authorized by a live or historically-proven `EncryptedValue`. Transient


### PR DESCRIPTION
## Summary

Reconciles 5 stale documentation claims identified by independent audit at 3eb1a2b. No code changes — docs only.

## Changes

| File | Fix |
|------|-----|
| solana/docs/EVM_PARITY.md | Fragility #3: acknowledge per-app per-slot HCU block cap (DD-039) instead of claiming no per-block metering. HCULimit row updated. |
| solana/docs/MMR_ACL_MVP.md | Event transport diagram: 8-event frames to single batch CPI 16 records (DD-038) |
| solana/programs/zama-host/README.md | HostConfig summary: add coprocessor signer set, KMS context pointer, gateway chain id, block cap. Step list: add Unary/Sum/IsIn/MulDiv (4 of 9 were missing). |
| solana/docs/TESTING_STRATEGY.md | Qualify per-suite CU budgets: token/batcher set 1.4M explicitly; host uses Mollusk default (stricter). |

## Why

These docs are the handoff artifact to production teams. The stale claims misframe the DoS surface and the capability surface. A security reviewer reading the Critical assessment section would build an incorrect operational model.

## Audit context

Findings #1, #7, #8, #9, #19 from the consolidated audit: https://gist.github.com/Eikix/8a30f62d85e35bcb6ebaa1a6103c61a6