### PR TITLE
docs(host-contracts): clarify KMS context-validity gates on lifecycle reads (N-05)

### DIFF
--- a/host-contracts/contracts/KMSGeneration.sol
+++ b/host-contracts/contracts/KMSGeneration.sol
@@ -869,6 +869,9 @@ contract KMSGeneration is IKMSGeneration, EIP712Upgradeable, UUPSUpgradeableEmpt
         address signerAddress,
         address txSenderAddress
     ) internal view virtual {
+        // This signer check requires an `Active` context. The other reads this contract makes on
+        // `PROTOCOL_CONFIG` accept any live context. Both gates agree today because every request
+        // pins its context from `getCurrentKmsContextAndEpoch`, which returns the active context.
         if (!PROTOCOL_CONFIG.isKmsSignerForContext(contextId, signerAddress)) {
             revert NotKmsSigner(signerAddress);
         }

--- a/host-contracts/contracts/interfaces/IProtocolConfig.sol
+++ b/host-contracts/contracts/interfaces/IProtocolConfig.sol
@@ -607,6 +607,9 @@ interface IProtocolConfig {
 
     /**
      * @notice Returns the kmsGen threshold for a given context.
+     * @dev The other threshold getters require an `Active` context. This one returns a value for any
+     *      live context, whatever its state, so the kmsGen threshold stays readable even before the
+     *      context becomes `Active`.
      * @param kmsContextId The context ID.
      * @return The kmsGen threshold for the context.
      */


### PR DESCRIPTION
Back-port of #3328 (240d6cd2fac696d6864b256d1e17d66170ebbcb0)  from `release/0.14.x` to `main`: documents the KMS context-validity gates on lifecycle read functions.
