### PR TITLE
fix(sdk): exclude tfhe v1.6.0-dev wasm from published package

### DIFF
--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -14,7 +14,8 @@
     "!**/*.template",
     "!**/*.tsbuildinfo",
     "!vitest.config.ts",
-    "!tsconfig.json"
+    "!tsconfig.json",
+    "!wasm/tfhe/*-dev/**"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- The `@fhevm/sdk` npm package currently packs the `wasm/tfhe/v1.6.0-dev/` directory (~2MB), a development-only tfhe wasm build that isn't meant to ship to consumers.
- Add `!wasm/tfhe/*-dev/**` to the `files` glob in `sdk/js-sdk/src/package.json` so any `*-dev` tfhe wasm variant is excluded from the published tarball, keeping package size down and avoiding shipping non-release artifacts.

## Test plan
- [x] Run `npm pack` (or equivalent) on `sdk/js-sdk/src/package.json` and confirm `wasm/tfhe/v1.6.0-dev/**` is absent from the tarball contents while `v1.5.3` and `v1.6.2` are still included.
