### PR TITLE
chore(kms-connector): reduce logs verbosity

### DIFF
--- a/kms-connector/crates/gw-listener/src/core/publish.rs
+++ b/kms-connector/crates/gw-listener/src/core/publish.rs
@@ -381,7 +381,7 @@ pub async fn update_last_block_polled<'e>(
     last_block_polled: Option<u64>,
 ) -> anyhow::Result<()> {
     let chain_name = chain.as_str();
-    info!(
+    debug!(
         last_block_polled,
         "Updating last block polled in DB for chain {chain_name}"
     );
@@ -396,7 +396,7 @@ pub async fn update_last_block_polled<'e>(
     .await?;
 
     if query_result.rows_affected() > 0 {
-        info!(
+        debug!(
             last_block_polled,
             "Last block polled updated for chain {chain_name}"
         );

--- a/kms-connector/crates/tx-sender/src/monitoring/operation_recovery.rs
+++ b/kms-connector/crates/tx-sender/src/monitoring/operation_recovery.rs
@@ -59,6 +59,7 @@ async fn fail_expired_decryptions(db_pool: &Pool<Postgres>, expiry: &PgInterval)
              WHERE status IN ('pending', 'under_process') AND created_at < NOW() - $1"
         );
         match sqlx::query(&query).bind(*expiry).execute(db_pool).await {
+            Ok(result) if result.rows_affected() == 0 => (),
             Ok(result) => info!(
                 "Marked {} expired rows in {table} as failed",
                 result.rows_affected()
@@ -84,6 +85,7 @@ async fn unlock_stuck_operations(
             .execute(db_pool)
             .await
         {
+            Ok(result) if result.rows_affected() == 0 => (),
             Ok(result) => info!("Unlocked {} stuck rows in {table}", result.rows_affected()),
             Err(e) => error!("Failed to unlock stuck rows in {table}: {e}"),
         }


### PR DESCRIPTION
### What

Move some logs from `info!` to `debug!` as they were quite noisy and not that useful.

Remove `operation_recovery` logs when no rows were updated.

### Why

Was playing with the preview-env and noticed logs were spammed with:

gw-listener:
```
2026-08-10T09:36:57.813515Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Last block polled updated for chain ethereum last_block_polled=675
2026-08-10T09:36:57.816697Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Updating last block polled in DB for chain gateway last_block_polled=659
2026-08-10T09:36:57.818625Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Last block polled updated for chain gateway last_block_polled=659
2026-08-10T09:36:58.818926Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Updating last block polled in DB for chain gateway last_block_polled=660
2026-08-10T09:36:58.819985Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Last block polled updated for chain gateway last_block_polled=660
2026-08-10T09:36:59.818255Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Updating last block polled in DB for chain gateway last_block_polled=661
2026-08-10T09:36:59.819542Z  INFO publish_batch:update_last_block_polled: gw_listener::core::publish: Last block polled updated for chain gateway last_block_polled=661
```

tx-sender:
```
2026-08-10T09:36:43.260418Z  INFO tx_sender::monitoring::operation_recovery: Marked 0 expired rows in public_decryption_requests as failed
2026-08-10T09:36:43.263433Z  INFO tx_sender::monitoring::operation_recovery: Marked 0 expired rows in user_decryption_requests as failed
2026-08-10T09:36:43.270272Z  INFO tx_sender::monitoring::operation_recovery: Marked 0 expired rows in public_decryption_responses as failed
2026-08-10T09:36:43.274556Z  INFO tx_sender::monitoring::operation_recovery: Marked 0 expired rows in user_decryption_responses as failed
2026-08-10T09:36:43.276317Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in public_decryption_requests
2026-08-10T09:36:43.281975Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in user_decryption_requests
2026-08-10T09:36:43.284170Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in public_decryption_responses
2026-08-10T09:36:43.306815Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in user_decryption_responses
2026-08-10T09:36:43.341768Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in prep_keygen_requests
2026-08-10T09:36:43.344520Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in keygen_requests
2026-08-10T09:36:43.347089Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in crsgen_requests
2026-08-10T09:36:43.350641Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in abort_keygen_requests
2026-08-10T09:36:43.351787Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in abort_crsgen_requests
2026-08-10T09:36:43.353882Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in prep_keygen_responses
2026-08-10T09:36:43.355753Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in keygen_responses
2026-08-10T09:36:43.356835Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in crsgen_responses
2026-08-10T09:36:43.359735Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in new_kms_context
2026-08-10T09:36:43.361846Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in new_kms_epoch
2026-08-10T09:36:43.363820Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in new_kms_context_responses
2026-08-10T09:36:43.365566Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in epoch_result_responses
2026-08-10T09:36:43.367469Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in kms_context_destroyed
2026-08-10T09:36:43.370230Z  INFO tx_sender::monitoring::operation_recovery: Unlocked 0 stuck rows in kms_epoch_destroyed
```