### PR TITLE
feat(solana): add demo architecture walkthrough

### DIFF
--- a/solana/demo-dapp/README.md
+++ b/solana/demo-dapp/README.md
@@ -18,6 +18,7 @@ bun run demo:start
 
 Open `http://127.0.0.1:5173/`. The built-in wallet works immediately. Phantom or another wallet
 that supports Solana Localnet can also connect. The demo gives the wallet fee SOL and test USDC.
+The scrolling architecture walkthrough is at `http://127.0.0.1:5173/architecture.html`.
 
 ```sh
 bun run demo:stop

--- a/solana/demo-dapp/architecture.html
+++ b/solana/demo-dapp/architecture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#09090b" />
+    <title>Zama on Solana · Architecture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/architecture/main.tsx"></script>
+  </body>
+</html>

--- a/solana/demo-dapp/bun.lock
+++ b/solana/demo-dapp/bun.lock
@@ -9,6 +9,7 @@
         "@solana/kit": "6.10.0",
         "@solana/wallet-account-signer": "6.10.0",
         "@wallet-standard/react": "1.0.3",
+        "mermaid": "^11.16.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
       },
@@ -26,6 +27,12 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
@@ -80,7 +87,13 @@
 
     "@fhevm/sdk": ["@fhevm/sdk@file:../../sdk/js-sdk/src", { "dependencies": { "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "1.2.6", "@solana/kit": "6.10.0", "@solana/program-client-core": "6.10.0", "wasm-feature-detect": "^1.8.0" }, "peerDependencies": { "ethers": ">=6.8.0", "typescript": ">=5.0.4", "viem": ">=2" }, "optionalPeers": ["ethers", "typescript", "viem"] }],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
 
@@ -270,9 +283,73 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
 
@@ -281,6 +358,10 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
@@ -330,9 +411,91 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+
     "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -344,7 +507,27 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
@@ -352,11 +535,19 @@
 
     "oxlint": ["oxlint@1.60.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.60.0", "@oxlint/binding-android-arm64": "1.60.0", "@oxlint/binding-darwin-arm64": "1.60.0", "@oxlint/binding-darwin-x64": "1.60.0", "@oxlint/binding-freebsd-x64": "1.60.0", "@oxlint/binding-linux-arm-gnueabihf": "1.60.0", "@oxlint/binding-linux-arm-musleabihf": "1.60.0", "@oxlint/binding-linux-arm64-gnu": "1.60.0", "@oxlint/binding-linux-arm64-musl": "1.60.0", "@oxlint/binding-linux-ppc64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-gnu": "1.60.0", "@oxlint/binding-linux-riscv64-musl": "1.60.0", "@oxlint/binding-linux-s390x-gnu": "1.60.0", "@oxlint/binding-linux-x64-gnu": "1.60.0", "@oxlint/binding-linux-x64-musl": "1.60.0", "@oxlint/binding-openharmony-arm64": "1.60.0", "@oxlint/binding-win32-arm64-msvc": "1.60.0", "@oxlint/binding-win32-ia32-msvc": "1.60.0", "@oxlint/binding-win32-x64-msvc": "1.60.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.18.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw=="],
 
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
@@ -368,7 +559,15 @@
 
     "react-test-renderer": ["react-test-renderer@19.2.7", "", { "dependencies": { "react-is": "^19.2.7", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.62.3", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.3", "@rollup/rollup-android-arm64": "4.62.3", "@rollup/rollup-darwin-arm64": "4.62.3", "@rollup/rollup-darwin-x64": "4.62.3", "@rollup/rollup-freebsd-arm64": "4.62.3", "@rollup/rollup-freebsd-x64": "4.62.3", "@rollup/rollup-linux-arm-gnueabihf": "4.62.3", "@rollup/rollup-linux-arm-musleabihf": "4.62.3", "@rollup/rollup-linux-arm64-gnu": "4.62.3", "@rollup/rollup-linux-arm64-musl": "4.62.3", "@rollup/rollup-linux-loong64-gnu": "4.62.3", "@rollup/rollup-linux-loong64-musl": "4.62.3", "@rollup/rollup-linux-ppc64-gnu": "4.62.3", "@rollup/rollup-linux-ppc64-musl": "4.62.3", "@rollup/rollup-linux-riscv64-gnu": "4.62.3", "@rollup/rollup-linux-riscv64-musl": "4.62.3", "@rollup/rollup-linux-s390x-gnu": "4.62.3", "@rollup/rollup-linux-x64-gnu": "4.62.3", "@rollup/rollup-linux-x64-musl": "4.62.3", "@rollup/rollup-openbsd-x64": "4.62.3", "@rollup/rollup-openharmony-arm64": "4.62.3", "@rollup/rollup-win32-arm64-msvc": "4.62.3", "@rollup/rollup-win32-ia32-msvc": "4.62.3", "@rollup/rollup-win32-x64-gnu": "4.62.3", "@rollup/rollup-win32-x64-msvc": "4.62.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -380,6 +579,8 @@
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -388,9 +589,13 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
@@ -405,5 +610,19 @@
     "@solana/rpc-transport-http/undici-types": ["undici-types@8.9.0", "", {}, "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg=="],
 
     "@wallet-standard/errors/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
   }
 }

--- a/solana/demo-dapp/package.json
+++ b/solana/demo-dapp/package.json
@@ -15,6 +15,7 @@
     "@solana/kit": "6.10.0",
     "@solana/wallet-account-signer": "6.10.0",
     "@wallet-standard/react": "1.0.3",
+    "mermaid": "^11.16.0",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/solana/demo-dapp/src/DeveloperEvidence.tsx
+++ b/solana/demo-dapp/src/DeveloperEvidence.tsx
@@ -6,6 +6,13 @@ import {
   readTransactionEvidence,
   type DecryptionEvidenceRecord,
 } from './evidenceStore';
+import {
+  FHE_BATCH_P95_QUERY,
+  jaegerDecryptUrl,
+  KMS_DECRYPT_P95_QUERY,
+  prometheusQueryUrl,
+  STACK_HEALTH_QUERY,
+} from './observabilityLinks';
 import { readConfidentialBalanceEvidence, type ConfidentialBalanceEvidence } from './revealShares';
 import type { DemoController } from './useDemoController';
 
@@ -211,6 +218,20 @@ export function DeveloperEvidence({ controller }: { readonly controller: DemoCon
             Refresh
           </button>
         </div>
+        <nav className="evidence-observability" aria-label="Local observability">
+          <a href={jaegerDecryptUrl()} target="_blank" rel="noreferrer">
+            User decrypt traces
+          </a>
+          <a href={prometheusQueryUrl(STACK_HEALTH_QUERY)} target="_blank" rel="noreferrer">
+            Stack health
+          </a>
+          <a href={prometheusQueryUrl(KMS_DECRYPT_P95_QUERY)} target="_blank" rel="noreferrer">
+            KMS decrypt p95
+          </a>
+          <a href={prometheusQueryUrl(FHE_BATCH_P95_QUERY)} target="_blank" rel="noreferrer">
+            FHE compute p95
+          </a>
+        </nav>
         <dl>
           <div>
             <dt>RPC</dt>
@@ -231,6 +252,9 @@ export function DeveloperEvidence({ controller }: { readonly controller: DemoCon
                 <dd>
                   <CopyValue label="cShares handle" value={shares.handle} />
                 </dd>
+                <a className="evidence-link" href={jaegerDecryptUrl(shares.handle)} target="_blank" rel="noreferrer">
+                  Trace in Jaeger
+                </a>
               </div>
               <div>
                 <dt>Encrypted-value account</dt>
@@ -246,6 +270,9 @@ export function DeveloperEvidence({ controller }: { readonly controller: DemoCon
               <dd>
                 <CopyValue label="cUSDC handle" value={claimedUsdc.handle} />
               </dd>
+              <a className="evidence-link" href={jaegerDecryptUrl(claimedUsdc.handle)} target="_blank" rel="noreferrer">
+                Trace in Jaeger
+              </a>
             </div>
           )}
         </dl>
@@ -299,6 +326,14 @@ export function DeveloperEvidence({ controller }: { readonly controller: DemoCon
                   <span className="decryption-identifiers">
                     <CopyValue label="decryption handle" value={decryption.handle} />
                     <CopyValue label="decryption job id" value={decryption.jobId} />
+                    <a
+                      className="evidence-link"
+                      href={jaegerDecryptUrl(decryption.handle)}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Trace in Jaeger
+                    </a>
                   </span>
                   <small>
                     {(decryption.totalElapsedMs / 1_000).toFixed(2)}s wallet→cleartext ·{' '}

--- a/solana/demo-dapp/src/PortfolioOverview.test.tsx
+++ b/solana/demo-dapp/src/PortfolioOverview.test.tsx
@@ -161,7 +161,7 @@ describe('PortfolioOverview', () => {
     ]);
     const reveal = renderer!.root
       .findAllByType('button')
-      .find((button) => button.children.includes('Reveal cUSDC to continue'));
+      .find((button) => button.children.includes('Decrypt cUSDC balance to continue'));
     act(() => reveal!.props.onClick());
     expect(value.actions.revealUsdc).toHaveBeenCalledOnce();
     expect(deposit).not.toHaveBeenCalled();

--- a/solana/demo-dapp/src/PortfolioOverview.tsx
+++ b/solana/demo-dapp/src/PortfolioOverview.tsx
@@ -196,11 +196,11 @@ export function PortfolioOverview({ controller }: { readonly controller: DemoCon
                   <button
                     className="balance-action"
                     type="button"
-                    aria-label={revealedUsdc === null ? 'Reveal cUSDC balance' : 'Hide cUSDC balance'}
+                    aria-label={revealedUsdc === null ? 'Decrypt cUSDC balance' : 'Hide cUSDC balance'}
                     disabled={privateActionRunning}
                     onClick={revealedUsdc === null ? actions.revealUsdc : actions.hideUsdc}
                   >
-                    {revealedUsdc === null ? 'Reveal' : 'Hide'}
+                    {revealedUsdc === null ? 'Decrypt' : 'Hide'}
                   </button>
                 )}
               </div>
@@ -327,7 +327,7 @@ export function PortfolioOverview({ controller }: { readonly controller: DemoCon
                       : 'One transaction'
               }
             >
-              {depositSource === 'cusdc' && revealedUsdc === null && <span>1 · Reveal balance</span>}
+              {depositSource === 'cusdc' && revealedUsdc === null && <span>1 · Decrypt balance</span>}
               {depositSource === 'usdc' && <span>1 · Shield if needed</span>}
               <span>
                 {depositSource === 'usdc' || (depositSource === 'cusdc' && revealedUsdc === null)
@@ -343,6 +343,11 @@ export function PortfolioOverview({ controller }: { readonly controller: DemoCon
             <button
               className="primary-action"
               type="button"
+              title={
+                confidentialBalanceUnknown
+                  ? 'Decrypts the balance only in this browser so the deposit amount can be checked.'
+                  : undefined
+              }
               disabled={
                 !connected ||
                 depositRunning ||
@@ -360,9 +365,9 @@ export function PortfolioOverview({ controller }: { readonly controller: DemoCon
               }}
             >
               {revealingUsdc && confidentialBalanceUnknown
-                ? 'Revealing cUSDC…'
+                ? 'Decrypting cUSDC…'
                 : confidentialBalanceUnknown
-                  ? 'Reveal cUSDC to continue'
+                  ? 'Decrypt cUSDC balance to continue'
                   : depositRunning
                     ? 'Depositing…'
                     : depositSource === 'usdc'
@@ -376,7 +381,7 @@ export function PortfolioOverview({ controller }: { readonly controller: DemoCon
             )}
             {confidentialBalanceTooLow && (
               <p className="input-error" role="alert">
-                Your revealed cUSDC balance is too low for this deposit.
+                The decrypted cUSDC balance is too low for this deposit.
               </p>
             )}
             {depositSource === 'cusdc' && revealedUsdc !== null && !confidentialBalanceTooLow && (

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -66,35 +66,6 @@ flowchart LR
 `,
   },
   {
-    title: 'Solana architecture',
-    statement: 'A cUSDC deposit updates three accounts across three programs.',
-    diagram: String.raw`
-flowchart TB
-    subgraph action["One atomic transaction"]
-        direction TB
-        Wallet["Wallet approves<br/>Deposit 100 cUSDC"]
-        Batcher["Batcher validates<br/>deposit eligibility"]
-        Token["Confidential token moves<br/>the encrypted amount"]
-        Host["Zama host records<br/>the encrypted calculation"]
-
-        Wallet --> Batcher
-        Batcher -->|"program call · CPI"| Token
-        Token -->|"requests encrypted arithmetic"| Host
-    end
-
-    subgraph state["Updated accounts"]
-        direction TB
-        UserBalance["cUSDC balance<br/>encrypted"]
-        JoinedAmount["Joined deposit<br/>encrypted"]
-        BatchState["Batch status<br/>public"]
-    end
-
-    Token --> UserBalance
-    Batcher --> JoinedAmount
-    Batcher --> BatchState
-`,
-  },
-  {
     title: 'Shield',
     statement: 'Shielding locks USDC and credits an encrypted cUSDC balance.',
     diagram: String.raw`
@@ -132,63 +103,57 @@ sequenceDiagram
 `,
   },
   {
-    title: 'Encrypted state',
-    statement: 'One EncryptedValue account tracks the current handle and permission history.',
+    title: 'Encrypted execution',
+    statement: 'Host instructions define handles; the coprocessor materializes their ciphertexts.',
     diagram: String.raw`
-flowchart LR
-    Value["EncryptedValue PDA<br/>stable logical balance"]
-    Value --> Current["Current handle H3"]
-    Value --> Subjects["Allowed users and programs"]
-    Value --> Peaks["Compact history peaks"]
-    H1["Old handle H1"] --> Peaks
-    H2["Old handle H2"] --> Peaks
-    Current --> Material["Encrypted material<br/>stored off-chain"]
-`,
-  },
-  {
-    title: 'Compute pipeline',
-    statement: 'The listener converts confirmed host instructions into coprocessor jobs.',
-    diagram: String.raw`
-flowchart LR
-    Tx["Confirmed transaction"] --> Yellowstone["Yellowstone stream"]
-    Yellowstone --> Listener["Host listener"]
-    Listener --> Job["Reconstructed computation"]
-    Job --> Worker["Encrypted compute worker"]
-    Worker --> Ciphertext["Encrypted result"]
-    Worker --> Material["Gateway material record"]
-`,
-  },
-  {
-    title: 'Public settlement',
-    statement: 'Settlement decrypts the batch total and deposits it into the vault.',
-    diagram: String.raw`
-sequenceDiagram
-    participant Batch as Batcher
-    participant Host as Zama host
-    participant Proof as Proof service
-    participant Keys as Key service
-    participant Settle as Solana settlement
-    participant Vault
+flowchart TB
+    subgraph solana["Solana"]
+        direction LR
+        Tx["Confirmed host instruction"]
+        Value["EncryptedValue PDA<br/>permissions and history"]
+        Handle["Current handle"]
+        Tx --> Value --> Handle
+    end
 
-    Batch->>Host: Burn encrypted batch balance
-    Host->>Host: Release the exact burned handle
-    Proof-->>Keys: History inclusion proof
-    Keys-->>Settle: Clear total and signed certificate
-    Settle->>Settle: Verify proof and certificate
-    Settle->>Vault: Deposit public batch total
+    subgraph services["Encrypted services"]
+        direction LR
+        Yellowstone["Yellowstone stream"]
+        Listener["Host listener"]
+        Worker["Encrypted compute"]
+        Material["Encrypted material"]
+        Yellowstone --> Listener --> Worker --> Material
+    end
+
+    Tx --> Yellowstone
+    Value --> History["Old permissions<br/>MMR peaks"]
+    Handle -.->|"identifies"| Material
 `,
   },
   {
-    title: 'Claim',
-    statement: 'A claim computes and transfers each encrypted share allocation.',
+    title: 'Settle and claim',
+    statement: 'The public vault receives the batch total; encrypted shares are allocated per deposit.',
     diagram: String.raw`
-flowchart LR
-    Deposit["Encrypted user deposit"] --> Formula["deposit × batch shares ÷ batch total"]
-    Shares["Public batch shares"] --> Formula
-    Total["Public batch total"] --> Formula
-    Formula --> Claim["Encrypted user allocation"]
-    Claim --> Transfer["Confidential transfer"]
-    Transfer --> Balance["User cShares"]
+flowchart TB
+    subgraph settlement["Settle public total"]
+        direction LR
+        Burn["Batcher burns<br/>encrypted batch balance"]
+        Proof["Proof service proves<br/>the released handle"]
+        KMS["KMS returns total<br/>and signed certificate"]
+        Solana["Solana verifies<br/>proof and certificate"]
+        Vault["Vault deposits total<br/>and returns public shares"]
+        Burn --> Proof --> KMS --> Solana --> Vault
+    end
+
+    subgraph claim["Claim encrypted shares"]
+        direction LR
+        Deposit["Encrypted deposit"]
+        Formula["deposit × shares ÷ total"]
+        Allocation["Encrypted cShares allocation"]
+        Deposit --> Formula --> Allocation
+    end
+
+    Vault -->|"public shares"| Formula
+    KMS -->|"public total"| Formula
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -118,56 +118,6 @@ flowchart TB
 `,
   },
   {
-    title: 'System architecture',
-    statement: 'The dApp connects Solana to encrypted services.',
-    diagram: String.raw`
-flowchart LR
-    subgraph browser["Browser"]
-        Dapp["Demo dApp"]
-        Wallet["Phantom"]
-        Dapp <--> Wallet
-    end
-
-    subgraph solana["Solana"]
-        Validator["Validator"]
-        Programs["Vault · Batcher · Token · Host"]
-        State["Accounts and PDAs"]
-        Validator --> Programs --> State
-    end
-
-    subgraph services["Encrypted services"]
-        Yellowstone["Yellowstone"]
-        Listener["Host listener"]
-        Compute["Encrypted compute"]
-        Storage["Encrypted data"]
-        Proof["History proofs"]
-        Relayer["Request service"]
-        Keys["Key service"]
-        Yellowstone --> Listener --> Compute --> Storage
-        Proof --> Keys
-        Relayer <--> Keys
-    end
-
-    Dapp --> Validator
-    Validator --> Yellowstone
-    Dapp --> Relayer
-    State -. authorization .-> Proof
-`,
-  },
-  {
-    title: 'Vault design',
-    statement: 'The batcher aggregates private deposits into one public vault deposit.',
-    diagram: String.raw`
-flowchart LR
-    Alice["Alice<br/>encrypted amount"] --> Batch["Confidential batcher"]
-    Bob["Bob<br/>encrypted amount"] --> Batch
-    Batch -->|"public total"| Vault["Public vault"]
-    Vault -->|"normal shares"| Batch
-    Batch -->|"encrypted allocation"| AliceShares["Alice cShares"]
-    Batch -->|"encrypted allocation"| BobShares["Bob cShares"]
-`,
-  },
-  {
     title: 'Shield',
     statement: 'Shielding locks USDC and credits an encrypted cUSDC balance.',
     diagram: String.raw`
@@ -249,20 +199,6 @@ sequenceDiagram
     Keys-->>Settle: Clear total and signed certificate
     Settle->>Settle: Verify proof and certificate
     Settle->>Vault: Deposit public batch total
-`,
-  },
-  {
-    title: 'History',
-    statement: 'MMR proofs preserve access to previous handles.',
-    diagram: String.raw`
-flowchart LR
-    H1["Handle H1"] --> L1["Alice could access H1"]
-    H2["Handle H2"] --> L2["Alice could access H2"]
-    H3["Current handle H3"] --> Value["EncryptedValue PDA"]
-    L1 --> MMR["MMR peaks on Solana"]
-    L2 --> MMR
-    MMR --> Proof["Small inclusion proof"]
-    Proof --> Check["Verified before decryption"]
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -1,22 +1,11 @@
 import mermaid from 'mermaid';
 import { useEffect } from 'react';
 
-type DiagramFrame = {
+type ArchitectureFrame = {
   readonly title: string;
   readonly statement: string;
   readonly diagram: string;
 };
-
-type GlossaryFrame = {
-  readonly title: string;
-  readonly statement: string;
-  readonly terms: readonly {
-    readonly term: string;
-    readonly definition: string;
-  }[];
-};
-
-type ArchitectureFrame = DiagramFrame | GlossaryFrame;
 
 const frames: readonly ArchitectureFrame[] = [
   {
@@ -71,64 +60,65 @@ flowchart LR
 `,
   },
   {
-    title: 'Protocol glossary',
-    statement: 'Each protocol layer has one job.',
-    terms: [
-      {
-        term: 'SDK',
-        definition: 'Encrypts inputs, builds requests and opens user-decrypt results.',
-      },
-      {
-        term: 'Host contract / program',
-        definition: 'Records encrypted operations and enforces who may use their results.',
-      },
-      {
-        term: 'Relayer',
-        definition: 'Carries SDK requests to protocol services and returns their results.',
-      },
-      {
-        term: 'Gateway',
-        definition: 'Keeps encrypted material and decryption work synchronized across the protocol.',
-      },
-      {
-        term: 'Coprocessor',
-        definition: 'Reconstructs confirmed operations and computes them over ciphertexts.',
-      },
-      {
-        term: 'KMS',
-        definition: 'Checks decryption rights and combines secret-key shares to release a result.',
-      },
-    ],
+    title: 'Protocol architecture',
+    statement: 'Each layer carries encrypted work to the next.',
+    diagram: String.raw`
+flowchart TB
+    subgraph client["User side"]
+        direction LR
+        User["User"] --> SDK["SDK<br/>encrypts inputs and opens results"]
+        SDK --> Relayer["Relayer<br/>carries requests and results"]
+    end
+
+    subgraph hostchain["Host chain"]
+        Host["Host contract / program<br/>records operations and permissions"]
+    end
+
+    subgraph network["Encrypted network"]
+        direction LR
+        Coprocessor["Coprocessor<br/>computes over ciphertexts"]
+        Gateway["Gateway<br/>coordinates encrypted material<br/>and decryption work"]
+        KMS["KMS<br/>checks rights and releases<br/>authorized results"]
+        Coprocessor --> Gateway
+    end
+
+    SDK -->|"encrypted transaction"| Host
+    Host -->|"confirmed operations"| Coprocessor
+    Relayer <-->|"request / protected result"| Gateway
+    Gateway <-->|"authorized decrypt"| KMS
+`,
   },
   {
-    title: 'Solana glossary',
-    statement: 'Solana gives every rule and encrypted value a concrete execution path.',
-    terms: [
-      {
-        term: 'Program',
-        definition: 'Executes code; mutable state lives in separate accounts.',
-      },
-      {
-        term: 'PDA',
-        definition: 'Gives a program a deterministic address with no private key.',
-      },
-      {
-        term: 'CPI',
-        definition: 'Lets one program call another with the authority already present.',
-      },
-      {
-        term: 'Handle',
-        definition: 'Identifies one ciphertext and its metadata; it is not the ciphertext.',
-      },
-      {
-        term: 'EncryptedValue',
-        definition: 'Keeps the current handle, permissions and compact history at one stable PDA.',
-      },
-      {
-        term: 'MMR',
-        definition: 'Commits old permissions into compact, append-only history.',
-      },
-    ],
+    title: 'Solana architecture',
+    statement: 'Programs execute the rules; accounts hold the encrypted state.',
+    diagram: String.raw`
+flowchart TB
+    subgraph transaction["One Solana transaction"]
+        direction LR
+        Instruction["Instruction<br/>names a program, accounts and data"]
+        ProgramA["Program<br/>executes code"]
+        CPI["CPI<br/>calls another program"]
+        ProgramB["Program<br/>reuses existing logic"]
+        Instruction --> ProgramA --> CPI --> ProgramB
+    end
+
+    subgraph state["Encrypted state"]
+        direction TB
+        PDA["PDA<br/>deterministic address<br/>with no private key"]
+        EncryptedValue["EncryptedValue<br/>stable account for one value"]
+        PDA --> EncryptedValue
+
+        Handle["Handle<br/>identifies the current ciphertext"]
+        Material["Encrypted material<br/>stored off-chain"]
+        EncryptedValue --> Handle --> Material
+
+        Permissions["Current permissions"]
+        MMR["MMR<br/>compact history of old permissions"]
+        EncryptedValue --> Permissions --> MMR
+    end
+
+    ProgramA -->|"reads and writes"| PDA
+`,
   },
   {
     title: 'Complete system',
@@ -374,20 +364,9 @@ export function ArchitecturePage() {
             </p>
             <h1>{frame.statement}</h1>
           </header>
-          {'diagram' in frame ? (
-            <div className="diagram-shell">
-              <pre className="mermaid">{frame.diagram}</pre>
-            </div>
-          ) : (
-            <dl className="glossary-grid">
-              {frame.terms.map(({ term, definition }) => (
-                <div className="glossary-entry" key={term}>
-                  <dt>{term}</dt>
-                  <dd>{definition}</dd>
-                </div>
-              ))}
-            </dl>
-          )}
+          <div className="diagram-shell">
+            <pre className="mermaid">{frame.diagram}</pre>
+          </div>
         </section>
       ))}
     </main>

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -126,30 +126,6 @@ sequenceDiagram
 `,
   },
   {
-    title: 'Join',
-    statement: 'Joining transfers encrypted cUSDC into the current batch.',
-    diagram: String.raw`
-sequenceDiagram
-    box User device
-        participant Wallet
-        participant SDK
-    end
-    box Solana
-        participant Batch as Batcher
-        participant Token as Confidential token
-        participant Host as Zama host
-    end
-
-    SDK->>Wallet: Build join with encrypted amount and attestation
-    Wallet->>Batch: Sign and submit join
-    Batch->>Token: Confidential transfer by CPI
-    Token->>Host: Verify coprocessor attestation inside transfer
-    Token->>Host: Record encrypted operations
-    Host-->>Token: New balance handles
-    Token-->>Batch: New encrypted joined amount
-`,
-  },
-  {
     title: 'Encrypted execution',
     statement: 'Host instructions define handles; the coprocessor materializes their ciphertexts.',
     diagram: String.raw`

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -1,0 +1,262 @@
+import mermaid from 'mermaid';
+import { useEffect } from 'react';
+
+type ArchitectureFrame = {
+  readonly title: string;
+  readonly statement: string;
+  readonly diagram: string;
+};
+
+const frames: readonly ArchitectureFrame[] = [
+  {
+    title: 'Complete system',
+    statement: 'Solana records the rules; encrypted services execute the work.',
+    diagram: String.raw`
+flowchart LR
+    subgraph browser["Browser"]
+        Dapp["Demo dApp"]
+        Wallet["Phantom"]
+        Dapp <--> Wallet
+    end
+
+    subgraph solana["Solana"]
+        Validator["Validator"]
+        Programs["Vault · Batcher · Token · Host"]
+        State["Accounts and PDAs"]
+        Validator --> Programs --> State
+    end
+
+    subgraph services["Encrypted services"]
+        Yellowstone["Yellowstone"]
+        Listener["Host listener"]
+        Compute["Encrypted compute"]
+        Storage["Encrypted data"]
+        Proof["History proofs"]
+        Relayer["Request service"]
+        Keys["Key service"]
+        Yellowstone --> Listener --> Compute --> Storage
+        Proof --> Keys
+        Relayer <--> Keys
+    end
+
+    Dapp --> Validator
+    Validator --> Yellowstone
+    Dapp --> Relayer
+    State -. authorization .-> Proof
+`,
+  },
+  {
+    title: 'Vault design',
+    statement: 'The batcher hides each amount and reveals only the total.',
+    diagram: String.raw`
+flowchart LR
+    Alice["Alice<br/>encrypted amount"] --> Batch["Confidential batcher"]
+    Bob["Bob<br/>encrypted amount"] --> Batch
+    Batch -->|"public total"| Vault["Public vault"]
+    Vault -->|"normal shares"| Batch
+    Batch -->|"encrypted allocation"| AliceShares["Alice cShares"]
+    Batch -->|"encrypted allocation"| BobShares["Bob cShares"]
+`,
+  },
+  {
+    title: 'Shield',
+    statement: 'Public USDC enters custody and becomes private spending power.',
+    diagram: String.raw`
+sequenceDiagram
+    participant Wallet
+    participant Token as Confidential token
+    participant SPL as SPL Token
+    participant Host as Zama host
+
+    Wallet->>Token: Shield public USDC
+    Token->>SPL: Move USDC into wrapper custody
+    Token->>Host: Encrypt the public amount
+    Token->>Host: Add to encrypted balance and supply
+    Host-->>Token: New balance and supply handles
+`,
+  },
+  {
+    title: 'Join',
+    statement: 'A verified encrypted amount moves into the private batch.',
+    diagram: String.raw`
+sequenceDiagram
+    participant Browser
+    participant Input as Input verification
+    participant Wallet
+    participant Batch as Batcher
+    participant Token as Confidential token
+    participant Host as Zama host
+
+    Browser->>Input: Encrypted deposit amount
+    Input-->>Browser: Signed verification
+    Wallet->>Batch: Join batch
+    Batch->>Token: Confidential transfer by CPI
+    Token->>Host: Verify input and record operations
+    Host-->>Batch: New encrypted joined amount
+`,
+  },
+  {
+    title: 'Encrypted state',
+    statement: 'The account stays fixed while its encrypted value changes.',
+    diagram: String.raw`
+flowchart LR
+    Value["EncryptedValue PDA<br/>stable logical balance"]
+    Value --> Current["Current handle H3"]
+    Value --> Subjects["Allowed users and programs"]
+    Value --> Peaks["Compact history peaks"]
+    H1["Old handle H1"] --> Peaks
+    H2["Old handle H2"] --> Peaks
+    Current --> Material["Encrypted material<br/>stored off-chain"]
+`,
+  },
+  {
+    title: 'Compute pipeline',
+    statement: 'Confirmed Solana instructions become encrypted computation jobs.',
+    diagram: String.raw`
+flowchart LR
+    Tx["Confirmed transaction"] --> Yellowstone["Yellowstone stream"]
+    Yellowstone --> Listener["Host listener"]
+    Listener --> Job["Reconstructed computation"]
+    Job --> Worker["Encrypted compute worker"]
+    Worker --> Ciphertext["Encrypted result"]
+    Worker --> Material["Gateway material record"]
+`,
+  },
+  {
+    title: 'Public settlement',
+    statement: 'A proven batch total crosses into the public vault.',
+    diagram: String.raw`
+sequenceDiagram
+    participant Batch as Batcher
+    participant Host as Zama host
+    participant Proof as Proof service
+    participant Keys as Key service
+    participant Settle as Solana settlement
+    participant Vault
+
+    Batch->>Host: Burn encrypted batch balance
+    Host->>Host: Release the exact burned handle
+    Proof-->>Keys: History inclusion proof
+    Keys-->>Settle: Clear total and signed certificate
+    Settle->>Settle: Verify proof and certificate
+    Settle->>Vault: Deposit public batch total
+`,
+  },
+  {
+    title: 'History',
+    statement: 'Compact history keeps old decrypt rights verifiable.',
+    diagram: String.raw`
+flowchart LR
+    H1["Handle H1"] --> L1["Alice could access H1"]
+    H2["Handle H2"] --> L2["Alice could access H2"]
+    H3["Current handle H3"] --> Value["EncryptedValue PDA"]
+    L1 --> MMR["MMR peaks on Solana"]
+    L2 --> MMR
+    MMR --> Proof["Small inclusion proof"]
+    Proof --> Check["Verified before decryption"]
+`,
+  },
+  {
+    title: 'Claim',
+    statement: 'Public ratios allocate encrypted shares without revealing deposits.',
+    diagram: String.raw`
+flowchart LR
+    Deposit["Encrypted user deposit"] --> Formula["deposit × batch shares ÷ batch total"]
+    Shares["Public batch shares"] --> Formula
+    Total["Public batch total"] --> Formula
+    Formula --> Claim["Encrypted user allocation"]
+    Claim --> Transfer["Confidential transfer"]
+    Transfer --> Balance["User cShares"]
+`,
+  },
+  {
+    title: 'User decrypt',
+    statement: 'The wallet authorizes a value that opens only in the browser.',
+    diagram: String.raw`
+sequenceDiagram
+    participant Browser
+    participant Wallet as Phantom
+    participant Relayer as Request service
+    participant Keys as Key service
+
+    Browser->>Browser: Create fresh transport key
+    Wallet->>Browser: Sign decryption request
+    Browser->>Relayer: Signed request and public key
+    Relayer->>Keys: Check Solana authorization
+    Keys-->>Relayer: Signcrypted response
+    Relayer-->>Browser: Opaque response
+    Browser->>Browser: Recover the clear value
+`,
+  },
+  {
+    title: 'Redeem',
+    statement: 'Encrypted shares return through the same private doorway.',
+    diagram: String.raw`
+flowchart LR
+    Shares["User cShares"] -->|"encrypted amount"| Batch["Redeem batch"]
+    Batch -->|"public share total"| Vault["Public vault"]
+    Vault -->|"public USDC payout"| Batch
+    Batch -->|"encrypted allocation"| Cusdc["User cUSDC"]
+`,
+  },
+  {
+    title: 'Trust boundary',
+    statement: 'The private path is real; the keys, assets, vault and yield source are local.',
+    diagram: String.raw`
+flowchart LR
+    subgraph real["Runs for real"]
+        Transactions["Solana transactions"]
+        Programs["On-chain programs"]
+        Encryption["Encrypted computation"]
+        Authorization["Authorization proofs"]
+        Decryption["User and public decrypt"]
+        Accounting["Vault accounting"]
+    end
+
+    subgraph poc["POC setting"]
+        Localnet["Local validator"]
+        TestAssets["Test assets and keys"]
+        Centralized["One key service"]
+        ToyVault["Toy public vault"]
+        Keeper["Local keeper"]
+        Yield["Demo-funded yield"]
+    end
+
+    Transactions --- Localnet
+    Programs --- ToyVault
+    Encryption --- TestAssets
+    Authorization --- Keeper
+    Decryption --- Centralized
+    Accounting --- Yield
+`,
+  },
+];
+
+const frameNumber = (index: number): string => String(index + 1).padStart(2, '0');
+
+export function ArchitecturePage() {
+  useEffect(() => {
+    void mermaid.run({ querySelector: '.mermaid', suppressErrors: false }).catch((error: unknown) => {
+      document.body.dataset.mermaidError = 'true';
+      console.error('Failed to render architecture diagrams', error);
+    });
+  }, []);
+
+  return (
+    <main className="architecture-page">
+      {frames.map((frame, index) => (
+        <section className="architecture-frame" id={`frame-${index + 1}`} key={frame.title}>
+          <header className="frame-heading">
+            <p className="frame-label">
+              {frameNumber(index)} / {frames.length} · {frame.title}
+            </p>
+            <h1>{frame.statement}</h1>
+          </header>
+          <div className="diagram-shell">
+            <pre className="mermaid">{frame.diagram}</pre>
+          </div>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -12,14 +12,14 @@ const frames: readonly ArchitectureFrame[] = [
     title: 'Encrypted computation',
     statement: 'Applications compute on encrypted values.',
     diagram: String.raw`
-flowchart TB
+flowchart LR
     subgraph input["Input"]
-        direction LR
+        direction TB
         Value["User value"] --> Encrypt["SDK<br/>encrypts inputs"] --> Ciphertext["Ciphertext"]
     end
 
     subgraph execution["Execution"]
-        direction LR
+        direction TB
         Host["Host program<br/>records operations and permissions"] --> Compute["Coprocessor<br/>computes over ciphertexts"] --> Result["Encrypted result"]
     end
 

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -1,13 +1,135 @@
 import mermaid from 'mermaid';
 import { useEffect } from 'react';
 
-type ArchitectureFrame = {
+type DiagramFrame = {
   readonly title: string;
   readonly statement: string;
   readonly diagram: string;
 };
 
+type GlossaryFrame = {
+  readonly title: string;
+  readonly statement: string;
+  readonly terms: readonly {
+    readonly term: string;
+    readonly definition: string;
+  }[];
+};
+
+type ArchitectureFrame = DiagramFrame | GlossaryFrame;
+
 const frames: readonly ArchitectureFrame[] = [
+  {
+    title: 'First principle',
+    statement: 'Applications compute on encrypted values without exposing them.',
+    diagram: String.raw`
+flowchart TB
+    subgraph input["Input"]
+        direction LR
+        Value["User value"] --> Encrypt["SDK encrypts"] --> Ciphertext["Ciphertext"]
+    end
+
+    subgraph execution["Execution"]
+        direction LR
+        Rules["Solana enforces<br/>rules and permissions"] --> Compute["Coprocessor computes<br/>over ciphertexts"] --> Result["Encrypted result"]
+    end
+
+    subgraph release["Release"]
+        direction LR
+        Authorized{"Who may learn it?"}
+        Authorized -->|"one user"| User["User decrypt"]
+        Authorized -->|"the program"| Public["Certified public decrypt"]
+    end
+
+    Ciphertext --> Rules
+    Result --> Authorized
+`,
+  },
+  {
+    title: 'Shared key',
+    statement: 'One public key connects encrypted applications; no single party holds the secret.',
+    diagram: String.raw`
+flowchart LR
+    PublicKey["Network public key"] --> AppA["App A encrypts"]
+    PublicKey --> AppB["App B encrypts"]
+    AppA --> Shared["Compatible ciphertexts"]
+    AppB --> Shared
+    Shared --> Compose["Encrypted results<br/>move between apps"]
+
+    subgraph kms["Production key service"]
+        Share1["Secret share 1"]
+        Share2["Secret share 2"]
+        Share3["Secret share 3"]
+        Quorum["Several parties<br/>must approve"]
+        Share1 --> Quorum
+        Share2 --> Quorum
+        Share3 --> Quorum
+    end
+
+    Compose --> Quorum
+    Quorum --> Decrypt["Authorized result"]
+`,
+  },
+  {
+    title: 'Protocol glossary',
+    statement: 'Each protocol layer has one job.',
+    terms: [
+      {
+        term: 'SDK',
+        definition: 'Encrypts inputs, builds requests and opens user-decrypt results.',
+      },
+      {
+        term: 'Host contract / program',
+        definition: 'Records encrypted operations and enforces who may use their results.',
+      },
+      {
+        term: 'Relayer',
+        definition: 'Carries SDK requests to protocol services and returns their results.',
+      },
+      {
+        term: 'Gateway',
+        definition: 'Keeps encrypted material and decryption work synchronized across the protocol.',
+      },
+      {
+        term: 'Coprocessor',
+        definition: 'Reconstructs confirmed operations and computes them over ciphertexts.',
+      },
+      {
+        term: 'KMS',
+        definition: 'Checks decryption rights and combines secret-key shares to release a result.',
+      },
+    ],
+  },
+  {
+    title: 'Solana glossary',
+    statement: 'Solana gives every rule and encrypted value a concrete execution path.',
+    terms: [
+      {
+        term: 'Program',
+        definition: 'Executes code; mutable state lives in separate accounts.',
+      },
+      {
+        term: 'PDA',
+        definition: 'Gives a program a deterministic address with no private key.',
+      },
+      {
+        term: 'CPI',
+        definition: 'Lets one program call another with the authority already present.',
+      },
+      {
+        term: 'Handle',
+        definition: 'Identifies one ciphertext and its metadata; it is not the ciphertext.',
+      },
+      {
+        term: 'EncryptedValue',
+        definition: 'Keeps the current handle, permissions and compact history at one stable PDA.',
+      },
+      {
+        term: 'MMR',
+        definition: 'Commits old permissions into compact, append-only history.',
+      },
+    ],
+  },
   {
     title: 'Complete system',
     statement: 'Solana records the rules; encrypted services execute the work.',
@@ -252,9 +374,20 @@ export function ArchitecturePage() {
             </p>
             <h1>{frame.statement}</h1>
           </header>
-          <div className="diagram-shell">
-            <pre className="mermaid">{frame.diagram}</pre>
-          </div>
+          {'diagram' in frame ? (
+            <div className="diagram-shell">
+              <pre className="mermaid">{frame.diagram}</pre>
+            </div>
+          ) : (
+            <dl className="glossary-grid">
+              {frame.terms.map(({ term, definition }) => (
+                <div className="glossary-entry" key={term}>
+                  <dt>{term}</dt>
+                  <dd>{definition}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
         </section>
       ))}
     </main>

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -9,35 +9,40 @@ type ArchitectureFrame = {
 
 const frames: readonly ArchitectureFrame[] = [
   {
-    title: 'Encrypted computation',
-    statement: 'Applications compute on encrypted values.',
+    title: 'Encrypted request',
+    statement: 'A wallet submits encrypted inputs and receives authorized plaintext results.',
     diagram: String.raw`
-flowchart LR
-    subgraph input["Input"]
-        direction TB
-        Value["User value"] --> Encrypt["SDK<br/>encrypts inputs"] --> Ciphertext["Ciphertext"]
+sequenceDiagram
+    box User device
+        participant Client as Wallet + SDK
+    end
+    box Solana
+        participant Host as Host program
+    end
+    box Protocol services
+        participant Copro as Coprocessor
+        participant Relayer
+        participant Gateway
+        participant KMS as KMS network
     end
 
-    subgraph execution["Execution"]
-        direction TB
-        Host["Host program<br/>records operations and permissions"] --> Compute["Coprocessor<br/>computes over ciphertexts"] --> Result["Encrypted result"]
-    end
+    Note over Client,Gateway: Encrypted transaction and event-driven FHE computation
+    Client->>Client: Encrypt input and approve action
+    Client->>Host: Submit encrypted input and verification
+    Host->>Host: Check input and permissions
+    Host->>Host: Record encrypted operation
+    Host-->>Copro: Confirmed operation
+    Copro->>Copro: Compute with FHE
+    Copro-->>Gateway: Store encrypted result
 
-    subgraph release["Release"]
-        direction TB
-        Gateway["Gateway<br/>coordinates encrypted material<br/>and decryption work"]
-        KMS["KMS<br/>checks rights and releases results"]
-        Authorized{"Decryption scope"}
-        Relayer["Relayer<br/>returns a protected user result"]
-        Browser["Browser opens result"]
-
-        Gateway --> KMS --> Authorized
-        Authorized -->|"one user"| Relayer --> Browser
-        Authorized -->|"the program"| Public["Certified public decrypt"]
-    end
-
-    Ciphertext --> Host
-    Result --> Gateway
+    Note over Client,KMS: Authorized decryption
+    Client->>Relayer: Signed decryption request
+    Relayer->>Gateway: Locate encrypted result
+    Gateway->>KMS: Request authorized decrypt
+    KMS-->>Gateway: Result protected for SDK
+    Gateway-->>Relayer: Protected result
+    Relayer-->>Client: Protected result
+    Client->>Client: Recover and display plaintext
 `,
   },
   {
@@ -70,10 +75,14 @@ flowchart LR
     statement: 'Shielding locks USDC and credits an encrypted cUSDC balance.',
     diagram: String.raw`
 sequenceDiagram
-    participant Wallet
-    participant Token as Confidential token
-    participant SPL as SPL Token
-    participant Host as Zama host
+    box User device
+        participant Wallet
+    end
+    box Solana
+        participant Token as Confidential token
+        participant SPL as SPL Token
+        participant Host as Zama host
+    end
 
     Wallet->>Token: Shield public USDC
     Token->>SPL: Move USDC into wrapper custody
@@ -87,15 +96,21 @@ sequenceDiagram
     statement: 'Joining transfers encrypted cUSDC into the current batch.',
     diagram: String.raw`
 sequenceDiagram
-    participant Browser
-    participant Input as Input verification
-    participant Wallet
-    participant Batch as Batcher
-    participant Token as Confidential token
-    participant Host as Zama host
+    box User device
+        participant Wallet
+        participant SDK
+    end
+    box Input service
+        participant Input as Input verifier
+    end
+    box Solana
+        participant Batch as Batcher
+        participant Token as Confidential token
+        participant Host as Zama host
+    end
 
-    Browser->>Input: Encrypted deposit amount
-    Input-->>Browser: Signed verification
+    SDK->>Input: Encrypted deposit amount
+    Input-->>SDK: Signed verification
     Wallet->>Batch: Join batch
     Batch->>Token: Confidential transfer by CPI
     Token->>Host: Verify input and record operations
@@ -158,21 +173,29 @@ flowchart TB
   },
   {
     title: 'User decrypt',
-    statement: 'User decryption returns plaintext only to the authorized browser.',
+    statement: 'The wallet authorizes the request; the SDK recovers the plaintext.',
     diagram: String.raw`
 sequenceDiagram
-    participant Browser
-    participant Wallet as Phantom
-    participant Relayer as Request service
-    participant Keys as Key service
+    box User device
+        participant Wallet as Phantom
+        participant SDK
+    end
+    box Protocol services
+        participant Relayer
+        participant Gateway
+        participant KMS as KMS network
+    end
 
-    Browser->>Browser: Create fresh transport key
-    Wallet->>Browser: Sign decryption request
-    Browser->>Relayer: Signed request and public key
-    Relayer->>Keys: Check Solana authorization
-    Keys-->>Relayer: Signcrypted response
-    Relayer-->>Browser: Opaque response
-    Browser->>Browser: Recover the clear value
+    SDK->>SDK: Create fresh transport key
+    SDK->>Wallet: Request authorization
+    Wallet-->>SDK: Signed decryption request
+    SDK->>Relayer: Signed request and public key
+    Relayer->>Gateway: Locate encrypted result
+    Gateway->>KMS: Check authorization and decrypt
+    KMS-->>Gateway: Result protected for SDK
+    Gateway-->>Relayer: Protected result
+    Relayer-->>SDK: Protected result
+    SDK->>SDK: Recover plaintext
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -9,8 +9,8 @@ type ArchitectureFrame = {
 
 const frames: readonly ArchitectureFrame[] = [
   {
-    title: 'First principle',
-    statement: 'Applications compute on encrypted values without exposing them.',
+    title: 'Encrypted computation',
+    statement: 'Applications compute on encrypted values.',
     diagram: String.raw`
 flowchart TB
     subgraph input["Input"]
@@ -35,8 +35,8 @@ flowchart TB
 `,
   },
   {
-    title: 'Shared key',
-    statement: 'One public key connects encrypted applications; no single party holds the secret.',
+    title: 'Shared network key',
+    statement: 'Applications encrypt with one shared public key.',
     diagram: String.raw`
 flowchart LR
     PublicKey["Network public key"] --> AppA["App A encrypts"]
@@ -61,7 +61,7 @@ flowchart LR
   },
   {
     title: 'Protocol architecture',
-    statement: 'Each layer carries encrypted work to the next.',
+    statement: 'Requests move between the user, host chain and encrypted services.',
     diagram: String.raw`
 flowchart TB
     subgraph client["User side"]
@@ -90,10 +90,10 @@ flowchart TB
   },
   {
     title: 'Solana architecture',
-    statement: 'One signed action moves through several programs and updates encrypted accounts.',
+    statement: 'A cUSDC deposit updates three accounts across three programs.',
     diagram: String.raw`
 flowchart TB
-    subgraph action["One transaction · every step succeeds or none does"]
+    subgraph action["One atomic transaction"]
         direction TB
         Wallet["Wallet approves<br/>Deposit 100 cUSDC"]
         Batcher["Batcher checks<br/>Can this deposit join?"]
@@ -101,11 +101,11 @@ flowchart TB
         Host["Zama host records<br/>the encrypted calculation"]
 
         Wallet --> Batcher
-        Batcher -->|"calls another program · CPI"| Token
+        Batcher -->|"program call · CPI"| Token
         Token -->|"requests encrypted arithmetic"| Host
     end
 
-    subgraph state["State updated by that action"]
+    subgraph state["Updated accounts"]
         direction TB
         UserBalance["Your cUSDC balance<br/>encrypted"]
         JoinedAmount["Your joined deposit<br/>encrypted"]
@@ -118,8 +118,8 @@ flowchart TB
 `,
   },
   {
-    title: 'Complete system',
-    statement: 'Solana records the rules; encrypted services execute the work.',
+    title: 'System architecture',
+    statement: 'The dApp connects Solana to encrypted services.',
     diagram: String.raw`
 flowchart LR
     subgraph browser["Browser"]
@@ -156,7 +156,7 @@ flowchart LR
   },
   {
     title: 'Vault design',
-    statement: 'The batcher hides each amount and reveals only the total.',
+    statement: 'The batcher aggregates private deposits into one public vault deposit.',
     diagram: String.raw`
 flowchart LR
     Alice["Alice<br/>encrypted amount"] --> Batch["Confidential batcher"]
@@ -169,7 +169,7 @@ flowchart LR
   },
   {
     title: 'Shield',
-    statement: 'Public USDC enters custody and becomes private spending power.',
+    statement: 'Shielding locks USDC and credits an encrypted cUSDC balance.',
     diagram: String.raw`
 sequenceDiagram
     participant Wallet
@@ -186,7 +186,7 @@ sequenceDiagram
   },
   {
     title: 'Join',
-    statement: 'A verified encrypted amount moves into the private batch.',
+    statement: 'Joining transfers encrypted cUSDC into the current batch.',
     diagram: String.raw`
 sequenceDiagram
     participant Browser
@@ -206,7 +206,7 @@ sequenceDiagram
   },
   {
     title: 'Encrypted state',
-    statement: 'The account stays fixed while its encrypted value changes.',
+    statement: 'One EncryptedValue account tracks the current handle and permission history.',
     diagram: String.raw`
 flowchart LR
     Value["EncryptedValue PDA<br/>stable logical balance"]
@@ -220,7 +220,7 @@ flowchart LR
   },
   {
     title: 'Compute pipeline',
-    statement: 'Confirmed Solana instructions become encrypted computation jobs.',
+    statement: 'The listener converts confirmed host instructions into coprocessor jobs.',
     diagram: String.raw`
 flowchart LR
     Tx["Confirmed transaction"] --> Yellowstone["Yellowstone stream"]
@@ -233,7 +233,7 @@ flowchart LR
   },
   {
     title: 'Public settlement',
-    statement: 'A proven batch total crosses into the public vault.',
+    statement: 'Settlement decrypts the batch total and deposits it into the vault.',
     diagram: String.raw`
 sequenceDiagram
     participant Batch as Batcher
@@ -253,7 +253,7 @@ sequenceDiagram
   },
   {
     title: 'History',
-    statement: 'Compact history keeps old decrypt rights verifiable.',
+    statement: 'MMR proofs preserve access to previous handles.',
     diagram: String.raw`
 flowchart LR
     H1["Handle H1"] --> L1["Alice could access H1"]
@@ -267,7 +267,7 @@ flowchart LR
   },
   {
     title: 'Claim',
-    statement: 'Public ratios allocate encrypted shares without revealing deposits.',
+    statement: 'A claim computes and transfers each encrypted share allocation.',
     diagram: String.raw`
 flowchart LR
     Deposit["Encrypted user deposit"] --> Formula["deposit × batch shares ÷ batch total"]
@@ -280,7 +280,7 @@ flowchart LR
   },
   {
     title: 'User decrypt',
-    statement: 'The wallet authorizes a value that opens only in the browser.',
+    statement: 'User decryption returns plaintext only to the authorized browser.',
     diagram: String.raw`
 sequenceDiagram
     participant Browser
@@ -299,7 +299,7 @@ sequenceDiagram
   },
   {
     title: 'Redeem',
-    statement: 'Encrypted shares return through the same private doorway.',
+    statement: 'Redemption converts encrypted cShares back into encrypted cUSDC.',
     diagram: String.raw`
 flowchart LR
     Shares["User cShares"] -->|"encrypted amount"| Batch["Redeem batch"]
@@ -309,8 +309,8 @@ flowchart LR
 `,
   },
   {
-    title: 'Trust boundary',
-    statement: 'The private path is real; the keys, assets, vault and yield source are local.',
+    title: 'POC boundary',
+    statement: 'The POC runs real protocol components with local keys, assets and yield.',
     diagram: String.raw`
 flowchart LR
     subgraph real["Runs for real"]

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -90,34 +90,31 @@ flowchart TB
   },
   {
     title: 'Solana architecture',
-    statement: 'Programs execute the rules; accounts hold the encrypted state.',
+    statement: 'One signed action moves through several programs and updates encrypted accounts.',
     diagram: String.raw`
 flowchart TB
-    subgraph transaction["One Solana transaction"]
-        direction LR
-        Instruction["Instruction<br/>names a program, accounts and data"]
-        ProgramA["Program<br/>executes code"]
-        CPI["CPI<br/>calls another program"]
-        ProgramB["Program<br/>reuses existing logic"]
-        Instruction --> ProgramA --> CPI --> ProgramB
-    end
-
-    subgraph state["Encrypted state"]
+    subgraph action["One transaction · every step succeeds or none does"]
         direction TB
-        PDA["PDA<br/>deterministic address<br/>with no private key"]
-        EncryptedValue["EncryptedValue<br/>stable account for one value"]
-        PDA --> EncryptedValue
+        Wallet["Wallet approves<br/>Deposit 100 cUSDC"]
+        Batcher["Batcher checks<br/>Can this deposit join?"]
+        Token["Confidential token moves<br/>the encrypted amount"]
+        Host["Zama host records<br/>the encrypted calculation"]
 
-        Handle["Handle<br/>identifies the current ciphertext"]
-        Material["Encrypted material<br/>stored off-chain"]
-        EncryptedValue --> Handle --> Material
-
-        Permissions["Current permissions"]
-        MMR["MMR<br/>compact history of old permissions"]
-        EncryptedValue --> Permissions --> MMR
+        Wallet --> Batcher
+        Batcher -->|"calls another program · CPI"| Token
+        Token -->|"requests encrypted arithmetic"| Host
     end
 
-    ProgramA -->|"reads and writes"| PDA
+    subgraph state["State updated by that action"]
+        direction TB
+        UserBalance["Your cUSDC balance<br/>encrypted"]
+        JoinedAmount["Your joined deposit<br/>encrypted"]
+        BatchState["Batch status<br/>public"]
+    end
+
+    Token --> UserBalance
+    Batcher --> JoinedAmount
+    Batcher --> BatchState
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -261,10 +261,15 @@ export function ArchitecturePage() {
       {frames.map((frame, index) => (
         <section className="architecture-frame" id={`frame-${index + 1}`} key={frame.title}>
           <header className="frame-heading">
-            <p className="frame-label">
-              {frameNumber(index)} / {frames.length} · {frame.title}
-            </p>
-            <h1>{frame.statement}</h1>
+            <h1>
+              <span className="frame-label">
+                {frameNumber(index)} / {frames.length} · {frame.title}
+              </span>
+              <span className="frame-separator" aria-hidden="true">
+                —
+              </span>
+              <span className="frame-statement">{frame.statement}</span>
+            </h1>
           </header>
           <div className="diagram-shell">
             <pre className="mermaid">{frame.diagram}</pre>

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -181,7 +181,7 @@ flowchart TB
   },
   {
     title: 'User decrypt',
-    statement: 'The wallet authorizes the request; the SDK recovers the plaintext.',
+    statement: 'Wallet signs the request. KMS nodes produce partial decryptions. SDK reconstructs plaintext.',
     diagram: String.raw`
 sequenceDiagram
     box User device
@@ -191,19 +191,23 @@ sequenceDiagram
     box Protocol services
         participant Relayer
         participant Gateway
-        participant KMS as KMS network
+        participant Connector as KMS connector
+        participant KMS as KMS node
     end
 
-    SDK->>SDK: Create fresh transport key
-    SDK->>Wallet: Request authorization
-    Wallet-->>SDK: Signed decryption request
-    SDK->>Relayer: Signed request and public key
-    Relayer->>Gateway: Locate encrypted result
-    Gateway->>KMS: Check authorization and decrypt
-    KMS-->>Gateway: Result protected for SDK
-    Gateway-->>Relayer: Protected result
-    Relayer-->>SDK: Protected result
-    SDK->>SDK: Recover plaintext
+    SDK->>SDK: Generate ephemeral transport key
+    SDK->>Wallet: Request decryption signature
+    Wallet-->>SDK: Signed user-decryption request
+    SDK->>Relayer: Submit request and transport public key
+    Relayer->>Gateway: Submit user-decryption transaction
+    Gateway-->>Connector: Emit user-decryption request
+    Connector->>Connector: Verify wallet signature and Solana access
+    Connector->>KMS: Request partial decryption
+    KMS-->>Connector: Signed, signcrypted partial share
+    Connector->>Gateway: Post partial share
+    Gateway-->>Relayer: Emit verified partial share
+    Relayer-->>SDK: Return threshold shares
+    SDK->>SDK: Verify, de-signcrypt and reconstruct plaintext
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -15,23 +15,29 @@ const frames: readonly ArchitectureFrame[] = [
 flowchart TB
     subgraph input["Input"]
         direction LR
-        Value["User value"] --> Encrypt["SDK encrypts"] --> Ciphertext["Ciphertext"]
+        Value["User value"] --> Encrypt["SDK<br/>encrypts inputs"] --> Ciphertext["Ciphertext"]
     end
 
     subgraph execution["Execution"]
         direction LR
-        Rules["Solana enforces<br/>rules and permissions"] --> Compute["Coprocessor computes<br/>over ciphertexts"] --> Result["Encrypted result"]
+        Host["Host program<br/>records operations and permissions"] --> Compute["Coprocessor<br/>computes over ciphertexts"] --> Result["Encrypted result"]
     end
 
     subgraph release["Release"]
-        direction LR
+        direction TB
+        Gateway["Gateway<br/>coordinates encrypted material<br/>and decryption work"]
+        KMS["KMS<br/>checks rights and releases results"]
         Authorized{"Decryption scope"}
-        Authorized -->|"one user"| User["User decrypt"]
+        Relayer["Relayer<br/>returns a protected user result"]
+        Browser["Browser opens result"]
+
+        Gateway --> KMS --> Authorized
+        Authorized -->|"one user"| Relayer --> Browser
         Authorized -->|"the program"| Public["Certified public decrypt"]
     end
 
-    Ciphertext --> Rules
-    Result --> Authorized
+    Ciphertext --> Host
+    Result --> Gateway
 `,
   },
   {
@@ -57,35 +63,6 @@ flowchart LR
 
     Compose --> Quorum
     Quorum --> Decrypt["Authorized result"]
-`,
-  },
-  {
-    title: 'Protocol architecture',
-    statement: 'Requests move between the user, host chain and encrypted services.',
-    diagram: String.raw`
-flowchart TB
-    subgraph client["User side"]
-        direction LR
-        User["User"] --> SDK["SDK<br/>encrypts inputs and opens results"]
-        SDK --> Relayer["Relayer<br/>carries requests and results"]
-    end
-
-    subgraph hostchain["Host chain"]
-        Host["Host contract / program<br/>records operations and permissions"]
-    end
-
-    subgraph network["Encrypted network"]
-        direction LR
-        Coprocessor["Coprocessor<br/>computes over ciphertexts"]
-        Gateway["Gateway<br/>coordinates encrypted material<br/>and decryption work"]
-        KMS["KMS<br/>checks rights and releases<br/>authorized results"]
-        Coprocessor --> Gateway
-    end
-
-    SDK -->|"encrypted transaction"| Host
-    Host -->|"confirmed operations"| Coprocessor
-    Relayer <-->|"request / protected result"| Gateway
-    Gateway <-->|"authorized decrypt"| KMS
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -9,8 +9,8 @@ type ArchitectureFrame = {
 
 const frames: readonly ArchitectureFrame[] = [
   {
-    title: 'Encrypted request',
-    statement: 'A wallet submits encrypted inputs and receives authorized plaintext results.',
+    title: 'Protocol overview',
+    statement: 'Zama end-to-end flow',
     diagram: String.raw`
 sequenceDiagram
     box User device

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -25,7 +25,7 @@ flowchart TB
 
     subgraph release["Release"]
         direction LR
-        Authorized{"Who may learn it?"}
+        Authorized{"Decryption scope"}
         Authorized -->|"one user"| User["User decrypt"]
         Authorized -->|"the program"| Public["Certified public decrypt"]
     end
@@ -96,7 +96,7 @@ flowchart TB
     subgraph action["One atomic transaction"]
         direction TB
         Wallet["Wallet approves<br/>Deposit 100 cUSDC"]
-        Batcher["Batcher checks<br/>Can this deposit join?"]
+        Batcher["Batcher validates<br/>deposit eligibility"]
         Token["Confidential token moves<br/>the encrypted amount"]
         Host["Zama host records<br/>the encrypted calculation"]
 
@@ -107,8 +107,8 @@ flowchart TB
 
     subgraph state["Updated accounts"]
         direction TB
-        UserBalance["Your cUSDC balance<br/>encrypted"]
-        JoinedAmount["Your joined deposit<br/>encrypted"]
+        UserBalance["cUSDC balance<br/>encrypted"]
+        JoinedAmount["Joined deposit<br/>encrypted"]
         BatchState["Batch status<br/>public"]
     end
 

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -10,7 +10,32 @@ type ArchitectureFrame = {
 const frames: readonly ArchitectureFrame[] = [
   {
     title: 'Protocol overview',
-    statement: 'Zama end-to-end flow',
+    statement: 'Encrypted execution and authorized decryption',
+    diagram: String.raw`
+sequenceDiagram
+    box User device
+        participant Client as Wallet + SDK
+    end
+    box Solana
+        participant Host as Host program
+    end
+    box Protocol services
+        participant Copro as Coprocessor
+        participant KMS as KMS network
+    end
+
+    Client->>Host: Encrypted transaction
+    Host-->>Copro: Confirmed operation
+    Copro->>Copro: FHE computation
+    Copro-->>KMS: Encrypted result available
+    Client->>KMS: Authorized decryption request
+    KMS-->>Client: Result protected for user
+    Client->>Client: Recover plaintext
+`,
+  },
+  {
+    title: 'Protocol detail',
+    statement: 'Input proof, gateway synchronization and signcryption',
     diagram: String.raw`
 sequenceDiagram
     box User device
@@ -27,10 +52,11 @@ sequenceDiagram
     end
 
     Note over Client,Copro: Input proof and attestation
-    Client->>Relayer: Encrypted input and proof
+    Client->>Client: Encrypt input and create zero-knowledge proof of knowledge
+    Client->>Relayer: Ciphertext and proof
     Relayer->>Gateway: Verification request
     Gateway->>Copro: Input proof
-    Copro->>Copro: Verify input proof
+    Copro->>Copro: Verify proof of knowledge
     Copro-->>Gateway: Ciphertext attestation
     Gateway-->>Relayer: Attestation
     Relayer-->>Client: Attestation
@@ -42,13 +68,15 @@ sequenceDiagram
     Copro-->>Gateway: FHE result
 
     Note over Client,KMS: Authorized decryption
-    Client->>Relayer: Signed decryption request
+    Client->>Client: Create transport key and sign request
+    Client->>Relayer: Signed request and transport public key
     Relayer->>Gateway: Decryption request
-    Gateway->>KMS: Authorized decrypt
-    KMS-->>Gateway: User-protected result
-    Gateway-->>Relayer: Protected result
-    Relayer-->>Client: Protected result
-    Client->>Client: Recover plaintext
+    Gateway->>KMS: Encrypted result and authorization
+    KMS->>KMS: Decrypt and re-encrypt for transport key
+    KMS-->>Gateway: Signcrypted result
+    Gateway-->>Relayer: Signcrypted result
+    Relayer-->>Client: Signcrypted result
+    Client->>Client: Open signcrypted result
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
+++ b/solana/demo-dapp/src/architecture/ArchitecturePage.tsx
@@ -26,23 +26,29 @@ sequenceDiagram
         participant KMS as KMS network
     end
 
-    Note over Client,Gateway: Encrypted transaction and event-driven FHE computation
-    Client->>Client: Encrypt input and approve action
-    Client->>Host: Submit encrypted input and verification
-    Host->>Host: Check input and permissions
-    Host->>Host: Record encrypted operation
+    Note over Client,Copro: Input proof and attestation
+    Client->>Relayer: Encrypted input and proof
+    Relayer->>Gateway: Verification request
+    Gateway->>Copro: Input proof
+    Copro->>Copro: Verify input proof
+    Copro-->>Gateway: Ciphertext attestation
+    Gateway-->>Relayer: Attestation
+    Relayer-->>Client: Attestation
+
+    Note over Client,Gateway: On-chain encrypted computation
+    Client->>Host: Encrypted action and attestation
+    Host->>Host: Verify coprocessor attestation and record operation
     Host-->>Copro: Confirmed operation
-    Copro->>Copro: Compute with FHE
-    Copro-->>Gateway: Store encrypted result
+    Copro-->>Gateway: FHE result
 
     Note over Client,KMS: Authorized decryption
     Client->>Relayer: Signed decryption request
-    Relayer->>Gateway: Locate encrypted result
-    Gateway->>KMS: Request authorized decrypt
-    KMS-->>Gateway: Result protected for SDK
+    Relayer->>Gateway: Decryption request
+    Gateway->>KMS: Authorized decrypt
+    KMS-->>Gateway: User-protected result
     Gateway-->>Relayer: Protected result
     Relayer-->>Client: Protected result
-    Client->>Client: Recover and display plaintext
+    Client->>Client: Recover plaintext
 `,
   },
   {
@@ -100,21 +106,19 @@ sequenceDiagram
         participant Wallet
         participant SDK
     end
-    box Input service
-        participant Input as Input verifier
-    end
     box Solana
         participant Batch as Batcher
         participant Token as Confidential token
         participant Host as Zama host
     end
 
-    SDK->>Input: Encrypted deposit amount
-    Input-->>SDK: Signed verification
-    Wallet->>Batch: Join batch
+    SDK->>Wallet: Build join with encrypted amount and attestation
+    Wallet->>Batch: Sign and submit join
     Batch->>Token: Confidential transfer by CPI
-    Token->>Host: Verify input and record operations
-    Host-->>Batch: New encrypted joined amount
+    Token->>Host: Verify coprocessor attestation inside transfer
+    Token->>Host: Record encrypted operations
+    Host-->>Token: New balance handles
+    Token-->>Batch: New encrypted joined amount
 `,
   },
   {

--- a/solana/demo-dapp/src/architecture/main.tsx
+++ b/solana/demo-dapp/src/architecture/main.tsx
@@ -48,7 +48,7 @@ mermaid.initialize({
     diagramMarginX: 20,
     diagramMarginY: 24,
     messageMargin: 30,
-    mirrorActors: false,
+    mirrorActors: true,
     width: 150,
   },
 });

--- a/solana/demo-dapp/src/architecture/main.tsx
+++ b/solana/demo-dapp/src/architecture/main.tsx
@@ -1,0 +1,56 @@
+import mermaid from 'mermaid';
+import { createRoot } from 'react-dom/client';
+
+import { ArchitecturePage } from './ArchitecturePage';
+import './styles.css';
+
+mermaid.initialize({
+  startOnLoad: false,
+  securityLevel: 'strict',
+  theme: 'base',
+  themeVariables: {
+    background: '#09090b',
+    primaryColor: '#241a38',
+    primaryBorderColor: '#a78bfa',
+    primaryTextColor: '#f6f6f7',
+    secondaryColor: '#102c24',
+    secondaryBorderColor: '#14f195',
+    secondaryTextColor: '#f6f6f7',
+    tertiaryColor: '#1b1b20',
+    tertiaryBorderColor: '#666672',
+    tertiaryTextColor: '#f6f6f7',
+    lineColor: '#a9a9b2',
+    textColor: '#f6f6f7',
+    actorBkg: '#1b1b20',
+    actorBorder: '#666672',
+    actorTextColor: '#f6f6f7',
+    actorLineColor: '#666672',
+    signalColor: '#d4d4d8',
+    signalTextColor: '#f6f6f7',
+    labelBoxBkgColor: '#1b1b20',
+    labelBoxBorderColor: '#666672',
+    labelTextColor: '#f6f6f7',
+    loopTextColor: '#f6f6f7',
+    noteBkgColor: '#241a38',
+    noteBorderColor: '#a78bfa',
+    noteTextColor: '#f6f6f7',
+    fontFamily: 'Inter, ui-sans-serif, system-ui, sans-serif',
+    fontSize: '18px',
+  },
+  flowchart: {
+    curve: 'basis',
+    htmlLabels: true,
+    nodeSpacing: 54,
+    rankSpacing: 64,
+  },
+  sequence: {
+    actorMargin: 64,
+    diagramMarginX: 32,
+    diagramMarginY: 24,
+    messageMargin: 36,
+    mirrorActors: false,
+    width: 190,
+  },
+});
+
+createRoot(document.getElementById('root')!).render(<ArchitecturePage />);

--- a/solana/demo-dapp/src/architecture/main.tsx
+++ b/solana/demo-dapp/src/architecture/main.tsx
@@ -44,12 +44,12 @@ mermaid.initialize({
     rankSpacing: 64,
   },
   sequence: {
-    actorMargin: 64,
-    diagramMarginX: 32,
+    actorMargin: 32,
+    diagramMarginX: 20,
     diagramMarginY: 24,
-    messageMargin: 36,
+    messageMargin: 30,
     mirrorActors: false,
-    width: 190,
+    width: 150,
   },
 });
 

--- a/solana/demo-dapp/src/architecture/styles.css
+++ b/solana/demo-dapp/src/architecture/styles.css
@@ -39,8 +39,7 @@ body {
 }
 
 .frame-heading,
-.diagram-shell,
-.glossary-grid {
+.diagram-shell {
   width: min(1440px, 100%);
   margin-inline: auto;
 }
@@ -97,38 +96,6 @@ h1 {
   max-height: 62vh;
 }
 
-.glossary-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-  align-self: start;
-  margin: 0 auto;
-}
-
-.glossary-entry {
-  min-height: 148px;
-  padding: clamp(22px, 2.4vw, 34px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 20px;
-  background: rgba(20, 20, 24, 0.76);
-  box-shadow: 0 20px 56px rgba(0, 0, 0, 0.2);
-}
-
-.glossary-entry dt {
-  margin-bottom: 12px;
-  color: #f6f6f7;
-  font-size: clamp(20px, 2vw, 30px);
-  font-weight: 760;
-  letter-spacing: -0.025em;
-}
-
-.glossary-entry dd {
-  margin: 0;
-  color: #b5b5bd;
-  font-size: clamp(15px, 1.35vw, 20px);
-  line-height: 1.45;
-}
-
 body[data-mermaid-error="true"]::before {
   position: fixed;
   z-index: 10;
@@ -157,14 +124,6 @@ body[data-mermaid-error="true"]::before {
   .diagram-shell {
     min-height: 460px;
     overflow-x: auto;
-  }
-
-  .glossary-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .glossary-entry {
-    min-height: auto;
   }
 
   .mermaid svg {

--- a/solana/demo-dapp/src/architecture/styles.css
+++ b/solana/demo-dapp/src/architecture/styles.css
@@ -39,7 +39,8 @@ body {
 }
 
 .frame-heading,
-.diagram-shell {
+.diagram-shell,
+.glossary-grid {
   width: min(1440px, 100%);
   margin-inline: auto;
 }
@@ -96,6 +97,38 @@ h1 {
   max-height: 62vh;
 }
 
+.glossary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  align-self: start;
+  margin: 0 auto;
+}
+
+.glossary-entry {
+  min-height: 148px;
+  padding: clamp(22px, 2.4vw, 34px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  background: rgba(20, 20, 24, 0.76);
+  box-shadow: 0 20px 56px rgba(0, 0, 0, 0.2);
+}
+
+.glossary-entry dt {
+  margin-bottom: 12px;
+  color: #f6f6f7;
+  font-size: clamp(20px, 2vw, 30px);
+  font-weight: 760;
+  letter-spacing: -0.025em;
+}
+
+.glossary-entry dd {
+  margin: 0;
+  color: #b5b5bd;
+  font-size: clamp(15px, 1.35vw, 20px);
+  line-height: 1.45;
+}
+
 body[data-mermaid-error="true"]::before {
   position: fixed;
   z-index: 10;
@@ -124,6 +157,14 @@ body[data-mermaid-error="true"]::before {
   .diagram-shell {
     min-height: 460px;
     overflow-x: auto;
+  }
+
+  .glossary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .glossary-entry {
+    min-height: auto;
   }
 
   .mermaid svg {

--- a/solana/demo-dapp/src/architecture/styles.css
+++ b/solana/demo-dapp/src/architecture/styles.css
@@ -1,0 +1,139 @@
+:root {
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #f6f6f7;
+  background: #09090b;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-snap-type: y proximity;
+  background: #09090b;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(130, 87, 229, 0.18), transparent 34rem),
+    radial-gradient(circle at 88% 20%, rgba(20, 241, 149, 0.07), transparent 30rem),
+    #09090b;
+}
+
+.architecture-page {
+  width: 100%;
+}
+
+.architecture-frame {
+  display: grid;
+  min-height: 100svh;
+  padding: clamp(32px, 5vw, 72px) clamp(24px, 6vw, 96px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  scroll-snap-align: start;
+}
+
+.frame-heading,
+.diagram-shell {
+  width: min(1440px, 100%);
+  margin-inline: auto;
+}
+
+.frame-heading {
+  align-self: end;
+  margin-bottom: clamp(24px, 3vh, 40px);
+}
+
+.frame-label {
+  margin: 0 0 14px;
+  color: #a78bfa;
+  font-size: clamp(12px, 1.2vw, 15px);
+  font-weight: 760;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  max-width: 1120px;
+  margin: 0;
+  font-size: clamp(32px, 4.2vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+}
+
+.diagram-shell {
+  display: grid;
+  min-height: min(64vh, 760px);
+  place-items: center;
+  align-self: start;
+  padding: clamp(20px, 3vw, 42px);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  background: rgba(20, 20, 24, 0.76);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.28);
+}
+
+.mermaid {
+  display: grid;
+  width: 100%;
+  margin: 0;
+  place-items: center;
+  color: #9c9ca4;
+  background: transparent;
+  font-family: inherit;
+  white-space: pre-wrap;
+}
+
+.mermaid svg {
+  width: 100%;
+  max-width: 1320px;
+  max-height: 62vh;
+}
+
+body[data-mermaid-error="true"]::before {
+  position: fixed;
+  z-index: 10;
+  top: 16px;
+  right: 16px;
+  padding: 10px 14px;
+  border: 1px solid rgba(248, 113, 113, 0.55);
+  border-radius: 10px;
+  background: #450a0a;
+  color: #fecaca;
+  content: "A diagram failed to render";
+  font-size: 13px;
+  font-weight: 700;
+}
+
+@media (max-width: 760px) {
+  html {
+    scroll-snap-type: none;
+  }
+
+  .architecture-frame {
+    min-height: auto;
+    padding-block: 48px;
+  }
+
+  .diagram-shell {
+    min-height: 460px;
+    overflow-x: auto;
+  }
+
+  .mermaid svg {
+    min-width: 720px;
+  }
+}
+
+@media print {
+  .architecture-frame {
+    min-height: 100vh;
+    break-after: page;
+  }
+}

--- a/solana/demo-dapp/src/architecture/styles.css
+++ b/solana/demo-dapp/src/architecture/styles.css
@@ -32,49 +32,63 @@ body {
 
 .architecture-frame {
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100svh;
   min-height: 100svh;
-  padding: clamp(32px, 5vw, 72px) clamp(24px, 6vw, 96px);
+  padding: clamp(12px, 1.5vw, 24px) clamp(12px, 2vw, 32px) clamp(16px, 2vw, 28px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   scroll-snap-align: start;
 }
 
 .frame-heading,
 .diagram-shell {
-  width: min(1440px, 100%);
+  width: min(1600px, 100%);
   margin-inline: auto;
 }
 
 .frame-heading {
-  align-self: end;
-  margin-bottom: clamp(24px, 3vh, 40px);
+  align-self: start;
+  margin-bottom: clamp(8px, 1vh, 12px);
+}
+
+.frame-heading h1 {
+  display: flex;
+  max-width: none;
+  margin: 0;
+  align-items: baseline;
+  gap: 8px 12px;
+  font-size: clamp(17px, 1.55vw, 24px);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
 }
 
 .frame-label {
-  margin: 0 0 14px;
+  flex: none;
   color: #a78bfa;
-  font-size: clamp(12px, 1.2vw, 15px);
+  font-size: clamp(10px, 0.75vw, 13px);
   font-weight: 760;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-h1 {
-  max-width: 1120px;
-  margin: 0;
-  font-size: clamp(32px, 4.2vw, 64px);
-  line-height: 1.02;
-  letter-spacing: -0.045em;
+.frame-separator {
+  color: #666672;
+}
+
+.frame-statement {
+  font-weight: 700;
 }
 
 .diagram-shell {
   display: grid;
-  min-height: min(64vh, 760px);
+  min-height: 0;
+  height: 100%;
   place-items: center;
-  align-self: start;
-  padding: clamp(20px, 3vw, 42px);
+  align-self: stretch;
+  padding: clamp(10px, 1.5vw, 24px);
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 24px;
+  border-radius: 18px;
   background: rgba(20, 20, 24, 0.76);
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.28);
 }
@@ -82,6 +96,8 @@ h1 {
 .mermaid {
   display: grid;
   width: 100%;
+  height: 100%;
+  min-height: 0;
   margin: 0;
   place-items: center;
   color: #9c9ca4;
@@ -92,8 +108,9 @@ h1 {
 
 .mermaid svg {
   width: 100%;
-  max-width: 1320px;
-  max-height: 62vh;
+  height: 100%;
+  max-width: 1520px;
+  max-height: 100%;
 }
 
 body[data-mermaid-error="true"]::before {
@@ -117,16 +134,33 @@ body[data-mermaid-error="true"]::before {
   }
 
   .architecture-frame {
+    grid-template-rows: auto auto;
+    height: auto;
     min-height: auto;
     padding-block: 48px;
   }
 
+  .frame-heading h1 {
+    display: block;
+  }
+
+  .frame-separator {
+    display: none;
+  }
+
+  .frame-statement {
+    display: block;
+    margin-top: 6px;
+  }
+
   .diagram-shell {
+    height: auto;
     min-height: 460px;
     overflow-x: auto;
   }
 
   .mermaid svg {
+    height: auto;
     min-width: 720px;
   }
 }

--- a/solana/demo-dapp/src/observabilityLinks.test.ts
+++ b/solana/demo-dapp/src/observabilityLinks.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  FHE_BATCH_P95_QUERY,
+  jaegerDecryptUrl,
+  KMS_DECRYPT_P95_QUERY,
+  prometheusQueryUrl,
+  STACK_HEALTH_QUERY,
+} from './observabilityLinks';
+
+describe('observability links', () => {
+  test('opens Jaeger on Solana user decrypt traces for one ciphertext handle', () => {
+    const handle = `0x${'ab'.repeat(32)}`;
+    const url = new URL(jaegerDecryptUrl(handle));
+
+    expect(url.origin).toBe('http://127.0.0.1:16686');
+    expect(url.pathname).toBe('/search');
+    expect(url.searchParams.get('service')).toBe('kms-connector-gw-listener');
+    expect(url.searchParams.get('operation')).toBe('handle_gateway_event');
+    expect(JSON.parse(url.searchParams.get('tags')!)).toEqual({
+      operation: 'solana_user_decrypt',
+      ciphertext_handle: handle,
+    });
+    expect(url.searchParams.get('lookback')).toBe('24h');
+  });
+
+  test.each([STACK_HEALTH_QUERY, KMS_DECRYPT_P95_QUERY, FHE_BATCH_P95_QUERY])(
+    'opens Prometheus with the intended expression',
+    (expression) => {
+      const url = new URL(prometheusQueryUrl(expression));
+      expect(url.origin).toBe('http://127.0.0.1:9090');
+      expect(url.pathname).toBe('/graph');
+      expect(url.searchParams.get('g0.expr')).toBe(expression);
+      expect(url.searchParams.get('g0.range_input')).toBe('1h');
+    },
+  );
+});

--- a/solana/demo-dapp/src/observabilityLinks.ts
+++ b/solana/demo-dapp/src/observabilityLinks.ts
@@ -1,0 +1,33 @@
+const JAEGER_URL = 'http://127.0.0.1:16686/search';
+const PROMETHEUS_URL = 'http://127.0.0.1:9090/graph';
+
+export const STACK_HEALTH_QUERY = 'up{job=~"coprocessor|kms-connector|kms-core|relayer"}';
+export const KMS_DECRYPT_P95_QUERY =
+  'histogram_quantile(0.95, sum by (le) (rate(kms_connector_worker_decryption_latency_seconds_bucket{event_type="user_decryption_request"}[5m])))';
+export const FHE_BATCH_P95_QUERY =
+  'histogram_quantile(0.95, sum by (le) (rate(coprocessor_fhe_batch_latency_seconds_bucket[5m])))';
+
+export const jaegerDecryptUrl = (handle?: string): string => {
+  const tags = {
+    operation: 'solana_user_decrypt',
+    ...(handle === undefined ? {} : { ciphertext_handle: handle }),
+  };
+  const query = new URLSearchParams({
+    service: 'kms-connector-gw-listener',
+    operation: 'handle_gateway_event',
+    tags: JSON.stringify(tags),
+    lookback: '24h',
+    limit: '20',
+  });
+  return `${JAEGER_URL}?${query.toString()}`;
+};
+
+export const prometheusQueryUrl = (expression: string): string => {
+  const query = new URLSearchParams({
+    'g0.expr': expression,
+    'g0.tab': '0',
+    'g0.stacked': '0',
+    'g0.range_input': '1h',
+  });
+  return `${PROMETHEUS_URL}?${query.toString()}`;
+};

--- a/solana/demo-dapp/src/styles/evidence.css
+++ b/solana/demo-dapp/src/styles/evidence.css
@@ -30,6 +30,8 @@
 .developer-evidence > summary:focus-visible,
 .evidence-toolbar button:focus-visible,
 .evidence-value button:focus-visible,
+.evidence-link:focus-visible,
+.evidence-observability a:focus-visible,
 .evidence-transactions a:focus-visible {
   outline: 2px solid #a78bfa;
   outline-offset: 2px;
@@ -78,6 +80,24 @@
 .evidence-toolbar button:disabled {
   cursor: wait;
   opacity: 0.55;
+}
+
+.evidence-observability {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.evidence-link,
+.evidence-observability a {
+  width: fit-content;
+  padding: 5px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  color: #c4b5fd;
+  background: rgba(124, 58, 237, 0.09);
+  font-size: 10px;
+  text-decoration: none;
 }
 
 .evidence-content dl {
@@ -134,6 +154,8 @@
 }
 
 .evidence-toolbar button:hover:not(:disabled),
+.evidence-link:hover,
+.evidence-observability a:hover,
 .evidence-value button:hover,
 .evidence-transactions a:hover {
   border-color: rgba(196, 181, 253, 0.4);

--- a/solana/demo-dapp/src/useDemoController.async.test.tsx
+++ b/solana/demo-dapp/src/useDemoController.async.test.tsx
@@ -208,6 +208,16 @@ describe('useDemoController generation safety', () => {
     expect(mocks.operator).not.toHaveBeenCalled();
   });
 
+  test('reads the live vault price even when this wallet has no shares', async () => {
+    mocks.hasShares.mockResolvedValue(false);
+
+    await connect(controller);
+    await flush();
+
+    expect(mocks.metrics).toHaveBeenCalled();
+    expect(controller.state.vaultMetrics).toEqual({ totalAssets: 125n, totalShares: 100n });
+  });
+
   test('prepares a new batch and preserves the existing private position for another deposit', async () => {
     const nextPosition = { ...position, batchIndex: 2n };
     mocks.lifecycle.mockResolvedValue(settled);
@@ -650,11 +660,14 @@ describe('useDemoController generation safety', () => {
     expect(controller.state.vaultMetrics).toEqual(afterHarvest);
   });
 
-  test('clears the private position after a completed full redemption', async () => {
+  test('clears the private position and reads the empty vault after a completed full redemption', async () => {
     mocks.findDeposit.mockResolvedValue(null);
     mocks.lifecycle.mockResolvedValue(settled);
     mocks.revealShares.mockResolvedValue({ value: 100_000_000n, handle: '0x01' });
     mocks.joinRedeem.mockResolvedValue(position);
+    mocks.metrics
+      .mockResolvedValueOnce({ totalAssets: 114_490_000n, totalShares: 100_000_000n })
+      .mockResolvedValueOnce({ totalAssets: 0n, totalShares: 0n });
     await connect(controller);
     await flush();
 
@@ -662,7 +675,7 @@ describe('useDemoController generation safety', () => {
     await flush();
 
     expect(controller.state.hasPrivateShares).toBe(false);
-    expect(controller.state.vaultMetrics).toBe(null);
+    expect(controller.state.vaultMetrics).toEqual({ totalAssets: 0n, totalShares: 0n });
     expect(controller.state.redeemPercentage).toBe(null);
   });
 });

--- a/solana/demo-dapp/src/useDemoController.async.test.tsx
+++ b/solana/demo-dapp/src/useDemoController.async.test.tsx
@@ -283,7 +283,7 @@ describe('useDemoController generation safety', () => {
 
     expect(controller.state.deposit).toEqual({
       kind: 'error',
-      message: 'Reveal your cUSDC balance before depositing.',
+      message: 'Decrypt the cUSDC balance before depositing.',
     });
     expect(mocks.fund).not.toHaveBeenCalled();
     expect(mocks.joinDeposit).not.toHaveBeenCalled();

--- a/solana/demo-dapp/src/useDemoController.ts
+++ b/solana/demo-dapp/src/useDemoController.ts
@@ -336,10 +336,10 @@ export function useDemoController() {
               revealedUsdc: null,
               revealUsdcError: null,
               ...(state.redeemPercentage === 100
-                ? { hasPrivateShares: false, revealedShares: null, vaultMetrics: null }
+                ? { hasPrivateShares: false, revealedShares: null }
                 : {}),
             });
-            if (state.redeemPercentage !== 100) void refreshVaultMetrics(generation);
+            void refreshVaultMetrics(generation);
             return;
           }
           commit(generation, { redeemLifecycle: next, redeemOperatorError: null });
@@ -365,13 +365,13 @@ export function useDemoController() {
   }, [advanceOperator, commit, refreshVaultMetrics, state.connection, state.generation, state.redeem, state.redeemPercentage]);
 
   useEffect(() => {
-    if (!state.hasPrivateShares) {
+    if (state.connection.kind !== 'ready') {
       commit(state.generation, { vaultMetrics: null });
       return;
     }
     const generation = state.generation;
     void refreshVaultMetrics(generation);
-  }, [commit, refreshVaultMetrics, state.generation, state.hasPrivateShares]);
+  }, [commit, refreshVaultMetrics, state.connection, state.generation]);
 
   const disconnect = useCallback(() => {
     const generation = sessionGeneration.current + 1;

--- a/solana/demo-dapp/src/useDemoController.ts
+++ b/solana/demo-dapp/src/useDemoController.ts
@@ -454,7 +454,7 @@ export function useDemoController() {
           kind: 'error',
           message:
             revealedSource === null
-              ? 'Reveal your cUSDC balance before depositing.'
+              ? 'Decrypt the cUSDC balance before depositing.'
               : 'Your cUSDC balance is too low for this deposit.',
         },
       });

--- a/solana/demo-dapp/vite.config.ts
+++ b/solana/demo-dapp/vite.config.ts
@@ -25,4 +25,9 @@ export default defineConfig(({ mode }) => ({
   // Vitest needs only transforms; omitting the development server plugin keeps tests independent
   // of runtime credentials without creating a credential bypass mode.
   plugins: mode === 'test' ? [] : [demoServerPlugin()],
+  build: {
+    rollupOptions: {
+      input: ['index.html', 'architecture.html'],
+    },
+  },
 }));

--- a/solana/programs/demo-vault/src/state.rs
+++ b/solana/programs/demo-vault/src/state.rs
@@ -52,6 +52,12 @@ pub fn assets_to_shares(assets: u64, total_assets: u64, total_shares: u64) -> Re
 ///
 /// `total_assets` / `total_shares` are the balances *before* this withdraw.
 pub fn shares_to_assets(shares: u64, total_assets: u64, total_shares: u64) -> Result<u64> {
+    // The virtual share owns the rounding remainder while real shares exist. Once the last real
+    // share exits, no holder remains for that remainder: drain the vault so its next lifecycle
+    // starts from the documented empty-vault 1:1 price.
+    if shares == total_shares {
+        return Ok(total_assets);
+    }
     let numerator = (shares as u128)
         .checked_mul((total_assets as u128).saturating_add(VIRTUAL_ASSETS))
         .ok_or(DemoVaultError::MathOverflow)?;
@@ -78,6 +84,14 @@ mod tests {
     }
 
     #[test]
+    fn full_exit_after_yield_returns_every_asset() {
+        assert_eq!(
+            shares_to_assets(100_000_000, 114_490_000, 100_000_000).unwrap(),
+            114_490_000
+        );
+    }
+
+    #[test]
     fn second_depositor_after_yield_gets_fewer_shares() {
         // First depositor: 1_000 assets -> 1_000 shares (1:1).
         let first = assets_to_shares(1_000, 0, 0).unwrap();
@@ -93,8 +107,8 @@ mod tests {
     fn rounding_is_down_on_both_sides() {
         // shares = 5 * (1 + 1) / (2 + 1) = 10 / 3 = 3.33... -> floor 3.
         assert_eq!(assets_to_shares(5, 2, 1).unwrap(), 3);
-        // assets = 1 * (4 + 1) / (1 + 1) = 5 / 2 = 2.5 -> floor 2.
-        assert_eq!(shares_to_assets(1, 4, 1).unwrap(), 2);
+        // assets = 2 * (4 + 1) / (3 + 1) = 10 / 4 = 2.5 -> floor 2.
+        assert_eq!(shares_to_assets(2, 4, 3).unwrap(), 2);
     }
 
     #[test]

--- a/solana/runtime-tests/cost-snapshots/vault_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/vault_mollusk.json
@@ -16,7 +16,7 @@
     "max_cpi_instruction_data_bytes": 10
   },
   "withdraw": {
-    "compute_units": 14836,
+    "compute_units": 14838,
     "unique_accounts": 10,
     "instruction_data_bytes": 16,
     "cpi_instructions": 2,

--- a/solana/runtime-tests/tests/vault_mollusk.rs
+++ b/solana/runtime-tests/tests/vault_mollusk.rs
@@ -442,6 +442,73 @@ fn mollusk_deposit_withdraw_round_trip_returns_principal() {
 }
 
 #[test]
+fn mollusk_full_exit_after_yield_resets_next_deposit_to_one_to_one() {
+    let fixture = VaultFixture::new();
+    let owner = Pubkey::new_unique();
+    let owner_underlying = Pubkey::new_unique();
+    let owner_shares = Pubkey::new_unique();
+    let donor = Pubkey::new_unique();
+    let donor_underlying = Pubkey::new_unique();
+    let next_depositor = Pubkey::new_unique();
+    let next_underlying = Pubkey::new_unique();
+    let next_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_underlying,
+        spl_token_account(fixture.underlying_mint, owner, 100_000_000),
+    );
+    accounts.insert(
+        owner_shares,
+        spl_token_account(fixture.share_mint, owner, 0),
+    );
+    accounts.insert(donor, system_account(1_000_000_000));
+    accounts.insert(
+        donor_underlying,
+        spl_token_account(fixture.underlying_mint, donor, 14_490_000),
+    );
+    accounts.insert(next_depositor, system_account(1_000_000_000));
+    accounts.insert(
+        next_underlying,
+        spl_token_account(fixture.underlying_mint, next_depositor, 100_000_000),
+    );
+    accounts.insert(
+        next_shares,
+        spl_token_account(fixture.share_mint, next_depositor, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    context.process_and_validate_instruction(
+        &deposit_ix(&fixture, owner, owner_underlying, owner_shares, 100_000_000),
+        &[Check::success()],
+    );
+    context.process_and_validate_instruction(
+        &harvest_ix(&fixture, donor, donor_underlying, 14_490_000),
+        &[Check::success()],
+    );
+    context.process_and_validate_instruction(
+        &withdraw_ix(&fixture, owner, owner_shares, owner_underlying, 100_000_000),
+        &[Check::success()],
+    );
+
+    assert_eq!(read_spl_amount(&context, fixture.vault_token_account), 0);
+    assert_eq!(read_mint_supply(&context, fixture.share_mint), 0);
+
+    context.process_and_validate_instruction(
+        &deposit_ix(
+            &fixture,
+            next_depositor,
+            next_underlying,
+            next_shares,
+            100_000_000,
+        ),
+        &[Check::success()],
+    );
+    assert_eq!(read_spl_amount(&context, next_shares), 100_000_000);
+}
+
+#[test]
 fn mollusk_harvest_raises_price_so_later_depositor_gets_fewer_shares() {
     // Vault already at 1:1 with 1_000 assets and 1_000 shares outstanding.
     let fixture = VaultFixture::new();

--- a/solana/scripts/demo/README.md
+++ b/solana/scripts/demo/README.md
@@ -47,8 +47,8 @@ signed transaction before submission. Confirm that Phantom shows `127.0.0.1:5173
 the rehearsal against a different site or network.
 
 The **Developer evidence** panel exposes the exact local signatures, compute consumption,
-ciphertext handles, and encrypted-value account. Use the Explorer links for transaction details
-and the copied handle for Jaeger correlation.
+ciphertext handles, and encrypted-value account. Its links open the matching transaction,
+handle-filtered Jaeger trace, or a prepared Prometheus query.
 
 Add `--observability` to `doctor`, `up`, or `serve` to reserve and start boot-owned Prometheus and
 Jaeger services:
@@ -88,11 +88,11 @@ internals, the relayer, or the native Solana listener as one distributed trace. 
 decryption histogram measures event creation through successful response persistence; report its
 p95 only with a meaningful sample count, and do not label it end-to-end browser latency.
 
-For a user decryption, copy the ciphertext handle from the dApp's **Developer evidence** panel,
-open Jaeger, select `kms-connector-gw-listener`, and filter the `handle_gateway_event` operation by
-the `ciphertext_handle` tag. Older locally built connector images expose the same value as
-`ciphertext_handles`. This trace proves the connector and KMS request path for that exact encrypted
-value; the dApp records the separate wallet-to-cleartext duration.
+For a user decryption, open **Trace in Jaeger** next to the ciphertext handle in the dApp's
+**Developer evidence** panel. The prepared search selects `kms-connector-gw-listener`, the
+`handle_gateway_event` operation, and the exact `ciphertext_handle`. This trace proves the
+connector and KMS request path for that encrypted value; the dApp records the separate
+wallet-to-cleartext duration.
 
 Prometheus exposes `kms_connector_worker_decryption_latency_seconds`. Keep the
 `event_type="user_decryption_request"` filter and show the sample count beside any percentile. A


### PR DESCRIPTION
Adds a separate scrolling architecture walkthrough for the confidential vault demo. It renders nine full-screen frames with concise speaking anchors: a first-principles protocol flow, the shared-key trust model, and the end-to-end Solana vault flow.

Mermaid is bundled locally so the walkthrough works offline at `/architecture.html`. The normal dApp entry is unchanged. Demo tests, type-check, lint, production build, and browser rendering of all frames pass.
