### PR TITLE
test(coprocessor): [DO NOT MERGE] reject V0_7_0 for recovery drill

### DIFF
--- a/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
+++ b/coprocessor/fhevm-engine/zkproof-worker/src/verifier.rs
@@ -710,6 +710,8 @@ pub(crate) fn proven_list_conformance_params(
         &crs.crs,
     )
     .forbid_hash_config(ZkPkeV2SupportedHashConfig::V0_4_0)
+    // TEST FIXTURE: force the mixed-consensus recovery path; do not merge.
+    .forbid_hash_config(ZkPkeV2SupportedHashConfig::V0_7_0)
     .forbid_compute_load(ZkComputeLoad::Proof)
 }
 


### PR DESCRIPTION
## [DO NOT MERGE]

Temporary `zkproof-worker` fixture built on #3433. It intentionally rejects V0_7_0 so the mixed-consensus recovery path can be validated. The only functional difference from #3433 is re-adding the V0_7_0 rejection.

### Runbook

1. Build and publish only `fhevm/coprocessor/zkproof-worker` from fixture commit `419f1e2bb44a257f0d9106bf387d112a07bda7fb`; use a clearly temporary image tag.
2. Keep every `gw-listener` and `transaction-sender` on the normal #3433 image.
3. Deploy this PR's `zkproof-worker` to one coprocessor only. Keep the other coprocessors on normal #3433 so Gateway quorum can accept the proof.
4. Submit one V0_7_0 input. Confirm the selected coprocessor rejects it locally, Gateway emits the final accepted `VerifyProofResponse`, the proof remains pending for replay, and its ciphertexts are absent locally.
5. Restore that coprocessor's normal #3433 `zkproof-worker` image. Wait for its next retry (about 60 seconds after the first failed replay).
6. Confirm the ciphertext handles appear locally, the retained proof row is removed, the dependent E2E/user-decryption flow succeeds, and the recovering coprocessor sends no second Gateway vote.
7. Restore all deployments, close this PR, and delete the fixture branch.

Never deploy this fixture as a release image.

### Validation

- `cargo fmt --manifest-path coprocessor/fhevm-engine/zkproof-worker/Cargo.toml --check`
- `SQLX_OFFLINE=true cargo check -p zkproof-worker`
- Repository pre-commit checks: workspace `cargo check` and CI-aligned Clippy
