### PR TITLE
feat(coprocessor): enable multi-chain support for Blue Green upgrades

### DIFF
--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -994,19 +994,32 @@ mod tests {
         };
 
         // 2 chains, 0 FHE ops (both empty), 1 GW input -> only GW notified -> NO cutover.
-        let all_quiet = HashMap::from([(1, track(1, Some(5), false)), (2, track(2, Some(6), false))]);
-        assert_eq!(unanimity_notifications(&all_quiet, &gateway), vec![(GW, 500)]);
+        let all_quiet =
+            HashMap::from([(1, track(1, Some(5), false)), (2, track(2, Some(6), false))]);
+        assert_eq!(
+            unanimity_notifications(&all_quiet, &gateway),
+            vec![(GW, 500)]
+        );
 
         // 2 chains, 1 FHE op (chain 2), chain 1 empty, 1 GW input -> all notified -> cutover.
         let mixed = HashMap::from([(1, track(1, Some(5), false)), (2, track(2, Some(6), true))]);
-        assert_eq!(sorted(unanimity_notifications(&mixed, &gateway)), vec![(1, 5), (2, 6), (GW, 500)]);
+        assert_eq!(
+            sorted(unanimity_notifications(&mixed, &gateway)),
+            vec![(1, 5), (2, 6), (GW, 500)]
+        );
 
         // 1 chain, 0 FHE ops (empty), 1 GW input -> only GW notified -> NO cutover.
         let single_quiet = HashMap::from([(1, track(1, Some(5), false))]);
-        assert_eq!(unanimity_notifications(&single_quiet, &gateway), vec![(GW, 500)]);
+        assert_eq!(
+            unanimity_notifications(&single_quiet, &gateway),
+            vec![(GW, 500)]
+        );
         // 1 chain, 1 FHE op, 1 GW input -> host + GW notified -> cutover.
         let single_nt = HashMap::from([(1, track(1, Some(5), true))]);
-        assert_eq!(sorted(unanimity_notifications(&single_nt, &gateway)), vec![(1, 5), (GW, 500)]);
+        assert_eq!(
+            sorted(unanimity_notifications(&single_nt, &gateway)),
+            vec![(1, 5), (GW, 500)]
+        );
     }
 
     #[test]

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -424,25 +424,20 @@ async fn host_consensus_candidates(
     Ok(rows.into_iter().map(|(b,)| b).collect())
 }
 
-/// True once finalized blocks reach `end_block`.
-async fn host_reached_end_block(
-    pool: &Pool<Postgres>,
-    host_chain_id: i64,
-    end_block: i64,
-) -> Result<bool, Error> {
+/// Latest finalized GCS host-chain block for `host_chain_id`, or -1 if none.
+async fn gcs_host_watermark(pool: &Pool<Postgres>, host_chain_id: i64) -> Result<i64, Error> {
     let sql = format!(
         "SELECT COALESCE(
                   (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.host_chain_blocks_valid
                     WHERE chain_id = $1 AND block_status = 'finalized'),
                   -1
-                ) >= $2"
+                )"
     );
-    let (reached,): (bool,) = sqlx::query_as(&sql)
+    let (watermark,): (i64,) = sqlx::query_as(&sql)
         .bind(host_chain_id)
-        .bind(end_block)
         .fetch_one(pool)
         .await?;
-    Ok(reached)
+    Ok(watermark)
 }
 
 /// Timeout state machine for the tracked window.
@@ -457,6 +452,35 @@ struct WindowState {
     /// Tracked proposal + per-chain window set; a change resets every track.
     tracked_window: Option<HostWindows>,
     timeout: WindowTimeout,
+    /// Stall detection: `chain_id -> (watermark, last-advance instant)`; reset with the window set.
+    host_progress: HashMap<i64, (i64, Instant)>,
+}
+
+/// Returns true if the timeout clock should start: either every chain finished its
+/// window, or one chain made no progress for `commitment_timeout` (a stuck listener
+/// that would otherwise leave the upgrade running forever). Also updates each chain's
+/// recorded progress.
+fn should_arm_timeout(
+    windows: &[(i64, i64, i64)],
+    watermarks: &HashMap<i64, i64>,
+    progress: &mut HashMap<i64, (i64, Instant)>,
+    now: Instant,
+    commitment_timeout: Duration,
+) -> bool {
+    let mut all_reached = true;
+    let mut stalled = false;
+    for &(chain_id, _start, end) in windows {
+        let watermark = watermarks.get(&chain_id).copied().unwrap_or(-1);
+        let entry = progress.entry(chain_id).or_insert((watermark, now));
+        if watermark > entry.0 {
+            *entry = (watermark, now);
+        }
+        if watermark < end {
+            all_reached = false;
+            stalled |= now.duration_since(entry.1) >= commitment_timeout;
+        }
+    }
+    all_reached || stalled
 }
 
 /// One pass over every host-chain track plus the Gateway track: resets tracks on
@@ -478,6 +502,7 @@ async fn consensus_pass(
         host_tracks.clear();
         gateway.reset();
         window_state.timeout = WindowTimeout::NotArmed;
+        window_state.host_progress.clear();
         window_state.tracked_window = active.clone();
     }
     let Some((proposal_id, proposal_block, windows)) = active else {
@@ -538,21 +563,24 @@ async fn consensus_pass(
         let max_end = windows.iter().map(|&(_, _, end)| end).max().unwrap_or(0);
         match window_state.timeout {
             WindowTimeout::NotArmed => {
-                let mut all_reached = true;
-                for &(chain_id, _, end) in &windows {
-                    if !host_reached_end_block(pool, chain_id, end).await? {
-                        all_reached = false;
-                        break;
-                    }
+                let mut watermarks = HashMap::with_capacity(windows.len());
+                for &(chain_id, _, _) in &windows {
+                    watermarks.insert(chain_id, gcs_host_watermark(pool, chain_id).await?);
                 }
-                if all_reached {
-                    window_state.timeout =
-                        WindowTimeout::Armed(Instant::now() + commitment_timeout);
+                let now = Instant::now();
+                if should_arm_timeout(
+                    &windows,
+                    &watermarks,
+                    &mut window_state.host_progress,
+                    now,
+                    commitment_timeout,
+                ) {
+                    window_state.timeout = WindowTimeout::Armed(now + commitment_timeout);
                     info!(
                         chains = windows.len(),
                         max_end_block = max_end,
                         timeout_secs = commitment_timeout.as_secs(),
-                        "all host chains reached end_block without unanimity — arming consensus timeout"
+                        "arming consensus timeout (all chains reached end_block, or a host listener stalled)"
                     );
                 }
             }
@@ -779,6 +807,7 @@ where
     let mut window_state = WindowState {
         tracked_window: None,
         timeout: WindowTimeout::NotArmed,
+        host_progress: HashMap::new(),
     };
 
     // The consensus poll cadence: re-attempt S3 every commitment_poll_interval,
@@ -853,6 +882,84 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const CT: Duration = Duration::from_secs(60);
+
+    #[test]
+    fn arm_timeout_when_all_chains_reached_end_block() {
+        let windows = vec![(1, 0, 100), (2, 0, 200)];
+        let watermarks = HashMap::from([(1, 100), (2, 200)]);
+        let mut progress = HashMap::new();
+        assert!(should_arm_timeout(
+            &windows,
+            &watermarks,
+            &mut progress,
+            Instant::now(),
+            CT
+        ));
+    }
+
+    #[test]
+    fn wait_while_a_chain_is_below_end_and_recently_seen() {
+        let windows = vec![(1, 0, 100), (2, 0, 200)];
+        let watermarks = HashMap::from([(1, 100), (2, 150)]);
+        let mut progress = HashMap::new();
+        assert!(!should_arm_timeout(
+            &windows,
+            &watermarks,
+            &mut progress,
+            Instant::now(),
+            CT
+        ));
+    }
+
+    #[test]
+    fn progressing_chain_never_stalls() {
+        let windows = vec![(1, 0, 100)];
+        let mut progress = HashMap::new();
+        let t0 = Instant::now();
+        // Below end_block, first observation → wait.
+        assert!(!should_arm_timeout(
+            &windows,
+            &HashMap::from([(1, 40)]),
+            &mut progress,
+            t0,
+            CT
+        ));
+        // Advanced after commitment_timeout — progress refreshes, so not stalled.
+        assert!(!should_arm_timeout(
+            &windows,
+            &HashMap::from([(1, 70)]),
+            &mut progress,
+            t0 + CT + Duration::from_secs(1),
+            CT,
+        ));
+    }
+
+    #[test]
+    fn stalled_listener_arms_after_commitment_timeout() {
+        // Chain 1 reached end_block; chain 2's GCS watermark is frozen below it.
+        let windows = vec![(1, 0, 100), (2, 0, 100)];
+        let watermarks = HashMap::from([(1, 100), (2, 40)]);
+        let mut progress = HashMap::new();
+        let t0 = Instant::now();
+        // First observation: not yet stalled.
+        assert!(!should_arm_timeout(
+            &windows,
+            &watermarks,
+            &mut progress,
+            t0,
+            CT
+        ));
+        // Still frozen commitment_timeout later → stalled listener → arm.
+        assert!(should_arm_timeout(
+            &windows,
+            &watermarks,
+            &mut progress,
+            t0 + CT + Duration::from_millis(1),
+            CT,
+        ));
+    }
 
     #[test]
     fn parses_new_block_payload() {

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -10,7 +10,9 @@
 //!
 //!   * **host chain** — for each finalized, fully-computed, *non-trivial* block
 //!     in `[start_block, end_block]` (one carrying a real FHE op, not only
-//!     `trivialEncrypt`), poll every operator's per-block state-hash blob.
+//!     `trivialEncrypt`), poll every operator's per-block state-hash blob. A chain
+//!     that finalizes the window with no non-trivial op anchors on any block
+//!     (readiness); at least one non-trivial anchor is still required across chains.
 //!   * **Gateway inputs** — likewise for each sealed Gateway block carrying
 //!     re-randomized ZK-proof input ciphertexts.
 //!
@@ -26,7 +28,8 @@
 //! it (RFC 021).
 //!
 //! `unanimity_consensus` is consumed only by the upgrade-controller, which
-//! authorizes cutover once BOTH tracks have anchored.
+//! authorizes cutover once every host track and the Gateway track have anchored,
+//! with at least one host anchor on a non-trivial block.
 //!
 //! **Timeout.** If a track is still un-anchored `commitment_timeout` after `end_block`,
 //! `unanimity_consensus_timeout` is emitted (and re-emitted each pass) until the
@@ -311,6 +314,8 @@ struct ConsensusTrack {
     chain_id: i64,
     /// The anchored block once unanimity is reached; `None` until then.
     anchored: Option<i64>,
+    /// Whether the anchor block carried a non-trivial FHE op.
+    anchored_nontrivial: bool,
     partial: HashMap<i64, Vec<Option<Vec<u8>>>>,
     /// Blocks we've already logged a divergence warning for. State hashes are
     /// deterministic per block, so a divergence is permanent — warn once per
@@ -323,6 +328,7 @@ impl ConsensusTrack {
         Self {
             chain_id,
             anchored: None,
+            anchored_nontrivial: false,
             partial: HashMap::new(),
             divergence_warned: HashSet::new(),
         }
@@ -331,6 +337,7 @@ impl ConsensusTrack {
     /// Clear state for a fresh upgrade window.
     fn reset(&mut self) {
         self.anchored = None;
+        self.anchored_nontrivial = false;
         self.partial.clear();
         self.divergence_warned.clear();
     }
@@ -344,6 +351,7 @@ async fn poll_track(
     urls: &[String],
     track: &mut ConsensusTrack,
     candidates: &[i64],
+    nontrivial: bool,
 ) -> Result<(), Error> {
     if track.anchored.is_some() || urls.is_empty() {
         return Ok(());
@@ -368,6 +376,7 @@ async fn poll_track(
             );
             // consensus_pass emits (and re-emits) the anchor; here we just record it.
             track.anchored = Some(block);
+            track.anchored_nontrivial = nontrivial;
             track.partial.clear();
             return Ok(());
         }
@@ -400,18 +409,23 @@ async fn host_consensus_candidates(
     host_chain_id: i64,
     start: i64,
     end: i64,
+    require_nontrivial: bool,
 ) -> Result<Vec<i64>, Error> {
+    let nontrivial = if require_nontrivial {
+        format!(
+            "AND EXISTS (SELECT 1 FROM {GCS_SCHEMA_QUOTED}.computations c
+                 WHERE c.host_chain_id = sh.chain_id AND c.block_number = sh.block_number
+                   AND c.is_error = false AND c.fhe_operation <> {FHE_TRIVIAL_ENCRYPT_OPCODE})"
+        )
+    } else {
+        String::new()
+    };
     let sql = format!(
         "SELECT sh.block_number
            FROM {GCS_SCHEMA_QUOTED}.state_hash sh
           WHERE sh.chain_id = $1
             AND sh.block_number >= $2 AND sh.block_number <= $3
-            AND EXISTS (
-                SELECT 1 FROM {GCS_SCHEMA_QUOTED}.computations c
-                 WHERE c.host_chain_id = sh.chain_id
-                   AND c.block_number = sh.block_number
-                   AND c.is_error = false
-                   AND c.fhe_operation <> {FHE_TRIVIAL_ENCRYPT_OPCODE})
+            {nontrivial}
           ORDER BY sh.block_number
           LIMIT {MAX_ANCHOR_CANDIDATES}"
     );
@@ -430,6 +444,22 @@ async fn gcs_host_watermark(pool: &Pool<Postgres>, host_chain_id: i64) -> Result
         "SELECT COALESCE(
                   (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.host_chain_blocks_valid
                     WHERE chain_id = $1 AND block_status = 'finalized'),
+                  -1
+                )"
+    );
+    let (watermark,): (i64,) = sqlx::query_as(&sql)
+        .bind(host_chain_id)
+        .fetch_one(pool)
+        .await?;
+    Ok(watermark)
+}
+
+/// Latest GCS host block that has a produced `state_hash`, or -1. Lags finalization,
+/// so `>= end_block` means every window block's records have landed.
+async fn gcs_state_hash_watermark(pool: &Pool<Postgres>, host_chain_id: i64) -> Result<i64, Error> {
+    let sql = format!(
+        "SELECT COALESCE(
+                  (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.state_hash WHERE chain_id = $1),
                   -1
                 )"
     );
@@ -483,6 +513,13 @@ fn should_arm_timeout(
     all_reached || stalled
 }
 
+/// Host side is ready: every chain anchored and at least one anchor is non-trivial.
+fn host_consensus_ready(host_tracks: &HashMap<i64, ConsensusTrack>) -> bool {
+    !host_tracks.is_empty()
+        && host_tracks.values().all(|t| t.anchored.is_some())
+        && host_tracks.values().any(|t| t.anchored_nontrivial)
+}
+
 /// One pass over every host-chain track plus the Gateway track: resets tracks on
 /// a window-set change, polls each chain's + the Gateway's candidates, re-emits
 /// anchors, and — once every host chain hit end_block without unanimity — emits a
@@ -518,8 +555,19 @@ async fn consensus_pass(
             .entry(chain_id)
             .or_insert_with(|| ConsensusTrack::new(chain_id));
         if track.anchored.is_none() {
-            let candidates = host_consensus_candidates(pool, chain_id, start, end).await?;
-            poll_track(http, &urls, track, &candidates).await?;
+            let candidates = host_consensus_candidates(pool, chain_id, start, end, true).await?;
+            poll_track(http, &urls, track, &candidates, true).await?;
+            // No FHE op in the whole window: let this chain anchor on any block so it
+            // doesn't block the upgrade. Gate on state_hash (not just finalization)
+            // reaching end_block, so we don't call it quiet before a late op is recorded.
+            if track.anchored.is_none()
+                && candidates.is_empty()
+                && gcs_state_hash_watermark(pool, chain_id).await? >= end
+            {
+                let readiness =
+                    host_consensus_candidates(pool, chain_id, start, end, false).await?;
+                poll_track(http, &urls, track, &readiness, false).await?;
+            }
         }
     }
 
@@ -531,7 +579,7 @@ async fn consensus_pass(
         ) {
             let candidates =
                 pending_gw_consensus_blocks(pool, gateway.chain_id, gw_start, gw_tip).await?;
-            poll_track(http, &urls, gateway, &candidates).await?;
+            poll_track(http, &urls, gateway, &candidates, true).await?;
         }
     }
 
@@ -558,7 +606,7 @@ async fn consensus_pass(
     // without agreeing, so the upgrade can be rerun.
     let all_host_anchored =
         !host_tracks.is_empty() && host_tracks.values().all(|t| t.anchored.is_some());
-    let both_anchored = all_host_anchored && gateway.anchored.is_some();
+    let both_anchored = host_consensus_ready(host_tracks) && gateway.anchored.is_some();
     if !both_anchored {
         let max_end = windows.iter().map(|&(_, _, end)| end).max().unwrap_or(0);
         match window_state.timeout {
@@ -599,6 +647,7 @@ async fn consensus_pass(
                     chains = windows.len(),
                     max_end_block = max_end,
                     all_host_anchored,
+                    nontrivial_anchored = host_tracks.values().any(|t| t.anchored_nontrivial),
                     gateway_anchored = gateway.anchored.is_some(),
                     unanchored_chains = ?unanchored,
                     "consensus timeout elapsed without unanimity on all tracks — emitting event_unanimity_consensus_timeout"
@@ -884,6 +933,30 @@ mod tests {
     use super::*;
 
     const CT: Duration = Duration::from_secs(60);
+
+    fn track(anchored: Option<i64>, nontrivial: bool) -> ConsensusTrack {
+        let mut t = ConsensusTrack::new(1);
+        t.anchored = anchored;
+        t.anchored_nontrivial = nontrivial;
+        t
+    }
+
+    #[test]
+    fn host_ready_needs_all_anchored_and_one_nontrivial() {
+        assert!(host_consensus_ready(&HashMap::from([
+            (1, track(Some(5), false)),
+            (2, track(Some(9), true)),
+        ])));
+        assert!(!host_consensus_ready(&HashMap::from([
+            (1, track(Some(5), false)),
+            (2, track(Some(7), false)),
+        ])));
+        assert!(!host_consensus_ready(&HashMap::from([
+            (1, track(Some(5), true)),
+            (2, track(None, false)),
+        ])));
+        assert!(!host_consensus_ready(&HashMap::new()));
+    }
 
     #[test]
     fn arm_timeout_when_all_chains_reached_end_block() {

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -139,6 +139,7 @@ pub struct NewBlockPayload {
 #[derive(Debug, Clone, Serialize)]
 struct UnanimityPayload<'a> {
     proposal_id: &'a [u8],
+    proposal_block: i64,
     chain_id: i64,
     block_height: i64,
     block_hash: &'a str,
@@ -239,34 +240,65 @@ fn all_slots_filled(slots: &[Option<Vec<u8>>]) -> bool {
     !slots.is_empty() && slots.iter().all(Option::is_some)
 }
 
-/// Returns `(proposal_id, start_block, end_block)` for the active GCS dry-run.
-/// `None` otherwise. Scoped to `stack_role = 'GCS'` because BCS also stays
-/// `status='in_progress'` during the upgrade and doesn't own the replay window.
-pub(crate) async fn active_upgrade_window<'e, E>(
-    executor: E,
-) -> Result<Option<(Vec<u8>, i64, i64)>, Error>
+/// An upgrade attempt and its per-chain windows:
+/// `(proposal_id, proposal_block, [(chain_id, start, end), ...])`.
+pub(crate) type HostWindows = (Vec<u8>, i64, Vec<(i64, i64, i64)>);
+
+/// Returns the complete per-chain window set for the active GCS dry-run.
+/// `None` otherwise. Proposal-level fields must agree across every row.
+pub(crate) async fn active_upgrade_windows<'e, E>(executor: E) -> Result<Option<HostWindows>, Error>
 where
     E: Executor<'e, Database = Postgres>,
 {
-    type ActiveWindowRow = (String, Option<Vec<u8>>, Option<i64>, Option<i64>);
-    let row: Option<ActiveWindowRow> = sqlx::query_as(
-        "SELECT state, proposal_id, start_block, end_block FROM upgrade_state
-          WHERE stack_role = 'GCS' AND status = 'in_progress'",
+    type ActiveWindowRow = (
+        String,
+        Option<Vec<u8>>,
+        Option<i64>,
+        i64,
+        Option<i64>,
+        Option<i64>,
+    );
+    let rows: Vec<ActiveWindowRow> = sqlx::query_as(
+        "SELECT state, proposal_id, proposal_block,
+                host_chain_id, start_block, end_block
+           FROM upgrade_state
+          WHERE stack_role = 'GCS' AND status = 'in_progress'
+          ORDER BY host_chain_id",
     )
-    .fetch_optional(executor)
+    .fetch_all(executor)
     .await?;
 
-    let Some((state, proposal_id, start_block, end_block)) = row else {
+    let Some((state, proposal_id, proposal_block, _, _, _)) = rows.first() else {
         return Ok(None);
     };
     if !matches!(state.as_str(), "UpgradeActivated" | "DryRunStarted") {
         debug!(state = %state, "GCS not in UpgradeActivated/DryRunStarted — ignoring");
         return Ok(None);
     }
-    Ok(proposal_id
-        .zip(start_block)
-        .zip(end_block)
-        .map(|((proposal_id, start), end)| (proposal_id, start, end)))
+    let (Some(proposal_id), Some(proposal_block)) = (proposal_id.as_ref(), *proposal_block) else {
+        return Err(Error::Payload(
+            "active GCS proposal is missing proposal_id or proposal_block".to_owned(),
+        ));
+    };
+
+    let mut windows = Vec::with_capacity(rows.len());
+    for (row_state, row_id, row_block, chain_id, start, end) in &rows {
+        if row_state != state
+            || row_id.as_deref() != Some(proposal_id.as_slice())
+            || *row_block != Some(proposal_block)
+        {
+            return Err(Error::Payload(
+                "active GCS upgrade_state rows do not describe one proposal".to_owned(),
+            ));
+        }
+        let (Some(start), Some(end)) = (*start, *end) else {
+            return Err(Error::Payload(format!(
+                "active GCS chain {chain_id} is missing its evaluation window"
+            )));
+        };
+        windows.push((*chain_id, start, end));
+    }
+    Ok(Some((proposal_id.clone(), proposal_block, windows)))
 }
 
 /// Per-track eager consensus state. We only need ONE unanimous block to anchor
@@ -413,18 +445,6 @@ async fn host_reached_end_block(
     Ok(reached)
 }
 
-/// Host chain id of the active GCS upgrade (set by upgrade-controller on
-/// activation). `None` when unset — host consensus is skipped until it appears.
-async fn active_host_chain_id(pool: &Pool<Postgres>) -> Result<Option<i64>, Error> {
-    let row: Option<(Option<i64>,)> = sqlx::query_as(
-        "SELECT host_chain_id FROM upgrade_state
-          WHERE stack_role = 'GCS' AND status = 'in_progress'",
-    )
-    .fetch_optional(pool)
-    .await?;
-    Ok(row.and_then(|(v,)| v))
-}
-
 /// Timeout state machine for the tracked window.
 enum WindowTimeout {
     /// No deadline running.
@@ -434,46 +454,47 @@ enum WindowTimeout {
 }
 
 struct WindowState {
-    /// The proposal and window currently being tracked.
-    tracked_window: Option<(Vec<u8>, i64, i64)>,
+    /// Tracked proposal + per-chain window set; a change resets every track.
+    tracked_window: Option<HostWindows>,
     timeout: WindowTimeout,
 }
 
-/// One consensus pass over both tracks. Reads the active window, resets track
-/// state when the window changes or closes (so a prior upgrade's anchors never
-/// carry over), then polls the host and Gateway candidates. Re-emits each
-/// anchored track's `unanimity_consensus`, and `unanimity_consensus_timeout` once
-/// past the deadline, every pass until the window closes.
+/// One pass over every host-chain track plus the Gateway track: resets tracks on
+/// a window-set change, polls each chain's + the Gateway's candidates, re-emits
+/// anchors, and — once every host chain hit end_block without unanimity — emits a
+/// single timeout past the deadline.
 async fn consensus_pass(
     pool: &Pool<Postgres>,
     http: &reqwest::Client,
     s3_urls: &Arc<RwLock<Vec<String>>>,
-    host: &mut ConsensusTrack,
+    host_tracks: &mut HashMap<i64, ConsensusTrack>,
     gateway: &mut ConsensusTrack,
     window_state: &mut WindowState,
     commitment_timeout: Duration,
 ) -> Result<(), Error> {
-    let window = active_upgrade_window(pool).await?;
-    if window_state.tracked_window != window {
-        host.reset();
+    let active = active_upgrade_windows(pool).await?;
+    if window_state.tracked_window != active {
+        // Window set changed: reset all tracks + timeout so no prior anchor carries over.
+        host_tracks.clear();
         gateway.reset();
-        // Reset the timeout for the new proposal or window.
         window_state.timeout = WindowTimeout::NotArmed;
-        window_state.tracked_window = window.clone();
+        window_state.tracked_window = active.clone();
     }
-    let Some((proposal_id, start, end)) = window else {
+    let Some((proposal_id, proposal_block, windows)) = active else {
         return Ok(());
     };
 
-    // Snapshot the URL list so both tracks see a stable operator set this pass.
+    // Snapshot the URL list so every track sees a stable operator set this pass.
     let urls = s3_urls.read().await.clone();
 
-    // Host track: needs the host chain id (set by upgrade-controller).
-    if host.anchored.is_none() {
-        if let Some(host_chain_id) = active_host_chain_id(pool).await? {
-            host.chain_id = host_chain_id;
-            let candidates = host_consensus_candidates(pool, host_chain_id, start, end).await?;
-            poll_track(http, &urls, host, &candidates).await?;
+    // Host tracks: one per chain window, each anchoring independently.
+    for &(chain_id, start, end) in &windows {
+        let track = host_tracks
+            .entry(chain_id)
+            .or_insert_with(|| ConsensusTrack::new(chain_id));
+        if track.anchored.is_none() {
+            let candidates = host_consensus_candidates(pool, chain_id, start, end).await?;
+            poll_track(http, &urls, track, &candidates).await?;
         }
     }
 
@@ -489,13 +510,15 @@ async fn consensus_pass(
         }
     }
 
-    // Re-emit each anchor every pass so a controller that missed the NOTIFY still latches.
-    for track in [&*host, &*gateway] {
+    // Re-emit each anchor every pass so a controller that missed the NOTIFY still
+    // latches; each track carries its own chain_id for per-chain latching.
+    for track in host_tracks.values().chain(std::iter::once(&*gateway)) {
         if let Some(block) = track.anchored {
             notify_unanimity(
                 pool,
                 UNANIMITY_CONSENSUS_CHANNEL,
                 &proposal_id,
+                proposal_block,
                 &NewBlockPayload {
                     chain_id: track.chain_id,
                     block_height: block,
@@ -506,47 +529,56 @@ async fn consensus_pass(
         }
     }
 
-    // If we reached the last block but didn't agree in time, give up so the
-    // upgrade can be rerun.
-    let both_anchored = host.anchored.is_some() && gateway.anchored.is_some();
+    // One global deadline, armed once every host chain reached its end_block
+    // without agreeing, so the upgrade can be rerun.
+    let all_host_anchored =
+        !host_tracks.is_empty() && host_tracks.values().all(|t| t.anchored.is_some());
+    let both_anchored = all_host_anchored && gateway.anchored.is_some();
     if !both_anchored {
+        let max_end = windows.iter().map(|&(_, _, end)| end).max().unwrap_or(0);
         match window_state.timeout {
-            // Arm once we reach end_block (chain_id is 0 until then).
-            WindowTimeout::NotArmed
-                if host.chain_id != 0
-                    && host_reached_end_block(pool, host.chain_id, end).await? =>
-            {
-                window_state.timeout = WindowTimeout::Armed(Instant::now() + commitment_timeout);
-                info!(
-                    host_chain_id = host.chain_id,
-                    end_block = end,
-                    timeout_secs = commitment_timeout.as_secs(),
-                    "host chain reached end_block without unanimity — arming consensus timeout"
-                );
+            WindowTimeout::NotArmed => {
+                let mut all_reached = true;
+                for &(chain_id, _, end) in &windows {
+                    if !host_reached_end_block(pool, chain_id, end).await? {
+                        all_reached = false;
+                        break;
+                    }
+                }
+                if all_reached {
+                    window_state.timeout =
+                        WindowTimeout::Armed(Instant::now() + commitment_timeout);
+                    info!(
+                        chains = windows.len(),
+                        max_end_block = max_end,
+                        timeout_secs = commitment_timeout.as_secs(),
+                        "all host chains reached end_block without unanimity — arming consensus timeout"
+                    );
+                }
             }
             // Still armed past the deadline — (re)emit the timeout.
             WindowTimeout::Armed(deadline) if Instant::now() >= deadline => {
                 warn!(
-                    host_chain_id = host.chain_id,
-                    start_block = start,
-                    end_block = end,
-                    host_anchored = host.anchored.is_some(),
+                    chains = windows.len(),
+                    max_end_block = max_end,
+                    all_host_anchored,
                     gateway_anchored = gateway.anchored.is_some(),
-                    "consensus timeout elapsed without both-track unanimity — emitting event_unanimity_consensus_timeout"
+                    "consensus timeout elapsed without unanimity on all tracks — emitting event_unanimity_consensus_timeout"
                 );
                 notify_unanimity(
                     pool,
                     UNANIMITY_CONSENSUS_TIMEOUT_CHANNEL,
                     &proposal_id,
+                    proposal_block,
                     &NewBlockPayload {
-                        chain_id: host.chain_id,
-                        block_height: end,
+                        chain_id: windows.first().map(|&(c, _, _)| c).unwrap_or(0),
+                        block_height: max_end,
                         block_hash: String::new(),
                     },
                 )
                 .await?;
             }
-            WindowTimeout::NotArmed | WindowTimeout::Armed(_) => {}
+            WindowTimeout::Armed(_) => {}
         }
     }
 
@@ -557,10 +589,12 @@ async fn notify_unanimity(
     pool: &Pool<Postgres>,
     channel: &str,
     proposal_id: &[u8],
+    proposal_block: i64,
     payload: &NewBlockPayload,
 ) -> Result<(), Error> {
     let body = serde_json::to_string(&UnanimityPayload {
         proposal_id,
+        proposal_block,
         chain_id: payload.chain_id,
         block_height: payload.block_height,
         block_hash: &payload.block_hash,
@@ -727,10 +761,9 @@ where
     listener.listen_all(channels).await?;
     info!(?channels, "listening for notifications");
 
-    // Per-track eager consensus state. Host chain id is discovered from
-    // upgrade_state each pass (starts unknown); the Gateway track is keyed by the
-    // provider-resolved gw_chain_id.
-    let mut host_track = ConsensusTrack::new(0);
+    // One host track per chain, discovered from upgrade_state each pass;
+    // the Gateway track is keyed by the provider-resolved gw_chain_id.
+    let mut host_tracks: HashMap<i64, ConsensusTrack> = HashMap::new();
     let mut gateway_track = ConsensusTrack::new(gw_chain_id);
     // Tracked window + its timeout state.
     let mut window_state = WindowState {
@@ -752,7 +785,7 @@ where
                     &pool,
                     &http,
                     &s3_urls,
-                    &mut host_track,
+                    &mut host_tracks,
                     &mut gateway_track,
                     &mut window_state,
                     config.commitment_timeout,

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -558,11 +558,21 @@ async fn consensus_pass(
             }
             // Still armed past the deadline — (re)emit the timeout.
             WindowTimeout::Armed(deadline) if Instant::now() >= deadline => {
+                let mut unanchored: Vec<i64> = host_tracks
+                    .iter()
+                    .filter(|(_, t)| t.anchored.is_none())
+                    .map(|(&c, _)| c)
+                    .collect();
+                unanchored.sort_unstable();
+                if gateway.anchored.is_none() {
+                    unanchored.push(gateway.chain_id);
+                }
                 warn!(
                     chains = windows.len(),
                     max_end_block = max_end,
                     all_host_anchored,
                     gateway_anchored = gateway.anchored.is_some(),
+                    unanchored_chains = ?unanchored,
                     "consensus timeout elapsed without unanimity on all tracks — emitting event_unanimity_consensus_timeout"
                 );
                 notify_unanimity(
@@ -571,7 +581,7 @@ async fn consensus_pass(
                     &proposal_id,
                     proposal_block,
                     &NewBlockPayload {
-                        chain_id: windows.first().map(|&(c, _, _)| c).unwrap_or(0),
+                        chain_id: unanchored.first().copied().unwrap_or(0),
                         block_height: max_end,
                         block_hash: String::new(),
                     },

--- a/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/lib.rs
@@ -454,20 +454,25 @@ async fn gcs_host_watermark(pool: &Pool<Postgres>, host_chain_id: i64) -> Result
     Ok(watermark)
 }
 
-/// Latest GCS host block that has a produced `state_hash`, or -1. Lags finalization,
-/// so `>= end_block` means every window block's records have landed.
-async fn gcs_state_hash_watermark(pool: &Pool<Postgres>, host_chain_id: i64) -> Result<i64, Error> {
+/// True once every block in `[start, end]` has a `state_hash`: counts the hashes and
+/// compares to the window size, so a gap below a hashed block still fails.
+async fn gcs_window_fully_hashed(
+    pool: &Pool<Postgres>,
+    host_chain_id: i64,
+    start: i64,
+    end: i64,
+) -> Result<bool, Error> {
     let sql = format!(
-        "SELECT COALESCE(
-                  (SELECT MAX(block_number) FROM {GCS_SCHEMA_QUOTED}.state_hash WHERE chain_id = $1),
-                  -1
-                )"
+        "SELECT (SELECT COUNT(*) FROM {GCS_SCHEMA_QUOTED}.state_hash
+                  WHERE chain_id = $1 AND block_number BETWEEN $2 AND $3) >= ($3 - $2 + 1)"
     );
-    let (watermark,): (i64,) = sqlx::query_as(&sql)
+    let (ok,): (bool,) = sqlx::query_as(&sql)
         .bind(host_chain_id)
+        .bind(start)
+        .bind(end)
         .fetch_one(pool)
         .await?;
-    Ok(watermark)
+    Ok(ok)
 }
 
 /// Timeout state machine for the tracked window.
@@ -520,6 +525,26 @@ fn host_consensus_ready(host_tracks: &HashMap<i64, ConsensusTrack>) -> bool {
         && host_tracks.values().any(|t| t.anchored_nontrivial)
 }
 
+/// `(chain_id, block)` anchors to notify: host anchors only once `host_consensus_ready`
+/// holds, plus the Gateway anchor whenever it is set.
+fn unanimity_notifications(
+    host_tracks: &HashMap<i64, ConsensusTrack>,
+    gateway: &ConsensusTrack,
+) -> Vec<(i64, i64)> {
+    let mut out = Vec::new();
+    if host_consensus_ready(host_tracks) {
+        for t in host_tracks.values() {
+            if let Some(block) = t.anchored {
+                out.push((t.chain_id, block));
+            }
+        }
+    }
+    if let Some(block) = gateway.anchored {
+        out.push((gateway.chain_id, block));
+    }
+    out
+}
+
 /// One pass over every host-chain track plus the Gateway track: resets tracks on
 /// a window-set change, polls each chain's + the Gateway's candidates, re-emits
 /// anchors, and — once every host chain hit end_block without unanimity — emits a
@@ -558,11 +583,11 @@ async fn consensus_pass(
             let candidates = host_consensus_candidates(pool, chain_id, start, end, true).await?;
             poll_track(http, &urls, track, &candidates, true).await?;
             // No FHE op in the whole window: let this chain anchor on any block so it
-            // doesn't block the upgrade. Gate on state_hash (not just finalization)
-            // reaching end_block, so we don't call it quiet before a late op is recorded.
+            // doesn't block the upgrade. Require every window block hashed (no gap), so a
+            // finalized-but-unfinished non-trivial block can't be mistaken for quiet.
             if track.anchored.is_none()
                 && candidates.is_empty()
-                && gcs_state_hash_watermark(pool, chain_id).await? >= end
+                && gcs_window_fully_hashed(pool, chain_id, start, end).await?
             {
                 let readiness =
                     host_consensus_candidates(pool, chain_id, start, end, false).await?;
@@ -584,22 +609,22 @@ async fn consensus_pass(
     }
 
     // Re-emit each anchor every pass so a controller that missed the NOTIFY still
-    // latches; each track carries its own chain_id for per-chain latching.
-    for track in host_tracks.values().chain(std::iter::once(&*gateway)) {
-        if let Some(block) = track.anchored {
-            notify_unanimity(
-                pool,
-                UNANIMITY_CONSENSUS_CHANNEL,
-                &proposal_id,
-                proposal_block,
-                &NewBlockPayload {
-                    chain_id: track.chain_id,
-                    block_height: block,
-                    block_hash: String::new(),
-                },
-            )
-            .await?;
-        }
+    // latches. Host anchors are withheld until host_consensus_ready holds (all host
+    // anchored + >=1 non-trivial), so the controller can't cut over on an all-quiet
+    // fleet; the Gateway anchor is independent.
+    for (chain_id, block) in unanimity_notifications(host_tracks, gateway) {
+        notify_unanimity(
+            pool,
+            UNANIMITY_CONSENSUS_CHANNEL,
+            &proposal_id,
+            proposal_block,
+            &NewBlockPayload {
+                chain_id,
+                block_height: block,
+                block_hash: String::new(),
+            },
+        )
+        .await?;
     }
 
     // One global deadline, armed once every host chain reached its end_block
@@ -934,8 +959,10 @@ mod tests {
 
     const CT: Duration = Duration::from_secs(60);
 
-    fn track(anchored: Option<i64>, nontrivial: bool) -> ConsensusTrack {
-        let mut t = ConsensusTrack::new(1);
+    const GW: i64 = 54321;
+
+    fn track(chain_id: i64, anchored: Option<i64>, nontrivial: bool) -> ConsensusTrack {
+        let mut t = ConsensusTrack::new(chain_id);
         t.anchored = anchored;
         t.anchored_nontrivial = nontrivial;
         t
@@ -944,18 +971,42 @@ mod tests {
     #[test]
     fn host_ready_needs_all_anchored_and_one_nontrivial() {
         assert!(host_consensus_ready(&HashMap::from([
-            (1, track(Some(5), false)),
-            (2, track(Some(9), true)),
+            (1, track(1, Some(5), false)),
+            (2, track(2, Some(9), true)),
         ])));
         assert!(!host_consensus_ready(&HashMap::from([
-            (1, track(Some(5), false)),
-            (2, track(Some(7), false)),
+            (1, track(1, Some(5), false)),
+            (2, track(2, Some(7), false)),
         ])));
         assert!(!host_consensus_ready(&HashMap::from([
-            (1, track(Some(5), true)),
-            (2, track(None, false)),
+            (1, track(1, Some(5), true)),
+            (2, track(2, None, false)),
         ])));
         assert!(!host_consensus_ready(&HashMap::new()));
+    }
+
+    #[test]
+    fn unanimity_notifications_gate_hosts_on_nontrivial() {
+        let gateway = track(GW, Some(500), true);
+        let sorted = |mut v: Vec<(i64, i64)>| {
+            v.sort_unstable();
+            v
+        };
+
+        // 2 chains, 0 FHE ops (both empty), 1 GW input -> only GW notified -> NO cutover.
+        let all_quiet = HashMap::from([(1, track(1, Some(5), false)), (2, track(2, Some(6), false))]);
+        assert_eq!(unanimity_notifications(&all_quiet, &gateway), vec![(GW, 500)]);
+
+        // 2 chains, 1 FHE op (chain 2), chain 1 empty, 1 GW input -> all notified -> cutover.
+        let mixed = HashMap::from([(1, track(1, Some(5), false)), (2, track(2, Some(6), true))]);
+        assert_eq!(sorted(unanimity_notifications(&mixed, &gateway)), vec![(1, 5), (2, 6), (GW, 500)]);
+
+        // 1 chain, 0 FHE ops (empty), 1 GW input -> only GW notified -> NO cutover.
+        let single_quiet = HashMap::from([(1, track(1, Some(5), false))]);
+        assert_eq!(unanimity_notifications(&single_quiet, &gateway), vec![(GW, 500)]);
+        // 1 chain, 1 FHE op, 1 GW input -> host + GW notified -> cutover.
+        let single_nt = HashMap::from([(1, track(1, Some(5), true))]);
+        assert_eq!(sorted(unanimity_notifications(&single_nt, &gateway)), vec![(1, 5), (GW, 500)]);
     }
 
     #[test]

--- a/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
+++ b/coprocessor/fhevm-engine/consensus-detector/src/state_hash.rs
@@ -60,12 +60,13 @@ async fn insert_state_hash(
     })
 }
 
-/// GCS path: stamp the GCS `state_hash` for blocks in `[start, end]` that don't
-/// already have an entry. Empty blocks (`fhe_event_count = 0`) get
+/// GCS path: stamp the GCS `state_hash` for one chain's blocks in `[start, end]`
+/// that don't already have an entry. Empty blocks (`fhe_event_count = 0`) get
 /// [`EMPTY_BLOCK_STATE_HASH`]; non-empty blocks get the SHA-256 over their
 /// GCS `ciphertexts`.
 async fn compute_and_insert_gcs(
     tx: &mut Transaction<'_, Postgres>,
+    chain_id: i64,
     start: i64,
     end: i64,
     batch_limit: i64,
@@ -92,17 +93,19 @@ async fn compute_and_insert_gcs(
         SELECT b.chain_id, b.block_number,
                bool_and(b.fhe_event_count = 0) AS is_empty
           FROM {GCS_SCHEMA_QUOTED}.host_chain_blocks_valid b
-         WHERE b.block_number BETWEEN $1 AND $2
+         WHERE b.chain_id = $1
+           AND b.block_number BETWEEN $2 AND $3
            AND b.block_status = 'finalized'
            AND NOT EXISTS (
                SELECT 1 FROM {GCS_SCHEMA_QUOTED}.state_hash sh
                 WHERE sh.chain_id = b.chain_id AND sh.block_number = b.block_number)
          GROUP BY b.chain_id, b.block_number
          ORDER BY b.block_number
-         LIMIT $3
+         LIMIT $4
         "#
     );
     let pending = sqlx::query(&pending_sql)
+        .bind(chain_id)
         .bind(start)
         .bind(end)
         .bind(batch_limit)
@@ -293,7 +296,9 @@ where
 {
     let row: Option<(Option<i64>,)> = sqlx::query_as(
         "SELECT gw_start_block FROM upgrade_state
-          WHERE stack_role = 'GCS' AND status = 'in_progress'",
+          WHERE stack_role = 'GCS' AND status = 'in_progress'
+          ORDER BY host_chain_id
+          LIMIT 1",
     )
     .fetch_optional(executor)
     .await?;
@@ -494,8 +499,10 @@ async fn compute_and_upload_state_hashes(
 
     // GCS hashes are only produced during an active upgrade window; BCS hashes
     // are not produced because they would never be uploaded or consumed.
-    if let Some((_, start, end)) = crate::active_upgrade_window(&mut *tx).await? {
-        compute_and_insert_gcs(&mut tx, start, end, batch_limit).await?;
+    if let Some((_, _, windows)) = crate::active_upgrade_windows(&mut *tx).await? {
+        for (chain_id, start, end) in windows {
+            compute_and_insert_gcs(&mut tx, chain_id, start, end, batch_limit).await?;
+        }
 
         // Gateway-inputs track: only once the GCS gw-listener has a watermark and
         // gw_start_block is set. Bounded to sealed blocks (< gw_tip).

--- a/coprocessor/fhevm-engine/db-migration/migrations/20260725120000_upgrade_state_per_chain_windows.sql
+++ b/coprocessor/fhevm-engine/db-migration/migrations/20260725120000_upgrade_state_per_chain_windows.sql
@@ -1,0 +1,22 @@
+-- Multi-chain Blue/Green.
+--
+-- A proposal is represented directly by one upgrade_state row per host-chain
+-- evaluation window. Proposal-level FSM fields are intentionally repeated on
+-- those rows; state transitions update the complete proposal atomically.
+--
+-- Rows created before host_chain_id existed predate multi-chain and can't name a
+-- real chain. Drop them rather than stamp a phantom id that would wedge consensus
+-- (never times out) and block every future proposal; any live upgrade re-seeds.
+DELETE FROM upgrade_state WHERE host_chain_id IS NULL;
+
+ALTER TABLE upgrade_state
+    ALTER COLUMN host_chain_id SET NOT NULL;
+
+ALTER TABLE upgrade_state
+    DROP CONSTRAINT IF EXISTS upgrade_state_pkey;
+
+ALTER TABLE upgrade_state
+    ADD PRIMARY KEY (stack_role, host_chain_id);
+
+CREATE INDEX IF NOT EXISTS upgrade_state_attempt_idx
+    ON upgrade_state (stack_role, proposal_id, proposal_block);

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/gcs_activation.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/gcs_activation.rs
@@ -100,10 +100,14 @@ pub async fn run_gcs_activation_watcher(
         // `start_block` column is populated one state earlier (UpgradeActivated),
         // before BCS has settled up to start_block and before pre-start rows are
         // pruned — too early to begin computing.
-        let row: Option<(String, Option<i64>)> =
-            sqlx::query_as("SELECT state, start_block FROM upgrade_state WHERE stack_role = 'GCS'")
-                .fetch_optional(pool)
-                .await?;
+        let row: Option<(String, Option<i64>)> = sqlx::query_as(
+            "SELECT state, start_block FROM upgrade_state
+              WHERE stack_role = 'GCS'
+              ORDER BY proposal_block DESC NULLS LAST, host_chain_id
+              LIMIT 1",
+        )
+        .fetch_optional(pool)
+        .await?;
 
         let current = state.load(Ordering::SeqCst);
         let next = row.as_ref().map_or(current, |(fsm_state, start_block)| {
@@ -175,7 +179,10 @@ pub async fn run_gcs_gw_activation_watcher(
         // early to begin re-randomizing. A `PAUSED` row (rolled-back dry-run)
         // re-pauses the worker.
         let row: Option<(String, bool, Option<i64>)> = sqlx::query_as(
-            "SELECT state, gw_dry_run_started, gw_start_block FROM upgrade_state WHERE stack_role = 'GCS'",
+            "SELECT state, gw_dry_run_started, gw_start_block FROM upgrade_state
+              WHERE stack_role = 'GCS'
+              ORDER BY proposal_block DESC NULLS LAST, host_chain_id
+              LIMIT 1",
         )
         .fetch_optional(pool)
         .await?;

--- a/coprocessor/fhevm-engine/host-listener/src/database/ingest.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/ingest.rs
@@ -10,7 +10,7 @@ use fhevm_engine_common::types::{
     Handle, COMPUTED_HANDLE_INDEX_MARKER, HANDLE_VERSION,
 };
 use sqlx::types::time::{OffsetDateTime, PrimitiveDateTime};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::cmd::block_history::{BlockHash, BlockSummary};
 use crate::cmd::InfiniteLogIter;
@@ -651,6 +651,13 @@ async fn notify_coprocessor_upgrade_proposed(
     proposal_block: i64,
 ) -> Result<(), sqlx::Error> {
     let listener_chain_id = chain_id.as_u64();
+    let Ok(listener_chain_id_i64) = i64::try_from(listener_chain_id) else {
+        warn!(
+            listener_chain_id,
+            "Rejecting CoprocessorUpgradeProposed: listener chain id exceeds i64 range"
+        );
+        return Ok(());
+    };
 
     if event.proposalId.is_zero() {
         warn!(
@@ -664,118 +671,233 @@ async fn notify_coprocessor_upgrade_proposed(
     let proposal_id_hex =
         format!("0x{}", alloy_primitives::hex::encode(proposal_id_bytes));
 
-    let Some(window) = event
-        .chainUpgradeWindows
-        .iter()
-        .find(|w| w.chainId == listener_chain_id)
+    // gwStartBlock is a single top-level field shared by every per-chain window.
+    let Ok(gw_start_block) = i64::try_from(event.gwStartBlock) else {
+        warn!(
+            listener_chain_id,
+            proposal_id = %proposal_id_hex,
+            gw_start_block = event.gwStartBlock,
+            "Rejecting CoprocessorUpgradeProposed: gwStartBlock exceeds i64 range"
+        );
+        return Ok(());
+    };
+
+    if event.chainUpgradeWindows.is_empty() {
+        warn!(
+            listener_chain_id,
+            proposal_id = %proposal_id_hex,
+            "CoprocessorUpgradeProposed carries no chain windows — nothing to activate"
+        );
+        return Ok(());
+    }
+
+    // Validate and materialize the complete set before touching durable state.
+    // Rejecting the whole event avoids a partially installed proposal.
+    let mut seen_chain_ids = HashSet::new();
+    let mut windows = Vec::with_capacity(event.chainUpgradeWindows.len());
+    for window in &event.chainUpgradeWindows {
+        let (Ok(window_chain_id), Ok(start_block), Ok(end_block)) = (
+            i64::try_from(window.chainId),
+            i64::try_from(window.startBlock),
+            i64::try_from(window.endBlock),
+        ) else {
+            warn!(
+                listener_chain_id,
+                proposal_id = %proposal_id_hex,
+                window_chain_id = window.chainId,
+                start_block = window.startBlock,
+                end_block = window.endBlock,
+                "Rejecting CoprocessorUpgradeProposed: chain/block field exceeds i64 range"
+            );
+            return Ok(());
+        };
+        if start_block > end_block {
+            warn!(
+                listener_chain_id,
+                proposal_id = %proposal_id_hex,
+                window_chain_id,
+                start_block,
+                end_block,
+                "Rejecting CoprocessorUpgradeProposed: start_block is after end_block"
+            );
+            return Ok(());
+        }
+        if !seen_chain_ids.insert(window_chain_id) {
+            warn!(
+                listener_chain_id,
+                proposal_id = %proposal_id_hex,
+                window_chain_id,
+                "Rejecting CoprocessorUpgradeProposed: duplicate host chain window"
+            );
+            return Ok(());
+        }
+        windows.push((window_chain_id, start_block, end_block));
+    }
+    windows.sort_unstable_by_key(|&(window_chain_id, _, _)| window_chain_id);
+
+    let Some(&(_, canonical_start, canonical_end)) =
+        windows.iter().find(|&&(window_chain_id, _, _)| {
+            window_chain_id == listener_chain_id_i64
+        })
     else {
         warn!(
             listener_chain_id,
             proposal_id = %proposal_id_hex,
-            nb_windows = event.chainUpgradeWindows.len(),
-            "CoprocessorUpgradeProposed does not include this chain — authority listener will not emit event_upgrade_activated"
+            nb_windows = windows.len(),
+            "Rejecting CoprocessorUpgradeProposed: proposal does not include the canonical listener chain"
         );
         return Ok(());
     };
 
-    // uint64 contract fields can exceed i64::MAX; reject out-of-range values so a bad
-    // proposal is skipped instead of failing the whole block ingest.
-    let (Ok(start_block), Ok(end_block), Ok(gw_start_block)) = (
-        i64::try_from(window.startBlock),
-        i64::try_from(window.endBlock),
-        i64::try_from(event.gwStartBlock),
-    ) else {
-        warn!(
-            listener_chain_id,
-            proposal_id = %proposal_id_hex,
-            start_block = window.startBlock,
-            end_block = window.endBlock,
-            gw_start_block = event.gwStartBlock,
-            "Rejecting CoprocessorUpgradeProposed: block field exceeds i64 range"
-        );
-        return Ok(());
-    };
-
-    sqlx::query("DELETE FROM upgrade_state WHERE stack_role = 'BCS'")
+    // ProtocolConfig ingestion replaces a proposal-wide row set. Serialize it
+    // with controller transitions and concurrent listeners so readers can
+    // never observe only a subset of the proposed chains.
+    sqlx::query("LOCK TABLE upgrade_state IN SHARE ROW EXCLUSIVE MODE")
         .execute(&mut **tx)
         .await?;
 
-    let result = sqlx::query(
-        r#"
-        INSERT INTO upgrade_state (
-            stack_role, state, status, proposal_id, version,
-            start_block, end_block, gw_start_block, host_chain_id,
-            host_consensus_reached, gw_consensus_reached, proposal_block, updated_at
-        )
-        VALUES ('GCS', 'UpgradeActivated', 'in_progress', $1, $2, $3, $4, $5, $6, FALSE, FALSE, $7, NOW())
-        ON CONFLICT (stack_role) DO UPDATE
-        SET state              = EXCLUDED.state,
-            status             = EXCLUDED.status,
-            proposal_id        = EXCLUDED.proposal_id,
-            version            = EXCLUDED.version,
-            start_block        = EXCLUDED.start_block,
-            end_block          = EXCLUDED.end_block,
-            gw_start_block     = EXCLUDED.gw_start_block,
-            host_chain_id      = EXCLUDED.host_chain_id,
-            proposal_block     = EXCLUDED.proposal_block,
-            -- Fresh window: clear the consensus latches and the gw gate flag so a
-            -- prior cycle's state can't authorize this cutover or release the
-            -- zkproof-worker before this window's Gateway readiness check.
-            host_consensus_reached = FALSE,
-            gw_consensus_reached   = FALSE,
-            gw_dry_run_started     = FALSE,
-            last_error         = NULL,
-            updated_at         = NOW()
-        WHERE (upgrade_state.proposal_block IS NULL
-            OR EXCLUDED.proposal_block > upgrade_state.proposal_block)
-          AND (upgrade_state.status = 'failed'
-            OR (upgrade_state.status = 'completed'
-              AND upgrade_state.proposal_id IS DISTINCT FROM EXCLUDED.proposal_id))
-        "#,
+    type ExistingWindow = (
+        String,
+        Option<Vec<u8>>,
+        Option<i64>,
+        i64,
+        Option<i64>,
+        Option<i64>,
+        Option<String>,
+        Option<i64>,
+    );
+    let existing: Vec<ExistingWindow> = sqlx::query_as(
+        "SELECT status, proposal_id, proposal_block, host_chain_id,
+                start_block, end_block, version, gw_start_block
+           FROM upgrade_state
+          WHERE stack_role = 'GCS'
+          ORDER BY host_chain_id
+          FOR UPDATE",
     )
-    .bind(&proposal_id_bytes[..])
-    .bind(&event.softwareVersion)
-    .bind(start_block)
-    .bind(end_block)
-    .bind(gw_start_block)
-    .bind(listener_chain_id as i64)
-    .bind(proposal_block)
-    .execute(&mut **tx)
+    .fetch_all(&mut **tx)
     .await?;
 
-    if result.rows_affected() == 0 {
+    let same_attempt = !existing.is_empty()
+        && existing.iter().all(
+            |(_, existing_id, existing_block, _, _, _, _, _)| {
+                existing_id.as_deref() == Some(&proposal_id_bytes[..])
+                    && *existing_block == Some(proposal_block)
+            },
+        );
+    if same_attempt {
+        let same_windows = existing.len() == windows.len()
+            && existing.iter().zip(&windows).all(
+                |(
+                    (
+                        _,
+                        _,
+                        _,
+                        existing_chain,
+                        existing_start,
+                        existing_end,
+                        existing_version,
+                        existing_gw_start,
+                    ),
+                    (chain, start, end),
+                )| {
+                    *existing_chain == *chain
+                        && *existing_start == Some(*start)
+                        && *existing_end == Some(*end)
+                        && existing_version.as_deref()
+                            == Some(event.softwareVersion.as_str())
+                        && *existing_gw_start == Some(gw_start_block)
+                },
+            );
+        if same_windows {
+            debug!(
+                proposal_id = %proposal_id_hex,
+                proposal_block,
+                "Ignoring exact replay of CoprocessorUpgradeProposed"
+            );
+        } else {
+            warn!(
+                proposal_id = %proposal_id_hex,
+                proposal_block,
+                "Rejecting CoprocessorUpgradeProposed: an existing attempt has different proposal data"
+            );
+        }
+        return Ok(());
+    }
+
+    let can_replace = existing.is_empty()
+        || existing.iter().all(
+            |(status, existing_id, existing_block, _, _, _, _, _)| {
+                existing_block.is_none_or(|block| proposal_block > block)
+                    && (status == "failed"
+                        || (status == "completed"
+                            && existing_id.as_deref()
+                                != Some(&proposal_id_bytes[..])))
+            },
+        );
+    if !can_replace {
         warn!(
             proposal_id = %proposal_id_hex,
-            "Rejected event_upgrade_activated: proposal is active, completed, or not newer"
+            proposal_block,
+            "Rejected event_upgrade_activated: another proposal is active, completed, or newer"
         );
         return Ok(());
+    }
+
+    sqlx::query("DELETE FROM upgrade_state WHERE stack_role IN ('BCS', 'GCS')")
+        .execute(&mut **tx)
+        .await?;
+
+    for &(window_chain_id, start_block, end_block) in &windows {
+        sqlx::query(
+            r#"
+            INSERT INTO upgrade_state (
+                stack_role, state, status, proposal_id, version,
+                start_block, end_block, gw_start_block, host_chain_id,
+                host_consensus_reached, gw_consensus_reached,
+                gw_dry_run_started, proposal_block, last_error, updated_at
+            )
+            VALUES (
+                'GCS', 'UpgradeActivated', 'in_progress', $1, $2,
+                $3, $4, $5, $6, FALSE, FALSE, FALSE, $7, NULL, NOW()
+            )
+            "#,
+        )
+        .bind(&proposal_id_bytes[..])
+        .bind(&event.softwareVersion)
+        .bind(start_block)
+        .bind(end_block)
+        .bind(gw_start_block)
+        .bind(window_chain_id)
+        .bind(proposal_block)
+        .execute(&mut **tx)
+        .await?;
     }
 
     info!(
         proposal_id = %proposal_id_hex,
         software_version = %event.softwareVersion,
-        chain_id = listener_chain_id,
-        start_block = window.startBlock,
-        end_block = window.endBlock,
+        chains = windows.len(),
         gw_start_block = event.gwStartBlock,
-        "Decoded CoprocessorUpgradeProposed, emitting pg_notify('event_upgrade_activated')"
+        "Persisted CoprocessorUpgradeProposed atomically, emitting pg_notify('event_upgrade_activated')"
     );
 
+    // One wake-up for the complete proposal; the controller reconciles from
+    // the durable per-chain rows.
     let payload = serde_json::json!({
-        "proposal_id":        &proposal_id_hex,
-        "chain_id":           listener_chain_id as i64,
-        "start_block":        start_block,
-        "end_block":          end_block,
-        "gw_start_block":     gw_start_block,
-        "version":            &event.softwareVersion,
+        "proposal_id":    &proposal_id_hex,
+        "chain_id":       listener_chain_id_i64,
+        "start_block":    canonical_start,
+        "end_block":      canonical_end,
+        "gw_start_block": gw_start_block,
+        "version":        &event.softwareVersion,
     });
-
     sqlx::query("SELECT pg_notify($1, $2)")
         .bind(UPGRADE_ACTIVATED_CHANNEL)
         .bind(payload.to_string())
         .execute(&mut **tx)
-        .await
-        .map(|_| ())
+        .await?;
+
+    Ok(())
 }
 
 pub async fn update_finalized_blocks(
@@ -1141,10 +1263,10 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block, proposal_block, updated_at
+                start_block, end_block, gw_start_block, host_chain_id, proposal_block, updated_at
             )
             VALUES ('BCS', 'PAUSED', 'completed', $1, 'v1',
-                    100, 200, 1, 100, NOW())
+                    100, 200, 1, 1, 100, NOW())
             "#,
         )
         .bind(&U256::from(1u64).to_be_bytes::<32>()[..])
@@ -1206,6 +1328,86 @@ mod tests {
         assert_eq!(row.try_get::<String, _>("status").unwrap(), "in_progress");
     }
 
+    /// A proposal with N windows atomically seeds N upgrade_state rows.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn upgrade_seeds_one_row_per_chain_window() {
+        use alloy::primitives::U256;
+        use sqlx::postgres::PgPoolOptions;
+        use sqlx::Row;
+        use test_harness::instance::{setup_test_db, ImportMode};
+
+        let instance = setup_test_db(ImportMode::None).await.expect("test db");
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect(instance.db_url())
+            .await
+            .expect("pool");
+
+        let event = ProtocolConfig::CoprocessorUpgradeProposed {
+            proposalId: U256::from(2u64),
+            softwareVersion: "v2".to_string(),
+            chainUpgradeWindows: vec![
+                ProtocolConfig::ChainUpgradeWindow {
+                    chainId: 1,
+                    startBlock: 100,
+                    endBlock: 200,
+                },
+                ProtocolConfig::ChainUpgradeWindow {
+                    chainId: 2,
+                    startBlock: 300,
+                    endBlock: 400,
+                },
+            ],
+            gwStartBlock: 5,
+        };
+
+        let mut tx = pool.begin().await.expect("tx");
+        // The canonical listener (chain 1) decodes the event and seeds *all*
+        // windows, not just its own.
+        notify_coprocessor_upgrade_proposed(
+            &mut tx,
+            ChainId::try_from(1_u64).expect("chain id"),
+            &event,
+            300,
+        )
+        .await
+        .expect("seed ok");
+        tx.commit().await.expect("commit");
+
+        let rows = sqlx::query(
+            "SELECT host_chain_id, start_block, end_block, gw_start_block,
+                    proposal_id, proposal_block, state, status
+               FROM upgrade_state
+              WHERE stack_role = 'GCS'
+              ORDER BY host_chain_id",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("rows");
+        assert_eq!(rows.len(), 2);
+
+        let expected = [(1_i64, 100_i64, 200_i64), (2_i64, 300_i64, 400_i64)];
+        for (row, (chain, start, end)) in rows.iter().zip(expected) {
+            assert_eq!(row.try_get::<i64, _>("host_chain_id").unwrap(), chain);
+            assert_eq!(row.try_get::<i64, _>("start_block").unwrap(), start);
+            assert_eq!(row.try_get::<i64, _>("end_block").unwrap(), end);
+            assert_eq!(row.try_get::<i64, _>("gw_start_block").unwrap(), 5);
+            assert_eq!(row.try_get::<i64, _>("proposal_block").unwrap(), 300);
+            assert_eq!(
+                row.try_get::<Vec<u8>, _>("proposal_id").unwrap(),
+                U256::from(2u64).to_be_bytes::<32>().to_vec()
+            );
+            assert_eq!(
+                row.try_get::<String, _>("state").unwrap(),
+                "UpgradeActivated"
+            );
+            assert_eq!(
+                row.try_get::<String, _>("status").unwrap(),
+                "in_progress"
+            );
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn upgrade_upsert_resets_gw_dry_run_started_for_new_gcs_proposal() {
         use alloy::primitives::U256;
@@ -1225,10 +1427,10 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block,
+                start_block, end_block, gw_start_block, host_chain_id,
                 gw_dry_run_started, proposal_block, updated_at
             )
-            VALUES ('GCS', 'LIVE', 'completed', $1, 'v1', 100, 200, 1, TRUE, 100, NOW())
+            VALUES ('GCS', 'LIVE', 'completed', $1, 'v1', 100, 200, 1, 1, TRUE, 100, NOW())
             "#,
         )
         .bind(&U256::from(1u64).to_be_bytes::<32>()[..])
@@ -1294,9 +1496,9 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block, proposal_block, updated_at
+                start_block, end_block, gw_start_block, host_chain_id, proposal_block, updated_at
             )
-            VALUES ('GCS', 'LIVE', 'completed', $1, 'v1', 100, 200, 1, 100, NOW())
+            VALUES ('GCS', 'LIVE', 'completed', $1, 'v1', 100, 200, 1, 1, 100, NOW())
             "#,
         )
         .bind(&U256::from(1u64).to_be_bytes::<32>()[..])
@@ -1354,11 +1556,11 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block, proposal_block,
+                start_block, end_block, gw_start_block, host_chain_id, proposal_block,
                 host_consensus_reached, gw_consensus_reached,
                 gw_dry_run_started, last_error, updated_at
             )
-            VALUES ('GCS', 'PAUSED', 'failed', $1, 'v1', 100, 200, 1, 100,
+            VALUES ('GCS', 'PAUSED', 'failed', $1, 'v1', 100, 200, 1, 1, 100,
                     TRUE, TRUE, TRUE, 'timeout', NOW())
             "#,
         )
@@ -1462,10 +1664,10 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block, proposal_block, updated_at
+                start_block, end_block, gw_start_block, host_chain_id, proposal_block, updated_at
             )
             VALUES ('GCS', 'UpgradeActivated', 'in_progress', $1, 'v1',
-                    100, 200, 1, 100, NOW())
+                    100, 200, 1, 1, 100, NOW())
             "#,
         )
         .bind(&U256::from(1u64).to_be_bytes::<32>()[..])
@@ -1476,11 +1678,18 @@ mod tests {
         let event = ProtocolConfig::CoprocessorUpgradeProposed {
             proposalId: U256::from(2u64),
             softwareVersion: "v2".to_string(),
-            chainUpgradeWindows: vec![ProtocolConfig::ChainUpgradeWindow {
-                chainId: 1,
-                startBlock: 300,
-                endBlock: 400,
-            }],
+            chainUpgradeWindows: vec![
+                ProtocolConfig::ChainUpgradeWindow {
+                    chainId: 1,
+                    startBlock: 300,
+                    endBlock: 400,
+                },
+                ProtocolConfig::ChainUpgradeWindow {
+                    chainId: 2,
+                    startBlock: 500,
+                    endBlock: 600,
+                },
+            ],
             gwStartBlock: 5,
         };
         let mut tx = pool.begin().await.expect("tx");
@@ -1501,6 +1710,16 @@ mod tests {
         .await
         .expect("proposal id");
         assert_eq!(proposal_id, U256::from(1u64).to_be_bytes::<32>());
+        let row_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM upgrade_state WHERE stack_role = 'GCS'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("row count");
+        assert_eq!(
+            row_count, 1,
+            "a rejected proposal must not install only its previously absent chain"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1522,9 +1741,9 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block, proposal_block, updated_at
+                start_block, end_block, gw_start_block, host_chain_id, proposal_block, updated_at
             )
-            VALUES ('GCS', 'LIVE', 'completed', $1, 'v2', 100, 200, 1, 100, NOW())
+            VALUES ('GCS', 'LIVE', 'completed', $1, 'v2', 100, 200, 1, 1, 100, NOW())
             "#,
         )
         .bind(&U256::from(2u64).to_be_bytes::<32>()[..])

--- a/coprocessor/fhevm-engine/tfhe-worker/src/bridge.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/bridge.rs
@@ -175,10 +175,14 @@ async fn bridge_writes_enabled(
         return Ok(true);
     }
 
-    let state: Option<String> =
-        sqlx::query_scalar("SELECT state FROM upgrade_state WHERE stack_role = 'GCS'")
-            .fetch_optional(&mut *conn)
-            .await?;
+    let state: Option<String> = sqlx::query_scalar(
+        "SELECT state FROM upgrade_state
+          WHERE stack_role = 'GCS'
+          ORDER BY proposal_block DESC NULLS LAST, host_chain_id
+          LIMIT 1",
+    )
+    .fetch_optional(&mut *conn)
+    .await?;
     match state.as_deref() {
         Some("LIVE") => Ok(true),
         // Without this schema, unqualified bridge writes would use public.

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/bridge.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/bridge.rs
@@ -273,9 +273,11 @@ async fn gcs_bridge_does_not_fall_back_to_public() {
     insert_ready_pair(&pool, &src, &dst).await;
     sqlx::query(
         "INSERT INTO upgrade_state
-            (stack_role, state, status, proposal_id, version, start_block, end_block, updated_at)
-         VALUES ('GCS', 'UpgradeActivated', 'in_progress', '\\x02', 'v0.15', 1, 2, NOW())
-         ON CONFLICT (stack_role) DO UPDATE
+            (stack_role, state, status, proposal_id, version,
+             start_block, end_block, host_chain_id, updated_at)
+         VALUES ('GCS', 'UpgradeActivated', 'in_progress', '\\x02', 'v0.15',
+                 1, 2, 1, NOW())
+         ON CONFLICT (stack_role, host_chain_id) DO UPDATE
          SET state = EXCLUDED.state, status = EXCLUDED.status",
     )
     .execute(&pool)

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -295,7 +295,7 @@ fn spawn_gcs_dry_run_readiness(
                             "pruned pre-start_block rows from gcs.computations"
                         ),
                         Err(e) => {
-                            error!(error = %e, "failed to prune gcs.computations; skipping transition");
+                            error!(chain_id, start_block, error = %e, "failed to prune gcs.computations; skipping transition");
                             return;
                         }
                     },
@@ -308,7 +308,7 @@ fn spawn_gcs_dry_run_readiness(
                         return;
                     }
                     Err(e) => {
-                        error!(error = %e, "GCS dry-run readiness loop failed");
+                        error!(chain_id, start_block, error = %e, "GCS dry-run readiness loop failed");
                         return;
                     }
                 }
@@ -1372,7 +1372,9 @@ pub async fn handle_unanimity_consensus(
             let set = sqlx::query(
                 "UPDATE upgrade_state
                     SET host_consensus_reached = TRUE, updated_at = NOW()
-                  WHERE stack_role = 'GCS' AND proposal_id = $1
+                  WHERE stack_role = 'GCS'
+                    AND state IN ('UpgradeActivated', 'DryRunStarted')
+                    AND proposal_id = $1
                     AND COALESCE(proposal_block, -1) = $2
                     AND host_chain_id = $3 AND NOT host_consensus_reached",
             )

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -2211,7 +2211,7 @@ mod tests {
         .await
         .expect("reconcile");
 
-        timeout(Duration::from_secs(10), async {
+        timeout(Duration::from_secs(30), async {
             loop {
                 let (started,): (bool,) = sqlx::query_as(
                     "SELECT gw_dry_run_started

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -64,8 +64,8 @@ const NO_READINESS_ATTEMPT: i64 = -2;
 struct GcsReadinessAttempt {
     proposal_id: Vec<u8>,
     proposal_block: i64,
-    chain_id: i64,
-    start_block: i64,
+    /// (chain_id, start_block) for every host chain in the proposal.
+    host_chains: Vec<(i64, i64)>,
     gw_start_block: i64,
 }
 
@@ -131,6 +131,11 @@ pub struct UpgradeActivatedPayload {
 #[derive(Debug, Clone, Deserialize)]
 pub struct UnanimityConsensusPayload {
     pub proposal_id: Vec<u8>,
+    /// The block containing the ProtocolConfig proposal. Optional only so a
+    /// rolling deployment can safely ignore notifications from an older
+    /// detector that did not yet carry attempt identity.
+    #[serde(default)]
+    pub proposal_block: Option<i64>,
     pub chain_id: i64,
     pub block_height: i64,
     pub block_hash: String,
@@ -193,8 +198,7 @@ fn spawn_gcs_dry_run_readiness(
     let GcsReadinessAttempt {
         proposal_id,
         proposal_block,
-        chain_id,
-        start_block,
+        host_chains,
         gw_start_block,
     } = attempt;
 
@@ -210,8 +214,8 @@ fn spawn_gcs_dry_run_readiness(
         }
     }
     info!(
-        chain_id,
-        start_block, gw_start_block, "arming GCS dry-run readiness"
+        chains = host_chains.len(),
+        gw_start_block, "arming GCS dry-run readiness"
     );
     let pool = pool.clone();
     let gw_cancel = cancel.child_token();
@@ -261,20 +265,21 @@ fn spawn_gcs_dry_run_readiness(
                 Err(e) => error!(error = %e, "GCS gateway dry-run readiness loop failed"),
             }
         };
-        // Host gate: wait until BCS settles up to start_block, prune, then flip to DryRunStarted.
+        // Host gate: every chain must settle to its start_block and be pruned
+        // before flipping the whole proposal to DryRunStarted.
         let host_gate = async {
-            match wait_until_dry_run_ready(
-                pool.clone(),
-                host_cancel,
-                &proposal_id,
-                proposal_block,
-                chain_id,
-                start_block,
-            )
-            .await
-            {
-                Ok(true) => {
-                    match prune_gcs_computations_before_start(
+            for &(chain_id, start_block) in &host_chains {
+                match wait_until_dry_run_ready(
+                    pool.clone(),
+                    host_cancel.child_token(),
+                    &proposal_id,
+                    proposal_block,
+                    chain_id,
+                    start_block,
+                )
+                .await
+                {
+                    Ok(true) => match prune_gcs_computations_before_start(
                         &pool,
                         &proposal_id,
                         proposal_block,
@@ -285,25 +290,32 @@ fn spawn_gcs_dry_run_readiness(
                     {
                         Ok(deleted) => info!(
                             chain_id,
-                            start_block, deleted, "pruned pre-start_block rows from gcs.computations"
+                            start_block,
+                            deleted,
+                            "pruned pre-start_block rows from gcs.computations"
                         ),
                         Err(e) => {
                             error!(error = %e, "failed to prune gcs.computations; skipping transition");
                             return;
                         }
+                    },
+                    Ok(false) => {
+                        info!(
+                            chain_id,
+                            start_block,
+                            "readiness loop exited without satisfying readiness — skipping transition"
+                        );
+                        return;
                     }
-                    if let Err(e) =
-                        transition_to_dry_run_started(&pool, &proposal_id, proposal_block).await
-                    {
-                        error!(error = %e, "failed to transition GCS to DryRunStarted");
+                    Err(e) => {
+                        error!(error = %e, "GCS dry-run readiness loop failed");
+                        return;
                     }
                 }
-                Ok(false) => info!(
-                    chain_id,
-                    start_block,
-                    "readiness loop exited without satisfying readiness — skipping prune and transition"
-                ),
-                Err(e) => error!(error = %e, "GCS dry-run readiness loop failed"),
+            }
+            if let Err(e) = transition_to_dry_run_started(&pool, &proposal_id, proposal_block).await
+            {
+                error!(error = %e, "failed to transition GCS to DryRunStarted");
             }
         };
         tokio::join!(gw_gate, host_gate);
@@ -510,7 +522,9 @@ async fn wait_until_dry_run_ready(
             "SELECT state FROM upgrade_state
                   WHERE stack_role = 'GCS'
                     AND proposal_id = $1
-                    AND COALESCE(proposal_block, -1) = $2",
+                    AND COALESCE(proposal_block, -1) = $2
+                  ORDER BY host_chain_id
+                  LIMIT 1",
         )
         .bind(proposal_id)
         .bind(proposal_block)
@@ -688,7 +702,9 @@ async fn wait_until_gw_dry_run_ready(
             "SELECT state, gw_dry_run_started FROM upgrade_state
               WHERE stack_role = 'GCS'
                 AND proposal_id = $1
-                AND COALESCE(proposal_block, -1) = $2",
+                AND COALESCE(proposal_block, -1) = $2
+              ORDER BY host_chain_id
+              LIMIT 1",
         )
         .bind(proposal_id)
         .bind(proposal_block)
@@ -952,29 +968,45 @@ pub async fn execute_cutover(pool: &Pool<Postgres>) -> Result<(), Error> {
         "cutover acquired exclusive advisory lock"
     );
 
-    // Re-read under the lock: a concurrent cutover may have already promoted this row.
-    let row: Option<(String, Option<i64>, Option<String>)> = sqlx::query_as(
-        "SELECT state, start_block, version FROM upgrade_state WHERE stack_role = 'GCS'",
+    // Re-read every chain row under a table lock: a concurrent activation or
+    // cutover cannot replace only part of the proposal while it is promoted.
+    sqlx::query("LOCK TABLE upgrade_state IN SHARE ROW EXCLUSIVE MODE")
+        .execute(&mut *tx)
+        .await?;
+    let rows: Vec<(String, Option<i64>, Option<String>)> = sqlx::query_as(
+        "SELECT state, start_block, version
+           FROM upgrade_state
+          WHERE stack_role = 'GCS'
+          ORDER BY host_chain_id
+          FOR UPDATE",
     )
-    .fetch_optional(&mut *tx)
+    .fetch_all(&mut *tx)
     .await?;
-    let stack_version = match row {
-        None => {
-            return Err(Error::Payload(
-                "no GCS row in upgrade_state — cannot run cutover".to_string(),
-            ));
-        }
-        Some((state, _, _)) if state != "UpgradeAuthorized" => {
-            info!(state = %state, "cutover: GCS row is not UpgradeAuthorized — skipping (already cut over)");
-            return Ok(());
-        }
-        Some((_, None, _)) => {
-            return Err(Error::Payload(
-                "GCS upgrade_state row is missing start_block".to_string(),
-            ));
-        }
-        Some((_, Some(_start_block), version)) => version.unwrap_or_default(),
+    let Some((first_state, _, first_version)) = rows.first() else {
+        return Err(Error::Payload(
+            "no GCS rows in upgrade_state — cannot run cutover".to_string(),
+        ));
     };
+    if rows.iter().any(|(state, _, _)| state != first_state) {
+        return Err(Error::Payload(
+            "GCS upgrade_state rows disagree on state".to_string(),
+        ));
+    }
+    if first_state != "UpgradeAuthorized" {
+        info!(state = %first_state, "cutover: GCS proposal is not UpgradeAuthorized — skipping (already cut over)");
+        return Ok(());
+    }
+    if rows.iter().any(|(_, start, _)| start.is_none()) {
+        return Err(Error::Payload(
+            "a GCS upgrade_state row is missing start_block".to_string(),
+        ));
+    }
+    if rows.iter().any(|(_, _, version)| version != first_version) {
+        return Err(Error::Payload(
+            "GCS upgrade_state rows disagree on version".to_string(),
+        ));
+    }
+    let stack_version = first_version.clone().unwrap_or_default();
 
     // 2. Promote the new stack version inside the cutover tx. This is the
     //    source of truth read by `resolve_gcs_mode` / `reconcile_stack_mode`:
@@ -1040,32 +1072,49 @@ pub async fn execute_cutover(pool: &Pool<Postgres>) -> Result<(), Error> {
     Ok(())
 }
 
-/// Flip to `UpgradeAuthorized` and cut over once both latches are set; guarded UPDATE, so duplicates no-op.
+/// Flip every GCS proposal row to `UpgradeAuthorized` and cut over once every
+/// row has its host and Gateway consensus latches set. Guarded UPDATE, so
+/// duplicates no-op.
 async fn try_cutover_if_consensus(pool: &Pool<Postgres>) -> Result<(), Error> {
     let result = sqlx::query(
         r#"
-        UPDATE upgrade_state
-        SET state = 'UpgradeAuthorized', updated_at = NOW()
-        WHERE stack_role = 'GCS' AND state = 'DryRunStarted'
-          AND host_consensus_reached AND gw_consensus_reached
+        WITH eligible_attempt AS (
+            SELECT proposal_id, COALESCE(proposal_block, -1) AS proposal_block
+              FROM upgrade_state
+             WHERE stack_role = 'GCS' AND status = 'in_progress'
+             GROUP BY proposal_id, COALESCE(proposal_block, -1)
+            HAVING COUNT(*) > 0
+               AND BOOL_AND(state = 'DryRunStarted')
+               AND BOOL_AND(host_consensus_reached)
+               AND BOOL_AND(gw_consensus_reached)
+        )
+        UPDATE upgrade_state u
+           SET state = 'UpgradeAuthorized', updated_at = NOW()
+          FROM eligible_attempt e
+         WHERE u.stack_role = 'GCS'
+           AND u.proposal_id = e.proposal_id
+           AND COALESCE(u.proposal_block, -1) = e.proposal_block
         "#,
     )
     .execute(pool)
     .await?;
     if result.rows_affected() == 0 {
-        debug!("cutover deferred — both consensus latches not yet set");
+        debug!("cutover deferred — gateway or a host chain's consensus latch not yet set");
         return Ok(());
     }
-    info!("both host and gateway consensus reached — transitioning to UpgradeAuthorized and running cutover");
+    info!("gateway + all host chains reached consensus — transitioning to UpgradeAuthorized and running cutover");
     execute_cutover(pool).await
 }
 
-/// Roll back a dry-run under the write lock: PAUSED/failed, reset schema, wake workers.
-/// Scoped to the proposal and end block. Returns whether it acted.
+/// Roll back a dry-run under the write lock: PAUSED/failed, reset schema, wake
+/// workers. Scoped to both the proposal and its maximum end block, which is the
+/// attempt identity carried by the detector's timeout notification. Returns
+/// whether it acted.
 async fn rollback_dry_run(
     pool: &Pool<Postgres>,
     proposal_id: &[u8],
-    end_block: i64,
+    proposal_block: i64,
+    timeout_end_block: i64,
 ) -> Result<bool, Error> {
     let mut tx = pool.begin().await?;
     sqlx::query("SELECT pg_advisory_xact_lock($1)")
@@ -1079,17 +1128,28 @@ async fn rollback_dry_run(
 
     let claimed = sqlx::query(
         r#"
-        UPDATE upgrade_state
+        UPDATE upgrade_state u
            SET state = 'PAUSED', status = 'failed',
                last_error = 'unanimity_consensus_timeout',
                host_consensus_reached = FALSE, gw_consensus_reached = FALSE,
                gw_dry_run_started = FALSE, updated_at = NOW()
-         WHERE stack_role = 'GCS' AND state IN ('UpgradeActivated', 'DryRunStarted')
-           AND proposal_id = $1 AND end_block = $2
+         WHERE u.stack_role = 'GCS'
+           AND u.state IN ('UpgradeActivated', 'DryRunStarted')
+           AND u.proposal_id = $1
+           AND COALESCE(u.proposal_block, -1) = $2
+           AND $3 = (
+               SELECT MAX(w.end_block)
+                 FROM upgrade_state w
+                WHERE w.stack_role = u.stack_role
+                  AND w.proposal_id = u.proposal_id
+                  AND COALESCE(w.proposal_block, -1) =
+                      COALESCE(u.proposal_block, -1)
+           )
         "#,
     )
     .bind(proposal_id)
-    .bind(end_block)
+    .bind(proposal_block)
+    .bind(timeout_end_block)
     .execute(&mut *tx)
     .await?;
     if claimed.rows_affected() == 0 {
@@ -1110,9 +1170,9 @@ type ReconcileRow = (
     Option<Vec<u8>>,
     i64,
     Option<i64>,
-    Option<i64>,
-    Option<i64>,
     bool,
+    i64,
+    Option<i64>,
 );
 
 /// Advance the upgrade from durable state: re-arm readiness, resume a cutover, or
@@ -1127,30 +1187,53 @@ async fn reconcile(
     if !gcs_mode {
         return Ok(());
     }
-    let row: Option<ReconcileRow> = sqlx::query_as(
+    let rows: Vec<ReconcileRow> = sqlx::query_as(
         "SELECT state, proposal_id, COALESCE(proposal_block, -1),
-                host_chain_id, start_block, gw_start_block, gw_dry_run_started
-           FROM upgrade_state WHERE stack_role = 'GCS' AND status = 'in_progress'",
+                gw_start_block, gw_dry_run_started, host_chain_id, start_block
+           FROM upgrade_state
+          WHERE stack_role = 'GCS' AND status = 'in_progress'
+          ORDER BY host_chain_id",
     )
-    .fetch_optional(pool)
+    .fetch_all(pool)
     .await?;
-    let Some((
-        state,
-        proposal_id,
-        proposal_block,
-        host_chain_id,
-        start_block,
-        gw_start_block,
-        gw_dry_run_started,
-    )) = row
+    let Some((state, proposal_id, proposal_block, gw_start_block, gw_dry_run_started, _, _)) =
+        rows.first()
     else {
         return Ok(());
     };
+    if rows.iter().any(
+        |(row_state, row_id, row_block, row_gw_start, row_gw_started, _, _)| {
+            row_state != state
+                || row_id != proposal_id
+                || row_block != proposal_block
+                || row_gw_start != gw_start_block
+                || row_gw_started != gw_dry_run_started
+        },
+    ) {
+        return Err(Error::Payload(
+            "in-progress GCS upgrade_state rows do not describe one proposal".to_string(),
+        ));
+    }
+    let host_chains: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|(_, _, _, _, _, chain_id, start)| {
+            start.map(|start| (*chain_id, start)).ok_or_else(|| {
+                Error::Payload(format!("GCS chain {chain_id} is missing start_block"))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let (state, proposal_id, proposal_block, gw_start_block, gw_dry_run_started) = (
+        state.clone(),
+        proposal_id.clone(),
+        *proposal_block,
+        *gw_start_block,
+        *gw_dry_run_started,
+    );
     match state.as_str() {
         // Re-arm readiness (no-op if already running).
         "UpgradeActivated" => {
-            if let (Some(proposal_id), Some(chain_id), Some(start), Some(gw_start)) =
-                (proposal_id, host_chain_id, start_block, gw_start_block)
+            if let (Some(proposal_id), Some(gw_start), false) =
+                (proposal_id, gw_start_block, host_chains.is_empty())
             {
                 spawn_gcs_dry_run_readiness(
                     pool,
@@ -1159,8 +1242,7 @@ async fn reconcile(
                     GcsReadinessAttempt {
                         proposal_id,
                         proposal_block,
-                        chain_id,
-                        start_block: start,
+                        host_chains,
                         gw_start_block: gw_start,
                     },
                 );
@@ -1173,8 +1255,8 @@ async fn reconcile(
         "DryRunStarted" => {
             // Restore an incomplete Gateway gate after a controller restart.
             if !gw_dry_run_started {
-                if let (Some(proposal_id), Some(chain_id), Some(start), Some(gw_start)) =
-                    (proposal_id, host_chain_id, start_block, gw_start_block)
+                if let (Some(proposal_id), Some(gw_start), false) =
+                    (proposal_id, gw_start_block, host_chains.is_empty())
                 {
                     spawn_gcs_dry_run_readiness(
                         pool,
@@ -1183,8 +1265,7 @@ async fn reconcile(
                         GcsReadinessAttempt {
                             proposal_id,
                             proposal_block,
-                            chain_id,
-                            start_block: start,
+                            host_chains,
                             gw_start_block: gw_start,
                         },
                     );
@@ -1200,18 +1281,15 @@ async fn reconcile(
 
 /// Handle an `event_unanimity_consensus` notification. consensus-detector emits
 /// this for TWO independent tracks, distinguished by the payload `chain_id`:
-///   - the **host chain** (`chain_id == upgrade_state.host_chain_id`), over the
-///     host-block state hashes, valid only for `block_height` within the FSM
-///     row's `[start_block, end_block]` window; and
+///   - a **host chain** (`chain_id` present in `upgrade_state`), over the
+///     host-block state hashes, valid only for `block_height` within that
+///     chain's `[start_block, end_block]` window; and
 ///   - the **Gateway** (any other `chain_id`), over the re-randomized input
 ///     ciphertexts, emitted per Gateway block.
 ///
-/// Cutover requires unanimity on BOTH tracks. Each track sets its own latch
-/// (`host_consensus_reached` / `gw_consensus_reached`); the row is transitioned
-/// to 'UpgradeAuthorized' — and `execute_cutover` run — only once both latches
-/// are set. The transition is a conditional UPDATE guarded on both latches +
-/// `state='DryRunStarted'`, so whichever event arrives second fires cutover
-/// exactly once and any later/replayed firing is a no-op.
+/// Cutover requires unanimity on every host-chain track plus the Gateway track.
+/// Each host latch lives on its chain row; the Gateway latch is repeated across
+/// every row. The guarded `DryRunStarted` transition fires cutover exactly once.
 ///
 /// Latches are *recorded* in either `UpgradeActivated` or `DryRunStarted`, but
 /// cutover only *fires* in `DryRunStarted`. This matters because the Gateway
@@ -1238,145 +1316,135 @@ pub async fn handle_unanimity_consensus(
     let payload: UnanimityConsensusPayload =
         serde_json::from_str(raw_payload).map_err(|e| Error::Payload(e.to_string()))?;
 
-    type GcsUpgradeStateRow = (
-        String,
-        Option<i64>,
-        Option<i64>,
-        Option<Vec<u8>>,
-        Option<i64>,
-        Option<i64>,
-    );
-    let row: Option<GcsUpgradeStateRow> = sqlx::query_as(
-        "SELECT state, start_block, end_block, proposal_id, host_chain_id, gw_start_block
-           FROM upgrade_state WHERE stack_role = 'GCS'",
+    type GcsBaseRow = (String, Option<Vec<u8>>, i64, Option<i64>);
+    let base: Option<GcsBaseRow> = sqlx::query_as(
+        "SELECT state, proposal_id, COALESCE(proposal_block, -1), gw_start_block
+           FROM upgrade_state
+          WHERE stack_role = 'GCS' AND status = 'in_progress'
+          ORDER BY host_chain_id
+          LIMIT 1",
     )
     .fetch_optional(pool)
     .await?;
 
-    match row {
-        Some((state, start_block, end_block, proposal_id, host_chain_id, gw_start_block))
-            if state == "UpgradeActivated" || state == "DryRunStarted" =>
-        {
-            if proposal_id.as_deref() != Some(payload.proposal_id.as_slice()) {
-                warn!("event_unanimity_consensus: proposal does not match — ignoring");
-                return Ok(());
-            }
-
-            // Classify the event. Host track iff chain_id matches the stored
-            // host_chain_id; everything else is the Gateway track. For a legacy
-            // row predating host_chain_id, fall back to window membership.
-            let is_host = match host_chain_id {
-                Some(h) => payload.chain_id == h,
-                None => matches!(
-                    (start_block, end_block),
-                    (Some(s), Some(e)) if (s..=e).contains(&payload.block_height)
-                ),
-            };
-
-            if is_host {
-                // Host consensus only counts within the host window — guards
-                // against late/replayed events for a prior upgrade window.
-                match (start_block, end_block) {
-                    (Some(start), Some(end)) if (start..=end).contains(&payload.block_height) => {
-                        // `AND NOT host_consensus_reached` so a re-emitted anchor no-ops.
-                        let set = sqlx::query(
-                            "UPDATE upgrade_state SET host_consensus_reached = TRUE, updated_at = NOW()
-                              WHERE stack_role = 'GCS'
-                                AND state IN ('UpgradeActivated', 'DryRunStarted')
-                                AND proposal_id = $1
-                                AND NOT host_consensus_reached",
-                        )
-                        .bind(&payload.proposal_id)
-                        .execute(pool)
-                        .await?;
-                        if set.rows_affected() > 0 {
-                            info!(
-                                chain_id = payload.chain_id,
-                                block_height = payload.block_height,
-                                start_block = start,
-                                end_block = end,
-                                proposal_id = ?proposal_id.as_deref().map(hex_encode),
-                                "event_unanimity_consensus: host-track unanimity — host_consensus_reached set"
-                            );
-                        }
-                    }
-                    (Some(start), Some(end)) => {
-                        warn!(
-                            payload_block_height = payload.block_height,
-                            start_block = start,
-                            end_block = end,
-                            "event_unanimity_consensus: host block_height outside [start_block, end_block] — ignoring"
-                        );
-                        return Ok(());
-                    }
-                    _ => {
-                        warn!(
-                            payload_block_height = payload.block_height,
-                            ?start_block,
-                            ?end_block,
-                            "event_unanimity_consensus: GCS row missing start_block or end_block — ignoring"
-                        );
-                        return Ok(());
-                    }
-                }
-            } else {
-                // Gateway consensus only counts at/after gw_start_block —
-                // symmetric with the host window guard above. Drops late/replayed
-                // events from an earlier Gateway window, and pre-window events
-                // misclassified as Gateway when host_chain_id is NULL (legacy row).
-                match gw_start_block {
-                    Some(gw_start) if payload.block_height >= gw_start => {
-                        // `AND NOT gw_consensus_reached` so a re-emitted anchor no-ops.
-                        let set = sqlx::query(
-                            "UPDATE upgrade_state SET gw_consensus_reached = TRUE, updated_at = NOW()
-                              WHERE stack_role = 'GCS'
-                                AND state IN ('UpgradeActivated', 'DryRunStarted')
-                                AND proposal_id = $1
-                                AND NOT gw_consensus_reached",
-                        )
-                        .bind(&payload.proposal_id)
-                        .execute(pool)
-                        .await?;
-                        if set.rows_affected() > 0 {
-                            info!(
-                                chain_id = payload.chain_id,
-                                block_height = payload.block_height,
-                                gw_start_block = gw_start,
-                                "event_unanimity_consensus: gateway-track unanimity — gw_consensus_reached set"
-                            );
-                        }
-                    }
-                    Some(gw_start) => {
-                        warn!(
-                            payload_block_height = payload.block_height,
-                            gw_start_block = gw_start,
-                            "event_unanimity_consensus: gateway block_height below gw_start_block — ignoring"
-                        );
-                        return Ok(());
-                    }
-                    None => {
-                        warn!(
-                            payload_block_height = payload.block_height,
-                            "event_unanimity_consensus: GCS row missing gw_start_block — ignoring gateway consensus"
-                        );
-                        return Ok(());
-                    }
-                }
-            }
-
-            try_cutover_if_consensus(pool).await?;
-        }
-        Some((state, _, _, _, _, _)) => {
-            warn!(
-                state,
-                "event_unanimity_consensus: GCS state is not UpgradeActivated/DryRunStarted — skipping cutover"
-            );
-        }
-        None => {
-            warn!("event_unanimity_consensus: no GCS row in upgrade_state — skipping cutover");
-        }
+    let Some((state, proposal_id, proposal_block, gw_start_block)) = base else {
+        warn!(
+            "event_unanimity_consensus: no in-progress GCS row in upgrade_state — skipping cutover"
+        );
+        return Ok(());
+    };
+    if state != "UpgradeActivated" && state != "DryRunStarted" {
+        warn!(
+            state,
+            "event_unanimity_consensus: GCS state is not UpgradeActivated/DryRunStarted — skipping cutover"
+        );
+        return Ok(());
+    }
+    if proposal_id.as_deref() != Some(payload.proposal_id.as_slice()) {
+        warn!("event_unanimity_consensus: proposal does not match — ignoring");
+        return Ok(());
+    }
+    if payload.proposal_block != Some(proposal_block) {
+        warn!(
+            payload_proposal_block = payload.proposal_block,
+            proposal_block, "event_unanimity_consensus: proposal attempt does not match — ignoring"
+        );
+        return Ok(());
     }
 
+    // Classify the event: it's a host track iff its chain_id is one of the
+    // proposal's host chains; everything else is the Gateway track.
+    let host_window: Option<(i64, i64)> = sqlx::query_as(
+        "SELECT start_block, end_block FROM upgrade_state
+          WHERE stack_role = 'GCS' AND proposal_id = $1
+            AND COALESCE(proposal_block, -1) = $2
+            AND host_chain_id = $3",
+    )
+    .bind(&payload.proposal_id)
+    .bind(proposal_block)
+    .bind(payload.chain_id)
+    .fetch_optional(pool)
+    .await?;
+
+    match host_window {
+        // Host track: set only this chain's latch, and only within its window.
+        Some((start, end)) if (start..=end).contains(&payload.block_height) => {
+            let set = sqlx::query(
+                "UPDATE upgrade_state
+                    SET host_consensus_reached = TRUE, updated_at = NOW()
+                  WHERE stack_role = 'GCS' AND proposal_id = $1
+                    AND COALESCE(proposal_block, -1) = $2
+                    AND host_chain_id = $3 AND NOT host_consensus_reached",
+            )
+            .bind(&payload.proposal_id)
+            .bind(proposal_block)
+            .bind(payload.chain_id)
+            .execute(pool)
+            .await?;
+            if set.rows_affected() > 0 {
+                info!(
+                    chain_id = payload.chain_id,
+                    block_height = payload.block_height,
+                    start_block = start,
+                    end_block = end,
+                    proposal_id = %hex_encode(&payload.proposal_id),
+                    "event_unanimity_consensus: host-track unanimity — host_consensus_reached set for chain"
+                );
+            }
+        }
+        Some((start, end)) => {
+            warn!(
+                chain_id = payload.chain_id,
+                payload_block_height = payload.block_height,
+                start_block = start,
+                end_block = end,
+                "event_unanimity_consensus: host block_height outside [start_block, end_block] — ignoring"
+            );
+            return Ok(());
+        }
+        // Not a host chain → Gateway track. Only counts at/after gw_start_block.
+        None => match gw_start_block {
+            Some(gw_start) if payload.block_height >= gw_start => {
+                let set = sqlx::query(
+                    "UPDATE upgrade_state SET gw_consensus_reached = TRUE, updated_at = NOW()
+                      WHERE stack_role = 'GCS'
+                        AND state IN ('UpgradeActivated', 'DryRunStarted')
+                        AND proposal_id = $1
+                        AND COALESCE(proposal_block, -1) = $2
+                        AND NOT gw_consensus_reached",
+                )
+                .bind(&payload.proposal_id)
+                .bind(proposal_block)
+                .execute(pool)
+                .await?;
+                if set.rows_affected() > 0 {
+                    info!(
+                        chain_id = payload.chain_id,
+                        block_height = payload.block_height,
+                        gw_start_block = gw_start,
+                        "event_unanimity_consensus: gateway-track unanimity — gw_consensus_reached set"
+                    );
+                }
+            }
+            Some(gw_start) => {
+                warn!(
+                    payload_block_height = payload.block_height,
+                    gw_start_block = gw_start,
+                    "event_unanimity_consensus: gateway block_height below gw_start_block — ignoring"
+                );
+                return Ok(());
+            }
+            None => {
+                warn!(
+                    payload_block_height = payload.block_height,
+                    "event_unanimity_consensus: GCS row missing gw_start_block — ignoring gateway consensus"
+                );
+                return Ok(());
+            }
+        },
+    }
+
+    try_cutover_if_consensus(pool).await?;
     Ok(())
 }
 
@@ -1399,7 +1467,22 @@ pub async fn handle_unanimity_consensus_timeout(
     let payload: UnanimityConsensusPayload =
         serde_json::from_str(raw_payload).map_err(|e| Error::Payload(e.to_string()))?;
 
-    if rollback_dry_run(pool, &payload.proposal_id, payload.block_height).await? {
+    let Some(proposal_block) = payload.proposal_block else {
+        warn!(
+            proposal_id = %hex_encode(&payload.proposal_id),
+            "event_unanimity_consensus_timeout: missing proposal_block — ignoring legacy timeout"
+        );
+        return Ok(());
+    };
+
+    if rollback_dry_run(
+        pool,
+        &payload.proposal_id,
+        proposal_block,
+        payload.block_height,
+    )
+    .await?
+    {
         warn!(
             chain_id = payload.chain_id,
             block_height = payload.block_height,
@@ -1551,12 +1634,14 @@ mod tests {
     fn parses_unanimity_consensus_payload() {
         let json = r#"{
             "proposal_id": [2],
+            "proposal_block": 10,
             "chain_id": 12345,
             "block_height": 200,
             "block_hash": "0xabc0000000000000000000000000000000000000000000000000000000000001"
         }"#;
         let p: UnanimityConsensusPayload = serde_json::from_str(json).unwrap();
         assert_eq!(p.proposal_id, vec![2]);
+        assert_eq!(p.proposal_block, Some(10));
         assert_eq!(p.chain_id, 12345);
         assert_eq!(p.block_height, 200);
         assert_eq!(
@@ -1592,11 +1677,11 @@ mod tests {
             r#"
             INSERT INTO upgrade_state (
                 stack_role, state, status, proposal_id, version,
-                start_block, end_block, gw_start_block, updated_at
+                start_block, end_block, gw_start_block, host_chain_id, updated_at
             )
             VALUES ('GCS', 'UpgradeAuthorized', 'in_progress', $1, 'v0.15',
-                    100, 200, 1, NOW())
-            ON CONFLICT (stack_role) DO UPDATE
+                    100, 200, 1, 1, NOW())
+            ON CONFLICT (stack_role, host_chain_id) DO UPDATE
             SET state = EXCLUDED.state, status = EXCLUDED.status,
                 version = EXCLUDED.version, updated_at = NOW()
             "#,
@@ -1651,11 +1736,11 @@ mod tests {
     }
 
     fn timeout_payload() -> String {
-        serde_json::json!({ "proposal_id": [2], "chain_id": 1_i64, "block_height": 200_i64, "block_hash": "0x00" })
+        serde_json::json!({ "proposal_id": [2], "proposal_block": 10, "chain_id": 1_i64, "block_height": 200_i64, "block_hash": "0x00" })
             .to_string()
     }
 
-    /// Seed a GCS row with all latches + `gw_dry_run_started`.
+    /// Seed one GCS proposal row with all latches set.
     async fn seed_gcs_row(pool: &Pool<Postgres>, state: &str, status: &str) {
         sqlx::query(
             r#"
@@ -1667,8 +1752,12 @@ mod tests {
             )
             VALUES ('GCS', $1, $2, $3, 'v0.15', 100, 200, 1, 1,
                     TRUE, TRUE, TRUE, 10, NOW())
-            ON CONFLICT (stack_role) DO UPDATE
+            ON CONFLICT (stack_role, host_chain_id) DO UPDATE
             SET state = EXCLUDED.state, status = EXCLUDED.status,
+                proposal_id = EXCLUDED.proposal_id,
+                start_block = EXCLUDED.start_block,
+                end_block = EXCLUDED.end_block,
+                host_chain_id = EXCLUDED.host_chain_id,
                 host_consensus_reached = EXCLUDED.host_consensus_reached,
                 gw_consensus_reached   = EXCLUDED.gw_consensus_reached,
                 gw_dry_run_started     = EXCLUDED.gw_dry_run_started,
@@ -1855,10 +1944,15 @@ mod tests {
     }
 
     async fn gcs_state(pool: &Pool<Postgres>) -> (String, String) {
-        sqlx::query_as("SELECT state, status FROM upgrade_state WHERE stack_role = 'GCS'")
-            .fetch_one(pool)
-            .await
-            .expect("GCS row")
+        sqlx::query_as(
+            "SELECT state, status FROM upgrade_state
+              WHERE stack_role = 'GCS'
+              ORDER BY host_chain_id
+              LIMIT 1",
+        )
+        .fetch_one(pool)
+        .await
+        .expect("GCS row")
     }
 
     /// Boot/poll reconcile resumes a cutover interrupted in `UpgradeAuthorized`.
@@ -1903,6 +1997,178 @@ mod tests {
         .expect("reconcile");
 
         assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
+    }
+
+    /// Seed one GCS chain row with an explicit host latch (aligned window
+    /// 100..200, proposal 0x02).
+    async fn seed_gcs_chain(
+        pool: &Pool<Postgres>,
+        chain_id: i64,
+        host_reached: bool,
+        gw_reached: bool,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO upgrade_state (
+                stack_role, state, status, proposal_id, version,
+                start_block, end_block, gw_start_block, host_chain_id,
+                host_consensus_reached, gw_consensus_reached, gw_dry_run_started,
+                proposal_block, updated_at
+            )
+            VALUES ('GCS', 'DryRunStarted', 'in_progress', $1, 'v0.15',
+                    100, 200, 1, $2, $3, $4, TRUE, 10, NOW())
+            ON CONFLICT (stack_role, host_chain_id) DO UPDATE
+            SET state = EXCLUDED.state,
+                status = EXCLUDED.status,
+                proposal_id = EXCLUDED.proposal_id,
+                proposal_block = EXCLUDED.proposal_block,
+                start_block = EXCLUDED.start_block,
+                end_block = EXCLUDED.end_block,
+                host_consensus_reached = EXCLUDED.host_consensus_reached,
+                gw_consensus_reached = EXCLUDED.gw_consensus_reached,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(&[0x02u8][..])
+        .bind(chain_id)
+        .bind(host_reached)
+        .bind(gw_reached)
+        .execute(pool)
+        .await
+        .expect("seed GCS chain row");
+    }
+
+    fn consensus_payload(chain_id: i64, block_height: i64) -> String {
+        serde_json::json!({
+            "proposal_id": [2], "proposal_block": 10, "chain_id": chain_id,
+            "block_height": block_height, "block_hash": "0x00"
+        })
+        .to_string()
+    }
+
+    async fn host_reached(pool: &Pool<Postgres>, chain_id: i64) -> bool {
+        let (v,): (bool,) = sqlx::query_as(
+            "SELECT host_consensus_reached FROM upgrade_state
+              WHERE stack_role = 'GCS' AND host_chain_id = $1",
+        )
+        .bind(chain_id)
+        .fetch_one(pool)
+        .await
+        .expect("host latch");
+        v
+    }
+
+    /// Multi-chain: cutover is withheld until *every* host chain has
+    /// reached consensus, then fires exactly once for all chains.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn try_cutover_defers_until_all_host_chains_reach_consensus() {
+        let (_instance, pool) = test_pool().await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+
+        // Two chains, gateway agreed on both, but only chain 1 has host consensus.
+        seed_gcs_chain(&pool, 1, true, true).await;
+        seed_gcs_chain(&pool, 2, false, true).await;
+
+        try_cutover_if_consensus(&pool).await.expect("try cutover");
+        assert_eq!(
+            gcs_state(&pool).await,
+            ("DryRunStarted".into(), "in_progress".into()),
+            "cutover must defer while a host chain is missing consensus"
+        );
+
+        // Chain 2 now reaches consensus → cutover fires for the whole proposal.
+        seed_gcs_chain(&pool, 2, true, true).await;
+        try_cutover_if_consensus(&pool)
+            .await
+            .expect("try cutover 2");
+
+        assert_eq!(gcs_state(&pool).await, ("LIVE".into(), "completed".into()));
+    }
+
+    /// Multi-chain: a host anchor for one chain sets ONLY that chain's
+    /// latch — a second host chain must not be marked as reached.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn host_unanimity_sets_only_the_matching_chain_latch() {
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_chain(&pool, 1, false, false).await;
+        seed_gcs_chain(&pool, 2, false, false).await;
+
+        // Host-track anchor for chain 1, block within [100, 200].
+        handle_unanimity_consensus(&pool, true, &consensus_payload(1, 150))
+            .await
+            .expect("handle chain 1");
+
+        assert!(host_reached(&pool, 1).await, "chain 1 latch must be set");
+        assert!(
+            !host_reached(&pool, 2).await,
+            "chain 2 latch must NOT be set by a chain-1 anchor"
+        );
+        // Not all chains agreed → still dry-running.
+        assert_eq!(
+            gcs_state(&pool).await,
+            ("DryRunStarted".into(), "in_progress".into())
+        );
+    }
+
+    /// Multi-chain: a gateway anchor sets the proposal-level Gateway
+    /// latch on every proposal row without changing any host latch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn gateway_unanimity_sets_latch_on_all_chain_rows() {
+        let (_instance, pool) = test_pool().await;
+
+        seed_gcs_chain(&pool, 1, false, false).await;
+        seed_gcs_chain(&pool, 2, false, false).await;
+
+        // Gateway chain id (999) is not a host chain; block >= gw_start_block (1).
+        handle_unanimity_consensus(&pool, true, &consensus_payload(999, 5))
+            .await
+            .expect("handle gateway");
+
+        let gw: bool = sqlx::query_scalar(
+            "SELECT COALESCE(BOOL_AND(gw_consensus_reached), FALSE)
+               FROM upgrade_state WHERE stack_role = 'GCS'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("gw latch");
+        assert!(gw, "gateway latch set on every proposal row");
+        assert!(!host_reached(&pool, 1).await);
+        assert!(!host_reached(&pool, 2).await);
+    }
+
+    /// Multi-chain: a consensus timeout rolls back the proposal and
+    /// resets every per-chain host latch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_rolls_back_all_chain_rows() {
+        let (_instance, pool) = test_pool().await;
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+
+        seed_gcs_chain(&pool, 1, true, true).await;
+        seed_gcs_chain(&pool, 2, false, true).await;
+
+        handle_unanimity_consensus_timeout(&pool, true, &consensus_payload(1, 200))
+            .await
+            .expect("rollback");
+
+        let row: (String, String, bool) = sqlx::query_as(
+            "SELECT state, status, gw_consensus_reached
+               FROM upgrade_state WHERE stack_role = 'GCS'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("header");
+        assert_eq!(row.0, "PAUSED");
+        assert_eq!(row.1, "failed");
+        assert!(!row.2, "gateway latch reset on rollback");
+        let host_latches: Vec<bool> = sqlx::query_scalar(
+            "SELECT host_consensus_reached FROM upgrade_state
+              WHERE stack_role = 'GCS' ORDER BY host_chain_id",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("host latches");
+        assert_eq!(host_latches, vec![false, false]);
     }
 
     /// A restart after the host gate finishes must restore an incomplete
@@ -1991,7 +2257,7 @@ mod tests {
 
         // Timeout for a different window (block_height 999 != end_block 200).
         let payload =
-            serde_json::json!({ "proposal_id": [2], "chain_id": 1_i64, "block_height": 999_i64, "block_hash": "0x00" })
+            serde_json::json!({ "proposal_id": [2], "proposal_block": 10, "chain_id": 1_i64, "block_height": 999_i64, "block_hash": "0x00" })
                 .to_string();
         handle_unanimity_consensus_timeout(&pool, true, &payload)
             .await
@@ -2000,6 +2266,37 @@ mod tests {
         assert!(
             marker_exists(&pool).await,
             "a timeout for another window must not reset the schema"
+        );
+        assert_eq!(
+            gcs_state(&pool).await,
+            ("DryRunStarted".into(), "in_progress".into())
+        );
+    }
+
+    /// Reusing a caller-supplied proposal id and numeric window must not let a
+    /// delayed timeout from the prior on-chain attempt roll back the retry.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_timeout_ignores_other_attempt() {
+        let (_instance, pool) = test_pool().await;
+        seed_gcs_row(&pool, "DryRunStarted", "in_progress").await; // proposal_block = 10
+        create_gcs_schema(&pool).await.expect("create gcs schema");
+        create_marker(&pool).await;
+
+        let payload = serde_json::json!({
+            "proposal_id": [2],
+            "proposal_block": 9,
+            "chain_id": 1_i64,
+            "block_height": 200_i64,
+            "block_hash": "0x00"
+        })
+        .to_string();
+        handle_unanimity_consensus_timeout(&pool, true, &payload)
+            .await
+            .expect("handler ok");
+
+        assert!(
+            marker_exists(&pool).await,
+            "a timeout for another attempt must not reset the schema"
         );
         assert_eq!(
             gcs_state(&pool).await,
@@ -2016,6 +2313,7 @@ mod tests {
 
         let payload = serde_json::json!({
             "proposal_id": [0x99],
+            "proposal_block": 10,
             "chain_id": 1_i64,
             "block_height": 200_i64,
             "block_hash": "0x00"
@@ -2047,6 +2345,7 @@ mod tests {
 
         let payload = serde_json::json!({
             "proposal_id": [0x99],
+            "proposal_block": 10,
             "chain_id": 1_i64,
             "block_height": 150_i64,
             "block_hash": "0x00"
@@ -2064,6 +2363,7 @@ mod tests {
         .await
         .expect("latches");
         assert_eq!(latches, (false, false));
+        assert!(!host_reached(&pool, 1).await);
     }
 
     /// A readiness task left over from an old proposal must not advance a newer one.
@@ -2245,7 +2545,7 @@ mod tests {
 
         let rollback_pool = pool.clone();
         let mut rollback =
-            tokio::spawn(async move { rollback_dry_run(&rollback_pool, &[0x02], 200).await });
+            tokio::spawn(async move { rollback_dry_run(&rollback_pool, &[0x02], 10, 200).await });
 
         assert!(
             timeout(Duration::from_millis(200), &mut rollback)

--- a/test-suite/e2e/hardhat.config.ts
+++ b/test-suite/e2e/hardhat.config.ts
@@ -163,13 +163,17 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
     default:
       throw new Error(`unsupported chain: ${chain}`);
   }
+  const chainId =
+    chain === 'staging' && process.env.CHAIN_ID_HOST
+      ? Number(process.env.CHAIN_ID_HOST)
+      : chainIds[chain];
   return {
     accounts: {
       count: NUM_ACCOUNTS,
       mnemonic,
       path: "m/44'/60'/0'/0",
     },
-    chainId: chainIds[chain],
+    chainId,
     url: jsonRpcUrl,
   };
 }

--- a/test-suite/e2e/test/userInput/inputFlow.ts
+++ b/test-suite/e2e/test/userInput/inputFlow.ts
@@ -42,6 +42,15 @@ describe('Input Flow', function () {
     expect(receipt.status).to.equal(1);
   });
 
+  // Encrypt only (no host tx): verifies a Gateway input while host chains stay quiet.
+  it('test gateway-only user input uint64 (no host tx)', async function () {
+    await this.instances.alice.encryptUint64({
+      value: 18446744073709550042n,
+      contractAddress: this.contractAddress,
+      userAddress: this.signers.alice.address,
+    });
+  });
+
   it('test add 42 to uint64 input and decrypt', async function () {
     await runAdd42InputAndDecrypt.call(this);
   });

--- a/test-suite/fhevm/scenarios/blue-green-multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/blue-green-multi-chain.yaml
@@ -1,0 +1,29 @@
+version: 1
+kind: blue-green
+name: Blue-Green Upgrade (multi-chain)
+description: >
+  Two-host-chain Blue-Green upgrade. A single coprocessor stack serves
+  both host chains; the upgrade proposal carries one ChainUpgradeWindow per chain
+  and cutover fires only after BOTH chains (and the Gateway) reach unanimity.
+  Runs the same failed-then-successful flow as blue-green.yaml, over two chains.
+
+    ./fhevm-cli up --scenario blue-green-multi-chain --build
+    ./fhevm-cli test blue-green
+
+hostChains:
+  - key: host
+    chainId: "12345"
+    rpcPort: 8545
+  - key: chain-b
+    chainId: "67890"
+    rpcPort: 8547
+
+bcs:
+  source:
+    mode: registry
+    tag: v0.14.0-4
+
+gcs:
+  source:
+    mode: local
+  stackVersion: "0.15.0"

--- a/test-suite/fhevm/scenarios/blue-green-two-of-three-multi-chain.yaml
+++ b/test-suite/fhevm/scenarios/blue-green-two-of-three-multi-chain.yaml
@@ -1,0 +1,33 @@
+version: 1
+kind: blue-green
+name: Blue-Green Upgrade (2-of-3, multi-chain)
+description: >
+  Three-operator Blue-Green upgrade (threshold 2) across two host chains.
+  Combines the 2-of-3 operator topology with two host chains: cutover still
+  requires unanimity across all N operators per RFC-021, now for BOTH chains
+  plus the Gateway. Same failed-then-successful flow as blue-green.yaml.
+
+    ./fhevm-cli up --scenario blue-green-two-of-three-multi-chain --build
+    ./fhevm-cli test blue-green
+
+topology:
+  count: 3
+  threshold: 2
+
+hostChains:
+  - key: host
+    chainId: "12345"
+    rpcPort: 8545
+  - key: chain-b
+    chainId: "67890"
+    rpcPort: 8547
+
+bcs:
+  source:
+    mode: registry
+    tag: v0.14.0-4
+
+gcs:
+  source:
+    mode: local
+  stackVersion: "0.15.0"

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -804,6 +804,7 @@ const waitUntil = async (opts: {
 };
 
 type TrafficStats = { iterations: number; retries: number; failures: number };
+type TrafficTarget = { label: string; argv: string[] };
 type TrafficStream = {
   stop: () => Promise<TrafficStats>;
   /** Rejects the moment any stream sees a permanent failure (retry didn't recover). */
@@ -811,16 +812,17 @@ type TrafficStream = {
 };
 
 /**
- * Spawns `streams` background loops of `./fhevm-cli test erc20` that keep firing
- * until `.stop()` is called or a permanent failure aborts them. Each iteration
- * retries up to `TRAFFIC_MAX_RETRIES` times with backoff — mirrors client-side
- * retry behavior around the cutover boundary (Zama SDK retries transient
- * failures multiple times). First permanent failure trips `errored` AND stops
- * every stream, so the caller can fail fast.
+ * Spawns background ERC-20 loops across the supplied chain-specific targets.
+ * Targets are assigned round-robin, with the caller ensuring at least one
+ * stream per chain. Each iteration retries up to `TRAFFIC_MAX_RETRIES` times
+ * with backoff. First permanent failure trips `errored` and stops every stream.
  */
 const TRAFFIC_MAX_RETRIES = 3;
 const TRAFFIC_RETRY_BACKOFF_MS = 2000;
-const startContinuousErc20Traffic = (streams: number): TrafficStream => {
+const startContinuousErc20Traffic = (targets: TrafficTarget[], streams: number): TrafficStream => {
+  if (targets.length === 0 || streams < targets.length) {
+    throw new Error("ERC-20 traffic requires at least one stream target per host chain");
+  }
   let stopped = false;
   let rejectErrored!: (err: Error) => void;
   const errored = new Promise<never>((_, reject) => {
@@ -829,10 +831,11 @@ const startContinuousErc20Traffic = (streams: number): TrafficStream => {
   errored.catch(() => undefined);
   const counters = Array.from({ length: streams }, () => ({ iterations: 0, retries: 0, failures: 0 }));
   const loops = counters.map((counter, streamIdx) => (async () => {
+    const target = targets[streamIdx % targets.length]!;
     while (!stopped) {
       counter.iterations += 1;
-      const label = `[traffic s${streamIdx}#${counter.iterations}]`;
-      let result = await run(["./fhevm-cli", "test", "erc20"], { allowFailure: true });
+      const label = `[traffic ${target.label} s${streamIdx}#${counter.iterations}]`;
+      let result = await run(target.argv, { allowFailure: true });
       for (let attempt = 1; attempt <= TRAFFIC_MAX_RETRIES && result.code !== 0 && !stopped; attempt += 1) {
         counter.retries += 1;
         console.warn(
@@ -840,7 +843,7 @@ const startContinuousErc20Traffic = (streams: number): TrafficStream => {
             `retry ${attempt}/${TRAFFIC_MAX_RETRIES} after ${TRAFFIC_RETRY_BACKOFF_MS}ms`,
         );
         await Bun.sleep(TRAFFIC_RETRY_BACKOFF_MS);
-        result = await run(["./fhevm-cli", "test", "erc20"], { allowFailure: true });
+        result = await run(target.argv, { allowFailure: true });
       }
       if (result.code !== 0) {
         // A failure after stop() is a shutdown artifact (retry budget denied by `stopped`) — don't count it.
@@ -890,7 +893,10 @@ const startContinuousErc20Traffic = (streams: number): TrafficStream => {
  * asserts the reset (PAUSED/failed, latches cleared, schema recreated empty,
  * versioning untouched) and the successful flow then reruns over the residue.
  */
-const runBlueGreenProfile = async (state: State): Promise<boolean> => {
+const runBlueGreenProfile = async (
+  state: State,
+  options: Pick<TestOptions, "network" | "noHardhatCompile">,
+): Promise<boolean> => {
   if (state.scenario.kind !== "blue-green") {
     throw new PreflightError(
       "test blue-green requires the stack to be booted with --scenario blue-green* " +
@@ -900,7 +906,6 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
 
   const gcsStackVersion = state.scenario.gcs.stackVersion;
   const gcsVersionLive = `v${gcsStackVersion}`;
-  const chainId = state.scenario.hostChains[0]?.chainId ?? DEFAULT_CHAIN_ID;
   const opCount = state.scenario.topology.count;
 
   const operatorDatabases: string[] = [];
@@ -908,7 +913,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
     operatorDatabases.push(coprocessorDatabaseName(index));
   }
 
-  const BLUE_GREEN_TRAFFIC_STREAMS = 2;
+  const MIN_BLUE_GREEN_TRAFFIC_STREAMS = 2;
   const CROSS_CUTOVER_CHAIN_DEPTH = 5;
 
   console.log(`\n==== blue-green E2E: ${opCount} operator(s) ====`);
@@ -938,29 +943,79 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
   const gatewayRpcUrl = hostReachableRpcUrl(state.discovery!.endpoints.gateway.http);
   const { deployerPk, protocolConfig } = await readBlueGreenOnChainCreds();
 
-  // An empty window carries no non-trivial FHE op, so no track can anchor and the
-  // detector's commitment_timeout forces the rollback this phase asserts.
-  console.log(`\n[2/11] failed upgrade: propose empty window (no traffic → no anchor)`);
-  const failHostBlock = Number((await run(
-    ["cast", "block-number", "--rpc-url", hostRpcUrl],
-  )).stdout.trim());
+  // One ChainUpgradeWindow per host chain, each off that chain's own current
+  // block. Single-chain yields a one-element array, as before.
+  const hostChains = state.scenario.hostChains;
+  const hostChainRpc = (key: string) =>
+    hostReachableRpcUrl(state.discovery!.endpoints.hosts[key]!.http);
+  const testSuiteEnv = await readEnvFile(envPath("test-suite"));
+  const erc20Grep = TEST_GREP.erc20;
+  if (!erc20Grep) {
+    throw new Error("blue-green profile requires the ERC-20 test grep");
+  }
+  const chainEnvValue = (index: number, primaryName: string, indexedSuffix: string): string => {
+    const key = index === 0 ? primaryName : `HOST_CHAIN_${index}_${indexedSuffix}`;
+    const value = testSuiteEnv[key];
+    if (!value) {
+      throw new Error(`blue-green traffic target is missing ${key} in the test-suite environment`);
+    }
+    return value;
+  };
+  const trafficTargets: TrafficTarget[] = hostChains.map((chain, index) => {
+    const overrides = [
+      ["RPC_URL", chainEnvValue(index, "RPC_URL", "RPC_URL")],
+      ["CHAIN_ID_HOST", chainEnvValue(index, "CHAIN_ID_HOST", "CHAIN_ID")],
+      ["ACL_CONTRACT_ADDRESS", chainEnvValue(index, "ACL_CONTRACT_ADDRESS", "ACL_CONTRACT_ADDRESS")],
+      ["KMS_VERIFIER_CONTRACT_ADDRESS", chainEnvValue(index, "KMS_VERIFIER_CONTRACT_ADDRESS", "KMS_VERIFIER_CONTRACT_ADDRESS")],
+      ["INPUT_VERIFIER_CONTRACT_ADDRESS", chainEnvValue(index, "INPUT_VERIFIER_CONTRACT_ADDRESS", "INPUT_VERIFIER_CONTRACT_ADDRESS")],
+      ["FHEVM_EXECUTOR_CONTRACT_ADDRESS", chainEnvValue(index, "FHEVM_EXECUTOR_CONTRACT_ADDRESS", "FHEVM_EXECUTOR_CONTRACT_ADDRESS")],
+      ["PROTOCOL_CONFIG_CONTRACT_ADDRESS", chainEnvValue(index, "PROTOCOL_CONFIG_CONTRACT_ADDRESS", "PROTOCOL_CONFIG_CONTRACT_ADDRESS")],
+    ];
+    const extraExecArgs = overrides.flatMap(([name, value]) => ["-e", `${name}=${value}`]);
+    return {
+      label: chain.key,
+      argv: buildTestContainerArgs(
+        runTestsArgs({
+          ...options,
+          verbose: false,
+          parallel: false,
+          grep: erc20Grep,
+        }),
+        extraExecArgs,
+      ),
+    };
+  });
+  const blueGreenTrafficStreams = Math.max(MIN_BLUE_GREEN_TRAFFIC_STREAMS, trafficTargets.length);
+  const buildWindowArray = async (startOffset: number, endOffset: number): Promise<string> => {
+    const tuples: string[] = [];
+    for (const chain of hostChains) {
+      const block = Number(
+        (await run(["cast", "block-number", "--rpc-url", hostChainRpc(chain.key)])).stdout.trim(),
+      );
+      tuples.push(`(${chain.chainId},${block + startOffset},${block + endOffset})`);
+    }
+    return `[${tuples.join(",")}]`;
+  };
+
+  // Empty windows carry no non-trivial FHE op, so no chain anchors and the
+  // commitment_timeout rolls back every chain's row — the rollback this asserts.
+  console.log(`\n[2/11] failed upgrade: propose empty window(s) (no traffic → no anchor)`);
   const failGwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
-  const failStartBlock = failHostBlock + 15;
-  const failEndBlock = failHostBlock + 45;
   const failGwStartBlock = failGwBlock + 10;
+  const failWindows = await buildWindowArray(15, 45);
   await run([
     "cast", "send", protocolConfig,
     "--rpc-url", hostRpcUrl,
     "--private-key", deployerPk,
     "proposeCoprocessorUpgrade(uint256,string,(uint64,uint64,uint64)[],uint64)",
     "1", gcsVersionLive,
-    `[(${chainId},${failStartBlock},${failEndBlock})]`,
+    failWindows,
     String(failGwStartBlock),
   ]);
   console.log(
-    `OK:   activation emitted (start=${failStartBlock} end=${failEndBlock} gw_start=${failGwStartBlock})`,
+    `OK:   activation emitted (windows=${failWindows} gw_start=${failGwStartBlock})`,
   );
 
   console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted per operator`);
@@ -969,8 +1024,15 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
       label: `${db}  GCS DryRunStarted`,
       timeoutSecs: 120,
       check: async () =>
-        (await psqlQuery(db, "SELECT state FROM upgrade_state WHERE stack_role='GCS';")) ===
-        "DryRunStarted",
+        (await psqlQuery(
+          db,
+          `SELECT CASE WHEN COUNT(*)=${hostChains.length}
+                              AND BOOL_AND(state='DryRunStarted')
+                              AND COUNT(DISTINCT proposal_id)=1
+                              AND COUNT(DISTINCT proposal_block)=1
+                       THEN 'ready' ELSE 'waiting' END
+             FROM upgrade_state WHERE stack_role='GCS';`,
+        )) === "ready",
     });
   }
 
@@ -980,19 +1042,28 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
       label: `${db}  GCS rolled back to PAUSED/failed`,
       timeoutSecs: 300,
       check: async () =>
-        (await psqlQuery(db, "SELECT state||' '||status FROM upgrade_state WHERE stack_role='GCS';")) ===
-        "PAUSED failed",
+        (await psqlQuery(
+          db,
+          `SELECT CASE WHEN COUNT(*)=${hostChains.length}
+                              AND BOOL_AND(state='PAUSED' AND status='failed')
+                              AND BOOL_AND(NOT host_consensus_reached)
+                              AND BOOL_AND(NOT gw_consensus_reached)
+                              AND BOOL_AND(NOT gw_dry_run_started)
+                       THEN 'rolled-back' ELSE 'waiting' END
+             FROM upgrade_state WHERE stack_role='GCS';`,
+        )) === "rolled-back",
     });
   }
   for (const db of operatorDatabases) {
     const flags = await psqlQuery(
       db,
-      "SELECT last_error||'|'||host_consensus_reached||'|'||gw_consensus_reached||'|'||gw_dry_run_started " +
-        "FROM upgrade_state WHERE stack_role='GCS';",
+      "SELECT MIN(last_error)||'|'||BOOL_OR(host_consensus_reached)||'|'||" +
+        "BOOL_OR(gw_consensus_reached)||'|'||BOOL_OR(gw_dry_run_started)||'|'||" +
+        "BOOL_OR(host_consensus_reached) FROM upgrade_state WHERE stack_role='GCS';",
     );
-    if (flags !== "unanimity_consensus_timeout|false|false|false") {
+    if (flags !== "unanimity_consensus_timeout|false|false|false|false") {
       throw new Error(
-        `${db} rollback left unexpected flags "${flags}", expected "unanimity_consensus_timeout|false|false|false"`,
+        `${db} rollback left unexpected flags "${flags}", expected "unanimity_consensus_timeout|false|false|false|false"`,
       );
     }
     const version = await psqlQuery(db, "SELECT stack_version FROM versioning;");
@@ -1050,25 +1121,22 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
   }
 
   console.log(`\n[6/11] propose upgrade on-chain (ProtocolConfig.proposeCoprocessorUpgrade)`);
-  const hostBlock = Number((await run(
-    ["cast", "block-number", "--rpc-url", hostRpcUrl],
-  )).stdout.trim());
   const gwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
-  const startBlock = hostBlock + 30;
-  const endBlock = hostBlock + 230;
   const gwStartBlock = gwBlock + 10;
+  // A wide window per chain so real dry-run traffic on every chain lands inside it.
+  const okWindows = await buildWindowArray(30, 230);
   await run([
     "cast", "send", protocolConfig,
     "--rpc-url", hostRpcUrl,
     "--private-key", deployerPk,
     "proposeCoprocessorUpgrade(uint256,string,(uint64,uint64,uint64)[],uint64)",
     "2", gcsVersionLive,
-    `[(${chainId},${startBlock},${endBlock})]`,
+    okWindows,
     String(gwStartBlock),
   ]);
-  console.log(`OK:   activation emitted (start=${startBlock} end=${endBlock} gw_start=${gwStartBlock})`);
+  console.log(`OK:   activation emitted (windows=${okWindows} gw_start=${gwStartBlock})`);
 
   console.log(`\n[7/11] wait for GCS DryRunStarted per operator`);
   for (const db of operatorDatabases) {
@@ -1076,16 +1144,23 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
       label: `${db}  GCS DryRunStarted`,
       timeoutSecs: 120,
       check: async () =>
-        (await psqlQuery(db, "SELECT state FROM upgrade_state WHERE stack_role='GCS';")) ===
-        "DryRunStarted",
+        (await psqlQuery(
+          db,
+          `SELECT CASE WHEN COUNT(*)=${hostChains.length}
+                              AND BOOL_AND(state='DryRunStarted')
+                              AND COUNT(DISTINCT proposal_id)=1
+                              AND COUNT(DISTINCT proposal_block)=1
+                       THEN 'ready' ELSE 'waiting' END
+             FROM upgrade_state WHERE stack_role='GCS';`,
+        )) === "ready",
     });
   }
 
   console.log(
-    `\n[8/11] start ${BLUE_GREEN_TRAFFIC_STREAMS} background stream(s) ` +
-      `+ cross-cutover chain (depth ${CROSS_CUTOVER_CHAIN_DEPTH})`,
+    `\n[8/11] start ${blueGreenTrafficStreams} background stream(s) across ` +
+      `${trafficTargets.length} host chain(s) + cross-cutover chain (depth ${CROSS_CUTOVER_CHAIN_DEPTH})`,
   );
-  const traffic = startContinuousErc20Traffic(BLUE_GREEN_TRAFFIC_STREAMS);
+  const traffic = startContinuousErc20Traffic(trafficTargets, blueGreenTrafficStreams);
   let trafficStats: { iterations: number; retries: number; failures: number };
   try {
     // The chain is a stress signal — a fence hit mid-transfer is expected; [11/11] verifies actual transferCount.
@@ -1137,10 +1212,22 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
     for (const db of operatorDatabases) {
       const gcsState = await psqlQuery(
         db,
-        "SELECT state||' '||status FROM upgrade_state WHERE stack_role='GCS';",
+        `SELECT CASE WHEN COUNT(*)=${hostChains.length}
+                            AND BOOL_AND(state='LIVE' AND status='completed')
+                     THEN 'LIVE completed' ELSE 'unexpected' END
+           FROM upgrade_state WHERE stack_role='GCS';`,
       );
       if (gcsState !== "LIVE completed") {
         throw new Error(`${db} GCS state = "${gcsState}", expected "LIVE completed"`);
+      }
+      const persistedWindows = await psqlQuery(
+        db,
+        "SELECT count(*) FROM upgrade_state WHERE stack_role='GCS';",
+      );
+      if (persistedWindows !== String(hostChains.length)) {
+        throw new Error(
+          `${db} persisted ${persistedWindows} chain windows, expected ${hostChains.length}`,
+        );
       }
       const leftoverSchemas = await psqlQuery(
         db,
@@ -1157,7 +1244,7 @@ const runBlueGreenProfile = async (state: State): Promise<boolean> => {
 
   console.log(`\n[11/11] stop background traffic + cross-cutover verify + continuity check`);
   console.log(
-    `  traffic stopped: ${trafficStats.iterations} iterations across ${BLUE_GREEN_TRAFFIC_STREAMS} stream(s), ` +
+    `  traffic stopped: ${trafficStats.iterations} iterations across ${blueGreenTrafficStreams} stream(s), ` +
       `${trafficStats.retries} retried, ${trafficStats.failures} failed after retry`,
   );
   if (trafficStats.failures > 0) {
@@ -1488,7 +1575,7 @@ export const test = async (testName: string | undefined, options: TestOptions) =
       return runKmsContextSwitchProfile(state, runUserDecryption, runInputProofSmoke);
     }
     if (name === "blue-green") {
-      return runBlueGreenProfile(state);
+      return runBlueGreenProfile(state, options);
     }
     if (name === "coprocessor-db-state-revert") {
       return runDbStateRevert(state, options);

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -953,6 +953,10 @@ const runBlueGreenProfile = async (
   if (!erc20Grep) {
     throw new Error("blue-green profile requires the ERC-20 test grep");
   }
+  const gatewayInputGrep = TEST_GREP["input-proof-gateway-only"];
+  if (!gatewayInputGrep) {
+    throw new Error("blue-green profile requires the gateway-only input-proof grep");
+  }
   const chainEnvValue = (index: number, primaryName: string, indexedSuffix: string): string => {
     const key = index === 0 ? primaryName : `HOST_CHAIN_${index}_${indexedSuffix}`;
     const value = testSuiteEnv[key];
@@ -961,8 +965,8 @@ const runBlueGreenProfile = async (
     }
     return value;
   };
-  const trafficTargets: TrafficTarget[] = hostChains.map((chain, index) => {
-    const overrides = [
+  const chainExtraExecArgs = (index: number): string[] =>
+    [
       ["RPC_URL", chainEnvValue(index, "RPC_URL", "RPC_URL")],
       ["CHAIN_ID_HOST", chainEnvValue(index, "CHAIN_ID_HOST", "CHAIN_ID")],
       ["ACL_CONTRACT_ADDRESS", chainEnvValue(index, "ACL_CONTRACT_ADDRESS", "ACL_CONTRACT_ADDRESS")],
@@ -970,21 +974,18 @@ const runBlueGreenProfile = async (
       ["INPUT_VERIFIER_CONTRACT_ADDRESS", chainEnvValue(index, "INPUT_VERIFIER_CONTRACT_ADDRESS", "INPUT_VERIFIER_CONTRACT_ADDRESS")],
       ["FHEVM_EXECUTOR_CONTRACT_ADDRESS", chainEnvValue(index, "FHEVM_EXECUTOR_CONTRACT_ADDRESS", "FHEVM_EXECUTOR_CONTRACT_ADDRESS")],
       ["PROTOCOL_CONFIG_CONTRACT_ADDRESS", chainEnvValue(index, "PROTOCOL_CONFIG_CONTRACT_ADDRESS", "PROTOCOL_CONFIG_CONTRACT_ADDRESS")],
-    ];
-    const extraExecArgs = overrides.flatMap(([name, value]) => ["-e", `${name}=${value}`]);
-    return {
-      label: chain.key,
-      argv: buildTestContainerArgs(
-        runTestsArgs({
-          ...options,
-          verbose: false,
-          parallel: false,
-          grep: erc20Grep,
-        }),
-        extraExecArgs,
-      ),
-    };
-  });
+    ].flatMap(([name, value]) => ["-e", `${name}=${value}`]);
+  const trafficTargets: TrafficTarget[] = hostChains.map((chain, index) => ({
+    label: chain.key,
+    argv: buildTestContainerArgs(
+      runTestsArgs({ ...options, verbose: false, parallel: false, grep: erc20Grep }),
+      chainExtraExecArgs(index),
+    ),
+  }));
+  const gatewayInputProbeArgv = buildTestContainerArgs(
+    runTestsArgs({ ...options, verbose: false, parallel: false, grep: gatewayInputGrep }),
+    chainExtraExecArgs(0),
+  );
   const blueGreenTrafficStreams = Math.max(MIN_BLUE_GREEN_TRAFFIC_STREAMS, trafficTargets.length);
   const buildWindowArray = async (startOffset: number, endOffset: number): Promise<string> => {
     const tuples: string[] = [];
@@ -997,9 +998,11 @@ const runBlueGreenProfile = async (
     return `[${tuples.join(",")}]`;
   };
 
-  // Empty windows carry no non-trivial FHE op, so no chain anchors and the
-  // commitment_timeout rolls back every chain's row — the rollback this asserts.
-  console.log(`\n[2/11] failed upgrade: propose empty window(s) (no traffic → no anchor)`);
+  // Host chains stay quiet (no non-trivial FHE op) while [3/11] anchors the Gateway
+  // track with one input. Cutover needs at least one non-trivial host anchor, so the
+  // controller withholds the hosts and commitment_timeout rolls back every row — the
+  // rollback this asserts. A regression that notified quiet hosts would cut over.
+  console.log(`\n[2/11] failed upgrade: Gateway input, hosts quiet (no non-trivial host → no cutover)`);
   const failGwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
@@ -1018,7 +1021,7 @@ const runBlueGreenProfile = async (
     `OK:   activation emitted (windows=${failWindows} gw_start=${failGwStartBlock})`,
   );
 
-  console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted per operator`);
+  console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted, then submit a Gateway-only input proof`);
   for (const db of operatorDatabases) {
     await waitUntil({
       label: `${db}  GCS DryRunStarted`,
@@ -1035,6 +1038,10 @@ const runBlueGreenProfile = async (
         )) === "ready",
     });
   }
+  // Verify one Gateway input inside the window. Host chains get no non-trivial FHE
+  // op, so cutover must be withheld and the window must time out (asserted in [4/11]).
+  await run(gatewayInputProbeArgv);
+  console.log(`OK:   Gateway input submitted (host chains remain quiet)`);
 
   console.log(`\n[4/11] failed upgrade: wait for unanimity timeout rollback + verify reset`);
   for (const db of operatorDatabases) {

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -762,11 +762,61 @@ const buildExtraCoprocessorListenerOverride = async (
         locallyBuilt ? {} : compat.coprocessorDropFlags,
       );
       adjusted.container_name = cloneName;
+      // Extra chains keep their env canonical id (default chain), so they don't decode proposals.
       applyCoprocessorSource(adjusted, baseName, instance, locallyBuilt);
       delete adjusted.depends_on;
       services[cloneName] = adjusted;
     }
   }
+
+  // Blue-green: clone the GCS host-listeners per extra chain too, so the
+  // GCS stack can ingest and dry-run each chain.
+  if (plan.blueGreen) {
+    const gcs = plan.blueGreen.gcs;
+    for (const instance of plan.coprocessor.instances) {
+      const prefix = instance.index === 0 ? "coprocessor-" : `coprocessor${instance.index}-`;
+      const gcsPrefix = `${prefix}gcs-`;
+      const envFileValue = envPath(`coprocessor-${chain.key}.${instance.index}`);
+      const instanceEnv = await readEnvFile(envFileValue);
+      const gcsInstance: ResolvedCoprocessorScenarioInstance = {
+        index: instance.index,
+        source: gcs.source,
+        env: gcs.env,
+        args: gcs.args,
+      };
+      for (const baseName of listenerServices) {
+        const suffix = baseName.replace(/^coprocessor-/, "");
+        const cloneName = `${gcsPrefix}${suffix}${chainSuffix}`;
+        const baseService = doc.services[baseName];
+        if (!baseService) continue;
+        const adjusted = applyInstanceAdjustments(
+          baseName,
+          baseService,
+          envFileValue,
+          instanceEnv,
+          gcsInstance,
+          compat.coprocessorArgs,
+          compat.coprocessorDropFlags,
+        );
+        adjusted.container_name = cloneName;
+        // GCS is always local-built and retagged to its stack version.
+        const buildSpec = localBuildSpecFor("coprocessor", baseName);
+        if (buildSpec) {
+          adjusted.image = retagLocal(baseService.image, `gcs-${gcs.stackVersion}`);
+          adjusted.build = {
+            ...buildSpec,
+            args: {
+              ...(buildSpec.args as Record<string, string> | undefined),
+              BUILD_STACK_VERSION: gcs.stackVersion,
+            },
+          };
+        }
+        delete adjusted.depends_on;
+        services[cloneName] = adjusted;
+      }
+    }
+  }
+
   return { services };
 };
 

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -281,6 +281,7 @@ export const TEST_GREP: Record<string, string> = {
   "paused-gateway-contracts":
     "test paused gateway user input|test paused gateway HTTP public decrypt",
   "input-proof": "test user input uint64",
+  "input-proof-gateway-only": "test gateway-only user input uint64",
   "input-proof-compute-decrypt": "test add 42 to uint64 input and decrypt",
   "priority-coprocessor": "test priority coprocessor input flow",
   "user-decryption": "test user decrypt",

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -480,6 +480,7 @@ gcs:
             container_name?: string;
             image?: string;
             build?: { args?: Record<string, string> } | undefined;
+            environment?: Record<string, string>;
           }
         >;
       };
@@ -496,6 +497,18 @@ gcs:
       expect(doc.services["coprocessor-db-migration"]?.build).toBeDefined();
       expect(doc.services["coprocessor-db-migration"]?.image).not.toContain(":v0.13.0");
       expect(doc.services["coprocessor-gcs-tfhe-worker"]?.build).toBeDefined();
+      expect(
+        doc.services["coprocessor-host-listener"]?.environment
+          ?.CANONICAL_PROTOCOL_CONFIG_CHAIN_ID,
+      ).toBeUndefined();
+      expect(
+        doc.services["coprocessor-host-listener-poller"]?.environment
+          ?.CANONICAL_PROTOCOL_CONFIG_CHAIN_ID,
+      ).toBeUndefined();
+      expect(
+        doc.services["coprocessor-gcs-host-listener"]?.environment
+          ?.CANONICAL_PROTOCOL_CONFIG_CHAIN_ID,
+      ).toBeUndefined();
       expect(doc.services["coprocessor-gcs-upgrade-controller"]?.container_name).toBe(
         "coprocessor-gcs-upgrade-controller",
       );

--- a/test-suite/fhevm/src/scenario.test.ts
+++ b/test-suite/fhevm/src/scenario.test.ts
@@ -347,11 +347,10 @@ gcs:
       ).toThrow("must be local");
     });
 
-    test("rejects more than one host chain", () => {
-      expect(() =>
-        resolveBlueGreenScenario(
-          "/tmp/bg-two-chains.yaml",
-          parseBlueGreenScenario(`
+    test("accepts multiple host chains (multi-chain blue-green)", () => {
+      const resolved = resolveBlueGreenScenario(
+        "/tmp/bg-two-chains.yaml",
+        parseBlueGreenScenario(`
 version: 1
 kind: blue-green
 hostChains:
@@ -364,8 +363,8 @@ hostChains:
 gcs:
   stackVersion: "0.15.0"
 `),
-        ),
-      ).toThrow("exactly one host chain");
+      );
+      expect(resolved.hostChains.map((c) => c.chainId)).toEqual(["12345", "67890"]);
     });
 
     test("--bcs-tag with a 7-char short SHA passes through unchanged", async () => {

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -726,9 +726,6 @@ export const resolveBlueGreenScenario = (
   filePath: string,
   input: BlueGreenScenario,
 ): ResolvedBlueGreenScenario => {
-  if ((input.hostChains?.length ?? 1) > 1) {
-    throw new Error("blue-green scenarios support exactly one host chain");
-  }
   const bcs: ResolvedBlueGreenScenarioFleet = {
     source: normalizeSource(input.bcs?.source),
     env: { ...(input.bcs?.env ?? {}) },


### PR DESCRIPTION
### Summary:

A single coprocessor stack can now dry-run and cut over an upgrade across N host chains in one proposal, instead of one.

- `upgrade_state` is keyed per `(stack_role, host_chain_id)` having one row per host-chain evaluation window. The host-listener seeds the full window set atomically from the on-chain proposal.
- Unanimity consensus is tracked independently per host chain. Dry-run readiness runs per chain before entering DryRunStarted.
- Cutover fires only after every host chain and the Gateway reach consensus; a timeout on any chain rolls back the whole proposal.
- E2E: two new scenarios added. `blue-green-multi-chain` (1 operator × 2 chains) and `blue-green-two-of-three-multi-chain` (2-of-3 operators × 2 chains). The test driver builds per-chain proposal windows and drives per-chain traffic.

Related: https://github.com/zama-ai/fhevm-internal/issues/1530