### PR TITLE
fix(coprocessor): sns-worker, S3 migration dedicated concurrency and db pool

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.13.8
+version: 0.13.9
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -1259,6 +1259,7 @@ snsWorker:
   #     --pg-notify-channel
   #     - event_ciphertext128_computed
   #     --work-items-batch-size=4
+  #     --s3-migration-max-concurrent-handles=16
   #     --pg-polling-interval=60
   #     --pg-pool-connections=10
   #     --pg-timeout=15s

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/sns_worker.rs
@@ -68,6 +68,7 @@ fn construct_config() -> Result<Config, fhevm_engine_common::database::DatabaseC
         s3_migration: args.s3_migration,
         s3_migration_sleep_duration: args.s3_migration_sleep_duration,
         s3_migration_max_retries: args.s3_migration_max_retries,
+        s3_migration_max_concurrent_handles: args.s3_migration_max_concurrent_handles,
     })
 }
 

--- a/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/bin/utils/daemon_cli.rs
@@ -6,7 +6,10 @@ use fhevm_engine_common::types::SignerType;
 use fhevm_engine_common::utils::DatabaseURL;
 use humantime::parse_duration;
 use sns_worker::metrics::SNS_LATENCY_OP_HISTOGRAM_CONF;
-use sns_worker::{S3MigrationMode, SchedulePolicy, DEFAULT_S3_MIGRATION_MAX_RETRIES};
+use sns_worker::{
+    S3MigrationMode, SchedulePolicy, DEFAULT_S3_MIGRATION_MAX_CONCURRENT_HANDLES,
+    DEFAULT_S3_MIGRATION_MAX_RETRIES,
+};
 use tracing::Level;
 
 #[derive(Parser, Debug, Clone)]
@@ -162,6 +165,10 @@ pub struct Args {
     /// Maximum recorded migration failures per handle before retry selection stops.
     #[arg(long, default_value_t = DEFAULT_S3_MIGRATION_MAX_RETRIES, value_parser = clap::value_parser!(i32).range(1..), env = "S3_MIGRATION_MAX_RETRIES")]
     pub s3_migration_max_retries: i32,
+
+    /// Maximum number of ciphertext handles migrated concurrently.
+    #[arg(long, default_value_t = DEFAULT_S3_MIGRATION_MAX_CONCURRENT_HANDLES, value_parser = clap::value_parser!(u32).range(1..))]
+    pub s3_migration_max_concurrent_handles: u32,
 }
 
 pub fn parse_args() -> Args {

--- a/coprocessor/fhevm-engine/sns-worker/src/lib.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/lib.rs
@@ -6,7 +6,9 @@ mod s3_migration_dry_run;
 mod squash_noise;
 
 pub mod metrics;
-pub use crate::s3_migration::{S3MigrationMode, DEFAULT_S3_MIGRATION_MAX_RETRIES};
+pub use crate::s3_migration::{
+    S3MigrationMode, DEFAULT_S3_MIGRATION_MAX_CONCURRENT_HANDLES, DEFAULT_S3_MIGRATION_MAX_RETRIES,
+};
 
 #[cfg(test)]
 mod tests;
@@ -151,6 +153,7 @@ pub struct Config {
     pub s3_migration: S3MigrationMode,
     pub s3_migration_sleep_duration: Duration,
     pub s3_migration_max_retries: i32,
+    pub s3_migration_max_concurrent_handles: u32,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -807,12 +810,39 @@ pub async fn run_all(
     .await?;
 
     let migration_config = S3MigrationConfig {
-        batch_size: 16,
+        batch_size: conf.s3_migration_max_concurrent_handles.into(),
         signer: signer.clone(),
         s3: conf.s3.clone(),
         mode: conf.s3_migration,
         sleep_duration: conf.s3_migration_sleep_duration,
         max_retries: conf.s3_migration_max_retries,
+    };
+
+    // Migration S3 work must not contend with the normal executor/uploader pool.
+    // Its capacity leaves room for the migration loop's status/failure queries
+    // while handle tasks are querying the DB.
+    let migration_pool_mngr = if matches!(migration_config.mode, S3MigrationMode::No) {
+        None
+    } else {
+        let migration_pool_connections = conf
+            .s3_migration_max_concurrent_handles
+            .checked_add(2)
+            .ok_or_else(|| anyhow::anyhow!("S3 migration max concurrent handles is too large"))?;
+        let Some(pool_mngr) = PostgresPoolManager::connect_pool_with_gcs_mode(
+            token.child_token(),
+            conf.db.url.as_str(),
+            conf.db.timeout,
+            migration_pool_connections,
+            Duration::from_secs(2),
+            conf.pg_auto_explain_with_min_duration,
+            conf.gcs_mode,
+        )
+        .await
+        else {
+            error!("Service was cancelled during S3 migration pool initialization");
+            return Ok(());
+        };
+        Some(pool_mngr)
     };
 
     let not_ready_error = Err(ExecutionError::BucketNotFound(conf.s3.bucket_ct128.clone()).into());
@@ -827,7 +857,10 @@ pub async fn run_all(
                 error!("S3 is not ready, migration cannot be done");
                 return not_ready_error;
             };
-            let db_pool = pool_mngr.pool();
+            let db_pool = migration_pool_mngr
+                .as_ref()
+                .expect("enabled S3 migration has a dedicated DB pool")
+                .pool();
             if matches!(migration_config.mode, S3MigrationMode::DryRun) {
                 run_startup_migration_dry_run(&migration_config, &db_pool, &client).await?;
             } else {
@@ -836,7 +869,10 @@ pub async fn run_all(
         }
         S3MigrationMode::Concurrent => {
             let token = token.clone();
-            let db_pool = pool_mngr.pool();
+            let db_pool = migration_pool_mngr
+                .as_ref()
+                .expect("enabled S3 migration has a dedicated DB pool")
+                .pool();
             let client = client.clone();
             let task = spawn(async move {
                 info!("S3 migration is enabled: {}", conf.s3_migration);

--- a/coprocessor/fhevm-engine/sns-worker/src/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/s3_migration.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 pub const DEFAULT_S3_MIGRATION_MAX_RETRIES: i32 = 100;
+pub const DEFAULT_S3_MIGRATION_MAX_CONCURRENT_HANDLES: u32 = 16;
 const NO_SNS_CIPHERTEXT_DIGEST: [u8; 32] = [0; 32];
 
 #[derive(Debug, Clone, Copy)]

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     keyset::fetch_client_key,
     squash_noise::safe_deserialize,
     Config, DBConfig, S3Config, S3MigrationMode, S3RetryPolicy, SchedulePolicy,
-    DEFAULT_S3_MIGRATION_MAX_RETRIES,
+    DEFAULT_S3_MIGRATION_MAX_CONCURRENT_HANDLES, DEFAULT_S3_MIGRATION_MAX_RETRIES,
 };
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{B256, U256};
@@ -1237,5 +1237,6 @@ fn build_test_config(url: DatabaseURL, enable_compression: bool) -> Config {
         s3_migration: S3MigrationMode::No,
         s3_migration_sleep_duration: Duration::from_mins(5),
         s3_migration_max_retries: DEFAULT_S3_MIGRATION_MAX_RETRIES,
+        s3_migration_max_concurrent_handles: DEFAULT_S3_MIGRATION_MAX_CONCURRENT_HANDLES,
     }
 }

--- a/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/tests/s3_migration.rs
@@ -853,7 +853,7 @@ async fn setup_direct_migration_env() -> DirectMigrationEnv {
 
 async fn run_direct_migration(env: &DirectMigrationEnv) -> Result<(), crate::ExecutionError> {
     let config = S3MigrationConfig {
-        batch_size: env.conf.db.batch_limit.into(),
+        batch_size: env.conf.s3_migration_max_concurrent_handles.into(),
         signer: env.signer.clone(),
         s3: env.conf.s3.clone(),
         mode: env.conf.s3_migration,


### PR DESCRIPTION
## Summary

  - Add `--s3-migration-max-concurrent-handles` (default: `16`) to configure S3 migration parallelism.
  - Use this setting as the migration batch size.
  - Create a dedicated database pool for S3 migration so it does not contend with the normal sns-worker pool.
  - Size the dedicated pool from the migration concurrency setting.
  - Document the new CLI option in chart values and bump the coprocessor chart version to `0.13.9`.