### PR TITLE
chore(common): prefixed s3 path for ct

### DIFF
--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -567,8 +567,14 @@ async fn upload_ct(
     Ok(result)
 }
 
-pub(crate) fn s3_ciphertext_key(handle: &[u8], context_id: U256) -> String {
-    hex::encode(handle) + "/" + &context_id.to_string()
+/// S3 key of the ct128 (SNS) ciphertext object.
+pub(crate) fn s3_ct128_key(handle: &[u8], context_id: U256) -> String {
+    format!("ct128/{}/{}", hex::encode(handle), context_id)
+}
+
+/// S3 key of the compressed ct64 ciphertext object.
+pub(crate) fn s3_ct64_key(handle: &[u8], context_id: U256) -> String {
+    format!("ct64/{}/{}", hex::encode(handle), context_id)
 }
 
 fn b256_from_bytes(field: &str, bytes: &[u8]) -> anyhow::Result<B256> {
@@ -725,7 +731,7 @@ async fn upload_ciphertexts(
     };
 
     if *ct128_digest != NO_SNS_CIPHERTEXT_DIGEST.to_vec() {
-        let key = s3_ciphertext_key(&task.handle, context_id);
+        let key = s3_ct128_key(&task.handle, context_id);
         let digest_key = hex::encode(ct128_digest);
 
         if preserve_legacy_s3_format {
@@ -826,7 +832,7 @@ async fn upload_ciphertexts(
     {
         let ct64_compressed = task.ct64_compressed.as_ref();
         let ct64_digest = &upload_material.ct64_digest;
-        let key = s3_ciphertext_key(&task.handle, context_id);
+        let key = s3_ct64_key(&task.handle, context_id);
         let ct64_checksum_sha256 = conf
             .verify_sha256_checksum
             .then(|| match ct64_compressed.is_empty() {
@@ -1848,7 +1854,7 @@ mod tests {
         assert_eq!(row.ciphertext128.as_deref(), Some(ct128_digest.as_slice()));
         assert_eq!(row.s3_format_version, Some(S3_FORMAT_VERSION_LEGACY));
 
-        let ct64_key = s3_ciphertext_key(&handle, COPROCESSOR_CONTEXT_ID_1);
+        let ct64_key = s3_ct64_key(&handle, COPROCESSOR_CONTEXT_ID_1);
         client
             .head_object()
             .bucket(bucket_ct64)
@@ -1863,10 +1869,13 @@ mod tests {
     fn s3_key_v1() {
         let handle = B256::ZERO;
         let coprocessor_context_id = U256::ZERO;
-        let s3_key = s3_ciphertext_key(handle.as_ref(), coprocessor_context_id);
         assert_eq!(
-            "0000000000000000000000000000000000000000000000000000000000000000/0",
-            &s3_key
+            "ct128/0000000000000000000000000000000000000000000000000000000000000000/0",
+            &s3_ct128_key(handle.as_ref(), coprocessor_context_id)
+        );
+        assert_eq!(
+            "ct64/0000000000000000000000000000000000000000000000000000000000000000/0",
+            &s3_ct64_key(handle.as_ref(), coprocessor_context_id)
         );
     }
 }

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -13,8 +13,8 @@ use aws_sdk_s3::Client;
 use base64::Engine;
 use bytesize::ByteSize;
 use ciphertext_attestation::{
-    CiphertextAttestation, CiphertextAttestationPayload, CiphertextFormat, Version,
-    S3_METADATA_ATTESTATION_KEY,
+    s3_ct128_key, s3_ct64_key, CiphertextAttestation, CiphertextAttestationPayload,
+    CiphertextFormat, Version, S3_METADATA_ATTESTATION_KEY,
 };
 use fhevm_engine_common::chain_id::ChainId;
 use fhevm_engine_common::database::EVENT_CIPHERTEXTS_UPLOADED;
@@ -565,16 +565,6 @@ async fn upload_ct(
         }
     }
     Ok(result)
-}
-
-/// S3 key of the ct128 (SNS) ciphertext object.
-pub(crate) fn s3_ct128_key(handle: &[u8], context_id: U256) -> String {
-    format!("ct128/{}/{}", hex::encode(handle), context_id)
-}
-
-/// S3 key of the compressed ct64 ciphertext object.
-pub(crate) fn s3_ct64_key(handle: &[u8], context_id: U256) -> String {
-    format!("ct64/{}/{}", hex::encode(handle), context_id)
 }
 
 fn b256_from_bytes(field: &str, bytes: &[u8]) -> anyhow::Result<B256> {

--- a/coprocessor/fhevm-engine/sns-worker/src/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/s3_migration.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, panic::AssertUnwindSafe, time::Duration, time::I
 use alloy_primitives::{Address, B256, U256};
 use aws_sdk_s3::{error::SdkError, primitives::ByteStream, types::MetadataDirective, Client};
 use ciphertext_attestation::{
-    CiphertextAttestation, CiphertextAttestationPayload, CiphertextFormat, Version,
-    S3_METADATA_ATTESTATION_KEY,
+    s3_ct128_key, s3_ct64_key, CiphertextAttestation, CiphertextAttestationPayload,
+    CiphertextFormat, Version, S3_METADATA_ATTESTATION_KEY,
 };
 use fhevm_engine_common::{types::CoproSigner, utils::to_hex};
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
@@ -12,9 +12,7 @@ use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::aws_upload::{
-    check_is_ready, compute_digest, s3_ct128_key, s3_ct64_key, COPROCESSOR_CONTEXT_ID_1,
-};
+use crate::aws_upload::{check_is_ready, compute_digest, COPROCESSOR_CONTEXT_ID_1};
 use crate::{
     Ciphertext128Format, ExecutionError, S3Config, CLEAN_OLD_S3_FORMAT_VERSION,
     S3_FORMAT_VERSION_V1,

--- a/coprocessor/fhevm-engine/sns-worker/src/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/s3_migration.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::aws_upload::{
-    check_is_ready, compute_digest, s3_ciphertext_key, COPROCESSOR_CONTEXT_ID_1,
+    check_is_ready, compute_digest, s3_ct128_key, s3_ct64_key, COPROCESSOR_CONTEXT_ID_1,
 };
 use crate::{
     Ciphertext128Format, ExecutionError, S3Config, CLEAN_OLD_S3_FORMAT_VERSION,
@@ -598,7 +598,7 @@ async fn migrate_ct64_object(
         return Ok(());
     }
 
-    let key = current_s3_ciphertext_key(&material.handle);
+    let key = current_s3_ct64_key(&material.handle);
     if object_has_current_attestation(
         client,
         &s3.bucket_ct64,
@@ -674,7 +674,7 @@ async fn migrate_ct128_object(
         return Ok(());
     }
 
-    let key = current_s3_ciphertext_key(&material.handle);
+    let key = current_s3_ct128_key(&material.handle);
     let legacy_key = legacy_s3_ciphertext_key(&material.ct128_digest);
     let digest_key = hex::encode(&material.ct128_digest);
     let ct_format = material.ct128_format.to_string();
@@ -764,13 +764,11 @@ async fn migrated_objects_are_current(
     s3: &S3Config,
     material: &MigrationMaterial,
 ) -> Result<bool, ExecutionError> {
-    let key = current_s3_ciphertext_key(&material.handle);
-
     if material.has_ct64
         && !object_has_current_attestation(
             client,
             &s3.bucket_ct64,
-            &key,
+            &current_s3_ct64_key(&material.handle),
             CiphertextKind::Ct64,
             material,
         )
@@ -784,7 +782,7 @@ async fn migrated_objects_are_current(
         let key_is_current = object_has_current_attestation(
             client,
             &s3.bucket_ct128,
-            &key,
+            &current_s3_ct128_key(&material.handle),
             CiphertextKind::Ct128,
             material,
         )
@@ -1234,8 +1232,12 @@ fn attestation_format(format: Ciphertext128Format) -> Result<CiphertextFormat, E
     }
 }
 
-pub(crate) fn current_s3_ciphertext_key(handle: &[u8]) -> String {
-    s3_ciphertext_key(handle, COPROCESSOR_CONTEXT_ID_1)
+pub(crate) fn current_s3_ct128_key(handle: &[u8]) -> String {
+    s3_ct128_key(handle, COPROCESSOR_CONTEXT_ID_1)
+}
+
+pub(crate) fn current_s3_ct64_key(handle: &[u8]) -> String {
+    s3_ct64_key(handle, COPROCESSOR_CONTEXT_ID_1)
 }
 
 pub(crate) fn legacy_s3_ciphertext_key(digest: &[u8]) -> String {

--- a/coprocessor/fhevm-engine/sns-worker/src/s3_migration_dry_run.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/s3_migration_dry_run.rs
@@ -6,8 +6,8 @@ use tracing::{info, warn};
 
 use crate::{
     s3_migration::{
-        count_failed_old_format_handles, count_pending_old_format_handles,
-        current_s3_ciphertext_key, download_existing_object, fetch_ct128_bytes_from_db,
+        count_failed_old_format_handles, count_pending_old_format_handles, current_s3_ct128_key,
+        current_s3_ct64_key, download_existing_object, fetch_ct128_bytes_from_db,
         fetch_ct64_bytes_from_db, legacy_s3_ciphertext_key, object_body_matches_expected,
         object_has_current_attestation, prepare_migration_material, CiphertextKind,
         CopySourceCandidate, MigrationMaterial, MigrationRow, S3MigrationConfig,
@@ -356,7 +356,7 @@ async fn plan_ct64_object(
         return Ok(());
     }
 
-    let key = current_s3_ciphertext_key(&material.handle);
+    let key = current_s3_ct64_key(&material.handle);
     if object_has_current_attestation(
         client,
         &config.s3.bucket_ct64,
@@ -423,7 +423,7 @@ async fn plan_ct128_object(
         return Ok(());
     }
 
-    let key = current_s3_ciphertext_key(&material.handle);
+    let key = current_s3_ct128_key(&material.handle);
     let legacy_key = legacy_s3_ciphertext_key(&material.ct128_digest);
     let digest_key = hex::encode(&material.ct128_digest);
 

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -940,13 +940,21 @@ async fn assert_ciphertext128(
         assert_ciphertext_uploaded(
             test_env,
             &test_env.conf.s3.bucket_ct128,
+            &crate::aws_upload::s3_ct128_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
             handle,
             Some(ct.len() as i64),
             Some((&expected_ct_format, expected_attestation_format)),
         )
         .await?;
-        assert_ciphertext_uploaded(test_env, &test_env.conf.s3.bucket_ct64, handle, None, None)
-            .await?;
+        assert_ciphertext_uploaded(
+            test_env,
+            &test_env.conf.s3.bucket_ct64,
+            &crate::aws_upload::s3_ct64_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+            handle,
+            None,
+            None,
+        )
+        .await?;
     }
 
     Ok(())
@@ -957,12 +965,11 @@ async fn assert_ciphertext128(
 async fn assert_ciphertext_uploaded(
     test_env: &TestEnvironment,
     bucket: &String,
+    ciphertext_key: &str,
     handle: &Vec<u8>,
     expected_ct_len: Option<i64>,
     expected_ct_format: Option<(&str, CiphertextFormat)>,
 ) -> anyhow::Result<()> {
-    let ciphertext_key =
-        crate::aws_upload::s3_ciphertext_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     use crate::S3_FORMAT_VERSION_V1;
 
     let (ciphertext_digest, sns_ciphertext_digest, s3_format_version) =
@@ -971,7 +978,7 @@ async fn assert_ciphertext_uploaded(
     s3_utils::assert_key_exists(
         test_env.s3_client.to_owned(),
         bucket,
-        &ciphertext_key,
+        &ciphertext_key.to_string(),
         expected_ct_len,
         100,
     )
@@ -1118,6 +1125,7 @@ async fn wait_for_ciphertext_digest_upload_state(
 async fn assert_ciphertext_uploaded(
     _test_env: &TestEnvironment,
     _bucket: &String,
+    _ciphertext_key: &str,
     _handle: &Vec<u8>,
     _expected_ct_len: Option<i64>,
     _expected_ct_format: Option<(&str, CiphertextFormat)>,

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -10,7 +10,8 @@ use alloy_primitives::{B256, U256};
 use anyhow::{anyhow, Ok};
 use aws_config::BehaviorVersion;
 use ciphertext_attestation::{
-    CiphertextAttestation, CiphertextFormat, S3_METADATA_ATTESTATION_KEY,
+    CiphertextAttestation, CiphertextFormat, S3_CT128_KEY_PREFIX, S3_CT64_KEY_PREFIX,
+    S3_METADATA_ATTESTATION_KEY,
 };
 use fhevm_engine_common::db_keys::DbKeyId;
 use fhevm_engine_common::utils::{to_hex, DatabaseURL};
@@ -172,8 +173,8 @@ async fn run_batch_computations(
 
     clean_up(pool).await?;
 
-    assert_ciphertext_s3_object_count(test_env, bucket128, 0i64).await;
-    assert_ciphertext_s3_object_count(test_env, bucket64, 0i64).await;
+    assert_ciphertext_s3_object_count(test_env, bucket128, Some(S3_CT128_KEY_PREFIX), 0i64).await;
+    assert_ciphertext_s3_object_count(test_env, bucket64, Some(S3_CT64_KEY_PREFIX), 0i64).await;
 
     info!(batch_size, "Inserting ciphertexts ...");
 
@@ -220,8 +221,23 @@ async fn run_batch_computations(
     info!(elapsed = ?elapsed, batch_size, "Batch execution completed");
 
     // Assert that all ciphertext objects are uploaded to S3
-    assert_ciphertext_s3_object_count(test_env, bucket128, batch_size as i64 + 1).await;
-    assert_ciphertext_s3_object_count(test_env, bucket64, batch_size as i64).await;
+    assert_ciphertext_s3_object_count(
+        test_env,
+        bucket128,
+        Some(S3_CT128_KEY_PREFIX),
+        batch_size as i64,
+    )
+    .await;
+    assert_ciphertext_s3_object_count(
+        test_env,
+        bucket64,
+        Some(S3_CT64_KEY_PREFIX),
+        batch_size as i64,
+    )
+    .await;
+    // The only other object in the bucket is the single digest-keyed
+    // backward-compatible copy of the ct128 shared by the whole batch
+    assert_ciphertext_s3_object_count(test_env, bucket128, None, 2 * batch_size as i64 + 1).await;
 
     anyhow::Result::<()>::Ok(())
 }
@@ -665,7 +681,9 @@ async fn setup_localstack(
     let client: aws_sdk_s3::Client = aws_sdk_s3::Client::new(&aws_conf);
 
     recreate_bucket(&client, &conf.s3.bucket_ct128).await?;
-    recreate_bucket(&client, &conf.s3.bucket_ct64).await?;
+    if conf.s3.bucket_ct64 != conf.s3.bucket_ct128 {
+        recreate_bucket(&client, &conf.s3.bucket_ct64).await?;
+    }
 
     Ok((localstack, client))
 }
@@ -1136,21 +1154,29 @@ async fn assert_ciphertext_uploaded(
     Ok(())
 }
 
-/// Asserts that the number of ciphertext128 objects in S3 matches the expected count
+/// Asserts that the number of ciphertext objects in S3 under the given key
+/// prefix (or in the whole bucket if `None`) matches the expected count
 #[cfg(not(feature = "gpu"))]
 async fn assert_ciphertext_s3_object_count(
     test_env: &TestEnvironment,
     bucket: &String,
+    key_prefix: Option<&str>,
     expected_count: i64,
 ) {
-    s3_utils::assert_object_count(test_env.s3_client.to_owned(), bucket, expected_count as i32)
-        .await;
+    s3_utils::assert_object_count(
+        test_env.s3_client.to_owned(),
+        bucket,
+        key_prefix.map(|p| format!("{p}/")).as_deref(),
+        expected_count as i32,
+    )
+    .await;
 }
 
 #[cfg(feature = "gpu")]
 async fn assert_ciphertext_s3_object_count(
     _te: &TestEnvironment,
     _bucket: &String,
+    _key_prefix: Option<&str>,
     _expected_count: i64,
 ) {
     // No-op when GPU feature is enabled
@@ -1181,8 +1207,10 @@ fn build_test_config(url: DatabaseURL, enable_compression: bool) -> Config {
             lifo: false,
         },
         s3: S3Config {
-            bucket_ct128: "ct128".to_owned(),
-            bucket_ct64: "ct64".to_owned(),
+            // Single bucket for both ct128 and ct64, as deployed in production.
+            // Ensures the tests catch any key collision between the two artifacts.
+            bucket_ct128: "copro".to_owned(),
+            bucket_ct64: "copro".to_owned(),
             max_concurrent_uploads: 2000,
             retry_policy: S3RetryPolicy {
                 max_retries_per_upload: 100,

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -884,7 +884,7 @@ async fn assert_ciphertext128(
         let res = safe_deserialize::<CompressedSquashedNoiseCiphertextList>(&ct);
         assert!(
             res.is_ok(),
-            "Could not deserialize compressed ciphertext128. 
+            "Could not deserialize compressed ciphertext128.
             This might indicate a failed squash_noise computation."
         );
         res?.get(0)?
@@ -893,7 +893,7 @@ async fn assert_ciphertext128(
         let res = safe_deserialize::<SquashedNoiseFheUint>(&ct);
         assert!(
             res.is_ok(),
-            "Could not deserialize ciphertext128. 
+            "Could not deserialize ciphertext128.
             This might indicate a failed squash_noise computation."
         );
         res?
@@ -923,6 +923,8 @@ async fn assert_ciphertext128(
 
     #[cfg(feature = "test_s3_use_handle_as_key")]
     {
+        use ciphertext_attestation::{s3_ct128_key, s3_ct64_key};
+
         info!("Asserting ciphertext uploaded to S3");
 
         let expected_ct_format = if with_compression {
@@ -940,7 +942,7 @@ async fn assert_ciphertext128(
         assert_ciphertext_uploaded(
             test_env,
             &test_env.conf.s3.bucket_ct128,
-            &crate::aws_upload::s3_ct128_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+            &s3_ct128_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
             handle,
             Some(ct.len() as i64),
             Some((&expected_ct_format, expected_attestation_format)),
@@ -949,7 +951,7 @@ async fn assert_ciphertext128(
         assert_ciphertext_uploaded(
             test_env,
             &test_env.conf.s3.bucket_ct64,
-            &crate::aws_upload::s3_ct64_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+            &s3_ct64_key(handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
             handle,
             None,
             None,

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use alloy::signers::local::PrivateKeySigner;
 use aws_sdk_s3::primitives::ByteStream;
+use ciphertext_attestation::{s3_ct128_key, s3_ct64_key};
 use fhevm_engine_common::types::CoproSigner;
 use serial_test::serial;
 use test_harness::{
@@ -174,8 +175,7 @@ async fn test_before_and_quit_migrates_ct64_from_legacy_digest_key() {
         .await
         .expect("upload legacy ct64 digest-key object");
 
-    let current_key =
-        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_key = s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     let bucket_ct64 = conf.s3.bucket_ct64.clone();
 
     let run_result = timeout(
@@ -302,10 +302,8 @@ async fn test_before_and_quit_migrates_ct64_and_ct128_from_legacy_digest_keys() 
         .await
         .expect("upload legacy ct128 digest-key object");
 
-    let current_ct64_key =
-        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
-    let current_ct128_key =
-        crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct64_key = s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct128_key = s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     let bucket_ct64 = conf.s3.bucket_ct64.clone();
     let bucket_ct128 = conf.s3.bucket_ct128.clone();
 
@@ -421,7 +419,7 @@ async fn test_before_and_quit_records_corrupted_ct64_object_error() {
     assert_object_missing(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
-        &crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+        &s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
     )
     .await;
 }
@@ -474,7 +472,7 @@ async fn test_before_and_quit_records_corrupted_ct128_object_error() {
     assert_object_missing(
         &env.s3_client,
         &env.conf.s3.bucket_ct128,
-        &crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+        &s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
     )
     .await;
 }
@@ -498,8 +496,7 @@ async fn test_before_and_quit_rebuilds_ct64_from_db_when_legacy_object_is_missin
 
     run_result.expect("missing legacy ct64 object should be rebuilt from DB bytes");
 
-    let current_key =
-        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_key = s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     assert_object_body_eq(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
@@ -545,8 +542,7 @@ async fn test_before_and_quit_rebuilds_ct128_from_db_when_legacy_object_is_missi
 
     run_result.expect("missing legacy ct128 object should be rebuilt from DB bytes");
 
-    let current_key =
-        crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_key = s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     assert_object_body_eq(
         &env.s3_client,
         &env.conf.s3.bucket_ct128,
@@ -598,10 +594,8 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
     )
     .await;
 
-    let current_ct64_key =
-        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
-    let current_ct128_key =
-        crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct64_key = s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct128_key = s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     put_object_with_stale_metadata(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
@@ -789,8 +783,7 @@ async fn test_before_and_quit_retries_recorded_failure_and_clears_error() {
 
     run_result.expect("recorded failure should be retried and migrated");
 
-    let current_key =
-        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_key = s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     env.s3_client
         .head_object()
         .bucket(&env.conf.s3.bucket_ct64)

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
@@ -598,12 +598,14 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
     )
     .await;
 
-    let current_key =
+    let current_ct64_key =
         crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct128_key =
+        crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     put_object_with_stale_metadata(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
-        &current_key,
+        &current_ct64_key,
         ct64_bytes.clone(),
     )
     .await;
@@ -617,7 +619,7 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
     put_object_with_stale_metadata(
         &env.s3_client,
         &env.conf.s3.bucket_ct128,
-        &current_key,
+        &current_ct128_key,
         ct128_bytes.clone(),
     )
     .await;
@@ -639,7 +641,7 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
         .s3_client
         .head_object()
         .bucket(&env.conf.s3.bucket_ct64)
-        .key(&current_key)
+        .key(&current_ct64_key)
         .send()
         .await
         .expect("current ct64 object should exist after metadata rewrite");
@@ -649,7 +651,7 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
         .s3_client
         .head_object()
         .bucket(&env.conf.s3.bucket_ct128)
-        .key(&current_key)
+        .key(&current_ct128_key)
         .send()
         .await
         .expect("current ct128 object should exist after metadata rewrite");
@@ -676,14 +678,14 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
     assert_object_body_eq(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
-        &current_key,
+        &current_ct64_key,
         &ct64_bytes,
     )
     .await;
     assert_object_body_eq(
         &env.s3_client,
         &env.conf.s3.bucket_ct128,
-        &current_key,
+        &current_ct128_key,
         &ct128_bytes,
     )
     .await;

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
@@ -175,7 +175,7 @@ async fn test_before_and_quit_migrates_ct64_from_legacy_digest_key() {
         .expect("upload legacy ct64 digest-key object");
 
     let current_key =
-        crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     let bucket_ct64 = conf.s3.bucket_ct64.clone();
 
     let run_result = timeout(
@@ -302,8 +302,10 @@ async fn test_before_and_quit_migrates_ct64_and_ct128_from_legacy_digest_keys() 
         .await
         .expect("upload legacy ct128 digest-key object");
 
-    let current_key =
-        crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct64_key =
+        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+    let current_ct128_key =
+        crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     let bucket_ct64 = conf.s3.bucket_ct64.clone();
     let bucket_ct128 = conf.s3.bucket_ct128.clone();
 
@@ -319,7 +321,7 @@ async fn test_before_and_quit_migrates_ct64_and_ct128_from_legacy_digest_keys() 
     s3_client
         .head_object()
         .bucket(bucket_ct64)
-        .key(&current_key)
+        .key(&current_ct64_key)
         .send()
         .await
         .expect("current ct64 object should exist after migration");
@@ -327,7 +329,7 @@ async fn test_before_and_quit_migrates_ct64_and_ct128_from_legacy_digest_keys() 
     let current_ct128 = s3_client
         .head_object()
         .bucket(&bucket_ct128)
-        .key(&current_key)
+        .key(&current_ct128_key)
         .send()
         .await
         .expect("current ct128 object should exist after migration");
@@ -419,7 +421,7 @@ async fn test_before_and_quit_records_corrupted_ct64_object_error() {
     assert_object_missing(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
-        &crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+        &crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
     )
     .await;
 }
@@ -472,7 +474,7 @@ async fn test_before_and_quit_records_corrupted_ct128_object_error() {
     assert_object_missing(
         &env.s3_client,
         &env.conf.s3.bucket_ct128,
-        &crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
+        &crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1),
     )
     .await;
 }
@@ -497,7 +499,7 @@ async fn test_before_and_quit_rebuilds_ct64_from_db_when_legacy_object_is_missin
     run_result.expect("missing legacy ct64 object should be rebuilt from DB bytes");
 
     let current_key =
-        crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     assert_object_body_eq(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
@@ -544,7 +546,7 @@ async fn test_before_and_quit_rebuilds_ct128_from_db_when_legacy_object_is_missi
     run_result.expect("missing legacy ct128 object should be rebuilt from DB bytes");
 
     let current_key =
-        crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+        crate::aws_upload::s3_ct128_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     assert_object_body_eq(
         &env.s3_client,
         &env.conf.s3.bucket_ct128,
@@ -597,7 +599,7 @@ async fn test_before_and_quit_rewrites_current_objects_with_stale_metadata() {
     .await;
 
     let current_key =
-        crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     put_object_with_stale_metadata(
         &env.s3_client,
         &env.conf.s3.bucket_ct64,
@@ -786,7 +788,7 @@ async fn test_before_and_quit_retries_recorded_failure_and_clears_error() {
     run_result.expect("recorded failure should be retried and migrated");
 
     let current_key =
-        crate::aws_upload::s3_ciphertext_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
+        crate::aws_upload::s3_ct64_key(&handle, crate::aws_upload::COPROCESSOR_CONTEXT_ID_1);
     env.s3_client
         .head_object()
         .bucket(&env.conf.s3.bucket_ct64)

--- a/coprocessor/fhevm-engine/test-harness/src/s3_utils.rs
+++ b/coprocessor/fhevm-engine/test-harness/src/s3_utils.rs
@@ -46,8 +46,14 @@ pub async fn assert_key_exists(
     );
 }
 
-/// Asserts that the number of objects in S3 matches the expected count
-pub async fn assert_object_count(client: Client, bucket: &String, expected_count: i32) {
+/// Asserts that the number of objects in S3 under an optional key prefix matches the expected
+/// count.
+pub async fn assert_object_count(
+    client: Client,
+    bucket: &String,
+    key_prefix: Option<&str>,
+    expected_count: i32,
+) {
     let max_keys = 100_000;
 
     assert!(
@@ -60,22 +66,26 @@ pub async fn assert_object_count(client: Client, bucket: &String, expected_count
     let result = client
         .list_objects()
         .set_max_keys(Some(max_keys))
+        .set_prefix(key_prefix.map(str::to_owned))
         .bucket(bucket)
         .send()
         .await
         .expect("Failed to list objects in S3 bucket");
 
     tracing::info!(
-        "Found {} objects in S3 bucket: {}",
+        "Found {} objects in S3 bucket: {} (prefix: {:?})",
         result.contents().len(),
-        bucket
+        bucket,
+        key_prefix
     );
 
     assert_eq!(
         result.contents().len(),
         expected_count as usize,
-        "Expected {} ct objects in S3 bucket, found {}",
+        "Expected {} ct objects in S3 bucket {} (prefix: {:?}), found {}",
         expected_count,
+        bucket,
+        key_prefix,
         result.contents().len()
     );
 }

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -15,7 +15,7 @@ use alloy::{
 };
 use anyhow::anyhow;
 use ciphertext_attestation::{
-    CiphertextAttestation, CiphertextFormat, S3_METADATA_ATTESTATION_HEADER,
+    CiphertextAttestation, CiphertextFormat, S3_METADATA_ATTESTATION_HEADER, s3_ct128_key,
 };
 use connector_utils::types::handle::extract_fhe_type_from_handle;
 use fhevm_gateway_bindings::decryption::Decryption::SnsCiphertextMaterial;
@@ -31,8 +31,8 @@ const OLD_CT_FORMAT_HEADER: &str = "x-amz-meta-Ct-Format";
 /// URL of a ciphertext object in a Coprocessor bucket (RFC 023 layout).
 fn rfc023_ciphertext_url(bucket_url: &str, handle: B256) -> String {
     format!(
-        "{bucket_url}/ct128/{}/{COPROCESSOR_CONTEXT_ID}",
-        hex::encode(handle)
+        "{bucket_url}/{}",
+        s3_ct128_key(handle.as_slice(), COPROCESSOR_CONTEXT_ID)
     )
 }
 

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -31,7 +31,7 @@ const OLD_CT_FORMAT_HEADER: &str = "x-amz-meta-Ct-Format";
 /// URL of a ciphertext object in a Coprocessor bucket (RFC 023 layout).
 fn rfc023_ciphertext_url(bucket_url: &str, handle: B256) -> String {
     format!(
-        "{bucket_url}/{}/{COPROCESSOR_CONTEXT_ID}",
+        "{bucket_url}/ct128/{}/{COPROCESSOR_CONTEXT_ID}",
         hex::encode(handle)
     )
 }

--- a/kms-connector/crates/kms-worker/tests/s3.rs
+++ b/kms-connector/crates/kms-worker/tests/s3.rs
@@ -35,8 +35,8 @@ async fn test_get_ciphertext_from_s3_rfc023_url_format() -> anyhow::Result<()> {
         .build();
     let s3_client = s3_http_client()?;
 
-    // This bucket only stores the ciphertext under the RFC-023 layout (`{handle}/{context_id}`),
-    // so a successful retrieval cannot have gone through the old-URL fallback.
+    // This bucket only stores the ciphertext under the `ct128/{handle}/{context_id}` RFC-023
+    // layout, so a successful retrieval cannot have gone through the old-URL fallback.
     let bucket_url = format!("{}/{S3_CT_RFC023_BUCKET}", test_instance.s3_url());
     let sns_ct = stored_sns_ct()?;
     let ct = retrieve_s3_ciphertext(&s3_client, &bucket_url, &sns_ct, S3_CT_DIGEST)
@@ -56,7 +56,7 @@ async fn test_get_ciphertext_from_s3_old_url_format() -> anyhow::Result<()> {
         .build();
     let s3_client = s3_http_client()?;
 
-    let bucket_url = format!("{}/ct128", test_instance.s3_url());
+    let bucket_url = format!("{}/copro", test_instance.s3_url());
     let sns_ct = stored_sns_ct()?;
     let ct = retrieve_s3_ciphertext(&s3_client, &bucket_url, &sns_ct, S3_CT_DIGEST)
         .await
@@ -84,7 +84,7 @@ async fn test_get_unstored_s3_ciphertext() -> anyhow::Result<()> {
         .build();
     let s3_client = s3_http_client()?;
 
-    let bucket_url = format!("{}/ct128", test_instance.s3_url());
+    let bucket_url = format!("{}/copro", test_instance.s3_url());
     let sns_ct = SnsCiphertextMaterial {
         ctHandle: rand_u256().into(),
         snsCiphertextDigest: <[u8; 32]>::try_from(hex::decode(S3_CT_UNSTORED)?)

--- a/kms-connector/crates/utils/src/tests/setup/s3.rs
+++ b/kms-connector/crates/utils/src/tests/setup/s3.rs
@@ -22,12 +22,12 @@ pub const MINIO_SECRET_KEY: &str = "fhevm-access-secret-key";
 pub const S3_CT_HANDLE: &str = "5a88e7aa46f312ff70df6e84c85eb40cdfd42b18a9ff00000000000030390500";
 pub const S3_CT_DIGEST: &str = "3a002df21130bda55f78d4403a73007a797f4a888174a620bbffc9052a045239";
 
-/// Bucket storing the test ciphertext under the RFC-023 layout (`{handle}/{context_id}`) only.
+/// Bucket storing the test ciphertext under the RFC-023 layout (`ct128/{handle}/{context_id}`) only.
 ///
-/// Kept separate from `ct128` (old `{digest}` layout only) so tests can exercise each URL
+/// Kept separate from `copro` (old `{digest}` layout only) so tests can exercise each URL
 /// format in isolation: retrieval from this bucket cannot succeed via the old-URL fallback,
-/// and retrieval from `ct128` cannot succeed via the RFC-023 URL.
-pub const S3_CT_RFC023_BUCKET: &str = "ct128-rfc023";
+/// and retrieval from `copro` cannot succeed via the RFC-023 URL.
+pub const S3_CT_RFC023_BUCKET: &str = "copro-rfc023";
 const COPROCESSOR_CONTEXT_ID: U256 = U256::ONE;
 
 /// The `keyId` bound by the test ciphertext attestation. On-chain `SnsCiphertextMaterial`
@@ -85,14 +85,14 @@ impl S3Instance {
             mc admin user add myminio {MINIO_ACCESS_KEY} {MINIO_SECRET_KEY} &&
             mc admin policy attach myminio readwrite --user {MINIO_ACCESS_KEY} &&
             mc mb --with-lock --ignore-existing myminio/kms-public &&
-            mc mb --with-lock --ignore-existing myminio/ct128 &&
+            mc mb --with-lock --ignore-existing myminio/copro &&
             mc mb --with-lock --ignore-existing myminio/{S3_CT_RFC023_BUCKET} &&
             mc anonymous set public myminio/kms-public &&
-            mc anonymous set public myminio/ct128 &&
+            mc anonymous set public myminio/copro &&
             mc anonymous set public myminio/{S3_CT_RFC023_BUCKET} &&
-            mc cp /data/{S3_CT_DIGEST} --attr Ct-Format=compressed_on_cpu myminio/ct128/{S3_CT_DIGEST} &&
+            mc cp /data/{S3_CT_DIGEST} --attr Ct-Format=compressed_on_cpu myminio/copro/{S3_CT_DIGEST} &&
             mc cp /data/{S3_CT_DIGEST} --attr \"ct-attestation='{attestation}'\" \
-                myminio/{S3_CT_RFC023_BUCKET}/{S3_CT_HANDLE}/{COPROCESSOR_CONTEXT_ID}",
+                myminio/{S3_CT_RFC023_BUCKET}/ct128/{S3_CT_HANDLE}/{COPROCESSOR_CONTEXT_ID}",
             self.url
         );
 

--- a/shared/ciphertext-attestation/src/lib.rs
+++ b/shared/ciphertext-attestation/src/lib.rs
@@ -44,6 +44,28 @@ pub const S3_METADATA_ATTESTATION_KEY: &str = "ct-attestation";
 /// [`CiphertextAttestation`] on every ciphertext object.
 pub const S3_METADATA_ATTESTATION_HEADER: &str = "x-amz-meta-ct-attestation";
 
+/// Key prefix of ct128 (SNS) ciphertext objects in Coprocessor buckets.
+pub const S3_CT128_KEY_PREFIX: &str = "ct128";
+
+/// Key prefix of compressed ct64 ciphertext objects in Coprocessor buckets.
+pub const S3_CT64_KEY_PREFIX: &str = "ct64";
+
+/// S3 key of a ct128 (SNS) ciphertext object: `ct128/{hex(handle)}/{context_id}`.
+pub fn s3_ct128_key(handle: &[u8], coprocessor_context_id: U256) -> String {
+    format!(
+        "{S3_CT128_KEY_PREFIX}/{}/{coprocessor_context_id}",
+        hex::encode(handle)
+    )
+}
+
+/// S3 key of a compressed ct64 ciphertext object: `ct64/{hex(handle)}/{context_id}`.
+pub fn s3_ct64_key(handle: &[u8], coprocessor_context_id: U256) -> String {
+    format!(
+        "{S3_CT64_KEY_PREFIX}/{}/{coprocessor_context_id}",
+        hex::encode(handle)
+    )
+}
+
 /// Versioned encoding of the attestation. The version byte is part of the signed
 /// payload, so a stripped or downgraded `version` field flips signature recovery
 /// and is caught at verification time.

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -162,8 +162,8 @@ services:
       - --work-items-batch-size=20
       - --pg-polling-interval=30
       - --pg-pool-connections=10
-      - --bucket-name-ct64=ct64
-      - --bucket-name-ct128=ct128
+      - --bucket-name-ct64=copro
+      - --bucket-name-ct128=copro
       - --s3-max-concurrent-uploads=100
       - --s3-max-retries-per-upload=100
       - --s3-max-backoff=10s

--- a/test-suite/fhevm/docker-compose/minio-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/minio-docker-compose.yml
@@ -35,11 +35,9 @@ services:
         cat /minio_secrets/access_key
         cat /minio_secrets/secret_key
         mc mb --with-lock --ignore-existing myminio/kms-public
-        mc mb --with-lock --ignore-existing myminio/ct64
-        mc mb --with-lock --ignore-existing myminio/ct128
+        mc mb --with-lock --ignore-existing myminio/copro
         mc anonymous set public myminio/kms-public
-        mc anonymous set public myminio/ct64
-        mc anonymous set public myminio/ct128
+        mc anonymous set public myminio/copro
     volumes:
       - minio_secrets:/minio_secrets
     depends_on:

--- a/test-suite/fhevm/env/staging/.env.gateway-sc
+++ b/test-suite/fhevm/env/staging/.env.gateway-sc
@@ -67,7 +67,7 @@ NUM_COPROCESSORS=1
 # Coprocessor addresses are the transaction senders' addresses (accounts[5] - Gateway)
 COPROCESSOR_TX_SENDER_ADDRESS_0=0x6254A198F67ad40290a2E7B48aDB2d19B71f67BD
 COPROCESSOR_SIGNER_ADDRESS_0=0x6254A198F67ad40290a2E7B48aDB2d19B71f67BD
-COPROCESSOR_S3_BUCKET_URL_0=http://minio:9000/ct128
+COPROCESSOR_S3_BUCKET_URL_0=http://minio:9000/copro
 
 # =============================================================================
 # CUSTODIAN CONFIGURATION

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -441,7 +441,7 @@ const buildInstanceEnvs = async (
     const wallet = await deriveWallet(mnemonic, COPROCESSOR_WALLET_INDICES[index]);
     envs["gateway-sc"][`COPROCESSOR_TX_SENDER_ADDRESS_${index}`] = wallet.address;
     envs["gateway-sc"][`COPROCESSOR_SIGNER_ADDRESS_${index}`] = wallet.address;
-    envs["gateway-sc"][`COPROCESSOR_S3_BUCKET_URL_${index}`] = `${MINIO_INTERNAL_URL}/ct128`;
+    envs["gateway-sc"][`COPROCESSOR_S3_BUCKET_URL_${index}`] = `${MINIO_INTERNAL_URL}/copro`;
     envs["host-sc"][`COPROCESSOR_SIGNER_ADDRESS_${index}`] = wallet.address;
     if (index === 0) {
       envs["coprocessor"].TX_SENDER_PRIVATE_KEY = wallet.privateKey;

--- a/test-suite/fhevm/templates/env/.env.gateway-sc
+++ b/test-suite/fhevm/templates/env/.env.gateway-sc
@@ -67,7 +67,7 @@ NUM_COPROCESSORS=1
 # Coprocessor addresses are the transaction senders' addresses (accounts[5] - Gateway)
 COPROCESSOR_TX_SENDER_ADDRESS_0=0x6254A198F67ad40290a2E7B48aDB2d19B71f67BD
 COPROCESSOR_SIGNER_ADDRESS_0=0x6254A198F67ad40290a2E7B48aDB2d19B71f67BD
-COPROCESSOR_S3_BUCKET_URL_0=http://minio:9000/ct128
+COPROCESSOR_S3_BUCKET_URL_0=http://minio:9000/copro
 
 # =============================================================================
 # CUSTODIAN CONFIGURATION


### PR DESCRIPTION
### Problem

`sns-worker` uploads the ct64 and ct128 ciphertexts under the same S3 key (`{handle}/{context_id}`), relying on the bucket to differentiate them.
In production the chart wires `--bucket-name-ct64` and `--bucket-name-ct128` to the same bucket, so the two concurrent uploads race for one object and the last writer wins.
`kms-worker`s then fail retrieval with a digest mismatch.

###  Fix

Prefix the S3 keys by artifact type so a single bucket is safe by construction:

- ct128: `ct128/{handle}/{context_id}`
- ct64: `ct64/{handle}/{context_id}`

### Changes:

- coprocessor (sns-worker): prefixed keys for uploads; S3 migration and dry-run target the prefixed layout (migration has not been run in any environment yet, so no legacy un-prefixed data exists).
- kms-connector (kms-worker): RFC-023 URL builder fetches `{bucket_url}/ct128/{handle}/{context_id}`. The digest-URL fallback is untouched, so buckets written by v0.13 coprocessors remain readable.
- test-suite: ct64/ct128 now share a single copro bucket, mirroring the production wiring. The e2e suite would now reproduce the collision on an unfixed sns-worker.

### Follow-ups

RFC 023 needs a follow-up amendment for the new layout; same for main (re-application, since the digest fallback/compat copy were removed there)