### PR TITLE
docs(host-contracts): clarify KMS context-validity gates on lifecycle reads (N-05)

### DIFF
--- a/host-contracts/contracts/KMSGeneration.sol
+++ b/host-contracts/contracts/KMSGeneration.sol
@@ -869,10 +869,9 @@ contract KMSGeneration is IKMSGeneration, EIP712Upgradeable, UUPSUpgradeableEmpt
         address signerAddress,
         address txSenderAddress
     ) internal view virtual {
-        // This signer check requires an `Active` context. The sibling response-path reads
-        // (tx-sender, kmsGen threshold, node) accept any live context. They agree today because
-        // every request pins its context from `getCurrentKmsContextAndEpoch`, which returns the
-        // active context. The live gates also permit a context that is not yet `Active`.
+        // This signer check requires an `Active` context. The other reads this contract makes on
+        // `PROTOCOL_CONFIG` accept any live context. Both gates agree today because every request
+        // pins its context from `getCurrentKmsContextAndEpoch`, which returns the active context.
         if (!PROTOCOL_CONFIG.isKmsSignerForContext(contextId, signerAddress)) {
             revert NotKmsSigner(signerAddress);
         }

--- a/host-contracts/contracts/KMSGeneration.sol
+++ b/host-contracts/contracts/KMSGeneration.sol
@@ -869,6 +869,10 @@ contract KMSGeneration is IKMSGeneration, EIP712Upgradeable, UUPSUpgradeableEmpt
         address signerAddress,
         address txSenderAddress
     ) internal view virtual {
+        // This signer check requires an `Active` context. The sibling response-path reads
+        // (tx-sender, kmsGen threshold, node) accept any live context. They agree today because
+        // every request pins its context from `getCurrentKmsContextAndEpoch`, which returns the
+        // active context. The live gates also permit a context that is not yet `Active`.
         if (!PROTOCOL_CONFIG.isKmsSignerForContext(contextId, signerAddress)) {
             revert NotKmsSigner(signerAddress);
         }

--- a/host-contracts/contracts/interfaces/IProtocolConfig.sol
+++ b/host-contracts/contracts/interfaces/IProtocolConfig.sol
@@ -607,6 +607,8 @@ interface IProtocolConfig {
 
     /**
      * @notice Returns the kmsGen threshold for a given context.
+     * @dev Unlike the peer threshold getters, this returns a value for an `Active`, `Pending` or
+     *      `Created` context, so a created-but-not-active context's kmsGen threshold stays readable.
      * @param kmsContextId The context ID.
      * @return The kmsGen threshold for the context.
      */

--- a/host-contracts/contracts/interfaces/IProtocolConfig.sol
+++ b/host-contracts/contracts/interfaces/IProtocolConfig.sol
@@ -607,8 +607,9 @@ interface IProtocolConfig {
 
     /**
      * @notice Returns the kmsGen threshold for a given context.
-     * @dev Unlike the peer threshold getters, this returns a value for an `Active`, `Pending` or
-     *      `Created` context, so a created-but-not-active context's kmsGen threshold stays readable.
+     * @dev The other threshold getters require an `Active` context. This one returns a value for any
+     *      live context, whatever its state, so the kmsGen threshold stays readable even before the
+     *      context becomes `Active`.
      * @param kmsContextId The context ID.
      * @return The kmsGen threshold for the context.
      */


### PR DESCRIPTION
Documents the deliberately looser live-context gate on KMS lifecycle reads and the active-only signer gate invariant, resolving audit finding N-05.
Closes https://github.com/zama-ai/fhevm-internal/issues/1793