### PR TITLE
fix(coprocessor): connect resolve_gcs_mode via PgConnectOptions

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/database.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/database.rs
@@ -139,6 +139,8 @@ async fn connect_options_for_database_url_with(
     }
 }
 
+/// URL with an IAM token embedded, for the `resolve_database_url` binary only.
+/// To connect, use [`connect_options_for_database_url`] instead.
 pub async fn resolve_runtime_database_url(
     database_url: &DatabaseURL,
 ) -> Result<String, DatabaseConnectionError> {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -180,15 +180,16 @@ pub async fn run_stack_version_listener(
 /// finished) — the service defaults to non-GCS (blue) mode rather than failing
 /// startup, so it does not CrashLoop waiting on migration ordering.
 pub async fn resolve_gcs_mode(database_url: &str) -> anyhow::Result<bool> {
-    // Route through `resolve_runtime_database_url` so that when AWS IAM auth is
-    // enabled we connect with a freshly rendered IAM token instead of the raw,
+    // Route through `connect_options_for_database_url` so that when AWS IAM auth is
+    // enabled we connect with a freshly minted IAM token instead of the raw,
     // password-less URL (which would bypass IAM auth and fail to authenticate).
-    // With IAM auth disabled this returns the URL unchanged.
-    let runtime_url = crate::database::resolve_runtime_database_url(
+    // Never render the token into a URL (`render_database_url_with_auth_token`):
+    // the round-trip percent-decodes it and breaks the SigV4 signature.
+    let options = crate::database::connect_options_for_database_url(
         &crate::utils::DatabaseURL::from(database_url),
     )
     .await?;
-    let mut conn = PgConnection::connect(&runtime_url).await?;
+    let mut conn = PgConnection::connect_with(&options).await?;
     let live = live_stack_version(&mut conn).await?;
     let _ = conn.close().await;
 


### PR DESCRIPTION
### Summary

`resolve_gcs_mode` passed the IAM token as the password inside a connection URL. The fix connects like the service pools already do, via `connect_options_for_database_url`, which passes the token unchanged.