### PR TITLE
test(test-suite): seed the Solana e2e scenario harness and port the confidential-transfer leg

### DIFF
--- a/.github/workflows/solana-e2e.yml
+++ b/.github/workflows/solana-e2e.yml
@@ -197,6 +197,14 @@ jobs:
       - name: Drive the Solana decrypt vertical (full-vertical.sh)
         run: bash solana/scripts/e2e/full-vertical.sh
 
+      - name: Run the Solana e2e scenario suite (SDK-driven, against the up stack)
+        # The stack from clean-e2e is still up. These bun:test scenarios drive product arcs through
+        # @fhevm/sdk Solana actions only; the confidential-transfer arc (encrypt input ->
+        # submitInputProof -> confidentialTransfer -> current user-decrypt) was moved here from
+        # full-vertical.sh's [sdk-transfer] leg. See solana/docs/TESTING.md ("Scenario layer").
+        working-directory: test-suite/fhevm
+        run: bun run test:e2e
+
       - name: Collect stack logs on failure
         if: ${{ failure() }}
         run: |

--- a/sdk/js-sdk/src/solana/actions/confidentialTransfer.ts
+++ b/sdk/js-sdk/src/solana/actions/confidentialTransfer.ts
@@ -170,7 +170,9 @@ export async function confidentialTransfer(
     createTransactionMessage({ version: 0 }),
     (m) => setTransactionMessageFeePayerSigner(feePayer, m),
     (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
-    (m) => setTransactionMessageComputeUnitLimit(400_000, m),
+    // A live transfer has been observed to exceed 400k CU (PDA bump search and
+    // emit_cpi! overhead vary per run); 800k keeps headroom under the 1.4M/tx cap.
+    (m) => setTransactionMessageComputeUnitLimit(800_000, m),
     (m) => appendTransactionMessageInstructions([instruction], m),
   );
   const transaction = await signTransactionMessageWithSigners(message);

--- a/solana/docs/TESTING.md
+++ b/solana/docs/TESTING.md
@@ -21,6 +21,7 @@ been exercised. Commands are run from `solana/` unless a row changes directory.
 | Direct real-TFHE conformance | `cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test --profile local -p fhevm-engine-common --test real_tfhe_conformance` | CPU/default-feature `perform_fhe_operation` consumes real encrypted inputs and produces typed ciphertexts that decrypt to explicit deterministic Bool, Uint8, and Uint64 oracles. It covers every operator removed from the full vertical, while grouping sibling operators into compact family tests. | Solana admission, listener/database behavior, GPU execution, random known-answer claims, or high-width scheduled coverage. | Coprocessor workspace dependencies. Warm: about 20 seconds; a cold optimized build can take minutes. |
 | Manual real-TFHE worker boundary | `cd ../coprocessor/fhevm-engine && SQLX_OFFLINE=true cargo test -p tfhe-worker tests::solana_poc::solana_confidential_transfer_with_real_ciphertexts_computes_and_decrypts -- --ignored --exact --nocapture` | A Solana confidential transfer can feed the real TFHE worker through the database and decrypt the computed ciphertexts. | Yellowstone/RPC ingestion, solana-proof-service delivery, KMS networking, or the complete deployed flow. | Intentionally ignored: testcontainers starts disposable migrated Postgres; test keys and built PoC programs are also required. Heavy and manual. |
 | Full vertical | `bash scripts/e2e/clean-e2e.sh` then `bash scripts/e2e/full-vertical.sh` | The local-validator path across SDK/input proof, programs, reconstruction, coprocessor, solana-proof-service MMR proofs, and public/user decrypt. It retains one live example for each distinct eval wiring shape: encrypted/encrypted and encrypted/scalar binary, unary type conversion, ternary, bounded randomness, `Sum`, `IsIn`, and `MulDiv`. | Exhaustive operator semantics (the pure layer owns the full contract; Mollusk and direct real-TFHE supply representative SBF and cryptographic evidence), production reliability, scale, or mainnet readiness. | Docker, Solana tools, Node/Rust toolchains, ports, and a clean local stack. Before operator thinning, four successful CI samples on July 13–14, 2026 ran `full-vertical.sh` in 4m15s–4m29s; complete jobs took 44m49s–53m53s because stack setup dominated. These are observations, not SLOs. |
+| Scenario layer (SDK-driven) | `cd ../test-suite/fhevm && bun run test:e2e` (stack already up) | Product arcs composed **only** through `@fhevm/sdk` Solana actions, against the live stack. Currently the confidential-transfer arc: encrypt input → `submitInputProof` → `confidentialTransfer` → current user-decrypt of both rotated balances (Alice 1000→600, Bob 0→400). | Instruction admission / guards / arithmetic / cost (Mollusk owns those), operator semantics, and provisioning correctness (mint / wrap / balance-state reads still run through the Rust live-client — see the SDK gaps below). | A stack from `clean-e2e.sh` already up, plus `bun` and the built `@fhevm/sdk`. In CI it runs as its own step right after `full-vertical.sh` (same up stack). |
 
 The cleartext evaluator used by `operator_conformance` and `operator_mollusk_conformance` is a
 test-owned model/mock. It is deliberately independent evidence for operator intent; it is not an
@@ -107,6 +108,57 @@ cd ../solana-proof-service     && make test
 > Note on a green test run: the suites print many `Program ... failed: custom program error: 0x...`
 > lines. Those are **negative tests** asserting expected reverts, not test failures. The
 > authoritative signal is the `test result: ok` summary lines and the process exit code.
+
+## Scenario layer (SDK-driven e2e)
+
+Lives in `test-suite/fhevm/e2e/` — a small harness (three files, not a framework) plus scenario
+files. It sits **on top of** the Mollusk ladder and the full vertical, and owns only what
+composition can break (proofs vs live state, KMS round-trips, relayer seams, timing) — never what
+the lower layers already prove.
+
+Runner: `bun:test`, not vitest. The standing plan (#1656) names vitest, but these scenarios reuse
+`test-suite/fhevm/src/solana/*` orchestrators whose `layout.ts` is bun-native (`import.meta.dir`),
+and node-based vitest workers do not provide it; vitest remains the target if/when `layout.ts` is
+ported off bun APIs.
+
+Two rules the layer holds itself to:
+
+1. **Each behavior is tested at exactly one layer.** Mollusk owns instruction admission, guards,
+   arithmetic and cost; scenarios never re-test that territory. When a leg moves here, it is
+   deleted from `full-vertical.sh` in the same change — no double coverage.
+2. **The harness carries zero protocol knowledge.** Scenarios reach the protocol only through
+   `@fhevm/sdk` Solana actions, and assertion reads go through SDK read paths. A missing SDK
+   read/action is an SDK gap to file, never something to hand-roll in the harness.
+
+The harness (`e2e/harness/`):
+
+- `loadEnv()` → a `TestEnv` (RPC/WS/relayer/proof-service/gateway URLs, the RFC-021 chain id, the
+  zama-host ACL identity, the user-decrypt context, the coprocessor DB container, the deployer
+  keypair root, and capability flags `faucet` / `freshMints` / `fastSlots`). Its source today is the
+  local `clean-e2e` stack (env-var overridable); it is structured so a demo-config JSON or a
+  devnet/mainnet manifest slots in as a second source without touching scenarios.
+- `personas` → named actors backed by on-disk keypairs, with a capability-gated `fund()` (local
+  airdrop).
+- `until(condition, { timeoutMs, intervalMs })` → a generic readiness-polling helper.
+
+Scenarios (`e2e/scenarios/`) are environment-blind: they read `TestEnv`, gate on readiness with
+`until`, and drive SDK actions. `confidential-transfer.scenario.test.ts` is the confidential-transfer
+arc ported from the `[sdk-transfer]` leg of `full-vertical.sh`; its assertion-to-bash mapping is in
+the file header.
+
+Run it locally against a stack that is already up (do **not** re-run `clean-e2e.sh` just for this):
+
+```bash
+# from repo root, after `bash solana/scripts/e2e/clean-e2e.sh` has left the stack up
+cd test-suite/fhevm
+bun run test:e2e            # the scenario suite (needs the live stack)
+bun run test:e2e:harness    # the harness unit tests (until / loadEnv — no stack needed)
+```
+
+Not yet portable to this layer (SDK gaps, tracked): the disclose / redeem consume arc, whose
+provisioning (wrap, burn, seal `make_handle_public`, `redeem_burned_amount`) and MMR-proof sourcing
+have no SDK actions/reads yet, so it stays in `full-vertical.sh`. Confidential-mint init, wrap, and
+balance-state reads used by the transfer arc's setup likewise still run through the Rust live-client.
 
 ## Traps & gotchas (read before you lose an afternoon)
 

--- a/solana/scripts/e2e/full-vertical.sh
+++ b/solana/scripts/e2e/full-vertical.sh
@@ -439,9 +439,8 @@ MDH_ACL="$(echo "$mdout" | grep -oE 'output encrypted value [A-Za-z0-9]+' | awk 
 [ -n "$MDH_ACL" ] || fail "no mulDiv output ACL record: $mdout"
 assert_decrypt "mulDiv" "$MDH" "$MDH_ACL" "$EXPECTED_MULDIV"
 
-echo "==> [sdk-transfer] two holders: Alice 1000 -> confidentialTransfer(400) -> Alice 600, Bob 400"
-( cd "$ROOT/test-suite/fhevm" && ./fhevm-cli test solana-two-holder-transfer ) \
-  || fail "SDK two-holder confidential transfer failed"
+# [sdk-transfer] leg (two-holder confidential transfer + current user-decrypt) moved to the TS
+# scenario harness (test-suite/fhevm/e2e/); the solana-e2e CI runs it after this vertical.
 
 echo "==> [consume] confidential mint + USDC; wrap -> burn -> release -> public-decrypt -> redeem(secp) + disclose(secp)"
 LCDIR="$ROOT/solana/scripts/e2e/live-client"

--- a/test-suite/fhevm/e2e/harness/index.ts
+++ b/test-suite/fhevm/e2e/harness/index.ts
@@ -1,0 +1,16 @@
+// The Solana e2e scenario harness — three primitives, no framework.
+//
+// Two rules (from the #1656 / #1658 plan):
+//   1. Each behavior is tested at exactly one layer. Mollusk owns instruction admission, guards,
+//      arithmetic and cost; scenarios own only composition seams (proofs vs live state, KMS
+//      round-trips, relayer seams, wire size, timing). No behavior is authored twice.
+//   2. The harness carries zero protocol knowledge. Scenarios reach the protocol only through
+//      `@fhevm/sdk` Solana actions; assertion reads go through SDK read paths. A missing SDK
+//      read/action is an SDK gap to report, never a thing to hand-roll here.
+
+export { loadEnv, resolveEnv } from "./loadEnv";
+export type { TestEnv, Capabilities } from "./loadEnv";
+export { loadPersonas } from "./personas";
+export type { Persona, Personas } from "./personas";
+export { until } from "./until";
+export type { UntilOptions } from "./until";

--- a/test-suite/fhevm/e2e/harness/loadEnv.test.ts
+++ b/test-suite/fhevm/e2e/harness/loadEnv.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadEnv, resolveEnv } from "./loadEnv";
+
+describe("loadEnv", () => {
+  test("defaults reproduce the local clean-e2e stack", () => {
+    const env = loadEnv({});
+    expect(env.source).toBe("local");
+    expect(env.rpcUrl).toBe("http://127.0.0.1:8899");
+    expect(env.relayerUrl).toBe("http://127.0.0.1:3000");
+    expect(env.proofServiceUrl).toBe("http://127.0.0.1:8088");
+    expect(env.chainId).toBe(9223372036854788153n);
+    expect(env.aclProgram).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(env.capabilities).toEqual({ faucet: true, freshMints: true, fastSlots: true });
+    expect(env.roots.deployerKeypairPath).toContain(".config/solana/id.json");
+  });
+
+  test("environment variables override defaults", () => {
+    const env = loadEnv({
+      SOLANA_RPC_URL: "http://10.0.0.1:8899",
+      PROOF_SERVICE_URL: "http://10.0.0.1:8088",
+      SOLANA_DEPLOYER_KEYPAIR: "/tmp/custom.json",
+    });
+    expect(env.rpcUrl).toBe("http://10.0.0.1:8899");
+    expect(env.proofServiceUrl).toBe("http://10.0.0.1:8088");
+    expect(env.roots.deployerKeypairPath).toBe("/tmp/custom.json");
+  });
+
+  test("rejects a non-Solana (low-bit) chain id", () => {
+    expect(() => resolveEnv({ chainId: "12345" })).toThrow(/not a Solana high-bit chain id/);
+  });
+
+  test("rejects a malformed ACL program identity", () => {
+    expect(() => resolveEnv({ aclProgram: "0xdeadbeef" })).toThrow(/32-byte hex/);
+  });
+
+  test("rejects a non-decimal user-decrypt context id", () => {
+    expect(() => resolveEnv({ userDecryptContextId: "0x01" })).toThrow(/unsigned decimal/);
+  });
+});

--- a/test-suite/fhevm/e2e/harness/loadEnv.ts
+++ b/test-suite/fhevm/e2e/harness/loadEnv.ts
@@ -1,0 +1,150 @@
+// loadEnv — builds the TestEnv that the Solana e2e scenarios run against.
+//
+// Zero protocol knowledge: it only assembles endpoints, chain identifiers, on-disk roots, and
+// capability flags. It never encodes/decodes protocol bytes — scenarios reach the protocol solely
+// through `@fhevm/sdk` Solana actions.
+//
+// Source for NOW: the local clean-e2e stack. Every value below is exactly what the current e2e
+// runtime provides, traced to where it lands:
+//   - urls/ids: `solana/scripts/e2e/full-vertical.sh` (RPC/GW_RPC/relayer/proof-service, SID, ACL,
+//     CTX) and `test-suite/fhevm/src/solana/two-holder-transfer.ts` (RPC/WS/relayer/ACL constants).
+//   - coprocessor DB container: `test-suite/fhevm/src/layout.ts` (COPROCESSOR_DB_CONTAINER).
+//   - deployer keypair: `~/.config/solana/id.json`, the wallet full-vertical.sh derives USER from.
+//   - gateway addresses (optional, for future legs): generated at `fhevm-cli up` time into
+//     `.fhevm/runtime/addresses/gateway/.env.gateway`.
+// Env vars override any field so a run can point at a non-default local stack.
+//
+// A second source (a demo-config JSON for local, or a devnet/mainnet manifest) will be added later.
+// `resolveEnv` is written as `defaults <- overrides` so that second source only has to produce a
+// `Partial<TestEnvOverrides>`; nothing else here changes.
+
+import os from "node:os";
+import path from "node:path";
+
+import {
+  COPROCESSOR_DB_CONTAINER,
+  SOLANA_ACL_PROGRAM,
+  SOLANA_DEFAULT_USER_DECRYPT_CONTEXT,
+} from "../../src/layout";
+
+export type Capabilities = {
+  /** Can fund actors with SOL (local validator airdrop). Local: true. Devnet/mainnet: false. */
+  readonly faucet: boolean;
+  /** Can create brand-new SPL / confidential mints for a scenario. Local & devnet: true. */
+  readonly freshMints: boolean;
+  /** Slots advance on demand (local validator). Live networks: false. */
+  readonly fastSlots: boolean;
+};
+
+export type TestEnv = {
+  /** The only source implemented today. Future: "demo-config" | "devnet" | "mainnet". */
+  readonly source: "local";
+  readonly rpcUrl: string;
+  readonly wsUrl: string;
+  readonly relayerUrl: string;
+  readonly proofServiceUrl: string;
+  readonly gatewayRpcUrl: string;
+  /** RFC-021 Solana host chain id (9223372036854788153); the high bit marks it a Solana chain. */
+  readonly chainId: bigint;
+  /** zama-host program id as a bytes32 hex — the Solana ACL identity. */
+  readonly aclProgram: `0x${string}`;
+  /** KMS/gateway user-decrypt context id, as an unsigned decimal string. */
+  readonly userDecryptContextId: string;
+  /** Docker container name of the coprocessor+KMS Postgres (for ciphertext-materialization waits). */
+  readonly coprocessorDbContainer: string;
+  readonly roots: { readonly deployerKeypairPath: string };
+  readonly capabilities: Capabilities;
+};
+
+type TestEnvOverrides = {
+  rpcUrl: string;
+  wsUrl: string;
+  relayerUrl: string;
+  proofServiceUrl: string;
+  gatewayRpcUrl: string;
+  chainId: string;
+  aclProgram: string;
+  userDecryptContextId: string;
+  coprocessorDbContainer: string;
+  deployerKeypairPath: string;
+};
+
+// The local clean-e2e stack. The endpoints are local-stack facts; the protocol identities
+// (ACL program, user-decrypt context, coprocessor DB container) are imported from the CLI's config
+// module so there is exactly one source of truth shared with the transfer orchestrator.
+const LOCAL_DEFAULTS = {
+  rpcUrl: "http://127.0.0.1:8899",
+  wsUrl: "ws://127.0.0.1:8900",
+  relayerUrl: "http://127.0.0.1:3000",
+  proofServiceUrl: "http://127.0.0.1:8088",
+  gatewayRpcUrl: "http://127.0.0.1:8546",
+  chainId: "9223372036854788153",
+  aclProgram: SOLANA_ACL_PROGRAM,
+  userDecryptContextId: SOLANA_DEFAULT_USER_DECRYPT_CONTEXT,
+  coprocessorDbContainer: COPROCESSOR_DB_CONTAINER,
+} as const;
+
+const CAPABILITIES_BY_SOURCE: Record<TestEnv["source"], Capabilities> = {
+  local: { faucet: true, freshMints: true, fastSlots: true },
+};
+
+const bytes32Hex = (value: string): `0x${string}` => {
+  if (!/^0x[0-9a-f]{64}$/i.test(value)) throw new Error(`expected a 0x-prefixed 32-byte hex value, got ${value}`);
+  return value as `0x${string}`;
+};
+
+const solanaChainId = (value: string): bigint => {
+  if (!/^\d+$/.test(value)) throw new Error(`chainId must be an unsigned decimal integer, got ${value}`);
+  const id = BigInt(value);
+  if ((id & (1n << 63n)) === 0n) throw new Error(`chainId ${value} is not a Solana high-bit chain id`);
+  return id;
+};
+
+const decimalString = (value: string, name: string): string => {
+  if (!/^\d+$/.test(value)) throw new Error(`${name} must be an unsigned decimal integer, got ${value}`);
+  return value;
+};
+
+/** Reads TestEnv overrides from the process environment (the "now" source). */
+const envOverrides = (env: NodeJS.ProcessEnv): Partial<TestEnvOverrides> => {
+  const pick = <K extends keyof TestEnvOverrides>(key: K, name: string): Partial<Pick<TestEnvOverrides, K>> => {
+    const value = env[name];
+    return value === undefined || value === "" ? {} : ({ [key]: value } as Pick<TestEnvOverrides, K>);
+  };
+  return {
+    ...pick("rpcUrl", "SOLANA_RPC_URL"),
+    ...pick("wsUrl", "SOLANA_WS_URL"),
+    ...pick("relayerUrl", "SOLANA_RELAYER_URL"),
+    ...pick("proofServiceUrl", "PROOF_SERVICE_URL"),
+    ...pick("gatewayRpcUrl", "GW_RPC"),
+    ...pick("chainId", "SOLANA_HOST_CHAIN_ID"),
+    ...pick("aclProgram", "SOLANA_ACL_PROGRAM"),
+    ...pick("userDecryptContextId", "SOLANA_UD_CONTEXT_ID"),
+    ...pick("coprocessorDbContainer", "COPROCESSOR_DB_CONTAINER"),
+    ...pick("deployerKeypairPath", "SOLANA_DEPLOYER_KEYPAIR"),
+  };
+};
+
+/** Assembles a validated TestEnv from `defaults <- overrides`. Exported for the scenario tests. */
+export const resolveEnv = (overrides: Partial<TestEnvOverrides> = {}): TestEnv => {
+  const merged = { ...LOCAL_DEFAULTS, ...overrides };
+  const deployerKeypairPath =
+    overrides.deployerKeypairPath ?? path.join(os.homedir(), ".config/solana/id.json");
+  return {
+    source: "local",
+    rpcUrl: merged.rpcUrl,
+    wsUrl: merged.wsUrl,
+    relayerUrl: merged.relayerUrl,
+    proofServiceUrl: merged.proofServiceUrl,
+    gatewayRpcUrl: merged.gatewayRpcUrl,
+    chainId: solanaChainId(merged.chainId),
+    aclProgram: bytes32Hex(merged.aclProgram),
+    userDecryptContextId: decimalString(merged.userDecryptContextId, "userDecryptContextId"),
+    coprocessorDbContainer: merged.coprocessorDbContainer,
+    roots: { deployerKeypairPath },
+    capabilities: CAPABILITIES_BY_SOURCE.local,
+  };
+};
+
+/** Builds the TestEnv the scenarios run against, from the current e2e runtime. */
+export const loadEnv = (env: NodeJS.ProcessEnv = process.env): TestEnv => resolveEnv(envOverrides(env));

--- a/test-suite/fhevm/e2e/harness/personas.ts
+++ b/test-suite/fhevm/e2e/harness/personas.ts
@@ -1,0 +1,53 @@
+// personas — named actors the scenarios act as.
+//
+// Zero protocol knowledge: a persona is just a Solana keypair on disk plus a capability-gated
+// funding helper. It never touches the fhevm protocol; scenarios drive the protocol through
+// `@fhevm/sdk` actions using these actors' keys.
+
+import fs from "node:fs/promises";
+
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+
+import { run } from "../../src/utils/process";
+import type { TestEnv } from "./loadEnv";
+
+export type Persona = {
+  readonly name: string;
+  readonly keypairPath: string;
+  readonly address: string;
+};
+
+const readKeypair = async (name: string, keypairPath: string): Promise<Persona> => {
+  const bytes = JSON.parse(await fs.readFile(keypairPath, "utf8")) as unknown;
+  if (!Array.isArray(bytes) || bytes.length !== 64 || bytes.some((b) => !Number.isInteger(b) || b < 0 || b > 255)) {
+    throw new Error(`persona ${name}: ${keypairPath} is not a 64-byte Solana keypair`);
+  }
+  // Derive the address from the keypair bytes directly (no `solana` CLI / PATH dependency); the SDK
+  // also validates the key material as it decodes it.
+  const signer = await createKeyPairSignerFromBytes(Uint8Array.from(bytes as number[]));
+  return { name, keypairPath, address: signer.address };
+};
+
+export type Personas = {
+  /** The stack deployer wallet — the actor whose ACL grants the default handle authorizations. */
+  readonly deployer: Persona;
+  /**
+   * Tops a persona up with SOL. Gated on the `faucet` capability: on a live network (no faucet) it
+   * throws rather than silently no-op, so a scenario that assumes funding fails loudly.
+   */
+  fund(persona: Persona, sol?: number): Promise<void>;
+};
+
+/** Resolves the personas available in this environment. Only the deployer is loaded from disk. */
+export const loadPersonas = async (env: TestEnv): Promise<Personas> => {
+  const deployer = await readKeypair("deployer", env.roots.deployerKeypairPath);
+  return {
+    deployer,
+    async fund(persona, sol = 5) {
+      if (!env.capabilities.faucet) {
+        throw new Error(`cannot fund ${persona.name}: environment "${env.source}" has no faucet capability`);
+      }
+      await run(["solana", "airdrop", String(sol), persona.address, "--url", env.rpcUrl]);
+    },
+  };
+};

--- a/test-suite/fhevm/e2e/harness/until.test.ts
+++ b/test-suite/fhevm/e2e/harness/until.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { until } from "./until";
+
+describe("until", () => {
+  test("returns the first truthy probe value", async () => {
+    let calls = 0;
+    const value = await until(
+      async () => {
+        calls += 1;
+        return calls >= 3 ? `ready-${calls}` : false;
+      },
+      { intervalMs: 1, timeoutMs: 1_000 },
+    );
+    expect(value).toBe("ready-3");
+    expect(calls).toBe(3);
+  });
+
+  test("treats a throwing probe as not-ready and recovers", async () => {
+    let calls = 0;
+    const value = await until(
+      async () => {
+        calls += 1;
+        if (calls < 2) throw new Error("boom");
+        return 42;
+      },
+      { intervalMs: 1, timeoutMs: 1_000 },
+    );
+    expect(value).toBe(42);
+  });
+
+  test("times out with the description and the last error", async () => {
+    await expect(
+      until(async () => Promise.reject(new Error("still-warming-up")), {
+        description: "relayer readiness",
+        intervalMs: 1,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow(/until\(relayer readiness\) timed out.*still-warming-up/);
+  });
+
+  test("does not treat 0 or empty string as ready", async () => {
+    let calls = 0;
+    const value = await until(
+      async () => {
+        calls += 1;
+        // 0 and "" are falsy but are legitimate results; only false/undefined/null mean "wait".
+        return calls === 1 ? undefined : calls === 2 ? 0 : "done";
+      },
+      { intervalMs: 1, timeoutMs: 1_000 },
+    );
+    expect(value).toBe(0);
+  });
+});

--- a/test-suite/fhevm/e2e/harness/until.ts
+++ b/test-suite/fhevm/e2e/harness/until.ts
@@ -1,0 +1,46 @@
+// until — a generic polling helper for the Solana e2e scenario layer.
+//
+// Zero protocol knowledge: it only repeats a caller-supplied async probe until it yields a truthy
+// value or a deadline passes. Scenarios use it to gate on stack readiness (relayer accepting POSTs,
+// proof-service reporting ready) instead of hand-rolling sleep loops.
+
+export type UntilOptions = {
+  /** Overall deadline. Default 120s — long enough for a freshly (re)started relayer/proof-service. */
+  readonly timeoutMs?: number;
+  /** Delay between attempts. Default 2s, matching the bash readiness loops it replaces. */
+  readonly intervalMs?: number;
+  /** Human-readable subject for the timeout error (e.g. "relayer readiness"). */
+  readonly description?: string;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Polls `condition` until it resolves to a truthy value, then returns that value. A probe that
+ * throws is treated as "not ready yet" (swallowed) until the deadline, at which point the last
+ * error — or a plain timeout — is thrown. `false`, `undefined`, and `null` all mean "keep waiting".
+ */
+export async function until<T>(
+  condition: () => Promise<T | false | undefined | null>,
+  options: UntilOptions = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const intervalMs = options.intervalMs ?? 2_000;
+  const subject = options.description ?? "condition";
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  for (;;) {
+    try {
+      const result = await condition();
+      if (result !== false && result !== undefined && result !== null) return result;
+      lastError = undefined;
+    } catch (error) {
+      lastError = error;
+    }
+    if (Date.now() >= deadline) {
+      const suffix = lastError ? `; last error: ${lastError instanceof Error ? lastError.message : String(lastError)}` : "";
+      throw new Error(`until(${subject}) timed out after ${timeoutMs}ms${suffix}`);
+    }
+    await sleep(intervalMs);
+  }
+}

--- a/test-suite/fhevm/e2e/scenarios/confidential-transfer.scenario.test.ts
+++ b/test-suite/fhevm/e2e/scenarios/confidential-transfer.scenario.test.ts
@@ -1,0 +1,74 @@
+// Scenario: confidential-transfer arc — the "portable now" token-flow leg ported from
+// `solana/scripts/e2e/full-vertical.sh` (the `==> [sdk-transfer]` leg).
+//
+// It drives the product arc entirely through `@fhevm/sdk` Solana actions:
+//   encrypt input -> submitInputProof -> confidentialTransfer -> userDecrypt (current handle).
+// The SDK-driven arc + its assertions live in `runSolanaTwoHolderTransfer`; this scenario supplies
+// the environment (via loadEnv), the readiness preconditions (via until), and the actor funding
+// (via personas), then runs the arc and lets its assertions stand.
+//
+// Assertion map — bash `[sdk-transfer]` leg  ->  this scenario (all in runSolanaTwoHolderTransfer):
+//   bash: "Alice 1000 -> confidentialTransfer(400) -> Alice 600, Bob 400"
+//     - Alice initial balance == 1000  (userDecrypt of Alice's current handle)
+//     - Bob   initial balance == 0      (userDecrypt of Bob's current handle)
+//     - transfer rotates BOTH current balance handles (else "did not rotate both …" throws)
+//     - Alice final balance   == 600    (userDecrypt of Alice's rotated handle)
+//     - Bob   final balance   == 400    (userDecrypt of Bob's rotated handle)
+// Every assertion is a live SDK current user-decrypt of a real on-chain balance — nothing is
+// hard-coded, so the leg cannot pass on a trivial value. Provisioning (confidential mint, wrap,
+// balance-state reads) still goes through the Rust live-client: those are SDK gaps (see the PR
+// report), not part of this leg's assertions.
+
+import { describe, test } from "bun:test";
+
+import {
+  createRealTwoHolderDependencies,
+  runSolanaTwoHolderTransfer,
+  solanaUserDecryptContext,
+} from "../../src/solana/two-holder-transfer";
+import { loadEnv, loadPersonas, until } from "../harness";
+
+// A live stack takes minutes: SNS-commit waits alone poll up to ~2min per handle, times four.
+const SCENARIO_TIMEOUT_MS = 15 * 60_000;
+
+describe("solana confidential-transfer scenario", () => {
+  test(
+    "two holders: Alice 1000 -> transfer(400) -> Alice 600, Bob 400 (SDK actions, current decrypt)",
+    async () => {
+      const env = loadEnv();
+      const personas = await loadPersonas(env);
+
+      // Precondition (the suite may run right after a relayer/proof-service (re)start): gate on both
+      // health endpoints before submitting. The relayer exposes GET /liveness (relayer's own
+      // http/server.rs); a 200 means it is up.
+      await until(
+        async () => (await fetch(`${env.relayerUrl}/liveness`)).ok,
+        { description: "relayer liveness", timeoutMs: 60_000 },
+      );
+      await until(
+        async () => {
+          const body = await (await fetch(`${env.proofServiceUrl}/health/readiness`)).text();
+          return /"ready"\s*:\s*true/.test(body);
+        },
+        { description: "solana-proof-service readiness", timeoutMs: 120_000 },
+      );
+
+      // The transfer arc pays its own tx fees from the deployer wallet; top it up where a faucet
+      // exists (local). This genuinely exercises the faucet capability + persona funding.
+      if (env.capabilities.faucet) await personas.fund(personas.deployer);
+
+      // Run the SDK-driven arc against the injected environment. Its internal assertions (mapped
+      // above) throw on any mismatch; reaching the end means the leg is green.
+      await runSolanaTwoHolderTransfer(
+        createRealTwoHolderDependencies({
+          rpcUrl: env.rpcUrl,
+          wsUrl: env.wsUrl,
+          relayerUrl: env.relayerUrl,
+          aclProgram: env.aclProgram,
+          userDecryptContext: solanaUserDecryptContext(env.userDecryptContextId),
+        }),
+      );
+    },
+    SCENARIO_TIMEOUT_MS,
+  );
+});

--- a/test-suite/fhevm/package.json
+++ b/test-suite/fhevm/package.json
@@ -6,6 +6,7 @@
     "check": "tsc --noEmit",
     "compat-smoke": "bun run src/compat/smoke.ts",
     "test": "bun test src",
+    "test:e2e:harness": "bun test e2e/harness",
     "start": "bun run src/cli.ts"
   },
   "dependencies": {

--- a/test-suite/fhevm/package.json
+++ b/test-suite/fhevm/package.json
@@ -7,6 +7,7 @@
     "compat-smoke": "bun run src/compat/smoke.ts",
     "test": "bun test src",
     "test:e2e:harness": "bun test e2e/harness",
+    "test:e2e": "bun test e2e/scenarios",
     "start": "bun run src/cli.ts"
   },
   "dependencies": {

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -129,6 +129,12 @@ export const MINIO_INTERNAL_URL = `http://minio:${MINIO_PORT}`;
 export const MINIO_EXTERNAL_URL = `http://localhost:${MINIO_PORT}`;
 export const POSTGRES_HOST = `db:${POSTGRES_PORT}`;
 export const COPROCESSOR_DB_CONTAINER = "coprocessor-and-kms-db";
+// Solana host program id as bytes32 — the Solana ACL identity. Single source for the transfer
+// orchestrator and the e2e harness's loadEnv default.
+export const SOLANA_ACL_PROGRAM = "0x4cd3022dff504a675caf2d9b4f4014d0b3dc3ea17ffb97ba355cec5a933a30ee";
+// Default KMS/gateway user-decrypt context id, as an unsigned decimal string.
+export const SOLANA_DEFAULT_USER_DECRYPT_CONTEXT =
+  "3166189940082864718613269121331309980362851143201109172953918312716374638593";
 export const KMS_CORE_CONTAINER = "kms-core";
 export const TEST_SUITE_CONTAINER = "fhevm-test-suite-e2e-debug";
 export const KEYGEN_ID_SELECTOR = "0xd52f10eb";

--- a/test-suite/fhevm/src/solana/two-holder-transfer.ts
+++ b/test-suite/fhevm/src/solana/two-holder-transfer.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 
 import { address, createKeyPairSignerFromBytes, getAddressEncoder } from "@solana/kit";
 
-import { COPROCESSOR_DB_CONTAINER, REPO_ROOT } from "../layout";
+import {
+  COPROCESSOR_DB_CONTAINER,
+  REPO_ROOT,
+  SOLANA_ACL_PROGRAM,
+  SOLANA_DEFAULT_USER_DECRYPT_CONTEXT,
+} from "../layout";
 import { runSolanaCurrentUserDecrypt } from "./current-user-decrypt";
 import { run } from "../utils/process";
 
@@ -15,9 +20,8 @@ export const SOLANA_TWO_HOLDER_TRANSFER_DESCRIPTION =
 const RPC_URL = "http://127.0.0.1:8899";
 const WS_URL = "ws://127.0.0.1:8900";
 const RELAYER_URL = "http://127.0.0.1:3000";
-const ACL_PROGRAM = "0x4cd3022dff504a675caf2d9b4f4014d0b3dc3ea17ffb97ba355cec5a933a30ee";
-const DEFAULT_USER_DECRYPT_CONTEXT =
-  "3166189940082864718613269121331309980362851143201109172953918312716374638593";
+const ACL_PROGRAM = SOLANA_ACL_PROGRAM;
+const DEFAULT_USER_DECRYPT_CONTEXT = SOLANA_DEFAULT_USER_DECRYPT_CONTEXT;
 const LIVE_CLIENT = path.join(REPO_ROOT, "solana/scripts/e2e/live-client/target/debug/poc-live-client");
 const LIVE_CLIENT_DIR = path.join(REPO_ROOT, "solana/scripts/e2e/live-client");
 const SDK_WORKER = path.join(REPO_ROOT, "test-suite/fhevm/solana-two-holder-transfer.ts");
@@ -43,6 +47,19 @@ export type TwoHolderScenario = {
   computeSigner: string;
   alice: Holder;
   bob: Holder;
+};
+
+/**
+ * The stack endpoints and identities the real transfer arc binds to. Defaults reproduce the local
+ * clean-e2e stack (the constants above); the e2e harness injects these from `loadEnv()` so the same
+ * arc can target another environment without editing this file.
+ */
+export type TwoHolderConfig = {
+  readonly rpcUrl: string;
+  readonly wsUrl: string;
+  readonly relayerUrl: string;
+  readonly aclProgram: string;
+  readonly userDecryptContext: string;
 };
 
 export type TwoHolderDependencies = {
@@ -154,7 +171,16 @@ const captureAddress = (output: string, label: string): string => {
   return match[1];
 };
 
-const realDependencies = (): TwoHolderDependencies => {
+const resolveConfig = (config: Partial<TwoHolderConfig>): TwoHolderConfig => ({
+  rpcUrl: config.rpcUrl ?? RPC_URL,
+  wsUrl: config.wsUrl ?? WS_URL,
+  relayerUrl: config.relayerUrl ?? RELAYER_URL,
+  aclProgram: config.aclProgram ?? ACL_PROGRAM,
+  userDecryptContext: config.userDecryptContext ?? solanaUserDecryptContext(),
+});
+
+export const createRealTwoHolderDependencies = (config: Partial<TwoHolderConfig> = {}): TwoHolderDependencies => {
+  const cfg = resolveConfig(config);
   let bobHome: string | undefined;
   return {
     async provision() {
@@ -168,12 +194,12 @@ const realDependencies = (): TwoHolderDependencies => {
       await run(["solana-keygen", "new", "--no-bip39-passphrase", "--silent", "--force", "--outfile", bobKeypair]);
       const bobOwner = (await run(["solana", "address", "-k", bobKeypair])).stdout.trim();
       if (!BASE58.test(bobOwner) || bobOwner === aliceOwner) throw new Error("Bob must have a distinct valid address");
-      await run(["solana", "airdrop", "5", bobOwner, "--url", RPC_URL]);
+      await run(["solana", "airdrop", "5", bobOwner, "--url", cfg.rpcUrl]);
 
-      const underlyingOutput = await run(["spl-token", "create-token", "--decimals", "9", "--url", RPC_URL]);
+      const underlyingOutput = await run(["spl-token", "create-token", "--decimals", "9", "--url", cfg.rpcUrl]);
       const underlying = captureAddress(`${underlyingOutput.stdout}\n${underlyingOutput.stderr}`, "Creating token");
-      await run(["spl-token", "create-account", underlying, "--url", RPC_URL]);
-      await run(["spl-token", "mint", underlying, "1000000", "--url", RPC_URL]);
+      await run(["spl-token", "create-account", underlying, "--url", cfg.rpcUrl]);
+      await run(["spl-token", "mint", underlying, "1000000", "--url", cfg.rpcUrl]);
       const mintOutput = await runLiveClient({ UNDERLYING_MINT: underlying });
       const mintText = `${mintOutput.stdout}\n${mintOutput.stderr}`;
       const mint = captureAddress(mintText, "confidential mint");
@@ -217,10 +243,10 @@ const realDependencies = (): TwoHolderDependencies => {
       const result = await run(["node", SDK_WORKER], {
         cwd: CLI_DIR,
         env: {
-          TRANSFER_RPC_URL: RPC_URL,
-          TRANSFER_WS_URL: WS_URL,
-          TRANSFER_RELAYER_URL: RELAYER_URL,
-          TRANSFER_ACL_PROGRAM: ACL_PROGRAM,
+          TRANSFER_RPC_URL: cfg.rpcUrl,
+          TRANSFER_WS_URL: cfg.wsUrl,
+          TRANSFER_RELAYER_URL: cfg.relayerUrl,
+          TRANSFER_ACL_PROGRAM: cfg.aclProgram,
           TRANSFER_CHAIN_ID: alice.chainId,
           TRANSFER_OWNER_KEYPAIR: scenario.alice.keypairPath,
           TRANSFER_OWNER: scenario.alice.owner,
@@ -237,11 +263,11 @@ const realDependencies = (): TwoHolderDependencies => {
     },
     decrypt: (scenario, holder, state, expected) =>
       runSolanaCurrentUserDecrypt({
-        UD_RELAYER_URL: RELAYER_URL,
+        UD_RELAYER_URL: cfg.relayerUrl,
         UD_CONTRACTS_CHAIN_ID: state.chainId,
         UD_HANDLE: state.currentHandle,
         UD_SECRET_KEY: holder.secretKey,
-        UD_CONTEXT_ID: solanaUserDecryptContext(),
+        UD_CONTEXT_ID: cfg.userDecryptContext,
         UD_ALLOWED_DOMAIN_KEYS: `0x${Buffer.from(getAddressEncoder().encode(address(scenario.mint))).toString("hex")}`,
         UD_ACL_VALUE_KEY: state.aclValueKey,
         UD_EXPECTED: expected.toString(),
@@ -254,7 +280,7 @@ const realDependencies = (): TwoHolderDependencies => {
 };
 
 /** Runs one real two-holder transfer and proves both current balances through independent SDK decrypts. */
-export const runSolanaTwoHolderTransfer = async (dependencies: TwoHolderDependencies = realDependencies()) => {
+export const runSolanaTwoHolderTransfer = async (dependencies: TwoHolderDependencies = createRealTwoHolderDependencies()) => {
   let scenario: TwoHolderScenario | undefined;
   try {
     scenario = await dependencies.provision();

--- a/test-suite/fhevm/tsconfig.json
+++ b/test-suite/fhevm/tsconfig.json
@@ -14,6 +14,7 @@
     "src/layout.ts",
     "src/types.ts",
     "src/**/*.ts",
-    "scripts/**/*.ts"
+    "scripts/**/*.ts",
+    "e2e/**/*.ts"
   ]
 }


### PR DESCRIPTION
First row of the `full-vertical.sh` deletion checklist. Standing plan: [architecture on #1656](https://github.com/zama-ai/fhevm-internal/issues/1656#issuecomment-5055206861), [end state + checklist on #1658](https://github.com/zama-ai/fhevm-internal/issues/1658#issuecomment-5055206711).

## WHAT

**Commit 1 — the harness seed** (`test-suite/fhevm/e2e/harness/`, independently green): `loadEnv()` builds an environment-injected `TestEnv` (urls, RFC-021 chain id, capability flags `{faucet, freshMints, fastSlots}`; every default traced to the current e2e runtime, env-var overridable; written `defaults <- overrides` so the demo-config/devnet manifest source slots in as a partial later); `personas` (capability-gated funding — throws loudly where no faucet exists; addresses derived natively via @solana/kit, no `solana` CLI subprocess); `until()` polling. Zero protocol knowledge — scenarios reach the protocol solely through `@fhevm/sdk` actions. Shared ACL/context constants hoisted to `layout.ts` (one copy; `two-holder-transfer.ts` and the harness both import it).

**Commit 2 — the first ported leg**: the `[sdk-transfer]` confidential-transfer arc moves from bash into `e2e/scenarios/`, driving the *same* orchestrator (`runSolanaTwoHolderTransfer`) through a new env-injection seam (`TwoHolderConfig`, defaults byte-identical — the 14 existing tests and the fhevm-cli profile are unchanged). Assertion set is identical by construction (same code path): Alice 1000 → transfer(400) → both handles rotate → Alice 600 / Bob 400, each a live SDK current user-decrypt. The scenario adds readiness gates (relayer `/liveness`, proof-service `/health/readiness`) the bash leg never had. The bash leg is deleted in the same commit; CI runs the scenario suite as a new step against the still-up stack, ordered before the `if: failure()` log-collection steps.

Deviation, recorded in TESTING.md: **bun:test, not vitest** — the reused orchestrator's `layout.ts` is bun-native (`import.meta.dir`); vitest remains the target if/when layout.ts is ported off bun APIs.

Also documented: the SDK gaps that keep the disclose/consume leg in bash for now (mint init, wrap, balance-state reads, burn/seal/redeem instructions, MMR proof sourcing — the last one is in flight as fhevm-internal#1721).

## Review trail

Independent adversarial round verified: the arc is fully self-provisioning (fresh mints/keypairs per run — moving it after the vertical creates no ordering flakes), CI failure propagation + log capture ordering correct, orchestrator refactor byte-neutral, commit 1 independently green, zizmor clean. Verdict APPROVE-WITH-NITS; its P3s plus a code-quality lookback (subprocess use, business-endpoint probe, filler assertion, constant drift, dead field) all folded.

## Test plan

- [x] `bun run check` / `bun run test:e2e:harness` (9) / `bun test src/solana/*.test.ts` (14) / `bash -n full-vertical.sh`
- [x] Commit 1 checked out alone: harness tests + typecheck green
- [ ] `solana-e2e` on this PR — the scenario step's first live execution IS this PR's CI run