### PR TITLE
chore(coprocessor): tonic 0.14 and yellowstone client v14.2.2

### DIFF
--- a/.github/workflows/coprocessor-cargo-clippy.yml
+++ b/.github/workflows/coprocessor-cargo-clippy.yml
@@ -30,6 +30,11 @@ jobs:
             rust-files:
               - .github/workflows/coprocessor-cargo-clippy.yml
               - coprocessor/fhevm-engine/**
+              # host-listener's solana-reconstruct feature compiles these three as path
+              # dependencies, so editing them can break a clippy lane that no other filter watches.
+              - solana/programs/zama-host/**
+              - solana/crates/zama-solana-acl/**
+              - solana/crates/zama-solana-transaction/**
   cargo-clippy:
     name: coprocessor-cargo-clippy/cargo-clippy
     needs: check-changes
@@ -82,6 +87,11 @@ jobs:
         # For now, only specify the `bench latency throughput` features as the
         # other ones require specific dependencies (e.g. GPU, etc.).
         SQLX_OFFLINE=true cargo clippy -p host-listener --all-targets \
+          -- -D warnings
+        # The Solana ingestion path is feature-gated, so the line above never compiles it — the
+        # whole yellowstone client and its tests were going unlinted.
+        SQLX_OFFLINE=true cargo clippy -p host-listener \
+          --features solana-grpc,solana-reconstruct --all-targets \
           -- -D warnings
         SQLX_OFFLINE=true cargo clippy --all-targets --features "bench latency throughput" \
           -- -D warnings

--- a/coprocessor/fhevm-engine/Cargo.lock
+++ b/coprocessor/fhevm-engine/Cargo.lock
@@ -1358,7 +1358,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -2081,15 +2081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "autotools"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "aws-config"
 version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -2613,7 +2604,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -2629,6 +2620,31 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2650,6 +2666,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2750,7 +2784,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3835,7 +3869,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70def8d72740e44d9f676d8dab2c933a236663d86dd24319b57a2bed4d694774"
 dependencies = [
- "petgraph",
+ "petgraph 0.7.1",
 ]
 
 [[package]]
@@ -4128,7 +4162,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4420,7 +4454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4541,7 +4575,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sigv4",
- "axum",
+ "axum 0.7.9",
  "bigdecimal",
  "bytesize",
  "clap",
@@ -4555,7 +4589,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
- "prost",
+ "prost 0.14.4",
  "rand 0.9.2",
  "rand_chacha 0.3.1",
  "serde",
@@ -4567,8 +4601,8 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
- "tonic",
- "tonic-build",
+ "tonic 0.14.6",
+ "tonic-prost-build",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5155,7 +5189,7 @@ version = "0.7.0"
 dependencies = [
  "alloy",
  "anyhow",
- "axum",
+ "axum 0.7.9",
  "clap",
  "fhevm-engine-common",
  "fhevm_gateway_bindings",
@@ -5479,7 +5513,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -5685,7 +5719,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -6481,6 +6515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6939,11 +6979,11 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.5",
  "reqwest 0.12.28",
  "thiserror 2.0.19",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
 ]
 
@@ -6955,8 +6995,8 @@ checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.13.5",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -7201,6 +7241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap 2.14.0",
 ]
 
@@ -7527,24 +7578,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost",
+ "prost 0.14.4",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.119",
  "tempfile",
@@ -7564,12 +7626,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.13.5"
+name = "prost-derive"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
- "prost",
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -7584,21 +7659,96 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
-dependencies = [
- "autotools",
-]
-
-[[package]]
 name = "protobuf-support"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.9.4",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -7678,7 +7828,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -7716,7 +7866,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8341,7 +8491,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8424,7 +8574,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8445,7 +8595,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -9099,7 +9249,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
- "prost",
+ "prost 0.14.4",
  "rayon",
  "serde",
  "serde_json",
@@ -9114,7 +9264,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -9137,7 +9287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -11490,7 +11640,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tracing",
  "unicode-width",
 ]
@@ -12031,7 +12181,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "aws-sdk-s3",
- "axum",
+ "axum 0.7.9",
  "bigdecimal",
  "bytesize",
  "chrono",
@@ -12046,7 +12196,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "lru 0.13.0",
- "prost",
+ "prost 0.14.4",
  "rand 0.9.2",
  "rayon",
  "regex",
@@ -12067,8 +12217,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
- "tonic",
- "tonic-build",
+ "tonic 0.14.6",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -12178,7 +12327,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "url",
  "zip",
 ]
@@ -12328,7 +12477,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -12829,9 +12978,34 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -12844,11 +13018,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
- "socket2 0.5.10",
+ "socket2 0.6.5",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -12857,9 +13031,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -12867,6 +13064,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.119",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -12897,9 +13096,12 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -13080,7 +13282,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
- "axum",
+ "axum 0.7.9",
  "bigdecimal",
  "clap",
  "fhevm-engine-common",
@@ -13162,6 +13364,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -13611,7 +13819,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -14264,15 +14472,19 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "5.0.0+solana.2.1.21"
-source = "git+https://github.com/rpcpool/yellowstone-grpc?tag=v5.0.1%2Bsolana.2.1.21#eeaab8a1c40d5779fff012be87e0e647e440ba20"
+version = "12.5.0"
+source = "git+https://github.com/rpcpool/yellowstone-grpc?tag=v14.2.2%2Bsolana.4.1.0#243d0086927b8d3e773b08ecf7a187b21ea10477"
 dependencies = [
  "anyhow",
- "prost",
+ "prost 0.14.4",
  "prost-types",
- "protobuf-src",
- "tonic",
- "tonic-build",
+ "protoc-bin-vendored",
+ "siphasher 1.0.3",
+ "solana-pubkey 4.3.0",
+ "thiserror 2.0.19",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]

--- a/coprocessor/fhevm-engine/Cargo.toml
+++ b/coprocessor/fhevm-engine/Cargo.toml
@@ -52,7 +52,7 @@ opentelemetry-otlp = { version = "0.29.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.29.0"
 prometheus = "0.14.0"
-prost = "0.13.5"
+prost = "0.14.0"
 rand = "0.9.1"
 rayon = "1.11.0"
 reqwest = { version = "0.12.20", default-features = false, features = [
@@ -89,8 +89,9 @@ tfhe-zk-pok = "=0.8.2"
 time = "0.3.47"
 tokio = { version = "1.45.0", features = ["full"] }
 tokio-util = "0.7.15"
-tonic = { version = "0.12.3", features = ["server"] }
-tonic-build = "0.12.3"
+tonic = { version = "0.14.0", features = ["server"] }
+tonic-prost = "0.14.0"
+tonic-prost-build = "0.14.0"
 tracing = "0.1.41"
 tracing-opentelemetry = "0.30.0"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "json"] }

--- a/coprocessor/fhevm-engine/fhevm-engine-common/Cargo.toml
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/Cargo.toml
@@ -60,7 +60,7 @@ compact-hex = []
 stack-version-override = []
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [[bin]]
 name = "generate-keys"

--- a/coprocessor/fhevm-engine/fhevm-engine-common/build.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/build.rs
@@ -10,7 +10,8 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BUILD_STACK_VERSION");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    tonic_build::configure()
+    // tonic 0.14 moved prost codegen out of tonic-build into tonic-prost-build.
+    tonic_prost_build::configure()
         .file_descriptor_set_path(out_dir.join("common_descriptor.bin"))
         .compile_protos(&["../../proto/common.proto"], &["../../proto"])
         .unwrap();

--- a/coprocessor/fhevm-engine/host-listener/Cargo.toml
+++ b/coprocessor/fhevm-engine/host-listener/Cargo.toml
@@ -72,23 +72,21 @@ solana-sdk = "3.0"
 
 # Yellowstone gRPC transport (optional; enabled via the `solana-grpc` feature).
 tonic = { workspace = true, optional = true }
-# Pinned to the SAME tag as the baked plugin so client proto == server proto.
-# default-features=false drops the `convert` feature, which would otherwise pull
-# solana-sdk 2.1.x and clash with the solana 3.0 crates above. We drive the tonic
-# GeyserClient directly (no yellowstone-grpc-client, which would re-enable convert).
+# Pinned to the SAME tag as the plugin solana/geyser/build-yellowstone-plugin.sh fetches, so the
+# client proto and the server proto are generated from the same file. The geyser plugin has no
+# stable ABI, so that tag also tracks the agave line the validator runs — 4.1 today.
 #
-# Still on the v5 tag while the plugin this talks to moved to v14.2.2+solana.4.1.0. That is safe on
-# the wire: every .proto change between the two tags is additive — new RPCs and messages, nothing
-# removed or renumbered — and the reconstruct lane passes against the v14 plugin.
+# The tag and the workspace tonic version move together and cannot be split: this crate's proto is
+# generated against whatever tonic the tag was cut with, and mixing that with a different tonic in
+# our own code gives two incompatible `Body`/`Interceptor` types with the same name.
 #
-# This skew is temporary and should not outlive the next couple of PRs. Bumping the tag here was
-# tried and backed out: it needs two new `cuckoo_*` filter fields (trivial) and tonic 0.12.3 -> 0.14
-# across this workspace (not trivial). v14's proto crate is generated against tonic 0.14, whose
-# `Body` is a different type from ours, so GeyserClient rejects our Channel; 0.14 also split prost
-# codegen into tonic-prost/tonic-prost-build, and tonic is a workspace dep shared by
-# fhevm-engine-common, sns-worker and stress-test-generator. Sequence: land the tonic upgrade on its
-# own, then bump this tag so client and plugin match again.
-yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc", tag = "v5.0.1+solana.2.1.21", default-features = false, features = ["tonic", "tonic-compression"], optional = true }
+# This crate also brings its own solana-pubkey (4.3.0) alongside the 3.0.0 one solana-sdk pulls in.
+# Harmless because nothing crosses the boundary as a Pubkey: the wire carries base58 strings and raw
+# bytes, and we parse those into our own types. Keep it that way — handing one crate's Pubkey to the
+# other does not compile, and the error names the type, not the version skew behind it.
+#
+# We drive the tonic GeyserClient directly rather than through yellowstone-grpc-client.
+yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc", tag = "v14.2.2+solana.4.1.0", default-features = false, features = ["tonic", "tonic-compression"], optional = true }
 
 # Phase 2 reconstruction (optional; enabled via the `solana-reconstruct` feature).
 # no-entrypoint builds the program crate as a host library so we can call its

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_listener.rs
@@ -1443,7 +1443,7 @@ mod fhe_execute_acl_tests {
         );
         let lifecycle_requirement = transaction_context_requirement(
             &config(),
-            &[make_public.clone()],
+            std::slice::from_ref(&make_public),
             false,
         );
         assert_eq!(

--- a/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/solana_grpc_source.rs
@@ -327,6 +327,11 @@ pub(super) fn build_subscribe_request(
             include_transactions: Some(true),
             include_accounts: Some(false),
             include_entries: Some(false),
+            // A cuckoo filter is the plugin's compact stand-in for a very long account list: the
+            // client ships a probabilistic membership set instead of the addresses themselves and
+            // accepts false positives in exchange. We subscribe to exactly one program, so the
+            // explicit list above is both smaller and exact.
+            cuckoo_account_include: None,
         },
     );
     let accounts = HashMap::from([(
@@ -339,6 +344,8 @@ pub(super) fn build_subscribe_request(
             owner: vec![],
             filters: vec![],
             nonempty_txn_signature: None,
+            // Two fixed sysvar addresses — same reasoning as cuckoo_account_include above.
+            cuckoo_accounts_filter: None,
         },
     )]);
     SubscribeRequest {

--- a/coprocessor/fhevm-engine/stress-test-generator/Cargo.toml
+++ b/coprocessor/fhevm-engine/stress-test-generator/Cargo.toml
@@ -35,7 +35,6 @@ tfhe-versionable = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
-tonic-build = { workspace = true }
 humantime = { workspace = true }
 bytesize = { workspace = true }
 itertools = "0.13.0" # not in workspace

--- a/solana/scripts/check_solana_abi.py
+++ b/solana/scripts/check_solana_abi.py
@@ -57,6 +57,37 @@ DEMO_PROGRAMS = {
 }
 
 
+# Every generated IDL records the version of the Anchor IDL format it was written in.
+# `anchor build` takes that from anchor-lang-idl-spec, so an Anchor upgrade can move it
+# without a line of program source changing.
+#
+# Comparing the committed copy against the build output cannot catch that by itself: a bump
+# appears on both sides at once the moment anyone runs sync-zama-host-idl.sh, and lands
+# looking like an ordinary regeneration. Pinning the version here forces it to be changed
+# deliberately, so that everything reading these files — the host-listener decoders, the KMS
+# layout mirrors, the dapp's Codama codegen — is checked against the new shape first.
+EXPECTED_IDL_SPEC = "0.1.0"
+
+
+def idl_spec_errors(root: pathlib.Path, which: str) -> list[str]:
+    """Check the IDL format version of every IDL, on whichever side `which` names."""
+    errors = []
+    for program, spec in vendored_idls().items():
+        path = (root / spec[which]).resolve()
+        if not path.exists():
+            # Absent files are reported by the caller, which knows why it wanted this one.
+            continue
+        found = load_json(path).get("metadata", {}).get("spec")
+        if found != EXPECTED_IDL_SPEC:
+            errors.append(
+                f"{program}: {path} is IDL spec {found!r}, expected "
+                f"{EXPECTED_IDL_SPEC!r}. An Anchor upgrade changed the IDL format. "
+                "Check the readers of these IDLs against the new shape, then update "
+                "EXPECTED_IDL_SPEC in this script."
+            )
+    return errors
+
+
 def vendored_idls() -> dict[str, dict[str, Any]]:
     """Every IDL whose committed copy must equal the build output.
 
@@ -147,6 +178,14 @@ def main() -> int:
     ).resolve()
 
     if args.write:
+        # Before copying anything: a sync is the one moment an IDL format bump can pass
+        # through unnoticed, and refusing it here leaves the tree untouched rather than
+        # half-updated.
+        spec_errors = idl_spec_errors(root, "target_idl")
+        if spec_errors:
+            for error in spec_errors:
+                print(f"error: {error}", file=sys.stderr)
+            return 1
         for spec in vendored_idls().values():
             shutil.copyfile(
                 root / spec["target_idl"],
@@ -162,7 +201,7 @@ def main() -> int:
         print(f"wrote {manifest_path}")
         return 0
 
-    errors: list[str] = []
+    errors: list[str] = idl_spec_errors(root, "vendored_idl")
     for program, spec in vendored_idls().items():
         target = root / spec["target_idl"]
         vendored = (root / spec["vendored_idl"]).resolve()

--- a/solana/scripts/lib/require-pinned-toolchain.sh
+++ b/solana/scripts/lib/require-pinned-toolchain.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# require-pinned-toolchain.sh — assert the local Solana and Anchor CLIs are the ones CI pins.
+#
+# Source it from a script whose working directory is solana/; it does not run on its own:
+#   . "$(dirname "${BASH_SOURCE[0]}")/lib/require-pinned-toolchain.sh"
+#
+# For the scripts that regenerate committed build output — cost snapshots, IDL and ABI
+# goldens. Those files are only comparable with the ones they replace if the same compiler
+# wrote both, and a regeneration under a different toolchain is indistinguishable from a real
+# change once it is committed.
+#
+# Reads the Anchor version from Anchor.toml and the Solana version from EXPECTED_SOLANA,
+# which callers set to match .github/workflows/solana-tests.yml. Override EXPECTED_SOLANA
+# only for experiments; do not commit output minted under a divergent toolchain.
+
+if [[ -z "${EXPECTED_SOLANA:-}" ]]; then
+  echo "error: EXPECTED_SOLANA must be set before sourcing require-pinned-toolchain.sh" >&2
+  exit 1
+fi
+
+EXPECTED_ANCHOR="$(awk -F'"' '/^anchor_version/ { print $2; exit }' Anchor.toml)"
+if [[ -z "$EXPECTED_ANCHOR" ]]; then
+  echo "error: could not read anchor_version from Anchor.toml" >&2
+  exit 1
+fi
+
+for cmd in solana anchor cargo; do
+  command -v "$cmd" >/dev/null || {
+    echo "error: missing required command: $cmd" >&2
+    exit 1
+  }
+done
+
+solana_ver="$(solana --version)"
+anchor_ver="$(anchor --version)"
+
+# Require an exact version token after `solana-cli` (followed by a space or end of string),
+# so e.g. 2.1.05 cannot satisfy EXPECTED_SOLANA=2.1.0.
+case "$solana_ver" in
+  "solana-cli ${EXPECTED_SOLANA}"|"solana-cli ${EXPECTED_SOLANA} "*) ;;
+  *)
+    echo "error: need Solana CLI ${EXPECTED_SOLANA} (got: ${solana_ver})" >&2
+    echo "       match CI: .github/workflows/solana-tests.yml SOLANA_VERSION" >&2
+    exit 1
+    ;;
+esac
+if [[ "$anchor_ver" != "anchor-cli ${EXPECTED_ANCHOR}" ]]; then
+  echo "error: need Anchor ${EXPECTED_ANCHOR} (got: ${anchor_ver})" >&2
+  echo "       match CI / Anchor.toml anchor_version" >&2
+  exit 1
+fi
+
+echo "toolchain ok: ${solana_ver}; ${anchor_ver}"

--- a/solana/scripts/lib/require-pinned-toolchain.sh
+++ b/solana/scripts/lib/require-pinned-toolchain.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # require-pinned-toolchain.sh — assert the local Solana and Anchor CLIs are the ones CI pins.
 #
-# Source it from a script whose working directory is solana/; it does not run on its own:
-#   . "$(dirname "${BASH_SOURCE[0]}")/lib/require-pinned-toolchain.sh"
+# Source it from a script whose working directory is solana/; it does not run on its own.
+# Anchor the path on the caller's absolute ROOT, not on ${BASH_SOURCE[0]}: callers resolve
+# ROOT and then cd into it, which leaves a relative BASH_SOURCE pointing at the old cwd.
+#   . "$ROOT/scripts/lib/require-pinned-toolchain.sh"
 #
 # For the scripts that regenerate committed build output — cost snapshots, IDL and ABI
 # goldens. Those files are only comparable with the ones they replace if the same compiler

--- a/solana/scripts/sync-zama-host-idl.sh
+++ b/solana/scripts/sync-zama-host-idl.sh
@@ -13,6 +13,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$ROOT"
+
+# The goldens this writes are compared byte for byte against a fresh `anchor build` in CI, so
+# minting them under a different Anchor than CI runs produces a diff that looks like a real
+# IDL change and fails the next unrelated PR. Keep in lockstep with solana-tests.yml.
+EXPECTED_SOLANA="${EXPECTED_SOLANA:-4.1.2}"
+. "$(dirname "${BASH_SOURCE[0]}")/lib/require-pinned-toolchain.sh"
+
 NO_DNA=1 anchor build --ignore-keys
 # Writes all four vendored IDLs, including the two demo-only programs whose copies live
 # with the dapp that consumes their generated clients. The list they come from is

--- a/solana/scripts/sync-zama-host-idl.sh
+++ b/solana/scripts/sync-zama-host-idl.sh
@@ -18,7 +18,7 @@ cd "$ROOT"
 # minting them under a different Anchor than CI runs produces a diff that looks like a real
 # IDL change and fails the next unrelated PR. Keep in lockstep with solana-tests.yml.
 EXPECTED_SOLANA="${EXPECTED_SOLANA:-4.1.2}"
-. "$(dirname "${BASH_SOURCE[0]}")/lib/require-pinned-toolchain.sh"
+. "$ROOT/scripts/lib/require-pinned-toolchain.sh"
 
 NO_DNA=1 anchor build --ignore-keys
 # Writes all four vendored IDLs, including the two demo-only programs whose copies live

--- a/solana/scripts/update-cost-snapshots.sh
+++ b/solana/scripts/update-cost-snapshots.sh
@@ -45,43 +45,7 @@ done
 
 # Keep in lockstep with .github/workflows/solana-tests.yml SOLANA_VERSION.
 EXPECTED_SOLANA="${EXPECTED_SOLANA:-4.1.2}"
-EXPECTED_ANCHOR="$(awk -F'"' '/^anchor_version/ { print $2; exit }' Anchor.toml)"
-if [[ -z "$EXPECTED_ANCHOR" ]]; then
-  echo "error: could not read anchor_version from Anchor.toml" >&2
-  exit 1
-fi
-
-require_cmd() {
-  command -v "$1" >/dev/null || {
-    echo "error: missing required command: $1" >&2
-    exit 1
-  }
-}
-
-require_cmd solana
-require_cmd anchor
-require_cmd cargo
-
-solana_ver="$(solana --version)"
-anchor_ver="$(anchor --version)"
-
-# Require an exact version token after `solana-cli` (space or end), so e.g.
-# 2.1.05 cannot satisfy EXPECTED_SOLANA=2.1.0.
-case "$solana_ver" in
-  "solana-cli ${EXPECTED_SOLANA}"|"solana-cli ${EXPECTED_SOLANA} "*) ;;
-  *)
-    echo "error: need Solana CLI ${EXPECTED_SOLANA} (got: ${solana_ver})" >&2
-    echo "       match CI: .github/workflows/solana-tests.yml SOLANA_VERSION" >&2
-    exit 1
-    ;;
-esac
-if [[ "$anchor_ver" != "anchor-cli ${EXPECTED_ANCHOR}" ]]; then
-  echo "error: need Anchor ${EXPECTED_ANCHOR} (got: ${anchor_ver})" >&2
-  echo "       match CI / Anchor.toml anchor_version" >&2
-  exit 1
-fi
-
-echo "toolchain ok: ${solana_ver}; ${anchor_ver}"
+. "$(dirname "${BASH_SOURCE[0]}")/lib/require-pinned-toolchain.sh"
 
 if [[ "$CLEAN" -eq 1 ]]; then
   echo "cargo clean (use --no-clean to skip after a trusted rebuild)"

--- a/solana/scripts/update-cost-snapshots.sh
+++ b/solana/scripts/update-cost-snapshots.sh
@@ -45,7 +45,7 @@ done
 
 # Keep in lockstep with .github/workflows/solana-tests.yml SOLANA_VERSION.
 EXPECTED_SOLANA="${EXPECTED_SOLANA:-4.1.2}"
-. "$(dirname "${BASH_SOURCE[0]}")/lib/require-pinned-toolchain.sh"
+. "$ROOT/scripts/lib/require-pinned-toolchain.sh"
 
 if [[ "$CLEAN" -eq 1 ]]; then
   echo "cargo clean (use --no-clean to skip after a trusted rebuild)"


### PR DESCRIPTION
Stacked on #3466 — review that one first. Base retargets to `feature/solana` automatically once #3466 merges.

#3466 moved the geyser plugin the e2e stack runs to `v14.2.2+solana.4.1.0` and left the client in `host-listener` on `v5.0.1+solana.2.1.21`. Nine major versions apart, with a comment promising to fix it shortly. This is that fix.

### Why it is one PR and not two

The plan was to land the tonic upgrade alone, then bump the tag. That does not work. `yellowstone-grpc-proto` re-exports the tonic it was generated against, so:

- v5 tag + tonic 0.14 → our `Interceptor` and `yellowstone_grpc_proto::tonic::service::Interceptor` are different traits with the same name
- v14 tag + tonic 0.12 → same story for `Body`, and `GeyserClient` rejects our `Channel`

Either split leaves `host-listener --features solana-grpc` uncompilable. Verified both directions before combining them.

### What changed

**tonic 0.12.3 → 0.14** — 0.14 moved prost codegen out of `tonic-build` into `tonic-prost-build`, so `fhevm-engine-common/build.rs` calls that instead. `prost` 0.13.5 → 0.14. That is the whole upgrade; nothing else in the workspace touched tonic's API surface.

`tonic-build` ends up with no users at all. `stress-test-generator` listed it under `[dependencies]` rather than `[build-dependencies]` and has no build script, so it was already dead weight — removed along with the workspace entry.

**Client tag → v14.2.2+solana.4.1.0** — matches what `build-yellowstone-plugin.sh` fetches. v14 adds an optional cuckoo filter to the block and account subscriptions: a probabilistic membership set for callers whose account list is too long to send literally, trading false positives for size. We subscribe to one program and two sysvars, so both fields are `None` and the explicit list stays smaller and exact.

The crate also brings its own `solana-pubkey` 4.3.0 next to the 3.0.0 that `solana-sdk` pulls in. Harmless as written — the wire carries base58 strings and raw bytes, and we parse those into our own types — but the Cargo.toml now says so, because the error you get from handing one crate's `Pubkey` to the other names the type and not the version behind it.

### Clippy was not looking at any of this

`cargo clippy -p host-listener --all-targets` never compiled the Solana ingestion path, because it is behind `solana-grpc` / `solana-reconstruct`. The entire yellowstone client and its tests were unlinted, and had already accumulated a `cloned_ref_to_slice_refs` warning from #3200. Added the feature-gated invocation, fixed the warning.

The workflow's path filter also only watched `coprocessor/fhevm-engine/**`, so a change to `zama-host` — which `solana-reconstruct` compiles as a path dependency — could break this lane without triggering the job. Added the three crates it actually builds against.

### Verification

Local, against the v14 proto:

- `cargo check --workspace --all-targets` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo clippy -p host-listener --features solana-grpc,solana-reconstruct --all-targets -- -D warnings` clean
- `cargo test -p host-listener --features solana-grpc,solana-reconstruct --lib` — 123 passed, 0 failed

`solana-tests/host-listener-reconstruct` runs here and covers the decode path.

`solana-e2e` does **not** run on this PR — it only triggers on PRs targeting `feature/solana`, and this one targets #3466's branch. So the wire-level check of a v14 client against a v14 plugin happens after #3466 merges and this retargets. Worth noting that a base change alone may not re-fire the workflow, so that run probably needs a `synchronize` push or a manual dispatch rather than being assumed.
