### PR TITLE
chore(kms-connector): bound per-handle fan-out in kms-worker request checks

### DIFF
--- a/kms-connector/Cargo.toml
+++ b/kms-connector/Cargo.toml
@@ -95,7 +95,10 @@ tonic = { version = "=0.14.6", default-features = true, features = [
     "tls-native-roots",
 ] }
 tonic-health = { version = "=0.14.5", default-features = false }
-tower = { version = "=0.5.3", default-features = false, features = ["util"] }
+tower = { version = "=0.5.3", default-features = false, features = [
+    "limit",
+    "util",
+] }
 tracing = { version = "=0.1.44", default-features = true }
 tracing-opentelemetry = "=0.31.0"
 tracing-subscriber = { version = "=0.3.20", default-features = true, features = [

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -56,7 +56,7 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # ENV: KMS_CONNECTOR_GRPC_REQUEST_RETRIES
 # grpc_request_retries = 3
 
-# The maximum number of decryption attempts before a decryption request is permanently removed (optional, defaults to 20)
+# The maximum number of decryption attempts before a decryption request is considered failed (optional, defaults to 20)
 # ENV: KMS_CONNECTOR_MAX_DECRYPTION_ATTEMPTS
 # max_decryption_attempts = 20
 
@@ -71,6 +71,19 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # Timeout to connect to a S3 bucket (optional, defaults to 3s)
 # ENV: KMS_CONNECTOR_S3_CONNECT_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
 # s3_connect_timeout = "3s"
+
+# Maximum number of calls in flight on a single host chain endpoint, across all requests (optional, defaults to 128)
+# ENV: KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS
+# host_rpc_max_concurrent_calls = 128
+
+# Maximum number of attestation HEAD requests in flight on a single Coprocessor bucket (optional, defaults to 64)
+# ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET
+# s3_max_concurrent_heads_per_bucket = 64
+
+# Maximum number of ciphertext GET requests in flight, across all requests and buckets (optional, defaults to 16)
+# Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
+# ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS
+# s3_max_concurrent_gets = 16
 
 # Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
 # Bounds resource use when verifying signatures from smart-account users (Safe, Argent,

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -72,9 +72,13 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # ENV: KMS_CONNECTOR_S3_CONNECT_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
 # s3_connect_timeout = "3s"
 
-# Maximum number of calls in flight on a single host chain endpoint, across all requests (optional, defaults to 128)
-# ENV: KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS
-# host_rpc_max_concurrent_calls = 128
+# Timeout of a single attestation HEAD request on a Coprocessor bucket (optional, defaults to 5s)
+# ENV: KMS_CONNECTOR_S3_HEAD_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
+# s3_head_timeout = "5s"
+
+# Timeout of a single ciphertext GET request, covering the whole response body (optional, defaults to 10s)
+# ENV: KMS_CONNECTOR_S3_GET_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
+# s3_get_timeout = "10s"
 
 # Maximum number of attestation HEAD requests in flight on a single Coprocessor bucket (optional, defaults to 64)
 # ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET
@@ -84,6 +88,18 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
 # ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS
 # s3_max_concurrent_gets = 16
+
+# Refresh interval of the Coprocessor registry read from the GatewayConfig contract (optional, defaults to 60s)
+# ENV: KMS_CONNECTOR_COPRO_REGISTRY_REFRESH (format: https://docs.rs/humantime/latest/humantime/)
+# copro_registry_refresh = "60s"
+
+# Maximum number of calls in flight on a host chain endpoint, across all requests (optional, defaults to 128)
+# ENV: KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS
+# host_rpc_max_concurrent_calls = 128
+
+# Timeout of a single host chain call (optional, defaults to 10s)
+# ENV: KMS_CONNECTOR_HOST_RPC_CALL_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
+# host_rpc_call_timeout = "10s"
 
 # Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
 # Bounds resource use when verifying signatures from smart-account users (Safe, Argent,
@@ -147,15 +163,6 @@ address = "0x0000000000000000000000000000000000000000"
 # EIP-712 domain version for ProtocolConfig contract (optional, defaults to "1")
 # ENV: KMS_CONNECTOR_PROTOCOL_CONFIG_CONTRACT__DOMAIN_VERSION
 # domain_version = "1"
-
-# Off-chain ciphertext-attestation verifier configuration
-# [ct_attestation]
-# Per-bucket S3 attestation HEAD request timeout in seconds (optional, defaults to 5)
-# ENV: KMS_CONNECTOR_CT_ATTESTATION__HEAD_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
-# head_timeout = 5s
-# Coprocessor registry snapshot refresh interval in seconds (optional, defaults to 60)
-# ENV: KMS_CONNECTOR_CT_ATTESTATION__REGISTRY_REFRESH (format: https://docs.rs/humantime/latest/humantime/)
-# registry_refresh = 60s
 
 # List of supported host chains (required)
 # ENV: KMS_CONNECTOR_HOST_CHAINS

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -76,9 +76,10 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # ENV: KMS_CONNECTOR_S3_HEAD_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
 # s3_head_timeout = "5s"
 
-# Timeout of a single ciphertext GET request, covering the whole response body (optional, defaults to 10s)
+# Timeout of a single ciphertext GET request (optional, defaults to 20s)
+# A retrieval retries over every winning-group buckets, so a slow bucket is better abandoned for one of its replicas.
 # ENV: KMS_CONNECTOR_S3_GET_TIMEOUT (format: https://docs.rs/humantime/latest/humantime/)
-# s3_get_timeout = "10s"
+# s3_get_timeout = "20s"
 
 # Maximum number of attestation HEAD requests in flight on a single Coprocessor bucket (optional, defaults to 64)
 # ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -305,6 +305,13 @@ mod tests {
             env::remove_var("KMS_CONNECTOR_MAX_DECRYPTION_ATTEMPTS");
             env::remove_var("KMS_CONNECTOR_S3_CIPHERTEXT_RETRIEVAL_ATTEMPTS");
             env::remove_var("KMS_CONNECTOR_S3_CONNECT_TIMEOUT");
+            env::remove_var("KMS_CONNECTOR_S3_HEAD_TIMEOUT");
+            env::remove_var("KMS_CONNECTOR_S3_GET_TIMEOUT");
+            env::remove_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET");
+            env::remove_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS");
+            env::remove_var("KMS_CONNECTOR_COPRO_REGISTRY_REFRESH");
+            env::remove_var("KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS");
+            env::remove_var("KMS_CONNECTOR_HOST_RPC_CALL_TIMEOUT");
             env::remove_var("KMS_CONNECTOR_SERVICE_NAME");
         }
     }
@@ -370,6 +377,13 @@ mod tests {
             env::set_var("KMS_CONNECTOR_MAX_DECRYPTION_ATTEMPTS", "300");
             env::set_var("KMS_CONNECTOR_S3_CIPHERTEXT_RETRIEVAL_ATTEMPTS", "5");
             env::set_var("KMS_CONNECTOR_S3_CONNECT_TIMEOUT", "4s");
+            env::set_var("KMS_CONNECTOR_S3_HEAD_TIMEOUT", "6s");
+            env::set_var("KMS_CONNECTOR_S3_GET_TIMEOUT", "30s");
+            env::set_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET", "32");
+            env::set_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS", "8");
+            env::set_var("KMS_CONNECTOR_COPRO_REGISTRY_REFRESH", "90s");
+            env::set_var("KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS", "64");
+            env::set_var("KMS_CONNECTOR_HOST_RPC_CALL_TIMEOUT", "15s");
             env::set_var("KMS_CONNECTOR_SERVICE_NAME", "kms-connector-test");
         }
 
@@ -421,7 +435,32 @@ mod tests {
         assert_eq!(config.max_decryption_attempts, 300);
         assert_eq!(config.s3_ciphertext_retrieval_attempts, 5);
         assert_eq!(config.s3_connect_timeout.as_secs(), 4);
+        assert_eq!(config.s3_head_timeout.as_secs(), 6);
+        assert_eq!(config.s3_get_timeout.as_secs(), 30);
+        assert_eq!(config.s3_max_concurrent_heads_per_bucket.get(), 32);
+        assert_eq!(config.s3_max_concurrent_gets.get(), 8);
+        assert_eq!(config.copro_registry_refresh.as_secs(), 90);
+        assert_eq!(config.host_rpc_max_concurrent_calls.get(), 64);
+        assert_eq!(config.host_rpc_call_timeout.as_secs(), 15);
         assert_eq!(config.service_name, "kms-connector-test");
+
+        cleanup_env_vars();
+    }
+
+    #[test]
+    #[serial(config_tests)]
+    fn test_zero_concurrency_ceiling_is_rejected() {
+        for ceiling in [
+            "KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET",
+            "KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS",
+            "KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS",
+        ] {
+            cleanup_env_vars();
+            unsafe { env::set_var(ceiling, "0") }
+
+            let config = Config::from_env_and_file(Some(example_config_path()));
+            assert!(config.is_err(), "{ceiling} = 0 should not have loaded");
+        }
 
         cleanup_env_vars();
     }

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -80,10 +80,12 @@ pub struct Config {
     /// Timeout to connect to a S3 bucket.
     #[serde(with = "humantime_serde", default = "default_s3_connect_timeout")]
     pub s3_connect_timeout: Duration,
-
-    /// Ceiling on the calls a single host chain endpoint may have in flight, across all requests.
-    #[serde(default = "default_host_rpc_max_concurrent_calls")]
-    pub host_rpc_max_concurrent_calls: NonZeroUsize,
+    /// Timeout of a single attestation `HEAD` on a Coprocessor bucket.
+    #[serde(with = "humantime_serde", default = "default_s3_head_timeout")]
+    pub s3_head_timeout: Duration,
+    /// Timeout of a single ciphertext `GET`, covering the whole response body.
+    #[serde(with = "humantime_serde", default = "default_s3_get_timeout")]
+    pub s3_get_timeout: Duration,
     /// Ceiling on the attestation `HEAD`s in flight on a single Coprocessor bucket, across all
     /// requests.
     #[serde(default = "default_s3_max_concurrent_heads_per_bucket")]
@@ -91,6 +93,16 @@ pub struct Config {
     /// Ceiling on the ciphertext `GET`s in flight, across all requests and buckets.
     #[serde(default = "default_s3_max_concurrent_gets")]
     pub s3_max_concurrent_gets: NonZeroUsize,
+    /// Refresh interval of the Coprocessor registry, read from the `GatewayConfig` contract.
+    #[serde(with = "humantime_serde", default = "default_copro_registry_refresh")]
+    pub copro_registry_refresh: Duration,
+
+    /// Ceiling on the calls a single host chain endpoint may have in flight, across all requests.
+    #[serde(default = "default_host_rpc_max_concurrent_calls")]
+    pub host_rpc_max_concurrent_calls: NonZeroUsize,
+    /// Timeout of a single host chain RPC call.
+    #[serde(with = "humantime_serde", default = "default_host_rpc_call_timeout")]
+    pub host_rpc_call_timeout: Duration,
 
     /// Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
     /// Bounded to prevent resource exhaustion from malicious smart-account contracts.
@@ -109,39 +121,6 @@ pub struct Config {
     /// The timeout to perform each external service connection healthcheck.
     #[serde(with = "humantime_serde", default = "default_healthcheck_timeout")]
     pub healthcheck_timeout: Duration,
-
-    /// Off-chain ciphertext-attestation verifier config.
-    #[serde(default)]
-    pub ct_attestation: CtAttestationConfig,
-}
-
-/// Configuration of the off-chain ciphertext-attestation verifier.
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[cfg_attr(test, derive(Serialize))]
-#[serde(default)]
-pub struct CtAttestationConfig {
-    /// Per-bucket S3 attestation HEAD request timeout, in seconds. Defaults to 5.
-    #[serde(
-        with = "humantime_serde",
-        default = "default_ct_attestation_head_timeout"
-    )]
-    pub head_timeout: Duration,
-
-    /// Coprocessor registry snapshot refresh interval, in seconds. Defaults to 60.
-    #[serde(
-        with = "humantime_serde",
-        default = "default_copro_registry_refresh_interval"
-    )]
-    pub registry_refresh: Duration,
-}
-
-impl Default for CtAttestationConfig {
-    fn default() -> Self {
-        Self {
-            head_timeout: default_ct_attestation_head_timeout(),
-            registry_refresh: default_copro_registry_refresh_interval(),
-        }
-    }
 }
 
 /// Configuration of a single Host Chain.
@@ -223,8 +202,24 @@ fn default_s3_connect_timeout() -> Duration {
     Duration::from_secs(3)
 }
 
+fn default_s3_head_timeout() -> Duration {
+    Duration::from_secs(5)
+}
+
+fn default_s3_get_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_copro_registry_refresh() -> Duration {
+    Duration::from_secs(60)
+}
+
 fn default_host_rpc_max_concurrent_calls() -> NonZeroUsize {
     NonZeroUsize::new(128).unwrap()
+}
+
+fn default_host_rpc_call_timeout() -> Duration {
+    Duration::from_secs(10)
 }
 
 fn default_s3_max_concurrent_heads_per_bucket() -> NonZeroUsize {
@@ -238,14 +233,6 @@ fn default_s3_max_concurrent_gets() -> NonZeroUsize {
 
 fn default_erc1271_gas_limit() -> u64 {
     100_000
-}
-
-fn default_ct_attestation_head_timeout() -> Duration {
-    Duration::from_secs(5)
-}
-
-fn default_copro_registry_refresh_interval() -> Duration {
-    Duration::from_secs(60)
 }
 
 impl DeserializeConfig for Config {}
@@ -277,15 +264,18 @@ impl Default for Config {
             max_decryption_attempts: default_max_decryption_attempts(),
             s3_ciphertext_retrieval_attempts: default_s3_ciphertext_retrieval_attempts(),
             s3_connect_timeout: default_s3_connect_timeout(),
-            host_rpc_max_concurrent_calls: default_host_rpc_max_concurrent_calls(),
+            s3_head_timeout: default_s3_head_timeout(),
+            s3_get_timeout: default_s3_get_timeout(),
             s3_max_concurrent_heads_per_bucket: default_s3_max_concurrent_heads_per_bucket(),
             s3_max_concurrent_gets: default_s3_max_concurrent_gets(),
+            copro_registry_refresh: default_copro_registry_refresh(),
+            host_rpc_max_concurrent_calls: default_host_rpc_max_concurrent_calls(),
+            host_rpc_call_timeout: default_host_rpc_call_timeout(),
             erc1271_gas_limit: default_erc1271_gas_limit(),
             service_name: default_service_name(),
             task_limit: default_task_limit(),
             monitoring_endpoint: default_monitoring_endpoint(),
             healthcheck_timeout: default_healthcheck_timeout(),
-            ct_attestation: CtAttestationConfig::default(),
         }
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -17,7 +17,7 @@ use connector_utils::{
 #[cfg(test)]
 use serde::Serialize;
 use serde::{Deserialize, Deserializer};
-use std::{net::SocketAddr, str::FromStr, time::Duration};
+use std::{net::SocketAddr, num::NonZeroUsize, str::FromStr, time::Duration};
 
 /// Configuration of the `KmsWorker`.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -80,6 +80,17 @@ pub struct Config {
     /// Timeout to connect to a S3 bucket.
     #[serde(with = "humantime_serde", default = "default_s3_connect_timeout")]
     pub s3_connect_timeout: Duration,
+
+    /// Ceiling on the calls a single host chain endpoint may have in flight, across all requests.
+    #[serde(default = "default_host_rpc_max_concurrent_calls")]
+    pub host_rpc_max_concurrent_calls: NonZeroUsize,
+    /// Ceiling on the attestation `HEAD`s in flight on a single Coprocessor bucket, across all
+    /// requests.
+    #[serde(default = "default_s3_max_concurrent_heads_per_bucket")]
+    pub s3_max_concurrent_heads_per_bucket: NonZeroUsize,
+    /// Ceiling on the ciphertext `GET`s in flight, across all requests and buckets.
+    #[serde(default = "default_s3_max_concurrent_gets")]
+    pub s3_max_concurrent_gets: NonZeroUsize,
 
     /// Gas cap for the host-chain `IERC1271.isValidSignature` static call (RFC-012).
     /// Bounded to prevent resource exhaustion from malicious smart-account contracts.
@@ -212,6 +223,19 @@ fn default_s3_connect_timeout() -> Duration {
     Duration::from_secs(3)
 }
 
+fn default_host_rpc_max_concurrent_calls() -> NonZeroUsize {
+    NonZeroUsize::new(128).unwrap()
+}
+
+fn default_s3_max_concurrent_heads_per_bucket() -> NonZeroUsize {
+    NonZeroUsize::new(64).unwrap()
+}
+
+fn default_s3_max_concurrent_gets() -> NonZeroUsize {
+    // Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
+    NonZeroUsize::new(16).unwrap()
+}
+
 fn default_erc1271_gas_limit() -> u64 {
     100_000
 }
@@ -253,6 +277,9 @@ impl Default for Config {
             max_decryption_attempts: default_max_decryption_attempts(),
             s3_ciphertext_retrieval_attempts: default_s3_ciphertext_retrieval_attempts(),
             s3_connect_timeout: default_s3_connect_timeout(),
+            host_rpc_max_concurrent_calls: default_host_rpc_max_concurrent_calls(),
+            s3_max_concurrent_heads_per_bucket: default_s3_max_concurrent_heads_per_bucket(),
+            s3_max_concurrent_gets: default_s3_max_concurrent_gets(),
             erc1271_gas_limit: default_erc1271_gas_limit(),
             service_name: default_service_name(),
             task_limit: default_task_limit(),

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -83,7 +83,7 @@ pub struct Config {
     /// Timeout of a single attestation `HEAD` on a Coprocessor bucket.
     #[serde(with = "humantime_serde", default = "default_s3_head_timeout")]
     pub s3_head_timeout: Duration,
-    /// Timeout of a single ciphertext `GET`, covering the whole response body.
+    /// Timeout of a single ciphertext `GET`.
     #[serde(with = "humantime_serde", default = "default_s3_get_timeout")]
     pub s3_get_timeout: Duration,
     /// Ceiling on the attestation `HEAD`s in flight on a single Coprocessor bucket, across all
@@ -207,7 +207,7 @@ fn default_s3_head_timeout() -> Duration {
 }
 
 fn default_s3_get_timeout() -> Duration {
-    Duration::from_secs(10)
+    Duration::from_secs(20)
 }
 
 fn default_copro_registry_refresh() -> Duration {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
@@ -9,7 +9,6 @@ use crate::core::{
 use alloy::{
     primitives::{Address, B256, U256},
     providers::Provider,
-    transports::http::Client,
 };
 use anyhow::anyhow;
 use ciphertext_attestation::{
@@ -18,7 +17,6 @@ use ciphertext_attestation::{
 };
 use futures::future::try_join_all;
 use kms_grpc::kms::v1::TypedCiphertext;
-use std::time::Duration;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -34,12 +32,6 @@ pub struct CiphertextManager<P: Provider> {
 
     /// HTTP client for the attestation HEAD fan-out and the ciphertext retrieval.
     s3_client: BoundedClient,
-
-    /// Timeout of a single attestation `HEAD` on a Coprocessor bucket.
-    head_timeout: Duration,
-
-    /// Number of attempts for S3 ciphertext retrieval.
-    s3_ciphertext_retrieval_attempts: u8,
 }
 
 impl<P> CiphertextManager<P>
@@ -48,7 +40,6 @@ where
 {
     pub async fn connect(
         provider: P,
-        client: Client,
         config: &Config,
         cancel_token: CancellationToken,
     ) -> anyhow::Result<Self> {
@@ -56,13 +47,7 @@ where
 
         Ok(Self {
             registry,
-            s3_client: BoundedClient::new(
-                client,
-                config.s3_max_concurrent_heads_per_bucket,
-                config.s3_max_concurrent_gets,
-            ),
-            head_timeout: config.s3_head_timeout,
-            s3_ciphertext_retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
+            s3_client: BoundedClient::from_config(config)?,
         })
     }
 
@@ -128,12 +113,7 @@ where
 
         let ciphertext = self
             .s3_client
-            .retrieve_verified_ciphertext(
-                handle,
-                &consensus.material,
-                &winning_buckets,
-                self.s3_ciphertext_retrieval_attempts,
-            )
+            .retrieve_verified_ciphertext(handle, &consensus.material, &winning_buckets)
             .await?;
 
         Ok(ResolvedHandle {
@@ -158,12 +138,10 @@ where
     ) -> anyhow::Result<ResolvedConsensus> {
         let mut fetch_attestation_tasks = JoinSet::new();
         for (tx_sender, bucket) in registry.tx_sender_to_bucket.iter() {
-            let (s3_client, head_timeout) = (self.s3_client.clone(), self.head_timeout);
+            let s3_client = self.s3_client.clone();
             let (bucket, tx_sender) = (bucket.clone(), *tx_sender);
             fetch_attestation_tasks.spawn(async move {
-                let result = s3_client
-                    .fetch_single_attestation(&bucket, handle, head_timeout)
-                    .await;
+                let result = s3_client.fetch_single_attestation(&bucket, handle).await;
                 (tx_sender, result)
             });
         }
@@ -285,17 +263,10 @@ where
     P: Provider + Clone + 'static,
 {
     /// Test constructor: an empty registry and default config.
-    pub fn for_test(provider: P, client: Client) -> Self {
-        let config = Config::default();
+    pub fn for_test(provider: P) -> Self {
         Self {
             registry: CoprocessorRegistry::empty(provider),
-            s3_client: BoundedClient::new(
-                client,
-                config.s3_max_concurrent_heads_per_bucket,
-                config.s3_max_concurrent_gets,
-            ),
-            head_timeout: config.s3_head_timeout,
-            s3_ciphertext_retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
+            s3_client: BoundedClient::from_config(&Config::default()).expect("S3 client"),
         }
     }
 }
@@ -365,14 +336,19 @@ mod tests {
             .connect_mocked_client(Asserter::new());
 
         // Single permit manager with an unreachable bucket
-        let mut manager = CiphertextManager::for_test(provider, Client::new());
+        let mut manager = CiphertextManager::for_test(provider);
         let snapshot = CoprocessorRegistrySnapshot::new(
             HashSet::from([Address::ZERO]),
             HashMap::from([(Address::ZERO, BUCKET.to_string())]),
             NonZeroUsize::MIN,
         );
         manager.registry = manager.registry.with_snapshot(snapshot);
-        manager.s3_client = BoundedClient::new(Client::new(), NonZeroUsize::MIN, NonZeroUsize::MIN);
+        manager.s3_client = BoundedClient::from_config(&Config {
+            s3_max_concurrent_heads_per_bucket: NonZeroUsize::MIN,
+            s3_max_concurrent_gets: NonZeroUsize::MIN,
+            ..Default::default()
+        })
+        .unwrap();
 
         let permit = manager.s3_client.acquire_head_for_test(BUCKET).await;
         let gated = tokio::time::timeout(

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
@@ -1,12 +1,9 @@
-use super::{
-    registry::{CoprocessorRegistry, CoprocessorRegistrySnapshot},
-    s3,
-};
+use super::registry::{CoprocessorRegistry, CoprocessorRegistrySnapshot};
 use crate::core::{
     config::{Config, CtAttestationConfig},
     event_processor::{
         ProcessingError, RequestCheckError, RequestCheckKind,
-        ciphertext::{COPROCESSOR_CONTEXT_ID, VerifiedCiphertexts},
+        ciphertext::{COPROCESSOR_CONTEXT_ID, VerifiedCiphertexts, s3::BoundedClient},
     },
 };
 use alloy::{
@@ -35,7 +32,7 @@ pub struct CiphertextManager<P: Provider> {
     registry: CoprocessorRegistry<P>,
 
     /// HTTP client for the attestation HEAD fan-out and the ciphertext retrieval.
-    client: Client,
+    s3_client: BoundedClient,
 
     /// Off-chain ciphertext-attestation verification config.
     config: CtAttestationConfig,
@@ -58,7 +55,11 @@ where
 
         Ok(Self {
             registry,
-            client,
+            s3_client: BoundedClient::new(
+                client,
+                config.s3_max_concurrent_heads_per_bucket,
+                config.s3_max_concurrent_gets,
+            ),
             config: config.ct_attestation.clone(),
             s3_ciphertext_retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
         })
@@ -124,14 +125,15 @@ where
             "Consensus reached for handle"
         );
 
-        let ciphertext = s3::retrieve_verified_ciphertext(
-            &self.client,
-            handle,
-            &consensus.material,
-            &winning_buckets,
-            self.s3_ciphertext_retrieval_attempts,
-        )
-        .await?;
+        let ciphertext = self
+            .s3_client
+            .retrieve_verified_ciphertext(
+                handle,
+                &consensus.material,
+                &winning_buckets,
+                self.s3_ciphertext_retrieval_attempts,
+            )
+            .await?;
 
         Ok(ResolvedHandle {
             key_id: consensus.material.key_id,
@@ -155,11 +157,12 @@ where
     ) -> anyhow::Result<ResolvedConsensus> {
         let mut fetch_attestation_tasks = JoinSet::new();
         for (tx_sender, bucket) in registry.tx_sender_to_bucket.iter() {
-            let (client, head_timeout) = (self.client.clone(), self.config.head_timeout);
+            let (s3_client, head_timeout) = (self.s3_client.clone(), self.config.head_timeout);
             let (bucket, tx_sender) = (bucket.clone(), *tx_sender);
             fetch_attestation_tasks.spawn(async move {
-                let result =
-                    s3::fetch_single_attestation(&client, &bucket, handle, head_timeout).await;
+                let result = s3_client
+                    .fetch_single_attestation(&bucket, handle, head_timeout)
+                    .await;
                 (tx_sender, result)
             });
         }
@@ -283,11 +286,16 @@ where
     /// Test constructor: an empty registry and default config. The resolution path is never
     /// exercised by the tests that use it (they fail earlier, at the ACL or signature stage).
     pub fn for_test(provider: P, client: Client) -> Self {
+        let config = Config::default();
         Self {
             registry: CoprocessorRegistry::empty(provider),
-            client,
+            s3_client: BoundedClient::new(
+                client,
+                config.s3_max_concurrent_heads_per_bucket,
+                config.s3_max_concurrent_gets,
+            ),
             config: CtAttestationConfig::default(),
-            s3_ciphertext_retrieval_attempts: Config::default().s3_ciphertext_retrieval_attempts,
+            s3_ciphertext_retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
         }
     }
 }
@@ -295,6 +303,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::providers::{ProviderBuilder, mock::Asserter};
+    use std::{
+        collections::{HashMap, HashSet},
+        num::NonZeroUsize,
+        time::Duration,
+    };
 
     fn resolved(key_id: U256, handle_byte: u8) -> ResolvedHandle {
         ResolvedHandle {
@@ -337,6 +351,47 @@ mod tests {
     #[test]
     fn aggregate_rejects_empty() {
         let result = aggregate_resolved_handles(vec![]);
+        assert!(matches!(result, Err(ProcessingError::Recoverable(_))));
+    }
+
+    /// No S3 request is issued without a permit: with the bucket's only one held, the resolution
+    /// cannot even start, and it does start again as soon as the permit is released.
+    #[tokio::test]
+    async fn s3_requests_wait_for_a_permit() {
+        const BUCKET: &str = "http://127.0.0.1:1";
+
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_mocked_client(Asserter::new());
+
+        // Single permit manager with an unreachable bucket
+        let mut manager = CiphertextManager::for_test(provider, Client::new());
+        let snapshot = CoprocessorRegistrySnapshot::new(
+            HashSet::from([Address::ZERO]),
+            HashMap::from([(Address::ZERO, BUCKET.to_string())]),
+            NonZeroUsize::MIN,
+        );
+        manager.registry = manager.registry.with_snapshot(snapshot);
+        manager.s3_client = BoundedClient::new(Client::new(), NonZeroUsize::MIN, NonZeroUsize::MIN);
+
+        let permit = manager.s3_client.acquire_head_for_test(BUCKET).await;
+        let gated = tokio::time::timeout(
+            Duration::from_millis(200),
+            manager.verify_and_retrieve(&[B256::ZERO]),
+        )
+        .await;
+        assert!(gated.is_err(), "resolution should not have started");
+
+        drop(permit);
+
+        // The bucket is unreachable, so consensus fails: reaching that error is the proof that the
+        // `HEAD` request was issued once the permit freed.
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            manager.verify_and_retrieve(&[B256::ZERO]),
+        )
+        .await
+        .expect("resolution should have resumed");
         assert!(matches!(result, Err(ProcessingError::Recoverable(_))));
     }
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
@@ -1,6 +1,6 @@
 use super::registry::{CoprocessorRegistry, CoprocessorRegistrySnapshot};
 use crate::core::{
-    config::{Config, CtAttestationConfig},
+    config::Config,
     event_processor::{
         ProcessingError, RequestCheckError, RequestCheckKind,
         ciphertext::{COPROCESSOR_CONTEXT_ID, VerifiedCiphertexts, s3::BoundedClient},
@@ -18,6 +18,7 @@ use ciphertext_attestation::{
 };
 use futures::future::try_join_all;
 use kms_grpc::kms::v1::TypedCiphertext;
+use std::time::Duration;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -34,8 +35,8 @@ pub struct CiphertextManager<P: Provider> {
     /// HTTP client for the attestation HEAD fan-out and the ciphertext retrieval.
     s3_client: BoundedClient,
 
-    /// Off-chain ciphertext-attestation verification config.
-    config: CtAttestationConfig,
+    /// Timeout of a single attestation `HEAD` on a Coprocessor bucket.
+    head_timeout: Duration,
 
     /// Number of attempts for S3 ciphertext retrieval.
     s3_ciphertext_retrieval_attempts: u8,
@@ -60,7 +61,7 @@ where
                 config.s3_max_concurrent_heads_per_bucket,
                 config.s3_max_concurrent_gets,
             ),
-            config: config.ct_attestation.clone(),
+            head_timeout: config.s3_head_timeout,
             s3_ciphertext_retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
         })
     }
@@ -157,7 +158,7 @@ where
     ) -> anyhow::Result<ResolvedConsensus> {
         let mut fetch_attestation_tasks = JoinSet::new();
         for (tx_sender, bucket) in registry.tx_sender_to_bucket.iter() {
-            let (s3_client, head_timeout) = (self.s3_client.clone(), self.config.head_timeout);
+            let (s3_client, head_timeout) = (self.s3_client.clone(), self.head_timeout);
             let (bucket, tx_sender) = (bucket.clone(), *tx_sender);
             fetch_attestation_tasks.spawn(async move {
                 let result = s3_client
@@ -283,8 +284,7 @@ impl<P> CiphertextManager<P>
 where
     P: Provider + Clone + 'static,
 {
-    /// Test constructor: an empty registry and default config. The resolution path is never
-    /// exercised by the tests that use it (they fail earlier, at the ACL or signature stage).
+    /// Test constructor: an empty registry and default config.
     pub fn for_test(provider: P, client: Client) -> Self {
         let config = Config::default();
         Self {
@@ -294,7 +294,7 @@ where
                 config.s3_max_concurrent_heads_per_bucket,
                 config.s3_max_concurrent_gets,
             ),
-            config: CtAttestationConfig::default(),
+            head_timeout: config.s3_head_timeout,
             s3_ciphertext_retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
         }
     }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/manager.rs
@@ -325,17 +325,16 @@ mod tests {
         assert!(matches!(result, Err(ProcessingError::Recoverable(_))));
     }
 
-    /// No S3 request is issued without a permit: with the bucket's only one held, the resolution
-    /// cannot even start, and it does start again as soon as the permit is released.
+    // Checks that the CiphertextManager waits for a permit before sending a `HEAD` request.
     #[tokio::test]
-    async fn s3_requests_wait_for_a_permit() {
+    async fn s3_head_requests_wait_for_a_permit() {
         const BUCKET: &str = "http://127.0.0.1:1";
 
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .connect_mocked_client(Asserter::new());
 
-        // Single permit manager with an unreachable bucket
+        // One `HEAD` permit for the whole bucket, whose address nothing listens on
         let mut manager = CiphertextManager::for_test(provider);
         let snapshot = CoprocessorRegistrySnapshot::new(
             HashSet::from([Address::ZERO]),
@@ -350,6 +349,8 @@ mod tests {
         })
         .unwrap();
 
+        // The `HEAD` request is gated by a permit, so it should not be issued until the permit is
+        // dropped
         let permit = manager.s3_client.acquire_head_for_test(BUCKET).await;
         let gated = tokio::time::timeout(
             Duration::from_millis(200),

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/registry.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/registry.rs
@@ -236,6 +236,13 @@ where
             )),
         }
     }
+
+    pub fn with_snapshot(self, snapshot: CoprocessorRegistrySnapshot) -> Self {
+        Self {
+            snapshot: Arc::new(RwLock::new(Arc::new(snapshot))),
+            ..self
+        }
+    }
 }
 
 #[cfg(test)]

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/registry.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/registry.rs
@@ -163,7 +163,7 @@ where
             gateway_config_contract,
             snapshot: Arc::new(RwLock::new(Arc::new(snapshot))),
         };
-        registry.spawn_refresh_task(config.ct_attestation.registry_refresh, cancel_token);
+        registry.spawn_refresh_task(config.copro_registry_refresh, cancel_token);
 
         Ok(registry)
     }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -8,7 +8,7 @@
 
 use super::COPROCESSOR_CONTEXT_ID;
 use crate::{
-    core::event_processor::ProcessingError,
+    core::{config::Config, event_processor::ProcessingError},
     monitoring::metrics::{S3_CIPHERTEXT_RETRIEVAL_COUNTER, S3_CIPHERTEXT_RETRIEVAL_ERRORS},
 };
 use alloy::{
@@ -38,7 +38,7 @@ use tracing::{debug, warn};
 
 /// An HTTP client with a ceiling on the requests it may have in flight.
 #[derive(Clone)]
-pub(crate) struct BoundedClient {
+pub struct BoundedClient {
     /// The inner HTTP client.
     client: Client,
 
@@ -51,35 +51,45 @@ pub(crate) struct BoundedClient {
     /// The global `GET` ceiling, as we query a single winning bucket to fetch ciphertexts.
     /// Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
     get_semaphore: Arc<Semaphore>,
+
+    /// Deadline of a single attestation `HEAD`.
+    head_timeout: Duration,
+
+    /// Number of attempts of a ciphertext retrieval, per winning-group bucket.
+    retrieval_attempts: u8,
 }
 
 impl BoundedClient {
-    pub(crate) fn new(
-        client: Client,
-        max_concurrent_heads_per_bucket: NonZeroUsize,
-        max_concurrent_gets: NonZeroUsize,
-    ) -> Self {
-        Self {
+    /// Builds the S3 client with the bounds of `config`.
+    pub fn from_config(config: &Config) -> anyhow::Result<Self> {
+        let client = Client::builder()
+            .connect_timeout(config.s3_connect_timeout)
+            .timeout(config.s3_get_timeout)
+            .build()
+            .map_err(|e| anyhow!("Failed to create S3 HTTP client: {e}"))?;
+
+        Ok(Self {
             client,
             head_semaphores: Arc::new(Mutex::new(HashMap::new())),
-            max_concurrent_heads_per_bucket,
-            get_semaphore: Arc::new(Semaphore::new(max_concurrent_gets.get())),
-        }
+            max_concurrent_heads_per_bucket: config.s3_max_concurrent_heads_per_bucket,
+            get_semaphore: Arc::new(Semaphore::new(config.s3_max_concurrent_gets.get())),
+            head_timeout: config.s3_head_timeout,
+            retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
+        })
     }
 
-    /// See [`fetch_single_attestation`].
-    pub(crate) async fn fetch_single_attestation(
+    /// Fetches the attestation for a `handle` from the specified bucket, using a `HEAD` request.
+    pub async fn fetch_single_attestation(
         &self,
         bucket: &str,
         handle: B256,
-        head_timeout: Duration,
     ) -> Result<CiphertextAttestation, FetchAttestationError> {
         let bucket_semaphore = self.bucket_semaphore(bucket);
         let _permit = bucket_semaphore
             .acquire()
             .await
             .expect("S3 HEAD semaphore closed");
-        fetch_single_attestation(&self.client, bucket, handle, head_timeout).await
+        fetch_single_attestation(&self.client, bucket, handle, self.head_timeout).await
     }
 
     /// The `HEAD` ceiling of `bucket`, created on first use.
@@ -98,23 +108,27 @@ impl BoundedClient {
         }
     }
 
-    /// See [`retrieve_verified_ciphertext`].
-    ///
-    /// One permit for the whole call: it retries the winning buckets sequentially.
-    pub(crate) async fn retrieve_verified_ciphertext(
+    /// Retrieves the SNS ciphertext of `handle` from a bucket in the winning consensus group and
+    /// verifies it against the attested digest (RFC 023, authoritative mode).
+    pub async fn retrieve_verified_ciphertext(
         &self,
         handle: B256,
         material: &ConsensusMaterial,
         winning_buckets: &[String],
-        attempts: u8,
     ) -> Result<TypedCiphertext, ProcessingError> {
         let _permit = self
             .get_semaphore
             .acquire()
             .await
             .expect("S3 GET semaphore closed");
-        retrieve_verified_ciphertext(&self.client, handle, material, winning_buckets, attempts)
-            .await
+        retrieve_verified_ciphertext(
+            &self.client,
+            handle,
+            material,
+            winning_buckets,
+            self.retrieval_attempts,
+        )
+        .await
     }
 }
 
@@ -128,7 +142,7 @@ fn rfc023_ciphertext_url(bucket_url: &str, handle: B256) -> String {
 
 /// Why a single bucket's HEAD attempt did not yield an attestation.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum FetchAttestationError {
+pub enum FetchAttestationError {
     #[error("HEAD request timed out")]
     Timeout,
     #[error("HEAD request failed: {0}")]
@@ -139,8 +153,7 @@ pub(crate) enum FetchAttestationError {
     MissingHeader,
 }
 
-/// Fetches the attestation for a `handle` from the specified bucket, using a `HEAD` request.
-pub(crate) async fn fetch_single_attestation(
+async fn fetch_single_attestation(
     client: &Client,
     bucket: &str,
     handle: B256,
@@ -171,9 +184,7 @@ pub(crate) async fn fetch_single_attestation(
     attestation_from_http_headers(response.headers())
 }
 
-/// Retrieves the SNS ciphertext of `handle` from a bucket in the winning consensus group and
-/// verifies it against the attested digest (RFC 023, authoritative mode).
-pub async fn retrieve_verified_ciphertext(
+async fn retrieve_verified_ciphertext(
     client: &Client,
     handle: B256,
     material: &ConsensusMaterial,
@@ -331,7 +342,12 @@ mod tests {
 
     /// A single-permit-per-ceiling client, to make permit starvation observable.
     fn single_permit_client() -> BoundedClient {
-        BoundedClient::new(Client::new(), NonZeroUsize::MIN, NonZeroUsize::MIN)
+        BoundedClient::from_config(&Config {
+            s3_max_concurrent_heads_per_bucket: NonZeroUsize::MIN,
+            s3_max_concurrent_gets: NonZeroUsize::MIN,
+            ..Default::default()
+        })
+        .unwrap()
     }
 
     fn material() -> ConsensusMaterial {
@@ -354,11 +370,7 @@ mod tests {
         // unreachable address — instead of waiting for the saturated bucket's permit.
         let issued = tokio::time::timeout(
             Duration::from_secs(5),
-            client.fetch_single_attestation(
-                OTHER_UNREACHABLE_BUCKET,
-                B256::ZERO,
-                Duration::from_secs(1),
-            ),
+            client.fetch_single_attestation(OTHER_UNREACHABLE_BUCKET, B256::ZERO),
         )
         .await
         .expect("a HEAD on another bucket should not wait for the saturated one");
@@ -367,7 +379,7 @@ mod tests {
         // While the saturated bucket does gate its own `HEAD`s.
         let gated = tokio::time::timeout(
             Duration::from_millis(200),
-            client.fetch_single_attestation(UNREACHABLE_BUCKET, B256::ZERO, Duration::from_secs(1)),
+            client.fetch_single_attestation(UNREACHABLE_BUCKET, B256::ZERO),
         )
         .await;
         assert!(gated.is_err(), "the saturated bucket should gate its HEADs");
@@ -386,7 +398,7 @@ mod tests {
         for handle in [B256::ZERO, B256::repeat_byte(0x02)] {
             let gated = tokio::time::timeout(
                 Duration::from_millis(200),
-                client.retrieve_verified_ciphertext(handle, &material, &buckets, 1),
+                client.retrieve_verified_ciphertext(handle, &material, &buckets),
             )
             .await;
             assert!(
@@ -401,11 +413,59 @@ mod tests {
         // the `GET` was issued once the permit freed.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            client.retrieve_verified_ciphertext(B256::ZERO, &material, &buckets, 1),
+            client.retrieve_verified_ciphertext(B256::ZERO, &material, &buckets),
         )
         .await
         .expect("retrieval should have resumed");
         assert!(matches!(result, Err(ProcessingError::Recoverable(_))));
+    }
+
+    /// A socket that accepts connections and never answers: a request sent to it can only end on
+    /// its own deadline. Returns its URL, and the handle of the accept loop to abort.
+    async fn black_hole_bucket() -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let accept_loop = tokio::spawn(async move {
+            // The accepted streams are kept alive, and left unanswered, until the test aborts us.
+            let mut accepted = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                accepted.push(stream);
+            }
+        });
+        (url, accept_loop)
+    }
+
+    /// Every request the client issues carries a deadline — the `HEAD` its own, the `GET` the
+    /// client-wide one: a bucket that accepts the connection then goes silent can hang neither.
+    #[tokio::test]
+    async fn requests_are_bounded_by_their_own_deadline() {
+        let (bucket, accept_loop) = black_hole_bucket().await;
+        let client = BoundedClient::from_config(&Config {
+            s3_head_timeout: Duration::from_millis(100),
+            s3_get_timeout: Duration::from_millis(300),
+            s3_ciphertext_retrieval_attempts: 1,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let head = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.fetch_single_attestation(&bucket, B256::ZERO),
+        )
+        .await
+        .expect("the HEAD should have ended on its own deadline");
+        assert!(matches!(head, Err(FetchAttestationError::Timeout)));
+
+        // The client-wide deadline covers the whole response body, so the silent bucket trips it.
+        let get = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.retrieve_verified_ciphertext(B256::ZERO, &material(), &[bucket]),
+        )
+        .await
+        .expect("the GET should have ended on its own deadline");
+        assert!(matches!(get, Err(ProcessingError::Recoverable(_))));
+
+        accept_loop.abort();
     }
 
     #[test]

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -27,8 +27,89 @@ use sha3::{
     Digest, Keccak256,
     digest::{consts::U32, generic_array::GenericArray},
 };
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::sync::Semaphore;
 use tracing::{debug, warn};
+
+/// An HTTP client with a ceiling on the requests it may have in flight.
+#[derive(Clone)]
+pub(crate) struct BoundedClient {
+    /// The inner HTTP client.
+    client: Client,
+
+    /// The per bucket HEAD request ceiling.
+    head_permits: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
+
+    /// The maximum number of concurrent HEAD requests per bucket.
+    max_concurrent_heads_per_bucket: NonZeroUsize,
+
+    /// The global `GET` ceiling, as we query a single winning bucket to fetch ciphertexts.
+    /// Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
+    get_permits: Arc<Semaphore>,
+}
+
+impl BoundedClient {
+    pub(crate) fn new(
+        client: Client,
+        max_concurrent_heads_per_bucket: NonZeroUsize,
+        max_concurrent_gets: NonZeroUsize,
+    ) -> Self {
+        Self {
+            client,
+            head_permits: Arc::new(Mutex::new(HashMap::new())),
+            max_concurrent_heads_per_bucket,
+            get_permits: Arc::new(Semaphore::new(max_concurrent_gets.get())),
+        }
+    }
+
+    /// See [`fetch_single_attestation`].
+    pub(crate) async fn fetch_single_attestation(
+        &self,
+        bucket: &str,
+        handle: B256,
+        head_timeout: Duration,
+    ) -> Result<CiphertextAttestation, FetchAttestationError> {
+        let bucket_permits = self.bucket_permit(bucket);
+        let _permit = bucket_permits.acquire().await;
+        fetch_single_attestation(&self.client, bucket, handle, head_timeout).await
+    }
+
+    /// The `HEAD` ceiling of `bucket`, created on first use.
+    fn bucket_permit(&self, bucket: &str) -> Arc<Semaphore> {
+        let mut permits = self
+            .head_permits
+            .lock()
+            .expect("S3 HEAD permits lock poisoned");
+
+        if let Some(permit) = permits.get(bucket) {
+            Arc::clone(permit)
+        } else {
+            let permit = Arc::new(Semaphore::new(self.max_concurrent_heads_per_bucket.get()));
+            permits.insert(bucket.to_string(), Arc::clone(&permit));
+            permit
+        }
+    }
+
+    /// See [`retrieve_verified_ciphertext`].
+    ///
+    /// One permit for the whole call: it retries the winning buckets sequentially.
+    pub(crate) async fn retrieve_verified_ciphertext(
+        &self,
+        handle: B256,
+        material: &ConsensusMaterial,
+        winning_buckets: &[String],
+        attempts: u8,
+    ) -> Result<TypedCiphertext, ProcessingError> {
+        let _permit = self.get_permits.acquire().await;
+        retrieve_verified_ciphertext(&self.client, handle, material, winning_buckets, attempts)
+            .await
+    }
+}
 
 /// URL of a ciphertext object in a Coprocessor bucket (RFC 023 layout).
 fn rfc023_ciphertext_url(bucket_url: &str, handle: B256) -> String {
@@ -211,6 +292,17 @@ fn attestation_from_http_headers(
 
     serde_json::from_slice(header.as_bytes())
         .map_err(|e| FetchAttestationError::BadHeader(e.to_string()))
+}
+
+#[cfg(test)]
+impl BoundedClient {
+    /// Takes a permit out of `bucket`'s ceiling, to check that its `HEAD`s wait for one.
+    pub(super) async fn acquire_head_for_test(
+        &self,
+        bucket: &str,
+    ) -> tokio::sync::OwnedSemaphorePermit {
+        self.bucket_permit(bucket).acquire_owned().await.unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -335,6 +335,7 @@ impl BoundedClient {
 mod tests {
     use super::*;
     use alloy::primitives::U256;
+    use connector_utils::tests::net::black_hole_server;
 
     /// Two addresses nothing can be listening on: a request to either fails at connection, fast.
     const UNREACHABLE_BUCKET: &str = "http://127.0.0.1:1";
@@ -420,26 +421,11 @@ mod tests {
         assert!(matches!(result, Err(ProcessingError::Recoverable(_))));
     }
 
-    /// A socket that accepts connections and never answers: a request sent to it can only end on
-    /// its own deadline. Returns its URL, and the handle of the accept loop to abort.
-    async fn black_hole_bucket() -> (String, tokio::task::JoinHandle<()>) {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let url = format!("http://{}", listener.local_addr().unwrap());
-        let accept_loop = tokio::spawn(async move {
-            // The accepted streams are kept alive, and left unanswered, until the test aborts us.
-            let mut accepted = Vec::new();
-            while let Ok((stream, _)) = listener.accept().await {
-                accepted.push(stream);
-            }
-        });
-        (url, accept_loop)
-    }
-
     /// Every request the client issues carries a deadline — the `HEAD` its own, the `GET` the
     /// client-wide one: a bucket that accepts the connection then goes silent can hang neither.
     #[tokio::test]
     async fn requests_are_bounded_by_their_own_deadline() {
-        let (bucket, accept_loop) = black_hole_bucket().await;
+        let (bucket, accept_loop) = black_hole_server().await;
         let client = BoundedClient::from_config(&Config {
             s3_head_timeout: Duration::from_millis(100),
             s3_get_timeout: Duration::from_millis(300),

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -43,14 +43,14 @@ pub(crate) struct BoundedClient {
     client: Client,
 
     /// The per bucket HEAD request ceiling.
-    head_permits: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
+    head_semaphores: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
 
     /// The maximum number of concurrent HEAD requests per bucket.
     max_concurrent_heads_per_bucket: NonZeroUsize,
 
     /// The global `GET` ceiling, as we query a single winning bucket to fetch ciphertexts.
     /// Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
-    get_permits: Arc<Semaphore>,
+    get_semaphore: Arc<Semaphore>,
 }
 
 impl BoundedClient {
@@ -61,9 +61,9 @@ impl BoundedClient {
     ) -> Self {
         Self {
             client,
-            head_permits: Arc::new(Mutex::new(HashMap::new())),
+            head_semaphores: Arc::new(Mutex::new(HashMap::new())),
             max_concurrent_heads_per_bucket,
-            get_permits: Arc::new(Semaphore::new(max_concurrent_gets.get())),
+            get_semaphore: Arc::new(Semaphore::new(max_concurrent_gets.get())),
         }
     }
 
@@ -74,24 +74,27 @@ impl BoundedClient {
         handle: B256,
         head_timeout: Duration,
     ) -> Result<CiphertextAttestation, FetchAttestationError> {
-        let bucket_permits = self.bucket_permit(bucket);
-        let _permit = bucket_permits.acquire().await;
+        let bucket_semaphore = self.bucket_semaphore(bucket);
+        let _permit = bucket_semaphore
+            .acquire()
+            .await
+            .expect("S3 HEAD semaphore closed");
         fetch_single_attestation(&self.client, bucket, handle, head_timeout).await
     }
 
     /// The `HEAD` ceiling of `bucket`, created on first use.
-    fn bucket_permit(&self, bucket: &str) -> Arc<Semaphore> {
-        let mut permits = self
-            .head_permits
+    fn bucket_semaphore(&self, bucket: &str) -> Arc<Semaphore> {
+        let mut semaphores = self
+            .head_semaphores
             .lock()
-            .expect("S3 HEAD permits lock poisoned");
+            .unwrap_or_else(|e| e.into_inner());
 
-        if let Some(permit) = permits.get(bucket) {
-            Arc::clone(permit)
+        if let Some(semaphore) = semaphores.get(bucket) {
+            Arc::clone(semaphore)
         } else {
-            let permit = Arc::new(Semaphore::new(self.max_concurrent_heads_per_bucket.get()));
-            permits.insert(bucket.to_string(), Arc::clone(&permit));
-            permit
+            let semaphore = Arc::new(Semaphore::new(self.max_concurrent_heads_per_bucket.get()));
+            semaphores.insert(bucket.to_string(), Arc::clone(&semaphore));
+            semaphore
         }
     }
 
@@ -105,7 +108,11 @@ impl BoundedClient {
         winning_buckets: &[String],
         attempts: u8,
     ) -> Result<TypedCiphertext, ProcessingError> {
-        let _permit = self.get_permits.acquire().await;
+        let _permit = self
+            .get_semaphore
+            .acquire()
+            .await
+            .expect("S3 GET semaphore closed");
         retrieve_verified_ciphertext(&self.client, handle, material, winning_buckets, attempts)
             .await
     }
@@ -301,13 +308,105 @@ impl BoundedClient {
         &self,
         bucket: &str,
     ) -> tokio::sync::OwnedSemaphorePermit {
-        self.bucket_permit(bucket).acquire_owned().await.unwrap()
+        self.bucket_semaphore(bucket).acquire_owned().await.unwrap()
+    }
+
+    /// Takes a permit out of the global `GET` ceiling, to check that retrievals wait for one.
+    pub(super) async fn acquire_get_for_test(&self) -> tokio::sync::OwnedSemaphorePermit {
+        Arc::clone(&self.get_semaphore)
+            .acquire_owned()
+            .await
+            .unwrap()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::U256;
+
+    /// Two addresses nothing can be listening on: a request to either fails at connection, fast.
+    const UNREACHABLE_BUCKET: &str = "http://127.0.0.1:1";
+    const OTHER_UNREACHABLE_BUCKET: &str = "http://127.0.0.1:2";
+
+    /// A single-permit-per-ceiling client, to make permit starvation observable.
+    fn single_permit_client() -> BoundedClient {
+        BoundedClient::new(Client::new(), NonZeroUsize::MIN, NonZeroUsize::MIN)
+    }
+
+    fn material() -> ConsensusMaterial {
+        ConsensusMaterial {
+            key_id: U256::ONE,
+            ciphertext_digest: B256::ZERO,
+            sns_ciphertext_digest: B256::ZERO,
+            format: CiphertextFormat::CompressedOnCpu,
+        }
+    }
+
+    /// `HEAD` ceilings are per bucket: a bucket with no permit left must not gate the others,
+    /// otherwise one unresponsive Coprocessor would stall the attestation fan-out of every bucket.
+    #[tokio::test]
+    async fn head_ceilings_are_per_bucket() {
+        let client = single_permit_client();
+        let _saturating = client.acquire_head_for_test(UNREACHABLE_BUCKET).await;
+
+        // The other bucket draws from its own ceiling: its `HEAD` is issued — and fails on the
+        // unreachable address — instead of waiting for the saturated bucket's permit.
+        let issued = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.fetch_single_attestation(
+                OTHER_UNREACHABLE_BUCKET,
+                B256::ZERO,
+                Duration::from_secs(1),
+            ),
+        )
+        .await
+        .expect("a HEAD on another bucket should not wait for the saturated one");
+        assert!(matches!(issued, Err(FetchAttestationError::Http(_))));
+
+        // While the saturated bucket does gate its own `HEAD`s.
+        let gated = tokio::time::timeout(
+            Duration::from_millis(200),
+            client.fetch_single_attestation(UNREACHABLE_BUCKET, B256::ZERO, Duration::from_secs(1)),
+        )
+        .await;
+        assert!(gated.is_err(), "the saturated bucket should gate its HEADs");
+    }
+
+    /// The `GET` ceiling is global: one permit gates the retrievals of every handle, rather than
+    /// each handle getting a ceiling of its own.
+    #[tokio::test]
+    async fn get_ceiling_is_shared_across_handles() {
+        let client = single_permit_client();
+        let (material, buckets) = (material(), [UNREACHABLE_BUCKET.to_string()]);
+
+        let permit = client.acquire_get_for_test().await;
+
+        // The only permit is held, so no handle can start retrieving.
+        for handle in [B256::ZERO, B256::repeat_byte(0x02)] {
+            let gated = tokio::time::timeout(
+                Duration::from_millis(200),
+                client.retrieve_verified_ciphertext(handle, &material, &buckets, 1),
+            )
+            .await;
+            assert!(
+                gated.is_err(),
+                "handle {handle} should wait for a GET permit"
+            );
+        }
+
+        drop(permit);
+
+        // The bucket is unreachable, so the retrieval fails: reaching that error is the proof that
+        // the `GET` was issued once the permit freed.
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.retrieve_verified_ciphertext(B256::ZERO, &material, &buckets, 1),
+        )
+        .await
+        .expect("retrieval should have resumed");
+        assert!(matches!(result, Err(ProcessingError::Recoverable(_))));
+    }
 
     #[test]
     fn test_attestation_from_http_headers_missing() {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -665,7 +665,6 @@ mod tests {
         rpc::types::Transaction as RpcTransaction,
         signers::{SignerSync, local::PrivateKeySigner},
         sol_types::SolValue,
-        transports::http::reqwest,
     };
     use connector_utils::{
         tests::rand::{rand_address, rand_digest, rand_handle, rand_public_key, rand_u256},
@@ -717,8 +716,7 @@ mod tests {
             chain_id,
             ACL::new(Address::default(), mock_provider.clone()),
         )]);
-        let ciphertext_manager =
-            CiphertextManager::for_test(mock_provider.clone(), reqwest::Client::new());
+        let ciphertext_manager = CiphertextManager::for_test(mock_provider.clone());
         DecryptionProcessor::new(
             &config,
             MockContextManager,

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -17,7 +17,10 @@ use crate::{
 use alloy::transports::http::reqwest;
 use anyhow::anyhow;
 use connector_utils::{
-    conn::{DefaultProvider, connect_to_db, connect_to_rpc_node},
+    conn::{
+        DefaultProvider, connect_to_db, connect_to_rpc_node,
+        connect_to_rpc_node_with_concurrency_limit,
+    },
     tasks::spawn_with_limit,
     types::{KmsResponse, ProtocolEvent},
 };
@@ -135,7 +138,12 @@ impl
 
         let mut acl_contracts = HashMap::new();
         for host_chain in &config.host_chains {
-            let provider = connect_to_rpc_node(host_chain.url.clone(), host_chain.chain_id).await?;
+            let provider = connect_to_rpc_node_with_concurrency_limit(
+                host_chain.url.clone(),
+                host_chain.chain_id,
+                config.host_rpc_max_concurrent_calls,
+            )
+            .await?;
             let acl_contract = ACL::new(host_chain.acl_address, provider);
             let host_chain_id = host_chain.chain_id;
             if acl_contracts.insert(host_chain_id, acl_contract).is_some() {

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -17,10 +17,7 @@ use crate::{
 use alloy::transports::http::reqwest;
 use anyhow::anyhow;
 use connector_utils::{
-    conn::{
-        DefaultProvider, connect_to_db, connect_to_rpc_node,
-        connect_to_rpc_node_with_concurrency_limit,
-    },
+    conn::{DefaultProvider, connect_to_db, connect_to_rpc_node, connect_to_rpc_node_with_bounds},
     tasks::spawn_with_limit,
     types::{KmsResponse, ProtocolEvent},
 };
@@ -138,10 +135,11 @@ impl
 
         let mut acl_contracts = HashMap::new();
         for host_chain in &config.host_chains {
-            let provider = connect_to_rpc_node_with_concurrency_limit(
+            let provider = connect_to_rpc_node_with_bounds(
                 host_chain.url.clone(),
                 host_chain.chain_id,
                 config.host_rpc_max_concurrent_calls,
+                config.host_rpc_call_timeout,
             )
             .await?;
             let acl_contract = ACL::new(host_chain.acl_address, provider);
@@ -157,6 +155,7 @@ impl
         let kms_health_client = KmsHealthClient::connect(&config.kms_core_endpoints).await?;
         let s3_client = reqwest::Client::builder()
             .connect_timeout(config.s3_connect_timeout)
+            .timeout(config.s3_get_timeout)
             .build()
             .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))?;
 

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -14,7 +14,6 @@ use crate::{
         metrics::register_event_latency,
     },
 };
-use alloy::transports::http::reqwest;
 use anyhow::anyhow;
 use connector_utils::{
     conn::{DefaultProvider, connect_to_db, connect_to_rpc_node, connect_to_rpc_node_with_bounds},
@@ -153,19 +152,13 @@ impl
 
         let kms_client = KmsClient::connect(&config).await?;
         let kms_health_client = KmsHealthClient::connect(&config.kms_core_endpoints).await?;
-        let s3_client = reqwest::Client::builder()
-            .connect_timeout(config.s3_connect_timeout)
-            .timeout(config.s3_get_timeout)
-            .build()
-            .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))?;
 
         let event_picker = DbEventPicker::connect(db_pool.clone(), &config).await?;
 
         let context_manager =
             DbContextManager::new(db_pool.clone(), &config, ethereum_provider.clone());
         let ciphertext_manager =
-            CiphertextManager::connect(gateway_provider.clone(), s3_client, &config, cancel_token)
-                .await?;
+            CiphertextManager::connect(gateway_provider.clone(), &config, cancel_token).await?;
         let decryption_processor = DecryptionProcessor::new(
             &config,
             context_manager.clone(),

--- a/kms-connector/crates/kms-worker/src/core/mod.rs
+++ b/kms-connector/crates/kms-worker/src/core/mod.rs
@@ -4,7 +4,7 @@ pub mod event_processor;
 mod kms_response_publisher;
 mod kms_worker;
 
-pub use config::{Config, CtAttestationConfig};
+pub use config::Config;
 pub use event_picker::{DbEventPicker, EventPicker};
 pub use kms_response_publisher::{DbKmsResponsePublisher, KmsResponsePublisher};
 pub use kms_worker::KmsWorker;

--- a/kms-connector/crates/kms-worker/tests/acl.rs
+++ b/kms-connector/crates/kms-worker/tests/acl.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use crate::common::{
-    create_mock_user_decryption_request_tx, init_kms_worker, mock_copro_registry_load,
-    testing_ct_attestation_config,
+    TEST_COPRO_REGISTRY_REFRESH, create_mock_user_decryption_request_tx, init_kms_worker,
+    mock_copro_registry_load,
 };
 use alloy::{
     primitives::U256,
@@ -99,7 +99,7 @@ async fn test_decryption_acl_failure(#[case] event_type: TestEventType) -> anyho
         kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
         max_decryption_attempts: MAX_DECRYPTION_ATTEMPTS,
         db_fast_event_polling: Duration::from_millis(500),
-        ct_attestation: testing_ct_attestation_config(),
+        copro_registry_refresh: TEST_COPRO_REGISTRY_REFRESH,
         ..Default::default()
     };
     let kms_worker = init_kms_worker(

--- a/kms-connector/crates/kms-worker/tests/attempt_limit.rs
+++ b/kms-connector/crates/kms-worker/tests/attempt_limit.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use crate::common::{
-    create_mock_user_decryption_request_tx, init_kms_worker, mock_copro_registry_load,
-    testing_ct_attestation_config,
+    TEST_COPRO_REGISTRY_REFRESH, create_mock_user_decryption_request_tx, init_kms_worker,
+    mock_copro_registry_load,
 };
 use alloy::{
     hex::FromHex,
@@ -120,7 +120,7 @@ async fn test_request_processing(#[case] event_type: TestEventType) -> anyhow::R
         grpc_request_retries: GRPC_REQUEST_RETRIES,
         db_fast_event_polling: Duration::from_millis(500),
         db_long_event_polling: Duration::from_millis(500),
-        ct_attestation: testing_ct_attestation_config(),
+        copro_registry_refresh: TEST_COPRO_REGISTRY_REFRESH,
         ..Default::default()
     };
     let kms_worker = init_kms_worker(

--- a/kms-connector/crates/kms-worker/tests/common/mod.rs
+++ b/kms-connector/crates/kms-worker/tests/common/mod.rs
@@ -18,7 +18,7 @@ use fhevm_gateway_bindings::{
 };
 use fhevm_host_bindings::acl::ACL::ACLInstance;
 use kms_worker::core::{
-    Config, CtAttestationConfig, DbEventPicker, DbKmsResponsePublisher, KmsWorker,
+    Config, DbEventPicker, DbKmsResponsePublisher, KmsWorker,
     event_processor::{
         CiphertextManager, DbContextManager, DbEventProcessor, DecryptionProcessor,
         KMSGenerationProcessor, KmsClient, ProtocolConfigProcessor,
@@ -52,7 +52,7 @@ pub async fn init_kms_worker<P>(
 where
     P: Provider + Clone + 'static,
 {
-    // The 24h refresh interval (see `testing_ct_attestation_config`) means the refresh task
+    // The 24h refresh interval (see `TEST_COPRO_REGISTRY_REFRESH`) means the refresh task
     // never fires during a test, so a throwaway token is fine here.
     let ciphertext_manager = CiphertextManager::connect(
         provider.clone(),
@@ -88,12 +88,8 @@ where
     Ok(kms_worker)
 }
 
-pub fn testing_ct_attestation_config() -> CtAttestationConfig {
-    CtAttestationConfig {
-        registry_refresh: Duration::from_hours(24), // Avoid refreshing the registry during test
-        ..Default::default()
-    }
-}
+/// Registry refresh interval used by the tests: long enough that the refresh task never fires.
+pub const TEST_COPRO_REGISTRY_REFRESH: Duration = Duration::from_hours(24);
 
 pub fn create_mock_user_decryption_request_tx(
     tx_hash: FixedBytes<32>,

--- a/kms-connector/crates/kms-worker/tests/common/mod.rs
+++ b/kms-connector/crates/kms-worker/tests/common/mod.rs
@@ -4,7 +4,6 @@ use alloy::{
     providers::{Provider, mock::Asserter},
     rpc::types::Transaction,
     sol_types::{SolCall, SolValue},
-    transports::http::reqwest,
 };
 use connector_utils::tests::{
     rand::rand_address,
@@ -52,15 +51,8 @@ pub async fn init_kms_worker<P>(
 where
     P: Provider + Clone + 'static,
 {
-    // The 24h refresh interval (see `TEST_COPRO_REGISTRY_REFRESH`) means the refresh task
-    // never fires during a test, so a throwaway token is fine here.
-    let ciphertext_manager = CiphertextManager::connect(
-        provider.clone(),
-        reqwest::Client::new(),
-        &config,
-        CancellationToken::new(),
-    )
-    .await?;
+    let ciphertext_manager =
+        CiphertextManager::connect(provider.clone(), &config, CancellationToken::new()).await?;
 
     let kms_client = KmsClient::connect(&config).await?;
     let event_picker = DbEventPicker::connect(db.clone(), &config).await?;

--- a/kms-connector/crates/kms-worker/tests/context.rs
+++ b/kms-connector/crates/kms-worker/tests/context.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use crate::common::{
-    create_mock_user_decryption_request_tx, init_kms_worker, mock_copro_registry_load,
-    testing_ct_attestation_config,
+    TEST_COPRO_REGISTRY_REFRESH, create_mock_user_decryption_request_tx, init_kms_worker,
+    mock_copro_registry_load,
 };
 use alloy::{
     primitives::U256,
@@ -112,7 +112,7 @@ async fn test_decryption_context_not_found(
         kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
         max_decryption_attempts: MAX_DECRYPTION_ATTEMPTS,
         db_fast_event_polling: Duration::from_millis(500),
-        ct_attestation: testing_ct_attestation_config(),
+        copro_registry_refresh: TEST_COPRO_REGISTRY_REFRESH,
         ..Default::default()
     };
     let kms_worker = init_kms_worker(
@@ -218,7 +218,7 @@ async fn test_decryption_context_invalid(#[case] event_type: TestEventType) -> a
         kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
         max_decryption_attempts: MAX_DECRYPTION_ATTEMPTS,
         db_fast_event_polling: Duration::from_millis(500),
-        ct_attestation: testing_ct_attestation_config(),
+        copro_registry_refresh: TEST_COPRO_REGISTRY_REFRESH,
         ..Default::default()
     };
     let kms_worker = init_kms_worker(
@@ -302,7 +302,7 @@ async fn test_context_destruction_invalidates_returned_epochs() -> anyhow::Resul
 
     let config = Config {
         kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
-        ct_attestation: testing_ct_attestation_config(),
+        copro_registry_refresh: TEST_COPRO_REGISTRY_REFRESH,
         ..Default::default()
     };
     let kms_worker = init_kms_worker(

--- a/kms-connector/crates/kms-worker/tests/integration_tests.rs
+++ b/kms-connector/crates/kms-worker/tests/integration_tests.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use crate::common::{
-    create_mock_user_decryption_request_tx, init_kms_worker, mock_copro_registry_load,
-    testing_ct_attestation_config,
+    TEST_COPRO_REGISTRY_REFRESH, create_mock_user_decryption_request_tx, init_kms_worker,
+    mock_copro_registry_load,
 };
 use alloy::{
     hex::FromHex,
@@ -164,7 +164,7 @@ async fn test_processing_request(
     // Starting kms_worker
     let config = Config {
         kms_core_endpoints: vec![kms_mock_server.base_url().unwrap().to_string()],
-        ct_attestation: testing_ct_attestation_config(),
+        copro_registry_refresh: TEST_COPRO_REGISTRY_REFRESH,
         ..Default::default()
     };
     let kms_worker = init_kms_worker(

--- a/kms-connector/crates/kms-worker/tests/s3.rs
+++ b/kms-connector/crates/kms-worker/tests/s3.rs
@@ -1,5 +1,4 @@
-use alloy::{hex, primitives::B256, transports::http::reqwest};
-use anyhow::anyhow;
+use alloy::{hex, primitives::B256};
 use ciphertext_attestation::{CiphertextFormat, consensus::ConsensusMaterial};
 use connector_utils::tests::setup::{
     S3_CT_BUCKET, S3_CT_DIGEST, S3_CT_HANDLE, S3_CT_KEY_ID, S3Instance, TestInstance,
@@ -7,17 +6,8 @@ use connector_utils::tests::setup::{
 use kms_grpc::kms::v1::CiphertextFormat as GrpcCiphertextFormat;
 use kms_worker::core::{
     Config,
-    event_processor::{ProcessingError, ciphertext::s3::retrieve_verified_ciphertext},
+    event_processor::{ProcessingError, ciphertext::s3::BoundedClient},
 };
-
-fn s3_http_client() -> anyhow::Result<reqwest::Client> {
-    let config = Config::default();
-    reqwest::Client::builder()
-        .connect_timeout(config.s3_connect_timeout)
-        .timeout(config.s3_get_timeout)
-        .build()
-        .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))
-}
 
 fn stored_handle() -> anyhow::Result<B256> {
     Ok(B256::from_slice(&hex::decode(S3_CT_HANDLE)?))
@@ -39,18 +29,13 @@ async fn test_get_ciphertext_from_winning_bucket() -> anyhow::Result<()> {
     let test_instance = TestInstance::builder()
         .with_s3(S3Instance::setup().await?)
         .build();
-    let s3_client = s3_http_client()?;
+    let s3_client = BoundedClient::from_config(&Config::default())?;
 
     let bucket_url = format!("{}/{S3_CT_BUCKET}", test_instance.s3_url());
-    let ct = retrieve_verified_ciphertext(
-        &s3_client,
-        stored_handle()?,
-        &stored_material()?,
-        &[bucket_url],
-        Config::default().s3_ciphertext_retrieval_attempts,
-    )
-    .await
-    .unwrap();
+    let ct = s3_client
+        .retrieve_verified_ciphertext(stored_handle()?, &stored_material()?, &[bucket_url])
+        .await
+        .unwrap();
 
     // The format is read from the attested material (`compressed_on_cpu`).
     assert_eq!(
@@ -66,22 +51,17 @@ async fn test_get_ciphertext_rejects_digest_mismatch() -> anyhow::Result<()> {
     let test_instance = TestInstance::builder()
         .with_s3(S3Instance::setup().await?)
         .build();
-    let s3_client = s3_http_client()?;
+    let s3_client = BoundedClient::from_config(&Config::default())?;
 
     let bucket_url = format!("{}/{S3_CT_BUCKET}", test_instance.s3_url());
     // The object is served, but its bytes do not match the attested digest: the copy is rejected.
     let mut material = stored_material()?;
     material.sns_ciphertext_digest = B256::repeat_byte(0xAB);
 
-    let err = retrieve_verified_ciphertext(
-        &s3_client,
-        stored_handle()?,
-        &material,
-        &[bucket_url],
-        Config::default().s3_ciphertext_retrieval_attempts,
-    )
-    .await
-    .unwrap_err();
+    let err = s3_client
+        .retrieve_verified_ciphertext(stored_handle()?, &material, &[bucket_url])
+        .await
+        .unwrap_err();
 
     assert!(matches!(err, ProcessingError::Recoverable(_)));
 
@@ -99,21 +79,16 @@ async fn test_get_unstored_ciphertext_is_unavailable() -> anyhow::Result<()> {
     let test_instance = TestInstance::builder()
         .with_s3(S3Instance::setup().await?)
         .build();
-    let s3_client = s3_http_client()?;
+    let s3_client = BoundedClient::from_config(&Config::default())?;
 
     let bucket_url = format!("{}/{S3_CT_BUCKET}", test_instance.s3_url());
     // A handle with no stored object: every winning-group bucket returns a not-found.
     let unstored_handle = B256::repeat_byte(0x02);
 
-    let err = retrieve_verified_ciphertext(
-        &s3_client,
-        unstored_handle,
-        &stored_material()?,
-        &[bucket_url],
-        Config::default().s3_ciphertext_retrieval_attempts,
-    )
-    .await
-    .unwrap_err();
+    let err = s3_client
+        .retrieve_verified_ciphertext(unstored_handle, &stored_material()?, &[bucket_url])
+        .await
+        .unwrap_err();
 
     // Unavailability is retryable: it surfaces as a recoverable error.
     assert!(matches!(err, ProcessingError::Recoverable(_)));

--- a/kms-connector/crates/kms-worker/tests/s3.rs
+++ b/kms-connector/crates/kms-worker/tests/s3.rs
@@ -14,6 +14,7 @@ fn s3_http_client() -> anyhow::Result<reqwest::Client> {
     let config = Config::default();
     reqwest::Client::builder()
         .connect_timeout(config.s3_connect_timeout)
+        .timeout(config.s3_get_timeout)
         .build()
         .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))
 }

--- a/kms-connector/crates/utils/Cargo.toml
+++ b/kms-connector/crates/utils/Cargo.toml
@@ -36,6 +36,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
@@ -49,7 +50,6 @@ toml = { workspace = true, optional = true }
 alloy = { workspace = true, features = ["json-rpc"] }
 serial_test.workspace = true
 toml.workspace = true
-tower.workspace = true
 
 [features]
 tests = [

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -73,8 +73,8 @@ pub type WalletProviderFillers = JoinFill<
 /// one of them may take.
 #[derive(Clone, Copy, Debug)]
 struct RpcCallBounds {
-    pub max_concurrent_calls: NonZeroUsize,
-    pub call_timeout: Duration,
+    max_concurrent_calls: NonZeroUsize,
+    call_timeout: Duration,
 }
 
 /// Tries to establish the connection with a RPC node.

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -11,11 +11,19 @@ use alloy::{
             WalletFiller,
         },
     },
-    transports::http::reqwest::Url,
+    rpc::client::{ClientBuilder, RpcClient},
+    transports::{
+        IntoBoxTransport, TransportFut,
+        http::{Http, reqwest::Url},
+    },
 };
 use anyhow::anyhow;
 use sqlx::{Pool, Postgres, postgres::PgPoolOptions};
-use std::{sync::Once, time::Duration};
+use std::{num::NonZeroUsize, sync::Once, time::Duration};
+use tower::{
+    limit::{GlobalConcurrencyLimitLayer, concurrency::future::ResponseFuture},
+    util::MapFutureLayer,
+};
 use tracing::{info, warn};
 
 /// The number of connection retry to connect to the database or to a RPC node.
@@ -66,7 +74,19 @@ pub async fn connect_to_rpc_node(
     rpc_node_url: Url,
     chain_id: u64,
 ) -> anyhow::Result<DefaultProvider> {
-    connect_to_rpc_node_inner(rpc_node_url, || {
+    connect_to_rpc_node_inner(rpc_node_url, None, || {
+        ProviderBuilder::new().with_chain_id(chain_id)
+    })
+    .await
+}
+
+/// Tries to establish the connection with a RPC node, bounding the calls it may have in flight.
+pub async fn connect_to_rpc_node_with_concurrency_limit(
+    rpc_node_url: Url,
+    chain_id: u64,
+    max_concurrent_calls: NonZeroUsize,
+) -> anyhow::Result<DefaultProvider> {
+    connect_to_rpc_node_inner(rpc_node_url, Some(max_concurrent_calls), || {
         ProviderBuilder::new().with_chain_id(chain_id)
     })
     .await
@@ -78,7 +98,7 @@ pub async fn connect_to_rpc_node_with_wallet(
     chain_id: u64,
     wallet: KmsWallet,
 ) -> anyhow::Result<WalletProvider> {
-    let provider = connect_to_rpc_node_inner(rpc_node_url, || {
+    let provider = connect_to_rpc_node_inner(rpc_node_url, None, || {
         ProviderBuilder::new()
             .disable_recommended_fillers()
             .with_chain_id(chain_id)
@@ -89,9 +109,26 @@ pub async fn connect_to_rpc_node_with_wallet(
     Ok(NonceManagedProvider::new(provider, wallet.address()))
 }
 
+/// An `RpcClient` which never has more than `max_concurrent_calls` JSON-RPC calls in flight.
+fn bounded_rpc_client<T: IntoBoxTransport>(
+    transport: T,
+    is_local: bool,
+    max_concurrent_calls: NonZeroUsize,
+) -> RpcClient {
+    ClientBuilder::default()
+        // Added first, so outermost: `ConcurrencyLimit` has a future type of its own, which has to
+        // be boxed back into the `TransportFut` that alloy's `Transport` bound requires.
+        .layer(MapFutureLayer::new(
+            |fut: ResponseFuture<TransportFut<'static>>| Box::pin(fut) as TransportFut<'static>,
+        ))
+        .layer(GlobalConcurrencyLimitLayer::new(max_concurrent_calls.get()))
+        .transport(transport, is_local)
+}
+
 /// Tries to establish the connection with a RPC node.
 async fn connect_to_rpc_node_inner<L, F>(
     rpc_node_url: Url,
+    max_concurrent_calls: Option<NonZeroUsize>,
     provider_builder_new: impl Fn() -> ProviderBuilder<L, F>,
 ) -> anyhow::Result<F::Provider>
 where
@@ -105,7 +142,14 @@ where
             .unwrap()
     });
 
-    let provider = provider_builder_new().connect_http(rpc_node_url.clone());
+    let transport = Http::new(rpc_node_url.clone());
+    let is_local = transport.guess_local();
+    let client = match max_concurrent_calls {
+        Some(max) => bounded_rpc_client(transport, is_local, max),
+        None => ClientBuilder::default().transport(transport, is_local),
+    };
+
+    let provider = provider_builder_new().connect_client(client);
     info!(
         "Connected to RPC node successfully ({})",
         rpc_node_url.host_str().unwrap_or("unexpected URL format")
@@ -115,3 +159,90 @@ where
 }
 
 static INSTALL_CRYPTO_PROVIDER_ONCE: Once = Once::new();
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        primitives::U64,
+        providers::Provider,
+        transports::mock::{Asserter, MockTransport},
+    };
+    use futures::future::join_all;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    const CALLS: usize = 8;
+
+    /// Highest number of calls ever in flight at the same time, and the current one.
+    #[derive(Default)]
+    struct InFlightRecorder {
+        current: AtomicUsize,
+        max: AtomicUsize,
+    }
+
+    /// A mocked node answering `CALLS` block numbers, slowly enough for the calls to overlap, and
+    /// recording how many of them are in flight.
+    fn slow_mocked_node() -> (impl IntoBoxTransport, Arc<InFlightRecorder>) {
+        let asserter = Asserter::new();
+        for _ in 0..CALLS {
+            asserter.push_success(&U64::from(1));
+        }
+
+        let in_flight = Arc::new(InFlightRecorder::default());
+        let recorder = in_flight.clone();
+        let transport = tower::ServiceBuilder::new()
+            .map_future(move |fut: TransportFut<'static>| {
+                let recorder = recorder.clone();
+                Box::pin(async move {
+                    // `fetch_add` returns the previous value, so `+ 1` is needed to get the
+                    // number of calls in flight including this one.
+                    let current = recorder.current.fetch_add(1, Ordering::SeqCst) + 1;
+                    recorder.max.fetch_max(current, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    let response = fut.await;
+                    recorder.current.fetch_sub(1, Ordering::SeqCst);
+                    response
+                }) as TransportFut<'static>
+            })
+            .service(MockTransport::new(asserter));
+
+        (transport, in_flight)
+    }
+
+    #[tokio::test]
+    async fn concurrency_limit_bounds_the_calls_in_flight() {
+        const MAX_IN_FLIGHT: usize = 2;
+
+        let (transport, in_flight) = slow_mocked_node();
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_client(bounded_rpc_client(
+                transport,
+                true,
+                NonZeroUsize::new(MAX_IN_FLIGHT).unwrap(),
+            ));
+
+        let calls_res = join_all((0..CALLS).map(|_| provider.get_block_number())).await;
+        assert!(calls_res.iter().all(|r| r.is_ok()), "{calls_res:?}");
+
+        assert_eq!(in_flight.max.load(Ordering::SeqCst), MAX_IN_FLIGHT);
+        assert_eq!(in_flight.current.load(Ordering::SeqCst), 0);
+    }
+
+    /// Guards the test above against a mocked node that would serialize the calls by itself.
+    #[tokio::test]
+    async fn unbounded_client_runs_every_call_at_once() {
+        let (transport, in_flight) = slow_mocked_node();
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .connect_client(ClientBuilder::default().transport(transport, true));
+
+        let calls_res = join_all((0..CALLS).map(|_| provider.get_block_number())).await;
+        assert!(calls_res.iter().all(|r| r.is_ok()), "{calls_res:?}");
+
+        assert_eq!(in_flight.max.load(Ordering::SeqCst), CALLS);
+    }
+}

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -14,7 +14,7 @@ use alloy::{
     rpc::client::{ClientBuilder, RpcClient},
     transports::{
         IntoBoxTransport, TransportFut,
-        http::{Http, reqwest::Url},
+        http::{Client, Http, reqwest::Url},
     },
 };
 use anyhow::anyhow;
@@ -69,6 +69,14 @@ pub type WalletProviderFillers = JoinFill<
     WalletFiller<EthereumWallet>,
 >;
 
+/// The ceilings of a RPC connection: how many calls it may have in flight, and how long any single
+/// one of them may take.
+#[derive(Clone, Copy, Debug)]
+struct RpcCallBounds {
+    pub max_concurrent_calls: NonZeroUsize,
+    pub call_timeout: Duration,
+}
+
 /// Tries to establish the connection with a RPC node.
 pub async fn connect_to_rpc_node(
     rpc_node_url: Url,
@@ -80,13 +88,19 @@ pub async fn connect_to_rpc_node(
     .await
 }
 
-/// Tries to establish the connection with a RPC node, bounding the calls it may have in flight.
-pub async fn connect_to_rpc_node_with_concurrency_limit(
+/// Tries to establish the connection with a RPC node, bounding the calls it may have in flight and
+/// the duration of each of them.
+pub async fn connect_to_rpc_node_with_bounds(
     rpc_node_url: Url,
     chain_id: u64,
     max_concurrent_calls: NonZeroUsize,
+    call_timeout: Duration,
 ) -> anyhow::Result<DefaultProvider> {
-    connect_to_rpc_node_inner(rpc_node_url, Some(max_concurrent_calls), || {
+    let bounds = RpcCallBounds {
+        max_concurrent_calls,
+        call_timeout,
+    };
+    connect_to_rpc_node_inner(rpc_node_url, Some(bounds), || {
         ProviderBuilder::new().with_chain_id(chain_id)
     })
     .await
@@ -128,7 +142,7 @@ fn bounded_rpc_client<T: IntoBoxTransport>(
 /// Tries to establish the connection with a RPC node.
 async fn connect_to_rpc_node_inner<L, F>(
     rpc_node_url: Url,
-    max_concurrent_calls: Option<NonZeroUsize>,
+    bounds: Option<RpcCallBounds>,
     provider_builder_new: impl Fn() -> ProviderBuilder<L, F>,
 ) -> anyhow::Result<F::Provider>
 where
@@ -142,11 +156,21 @@ where
             .unwrap()
     });
 
-    let transport = Http::new(rpc_node_url.clone());
-    let is_local = transport.guess_local();
-    let client = match max_concurrent_calls {
-        Some(max) => bounded_rpc_client(transport, is_local, max),
-        None => ClientBuilder::default().transport(transport, is_local),
+    let client = match bounds {
+        Some(bounds) => {
+            let http_client = Client::builder()
+                .timeout(bounds.call_timeout)
+                .build()
+                .map_err(|e| anyhow!("Failed to create the RPC HTTP client: {e}"))?;
+            let transport = Http::with_client(http_client, rpc_node_url.clone());
+            let is_local = transport.guess_local();
+            bounded_rpc_client(transport, is_local, bounds.max_concurrent_calls)
+        }
+        None => {
+            let transport = Http::new(rpc_node_url.clone());
+            let is_local = transport.guess_local();
+            ClientBuilder::default().transport(transport, is_local)
+        }
     };
 
     let provider = provider_builder_new().connect_client(client);

--- a/kms-connector/crates/utils/src/conn.rs
+++ b/kms-connector/crates/utils/src/conn.rs
@@ -187,6 +187,7 @@ static INSTALL_CRYPTO_PROVIDER_ONCE: Once = Once::new();
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::net::black_hole_server;
     use alloy::{
         primitives::U64,
         providers::Provider,
@@ -254,6 +255,29 @@ mod tests {
 
         assert_eq!(in_flight.max.load(Ordering::SeqCst), MAX_IN_FLIGHT);
         assert_eq!(in_flight.current.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn bounded_calls_end_on_their_deadline() {
+        const CALL_TIMEOUT: Duration = Duration::from_millis(200);
+
+        let (url, accept_loop) = black_hole_server().await;
+        let url = Url::parse(&url).unwrap();
+        let provider = connect_to_rpc_node_with_bounds(url, 1, NonZeroUsize::MIN, CALL_TIMEOUT)
+            .await
+            .expect("the bounded provider should have been built");
+
+        // Without the deadline, the silent node would leave this call pending forever.
+        let started = std::time::Instant::now();
+        let call = tokio::time::timeout(Duration::from_secs(5), provider.get_block_number())
+            .await
+            .expect("the call should have ended on its own deadline");
+        assert!(call.is_err(), "{call:?}");
+
+        // And the deadline is what ended it, rather than the call failing on the spot.
+        assert!(started.elapsed() >= CALL_TIMEOUT, "{:?}", started.elapsed());
+
+        accept_loop.abort();
     }
 
     /// Guards the test above against a mocked node that would serialize the calls by itself.

--- a/kms-connector/crates/utils/src/lib.rs
+++ b/kms-connector/crates/utils/src/lib.rs
@@ -7,5 +7,5 @@ pub mod signal;
 pub mod tasks;
 pub mod types;
 
-#[cfg(feature = "tests")]
+#[cfg(any(test, feature = "tests"))]
 pub mod tests;

--- a/kms-connector/crates/utils/src/tests/mod.rs
+++ b/kms-connector/crates/utils/src/tests/mod.rs
@@ -1,3 +1,8 @@
+// `net` needs no optional dependency, so it also serves this crate's own unit tests.
+#[cfg(feature = "tests")]
 pub mod db;
+pub mod net;
+#[cfg(feature = "tests")]
 pub mod rand;
+#[cfg(feature = "tests")]
 pub mod setup;

--- a/kms-connector/crates/utils/src/tests/net.rs
+++ b/kms-connector/crates/utils/src/tests/net.rs
@@ -1,0 +1,18 @@
+use tokio::{net::TcpListener, task::JoinHandle};
+
+/// Starts a socket that accepts connections and never answers them: a request sent to it can only
+/// end on a deadline of the caller's own.
+///
+/// Returns the URL of the socket, and the handle of its accept loop to abort.
+pub async fn black_hole_server() -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let accept_loop = tokio::spawn(async move {
+        // The accepted streams are kept alive, and left unanswered, until the caller aborts us.
+        let mut accepted = Vec::new();
+        while let Ok((stream, _)) = listener.accept().await {
+            accepted.push(stream);
+        }
+    });
+    (url, accept_loop)
+}


### PR DESCRIPTION
### What

The `KmsWorker` fans out one attestation `HEAD` per Coprocessor bucket and one ACL call per host chain for every decryption request it processes. With up to `task_limit` (1000) requests in flight, nothing capped how many of those outbound requests could pile up, nor how long each could hang.

This PR puts a ceiling and a timeout on both paths:

- **Host chain RPC**: `connect_to_rpc_node_with_bounds` builds the provider with a `tower` `GlobalConcurrencyLimitLayer` and a reqwest client timeout. One ceiling per configured host chain.
- **S3**: a `BoundedClient` wrapper holding a semaphore per bucket for `HEAD`s and one global semaphore for ciphertext `GET`s.

### Config

| Field | Default |
| --- | --- |
| `host_rpc_max_concurrent_calls` | 128 |
| `host_rpc_call_timeout` | 10s |
| `s3_max_concurrent_heads_per_bucket` | 64 |
| `s3_max_concurrent_gets` | 16 |
| `s3_get_timeout` | 10s |
| `s3_head_timeout` | 5s |
| `copro_registry_refresh` | 60s |

All optional, all documented in `config/kms-worker.toml`.

The two concurrency ceilings sitting high (128 ACL calls, 64 `HEAD`s per bucket) bound cheap requests: an `eth_call` and a header-only `HEAD` cost the worker almost nothing, so the point is to stay within a provider's rate limits without throttling the fan-out. `s3_max_concurrent_gets` is much lower because it bounds memory rather than requests: each `GET` buffers a whole SNS ciphertext, so 16 at once is already a lot of the worker's heap.

The timeouts are all sized well above a healthy response, as they only exist to release a hung request — neither alloy nor reqwest sets one by default. `s3_head_timeout` is the tightest since a `HEAD` returns headers only and sits in the consensus critical path, while `s3_get_timeout` has to cover a full ciphertext download.

### Issue

Closes https://github.com/zama-ai/fhevm-internal/issues/1846