### PR TITLE
fix(coprocessor): park stalled dependency chains

### DIFF
--- a/coprocessor/fhevm-engine/tfhe-worker/src/dependence_chain.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/dependence_chain.rs
@@ -582,6 +582,20 @@ impl LockMngr {
         self.lock.as_ref().map(|(lock, _)| lock.clone())
     }
 
+    /// Stop extending the current lock without modifying its database row.
+    /// The chain becomes eligible for work-stealing after its existing TTL.
+    pub fn park_current_lock(&mut self) {
+        if let Some((lock, _)) = self.lock.take() {
+            info!(
+                dcid = %hex::encode(&lock.dependence_chain_id),
+                expires_at = ?lock.lock_expires_at,
+                "Parked lock until expiration"
+            );
+        } else {
+            debug!("No lock to park");
+        }
+    }
+
     pub fn worker_id(&self) -> Uuid {
         self.worker_id
     }

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/dependence_chain.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/dependence_chain.rs
@@ -106,6 +106,86 @@ async fn test_acquire_next_lock_prefers_fast_lane() {
 
 #[tokio::test]
 #[serial(db)]
+async fn test_parked_chain_yields_until_lock_expiry() {
+    let instance = setup().await;
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(instance.db_url())
+        .await
+        .expect("Failed to connect to the database");
+
+    let stalled_id = vec![1u8];
+    let ready_id = vec![2u8];
+
+    sqlx::query(
+        r#"
+        INSERT INTO dependence_chain
+            (dependence_chain_id, status, last_updated_at, block_timestamp, block_height)
+        VALUES
+            ($1, 'updated', NOW() - INTERVAL '2 minutes', NOW(), 1),
+            ($2, 'updated', NOW() - INTERVAL '1 minute', NOW(), 2)
+        "#,
+    )
+    .bind(stalled_id.clone())
+    .bind(ready_id.clone())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let lock_ttl_sec = 5;
+    let mut mgr = LockMngr::new_with_conf(
+        Uuid::new_v4(),
+        pool.clone(),
+        lock_ttl_sec,
+        false,
+        None,
+        None,
+        None,
+    );
+    let (acquired, reason) = mgr.acquire_next_lock().await.unwrap();
+    assert_eq!(acquired, Some(stalled_id.clone()));
+    assert_eq!(reason, LockingReason::UpdatedUnowned);
+
+    let parked_lock = mgr.get_current_lock().unwrap();
+    mgr.park_current_lock();
+    assert!(mgr.get_current_lock().is_none());
+
+    let parked_row: (
+        String,
+        Option<Uuid>,
+        Option<chrono::DateTime<chrono::Utc>>,
+        chrono::DateTime<chrono::Utc>,
+    ) = sqlx::query_as(
+        "SELECT status, worker_id, lock_expires_at, last_updated_at
+         FROM dependence_chain WHERE dependence_chain_id = $1",
+    )
+    .bind(&stalled_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(parked_row.0, "processing");
+    assert_eq!(parked_row.1, Some(mgr.worker_id()));
+    assert_eq!(parked_row.2, parked_lock.lock_expires_at);
+    assert_eq!(parked_row.3, parked_lock.last_updated_at);
+
+    let (acquired, reason) = mgr.acquire_next_lock().await.unwrap();
+    assert_eq!(acquired, Some(ready_id));
+    assert_eq!(reason, LockingReason::UpdatedUnowned);
+    mgr.release_current_lock(true, None).await.unwrap();
+
+    assert_eq!(
+        mgr.acquire_next_lock().await.unwrap(),
+        (None, LockingReason::Missing)
+    );
+
+    sleep(Duration::from_secs(lock_ttl_sec as u64 + 1)).await;
+    let (acquired, reason) = mgr.acquire_next_lock().await.unwrap();
+    assert_eq!(acquired, Some(stalled_id));
+    assert_eq!(reason, LockingReason::ExpiredLock);
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn test_acquire_early_lock_ignores_priority() {
     let instance = setup().await;
     let pool = PgPoolOptions::new()

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -261,7 +261,7 @@ async fn tfhe_worker_cycle(
         };
 
         // Query for transactions to execute
-        let (mut transactions, earliest_computation, has_more_work) = query_for_work(
+        let (mut transactions, _, has_more_work) = query_for_work(
             args,
             &health_check,
             &mut trx,
@@ -337,14 +337,11 @@ async fn tfhe_worker_cycle(
         } else {
             no_progress_cycles += 1;
             if no_progress_cycles >= args.dcid_max_no_progress_cycles {
-                // If we're not making progress on this dependence
-                // chain, update the last_updated_at field and
-                // release the lock so we can try to execute
-                // another chain.
-                info!(target: "tfhe_worker", "no progress on dependence chain, releasing");
-                dcid_mngr
-                    .release_current_lock(false, Some(earliest_computation))
-                    .await?;
+                // Stop extending this chain's lock so another chain can run.
+                // The parked chain remains pending and can be work-stolen
+                // after its existing lock TTL expires.
+                info!(target: "tfhe_worker", "no progress on dependence chain, parking until lock expiry");
+                dcid_mngr.park_current_lock();
             }
         }
         trx.commit().await?;


### PR DESCRIPTION
Ports the approved change from #3424 unchanged from `release/0.14.x` to `main`.
When a dependency chain reaches the no-progress limit, the worker drops only its in-memory lock reference and leaves the database lease to expire, allowing other chains to proceed while preserving retryability.
The stable patch ID is `19b572f0f80326bf9b231904d4add2bdd16137d0` for both source commit `c7c4456f9` and this main port.
Validated with targeted formatting and `SQLX_OFFLINE=true cargo check -p tfhe-worker --all-targets`.
