### PR TITLE
chore(common): add mergify retry

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,6 +39,8 @@ queue_rules:
       - -files~=^(?!charts/)
 
   - name: main
+    # Allow 1 retry per-job in case of flaky runner failing the job
+    max_checks_retries: 1
     batch_size: 3
     batch_max_wait_time: 1h
     checks_timeout: 5h


### PR DESCRIPTION
### Motivation

Attempt to mitigate Mergify's batch PRs being aborted due to flaky runners or Github.

Here's an example: 2026-07-31, the merge queue batch [#3398](https://github.com/zama-ai/fhevm/pull/3398) was rejected even though nothing was actually broken:

- `08:18:45` — the three required e2e shards ended as `cancelled`, annotated by GitHub with "GitHub Actions has encountered an internal error when running your job".
- `08:19:20` — RunsOn automatically re-ran the workflow (attempt 2).
- `08:19:26` — Mergify evaluated the batch, read the stale `cancelled` conclusions as a failure, and reject the batch.
- `08:21:20` — GitHub finally published attempt 2's check runs.
- `08:58` — all three e2e shards passed on the exact same SHA.

Mergify rejected in the ~2 minute window where the retry had already started but GitHub had not yet published the new check runs, so the only conclusions visible to it were the transient cancelled ones. Since our e2e suite takes roughly an hour, a spurious split costs two full batch cycles.

### Change

`max_checks_retries: 1` on the `main` queue rule. Mergify now recreates the draft PR and triggers a fresh CI run once before falling back to its normal failure resolution (splitting, then dequeuing), so a one-off infrastructure failure is absorbed instead of destroying the batch.

### Trade-off

A genuine test failure now burns one extra e2e cycle before Mergify starts splitting. This was explicitly discussed with the Mergify team, who confirmed the option and the trade-off:

> For now, `max_checks_retries` is what we recommend, even if it is not perfect. I was more reserved last week given your numbers, but if these interruptions keep happening, a wasted rerun beats losing a batch (that's a trade off to do on your side).
>
> Good news though: we are working to make it a lot less costly. The idea is that a rerun replays only the tests that actually failed instead of the whole suite, which takes most of the pain out of it.

Keeping the value at `1` bounds the worst case to a single extra run. It can be revisited once Mergify ships the partial rerun.