### PR TITLE
fix(coprocessor): re-allow V0_7_0 ZK proof hash config in zk-worker

### DIFF
--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -601,9 +601,11 @@ pub(crate) fn verify_proof(
 /// during the conformance check, i.e. *before* any ZK verification runs, which
 /// keeps the attack surface of the proof verifier down to what is strictly needed:
 ///
-/// * Hash config: only `V0_8_0` (tfhe-zk-pok 0.8.0+, produced by tfhe-rs 1.5.0+)
-///   is accepted; the legacy `V0_4_0` (tfhe-rs 0.11.x–1.2.x) and `V0_7_0`
-///   (tfhe-rs 1.3.0–1.4.x) configs are forbidden.
+/// * Hash config: `V0_8_0` (tfhe-zk-pok 0.8.0+, produced by tfhe-rs 1.5.0+) and
+///   `V0_7_0` (tfhe-rs 1.3.0–1.4.x, still emitted by the tfhe wasm pinned in
+///   relayer-sdk 0.4.x) are accepted; the legacy `V0_4_0` (tfhe-rs
+///   0.11.x–1.2.x) config is forbidden. `V0_7_0` must stay accepted until no
+///   deployed client encrypts with a pre-1.5.0 tfhe wasm.
 /// * Compute load: only [`ZkComputeLoad::Verify`] is accepted — the load the
 ///   clients emit — and `ZkComputeLoad::Proof` is forbidden.
 /// * Packing: `allow_unpacked` is left off, so only packed (and therefore
@@ -617,7 +619,6 @@ pub(crate) fn proven_list_conformance_params(
         &crs.crs,
     )
     .forbid_hash_config(ZkPkeV2SupportedHashConfig::V0_4_0)
-    .forbid_hash_config(ZkPkeV2SupportedHashConfig::V0_7_0)
     .forbid_compute_load(ZkComputeLoad::Proof)
 }
 


### PR DESCRIPTION
## Problem

After the coprocessor v0.14 upgrade on zws-dev, every e2e test that submits an input proof via `relayer-sdk@0.4.4` fails with `InputProof rejected` (Slack: https://zama-ai.slack.com/archives/C0A6WGZ5UAD/p1785433187727189).

Root cause (credit: Nicolas B. / Stéphane / Arthur in the thread): `relayer-sdk@0.4.4` statically pins the `tfhe@1.4.0-alpha.3` wasm, which ships `tfhe-zk-pok ^0.7.3`, so every PkeV2 ZK proof it produces carries the legacy `V0_7_0` hash configuration. Since #2800 the zkproof-worker conformance check forbids `V0_7_0` by policy, so these proofs are rejected before verification even runs. This is a policy rejection, not a verification failure — tfhe-zk-pok still fully supports verifying `V0_7_0` proofs.

## Fix

Remove `forbid_hash_config(V0_7_0)` from `proven_list_conformance_params` so proofs from deployed clients verify again. Kept as-is:

- `V0_4_0` stays forbidden (tfhe-rs ≤1.2.x, no known live client).
- `forbid_compute_load(ZkComputeLoad::Proof)` stays: Arthur flagged the compute load as a possible second blocker, but `relayer-sdk@0.4.4` passes `ZkComputeLoadVerify` on both of its encryption paths (`src/sdk/encrypt.ts:187`, `src/sdk/lowlevel/TFHEZKProofBuilder.ts:251` at tag v0.4.4), so it does not need re-allowing.

This trades back the part of #2800's attack-surface reduction that broke deployed clients. `V0_7_0` should be re-forbidden once no supported relayer-sdk pins a pre-1.5.0 tfhe wasm (tracked for v0.15 backward-compat work per the thread).

## Testing

- `cargo check -p zkproof-worker` and `cargo test -p zkproof-worker --no-run` pass locally.
- Needs validation on zws-dev: rerun the relayer-sdk 0.4.4 e2e input-proof suite against a coprocessor built from this branch.