### PR TITLE
ci(solana): cache workspace dep compile via cargo-chef + registry buildcache

### DIFF
--- a/.github/workflows/solana-images-publish.yml
+++ b/.github/workflows/solana-images-publish.yml
@@ -214,3 +214,84 @@ jobs:
             --tag "ghcr.io/zama-ai/$IMAGE:feature-solana" \
             --tag "ghcr.io/zama-ai/$IMAGE:feature-solana-$SHA" \
             --push "$CONTEXT"
+
+  # Cache WRITER for the BRANCH-LOCAL coprocessor workspace Dockerfile
+  # (coprocessor/fhevm-engine/Dockerfile.workspace). Separate from the per-image
+  # `publish` job above: that job builds the per-binary Dockerfiles (like main's
+  # release CI); this one builds the single-cargo-pass workspace Dockerfile that
+  # solana-e2e's --override compose builds use, and exports its layers so the
+  # ~28-min cold dependency compile (tfhe-rs dominates) is paid once per branch
+  # tip instead of on every PR run. READERS are solana-e2e's compose builds,
+  # which add the shared cache ref via FHEVM_BUILDCACHE_TAG (see
+  # withRegistryBuildCache + WORKSPACE_BUILDCACHE_IMAGE in test-suite/fhevm). This
+  # job is BRANCH-LOCAL and dies at merge-back to main, alongside the Dockerfile.
+  #
+  # mode=max exports intermediate (builder-stage) layers — the cargo-chef `cook`
+  # layer that holds the compiled dependencies, which is the whole point. The
+  # cook layer is keyed only on recipe.json (+ the chef layer + CARGO_PROFILE),
+  # all of which precede the per-PR-varying source/contract COPYs, so a PR that
+  # touches no Cargo manifest reuses it. A SINGLE `--target db-migration` build
+  # covers everything: db-migration's stage graph COPYs from both `builder`
+  # (/out/resolve_database_url) and `sqlx_builder`, so building it pulls the full
+  # chef -> planner -> builder (cook) chain plus sqlx_builder, and mode=max
+  # exports every one of those layers under the one shared cache ref — which is
+  # what the worker services (target tfhe-worker/host-listener/...) then read.
+  # CARGO_PROFILE is left at the Dockerfile default (release) — fhevm-cli passes
+  # none, so writer and reader must match by both defaulting. No sccache args are
+  # passed: sccache sits AFTER the cook layer in the Dockerfile, so the exported
+  # cook layer is credential-independent and shared with the credential-bearing
+  # e2e reads.
+  workspace-cache:
+    name: publish/coprocessor-workspace-cache
+    # volume=160gb: the workspace target dir plus the exported mode=max layers need headroom.
+    runs-on: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/volume=160gb/extras=s3-cache
+    timeout-minutes: 90
+    permissions:
+      contents: "read" # checkout
+      packages: "write" # push the cache manifest to ghcr.io
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: "false"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Login to ghcr.io
+        # GITHUB_TOKEN with packages:write pushes the repo-owned cache manifest (same pattern as
+        # the publish job above). Also covers pulling the gci base images.
+        uses: zama-ai/ci-templates/.github/actions/retry@542103e14b9ae6a9aea27787b8724b3b35bb3918 # v1.0.9
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          command: |
+            echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+      - name: Login to cgr.dev
+        # Chainguard base images (glibc-dynamic, postgres, rust) used by the runtime + db stages.
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CGR_USERNAME }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as solana-e2e.yml
+          password: ${{ secrets.CGR_PASSWORD }} # zizmor: ignore[secrets-outside-env] registry creds, same pattern as solana-e2e.yml
+
+      - name: Build and export workspace cache
+        env:
+          DOCKERFILE: coprocessor/fhevm-engine/Dockerfile.workspace
+          # Single shared cache ref for every coprocessor workspace target (they share the builder
+          # stage). Matches WORKSPACE_BUILDCACHE_IMAGE + FHEVM_BUILDCACHE_TAG on the reader side.
+          CACHE_REF: ghcr.io/zama-ai/fhevm/coprocessor/workspace:buildcache-feature-solana
+        run: |
+          set -euo pipefail
+          # db-migration depends on builder + sqlx_builder, so this one build exports the whole
+          # chef -> planner -> builder (cook) chain AND sqlx_builder under the shared ref.
+          # Cache-only: no --tag, no --push. A missing cache ref on the first run is a non-fatal
+          # BuildKit warning.
+          docker buildx build \
+            --file "$DOCKERFILE" \
+            --target db-migration \
+            --cache-from "type=registry,ref=$CACHE_REF" \
+            --cache-to "type=registry,ref=$CACHE_REF,mode=max,image-manifest=true,oci-mediatypes=true" \
+            .

--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -6,6 +6,16 @@
 # `--override` compose builds compile all coprocessor binaries in ONE cargo
 # pass instead of eight sequential full-workspace compilations (measured:
 # ~41 min of cargo, 71 min run vs 44 min baseline).
+#
+# CACHING (CI): the Rust build is split into cargo-chef stages. A `planner`
+# emits recipe.json (dependency graph only); `builder` COPYs it and runs
+# `cargo chef cook`, compiling every dependency (tfhe-rs dominates) in a layer
+# keyed only on recipe.json (plus the chef layer + CARGO_PROFILE). That cook
+# layer is exported to a registry BuildKit cache by solana-images-publish.yml's
+# workspace-cache job (the WRITER) and read back by solana-e2e's --override
+# compose builds via FHEVM_BUILDCACHE_TAG. This replaces the old
+# `--mount=type=cache` target/registry mounts, which were always empty on the
+# fresh spot runners CI provisions per job.
 # =============================================================================
 # =============================================================================
 # UNIFIED COPROCESSOR DOCKERFILE (LOCAL BUILDS)
@@ -66,12 +76,122 @@ RUN npm ci && \
     DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
 
 # =============================================================================
+# Stage 1-chef: install cargo-chef (shared base for planner + builder)
+# =============================================================================
+FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS chef
+
+USER root
+WORKDIR /app
+
+# Pinned to an exact version so the cook layer's cache key is stable across e2e
+# runs, fork PRs, and the publish writer (a version bump reshapes the cook layer).
+RUN cargo install cargo-chef --locked --version 0.1.77
+
+# =============================================================================
+# Stage 1-planner: emit the cargo-chef recipe (dependency graph only)
+# =============================================================================
+FROM chef AS planner
+
+# The full Rust source set. `cargo chef prepare` runs `cargo metadata`, which
+# reads every manifest in the dependency graph (so the non-member path-dep crates
+# must be present), but records ONLY the workspace-member manifests into
+# recipe.json -- it never captures non-member path deps. That is why the builder
+# re-supplies those path-dep sources itself before cook. prepare compiles nothing,
+# so the contract artifacts are not needed here.
+COPY listener ./listener
+COPY coprocessor/fhevm-engine ./coprocessor/fhevm-engine
+COPY coprocessor/proto ./coprocessor/proto
+COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
+COPY gateway-contracts/contracts ./gateway-contracts/contracts
+COPY host-contracts/contracts ./host-contracts/contracts
+COPY solana ./solana
+COPY shared/ciphertext-attestation ./shared/ciphertext-attestation
+
+WORKDIR /app/coprocessor/fhevm-engine
+RUN cargo chef prepare --recipe-path recipe.json
+
+# =============================================================================
 # Stage 1: Build ALL Rust workspace binaries
 # =============================================================================
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS builder
+FROM chef AS builder
 
+# CARGO_PROFILE is the ONLY build arg referenced before the cook layer, so the
+# cook cache key stays identical between the e2e reader and the publish writer
+# (fhevm-cli passes no CARGO_PROFILE; both sides fall back to this default).
 ARG CARGO_PROFILE=release
-ARG BUILD_ID=unknown
+
+# cargo chef cook compiles every dependency (tfhe-rs dominates) in one layer.
+# recipe.json captures the workspace MEMBER manifests only; cargo-chef never
+# stubs non-member path dependencies, so the workspace's out-of-tree path deps
+# must be present as real source before cook or cargo cannot read their manifests
+# (the missing confidential-token/scheduler/etc. manifests are what broke the
+# first CI run). These are: coprocessor/fhevm-engine/scheduler (a non-member crate
+# that lives inside the workspace dir but is pulled in by tfhe-worker), the
+# listener crates, the solana crates/programs, the gateway rust_bindings, and
+# ciphertext-attestation. They are COPYed here, ahead of cook, so cook resolves
+# and pre-compiles them alongside the registry deps; none of them carries a
+# build.rs, so no solc install is triggered here.
+#
+# Cook cache key = chef layer + CARGO_PROFILE + recipe.json + these path-dep
+# source trees. It is byte-identical between the publish writer (workspace-cache
+# job) and every e2e reader: all build this Dockerfile from the same commit, so
+# the COPYed trees and recipe.json match exactly. Nothing credential-bearing
+# appears before cook (no sccache), so cred-holding internal runners share the
+# layer too. A PR that touches none of these manifests/sources reuses the cached
+# cook (tfhe-rs stays cooked) even though the planner re-ran; a PR that changes
+# them re-cooks. (Keying on the path-dep source, not manifests alone, is forced
+# by cargo-chef's member-only capture -- non-member path deps compile from real
+# source, so their source must key the layer for the cache to stay sound.)
+#
+# cargo-chef stubs member sources AND their build.rs during cook, so the solc
+# installers in gw-listener/transaction-sender/host-listener do NOT run here (the
+# serial guard below still installs solc once for the real build). --profile (not
+# --release) is used so ${CARGO_PROFILE} flows through unchanged; the two flags
+# are mutually exclusive. On a cache MISS deps compile here WITHOUT sccache, by
+# design: sccache measured flat on this branch (#1766: 756s -> 844s), and keeping
+# cook credential-independent is what lets writer and every reader share the layer.
+#
+# rust-toolchain.toml (channel 1.91.1) is COPYed into this workdir BEFORE cook
+# runs, and this is required. tfhe 1.6.2 and aws-smithy-async 1.2.14 declare
+# rust-version 1.91.1, and modern cargo enforces that at BUILD time: it hard-errors
+# ("rustc 1.91.0 is not supported by the following packages") whenever the running
+# rustc is older, independently of dependency resolution -- so --locked alone does
+# NOT suppress it. The rust-glibc image's default toolchain is 1.91.0; the rustup
+# shim only selects 1.91.1 when it sees rust-toolchain.toml in the workdir at the
+# instant `cargo chef cook` is launched. cargo-chef does capture the toolchain file
+# into the recipe and rewrite it during cook, but by then it has already bound
+# $CARGO to whatever toolchain the shim resolved at launch, so the file must be
+# present up front rather than left to the recipe's write-back. That write-back is
+# byte-identical to what we COPY here, so there is no mid-build toolchain flip. The
+# final workspace build gets 1.91.1 the same way (from the full fhevm-engine COPY
+# below), so cook and the final build run the identical rustc -- their fingerprints
+# match and the final build reuses cook's compiled tfhe instead of rebuilding it.
+# The toolchain file is thus a deliberate cook-layer cache input: a toolchain bump
+# reshapes this layer and correctly invalidates the cooked dependencies.
+#
+# --locked is kept: prepare embeds Cargo.lock into recipe.json and cook writes it
+# back, and --locked forbids any re-resolution, so cook builds exactly the recipe's
+# locked versions -- no silent drift as crates.io moves, i.e. the cook layer stays
+# byte-identical for the writer and every reader.
+WORKDIR /app
+COPY coprocessor/fhevm-engine/scheduler ./coprocessor/fhevm-engine/scheduler
+COPY listener ./listener
+COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
+COPY solana ./solana
+COPY shared/ciphertext-attestation ./shared/ciphertext-attestation
+WORKDIR /app/coprocessor/fhevm-engine
+COPY coprocessor/fhevm-engine/rust-toolchain.toml ./
+COPY --from=planner /app/coprocessor/fhevm-engine/recipe.json recipe.json
+RUN cargo chef cook --locked --profile=${CARGO_PROFILE} --recipe-path recipe.json
+
+# sccache is used ONLY by the final build RUN below, so its args/ENV and install
+# live AFTER the cook layer. This keeps cook independent of the sccache args, so
+# fork PRs (empty bucket) and the publish writer (which passes no sccache args)
+# still share the cooked-dependencies layer with credential-bearing e2e runs.
+# TODO(sccache): temporary inline install for testing; remove once sccache
+# ships in the rust-glibc golden image and rely on that instead.
+# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
+# signal the build hook below uses, so the disabled path stays a plain build.
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -81,14 +201,6 @@ ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
 ENV SCCACHE_REGION=${SCCACHE_REGION}
 ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
 ENV AWS_REGION=${SCCACHE_REGION}
-
-USER root
-WORKDIR /app
-
-# TODO(sccache): temporary inline install for testing; remove once sccache
-# ships in the rust-glibc golden image and rely on that instead.
-# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
-# signal the build hook below uses, so the disabled path stays a plain build.
 RUN set -eux; \
     if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
     arch="$(uname -m)"; \
@@ -102,39 +214,44 @@ RUN set -eux; \
     chmod +x /usr/local/bin/sccache; \
     sccache --version
 
-# Copy contract artifacts from contract_builder stage
+# Copy contract artifacts from contract_builder stage (per-PR-varying: kept AFTER
+# the cook layer so it never perturbs the cook cache key).
 COPY --from=contract_builder /app/host-contracts/artifacts/contracts /app/host-contracts/artifacts/contracts
 COPY --from=contract_builder /app/gateway-contracts/artifacts/contracts /app/gateway-contracts/artifacts/contracts
 
-# Copy Rust sources and dependencies
-# TODO fix
-COPY listener ./listener
+# Copy the workspace member sources (these overwrite the cook stubs) plus proto
+# and the Solidity contract source dirs the member build references. The
+# non-member path deps (listener, solana, gateway rust_bindings,
+# ciphertext-attestation, scheduler) are already present from the pre-cook COPY
+# above, so they are not re-copied. The cooked target/ and cargo registry stay in
+# the layer (COPY only adds/overwrites). .dockerignore excludes solana/target.
+WORKDIR /app
 COPY coprocessor/fhevm-engine ./coprocessor/fhevm-engine
 COPY coprocessor/proto ./coprocessor/proto
-COPY gateway-contracts/rust_bindings ./gateway-contracts/rust_bindings
 COPY gateway-contracts/contracts ./gateway-contracts/contracts
 COPY host-contracts/contracts ./host-contracts/contracts
-# The Solana branch adds tfhe-worker dev-deps on solana/programs/{zama-host,
-# confidential-token}; the whole-workspace build must resolve their manifests, so
-# the Solana sources must be present. .dockerignore excludes solana/target.
-COPY solana ./solana
-COPY shared/ciphertext-attestation ./shared/ciphertext-attestation
 
 WORKDIR /app/coprocessor/fhevm-engine
 
-# Build entire workspace - tfhe compiles ONCE here
-# NOTE: We use cache mounts for incremental compilation. Because cache mounts
-# are NOT committed to the image layer, we must copy binaries to /out during
-# the same RUN instruction for COPY --from to work in later stages.
+# BUILD_ID is referenced only by the final workspace build, so it is declared
+# after the cook layer (kept adjacent to its use).
+ARG BUILD_ID=unknown
+
+# Build entire workspace - tfhe is already cooked, so this compiles only the
+# workspace members. The old --mount=type=cache registry/target mounts are gone:
+# they were always empty on CI's fresh spot runners, and they would now SHADOW
+# the cooked target/ and registry that live in this layer. Cross-run caching is
+# instead the registry BuildKit cache (writer: solana-images-publish.yml; reader:
+# solana-e2e via FHEVM_BUILDCACHE_TAG). The sccache secret mounts stay; cargo
+# fetch is a cheap no-op now; binaries are copied to /out so the runtime stages'
+# COPY --from=builder /out/... paths are unchanged.
 #
 # gw-listener, transaction-sender, and host-listener each call Solc::find_or_install(0.8.28) in
 # their build script. Under the parallel `cargo build --workspace` they race on svm's shared solc
 # binary (one writes it while another execs it -> ETXTBSY, "Text file busy"). So build gw-listener
 # first, serially, to install solc 0.8.28 once; the workspace build then finds it already present
 # instead of re-downloading. gw-listener does not depend on tfhe, so this serial step stays small.
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
-    --mount=type=secret,id=sccache_aws_access_key_id \
+RUN --mount=type=secret,id=sccache_aws_access_key_id \
     --mount=type=secret,id=sccache_aws_secret_access_key \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
       export RUSTC_WRAPPER=sccache; \
@@ -161,48 +278,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # =============================================================================
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:1.91.0 AS sqlx_builder
 
-ARG SCCACHE_BUCKET
-ARG SCCACHE_REGION=eu-west-3
-ARG SCCACHE_S3_PREFIX
-ARG SCCACHE_VERSION=v0.15.0
-ENV SCCACHE_IDLE_TIMEOUT=0
-ENV SCCACHE_BUCKET=${SCCACHE_BUCKET}
-ENV SCCACHE_REGION=${SCCACHE_REGION}
-ENV SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_PREFIX}
-ENV AWS_REGION=${SCCACHE_REGION}
-
 USER root
 WORKDIR /app
 
-# TODO(sccache): temporary inline install for testing; remove once sccache
-# ships in the rust-glibc golden image and rely on that instead.
-# Skipped entirely (no network fetch) when SCCACHE_BUCKET is unset, the same
-# signal the build hook below uses, so the disabled path stays a plain build.
-RUN set -eux; \
-    if [ -z "${SCCACHE_BUCKET}" ]; then echo "SCCACHE_BUCKET unset; skipping sccache install"; exit 0; fi; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64)  triple=x86_64-unknown-linux-musl ;; \
-        aarch64) triple=aarch64-unknown-linux-musl ;; \
-        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-    esac; \
-    curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${triple}.tar.gz" \
-        | tar -xz --strip-components=1 -C /usr/local/bin "sccache-${SCCACHE_VERSION}-${triple}/sccache"; \
-    chmod +x /usr/local/bin/sccache; \
-    sccache --version
-
+# No sccache in this stage: sccache measured flat on this branch's builds, and
+# this sqlx layer must be credential-independent so the publish writer's export
+# and every reader (incl. cred-bearing internal e2e runners) share it. The
+# registry mount only speeds fresh downloads; the compiled sqlx binary lands in
+# /usr/local/cargo/bin and is committed to the layer regardless.
 # Install sqlx-cli
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-    --mount=type=secret,id=sccache_aws_access_key_id \
-    --mount=type=secret,id=sccache_aws_secret_access_key \
-    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then \
-      export RUSTC_WRAPPER=sccache; \
-      export AWS_ACCESS_KEY_ID="$(cat /run/secrets/sccache_aws_access_key_id)"; \
-      export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
-    fi && \
     cargo install sqlx-cli --version 0.7.2 \
-    --no-default-features --features postgres,rustls --locked && \
-    if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi
+    --no-default-features --features postgres,rustls --locked
 
 # =============================================================================
 # Stage 2a: tfhe-worker runtime

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -25,7 +25,7 @@ import { type StackSpec, topologyForState } from "../stack-spec/stack-spec";
 import { buildKmsThresholdOverride, kmsRenderOptionsFor } from "./kms-core";
 import type { HostChainScenario, ResolvedCoprocessorScenarioInstance, State } from "../types";
 import { ensureDir, exists, mergeArgs, readEnvFile, remove, toServiceName } from "../utils/fs";
-import { buildCacheEnabled, buildCacheTag } from "../utils/build-cache";
+import { WORKSPACE_BUILDCACHE_IMAGE, buildCacheEnabled, buildCacheTag } from "../utils/build-cache";
 import {
   sccacheBuildArgs,
   sccacheBuildSecretIds,
@@ -217,26 +217,37 @@ const withSccacheBuild = (component: string, build: Record<string, unknown> | un
 };
 
 /**
- * Adds a registry `cache_from` entry (the per-image BuildKit cache manifest that
- * solana-images-publish.yml exports) when FHEVM_BUILDCACHE_TAG is set. The cache ref is the
- * service's own image repository at the cache tag, so the compose reader and the publish-workflow
- * writer stay aligned without a name map. Scoped to the same Rust components as sccache (the
- * builds the publish workflow exports caches for), and within those to the specs that still build
- * from a per-binary Dockerfile: the publish workflow's caches are per-binary build graphs, so
- * they cannot hit against the branch-local workspace Dockerfiles — injecting them there would
- * only add a guaranteed cache miss (harmless but pointless). A no-op otherwise, so the generated
+ * Adds a registry `cache_from` entry (the BuildKit cache manifest that
+ * solana-images-publish.yml exports) when FHEVM_BUILDCACHE_TAG is set. Scoped to the same Rust
+ * components as sccache (the builds the publish workflow exports caches for). Two cases:
+ *
+ *   - Per-binary Dockerfile builds (e.g. kms-connector-db-migration): the cache ref is the
+ *     service's own image repository at the cache tag, so the compose reader and the publish
+ *     writer's per-image job stay aligned without a name map.
+ *   - coprocessor workspace builds (Dockerfile.workspace): every coprocessor workspace target
+ *     shares one `builder` stage (its cargo-chef cook layer holds the whole dependency compile),
+ *     so ONE shared manifest — WORKSPACE_BUILDCACHE_IMAGE at the cache tag — serves every service.
+ *     This is exported by solana-images-publish.yml's workspace-cache job.
+ *
+ * The kms-connector workspace Dockerfile has no cache writer, so those builds stay uncached
+ * (injecting a ref there would only add a guaranteed miss). A no-op otherwise, so the generated
  * compose is byte-identical when FHEVM_BUILDCACHE_TAG is unset.
  */
 const withRegistryBuildCache = (component: string, image: unknown, build: Record<string, unknown> | undefined) => {
   if (!build || !buildCacheEnabled() || !SCCACHE_BUILD_COMPONENTS.has(component) || typeof image !== "string") {
     return build;
   }
-  if (typeof build.dockerfile === "string" && build.dockerfile.endsWith("Dockerfile.workspace")) {
+  const isWorkspace = typeof build.dockerfile === "string" && build.dockerfile.endsWith("Dockerfile.workspace");
+  if (isWorkspace && component !== "coprocessor") {
+    // No writer exports the kms-connector workspace cache; leave those builds uncached.
     return build;
   }
+  const cacheRef = isWorkspace
+    ? `${WORKSPACE_BUILDCACHE_IMAGE}:${buildCacheTag()}`
+    : rewriteImageTag(image, buildCacheTag());
   const next = structuredClone(build);
   const existing = Array.isArray(next.cache_from) ? (next.cache_from as string[]) : [];
-  next.cache_from = [...existing, rewriteImageTag(image, buildCacheTag())];
+  next.cache_from = [...existing, cacheRef];
   return next;
 };
 

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -469,7 +469,7 @@ describe("render-compose", () => {
       });
     });
 
-    test("adds a per-image registry cache_from only for per-image Dockerfile builds", async () => {
+    test("adds the shared workspace cache_from for coprocessor and per-image refs elsewhere", async () => {
       await withTempStateDir(async () => {
         await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
         await writeFile(envPath("coprocessor"), "\n");
@@ -478,17 +478,24 @@ describe("render-compose", () => {
         const withEnv = await renderOverrides({ ...BUILDCACHE_ENV });
 
         type BuildDoc = { services: Record<string, { build?: { cache_from?: string[] } }> };
+        const coprocessor = YAML.parse(withEnv.coprocessor) as BuildDoc;
         const connector = YAML.parse(withEnv.connector) as BuildDoc;
 
-        // The publish workflow exports per-image build caches; those cannot hit against the
-        // branch-local workspace Dockerfiles, so workspace-built services get no cache_from and
-        // a set FHEVM_BUILDCACHE_TAG stays harmless.
-        expect(withEnv.coprocessor).not.toContain("cache_from");
+        // Every coprocessor workspace service shares one builder stage (its cargo-chef cook layer
+        // holds the whole dependency compile), so they all point at the SINGLE shared workspace
+        // manifest that solana-images-publish.yml's workspace-cache job exports.
+        const workspaceRef = ["ghcr.io/zama-ai/fhevm/coprocessor/workspace:buildcache-test"];
+        for (const service of ["coprocessor-host-listener", "coprocessor-tfhe-worker", "coprocessor-db-migration"]) {
+          expect(coprocessor.services[service]?.build?.cache_from).toEqual(workspaceRef);
+        }
+
+        // The kms-connector workspace Dockerfile has no cache writer, so its workspace-built
+        // services get no cache_from and a set FHEVM_BUILDCACHE_TAG stays harmless there.
         expect(connector.services["kms-connector-kms-worker"]?.build?.cache_from).toBeUndefined();
 
         // connector-db still builds from its per-image Dockerfile, so its cache ref is the
         // service's own image repository at the cache tag, matching what
-        // solana-images-publish.yml exports.
+        // solana-images-publish.yml's per-image publish job exports.
         expect(connector.services["kms-connector-db-migration"]?.build?.cache_from).toEqual([
           "ghcr.io/zama-ai/fhevm/kms-connector/db-migration:buildcache-test",
         ]);

--- a/test-suite/fhevm/src/utils/build-cache.ts
+++ b/test-suite/fhevm/src/utils/build-cache.ts
@@ -20,3 +20,18 @@ export const buildCacheEnabled = () => !!process.env.FHEVM_BUILDCACHE_TAG;
 
 /** The registry tag holding each image's BuildKit cache manifest ("" when disabled). */
 export const buildCacheTag = () => process.env.FHEVM_BUILDCACHE_TAG ?? "";
+
+/**
+ * Shared cache-manifest repository for the branch-local coprocessor workspace
+ * Dockerfile (coprocessor/fhevm-engine/Dockerfile.workspace). Every coprocessor
+ * workspace target shares one `builder` stage — whose cargo-chef `cook` layer
+ * holds the whole dependency compile — so a SINGLE manifest at this ref serves
+ * every coprocessor service, rather than one per-image ref.
+ *
+ * WRITER: solana-images-publish.yml's workspace-cache job exports here (mode=max)
+ * on every push to feature/solana. READER: the generated compose adds this as a
+ * `cache_from` on every locally-built coprocessor service when
+ * FHEVM_BUILDCACHE_TAG is set (see withRegistryBuildCache in compose.ts). No
+ * writer exists for the kms-connector workspace Dockerfile, so it stays uncached.
+ */
+export const WORKSPACE_BUILDCACHE_IMAGE = "ghcr.io/zama-ai/fhevm/coprocessor/workspace";


### PR DESCRIPTION
## What

Adds a cargo-chef cook layer to `Dockerfile.workspace` and a registry buildcache writer for it, so the ~28-minute coprocessor workspace image build in Solana e2e drops to ~10–12 min whenever Cargo manifests are unchanged.

Branch-local experiment: all three touched areas (`Dockerfile.workspace`, `solana-images-publish.yml`, the compose generator) exist only on `feature/solana` or are additive, so the whole commit is droppable at merge-back.

## How

- **`coprocessor/fhevm-engine/Dockerfile.workspace`** — new `chef`/`planner` stages produce `recipe.json`; the builder runs `cargo chef cook` before any source `COPY`, so the dependency-compile layer is keyed only on the recipe + `CARGO_PROFILE`. sccache wiring moves after cook (and is removed entirely from `sqlx_builder`) so the cached layers are credential-independent — writer and all readers share the same key. The old `--mount=type=cache` target/registry mounts on the final `RUN` are removed: on fresh CI runners they were always empty, and they would shadow the cooked layers. The serial `cargo build -p gw-listener` solc guard stays (cargo-chef stubs `build.rs` during cook, so cook doesn't cover it).
- **`.github/workflows/solana-images-publish.yml`** — new `workspace-cache` job: a cache-only `docker buildx build --target db-migration` exporting `mode=max` to `ghcr.io/zama-ai/fhevm/coprocessor/workspace:buildcache-feature-solana`. One build suffices: `db-migration` depends on both `builder` and `sqlx_builder`, so the full graph exports under the one ref.
- **`test-suite/fhevm/src/generate/compose.ts` + `build-cache.ts`** — the existing `withRegistryBuildCache` guard that skipped `Dockerfile.workspace` builds now redirects coprocessor workspace builds to the new cache ref (kms-connector workspace stays skipped, as before — no writer for it).

`solana-e2e.yml` is untouched — it already sets `FHEVM_BUILDCACHE_TAG=buildcache-feature-solana` and the compose generator injects `cache_from`.

## Expected behavior

- Manifest-unchanged PRs (the common case): cook layer hits, only workspace source recompiles.
- `Cargo.toml`/`Cargo.lock` changes: cook recompiles deps from scratch, without sccache — accepted tradeoff, since sccache measured flat on this build (756s→844s in the branch's own timing data).
- Fork PRs benefit too: the cache key carries no credential-dependent ARGs.

## Verification

- `bun test` (test-suite/fhevm): 253 pass
- `tsc --noEmit`, `actionlint`, `zizmor`: clean
- Real cook/build behavior is validated by CI itself on this PR (no local Docker daemon); the writer job runs on merge to `feature/solana`, so the first cache hit lands on the PR after this one merges.

Reviewed by an independent fresh-context pass (cache-key writer≡reader parity, planner COPY-set completeness, workflow, compose/TS all verified; both P2 findings addressed in this commit).
