### PR TITLE
ci(solana): stop rebuilding all images for e2e scenario and demo script changes

### DIFF
--- a/solana/scripts/e2e/select-overrides.sh
+++ b/solana/scripts/e2e/select-overrides.sh
@@ -11,7 +11,9 @@
 # Selection rule:
 #   1. Diff <base-sha>..HEAD and map changed paths to the five groups (see path map below).
 #      Paths that affect the build recipe itself (this script, the e2e/publish workflows,
-#      test-suite/fhevm, clean-e2e.sh) force building everything.
+#      test-suite/fhevm, clean-e2e.sh) force building everything — except the pure stack
+#      consumers test-suite/fhevm/e2e/ and test-suite/fhevm/demo/, which run from PR source
+#      and are copied into no image.
 #   2. Groups whose image inputs changed are built from source (--override), exactly as before.
 #   3. The untouched groups run the immutable base-commit images
 #      `ghcr.io/zama-ai/fhevm/<image>:feature-solana-<base-sha>` (bit-for-bit the code the PR is
@@ -88,6 +90,10 @@ images_for() {
 groups_for_path() {
   local path="$1"
   case "$path" in
+    # Stack consumers, not build inputs: e2e tests and demo scripts run from PR source against
+    # the already-built stack (no Dockerfile copies these trees), so they never change image
+    # contents. Matched before the test-suite/fhevm/* recipe rule below.
+    test-suite/fhevm/e2e/*|test-suite/fhevm/demo/*) echo "" ;;
     # Build-recipe changes: rebuild everything (a stale published image could mask the change).
     solana/scripts/e2e/select-overrides.sh|solana/scripts/e2e/clean-e2e.sh|.github/workflows/solana-e2e.yml|.github/workflows/solana-images-publish.yml|test-suite/fhevm/*|package.json|package-lock.json)
       echo "all" ;;

--- a/solana/scripts/e2e/select-overrides.test.sh
+++ b/solana/scripts/e2e/select-overrides.test.sh
@@ -131,6 +131,26 @@ check "sdk-only change -> no overrides" \
   "none" \
   "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
 
+# e2e tests and demo scripts run from PR source against the built stack; no image copies them.
+check "e2e scenario change -> no overrides" \
+  "test-suite/fhevm/e2e/scenarios/deposit-arc.scenario.test.ts" \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
+check "demo script change -> no overrides" \
+  "test-suite/fhevm/demo/demo-up.sh" \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
+# The SDK-plus-scenario PR shape that used to pay for a full workspace rebuild.
+check "sdk + scenario change -> no overrides" \
+  $'sdk/js-sdk/src/solana/vault/index.ts\ntest-suite/fhevm/e2e/scenarios/deposit-arc.scenario.test.ts' \
+  "true" \
+  "none" \
+  "$PINS_GATEWAY $PINS_HOST $PINS_COPRO $PINS_RELAYER $PINS_CONNECTOR"
+
 # Build-recipe changes force full source builds regardless of published images.
 check "workflow change -> build all" \
   ".github/workflows/solana-e2e.yml" \


### PR DESCRIPTION
## Problem

`select-overrides.sh` maps every `test-suite/fhevm/*` change to the build-recipe rule ("rebuild all five image groups from source"). But that tree mostly contains stack **consumers**: `e2e/` (scenario tests) and `demo/` (demo scripts, faucet, config seeding) run from PR source against the already-built stack — no docker image copies them. The result: SDK+scenario PRs like #3324 paid the full coprocessor workspace source build (~18 min) for changes that cannot affect image contents.

## Change

Two-line carve-out in the path map, matched ahead of the recipe rule:

- `test-suite/fhevm/e2e/*` and `test-suite/fhevm/demo/*` → no groups (published base-commit images stay valid).
- Everything else under `test-suite/fhevm/` (fhevm-cli `src/`, `docker-compose/`, `templates/`, `env/`, lockfiles, `solana-images.env`) keeps forcing full source builds — those genuinely shape how images are built and selected.

## Safety argument

Image selection asks one question: would this PR's source produce different image contents than the published base-commit images? For these two trees the answer is structurally no:

- `grep -rn test-suite --include='Dockerfile*'` across the repo: the only Dockerfiles copying test-suite trees are `test-suite/e2e` (the EVM suite — a different tree) and `test-suite/gateway-stress`; neither is one of the five solana-e2e groups. The `Dockerfile.workspace` hits are usage-hint comments.
- The e2e and demo phases execute these files from the checked-out PR source (`bun test`, `bun run demo:smoke`, `demo-up.sh`), so the changed behavior is always exercised.

## Verification

- `select-overrides.test.sh`: 20/20 pass — 3 new cases (e2e scenario → none, demo script → none, and the SDK+scenario combination that motivated this) plus the pre-existing `test-suite/fhevm/src` → build-all case unchanged.
- shellcheck clean on both files.