### PR TITLE
docs(host-contracts): document canonical-only KMS context anchor (N-02)

### DIFF
--- a/host-contracts/contracts/interfaces/IProtocolConfig.sol
+++ b/host-contracts/contracts/interfaces/IProtocolConfig.sol
@@ -449,6 +449,11 @@ interface IProtocolConfig {
     // these import, so they skip the confirmation flow and land it as Active. Owner-only; the
     // operator must fan each Ethereum rotation out to every replica in order. The strictly-increasing
     // ID checks guard against rollback, not skipped calls.
+    //
+    // The contract does not track deployment mode on-chain. The mirror entry points target a replica
+    // only. The committee and owner entry points target a canonical deployment only. Nothing reverts
+    // when a caller uses the wrong entry points on the wrong deployment. This wrong use is unsupported
+    // operator misuse.
     // -----------------------------------------------------------------------------------------
 
     /**
@@ -493,9 +498,13 @@ interface IProtocolConfig {
 
     /**
      * @notice Returns the context anchor recorded when NewKmsContext was emitted.
+     * @dev Canonical-only. The canonical definition and bootstrap paths record the anchor. The replica
+     *      paths (`initializeFromCanonical` and `mirrorKmsContextAndEpoch`) do not record it. On a
+     *      replica this returns `(0, 0x0)` for every mirrored context. Cross-chain verification tooling
+     *      must not compare the anchor on a replica.
      * @param contextId The context ID.
-     * @return emissionBlockNumber The block where NewKmsContext was emitted.
-     * @return contextInfoHash Hash of the emitted context payload.
+     * @return emissionBlockNumber The block where NewKmsContext was emitted, or 0 on a replica.
+     * @return contextInfoHash Hash of the emitted context payload, or 0x0 on a replica.
      */
     function getKmsContextAnchor(
         uint256 contextId


### PR DESCRIPTION
Back-port of #3325 (f85492e100d425a3530f0a84e8661f38da37a357) from `release/0.14.x` to `main`: documents that the KMS context anchor is canonical-only.