### PR TITLE
test(test-suite): cover GPU key migration

### DIFF
--- a/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/checks.ts
+++ b/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/checks.ts
@@ -1,0 +1,54 @@
+export type ConnectorObservation = {
+  cursor: number;
+  hasMigrationSchema: boolean;
+  image: string;
+  party: number;
+};
+export const assertConnectorMigrationReady = (
+  observations: readonly ConnectorObservation[],
+  deploymentBoundary: number,
+) => {
+  if (observations.length === 0) {
+    throw new Error("connector gate found no KMS Connectors");
+  }
+  const images = new Set(observations.map((item) => item.image));
+  if (images.size !== 1) {
+    throw new Error("connector gate blocked: connector images differ");
+  }
+  const missingSchema = observations.filter((item) => !item.hasMigrationSchema).map((item) => item.party);
+  if (missingSchema.length) {
+    throw new Error(`connector gate blocked: migration schema missing on parties ${missingSchema.join(", ")}`);
+  }
+  const behind = observations
+    .filter((item) => item.cursor < deploymentBoundary)
+    .map((item) => `${item.party}:${item.cursor}`);
+  if (behind.length) {
+    throw new Error(
+      `connector gate blocked: listener cursor is before deployment block ${deploymentBoundary} on ${behind.join(", ")}`,
+    );
+  }
+};
+
+export type OperatorMaterial = {
+  compressed: boolean;
+  digest: string;
+  keyId: string;
+  legacy: boolean;
+  operator: number;
+  status: string;
+};
+
+export const assertOperatorMaterialAgreement = (rows: readonly OperatorMaterial[]) => {
+  if (rows.length === 0) {
+    throw new Error("material gate found no coprocessor operators");
+  }
+  for (const row of rows) {
+    if (row.status !== "applied" || !row.legacy || !row.compressed) {
+      throw new Error(`material gate blocked: operator ${row.operator} is incomplete`);
+    }
+  }
+  const identities = new Set(rows.map((row) => `${row.keyId}:${row.digest}`));
+  if (identities.size !== 1) {
+    throw new Error("material gate blocked: operator key ID or digest differs");
+  }
+};

--- a/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/run.ts
+++ b/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/run.ts
@@ -1,0 +1,362 @@
+import path from "node:path";
+
+import type { RolloutRunContext } from "../../src/commands/rollout-run";
+import { waitForContainer } from "../../src/flow/readiness";
+import {
+  COPROCESSOR_DB_CONTAINER,
+  DEFAULT_POSTGRES_PASSWORD,
+  DEFAULT_POSTGRES_USER,
+  coprocessorDatabaseName,
+  defaultHostChainKey,
+  dockerArgs,
+} from "../../src/layout";
+import { kmsConnectorDbName, kmsConnectorPrefix, kmsPartyIds } from "../../src/kms-party";
+import { hostReachableRpcUrl } from "../../src/utils/fs";
+import { run, runStreaming } from "../../src/utils/process";
+import {
+  type ConnectorObservation,
+  type OperatorMaterial,
+  assertConnectorMigrationReady,
+  assertOperatorMaterialAgreement,
+} from "./checks";
+import { connectorVersionKeys, migrationVersions, versionSources } from "./versions";
+
+const CONNECTOR_PARTIES = 4;
+const OPERATOR_COUNT = 2;
+const CONNECTOR_SERVICES = ["db-migration", "gw-listener", "kms-worker", "tx-sender"] as const;
+const KEY_WORKERS = ["tfhe-worker", "zkproof-worker", "sns-worker"] as const;
+
+const logPhase = (label: string) => console.log(`\n[GPU key migration] ${label}`);
+
+const sqlScalar = async (database: string, sql: string): Promise<string> => {
+  const result = await run([
+    "docker",
+    "exec",
+    "-e",
+    `PGPASSWORD=${DEFAULT_POSTGRES_PASSWORD}`,
+    COPROCESSOR_DB_CONTAINER,
+    "psql",
+    "-U",
+    DEFAULT_POSTGRES_USER,
+    "-d",
+    database,
+    "-t",
+    "-A",
+    "-c",
+    sql,
+  ]);
+  return result.stdout.trim();
+};
+
+const waitUntil = async (
+  label: string,
+  check: () => Promise<boolean>,
+  timeoutSeconds = Number(process.env.RFC029_MIGRATION_TIMEOUT_SECONDS || 3600),
+) => {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (!(await check())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`${label} timed out after ${timeoutSeconds}s`);
+    }
+    await Bun.sleep(2_000);
+  }
+  console.log(`[ready] ${label}`);
+};
+
+export const migrationScenario = (blueTag: string) => `version: 1
+kind: blue-green
+name: RFC 029 production migration
+hostChains:
+  - key: host
+    chainId: "12345"
+    rpcPort: 8545
+  - key: chain-b
+    chainId: "67890"
+    rpcPort: 8547
+topology:
+  count: ${OPERATOR_COUNT}
+  threshold: ${OPERATOR_COUNT}
+bcs:
+  source:
+    mode: registry
+    tag: ${JSON.stringify(blueTag)}
+  env:
+    SERVER_KEY_REPRESENTATION: legacy
+gcs:
+  source:
+    mode: local
+  stackVersion: "0.15.0"
+  env:
+    SERVER_KEY_REPRESENTATION: compressed-xof
+kms:
+  mode: threshold
+  parties: ${CONNECTOR_PARTIES}
+  threshold: 1
+  fheParams: Test
+`;
+
+const connectorObservation = async (party: number): Promise<ConnectorObservation> => {
+  const database = kmsConnectorDbName(party);
+  const prefix = kmsConnectorPrefix(party);
+  const [cursorText, schemaText, imageResult] = await Promise.all([
+    sqlScalar(
+      database,
+      "SELECT COALESCE(block_number, -1) FROM last_block_polled_by_chain WHERE chain_name = 'ethereum';",
+    ),
+    sqlScalar(
+      database,
+      "SELECT EXISTS (SELECT 1 FROM information_schema.columns " +
+        "WHERE table_name='keygen_requests' AND column_name='migration_key_id')::int;",
+    ),
+    run(["docker", "inspect", "--format", "{{.Config.Image}}", `${prefix}-gw-listener`]),
+  ]);
+  return {
+    cursor: Number(cursorText || -1),
+    hasMigrationSchema: schemaText === "1",
+    image: imageResult.stdout.trim(),
+    party,
+  };
+};
+
+const connectorObservations = () =>
+  Promise.all(kmsPartyIds(CONNECTOR_PARTIES).map(connectorObservation));
+
+const upgradeFirstConnectorOnly = async () => {
+  const names = CONNECTOR_SERVICES.map((suffix) => `kms-connector-${suffix}`);
+  await runStreaming([...dockerArgs("kms-connector"), "build", ...names]);
+  await runStreaming([
+    ...dockerArgs("kms-connector"),
+    "up",
+    "-d",
+    "--no-deps",
+    "--force-recreate",
+    "kms-connector-db-migration",
+  ]);
+  await waitForContainer("kms-connector-db-migration", "complete");
+  const runtime = names.filter((name) => !name.endsWith("db-migration"));
+  await runStreaming([
+    ...dockerArgs("kms-connector"),
+    "up",
+    "-d",
+    "--no-deps",
+    "--force-recreate",
+    ...runtime,
+  ]);
+  for (const name of runtime) {
+    await waitForContainer(name, "running");
+  }
+};
+
+const operatorMaterial = async (operator: number): Promise<OperatorMaterial | undefined> => {
+  const database = coprocessorDatabaseName(operator);
+  const value = await sqlScalar(
+    database,
+    `SELECT encode(e.key_id, 'hex') || '|' || encode(e.key_digest, 'hex') || '|' ||
+            e.status || '|' || (k.sks_key IS NOT NULL)::int || '|' ||
+            (k.compressed_xof_keyset IS NOT NULL)::int
+       FROM kms_compressed_key_material_events e
+       JOIN keys k ON k.key_id = e.key_id
+      WHERE e.status = 'applied'
+      ORDER BY e.block_number DESC
+      LIMIT 1;`,
+  );
+  if (!value) return undefined;
+  const [keyId, digest, status, legacy, compressed] = value.split("|");
+  return {
+    compressed: compressed === "1",
+    digest: digest ?? "",
+    keyId: keyId ?? "",
+    legacy: legacy === "1",
+    operator,
+    status: status ?? "",
+  };
+};
+
+const selectedRepresentation = async (container: string): Promise<string | undefined> => {
+  const result = await run(["docker", "inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", container]);
+  return result.stdout
+    .split("\n")
+    .find((line) => line.startsWith("SERVER_KEY_REPRESENTATION="))
+    ?.split("=")
+    .slice(1)
+    .join("=");
+};
+
+const assertFleetSelection = async () => {
+  for (let operator = 0; operator < OPERATOR_COUNT; operator += 1) {
+    const prefix = operator === 0 ? "coprocessor-" : `coprocessor${operator}-`;
+    for (const worker of KEY_WORKERS) {
+      const blue = `${prefix}${worker}`;
+      const green = `${prefix}gcs-${worker}`;
+      if ((await selectedRepresentation(blue)) !== "legacy") {
+        throw new Error(`${blue} is not pinned to legacy`);
+      }
+      if ((await selectedRepresentation(green)) !== "compressed-xof") {
+        throw new Error(`${green} is not pinned to compressed-xof`);
+      }
+    }
+  }
+};
+
+const upgradeKmsGeneration = async (ctx: RolloutRunContext, targetLock: string) => {
+  await ctx.snapshotContracts("host");
+  await ctx.applyVersionLock("RFC 029 host contract source", {
+    lockFile: targetLock,
+    allowedVersionKeys: ["HOST_VERSION"],
+    overrides: [{ group: "host-contracts" }],
+  });
+  await ctx.runHostContractTask(
+    [
+      "npx hardhat task:upgradeKMSGeneration",
+      "--current-implementation previous-contracts/KMSGeneration.sol:KMSGeneration",
+      "--new-implementation contracts/KMSGeneration.sol:KMSGeneration",
+      "--verify-contract false",
+      "--use-internal-proxy-address true",
+    ].join(" "),
+  );
+};
+
+export default async function runMigration(ctx: RolloutRunContext) {
+  const versions = migrationVersions();
+  const baselineLock = await ctx.resolveVersionLock("rfc029-00-baseline", {
+    versions: versions.baseline,
+    sources: versionSources,
+  });
+  const targetLock = await ctx.resolveVersionLock("rfc029-01-target", {
+    versions: { CORE_VERSION: versions.baseline.CORE_VERSION! },
+    sources: versionSources,
+  });
+  const scenario = path.join(ctx.stateDir(), "rollout", "rfc029-blue-green.yaml");
+  await Bun.write(scenario, migrationScenario(versions.blueTag));
+
+  logPhase("00 boot a real legacy-key baseline");
+  await ctx.up({
+    lockFile: baselineLock,
+    scenario,
+    overrides: [{ group: "test-suite" }],
+  });
+  await assertFleetSelection();
+  for (let operator = 0; operator < OPERATOR_COUNT; operator += 1) {
+    const state = await sqlScalar(
+      coprocessorDatabaseName(operator),
+      "SELECT (sks_key IS NOT NULL)::int || '|' || " +
+        "(compressed_xof_keyset IS NOT NULL)::int FROM keys ORDER BY sequence_number DESC LIMIT 1;",
+    );
+    if (state !== "1|0") {
+      throw new Error(`operator ${operator} did not start with legacy-only key material: ${state}`);
+    }
+  }
+  await ctx.test("input-proof-compute-decrypt", { parallel: false });
+  const preMigrationHandles = await Promise.all(
+    Array.from({ length: OPERATOR_COUNT }, (_, operator) =>
+      sqlScalar(
+        coprocessorDatabaseName(operator),
+        "SELECT encode(handle, 'hex') FROM ciphertexts ORDER BY created_at LIMIT 1;",
+      ),
+    ),
+  );
+  if (preMigrationHandles.some((handle) => !handle)) {
+    throw new Error("baseline traffic did not create a ciphertext on every operator");
+  }
+
+  logPhase("01 upgrade KMSGeneration without invoking migration");
+  await upgradeKmsGeneration(ctx, targetLock);
+  const state = await ctx.readState();
+  const hostKey = defaultHostChainKey(state.scenario.hostChains);
+  const hostRpc = hostReachableRpcUrl(state.discovery!.endpoints.hosts[hostKey]!.http);
+  const deploymentBoundary = Number((await run(["cast", "block-number", "--rpc-url", hostRpc])).stdout.trim());
+
+  logPhase("02 prove a mixed connector fleet blocks the request");
+  await ctx.applyVersionLock("RFC 029 connector source", {
+    lockFile: targetLock,
+    allowedVersionKeys: [...connectorVersionKeys],
+    overrides: [{ group: "kms-connector" }],
+  });
+  await upgradeFirstConnectorOnly();
+  let mixedBlocked = false;
+  try {
+    assertConnectorMigrationReady(await connectorObservations(), deploymentBoundary);
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.startsWith("connector gate blocked:")) {
+      throw error;
+    }
+    mixedBlocked = true;
+    console.log(`[expected] ${error.message}`);
+  }
+  if (!mixedBlocked) {
+    throw new Error("connector gate accepted a mixed connector deployment");
+  }
+
+  logPhase("03 upgrade every connector and establish finalized listener boundaries");
+  await ctx.upgradeRuntimeGroup("kms-connector");
+  await waitUntil("all connector listeners crossed the deployment boundary", async () => {
+    try {
+      assertConnectorMigrationReady(await connectorObservations(), deploymentBoundary);
+      return true;
+    } catch {
+      return false;
+    }
+  }, 300);
+
+  logPhase("04 request compressed material for the existing active key");
+  const keyIdHex = await sqlScalar(
+    coprocessorDatabaseName(0),
+    "SELECT encode(key_id, 'hex') FROM keys ORDER BY sequence_number DESC LIMIT 1;",
+  );
+  const keyId = BigInt(`0x${keyIdHex}`).toString();
+  await run(["docker", "stop", "coprocessor1-gcs-host-listener"]);
+  await ctx.runHostContractTask(
+    `npx hardhat task:migrateToCompressedKeySet --key-id ${keyId} --use-internal-proxy-address true`,
+  );
+  await run(["docker", "restart", "kms-connector-4-kms-worker"]);
+
+  logPhase("05 wait for threshold publication and every operator's passive ingestion");
+  await waitUntil("operator 0 applied compressed material while operator 1 was delayed", async () =>
+    Boolean(await operatorMaterial(0)),
+  );
+  if (await operatorMaterial(1)) {
+    throw new Error("material gate accepted operator 1 while its Green listener was stopped");
+  }
+  await run(["docker", "start", "coprocessor1-gcs-host-listener"]);
+  await waitForContainer("coprocessor1-gcs-host-listener", "running");
+  let materialRows: OperatorMaterial[] = [];
+  await waitUntil("all operators applied identical compressed material", async () => {
+    const rows = await Promise.all(
+      Array.from({ length: OPERATOR_COUNT }, (_, operator) => operatorMaterial(operator)),
+    );
+    if (rows.some((row) => !row)) return false;
+    materialRows = rows as OperatorMaterial[];
+    try {
+      assertOperatorMaterialAgreement(materialRows);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  assertOperatorMaterialAgreement(materialRows);
+  await assertFleetSelection();
+  await run(["docker", "restart", "coprocessor1-gcs-tfhe-worker"]);
+  await waitForContainer("coprocessor1-gcs-tfhe-worker", "running");
+
+  // Publication is passive: Blue must still compute successfully after every
+  // database contains the compressed representation.
+  await ctx.test("input-proof-compute-decrypt", { parallel: false });
+
+  logPhase("06 run the existing blue-green failure, retry, unanimity, and cutover battery");
+  await ctx.test("blue-green", { parallel: false });
+
+  logPhase("07 verify preserved history and post-cutover protocol paths");
+  for (let operator = 0; operator < OPERATOR_COUNT; operator += 1) {
+    const handle = preMigrationHandles[operator]!;
+    const present = await sqlScalar(
+      coprocessorDatabaseName(operator),
+      `SELECT EXISTS (SELECT 1 FROM ciphertexts WHERE handle=decode('${handle}', 'hex'))::int;`,
+    );
+    if (present !== "1") {
+      throw new Error(`operator ${operator} lost pre-migration ciphertext ${handle}`);
+    }
+  }
+  await ctx.test("rollout-standard", { parallel: false });
+  await ctx.test("public-decryption", { parallel: false });
+  await ctx.test("user-decryption", { parallel: false });
+}

--- a/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/run.ts
+++ b/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/run.ts
@@ -81,13 +81,11 @@ bcs:
     mode: registry
     tag: ${JSON.stringify(blueTag)}
   env:
-    SERVER_KEY_REPRESENTATION: legacy
+    FORCE_LEGACY_SERVER_KEY: "true"
 gcs:
   source:
     mode: local
   stackVersion: "0.15.0"
-  env:
-    SERVER_KEY_REPRESENTATION: compressed-xof
 kms:
   mode: threshold
   parties: ${CONNECTOR_PARTIES}
@@ -172,27 +170,24 @@ const operatorMaterial = async (operator: number): Promise<OperatorMaterial | un
   };
 };
 
-const selectedRepresentation = async (container: string): Promise<string | undefined> => {
+const forcesLegacyServerKey = async (container: string): Promise<boolean> => {
   const result = await run(["docker", "inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", container]);
   return result.stdout
     .split("\n")
-    .find((line) => line.startsWith("SERVER_KEY_REPRESENTATION="))
-    ?.split("=")
-    .slice(1)
-    .join("=");
+    .some((line) => line === "FORCE_LEGACY_SERVER_KEY=true");
 };
 
-const assertFleetSelection = async () => {
+const assertFleetSafeguard = async () => {
   for (let operator = 0; operator < OPERATOR_COUNT; operator += 1) {
     const prefix = operator === 0 ? "coprocessor-" : `coprocessor${operator}-`;
     for (const worker of KEY_WORKERS) {
       const blue = `${prefix}${worker}`;
       const green = `${prefix}gcs-${worker}`;
-      if ((await selectedRepresentation(blue)) !== "legacy") {
-        throw new Error(`${blue} is not pinned to legacy`);
+      if (!(await forcesLegacyServerKey(blue))) {
+        throw new Error(`${blue} is not forced to use legacy material`);
       }
-      if ((await selectedRepresentation(green)) !== "compressed-xof") {
-        throw new Error(`${green} is not pinned to compressed-xof`);
+      if (await forcesLegacyServerKey(green)) {
+        throw new Error(`${green} must not receive the force-legacy safeguard`);
       }
     }
   }
@@ -235,7 +230,7 @@ export default async function runMigration(ctx: RolloutRunContext) {
     scenario,
     overrides: [{ group: "test-suite" }],
   });
-  await assertFleetSelection();
+  await assertFleetSafeguard();
   for (let operator = 0; operator < OPERATOR_COUNT; operator += 1) {
     const state = await sqlScalar(
       coprocessorDatabaseName(operator),
@@ -334,7 +329,7 @@ export default async function runMigration(ctx: RolloutRunContext) {
     }
   });
   assertOperatorMaterialAgreement(materialRows);
-  await assertFleetSelection();
+  await assertFleetSafeguard();
   await run(["docker", "restart", "coprocessor1-gcs-tfhe-worker"]);
   await waitForContainer("coprocessor1-gcs-tfhe-worker", "running");
 

--- a/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/versions.ts
+++ b/test-suite/fhevm/rollouts/v0.14-to-v0.15-gpu-key-migration/versions.ts
@@ -1,0 +1,55 @@
+type Env = Record<string, string | undefined>;
+
+const required = (env: Env, name: string): string => {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required and must be an exact image tag or commit SHA`);
+  }
+  return value;
+};
+
+export const connectorVersionKeys = [
+  "CONNECTOR_DB_MIGRATION_VERSION",
+  "CONNECTOR_GW_LISTENER_VERSION",
+  "CONNECTOR_KMS_WORKER_VERSION",
+  "CONNECTOR_TX_SENDER_VERSION",
+] as const;
+
+export const coprocessorVersionKeys = [
+  "COPROCESSOR_DB_MIGRATION_VERSION",
+  "COPROCESSOR_HOST_LISTENER_VERSION",
+  "COPROCESSOR_GW_LISTENER_VERSION",
+  "COPROCESSOR_TX_SENDER_VERSION",
+  "COPROCESSOR_TFHE_WORKER_VERSION",
+  "COPROCESSOR_ZKPROOF_WORKER_VERSION",
+  "COPROCESSOR_SNS_WORKER_VERSION",
+  "COPROCESSOR_CONSENSUS_DETECTOR_VERSION",
+  "COPROCESSOR_UPGRADE_CONTROLLER_VERSION",
+] as const;
+
+export type MigrationVersions = {
+  baseline: Record<string, string>;
+  blueTag: string;
+};
+
+export const migrationVersions = (env: Env = process.env): MigrationVersions => {
+  const releaseTag = env.RFC029_BASELINE_FHEVM_TAG?.trim() || "v0.14.0-7";
+  const blueTag = required(env, "RFC029_BLUE_HOTFIX_TAG");
+  const kmsCoreTag = env.RFC029_KMS_CORE_TAG?.trim() || "v0.14.0-1";
+
+  return {
+    blueTag,
+    baseline: {
+      GATEWAY_VERSION: releaseTag,
+      HOST_VERSION: releaseTag,
+      CORE_VERSION: kmsCoreTag,
+      ...Object.fromEntries(connectorVersionKeys.map((key) => [key, releaseTag])),
+      ...Object.fromEntries(coprocessorVersionKeys.map((key) => [key, blueTag])),
+    },
+  };
+};
+
+export const versionSources = [
+  "rollout=v0.14-to-v0.15-gpu-key-migration",
+  "migration=same-key-compressed-xof",
+];

--- a/test-suite/fhevm/src/rollout-v014-v015-gpu-key-migration.test.ts
+++ b/test-suite/fhevm/src/rollout-v014-v015-gpu-key-migration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  assertConnectorMigrationReady,
+  assertOperatorMaterialAgreement,
+} from "../rollouts/v0.14-to-v0.15-gpu-key-migration/checks";
+import { migrationScenario } from "../rollouts/v0.14-to-v0.15-gpu-key-migration/run";
+import { migrationVersions } from "../rollouts/v0.14-to-v0.15-gpu-key-migration/versions";
+import { parseBlueGreenScenario } from "./scenario/resolve";
+
+describe("RFC 029 rollout gates", () => {
+  test("requires an exact Blue hotfix tag", () => {
+    expect(() => migrationVersions({})).toThrow("RFC029_BLUE_HOTFIX_TAG is required");
+    expect(migrationVersions({ RFC029_BLUE_HOTFIX_TAG: "v0.14.1-0" }).blueTag).toBe("v0.14.1-0");
+  });
+
+  test("pins Blue to legacy and Green to compressed XOF", () => {
+    const scenario = parseBlueGreenScenario(migrationScenario("v0.14.1-0"), "generated RFC 029 scenario");
+    expect(scenario.bcs?.env?.SERVER_KEY_REPRESENTATION).toBe("legacy");
+    expect(scenario.gcs.env?.SERVER_KEY_REPRESENTATION).toBe("compressed-xof");
+    expect(scenario.hostChains).toHaveLength(2);
+    expect(scenario.kms).toEqual({ mode: "threshold", parties: 4, threshold: 1, fheParams: "Test" });
+  });
+
+  test("blocks a mixed connector deployment", () => {
+    expect(() =>
+      assertConnectorMigrationReady([
+        { cursor: 100, hasMigrationSchema: true, image: "target", party: 1 },
+        { cursor: 100, hasMigrationSchema: false, image: "legacy", party: 2 },
+      ], 90),
+    ).toThrow("connector images differ");
+  });
+
+  test("blocks a connector behind the deployment boundary", () => {
+    expect(() =>
+      assertConnectorMigrationReady([
+        { cursor: 89, hasMigrationSchema: true, image: "target", party: 1 },
+        { cursor: 100, hasMigrationSchema: true, image: "target", party: 2 },
+      ], 90),
+    ).toThrow("listener cursor is before deployment block");
+  });
+
+  test("blocks delayed or disagreeing operator material", () => {
+    expect(() =>
+      assertOperatorMaterialAgreement([
+        { compressed: true, digest: "aa", keyId: "01", legacy: true, operator: 0, status: "applied" },
+        { compressed: false, digest: "aa", keyId: "01", legacy: true, operator: 1, status: "ready" },
+      ]),
+    ).toThrow("operator 1 is incomplete");
+    expect(() =>
+      assertOperatorMaterialAgreement([
+        { compressed: true, digest: "aa", keyId: "01", legacy: true, operator: 0, status: "applied" },
+        { compressed: true, digest: "bb", keyId: "01", legacy: true, operator: 1, status: "applied" },
+      ]),
+    ).toThrow("key ID or digest differs");
+  });
+});

--- a/test-suite/fhevm/src/rollout-v014-v015-gpu-key-migration.test.ts
+++ b/test-suite/fhevm/src/rollout-v014-v015-gpu-key-migration.test.ts
@@ -14,10 +14,10 @@ describe("RFC 029 rollout gates", () => {
     expect(migrationVersions({ RFC029_BLUE_HOTFIX_TAG: "v0.14.1-0" }).blueTag).toBe("v0.14.1-0");
   });
 
-  test("pins Blue to legacy and Green to compressed XOF", () => {
+  test("forces Blue to legacy and leaves the safeguard off Green", () => {
     const scenario = parseBlueGreenScenario(migrationScenario("v0.14.1-0"), "generated RFC 029 scenario");
-    expect(scenario.bcs?.env?.SERVER_KEY_REPRESENTATION).toBe("legacy");
-    expect(scenario.gcs.env?.SERVER_KEY_REPRESENTATION).toBe("compressed-xof");
+    expect(scenario.bcs?.env?.FORCE_LEGACY_SERVER_KEY).toBe("true");
+    expect(scenario.gcs.env?.FORCE_LEGACY_SERVER_KEY).toBeUndefined();
     expect(scenario.hostChains).toHaveLength(2);
     expect(scenario.kms).toEqual({ mode: "threshold", parties: 4, threshold: 1, fheParams: "Test" });
   });


### PR DESCRIPTION
## Context

This is the rollout test for [RFC 029](https://github.com/zama-ai/tech-spec/pull/499) and [the production migration plan](https://github.com/zama-ai/fhevm-internal/issues/1621).

It is stacked on [the coprocessor migration draft](https://github.com/zama-ai/fhevm/pull/3448).

## What the runbook proves

- Boots version-pinned 0.14 contracts, connectors, KMS Core, and a published 0.14.1 Blue image.
- Generates legacy-only material and completes work before migration.
- Enables `FORCE_LEGACY_SERVER_KEY=true` only on Blue.
- Proves Green does not receive the safeguard.
- Upgrades `KMSGeneration` without invoking migration.
- Rejects mixed connector versions and waits for every finalized listener cursor.
- Requests compressed material for the existing active key.
- Recovers from connector, listener, and worker restarts.
- Rejects a delayed Green listener.
- Verifies the same key ID and signed digest in every operator database.
- Verifies both representations remain present.
- Proves Blue still computes after compressed material is published.
- Runs the existing two-chain blue-green failure, retry, unanimity, traffic, and cutover battery.
- Verifies preserved ciphertexts and post-cutover computation, public decryption, and user decryption.

KMS Core is pinned but not upgraded because its existing `UseExisting + CompressedAll` path already performs this migration.

## Running it

An exact published 0.14.1 Blue image is mandatory:

```sh
RFC029_BLUE_HOTFIX_TAG=<exact-tag-or-sha> \
  ./fhevm-cli rollout run rollouts/v0.14-to-v0.15-gpu-key-migration/run.ts
```

The runbook refuses to start without `RFC029_BLUE_HOTFIX_TAG`.

## Validation

- TypeScript check passes.
- Five focused gate tests cover missing pins, the Blue-only safeguard, mixed connectors, stale listener cursors, delayed operators, and digest disagreement.

The complete ceremony was not run locally because 0.14.0 and the published 0.14.1 safeguard image do not exist yet. This PR remains draft until that image exists and the runbook passes in the rollout environment.
