### PR TITLE
test(test-suite): add threshold KMS Rand repro

### DIFF
--- a/.github/workflows/test-suite-e2e-threshold-post-merge.yml
+++ b/.github/workflows/test-suite-e2e-threshold-post-merge.yml
@@ -43,7 +43,7 @@ jobs:
       orchestrated: false
       build: false
       scenario: four-party-threshold-kms
-      test-profile: kms-generation
+      test-profile: kms-generation-random
 
   threshold-kms-context-switch:
     uses: ./.github/workflows/test-suite-e2e-tests.yml

--- a/.github/workflows/test-suite-orchestrate-e2e-tests.yml
+++ b/.github/workflows/test-suite-orchestrate-e2e-tests.yml
@@ -336,14 +336,14 @@ jobs:
       test-suite-version: ${{ needs.create-e2e-tests-input.outputs.test-suite-version }}
 
   # Same orchestrated PR-built images and base-sha lock as run-e2e-tests, exercised against a real
-  # 4-party threshold-mode KMS (secure keygen, Test params) via the kms-generation acceptance profile.
+  # 4-party threshold-mode KMS (secure keygen, Test params) via the combined KMS/Rand repro profile.
   # NOT a merge-queue gate, and since it competes with the gating shards for the same runner pool it
   # deliberately does NOT run on mergify merge-queue PRs — the same coverage runs post-merge on every
   # main push via test-suite-e2e-threshold-post-merge.yml. It still runs here for release branches and
   # PRs labeled `e2e orchestrate test`. For a standalone threshold run (no full image build), dispatch
   # the reusable workflow directly:
   #   gh workflow run test-suite-e2e-tests.yml -f scenario=four-party-threshold-kms \
-  #     -f test-profile=kms-generation -f build=false
+  #     -f test-profile=kms-generation-random -f build=false
   run-e2e-tests-threshold-kms:
     needs: [create-e2e-tests-input]
     if: &threshold-trigger-condition |
@@ -380,7 +380,7 @@ jobs:
       relayer-migrate-version: ${{ needs.create-e2e-tests-input.outputs.relayer-migrate-version }}
       relayer-version: ${{ needs.create-e2e-tests-input.outputs.relayer-version }}
       scenario: four-party-threshold-kms
-      test-profile: kms-generation
+      test-profile: kms-generation-random
       test-suite-version: ${{ needs.create-e2e-tests-input.outputs.test-suite-version }}
 
   # Same orchestrated images/lock, exercised against the kms-context-switch acceptance profile on the

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -71,6 +71,7 @@ const TEST_PROFILE_NAMES = [
   "heavy",
   "kms-context-switch",
   "kms-generation",
+  "kms-generation-random",
   "kms-generation-abort",
   "light",
   "rollout-standard",
@@ -133,6 +134,8 @@ const TEST_PROFILE_DESCRIPTIONS: Partial<Record<(typeof TEST_PROFILE_NAMES)[numb
   "coprocessor-db-state-revert": "Run coprocessor DB state revert checks.",
   "kms-generation":
     "Audit the on-chain key/CRS generation state (KMSGeneration contract) and prove the 2t+1 decryption quorum (threshold-mode KMS).",
+  "kms-generation-random":
+    "Run the threshold KMS generation/quorum audit, then run the 64-bit Rand subset on the same recovered Test-parameter stack.",
   "kms-generation-abort":
     "Abort an in-flight keygen and crsgen, prove the contract and every kms-connector retire the requests, then prove the pipeline recovers with a fresh keygen/crsgen to full activation. Disruptive: rotates the active key/CRS — run last or re-up afterwards.",
   "kms-context-switch":
@@ -1480,6 +1483,16 @@ export const test = async (testName: string | undefined, options: TestOptions) =
   const runProfile = async (name: string) => {
     if (name === "kms-generation") {
       return runKmsGenerationProfile(state, runUserDecryption);
+    }
+    if (name === "kms-generation-random") {
+      await runKmsGenerationProfile(state, runUserDecryption);
+      const grep = TEST_GREP["random-subset"];
+      if (!grep) {
+        throw new PreflightError("kms-generation-random: missing random-subset grep pattern");
+      }
+      await runNamedE2e(options, grep, "kms-generation-random: random-subset");
+      console.log("[kms-generation-random] PASS — threshold KMS audit and Rand repro completed on one stack");
+      return;
     }
     if (name === "kms-generation-abort") {
       return runKmsGenerationAbortProfile(state);


### PR DESCRIPTION
## Summary
- add a `kms-generation-random` profile that runs the existing threshold KMSGeneration/quorum audit and then the 64-bit Rand subset after all parties recover
- run that profile from the existing four-party Test-parameter threshold CI paths, preserving the current CI trigger conditions

This makes a Rand failure actionable: the same fresh stack proves key/CRS activation, signer registration, ordinary decryption, and 2t+1 quorum before running Rand.

## Validation
- `bun run check`
- `bun test src` (309 pass)
- workflow YAML parsing and `actionlint`
