### PR TITLE
docs(host-contracts): correct the MPC threshold docs/natspecs

### DIFF
--- a/host-contracts/contracts/interfaces/IProtocolConfig.sol
+++ b/host-contracts/contracts/interfaces/IProtocolConfig.sol
@@ -19,7 +19,7 @@ interface IProtocolConfig {
      * @param publicDecryption Minimum signatures required for public decryption verification.
      * @param userDecryption Minimum signatures required for user decryption verification.
      * @param kmsGen Minimum signatures required for key/CRS generation consensus.
-     * @param mpc Minimum signatures required for MPC computation quorums.
+     * @param mpc MPC fault threshold `t`: max faulty or malicious MPC nodes tolerated.
      */
     struct KmsThresholds {
         uint256 publicDecryption;


### PR DESCRIPTION
Note that the second recommendation was not considered because:

- It contradicts a deliberate design decision. The quorum comment explicitly states "the contract itself does not enforce the topology," and the quorum is floored at 1 precisely so "the degenerate t = n config cannot make the quorum zero."
- The trust boundary is governance, not an attacker. Both defineNewKmsContextAndEpoch and updateMpcThresholdForContext are onlyACLOwner (the DAO). The finding itself says no exploitable condition exists today; the risk is a documentation-induced operational mistake by a trusted operator. 

In summary, we didn't add this check because we decided to allow the "degenerate t = n config" from our testing cases. In other words, the honest value for a 1-node dev committee (from our E2E tests) is t = 0, which _checkThreshold currently rejects. So we floored the quorum at 1 and avoided checking n - t > t.

Closes https://github.com/zama-ai/fhevm-internal/issues/1785