### PR TITLE
feat(test-suite): ship fhevm-sdk CLI in e2e image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -131,6 +131,8 @@ golden-container-images/
 sdk/*
 !sdk/js-sdk/
 !sdk/js-sdk/**
+!sdk/cli-js-sdk/
+!sdk/cli-js-sdk/**
 
 # -----------------------------------------------------------------------------
 # CI directory (not used by any Dockerfile)

--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -67,6 +67,7 @@ jobs:
           - '.github/workflows/test-suite-docker-build.yml'
           - 'test-suite/e2e/**'
           - 'library-solidity/**'
+          - 'sdk/cli-js-sdk/**'
 
   build:
     needs: [is-latest-commit, check-changes]

--- a/ci/preview-env/test-suite/values-test-suite-e2e.yaml
+++ b/ci/preview-env/test-suite/values-test-suite-e2e.yaml
@@ -145,3 +145,6 @@ env:
     valueFrom: {configMapKeyRef: {name: gw-sc-addresses, key: protocol_payment.address, optional: true}}
   - name: ZAMA_OFT_ADDRESS
     valueFrom: {configMapKeyRef: {name: gw-sc-addresses, key: mocked_zama_oft.address, optional: true}}
+  # fhevm-sdk CLI (in real/long-lived environments these should come from Secrets via secretKeyRef)
+  - {name: PRIVATE_KEY, value: "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"}
+  - {name: SEPOLIA_RPC_URL, value: "http://anvil-host-anvil-node:8545"}

--- a/ci/preview-env/test-suite/values-test-suite-e2e.yaml
+++ b/ci/preview-env/test-suite/values-test-suite-e2e.yaml
@@ -133,3 +133,6 @@ env:
   - {name: DEPLOYER_PRIVATE_KEY, value: "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"}
   - {name: RELAYER_URL, value: "http://relayer:3000/v2"}
   - {name: RELAYER_SDK_VERSION, value: ""}
+  # fhevm-sdk CLI (in real/long-lived environments these should come from Secrets via secretKeyRef)
+  - {name: PRIVATE_KEY, value: "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"}
+  - {name: SEPOLIA_RPC_URL, value: "http://anvil-host-anvil-node:8545"}

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -55,6 +55,26 @@ WORKDIR /app/test-suite/e2e
 
 RUN npx hardhat compile
 
+# --- CLI Builder Stage ---
+# sdk/cli-js-sdk is a standalone pnpm workspace (not part of the root npm
+# workspaces), so it gets its own stage. `pnpm deploy` produces a
+# self-contained folder (package + resolved prod node_modules, no store
+# symlinks) suitable for copying into the runtime stage.
+FROM node:${NODE_VERSION} AS cli-builder
+
+# pnpm prompts before purging an out-of-sync modules dir; CI=true makes it
+# non-interactive.
+ENV CI=true
+
+RUN npm install -g pnpm@11.9.0
+
+WORKDIR /cli
+COPY sdk/cli-js-sdk ./
+
+RUN pnpm install --frozen-lockfile --filter cli-fhevm-sdk... && \
+    pnpm --filter cli-fhevm-sdk build && \
+    pnpm --filter cli-fhevm-sdk deploy --prod --legacy /out/fhevm-cli
+
 # --- Runtime Stage ---
 FROM node:${NODE_VERSION} AS prod
 ARG RELAYER_SDK_VERSION=""
@@ -73,6 +93,11 @@ COPY --from=builder /etc/group /etc/group
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
 COPY --from=builder --chown=fhevm:fhevm /app /app
+
+# fhevm-sdk CLI: wallet/API key/RPC URL are injected at runtime via env vars
+# (PRIVATE_KEY, MNEMONIC, ZAMA_FHEVM_API_KEY, SEPOLIA_RPC_URL, ...).
+COPY --from=cli-builder --chown=fhevm:fhevm /out/fhevm-cli /app/fhevm-cli
+RUN ln -s /app/fhevm-cli/bin/fhevm-sdk.mjs /usr/local/bin/fhevm-sdk
 
 USER fhevm:fhevm
 

--- a/test-suite/e2e/Dockerfile
+++ b/test-suite/e2e/Dockerfile
@@ -47,6 +47,26 @@ WORKDIR /app/test-suite/e2e
 
 RUN npx hardhat compile
 
+# --- CLI Builder Stage ---
+# sdk/cli-js-sdk is a standalone pnpm workspace (not part of the root npm
+# workspaces), so it gets its own stage. `pnpm deploy` produces a
+# self-contained folder (package + resolved prod node_modules, no store
+# symlinks) suitable for copying into the runtime stage.
+FROM node:${NODE_VERSION} AS cli-builder
+
+# pnpm prompts before purging an out-of-sync modules dir; CI=true makes it
+# non-interactive.
+ENV CI=true
+
+RUN npm install -g pnpm@11.9.0
+
+WORKDIR /cli
+COPY sdk/cli-js-sdk ./
+
+RUN pnpm install --frozen-lockfile --filter cli-fhevm-sdk... && \
+    pnpm --filter cli-fhevm-sdk build && \
+    pnpm --filter cli-fhevm-sdk deploy --prod --legacy /out/fhevm-cli
+
 # --- Runtime Stage ---
 FROM node:${NODE_VERSION} AS prod
 
@@ -64,6 +84,11 @@ RUN apk add --no-cache bash docker-cli
 
 COPY --from=builder --chown=fhevm:fhevm /home/fhevm /home/fhevm
 COPY --from=builder --chown=fhevm:fhevm /app /app
+
+# fhevm-sdk CLI: wallet/API key/RPC URL are injected at runtime via env vars
+# (PRIVATE_KEY, MNEMONIC, ZAMA_FHEVM_API_KEY, SEPOLIA_RPC_URL, ...).
+COPY --from=cli-builder --chown=fhevm:fhevm /out/fhevm-cli /app/fhevm-cli
+RUN ln -s /app/fhevm-cli/bin/fhevm-sdk.mjs /usr/local/bin/fhevm-sdk
 
 USER fhevm:fhevm
 


### PR DESCRIPTION
Ship the `fhevm-sdk` CLI (from `sdk/cli-js-sdk/packages/cli`) inside the test-suite/e2e image, so it is readily available on PATH in environments where the image is deployed (preview envs, devnet ArgoCD) and users can run it directly after `kubectl exec` with the wallet already configured.

## Changes

- **`test-suite/e2e/Dockerfile`**: new `cli-builder` stage — `sdk/cli-js-sdk` is a standalone pnpm workspace (not part of the root npm workspaces), so it is built separately (`pnpm install --frozen-lockfile` → `tsdown` build → `pnpm deploy --prod --legacy`) and copied into the prod stage as a self-contained folder at `/app/fhevm-cli`, symlinked to `/usr/local/bin/fhevm-sdk`.
- **`.dockerignore`**: un-ignore `sdk/cli-js-sdk/**` (its `node_modules/`, `dist/` and `.env` remain excluded by the global rules — no secrets reach the build context).
- **`.github/workflows/test-suite-docker-build.yml`**: add `sdk/cli-js-sdk/**` to the rebuild-vs-retag path filter.
- **`ci/preview-env/test-suite/values-test-suite-e2e.yaml`**: wire `PRIVATE_KEY` and `SEPOLIA_RPC_URL` into the preview-env Job (plain test values, matching the existing pattern).

## Runtime configuration (Kubernetes env vars)

The CLI is configured entirely via env vars (precedence: CLI flag > env var > built-in per-network default). In real/long-lived environments these should come from Secrets via `secretKeyRef`:

| Env var | Purpose |
| --- | --- |
| `PRIVATE_KEY` | Wallet private key |
| `MNEMONIC` | Wallet mnemonic (alternative to `PRIVATE_KEY`) |
| `ZAMA_FHEVM_API_KEY` | Relayer API key |
| `SEPOLIA_RPC_URL` | RPC URL for `testnet` / `devnet` networks |
| `POLYGON_AMOY_RPC_URL` | RPC URL for `testnet-amoy` / `devnet-amoy` networks |
| `MAINNET_RPC_URL` | RPC URL for `mainnet` |
| `DELEGATOR_PRIVATE_KEY` / `DELEGATOR_MNEMONIC` | Delegator credentials for delegated user-decrypt flows |

Note: the CLI's RPC env var names are per-network and differ from the `RPC_URL` var used by the hardhat tests — both must be set where both tools are used.

## Tested locally

```bash
docker build -f test-suite/e2e/Dockerfile --target prod -t e2e-cli-test .
docker run --rm e2e-cli-test "which fhevm-sdk && fhevm-sdk --version && whoami"
docker run --rm e2e-cli-test "fhevm-sdk --help"
docker run --rm e2e-cli-test "find /app/fhevm-cli -name '.env*'"   # prints nothing: no env file baked in
docker run --rm e2e-cli-test "fhevm-sdk -n testnet input-proof"    # full flow against testnet
docker run --rm -e PRIVATE_KEY=0x... e2e-cli-test "fhevm-sdk -n devnet user-decrypt stored"