### PR TITLE
chore(common): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,17 +3,13 @@
 # All pull request should be reviewed by at least one of the members of fhevm-devs
 *    @zama-ai/fhevm-devs
 
-# Production Dockerfiles should be reviewed by members of fhevm-devops
-**/Dockerfile @zama-ai/fhevm-devops
-
-# Test tooling Dockerfiles can be reviewed by members of fhevm-devs
-coprocessor/fhevm-engine/stress-test-generator/Dockerfile @zama-ai/fhevm-devs
-test-suite/gateway-stress/Dockerfile @zama-ai/fhevm-devs
+# Shared ownership
+/shared/ciphertext-attestation/ @zama-ai/fhevm-devs @zama-ai/mpc-devs
+/shared/user-decryption-signature/ @zama-ai/fhevm-devs @zama-ai/mpc-devs
+/test-suite/ @zama-ai/fhevm-devs @zama-ai/mpc-devs
 
 # Gateway Team ownership
 /gateway-contracts/ @zama-ai/fhevm-gateway
-/host-contracts/ @zama-ai/fhevm-gateway
-/library-solidity/ @zama-ai/fhevm-gateway
 /relayer/ @zama-ai/fhevm-gateway
 
 # Coprocessor Team ownership
@@ -29,11 +25,15 @@ test-suite/gateway-stress/Dockerfile @zama-ai/fhevm-devs
 
 # MPC Team ownership
 /kms-connector/ @zama-ai/mpc-devs
-
-# Shared ownership
-/shared/ciphertext-attestation/ @zama-ai/fhevm-devs @zama-ai/mpc-devs
-/shared/user-decryption-signature/ @zama-ai/fhevm-devs @zama-ai/mpc-devs
+/test-suite/gateway-stress/ @zama-ai/mpc-devs
 
 # Enforces changes in Sandboxed AI CI/CD
-.github/squid/sandbox-*.conf @zama-ai/security-team 
-.github/workflows/claude-*.yml @zama-ai/security-team 
+.github/squid/sandbox-*.conf @zama-ai/security-team
+.github/workflows/claude-*.yml @zama-ai/security-team
+
+# Production Dockerfiles should be reviewed by members of fhevm-devops
+**/Dockerfile @zama-ai/fhevm-devops
+
+# Test tooling Dockerfiles can be reviewed by members of fhevm-devs / mpc-devs
+/coprocessor/fhevm-engine/stress-test-generator/Dockerfile @zama-ai/fhevm-devs
+/test-suite/gateway-stress/Dockerfile @zama-ai/mpc-devs


### PR DESCRIPTION
Mainly did this update to share the ownership of `test-suite` to both fhevm-devs and mpc-devs.

AFAIU, in CODEOWNERS, the ordering matters: the last line to match a file wins the ownership. So I moved a bit things to be more coherent.
For ex, host-contracts was first assigned to gateway-team, then to copro-team. Only the last one (copro-team) was applied in reality, so I removed the first gateway-team ownership line.

I moved the shared "broad" shared ownership at the top of the file so it can be overriden more easily (ex: `test-suite` owned by mpc+fhevm-devs, but `test-suite/gateway-stress` is mpc-devs only now), and moved the Dockerfile ownership by `fhevm-devops` at the bottom (it was overriden by sub-team ownership, thus not applied)