### PR TITLE
chore(kms-connector): improve acl checks concurrency

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -22,7 +22,10 @@ use fhevm_gateway_bindings::decryption::Decryption::{
     delegatedUserDecryptionRequestCall, userDecryptionRequest_1Call as userDecryptionRequestCall,
 };
 use fhevm_host_bindings::acl::ACL::ACLInstance;
-use futures::future::{join_all, try_join_all};
+use futures::{
+    future::try_join_all,
+    stream::{FuturesUnordered, StreamExt},
+};
 use kms_grpc::kms::v1::{Eip712DomainMsg, PublicDecryptionRequest, UserDecryptionRequest};
 use sqlx::types::chrono::Utc;
 use std::collections::HashMap;
@@ -91,7 +94,7 @@ where
     ) -> Result<(), RequestCheckError> {
         info!("Starting ACL check for {} handles...", handles.len());
 
-        for handle in handles {
+        try_join_all(handles.iter().map(|handle| async move {
             let ct_chain_id = extract_chain_id_from_handle(*handle)
                 .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
             let acl_contract = self.acl_contracts.get(&ct_chain_id).ok_or_else(|| {
@@ -112,7 +115,9 @@ where
                     anyhow!("Decryption is not allowed for {handle}"),
                 ));
             }
-        }
+            Ok(())
+        }))
+        .await?;
 
         info!("ACL check passed for {} handles!", handles.len());
         Ok(())
@@ -155,7 +160,9 @@ where
                 .iter()
                 .map(|c| (c.ctHandle, c.contractAddress)),
         );
-        for handle in handles {
+        let contracts_map_ref = &contracts_map;
+
+        try_join_all(handles.iter().map(|handle| async move {
             let ct_chain_id = extract_chain_id_from_handle(*handle)
                 .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
             let acl_contract = self.acl_contracts.get(&ct_chain_id).ok_or_else(|| {
@@ -164,7 +171,7 @@ where
                     anyhow!("No ACL contract config found for chain id {ct_chain_id}"),
                 )
             })?;
-            let contract_address = contracts_map.get(handle.as_slice()).ok_or_else(|| {
+            let contract_address = contracts_map_ref.get(handle.as_slice()).ok_or_else(|| {
                 RequestCheckError::irrecoverable(
                     RequestCheckKind::Acl,
                     anyhow!("Could not find contract address for handle {handle}"),
@@ -179,7 +186,7 @@ where
                     *contract_address,
                     delegator_addr,
                 )
-                .await?;
+                .await
             } else {
                 self.inner_acl_check_for_user_decryption(
                     acl_contract,
@@ -187,9 +194,10 @@ where
                     user_address,
                     *contract_address,
                 )
-                .await?;
+                .await
             }
-        }
+        }))
+        .await?;
 
         info!("ACL check passed for {} handles!", handles.len());
         Ok(())
@@ -455,25 +463,29 @@ where
             return Ok(());
         }
 
-        let calls = allowed_contracts
+        let mut calls: FuturesUnordered<_> = allowed_contracts
             .iter()
-            .map(|c| async move { acl_contract.isAllowed(handle, *c).call().await });
-        let results = join_all(calls).await;
+            .map(|c| async move { (c, acl_contract.isAllowed(handle, *c).call().await) })
+            .collect();
 
-        // Short-circuit on first positive. Individual transport errors are tolerated as long as at
-        // least one contract returns true.
-        if results.iter().any(|r| matches!(r, Ok(true))) {
-            Ok(())
-        } else {
-            // This branch covers both a genuine denial and an all-RPC-failed wave; the two can't
-            // be cleanly separated here, so it counts as a single ACL rejection.
-            Err(RequestCheckError::recoverable(
-                RequestCheckKind::Acl,
-                anyhow!(
-                    "No contract in allowedContracts is allowed to decrypt handle {handle} ({results:?})",
-                ),
-            ))
+        // All calls run concurrently; short-circuit on the first positive, dropping `calls`
+        // to cancel the remaining in-flight requests.
+        let mut rejections = Vec::with_capacity(allowed_contracts.len());
+        while let Some((contract, result)) = calls.next().await {
+            match result {
+                Ok(true) => return Ok(()),
+                Ok(false) => rejections.push(format!("{contract}: not allowed")),
+                Err(e) => rejections.push(format!("{contract}: {e}")),
+            }
         }
+
+        // All RPC calls failed.
+        Err(RequestCheckError::recoverable(
+            RequestCheckKind::Acl,
+            anyhow!(
+                "No contract in allowedContracts is allowed to decrypt handle {handle} ({rejections:?})",
+            ),
+        ))
     }
 
     /// RFC016 signature invalidation check. Rejects if `startTimestamp < invalidationTs`, meaning

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -479,7 +479,7 @@ where
             }
         }
 
-        // All RPC calls failed.
+        // No contract returned true (all denied, all RPC calls failed, or a mix of both).
         Err(RequestCheckError::recoverable(
             RequestCheckKind::Acl,
             anyhow!(

--- a/kms-connector/tests/contracts/DecryptionMock.sol
+++ b/kms-connector/tests/contracts/DecryptionMock.sol
@@ -157,11 +157,11 @@ contract DecryptionMock {
 
     function userDecryptionRequest(
         CtHandleContractPair[] calldata ctHandleContractPairs,
-        RequestValidity calldata requestValidity,
-        ContractsInfo calldata contractsInfo,
+        RequestValidity calldata /* requestValidity */,
+        ContractsInfo calldata /* contractsInfo */,
         address userAddress,
         bytes calldata publicKey,
-        bytes calldata signature,
+        bytes calldata /* signature */,
         bytes calldata extraData
     ) external {
         userDecryptionCounter++;
@@ -203,11 +203,11 @@ contract DecryptionMock {
 
     function delegatedUserDecryptionRequest(
         CtHandleContractPair[] calldata ctHandleContractPairs,
-        RequestValidity calldata requestValidity,
-        DelegationAccounts calldata delegationAccounts,
-        ContractsInfo calldata contractsInfo,
+        RequestValidity calldata /* requestValidity */,
+        DelegationAccounts calldata /* delegationAccounts */,
+        ContractsInfo calldata /* contractsInfo */,
         bytes calldata publicKey,
-        bytes calldata signature,
+        bytes calldata /* signature */,
         bytes calldata extraData
     ) external {
         userDecryptionCounter++;


### PR DESCRIPTION
### Summary

Makes the KMS connector's ACL checks concurrent instead of sequential.

- `check_ciphertexts_allowed_for_public_decryption` and `check_ciphertexts_allowed_for_user_decryption` now check  ACL for handles concurrently.
- `inner_acl_check_for_allowed_contracts` switches from `join_all` to `FuturesUnordered`. `join_all` waited for *every* `isAllowed` call before looking at the results. Now, we check calls as soon as they land, return `Ok(())` on first positive, and drops the remaining in-flight requests. No behavior changes, only less RPC calls.

Partial improvement for https://github.com/zama-ai/fhevm-internal/issues/1743

### Misc

- `DecryptionMock.sol` comments out the names of parameters the mock never reads, silencing the solc unused-parameter warnings.
