### PR TITLE
feat(host-contracts): add tasks to mirror canonical KMS context/epoch onto replicas

### DIFF
--- a/host-contracts/README.md
+++ b/host-contracts/README.md
@@ -205,5 +205,10 @@ When deploying a full non-canonical host stack, `task:deployAllHostContracts
 the same environment variables (this is what the fhevm-cli multi-chain stack uses, so e2e seeds
 non-canonical chains exactly like production).
 
-Later canonical rotations are mirrored manually with `mirrorKmsContextAndEpoch` / `mirrorKmsEpoch`, as
-described in [Mirror methods](#mirror-methods-non-canonical-write-path).
+Later canonical rotations are mirrored with `task:buildMirrorKmsContextAndEpochCalldata` /
+`task:mirrorKmsContextAndEpoch` (context switch) and `task:buildMirrorKmsEpochCalldata` /
+`task:mirrorKmsEpoch` (same-set epoch rotation), defined in `tasks/mirrorKmsContext.ts`. Both read
+canonical's active KMS context/epoch over `--canonical-rpc-url` / `--canonical-protocol-config-address`
+(the context-switch pair also cross-checks the recovered `NewKmsContext` event data against the
+canonical `contextInfoHash` anchor) and call the replica's `mirrorKmsContextAndEpoch` /
+`mirrorKmsEpoch` described in [Mirror methods](#mirror-methods-non-canonical-write-path).

--- a/host-contracts/hardhat.config.ts
+++ b/host-contracts/hardhat.config.ts
@@ -18,6 +18,7 @@ import './tasks/examples/cOFT';
 import './tasks/examples/handlesList';
 import './tasks/generateKmsMaterials';
 import './tasks/kmsContext';
+import './tasks/mirrorKmsContext';
 import './tasks/ownership';
 import './tasks/pauseContracts';
 import './tasks/taskDeploy';

--- a/host-contracts/tasks/kmsContext.ts
+++ b/host-contracts/tasks/kmsContext.ts
@@ -33,7 +33,7 @@ function resolveProtocolConfigAddress(useInternalProxyAddress: boolean): string 
   return address && address.trim() !== '' ? address : undefined;
 }
 
-function requireProtocolConfigAddress(useInternalProxyAddress: boolean): string {
+export function requireProtocolConfigAddress(useInternalProxyAddress: boolean): string {
   const address = resolveProtocolConfigAddress(useInternalProxyAddress);
   if (!address) {
     throw new Error(
@@ -91,7 +91,7 @@ export function encodeDestroyKmsEpoch(iface: Interface, epochId: bigint): Encode
 
 // Broadcasts the byte-identical payload the DAO would sign, using the deployer key. On devnet / the
 // test-suite the deployer is the ACL owner, so the call is authorized; this is the no-DAO path.
-async function broadcast(hre: HardhatRuntimeEnvironment, target: string, calldata: string): Promise<string> {
+export async function broadcast(hre: HardhatRuntimeEnvironment, target: string, calldata: string): Promise<string> {
   const deployer = new hre.ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(hre.ethers.provider);
   const tx = await deployer.sendTransaction({ to: target, data: calldata });
   await tx.wait();

--- a/host-contracts/tasks/mirrorKmsContext.ts
+++ b/host-contracts/tasks/mirrorKmsContext.ts
@@ -1,0 +1,331 @@
+import { Interface, type Provider } from 'ethers';
+import { task, types } from 'hardhat/config';
+import type { ConfigurableTaskDefinition, HardhatRuntimeEnvironment } from 'hardhat/types';
+
+import type { ProtocolConfig } from '../types';
+import type { KmsNodeParamsStruct, PcrValuesStruct } from '../types/contracts/ProtocolConfig';
+import { broadcast, getProtocolConfigInterface, requireProtocolConfigAddress } from './kmsContext';
+import { type KmsThresholds, readCanonicalSnapshot } from './protocolConfigMirror';
+
+// This file defines tasks that mirror the canonical (Ethereum) ProtocolConfig's active KMS context
+// and epoch onto a non-canonical replica (e.g. Polygon) after a rotation has gone active on
+// canonical. It follows the same build-calldata (DAO path, never broadcasts) / broadcast (no-DAO
+// path for devnet / test-suite) convention as kmsContext.ts, calling the replica's
+// `mirrorKmsContextAndEpoch` (context switch) or `mirrorKmsEpoch` (same-set epoch rotation).
+
+// -----------------------------------------------------------------------------------------
+// mirrorKmsContextAndEpoch: mirrors a context switch (new signer set) plus its first epoch.
+// -----------------------------------------------------------------------------------------
+
+export interface MirrorContextArgs {
+  contextId: bigint;
+  epochId: bigint;
+  kmsNodeParams: KmsNodeParamsStruct[];
+  thresholds: KmsThresholds;
+  softwareVersion: string;
+  pcrValues: PcrValuesStruct[];
+}
+
+// Recomputes the on-chain `contextInfoHash` anchor from candidate event args. The encode types come
+// straight off `mirrorKmsContextAndEpoch`'s ABI fragment (minus the leading id params), so the tuple
+// layout cannot drift from the contract's `abi.encode(...)`.
+function computeContextInfoHash(
+  hre: HardhatRuntimeEnvironment,
+  iface: Interface,
+  args: Pick<MirrorContextArgs, 'kmsNodeParams' | 'thresholds' | 'softwareVersion' | 'pcrValues'>,
+): string {
+  const encodeTypes = iface.getFunction('mirrorKmsContextAndEpoch')!.inputs.slice(2);
+  const encoded = hre.ethers.AbiCoder.defaultAbiCoder().encode(encodeTypes, [
+    args.kmsNodeParams,
+    args.thresholds,
+    args.softwareVersion,
+    args.pcrValues,
+  ]);
+  return hre.ethers.keccak256(encoded);
+}
+
+// Reads canonical's active KMS context as `mirrorKmsContextAndEpoch` args. The node/software-version/
+// PCR data only exists in the `NewKmsContext` event, so this reads the event at the block the context
+// anchor records and verifies its hash against the anchor. Thresholds come from live state, because
+// governance can update them after the event without touching the anchor.
+export async function readCanonicalContextSwitch(
+  hre: HardhatRuntimeEnvironment,
+  options: {
+    canonicalProvider: Provider;
+    canonicalProtocolConfigAddress: string;
+    blockNumber?: number;
+  },
+  iface: Interface,
+): Promise<MirrorContextArgs> {
+  const { canonicalProvider, canonicalProtocolConfigAddress, blockNumber } = options;
+  const snapshot = await readCanonicalSnapshot(hre, { canonicalProvider, canonicalProtocolConfigAddress, blockNumber });
+
+  const canonicalProtocolConfig = (
+    await hre.ethers.getContractAt('ProtocolConfig', canonicalProtocolConfigAddress)
+  ).connect(canonicalProvider) as unknown as ProtocolConfig;
+
+  const [emissionBlockNumber, expectedHash] = await canonicalProtocolConfig.getKmsContextAnchor(
+    snapshot.currentKmsContextId,
+    { blockTag: snapshot.blockNumber },
+  );
+  if (emissionBlockNumber === 0n) {
+    throw new Error(
+      `${canonicalProtocolConfigAddress} has no context anchor recorded for context ${snapshot.currentKmsContextId}. `,
+    );
+  }
+
+  const [event] = await canonicalProtocolConfig.queryFilter(
+    canonicalProtocolConfig.filters.NewKmsContext(snapshot.currentKmsContextId),
+    Number(emissionBlockNumber),
+    Number(emissionBlockNumber),
+  );
+  if (!event) {
+    throw new Error(
+      `No NewKmsContext(${snapshot.currentKmsContextId}) event at block ${emissionBlockNumber} on ${canonicalProtocolConfigAddress}. `,
+    );
+  }
+
+  const kmsNodeParams: KmsNodeParamsStruct[] = event.args.kmsNodeParams.map((node) => ({
+    txSenderAddress: node.txSenderAddress,
+    signerAddress: node.signerAddress,
+    ipAddress: node.ipAddress,
+    storageUrl: node.storageUrl,
+    partyId: node.partyId,
+    mpcIdentity: node.mpcIdentity,
+    caCert: node.caCert,
+    storagePrefix: node.storagePrefix,
+  }));
+  const eventThresholds: KmsThresholds = {
+    publicDecryption: event.args.thresholds.publicDecryption,
+    userDecryption: event.args.thresholds.userDecryption,
+    kmsGen: event.args.thresholds.kmsGen,
+    mpc: event.args.thresholds.mpc,
+  };
+  const pcrValues: PcrValuesStruct[] = event.args.pcrValues.map((pcr) => ({
+    pcr0: pcr.pcr0,
+    pcr1: pcr.pcr1,
+    pcr2: pcr.pcr2,
+  }));
+  const softwareVersion = event.args.softwareVersion;
+
+  const hash = computeContextInfoHash(hre, iface, {
+    kmsNodeParams,
+    thresholds: eventThresholds,
+    softwareVersion,
+    pcrValues,
+  });
+  if (hash !== expectedHash) {
+    throw new Error(
+      `NewKmsContext(${snapshot.currentKmsContextId}) event at block ${emissionBlockNumber} on ${canonicalProtocolConfigAddress} does not match the on-chain contextInfoHash.`,
+    );
+  }
+
+  return {
+    contextId: snapshot.currentKmsContextId,
+    epochId: snapshot.currentEpochId,
+    kmsNodeParams,
+    thresholds: snapshot.thresholds,
+    softwareVersion,
+    pcrValues,
+  };
+}
+
+export function encodeMirrorKmsContextAndEpoch(iface: Interface, args: MirrorContextArgs): string {
+  return iface.encodeFunctionData('mirrorKmsContextAndEpoch', [
+    args.contextId,
+    args.epochId,
+    args.kmsNodeParams,
+    args.thresholds,
+    args.softwareVersion,
+    args.pcrValues,
+  ]);
+}
+
+// Fails with an explicit mismatch message instead of the replica's NonIncreasingKmsContextId revert.
+export async function assertReplicaNeedsContextSwitch(
+  hre: HardhatRuntimeEnvironment,
+  replicaProtocolConfigAddress: string,
+  canonicalContextId: bigint,
+): Promise<void> {
+  const replica = (await hre.ethers.getContractAt(
+    'ProtocolConfig',
+    replicaProtocolConfigAddress,
+  )) as unknown as ProtocolConfig;
+  const [replicaContextId] = await replica.getCurrentKmsContextAndEpoch();
+  if (canonicalContextId <= replicaContextId) {
+    throw new Error(
+      `Replica ${replicaProtocolConfigAddress} is already at context ${replicaContextId}, which is >= canonical's ${canonicalContextId}. `,
+    );
+  }
+}
+
+// All four mirror tasks share the same CLI surface.
+function addMirrorTaskParams(definition: ConfigurableTaskDefinition, readTarget: string): ConfigurableTaskDefinition {
+  return definition
+    .addParam(
+      'canonicalRpcUrl',
+      'RPC URL of the canonical host chain (Ethereum) to read ProtocolConfig from.',
+      undefined,
+      types.string,
+    )
+    .addParam(
+      'canonicalProtocolConfigAddress',
+      'Address of the ProtocolConfig contract on the canonical host chain.',
+      undefined,
+      types.string,
+    )
+    .addOptionalParam(
+      'blockNumber',
+      `Canonical block height to read ${readTarget} from. Defaults to the latest finalized block.`,
+      undefined,
+      types.int,
+    )
+    .addOptionalParam(
+      'useInternalProxyAddress',
+      'Resolve the replica ProtocolConfig address from the /addresses directory instead of the environment',
+      false,
+      types.boolean,
+    );
+}
+
+addMirrorTaskParams(
+  task(
+    'task:buildMirrorKmsContextAndEpochCalldata',
+    "Builds Aragon proposal calldata for the replica ProtocolConfig.mirrorKmsContextAndEpoch from canonical's active KMS context (DAO path, never broadcasts)",
+  ),
+  'the context switch',
+).setAction(async function (
+  { canonicalRpcUrl, canonicalProtocolConfigAddress, blockNumber, useInternalProxyAddress },
+  hre,
+): Promise<void> {
+  const iface = await getProtocolConfigInterface(hre);
+  const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+  const args = await readCanonicalContextSwitch(
+    hre,
+    { canonicalProvider, canonicalProtocolConfigAddress, blockNumber },
+    iface,
+  );
+  const target = requireProtocolConfigAddress(useInternalProxyAddress);
+  await assertReplicaNeedsContextSwitch(hre, target, args.contextId);
+  const calldata = encodeMirrorKmsContextAndEpoch(iface, args);
+
+  console.log('ProtocolConfig.mirrorKmsContextAndEpoch');
+  console.log('  contextId:', args.contextId.toString());
+  console.log('  epochId:', args.epochId.toString());
+  console.log('  kmsNodes:', args.kmsNodeParams.length);
+  console.log('  target:', target);
+  console.log('  calldata:', calldata);
+});
+
+addMirrorTaskParams(
+  task(
+    'task:mirrorKmsContextAndEpoch',
+    "Broadcasts the replica ProtocolConfig.mirrorKmsContextAndEpoch from canonical's active KMS context with the deployer key",
+  ),
+  'the context switch',
+).setAction(async function (
+  { canonicalRpcUrl, canonicalProtocolConfigAddress, blockNumber, useInternalProxyAddress },
+  hre,
+): Promise<void> {
+  const iface = await getProtocolConfigInterface(hre);
+  const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+  const args = await readCanonicalContextSwitch(
+    hre,
+    { canonicalProvider, canonicalProtocolConfigAddress, blockNumber },
+    iface,
+  );
+  const target = requireProtocolConfigAddress(useInternalProxyAddress);
+  await assertReplicaNeedsContextSwitch(hre, target, args.contextId);
+  const calldata = encodeMirrorKmsContextAndEpoch(iface, args);
+  const hash = await broadcast(hre, target, calldata);
+  console.log(
+    `Broadcast mirrorKmsContextAndEpoch(context=${args.contextId}, epoch=${args.epochId}) on ${target} (tx: ${hash}).`,
+  );
+});
+
+// -----------------------------------------------------------------------------------------
+// mirrorKmsEpoch: mirrors a same-set epoch rotation (no signer-set change) under the context
+// already active on the replica.
+// -----------------------------------------------------------------------------------------
+
+export function encodeMirrorKmsEpoch(iface: Interface, contextId: bigint, epochId: bigint): string {
+  return iface.encodeFunctionData('mirrorKmsEpoch', [contextId, epochId]);
+}
+
+export async function assertReplicaNeedsEpochMirror(
+  hre: HardhatRuntimeEnvironment,
+  replicaProtocolConfigAddress: string,
+  canonicalContextId: bigint,
+  canonicalEpochId: bigint,
+): Promise<void> {
+  const replica = (await hre.ethers.getContractAt(
+    'ProtocolConfig',
+    replicaProtocolConfigAddress,
+  )) as unknown as ProtocolConfig;
+  const [replicaContextId, replicaEpochId] = await replica.getCurrentKmsContextAndEpoch();
+  if (canonicalContextId !== replicaContextId) {
+    throw new Error(
+      `Replica ${replicaProtocolConfigAddress} is at context ${replicaContextId}, but canonical's active context is ${canonicalContextId}. ` +
+        `Run task:mirrorKmsContextAndEpoch first to mirror the context switch.`,
+    );
+  }
+  if (canonicalEpochId <= replicaEpochId) {
+    throw new Error(
+      `Replica ${replicaProtocolConfigAddress} is already at epoch ${replicaEpochId}, which is >= canonical's ${canonicalEpochId}. Nothing to mirror.`,
+    );
+  }
+}
+
+addMirrorTaskParams(
+  task(
+    'task:buildMirrorKmsEpochCalldata',
+    "Builds Aragon proposal calldata for the replica ProtocolConfig.mirrorKmsEpoch from canonical's active KMS epoch (DAO path, never broadcasts)",
+  ),
+  'the active epoch',
+).setAction(async function (
+  { canonicalRpcUrl, canonicalProtocolConfigAddress, blockNumber, useInternalProxyAddress },
+  hre,
+): Promise<void> {
+  const iface = await getProtocolConfigInterface(hre);
+  const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+  const snapshot = await readCanonicalSnapshot(hre, {
+    canonicalProvider,
+    canonicalProtocolConfigAddress,
+    blockNumber,
+  });
+  const target = requireProtocolConfigAddress(useInternalProxyAddress);
+  await assertReplicaNeedsEpochMirror(hre, target, snapshot.currentKmsContextId, snapshot.currentEpochId);
+  const calldata = encodeMirrorKmsEpoch(iface, snapshot.currentKmsContextId, snapshot.currentEpochId);
+
+  console.log('ProtocolConfig.mirrorKmsEpoch');
+  console.log('  contextId:', snapshot.currentKmsContextId.toString());
+  console.log('  epochId:', snapshot.currentEpochId.toString());
+  console.log('  target:', target);
+  console.log('  calldata:', calldata);
+});
+
+addMirrorTaskParams(
+  task(
+    'task:mirrorKmsEpoch',
+    "Broadcasts the replica ProtocolConfig.mirrorKmsEpoch from canonical's active KMS epoch with the deployer key",
+  ),
+  'the active epoch',
+).setAction(async function (
+  { canonicalRpcUrl, canonicalProtocolConfigAddress, blockNumber, useInternalProxyAddress },
+  hre,
+): Promise<void> {
+  const iface = await getProtocolConfigInterface(hre);
+  const canonicalProvider = new hre.ethers.JsonRpcProvider(canonicalRpcUrl);
+  const snapshot = await readCanonicalSnapshot(hre, {
+    canonicalProvider,
+    canonicalProtocolConfigAddress,
+    blockNumber,
+  });
+  const target = requireProtocolConfigAddress(useInternalProxyAddress);
+  await assertReplicaNeedsEpochMirror(hre, target, snapshot.currentKmsContextId, snapshot.currentEpochId);
+  const calldata = encodeMirrorKmsEpoch(iface, snapshot.currentKmsContextId, snapshot.currentEpochId);
+  const hash = await broadcast(hre, target, calldata);
+  console.log(
+    `Broadcast mirrorKmsEpoch(context=${snapshot.currentKmsContextId}, epoch=${snapshot.currentEpochId}) on ${target} (tx: ${hash}).`,
+  );
+});

--- a/host-contracts/test/tasks/mirrorKmsContext.ts
+++ b/host-contracts/test/tasks/mirrorKmsContext.ts
@@ -1,0 +1,240 @@
+import { expect } from 'chai';
+import hre, { ethers } from 'hardhat';
+
+import { getProtocolConfigInterface } from '../../tasks/kmsContext';
+import {
+  assertReplicaNeedsContextSwitch,
+  assertReplicaNeedsEpochMirror,
+  encodeMirrorKmsContextAndEpoch,
+  encodeMirrorKmsEpoch,
+  readCanonicalContextSwitch,
+} from '../../tasks/mirrorKmsContext';
+import { getRequiredEnvVar } from '../../tasks/utils/loadVariables';
+import type { ProtocolConfig } from '../../types';
+import {
+  buildControllableKmsCommittee,
+  buildProtocolConfigNodes,
+  buildProtocolConfigThresholds,
+  buildSingleKeyAndCrsActivationPayload,
+  deployFreshProtocolConfigProxy,
+  deployFreshUninitializedProtocolConfigProxy,
+  rotateToNewKmsContext,
+} from './taskHelpers';
+
+// These tests drive the mirroring helpers directly: `ethers.provider` stands in for the canonical
+// RPC provider. The CLI layer itself (`--canonical-rpc-url` constructing a real JsonRpcProvider) is
+// untested.
+describe('KMS mirror tasks', function () {
+  const deployer = new ethers.Wallet(getRequiredEnvVar('DEPLOYER_PRIVATE_KEY')).connect(ethers.provider);
+
+  describe('readCanonicalContextSwitch', function () {
+    it('recovers the rotated context from the NewKmsContext event and matches live ids', async function () {
+      const committee = await buildControllableKmsCommittee();
+      const canonicalAddress = await deployFreshProtocolConfigProxy(deployer, committee.nodes, committee.thresholds);
+      const contextId = await rotateToNewKmsContext(canonicalAddress, deployer, committee);
+
+      const canonical = (await ethers.getContractAt('ProtocolConfig', canonicalAddress)) as unknown as ProtocolConfig;
+      const [liveContextId, liveEpochId] = await canonical.getCurrentKmsContextAndEpoch();
+      expect(liveContextId).to.equal(contextId);
+
+      const iface = await getProtocolConfigInterface(hre);
+      const args = await readCanonicalContextSwitch(
+        hre,
+        { canonicalProvider: ethers.provider, canonicalProtocolConfigAddress: canonicalAddress },
+        iface,
+      );
+
+      expect(args.contextId).to.equal(liveContextId);
+      expect(args.epochId).to.equal(liveEpochId);
+      expect(args.kmsNodeParams.length).to.equal(committee.nodes.length);
+      committee.nodes.forEach((node, i) => {
+        expect(args.kmsNodeParams[i].txSenderAddress).to.equal(node.txSenderAddress);
+        expect(args.kmsNodeParams[i].signerAddress).to.equal(node.signerAddress);
+        expect(args.kmsNodeParams[i].mpcIdentity).to.equal(node.mpcIdentity);
+      });
+      expect(args.thresholds.mpc).to.equal(BigInt(committee.thresholds.mpc));
+    });
+
+    it('mirrors live thresholds rather than the thresholds in the NewKmsContext event', async function () {
+      const committee = await buildControllableKmsCommittee();
+      const canonicalAddress = await deployFreshProtocolConfigProxy(deployer, committee.nodes, committee.thresholds);
+      const contextId = await rotateToNewKmsContext(canonicalAddress, deployer, committee);
+
+      // updateMpcThresholdForContext mutates live state without touching the NewKmsContext anchor, so
+      // a naive event-only read would mirror the stale value defined at context-creation time.
+      const asOwner = (await ethers.getContractAt(
+        'ProtocolConfig',
+        canonicalAddress,
+        deployer,
+      )) as unknown as ProtocolConfig;
+      await (await asOwner.updateMpcThresholdForContext(contextId, 2)).wait();
+
+      const iface = await getProtocolConfigInterface(hre);
+      const args = await readCanonicalContextSwitch(
+        hre,
+        { canonicalProvider: ethers.provider, canonicalProtocolConfigAddress: canonicalAddress },
+        iface,
+      );
+
+      expect(args.thresholds.mpc).to.equal(2n);
+      expect(args.thresholds.mpc).to.not.equal(BigInt(committee.thresholds.mpc));
+    });
+
+    it('rejects an address with no context anchor as non-canonical', async function () {
+      // `initializeFromCanonical` (the replica bootstrap path) never writes a context anchor, so a
+      // replica passed as canonical must be rejected before any event scan. It requires ids matching
+      // a canonical genesis, so read them from a real canonical.
+      const canonicalAddress = await deployFreshProtocolConfigProxy(
+        deployer,
+        buildProtocolConfigNodes(),
+        buildProtocolConfigThresholds(),
+      );
+      const canonical = (await ethers.getContractAt('ProtocolConfig', canonicalAddress)) as unknown as ProtocolConfig;
+      const [canonicalContextId, canonicalEpochId] = await canonical.getCurrentKmsContextAndEpoch();
+
+      const replicaAddress = await deployFreshUninitializedProtocolConfigProxy(deployer);
+      const replica = (await ethers.getContractAt(
+        'ProtocolConfig',
+        replicaAddress,
+        deployer,
+      )) as unknown as ProtocolConfig;
+      await (
+        await replica.initializeFromCanonical(
+          canonicalContextId,
+          canonicalEpochId,
+          buildProtocolConfigNodes(),
+          buildProtocolConfigThresholds(),
+        )
+      ).wait();
+
+      const iface = await getProtocolConfigInterface(hre);
+      await expect(
+        readCanonicalContextSwitch(
+          hre,
+          { canonicalProvider: ethers.provider, canonicalProtocolConfigAddress: replicaAddress },
+          iface,
+        ),
+      ).to.be.rejectedWith(/has no context anchor recorded/);
+    });
+  });
+
+  describe('encodeMirrorKmsContextAndEpoch', function () {
+    it('builds calldata that decodes back to the recovered args', async function () {
+      const committee = await buildControllableKmsCommittee();
+      const canonicalAddress = await deployFreshProtocolConfigProxy(deployer, committee.nodes, committee.thresholds);
+      await rotateToNewKmsContext(canonicalAddress, deployer, committee);
+
+      const iface = await getProtocolConfigInterface(hre);
+      const args = await readCanonicalContextSwitch(
+        hre,
+        { canonicalProvider: ethers.provider, canonicalProtocolConfigAddress: canonicalAddress },
+        iface,
+      );
+      const calldata = encodeMirrorKmsContextAndEpoch(iface, args);
+      const decoded = iface.decodeFunctionData('mirrorKmsContextAndEpoch', calldata);
+
+      expect(decoded[0]).to.equal(args.contextId);
+      expect(decoded[1]).to.equal(args.epochId);
+      expect(decoded[2].length).to.equal(args.kmsNodeParams.length);
+    });
+  });
+
+  describe('replica readiness guards', function () {
+    it('assertReplicaNeedsContextSwitch throws once the replica is already at the target context', async function () {
+      const nodes = (await buildControllableKmsCommittee()).nodes;
+      const thresholds = { publicDecryption: 1, userDecryption: 1, kmsGen: 1, mpc: 1 };
+      const replicaAddress = await deployFreshProtocolConfigProxy(deployer, nodes, thresholds);
+      const replica = (await ethers.getContractAt('ProtocolConfig', replicaAddress)) as unknown as ProtocolConfig;
+      const [replicaContextId] = await replica.getCurrentKmsContextAndEpoch();
+
+      await expect(assertReplicaNeedsContextSwitch(hre, replicaAddress, replicaContextId)).to.be.rejectedWith(
+        /is already at context/,
+      );
+      await expect(assertReplicaNeedsContextSwitch(hre, replicaAddress, replicaContextId + 1n)).to.not.be.rejected;
+    });
+
+    it('assertReplicaNeedsEpochMirror throws on a context mismatch and on a non-increasing epoch', async function () {
+      const nodes = (await buildControllableKmsCommittee()).nodes;
+      const thresholds = { publicDecryption: 1, userDecryption: 1, kmsGen: 1, mpc: 1 };
+      const replicaAddress = await deployFreshProtocolConfigProxy(deployer, nodes, thresholds);
+      const replica = (await ethers.getContractAt('ProtocolConfig', replicaAddress)) as unknown as ProtocolConfig;
+      const [replicaContextId, replicaEpochId] = await replica.getCurrentKmsContextAndEpoch();
+
+      await expect(
+        assertReplicaNeedsEpochMirror(hre, replicaAddress, replicaContextId + 1n, replicaEpochId + 1n),
+      ).to.be.rejectedWith(/but canonical's active context is/);
+      await expect(
+        assertReplicaNeedsEpochMirror(hre, replicaAddress, replicaContextId, replicaEpochId),
+      ).to.be.rejectedWith(/Nothing to mirror/);
+      await expect(assertReplicaNeedsEpochMirror(hre, replicaAddress, replicaContextId, replicaEpochId + 1n)).to.not.be
+        .rejected;
+    });
+  });
+
+  describe('end-to-end mirror onto a replica', function () {
+    it('mirrors a context switch, then a same-set epoch rotation, onto an independent replica', async function () {
+      const committee = await buildControllableKmsCommittee();
+      const canonicalAddress = await deployFreshProtocolConfigProxy(deployer, committee.nodes, committee.thresholds);
+      await rotateToNewKmsContext(canonicalAddress, deployer, committee);
+
+      // The replica is a wholly separate deployment, starting at its own genesis context (id 1), so
+      // canonical's rotated context (id 2) is strictly ahead of it. This is the context-switch case.
+      const replicaAddress = await deployFreshProtocolConfigProxy(deployer, committee.nodes, committee.thresholds);
+
+      const iface = await getProtocolConfigInterface(hre);
+      const switchArgs = await readCanonicalContextSwitch(
+        hre,
+        { canonicalProvider: ethers.provider, canonicalProtocolConfigAddress: canonicalAddress },
+        iface,
+      );
+      await assertReplicaNeedsContextSwitch(hre, replicaAddress, switchArgs.contextId);
+      const contextCalldata = encodeMirrorKmsContextAndEpoch(iface, switchArgs);
+
+      await (await deployer.sendTransaction({ to: replicaAddress, data: contextCalldata })).wait();
+
+      const replica = (await ethers.getContractAt('ProtocolConfig', replicaAddress)) as unknown as ProtocolConfig;
+      const [mirroredContextId, mirroredEpochId] = await replica.getCurrentKmsContextAndEpoch();
+      expect(mirroredContextId).to.equal(switchArgs.contextId);
+      expect(mirroredEpochId).to.equal(switchArgs.epochId);
+
+      // Now drive a same-set rotation on canonical and mirror just the epoch.
+      const asCanonicalOwner = (await ethers.getContractAt(
+        'ProtocolConfig',
+        canonicalAddress,
+        deployer,
+      )) as unknown as ProtocolConfig;
+      const rotateReceipt = await (await asCanonicalOwner.defineNewEpochForCurrentKmsContext()).wait();
+      const [newEpochEvent] = await asCanonicalOwner.queryFilter(
+        asCanonicalOwner.filters.NewKmsEpoch(),
+        rotateReceipt!.blockNumber,
+        rotateReceipt!.blockNumber,
+      );
+      const newEpochId = newEpochEvent.args.epochId;
+      for (let i = 0; i < committee.txSenderSigners.length; i++) {
+        const asTxSender = (await ethers.getContractAt(
+          'ProtocolConfig',
+          canonicalAddress,
+          committee.txSenderSigners[i],
+        )) as unknown as ProtocolConfig;
+        const { keys, crsList } = await buildSingleKeyAndCrsActivationPayload(
+          committee.signerSigners[i],
+          canonicalAddress,
+          switchArgs.contextId,
+          newEpochId,
+        );
+        await (await asTxSender.confirmEpochActivation(newEpochId, keys, crsList)).wait();
+      }
+
+      const [, canonicalEpochIdAfterRotation] = await asCanonicalOwner.getCurrentKmsContextAndEpoch();
+      expect(canonicalEpochIdAfterRotation).to.equal(newEpochId);
+
+      await assertReplicaNeedsEpochMirror(hre, replicaAddress, switchArgs.contextId, newEpochId);
+      const epochCalldata = encodeMirrorKmsEpoch(iface, switchArgs.contextId, newEpochId);
+      await (await deployer.sendTransaction({ to: replicaAddress, data: epochCalldata })).wait();
+
+      const [finalContextId, finalEpochId] = await replica.getCurrentKmsContextAndEpoch();
+      expect(finalContextId).to.equal(switchArgs.contextId);
+      expect(finalEpochId).to.equal(newEpochId);
+    });
+  });
+});


### PR DESCRIPTION
Adds build-calldata and broadcast Hardhat tasks that mirror the canonical ProtocolConfig's active KMS context and epoch onto non-canonical replicas, with tests.