### PR TITLE
chore(kms-connector): bound ct download size

### DIFF
--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -60,7 +60,6 @@ use crate::{
 };
 
 pub const UPLOAD_QUEUE_SIZE: usize = 20;
-pub const SAFE_SER_LIMIT: u64 = 1024 * 1024 * 66;
 
 pub(crate) const CLEAN_OLD_S3_FORMAT_VERSION: i16 = 0;
 pub(crate) const S3_FORMAT_VERSION_V0: i16 = 0;

--- a/coprocessor/fhevm-engine/sns-worker/src/squash_noise.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/squash_noise.rs
@@ -1,5 +1,5 @@
 use crate::ExecutionError;
-use crate::SAFE_SER_LIMIT;
+use ciphertext_attestation::MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE;
 use opentelemetry::trace::Status;
 use serde::Serialize;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -304,7 +304,7 @@ pub fn safe_serialize<T: Serialize + Named + Versionize>(
     object: &T,
 ) -> Result<Vec<u8>, ExecutionError> {
     let mut out = vec![];
-    tfhe::safe_serialization::safe_serialize(object, &mut out, SAFE_SER_LIMIT)
+    tfhe::safe_serialization::safe_serialize(object, &mut out, MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE)
         .map_err(|e| ExecutionError::SerializationError(e.to_string()))?;
     Ok(out)
 }
@@ -313,7 +313,7 @@ pub fn safe_serialize<T: Serialize + Named + Versionize>(
 pub fn safe_deserialize<T: serde::de::DeserializeOwned + Named + tfhe::Unversionize>(
     input: &[u8],
 ) -> Result<T, ExecutionError> {
-    let res = tfhe::safe_serialization::safe_deserialize(input, SAFE_SER_LIMIT)
+    let res = tfhe::safe_serialization::safe_deserialize(input, MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE)
         .map_err(ExecutionError::DeserializationError)?;
     Ok(res)
 }

--- a/kms-connector/Cargo.lock
+++ b/kms-connector/Cargo.lock
@@ -1213,6 +1213,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1254,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1272,6 +1299,19 @@ name = "ark-ff-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1323,7 +1363,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1332,10 +1372,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1371,6 +1435,16 @@ dependencies = [
  "num-traits",
  "rand 0.8.6",
  "rayon",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2963,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4417,7 +4491,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5595,14 +5669,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -5673,7 +5748,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5732,7 +5807,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6644,7 +6719,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7846,7 +7921,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -90,6 +90,12 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS
 # s3_max_concurrent_gets = 16
 
+# Maximum size of a single ciphertext body, in bytes (optional, defaults to 67108864, 64MiB)
+# Mainnet serves ~96KiB compressed_on_cpu ciphertexts, but the uncompressed formats may reach ~32MiB,
+# and a ceiling below a legitimate ciphertext would have every bucket turn it down.
+# ENV: KMS_CONNECTOR_S3_MAX_CIPHERTEXT_SIZE
+# s3_max_ciphertext_size = 67108864
+
 # Refresh interval of the Coprocessor registry read from the GatewayConfig contract (optional, defaults to 60s)
 # ENV: KMS_CONNECTOR_COPRO_REGISTRY_REFRESH (format: https://docs.rs/humantime/latest/humantime/)
 # copro_registry_refresh = "60s"

--- a/kms-connector/config/kms-worker.toml
+++ b/kms-connector/config/kms-worker.toml
@@ -90,11 +90,10 @@ database_url = "postgres://postgres:postgres@localhost/kms-connector"
 # ENV: KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS
 # s3_max_concurrent_gets = 16
 
-# Maximum size of a single ciphertext body, in bytes (optional, defaults to 67108864, 64MiB)
-# Mainnet serves ~96KiB compressed_on_cpu ciphertexts, but the uncompressed formats may reach ~32MiB,
-# and a ceiling below a legitimate ciphertext would have every bucket turn it down.
+# Maximum size of a single ciphertext body, in bytes (optional, defaults to 69206016, 66MiB)
+# The default is MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE, also used by the sns-worker when uploading ciphertexts.
 # ENV: KMS_CONNECTOR_S3_MAX_CIPHERTEXT_SIZE
-# s3_max_ciphertext_size = 67108864
+# s3_max_ciphertext_size = 69206016
 
 # Refresh interval of the Coprocessor registry read from the GatewayConfig contract (optional, defaults to 60s)
 # ENV: KMS_CONNECTOR_COPRO_REGISTRY_REFRESH (format: https://docs.rs/humantime/latest/humantime/)

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -93,6 +93,9 @@ pub struct Config {
     /// Ceiling on the ciphertext `GET`s in flight, across all requests and buckets.
     #[serde(default = "default_s3_max_concurrent_gets")]
     pub s3_max_concurrent_gets: NonZeroUsize,
+    /// Ceiling on the size of a single ciphertext body, in bytes.
+    #[serde(default = "default_s3_max_ciphertext_size")]
+    pub s3_max_ciphertext_size: NonZeroUsize,
     /// Refresh interval of the Coprocessor registry, read from the `GatewayConfig` contract.
     #[serde(with = "humantime_serde", default = "default_copro_registry_refresh")]
     pub copro_registry_refresh: Duration,
@@ -231,6 +234,12 @@ fn default_s3_max_concurrent_gets() -> NonZeroUsize {
     NonZeroUsize::new(16).unwrap()
 }
 
+fn default_s3_max_ciphertext_size() -> NonZeroUsize {
+    // Mainnet serves ~96KiB compressed_on_cpu ciphertexts, but the uncompressed formats may reach ~32MiB,
+    // and a ceiling below a legitimate ciphertext would have every bucket turn it down.
+    NonZeroUsize::new(64 * 1024 * 1024).unwrap()
+}
+
 fn default_erc1271_gas_limit() -> u64 {
     100_000
 }
@@ -268,6 +277,7 @@ impl Default for Config {
             s3_get_timeout: default_s3_get_timeout(),
             s3_max_concurrent_heads_per_bucket: default_s3_max_concurrent_heads_per_bucket(),
             s3_max_concurrent_gets: default_s3_max_concurrent_gets(),
+            s3_max_ciphertext_size: default_s3_max_ciphertext_size(),
             copro_registry_refresh: default_copro_registry_refresh(),
             host_rpc_max_concurrent_calls: default_host_rpc_max_concurrent_calls(),
             host_rpc_call_timeout: default_host_rpc_call_timeout(),
@@ -309,6 +319,7 @@ mod tests {
             env::remove_var("KMS_CONNECTOR_S3_GET_TIMEOUT");
             env::remove_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET");
             env::remove_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS");
+            env::remove_var("KMS_CONNECTOR_S3_MAX_CIPHERTEXT_SIZE");
             env::remove_var("KMS_CONNECTOR_COPRO_REGISTRY_REFRESH");
             env::remove_var("KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS");
             env::remove_var("KMS_CONNECTOR_HOST_RPC_CALL_TIMEOUT");
@@ -381,6 +392,7 @@ mod tests {
             env::set_var("KMS_CONNECTOR_S3_GET_TIMEOUT", "30s");
             env::set_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET", "32");
             env::set_var("KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS", "8");
+            env::set_var("KMS_CONNECTOR_S3_MAX_CIPHERTEXT_SIZE", "1048576");
             env::set_var("KMS_CONNECTOR_COPRO_REGISTRY_REFRESH", "90s");
             env::set_var("KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS", "64");
             env::set_var("KMS_CONNECTOR_HOST_RPC_CALL_TIMEOUT", "15s");
@@ -439,6 +451,7 @@ mod tests {
         assert_eq!(config.s3_get_timeout.as_secs(), 30);
         assert_eq!(config.s3_max_concurrent_heads_per_bucket.get(), 32);
         assert_eq!(config.s3_max_concurrent_gets.get(), 8);
+        assert_eq!(config.s3_max_ciphertext_size.get(), 1048576);
         assert_eq!(config.copro_registry_refresh.as_secs(), 90);
         assert_eq!(config.host_rpc_max_concurrent_calls.get(), 64);
         assert_eq!(config.host_rpc_call_timeout.as_secs(), 15);
@@ -449,10 +462,11 @@ mod tests {
 
     #[test]
     #[serial(config_tests)]
-    fn test_zero_concurrency_ceiling_is_rejected() {
+    fn test_zero_ceiling_is_rejected() {
         for ceiling in [
             "KMS_CONNECTOR_S3_MAX_CONCURRENT_HEADS_PER_BUCKET",
             "KMS_CONNECTOR_S3_MAX_CONCURRENT_GETS",
+            "KMS_CONNECTOR_S3_MAX_CIPHERTEXT_SIZE",
             "KMS_CONNECTOR_HOST_RPC_MAX_CONCURRENT_CALLS",
         ] {
             cleanup_env_vars();

--- a/kms-connector/crates/kms-worker/src/core/config.rs
+++ b/kms-connector/crates/kms-worker/src/core/config.rs
@@ -1,4 +1,5 @@
 use alloy::{primitives::Address, transports::http::reqwest::Url};
+use ciphertext_attestation::MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE;
 use connector_utils::{
     config::{
         ContractConfig, DeserializeConfig,
@@ -235,9 +236,7 @@ fn default_s3_max_concurrent_gets() -> NonZeroUsize {
 }
 
 fn default_s3_max_ciphertext_size() -> NonZeroUsize {
-    // Mainnet serves ~96KiB compressed_on_cpu ciphertexts, but the uncompressed formats may reach ~32MiB,
-    // and a ceiling below a legitimate ciphertext would have every bucket turn it down.
-    NonZeroUsize::new(64 * 1024 * 1024).unwrap()
+    NonZeroUsize::new(MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE as usize).unwrap()
 }
 
 fn default_erc1271_gas_limit() -> u64 {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -239,8 +239,7 @@ impl BoundedClient {
             ));
         }
 
-        // That header is optional, and a bucket is free to lie about it, so the read is capped too.
-        let mut body = Vec::with_capacity(usize::try_from(expected_size).unwrap_or(0));
+        let mut body = Vec::new();
         while let Some(chunk) = response
             .chunk()
             .await

--- a/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/ciphertext/s3.rs
@@ -14,7 +14,10 @@ use crate::{
 use alloy::{
     hex,
     primitives::{B256, FixedBytes},
-    transports::http::{Client, reqwest::header::HeaderMap},
+    transports::http::{
+        Client,
+        reqwest::{self, header::HeaderMap},
+    },
 };
 use anyhow::anyhow;
 use ciphertext_attestation::{
@@ -52,6 +55,9 @@ pub struct BoundedClient {
     /// Kept low: SNS ciphertexts are big, so too many buffered at once would OOM the worker.
     get_semaphore: Arc<Semaphore>,
 
+    /// Ceiling on the size of a single ciphertext body, in bytes.
+    max_ciphertext_size: NonZeroUsize,
+
     /// Deadline of a single attestation `HEAD`.
     head_timeout: Duration,
 
@@ -73,6 +79,7 @@ impl BoundedClient {
             head_semaphores: Arc::new(Mutex::new(HashMap::new())),
             max_concurrent_heads_per_bucket: config.s3_max_concurrent_heads_per_bucket,
             get_semaphore: Arc::new(Semaphore::new(config.s3_max_concurrent_gets.get())),
+            max_ciphertext_size: config.s3_max_ciphertext_size,
             head_timeout: config.s3_head_timeout,
             retrieval_attempts: config.s3_ciphertext_retrieval_attempts,
         })
@@ -89,7 +96,23 @@ impl BoundedClient {
             .acquire()
             .await
             .expect("S3 HEAD semaphore closed");
-        fetch_single_attestation(&self.client, bucket, handle, self.head_timeout).await
+
+        let url = rfc023_ciphertext_url(bucket, handle);
+        let response = self
+            .client
+            .head(&url)
+            .timeout(self.head_timeout)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(FetchAttestationError::Http(format!(
+                "status {}",
+                response.status()
+            )));
+        }
+
+        attestation_from_http_headers(response.headers())
     }
 
     /// The `HEAD` ceiling of `bucket`, created on first use.
@@ -116,19 +139,120 @@ impl BoundedClient {
         material: &ConsensusMaterial,
         winning_buckets: &[String],
     ) -> Result<TypedCiphertext, ProcessingError> {
-        let _permit = self
-            .get_semaphore
-            .acquire()
+        // A handle that carries no valid FHE type is malformed; retrying cannot fix it.
+        let fhe_type = extract_fhe_type_from_handle(handle.as_slice()).map_err(|e| {
+            ProcessingError::Irrecoverable(anyhow!(
+                "cannot extract FHE type from handle {handle}: {e}"
+            ))
+        })?;
+        let ct_format = grpc_ciphertext_format(material.format);
+
+        if winning_buckets.is_empty() {
+            return Err(ProcessingError::Recoverable(anyhow!(
+                "no winning-group bucket resolved for handle {handle}"
+            )));
+        }
+
+        let mut last_error = "no retrieval attempt made".to_string();
+        let mut digest_mismatch = false;
+        for attempt in 1..=self.retrieval_attempts {
+            for bucket in winning_buckets {
+                let url = rfc023_ciphertext_url(bucket, handle);
+
+                let _permit = self
+                    .get_semaphore
+                    .acquire()
+                    .await
+                    .expect("S3 GET semaphore closed");
+                let body = match self.retrieve_ciphertext_via_http(&url).await {
+                    Ok(body) => body,
+                    Err(e) => {
+                        S3_CIPHERTEXT_RETRIEVAL_ERRORS.inc();
+                        last_error = format!("bucket {bucket}: {e}");
+                        warn!(attempt, %handle, "Failed to retrieve ciphertext: {last_error}");
+                        continue;
+                    }
+                };
+
+                let calculated_digest = compute_keccak256_digest(&body);
+                if calculated_digest.as_slice() != material.sns_ciphertext_digest.as_slice() {
+                    S3_CIPHERTEXT_RETRIEVAL_ERRORS.inc();
+                    digest_mismatch = true;
+                    last_error = format!(
+                        "bucket {bucket}: digest mismatch (expected {}, got {})",
+                        material.sns_ciphertext_digest,
+                        FixedBytes::<32>::from_slice(&calculated_digest),
+                    );
+                    warn!(attempt, %handle, "Ciphertext digest mismatch: {last_error}");
+                    continue;
+                }
+
+                S3_CIPHERTEXT_RETRIEVAL_COUNTER.inc();
+                debug!(
+                    %handle,
+                    "Ciphertext retrieved and verified: format {}, length {}, FHE type {:?}",
+                    ct_format.as_str_name(),
+                    body.len(),
+                    fhe_type
+                );
+                return Ok(TypedCiphertext {
+                    ciphertext: body,
+                    external_handle: handle.to_vec(),
+                    fhe_type: fhe_type as i32,
+                    ciphertext_format: ct_format.into(),
+                });
+            }
+        }
+
+        if digest_mismatch {
+            warn!(%handle, "All winning-group buckets failed ciphertext digest verification");
+        }
+        Err(ProcessingError::Recoverable(anyhow!(
+            "ciphertext unavailable for handle {handle}: all retrieval attempts failed \
+             (last: {last_error})"
+        )))
+    }
+
+    /// Retrieves a ciphertext body directly via HTTP, holding at most `max_ciphertext_size` of it.
+    async fn retrieve_ciphertext_via_http(&self, url: &str) -> anyhow::Result<Vec<u8>> {
+        debug!("Attempting direct HTTP retrieval from URL: {url}");
+        let max_size = self.max_ciphertext_size.get();
+
+        let mut response = self
+            .client
+            .get(url)
+            .send()
             .await
-            .expect("S3 GET semaphore closed");
-        retrieve_verified_ciphertext(
-            &self.client,
-            handle,
-            material,
-            winning_buckets,
-            self.retrieval_attempts,
-        )
-        .await
+            .map_err(|e| anyhow!("HTTP request failed: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!(
+                "HTTP request failed with status: {}",
+                response.status()
+            ));
+        }
+
+        let expected_size = response.content_length().unwrap_or(0);
+        if expected_size > max_size as u64 {
+            return Err(anyhow!(
+                "announced body of {expected_size} bytes exceeds the ceiling of {max_size}"
+            ));
+        }
+
+        // That header is optional, and a bucket is free to lie about it, so the read is capped too.
+        let mut body = Vec::with_capacity(usize::try_from(expected_size).unwrap_or(0));
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| anyhow!("Failed to read HTTP response body: {e}"))?
+        {
+            if body.len() + chunk.len() > max_size {
+                return Err(anyhow!("body exceeds the ceiling of {max_size} bytes"));
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        Ok(body)
     }
 }
 
@@ -153,133 +277,14 @@ pub enum FetchAttestationError {
     MissingHeader,
 }
 
-async fn fetch_single_attestation(
-    client: &Client,
-    bucket: &str,
-    handle: B256,
-    head_timeout: Duration,
-) -> Result<CiphertextAttestation, FetchAttestationError> {
-    let url = rfc023_ciphertext_url(bucket, handle);
-
-    let response = client
-        .head(&url)
-        .timeout(head_timeout)
-        .send()
-        .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                FetchAttestationError::Timeout
-            } else {
-                FetchAttestationError::Http(e.to_string())
-            }
-        })?;
-
-    if !response.status().is_success() {
-        return Err(FetchAttestationError::Http(format!(
-            "status {}",
-            response.status()
-        )));
-    }
-
-    attestation_from_http_headers(response.headers())
-}
-
-async fn retrieve_verified_ciphertext(
-    client: &Client,
-    handle: B256,
-    material: &ConsensusMaterial,
-    winning_buckets: &[String],
-    attempts: u8,
-) -> Result<TypedCiphertext, ProcessingError> {
-    // A handle that carries no valid FHE type is malformed; retrying cannot fix it.
-    let fhe_type = extract_fhe_type_from_handle(handle.as_slice()).map_err(|e| {
-        ProcessingError::Irrecoverable(anyhow!("cannot extract FHE type from handle {handle}: {e}"))
-    })?;
-    let ct_format = grpc_ciphertext_format(material.format);
-
-    if winning_buckets.is_empty() {
-        return Err(ProcessingError::Recoverable(anyhow!(
-            "no winning-group bucket resolved for handle {handle}"
-        )));
-    }
-
-    let mut last_error = "no retrieval attempt made".to_string();
-    let mut digest_mismatch = false;
-    for attempt in 1..=attempts {
-        for bucket in winning_buckets {
-            let url = rfc023_ciphertext_url(bucket, handle);
-            let body = match retrieve_ciphertext_via_http(client, &url).await {
-                Ok(body) => body,
-                Err(e) => {
-                    S3_CIPHERTEXT_RETRIEVAL_ERRORS.inc();
-                    last_error = format!("bucket {bucket}: {e}");
-                    warn!(attempt, %handle, "Failed to retrieve ciphertext: {last_error}");
-                    continue;
-                }
-            };
-
-            let calculated_digest = compute_keccak256_digest(&body);
-            if calculated_digest.as_slice() != material.sns_ciphertext_digest.as_slice() {
-                S3_CIPHERTEXT_RETRIEVAL_ERRORS.inc();
-                digest_mismatch = true;
-                last_error = format!(
-                    "bucket {bucket}: digest mismatch (expected {}, got {})",
-                    material.sns_ciphertext_digest,
-                    FixedBytes::<32>::from_slice(&calculated_digest),
-                );
-                warn!(attempt, %handle, "Ciphertext digest mismatch: {last_error}");
-                continue;
-            }
-
-            S3_CIPHERTEXT_RETRIEVAL_COUNTER.inc();
-            debug!(
-                %handle,
-                "Ciphertext retrieved and verified: format {}, length {}, FHE type {:?}",
-                ct_format.as_str_name(),
-                body.len(),
-                fhe_type
-            );
-            return Ok(TypedCiphertext {
-                ciphertext: body,
-                external_handle: handle.to_vec(),
-                fhe_type: fhe_type as i32,
-                ciphertext_format: ct_format.into(),
-            });
+impl From<reqwest::Error> for FetchAttestationError {
+    fn from(err: reqwest::Error) -> Self {
+        if err.is_timeout() {
+            FetchAttestationError::Timeout
+        } else {
+            FetchAttestationError::Http(err.to_string())
         }
     }
-
-    if digest_mismatch {
-        warn!(%handle, "All winning-group buckets failed ciphertext digest verification");
-    }
-    Err(ProcessingError::Recoverable(anyhow!(
-        "ciphertext unavailable for handle {handle}: all retrieval attempts failed \
-         (last: {last_error})"
-    )))
-}
-
-/// Retrieves a ciphertext body directly via HTTP.
-async fn retrieve_ciphertext_via_http(client: &Client, url: &str) -> anyhow::Result<Vec<u8>> {
-    debug!("Attempting direct HTTP retrieval from URL: {url}");
-
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| anyhow!("HTTP request failed: {}", e))?;
-
-    if !response.status().is_success() {
-        return Err(anyhow!(
-            "HTTP request failed with status: {}",
-            response.status()
-        ));
-    }
-
-    let body = response
-        .bytes()
-        .await
-        .map_err(|e| anyhow!("Failed to read HTTP response body: {}", e))?;
-
-    Ok(body.to_vec())
 }
 
 /// Maps the attested [`CiphertextFormat`] onto the KMS gRPC format.
@@ -336,6 +341,7 @@ mod tests {
     use super::*;
     use alloy::primitives::U256;
     use connector_utils::tests::net::black_hole_server;
+    use tokio::{io::AsyncWriteExt, task::JoinHandle};
 
     /// Two addresses nothing can be listening on: a request to either fails at connection, fast.
     const UNREACHABLE_BUCKET: &str = "http://127.0.0.1:1";
@@ -452,6 +458,66 @@ mod tests {
         assert!(matches!(get, Err(ProcessingError::Recoverable(_))));
 
         accept_loop.abort();
+    }
+
+    /// A bucket serving `body` on any path, its length announced in a `Content-Length` header or
+    /// left for the connection close to frame. Returns its URL, and its accept loop to abort.
+    async fn ciphertext_bucket(body: Vec<u8>, announce_length: bool) -> (String, JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let accept_loop = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let framing = if announce_length {
+                    format!("Content-Length: {}", body.len())
+                } else {
+                    "Connection: close".to_string()
+                };
+                let head = format!("HTTP/1.1 200 OK\r\n{framing}\r\n\r\n");
+                let _ = stream.write_all(head.as_bytes()).await;
+                let _ = stream.write_all(&body).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (url, accept_loop)
+    }
+
+    /// A body above the ceiling is turned down, announced or not. Every served body here verifies
+    /// against the attested digest, so the ceiling is the only thing that can reject one — and the
+    /// body that fits proves as much.
+    #[tokio::test]
+    async fn oversized_ciphertext_bodies_are_rejected() {
+        const CEILING: usize = 1024;
+
+        for (body_len, announce_length, expected_ok) in [
+            (CEILING, true, true),
+            (4 * CEILING, true, false),
+            (4 * CEILING, false, false),
+        ] {
+            let body = vec![0u8; body_len];
+            let material = ConsensusMaterial {
+                sns_ciphertext_digest: B256::from_slice(&compute_keccak256_digest(&body)),
+                ..material()
+            };
+            let (bucket, accept_loop) = ciphertext_bucket(body, announce_length).await;
+
+            let client = BoundedClient::from_config(&Config {
+                s3_max_ciphertext_size: NonZeroUsize::new(CEILING).unwrap(),
+                s3_ciphertext_retrieval_attempts: 1,
+                ..Default::default()
+            })
+            .unwrap();
+            let result = client
+                .retrieve_verified_ciphertext(B256::ZERO, &material, &[bucket])
+                .await;
+
+            assert_eq!(
+                result.is_ok(),
+                expected_ok,
+                "{body_len} bytes announced as {announce_length}: {result:?}"
+            );
+
+            accept_loop.abort();
+        }
     }
 
     #[test]

--- a/shared/ciphertext-attestation/src/lib.rs
+++ b/shared/ciphertext-attestation/src/lib.rs
@@ -44,6 +44,9 @@ pub const S3_METADATA_ATTESTATION_KEY: &str = "ct-attestation";
 /// [`CiphertextAttestation`] on every ciphertext object.
 pub const S3_METADATA_ATTESTATION_HEADER: &str = "x-amz-meta-ct-attestation";
 
+/// Ceiling on the serialized size of an SNS ciphertext in bytes.
+pub const MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE: u64 = 66 * 1024 * 1024;
+
 /// Versioned encoding of the attestation. The version byte is part of the signed
 /// payload, so a stripped or downgraded `version` field flips signature recovery
 /// and is caught at verification time.


### PR DESCRIPTION
Closes https://github.com/zama-ai/fhevm-internal/issues/1856

### Why

The `kms-worker` downloads SNS ciphertexts from Coprocessor S3 buckets and buffers each body fully in memory before verifying its digest. Until now nothing bounded the size of a single body: a malicious or buggy bucket could serve an arbitrarily large response and OOM the worker. Concurrency is already capped (`s3_max_concurrent_gets`, default 16), but each in-flight GET could still grow without limit.

### What

Ciphertext downloads are now capped by a new `s3_max_ciphertext_size` setting (env: `KMS_CONNECTOR_S3_MAX_CIPHERTEXT_SIZE`):
- If the response announces a `Content-Length` above the ceiling, it is rejected before reading anything.
- The body is then read in chunks against a running budget, since the header is optional and a bucket is free to lie about it. The download aborts as soon as the budget is exceeded.

### Choosing the ceiling

The default is 66MiB, which is not arbitrary: it is the `tfhe-rs` safe-serialization limit the `sns-worker` applies when producing SNS ciphertexts. A body larger than that cannot be a legitimate ciphertext, while a smaller ceiling could make every bucket reject a legitimate one (an uncompressed `ebytes256` is just above 64MiB).

To keep producer and consumer in sync by construction, that limit now lives in the shared `ciphertext-attestation` crate as `MAX_SNS_CIPHERTEXT_SERIALIZED_SIZE`, replacing the `SAFE_SER_LIMIT` constant previously private to the `sns-worker`.

### Misc

Also merged the duplicated `fetch_single_attestation`, `retrieve_verified_ciphertext`, `retrieve_ciphertext_via_http` functions into a single one within the `BoundedClient`. (mechanical change)