### PR TITLE
refactor(test-suite): let fhevm-cli own the Solana host node

### DIFF
--- a/solana/scripts/e2e/clean-e2e.sh
+++ b/solana/scripts/e2e/clean-e2e.sh
@@ -295,7 +295,7 @@ PY
 # 2. Clean rebuild of the whole EVM stack with the Solana code baked in from bootstrap.
 #    The `solana` scenario declares the RFC-021 Solana host alongside the default EVM host, so
 #    fhevm-cli generates the Solana relayer + kms-connector config and boots solana-proof-service
-#    (the solana-side bring-up below no longer patches those — single config writer).
+#    (the Solana host-process step does not patch those — single config writer).
 #    `--override solana-proof-service` rebuilds the standalone proof image from this worktree so a
 #    stale `solana-proof-service:local` / `:fhevm-local` image cannot outlive HEAD.
 #    SOLANA_E2E_SCENARIO selects the fhevm-cli scenario. Default `solana` (centralized KMS).
@@ -319,12 +319,11 @@ trap - EXIT
 # instead. `--override solana-proof-service` rebuilds the standalone proof
 # image so a stale `:local` / `:fhevm-local` tag cannot outlive HEAD.
 
-# 3. Bring the Solana side-stack online against the freshly-deployed live backend
-#    (test-suite/fhevm/src/solana/deploy.ts): fresh geyser validator + program deploy, the typed
-#    zama-host bootstrap (reads gateway addresses + KMS/coprocessor signer set live, so it tracks
-#    the new signer), host-chain registration, and the host-listener. Ordinary computation facts
-#    are ingested by reconstructing them from instruction data over Yellowstone, not from events.
-( cd "$FHEVM" && bun run src/solana/deploy.ts )
+# 3. The Solana side-stack (fresh geyser validator + program deploy, the typed zama-host bootstrap,
+#    host-chain registration, the host-listener) is no longer a separate call: the `solana` scenario
+#    resolves its host chain to `nodeProvisioning: host-process`, so the `up` above ran it as the
+#    `host-process` pipeline step. `bun run src/solana/deploy.ts` still provisions the same thing
+#    standalone when a node needs rebuilding without a full stack cycle.
 
 echo "[clean-e2e] stack ready. Run the typed scenario suite (compute -> public/user-decrypt ->"
 echo "  input-flow -> transfer -> consume), user-decrypt is PURE-SDK (no kms checkout):"

--- a/test-suite/fhevm/ARCHITECTURE.md
+++ b/test-suite/fhevm/ARCHITECTURE.md
@@ -37,7 +37,8 @@ flowchart TD
   F8 --> F9["12. kms-connector"]
   F9 --> F10["13. bootstrap"]
   F10 --> F11["14. relayer"]
-  F11 --> F12["15. test-suite"]
+  F11 --> F12["15. host-process: nodes fhevm-cli runs outside compose (Solana validator + deploy)"]
+  F12 --> F13["16. test-suite"]
 
   G["Local overrides (group or runtime service)"] --> C2
   H["Scenario-driven topology (host chains + coprocessor instances)"] --> C2

--- a/test-suite/fhevm/scenarios/solana-threshold-kms.yaml
+++ b/test-suite/fhevm/scenarios/solana-threshold-kms.yaml
@@ -36,7 +36,6 @@ hostChains:
     rpcPort: 8545
   - key: solana
     type: solana
-    nodeProvisioning: host-process # fhevm-cli runs the solana-test-validator and deploys the programs
     chainId: "9223372036854788153"
     rpcPort: 8899
 topology:

--- a/test-suite/fhevm/scenarios/solana-threshold-kms.yaml
+++ b/test-suite/fhevm/scenarios/solana-threshold-kms.yaml
@@ -36,7 +36,7 @@ hostChains:
     rpcPort: 8545
   - key: solana
     type: solana
-    nodeProvisioning: external # host-native solana-test-validator; fhevm-cli owns only its config
+    nodeProvisioning: host-process # fhevm-cli runs the solana-test-validator and deploys the programs
     chainId: "9223372036854788153"
     rpcPort: 8899
 topology:

--- a/test-suite/fhevm/scenarios/solana.yaml
+++ b/test-suite/fhevm/scenarios/solana.yaml
@@ -12,7 +12,6 @@ hostChains:
     rpcPort: 8545
   - key: solana
     type: solana
-    nodeProvisioning: host-process # fhevm-cli runs the solana-test-validator and deploys the programs
     chainId: "9223372036854788153"
     rpcPort: 8899
 topology:

--- a/test-suite/fhevm/scenarios/solana.yaml
+++ b/test-suite/fhevm/scenarios/solana.yaml
@@ -2,17 +2,17 @@ version: 1
 kind: coprocessor-consensus
 name: Solana Host
 description: >-
-  EVM gateway + coprocessor stack with an RFC-021 Solana host chain. fhevm-cli owns the EVM stack
-  and the Solana host's relayer + kms-connector config; the Solana validator (host-native
-  solana-test-validator), program deploy, bootstrap, DB registration, gateway addHostChain, and
-  listeners are provisioned by the solana-side bring-up against the host validator.
+  EVM gateway + coprocessor stack with an RFC-021 Solana host chain. fhevm-cli owns the whole
+  stack: the EVM services in compose, and the Solana host as a host process (solana-test-validator
+  with the geyser plugin, program deploy, zama-host bootstrap, DB registration, gateway
+  addHostChain, and the host-listener) in the `host-process` pipeline step.
 hostChains:
   - key: host
     chainId: "12345"
     rpcPort: 8545
   - key: solana
     type: solana
-    nodeProvisioning: external # host-native solana-test-validator; fhevm-cli owns only its config
+    nodeProvisioning: host-process # fhevm-cli runs the solana-test-validator and deploys the programs
     chainId: "9223372036854788153"
     rpcPort: 8899
 topology:

--- a/test-suite/fhevm/src/flow/artifacts.ts
+++ b/test-suite/fhevm/src/flow/artifacts.ts
@@ -19,7 +19,7 @@ import {
   composePath,
   hostChainAddressesPath,
   hostChainAddressesSolidityPath,
-  runsInCompose,
+  isEvmHost,
 } from "../layout";
 import type { State, StepName } from "../types";
 import { exists, readEnvFile } from "../utils/fs";
@@ -120,7 +120,7 @@ export const multiChainComposeEntries = (state: Pick<State, "scenario">): Array<
   const entries: Array<[string, StepName]> = [];
   // Externally-provisioned hosts (Solana) have no fhevm-cli node/sc/coprocessor compose, so there
   // is nothing to bring up or tear down here.
-  for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
+  for (const chain of extraHostChains(state).filter((c) => isEvmHost(c))) {
     const { node, sc, copro } = chain;
     entries.push([node, "base"]);
     entries.push([sc, "host-deploy"]);

--- a/test-suite/fhevm/src/flow/artifacts.ts
+++ b/test-suite/fhevm/src/flow/artifacts.ts
@@ -19,7 +19,7 @@ import {
   composePath,
   hostChainAddressesPath,
   hostChainAddressesSolidityPath,
-  isExternalNode,
+  runsInCompose,
 } from "../layout";
 import type { State, StepName } from "../types";
 import { exists, readEnvFile } from "../utils/fs";
@@ -120,7 +120,7 @@ export const multiChainComposeEntries = (state: Pick<State, "scenario">): Array<
   const entries: Array<[string, StepName]> = [];
   // Externally-provisioned hosts (Solana) have no fhevm-cli node/sc/coprocessor compose, so there
   // is nothing to bring up or tear down here.
-  for (const chain of extraHostChains(state).filter((c) => !isExternalNode(c))) {
+  for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
     const { node, sc, copro } = chain;
     entries.push([node, "base"]);
     entries.push([sc, "host-deploy"]);

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -70,7 +70,7 @@ import {
   envPath,
   gatewayAddressesPath,
   hostChainAddressesPath,
-  runsInCompose,
+  isEvmHost,
   realLzEndpointFor,
 } from "../layout";
 import type {
@@ -194,7 +194,7 @@ export const preflightPorts = (state: Pick<State, "scenario">) =>
   // Nodes outside compose (the Solana validator) bind their own port. fhevm-cli only starts that
   // one much later, in `host-process`, and a leftover validator still holding the port is a
   // condition that step resolves — so it is not a preflight conflict. Exclude it.
-  [...new Set([...PORTS, ...state.scenario.hostChains.filter((c) => runsInCompose(c)).map((c) => c.rpcPort)])];
+  [...new Set([...PORTS, ...state.scenario.hostChains.filter((c) => isEvmHost(c)).map((c) => c.rpcPort)])];
 
 /** Throws if Docker memory is below the scenario minimum: 16 GB standard, 32 GB for multi-chain + multi-coprocessor.
  *  Uses a 1 GB slack to account for VM overhead. */
@@ -634,7 +634,7 @@ export const runStep = async (state: State, step: StepName) => {
       await generateRuntime(state, stackSpecForState(state));
       // Only compose nodes come up here. The Solana validator is started later, by `host-process`,
       // because its bootstrap reads gateway addresses and the signer set that do not exist yet.
-      for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
+      for (const chain of extraHostChains(state).filter((c) => isEvmHost(c))) {
         await multiChainComposeUp(chain.node);
         await waitForRpc(`http://localhost:${chain.rpcPort}`, chain.type);
       }
@@ -696,7 +696,7 @@ export const runStep = async (state: State, step: StepName) => {
       // its deploy container starts. Solana hosts deploy their programs in the `host-process`
       // step, not via host-sc.
       const canonicalSeedingArgs = await canonicalProtocolConfigSeedingArgs(state);
-      for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
+      for (const chain of extraHostChains(state).filter((c) => isEvmHost(c))) {
         const scKey = chain.sc;
         if (canonicalSeedingArgs || provisionBridgeProxy) {
           const scEnvPath = envPath(scKey);
@@ -857,7 +857,7 @@ export const runStep = async (state: State, step: StepName) => {
       }
       await postBootHealthGate(coprocessorHealthContainers(state));
       // Solana hosts register + start their listeners in the `host-process` step, not here.
-      for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
+      for (const chain of extraHostChains(state).filter((c) => isEvmHost(c))) {
         const suffix = chain.suffix;
         await timed(`[multi-chain] register ${chain.key} in coprocessor DBs`, () =>
           registerExtraChainInCoprocessor(state, chain),
@@ -984,9 +984,9 @@ export const runStep = async (state: State, step: StepName) => {
       }
       break;
     case "host-process": {
-      // Nodes fhevm-cli runs itself but outside compose — today, Solana hosts. Imported lazily so
-      // an EVM-only `up` never loads the Solana client stack.
-      for (const chain of hostChainsForState(state).filter((c) => !runsInCompose(c))) {
+      // The nodes fhevm-cli spawns itself rather than handing to compose. Imported lazily so an
+      // EVM-only `up` never loads the Solana client stack.
+      for (const chain of hostChainsForState(state).filter((c) => c.type === "solana")) {
         const { provisionSolanaHostNode } = await import("../solana/deploy");
         const { zamaHostId } = await provisionSolanaHostNode();
         console.log(`  ${chain.key}: zama_host=${zamaHostId}`);

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -70,7 +70,8 @@ import {
   envPath,
   gatewayAddressesPath,
   hostChainAddressesPath,
-  isExternalNode,
+  isCliManagedHostProcess,
+  runsInCompose,
   realLzEndpointFor,
 } from "../layout";
 import type {
@@ -191,9 +192,10 @@ const SCHEMA_GUARDS = {
 
 const SCHEMA_GUARD_TARGETS = new Set<VersionBundle["target"]>(["latest-supported", "latest-main", "sha"]);
 export const preflightPorts = (state: Pick<State, "scenario">) =>
-  // Externally-provisioned hosts (Solana host-native validator) bind their own port outside
-  // fhevm-cli, so that port being "in use" is expected, not a conflict — exclude it.
-  [...new Set([...PORTS, ...state.scenario.hostChains.filter((c) => !isExternalNode(c)).map((c) => c.rpcPort)])];
+  // Nodes outside compose (the Solana validator) bind their own port. fhevm-cli only starts that
+  // one much later, in `host-process`, and a leftover validator still holding the port is a
+  // condition that step resolves — so it is not a preflight conflict. Exclude it.
+  [...new Set([...PORTS, ...state.scenario.hostChains.filter((c) => runsInCompose(c)).map((c) => c.rpcPort)])];
 
 /** Throws if Docker memory is below the scenario minimum: 16 GB standard, 32 GB for multi-chain + multi-coprocessor.
  *  Uses a 1 GB slack to account for VM overhead. */
@@ -631,9 +633,9 @@ export const runStep = async (state: State, step: StepName) => {
         };
       }
       await generateRuntime(state, stackSpecForState(state));
-      // Solana hosts are externally provisioned (host-native validator + solana-side bring-up);
-      // fhevm-cli neither starts their node nor probes it.
-      for (const chain of extraHostChains(state).filter((c) => !isExternalNode(c))) {
+      // Only compose nodes come up here. The Solana validator is started later, by `host-process`,
+      // because its bootstrap reads gateway addresses and the signer set that do not exist yet.
+      for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
         await multiChainComposeUp(chain.node);
         await waitForRpc(`http://localhost:${chain.rpcPort}`, chain.type);
       }
@@ -692,10 +694,10 @@ export const runStep = async (state: State, step: StepName) => {
       // Production topology: non-canonical chains seed ProtocolConfig from the canonical chain
       // (export → mirror), not "fresh" from env. The canonical address only exists after the
       // canonical deploy above, so the placeholder env var is patched here, per chain, before
-      // its deploy container starts. Solana hosts deploy their programs host-side (solana-side
-      // bring-up), not via host-sc.
+      // its deploy container starts. Solana hosts deploy their programs in the `host-process`
+      // step, not via host-sc.
       const canonicalSeedingArgs = await canonicalProtocolConfigSeedingArgs(state);
-      for (const chain of extraHostChains(state).filter((c) => !isExternalNode(c))) {
+      for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
         const scKey = chain.sc;
         if (canonicalSeedingArgs || provisionBridgeProxy) {
           const scEnvPath = envPath(scKey);
@@ -855,8 +857,8 @@ export const runStep = async (state: State, step: StepName) => {
         await applyLegacyHostChainSeedShim(state);
       }
       await postBootHealthGate(coprocessorHealthContainers(state));
-      // Solana hosts register + start their listeners via the solana-side bring-up, not here.
-      for (const chain of extraHostChains(state).filter((c) => !isExternalNode(c))) {
+      // Solana hosts register + start their listeners in the `host-process` step, not here.
+      for (const chain of extraHostChains(state).filter((c) => runsInCompose(c))) {
         const suffix = chain.suffix;
         await timed(`[multi-chain] register ${chain.key} in coprocessor DBs`, () =>
           registerExtraChainInCoprocessor(state, chain),
@@ -974,14 +976,29 @@ export const runStep = async (state: State, step: StepName) => {
       await waitForContainer("fhevm-relayer", "running");
       await waitForLog("fhevm-relayer", /All servers are ready and responding/);
       if (hostChainsForState(state).some((chain) => chain.type === "solana")) {
-        // Standalone MMR proof service (RFC-024). Yellowstone may not be up yet (the side-stack setup
-        // starts geyser after fhevm-cli up); ingest reconnects with backoff until it is.
+        // Standalone MMR proof service (RFC-024). Yellowstone is not up yet — the validator starts
+        // in the later `host-process` step; ingest reconnects with backoff until it is.
         await stepComposeUp("solana-proof-service", state);
         await waitForContainer("fhevm-solana-proof-db", "healthy");
         await waitForContainer("fhevm-solana-proof-service", "running");
         await waitForLog("fhevm-solana-proof-service", /HTTP listening/);
       }
       break;
+    case "host-process": {
+      // Nodes fhevm-cli runs itself but outside compose. Imported lazily so an EVM-only `up` never
+      // loads the Solana client stack.
+      for (const chain of hostChainsForState(state).filter(isCliManagedHostProcess)) {
+        if (chain.type !== "solana") {
+          throw new Error(
+            `host-process provisioning is implemented for solana host chains only; ${chain.key} is ${chain.type}`,
+          );
+        }
+        const { provisionSolanaHostNode } = await import("../solana/deploy");
+        const { zamaHostId } = await provisionSolanaHostNode();
+        console.log(`  ${chain.key}: zama_host=${zamaHostId}`);
+      }
+      break;
+    }
     case "test-suite":
       await stepComposeUp("test-suite", state);
       await waitForTestSuite();

--- a/test-suite/fhevm/src/flow/up-flow.ts
+++ b/test-suite/fhevm/src/flow/up-flow.ts
@@ -70,7 +70,6 @@ import {
   envPath,
   gatewayAddressesPath,
   hostChainAddressesPath,
-  isCliManagedHostProcess,
   runsInCompose,
   realLzEndpointFor,
 } from "../layout";
@@ -985,14 +984,9 @@ export const runStep = async (state: State, step: StepName) => {
       }
       break;
     case "host-process": {
-      // Nodes fhevm-cli runs itself but outside compose. Imported lazily so an EVM-only `up` never
-      // loads the Solana client stack.
-      for (const chain of hostChainsForState(state).filter(isCliManagedHostProcess)) {
-        if (chain.type !== "solana") {
-          throw new Error(
-            `host-process provisioning is implemented for solana host chains only; ${chain.key} is ${chain.type}`,
-          );
-        }
+      // Nodes fhevm-cli runs itself but outside compose — today, Solana hosts. Imported lazily so
+      // an EVM-only `up` never loads the Solana client stack.
+      for (const chain of hostChainsForState(state).filter((c) => !runsInCompose(c))) {
         const { provisionSolanaHostNode } = await import("../solana/deploy");
         const { zamaHostId } = await provisionSolanaHostNode();
         console.log(`  ${chain.key}: zama_host=${zamaHostId}`);

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -26,7 +26,7 @@ import {
   envPath,
   hostChainNames,
   hostChainRuntimes,
-  isExternalNode,
+  runsInCompose,
 } from "../layout";
 import { kmsConnectorEnvName, kmsConnectorPrefix } from "../kms-party";
 import { type StackSpec, topologyForState } from "../stack-spec/stack-spec";
@@ -824,7 +824,7 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
   }
   // Externally-provisioned hosts (e.g. the Solana host-native validator) get no node/sc/coprocessor
   // compose from fhevm-cli — only their relayer + kms-connector config (generate/config.ts, env.ts).
-  const extraChains = chains.filter((chain) => !chain.isDefault && !isExternalNode(chain));
+  const extraChains = chains.filter((chain) => !chain.isDefault && runsInCompose(chain));
   const extraChainFileNames: string[] = [];
   for (const chain of extraChains) {
     const { node, sc, copro } = chain;

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -26,7 +26,7 @@ import {
   envPath,
   hostChainNames,
   hostChainRuntimes,
-  runsInCompose,
+  isEvmHost,
 } from "../layout";
 import { kmsConnectorEnvName, kmsConnectorPrefix } from "../kms-party";
 import { type StackSpec, topologyForState } from "../stack-spec/stack-spec";
@@ -824,7 +824,7 @@ export const generateComposeOverrides = async (_state: State, plan: StackSpec) =
   }
   // Externally-provisioned hosts (e.g. the Solana host-native validator) get no node/sc/coprocessor
   // compose from fhevm-cli — only their relayer + kms-connector config (generate/config.ts, env.ts).
-  const extraChains = chains.filter((chain) => !chain.isDefault && runsInCompose(chain));
+  const extraChains = chains.filter((chain) => !chain.isDefault && isEvmHost(chain));
   const extraChainFileNames: string[] = [];
   for (const chain of extraChains) {
     const { node, sc, copro } = chain;

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -19,7 +19,7 @@ import {
   POSTGRES_HOST,
   coprocessorDatabaseName,
   hostChainRuntimes,
-  runsInCompose,
+  isEvmHost,
   realLzEndpointFor,
 } from "../layout";
 import { kmsConnectorDbName, kmsConnectorEnvName, kmsCoreName, kmsMpcPort, kmsPublicPrefix, kmsServicePort, reconstructionThreshold } from "../kms-party";
@@ -570,7 +570,7 @@ export const renderEnvMaps = async (
   // Externally-provisioned hosts (Solana) are seeded by their own bring-up — which maps the
   // RFC-021 u64 chain id to the signed i64 the `bigint` column requires and mirrors the keyset
   // (only available post-keygen) — so they're excluded here; indices stay contiguous (0..N-1).
-  const seedHostChains = chains.filter((chain) => runsInCompose(chain));
+  const seedHostChains = chains.filter((chain) => isEvmHost(chain));
   envs["coprocessor"].HOST_CHAINS_COUNT = String(seedHostChains.length);
   seedHostChains.forEach((chain, chainIndex) => {
     const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
@@ -610,7 +610,7 @@ export const renderEnvMaps = async (
   // gateway-sc indexed vars for fhevm-cli-provisioned hosts. Externally-provisioned hosts (Solana)
   // are registered on the gateway by their own bring-up (addHostChain), so they're excluded here;
   // indices stay contiguous (0..N-1) as the gateway task expects.
-  const gatewayHostChains = chains.filter((chain) => runsInCompose(chain));
+  const gatewayHostChains = chains.filter((chain) => isEvmHost(chain));
   envs["gateway-sc"].NUM_HOST_CHAINS = String(gatewayHostChains.length);
   gatewayHostChains.forEach((chain, chainIndex) => {
     const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
@@ -626,7 +626,7 @@ export const renderEnvMaps = async (
 
   // Non-default fhevm-cli-provisioned chain infrastructure: host-node, host-sc, coprocessor, and
   // test-suite env files. Externally-provisioned hosts (Solana) get none of these.
-  for (const chain of chains.filter((item) => !item.isDefault && runsInCompose(item))) {
+  for (const chain of chains.filter((item) => !item.isDefault && isEvmHost(item))) {
     const chainIndex = chain.index;
     const hostHttp = `http://${chain.node}:${chain.rpcPort}`;
     const hostWs = `ws://${chain.node}:${chain.rpcPort}`;

--- a/test-suite/fhevm/src/generate/env.ts
+++ b/test-suite/fhevm/src/generate/env.ts
@@ -19,7 +19,7 @@ import {
   POSTGRES_HOST,
   coprocessorDatabaseName,
   hostChainRuntimes,
-  isExternalNode,
+  runsInCompose,
   realLzEndpointFor,
 } from "../layout";
 import { kmsConnectorDbName, kmsConnectorEnvName, kmsCoreName, kmsMpcPort, kmsPublicPrefix, kmsServicePort, reconstructionThreshold } from "../kms-party";
@@ -570,7 +570,7 @@ export const renderEnvMaps = async (
   // Externally-provisioned hosts (Solana) are seeded by their own bring-up — which maps the
   // RFC-021 u64 chain id to the signed i64 the `bigint` column requires and mirrors the keyset
   // (only available post-keygen) — so they're excluded here; indices stay contiguous (0..N-1).
-  const seedHostChains = chains.filter((chain) => !isExternalNode(chain));
+  const seedHostChains = chains.filter((chain) => runsInCompose(chain));
   envs["coprocessor"].HOST_CHAINS_COUNT = String(seedHostChains.length);
   seedHostChains.forEach((chain, chainIndex) => {
     const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
@@ -610,7 +610,7 @@ export const renderEnvMaps = async (
   // gateway-sc indexed vars for fhevm-cli-provisioned hosts. Externally-provisioned hosts (Solana)
   // are registered on the gateway by their own bring-up (addHostChain), so they're excluded here;
   // indices stay contiguous (0..N-1) as the gateway task expects.
-  const gatewayHostChains = chains.filter((chain) => !isExternalNode(chain));
+  const gatewayHostChains = chains.filter((chain) => runsInCompose(chain));
   envs["gateway-sc"].NUM_HOST_CHAINS = String(gatewayHostChains.length);
   gatewayHostChains.forEach((chain, chainIndex) => {
     const hostAddresses = state.discovery?.hosts[chain.key] ?? {};
@@ -626,7 +626,7 @@ export const renderEnvMaps = async (
 
   // Non-default fhevm-cli-provisioned chain infrastructure: host-node, host-sc, coprocessor, and
   // test-suite env files. Externally-provisioned hosts (Solana) get none of these.
-  for (const chain of chains.filter((item) => !item.isDefault && !isExternalNode(item))) {
+  for (const chain of chains.filter((item) => !item.isDefault && runsInCompose(item))) {
     const chainIndex = chain.index;
     const hostHttp = `http://${chain.node}:${chain.rpcPort}`;
     const hostWs = `ws://${chain.node}:${chain.rpcPort}`;

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -207,6 +207,8 @@ export const COMPONENT_BY_STEP: Record<StepName, string[]> = {
   "kms-connector": ["kms-connector"],
   "bootstrap": ["gateway-sc", "host-sc"],
   "relayer": ["relayer", "solana-proof-service"],
+  // No compose components by design: this step runs host-process nodes outside compose.
+  "host-process": [],
   "test-suite": ["test-suite"],
 };
 
@@ -497,17 +499,26 @@ export const hostChainNames = (key: string, defaultKey = DEFAULT_HOST_CHAIN_KEY)
 });
 /**
  * Resolves how a host node is provisioned. Explicit `nodeProvisioning` wins; otherwise defaults by
- * kind: solana ⇒ external (host-native validator + solana-side bring-up own node/deploy/register),
- * evm ⇒ container (fhevm-cli runs them).
+ * kind: solana ⇒ host-process (fhevm-cli runs the validator and deploys the programs itself),
+ * evm ⇒ container (fhevm-cli runs them as compose services).
  */
 export const resolveNodeProvisioning = (
   chain: Pick<HostChainScenario, "type" | "nodeProvisioning">,
 ): HostChainNodeProvisioning =>
-  chain.nodeProvisioning ?? ((chain.type ?? "evm") === "solana" ? "external" : "container");
+  chain.nodeProvisioning ?? ((chain.type ?? "evm") === "solana" ? "host-process" : "container");
 
-/** True when the host node is provisioned outside fhevm-cli (no node/sc/coprocessor compose). */
-export const isExternalNode = (chain: Pick<HostChainScenario, "type" | "nodeProvisioning">): boolean =>
-  resolveNodeProvisioning(chain) === "external";
+/**
+ * True when compose owns the node — so it gets a node/sc/coprocessor service, a port to wait on,
+ * and contract artifacts. Both `host-process` and `external` nodes live outside compose; they
+ * differ in who runs them, which is {@link isCliManagedHostProcess}, not this.
+ */
+export const runsInCompose = (chain: Pick<HostChainScenario, "type" | "nodeProvisioning">): boolean =>
+  resolveNodeProvisioning(chain) === "container";
+
+/** True when fhevm-cli runs this node as a host process it owns (start, deploy, register). */
+export const isCliManagedHostProcess = (
+  chain: Pick<HostChainScenario, "type" | "nodeProvisioning">,
+): boolean => resolveNodeProvisioning(chain) === "host-process";
 
 export type HostChainRuntime = HostChainScenario & {
   /** Resolved host-chain kind: defaults to `evm` when the scenario omits `type`. */

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -497,18 +497,13 @@ export const hostChainNames = (key: string, defaultKey = DEFAULT_HOST_CHAIN_KEY)
   suffix: hostChainSuffix(key, defaultKey),
 });
 /**
- * True when compose owns the node — so it gets a node/sc/coprocessor service, a port to wait on,
- * contract artifacts, and seeding.
- *
- * fhevm-cli owns every node's lifecycle; this is only about *how* it runs one. A Solana host is
- * always a native `solana-test-validator` process (it loads the geyser plugin from the worktree,
- * and a host-native validator is the ecosystem norm on macOS), so compose never runs it and the
- * `host-process` step does. That follows from the chain kind, so it is derived from `type` rather
- * than configured: a scenario cannot put a Solana node in compose, and saying otherwise would not
- * make it work.
+ * True for an EVM host chain — the only kind with the Solidity pipeline. Gates everything that
+ * pipeline produces: a node/sc/coprocessor compose service, a port to wait on, deployed contract
+ * artifacts, and seeding. A Solana host has none of them; `fhevm-cli` runs its validator itself in
+ * the `host-process` step.
  */
-export const runsInCompose = (chain: Pick<HostChainScenario, "type">): boolean =>
-  (chain.type ?? "evm") !== "solana";
+export const isEvmHost = (chain: Pick<HostChainScenario, "type">): boolean =>
+  (chain.type ?? "evm") === "evm";
 
 export type HostChainRuntime = HostChainScenario & {
   /** Resolved host-chain kind: defaults to `evm` when the scenario omits `type`. */

--- a/test-suite/fhevm/src/layout.ts
+++ b/test-suite/fhevm/src/layout.ts
@@ -5,7 +5,6 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 
 import type {
-  HostChainNodeProvisioning,
   HostChainScenario,
   HostChainType,
   OverrideGroup,
@@ -498,33 +497,22 @@ export const hostChainNames = (key: string, defaultKey = DEFAULT_HOST_CHAIN_KEY)
   suffix: hostChainSuffix(key, defaultKey),
 });
 /**
- * Resolves how a host node is provisioned. Explicit `nodeProvisioning` wins; otherwise defaults by
- * kind: solana ⇒ host-process (fhevm-cli runs the validator and deploys the programs itself),
- * evm ⇒ container (fhevm-cli runs them as compose services).
- */
-export const resolveNodeProvisioning = (
-  chain: Pick<HostChainScenario, "type" | "nodeProvisioning">,
-): HostChainNodeProvisioning =>
-  chain.nodeProvisioning ?? ((chain.type ?? "evm") === "solana" ? "host-process" : "container");
-
-/**
  * True when compose owns the node — so it gets a node/sc/coprocessor service, a port to wait on,
- * and contract artifacts. Both `host-process` and `external` nodes live outside compose; they
- * differ in who runs them, which is {@link isCliManagedHostProcess}, not this.
+ * contract artifacts, and seeding.
+ *
+ * fhevm-cli owns every node's lifecycle; this is only about *how* it runs one. A Solana host is
+ * always a native `solana-test-validator` process (it loads the geyser plugin from the worktree,
+ * and a host-native validator is the ecosystem norm on macOS), so compose never runs it and the
+ * `host-process` step does. That follows from the chain kind, so it is derived from `type` rather
+ * than configured: a scenario cannot put a Solana node in compose, and saying otherwise would not
+ * make it work.
  */
-export const runsInCompose = (chain: Pick<HostChainScenario, "type" | "nodeProvisioning">): boolean =>
-  resolveNodeProvisioning(chain) === "container";
-
-/** True when fhevm-cli runs this node as a host process it owns (start, deploy, register). */
-export const isCliManagedHostProcess = (
-  chain: Pick<HostChainScenario, "type" | "nodeProvisioning">,
-): boolean => resolveNodeProvisioning(chain) === "host-process";
+export const runsInCompose = (chain: Pick<HostChainScenario, "type">): boolean =>
+  (chain.type ?? "evm") !== "solana";
 
 export type HostChainRuntime = HostChainScenario & {
   /** Resolved host-chain kind: defaults to `evm` when the scenario omits `type`. */
   type: HostChainType;
-  /** Resolved node provisioning: see {@link resolveNodeProvisioning}. */
-  nodeProvisioning: HostChainNodeProvisioning;
   index: number;
   isDefault: boolean;
   suffix: string;
@@ -541,7 +529,6 @@ export const hostChainRuntime = (
 ): HostChainRuntime => ({
   ...chain,
   type: chain.type ?? "evm",
-  nodeProvisioning: resolveNodeProvisioning(chain),
   index,
   isDefault: chain.key === defaultKey,
   ...hostChainNames(chain.key, defaultKey),

--- a/test-suite/fhevm/src/provisioning.test.ts
+++ b/test-suite/fhevm/src/provisioning.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import YAML from "yaml";
+
+import { COMPONENT_BY_STEP, isCliManagedHostProcess, resolveNodeProvisioning, runsInCompose } from "./layout";
+import { HOST_CHAIN_NODE_PROVISIONING, STEP_NAMES } from "./types";
+
+const scenario = async (name: string) => {
+  const file = path.join(import.meta.dir, "..", "scenarios", `${name}.yaml`);
+  return YAML.parse(await Bun.file(file).text()) as {
+    hostChains: { key: string; type?: string; nodeProvisioning?: string }[];
+  };
+};
+
+describe("host node provisioning", () => {
+  test("defaults by chain kind: solana runs as a host process, evm in compose", () => {
+    expect(resolveNodeProvisioning({ type: "solana" })).toBe("host-process");
+    expect(resolveNodeProvisioning({ type: "evm" })).toBe("container");
+    expect(resolveNodeProvisioning({})).toBe("container");
+  });
+
+  test("an explicit nodeProvisioning beats the per-kind default", () => {
+    expect(resolveNodeProvisioning({ type: "solana", nodeProvisioning: "external" })).toBe("external");
+    expect(resolveNodeProvisioning({ type: "evm", nodeProvisioning: "host-process" })).toBe("host-process");
+  });
+
+  // The reason `runsInCompose` exists rather than `!isExternalNode`: a host-process node is owned
+  // by fhevm-cli but has no compose service, so "not external" is not the same question as "does
+  // compose run it". Getting this wrong generates a compose service for the validator.
+  test("only container nodes run in compose", () => {
+    expect(runsInCompose({ nodeProvisioning: "container" })).toBe(true);
+    expect(runsInCompose({ nodeProvisioning: "host-process" })).toBe(false);
+    expect(runsInCompose({ nodeProvisioning: "external" })).toBe(false);
+    expect(runsInCompose({ type: "solana" })).toBe(false);
+  });
+
+  test("only host-process nodes are fhevm-cli-managed processes", () => {
+    expect(isCliManagedHostProcess({ nodeProvisioning: "host-process" })).toBe(true);
+    expect(isCliManagedHostProcess({ nodeProvisioning: "container" })).toBe(false);
+    expect(isCliManagedHostProcess({ nodeProvisioning: "external" })).toBe(false);
+  });
+
+  test("compose ownership and cli-process ownership are mutually exclusive", () => {
+    for (const nodeProvisioning of HOST_CHAIN_NODE_PROVISIONING) {
+      expect(runsInCompose({ nodeProvisioning }) && isCliManagedHostProcess({ nodeProvisioning })).toBe(false);
+    }
+  });
+});
+
+describe("the host-process pipeline step", () => {
+  // Ordering is load-bearing, not cosmetic: the Solana bring-up reads live gateway addresses and
+  // the KMS/coprocessor signer set, so it cannot precede the steps that deploy and register them.
+  test("runs after the stack is live and before the test-suite", () => {
+    expect(STEP_NAMES.indexOf("host-process")).toBeGreaterThan(STEP_NAMES.indexOf("relayer"));
+    expect(STEP_NAMES.indexOf("host-process")).toBeLessThan(STEP_NAMES.indexOf("test-suite"));
+  });
+
+  test("declares no compose components, because it runs nodes outside compose", () => {
+    expect(COMPONENT_BY_STEP["host-process"]).toEqual([]);
+  });
+
+  test("every step has a component mapping", () => {
+    for (const step of STEP_NAMES) {
+      expect(COMPONENT_BY_STEP[step]).toBeDefined();
+    }
+  });
+});
+
+describe("the shipped Solana scenarios", () => {
+  // Pins the #1879 retirement itself: these declare host-process, so `fhevm-cli up` owns the
+  // validator and program deploy. If either reverts to `external`, clean-e2e.sh's dropped step 3
+  // silently stops happening and the suite runs against no Solana node at all.
+  test.each(["solana", "solana-threshold-kms"])("%s declares its Solana host as host-process", async (name) => {
+    const chains = (await scenario(name)).hostChains;
+    const solana = chains.find((chain) => chain.type === "solana");
+    expect(solana).toBeDefined();
+    expect(solana?.nodeProvisioning).toBe("host-process");
+  });
+
+  test("solana keeps its EVM host in compose", async () => {
+    const evm = (await scenario("solana")).hostChains.find((chain) => chain.type === undefined);
+    expect(evm).toBeDefined();
+    expect(runsInCompose(evm as { nodeProvisioning?: undefined })).toBe(true);
+  });
+});

--- a/test-suite/fhevm/src/provisioning.test.ts
+++ b/test-suite/fhevm/src/provisioning.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import YAML from "yaml";
 
-import { COMPONENT_BY_STEP, runsInCompose } from "./layout";
+import { COMPONENT_BY_STEP, isEvmHost } from "./layout";
 import { STEP_NAMES } from "./types";
 
 const scenario = async (name: string) => {
@@ -12,14 +12,14 @@ const scenario = async (name: string) => {
   };
 };
 
-describe("which nodes compose runs", () => {
-  // fhevm-cli owns every node's lifecycle; this only says how it runs one. A Solana host is always
-  // a native solana-test-validator, so the answer follows from the chain kind and is derived rather
-  // than configured.
-  test("every host runs in compose except Solana", () => {
-    expect(runsInCompose({ type: "evm" })).toBe(true);
-    expect(runsInCompose({})).toBe(true);
-    expect(runsInCompose({ type: "solana" })).toBe(false);
+describe("which hosts carry the EVM contract pipeline", () => {
+  // What this gates is the Solidity machinery — compose services, contract artifacts, seeding —
+  // not how a node is launched. Both are one boolean today only because every EVM host runs in
+  // compose and the sole non-EVM host does not; keep them distinguishable in the reading.
+  test("EVM hosts do, including when the scenario omits the type", () => {
+    expect(isEvmHost({ type: "evm" })).toBe(true);
+    expect(isEvmHost({})).toBe(true);
+    expect(isEvmHost({ type: "solana" })).toBe(false);
   });
 });
 
@@ -31,7 +31,7 @@ describe("the host-process pipeline step", () => {
     expect(STEP_NAMES.indexOf("host-process")).toBeLessThan(STEP_NAMES.indexOf("test-suite"));
   });
 
-  test("declares no compose components, because it runs nodes outside compose", () => {
+  test("declares no compose components, because fhevm-cli spawns these nodes itself", () => {
     expect(COMPONENT_BY_STEP["host-process"]).toEqual([]);
   });
 
@@ -43,18 +43,18 @@ describe("the host-process pipeline step", () => {
 });
 
 describe("the shipped Solana scenarios", () => {
-  // Pins the #1879 retirement: the step picks its work by finding host chains compose does not run,
-  // so a Solana host in these scenarios is what makes `up` provision the validator at all. If the
-  // `type: solana` entry goes away, clean-e2e.sh's dropped step 3 silently stops happening.
-  test.each(["solana", "solana-threshold-kms"])("%s declares a Solana host outside compose", async (name) => {
+  // Pins the #1879 retirement: the step picks its work by chain kind, so a `type: solana` host in
+  // these scenarios is what makes `up` provision the validator at all. If that entry goes away,
+  // clean-e2e.sh's dropped step 3 silently stops happening.
+  test.each(["solana", "solana-threshold-kms"])("%s declares a Solana host", async (name) => {
     const solana = (await scenario(name)).hostChains.find((chain) => chain.type === "solana");
     expect(solana).toBeDefined();
-    expect(runsInCompose({ type: "solana" })).toBe(false);
+    expect(isEvmHost({ type: "solana" })).toBe(false);
   });
 
-  test("solana keeps its EVM host in compose", async () => {
+  test("solana keeps an EVM host alongside it", async () => {
     const evm = (await scenario("solana")).hostChains.find((chain) => chain.type === undefined);
     expect(evm).toBeDefined();
-    expect(runsInCompose(evm as { type?: undefined })).toBe(true);
+    expect(isEvmHost(evm as { type?: undefined })).toBe(true);
   });
 });

--- a/test-suite/fhevm/src/provisioning.test.ts
+++ b/test-suite/fhevm/src/provisioning.test.ts
@@ -2,48 +2,24 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import YAML from "yaml";
 
-import { COMPONENT_BY_STEP, isCliManagedHostProcess, resolveNodeProvisioning, runsInCompose } from "./layout";
-import { HOST_CHAIN_NODE_PROVISIONING, STEP_NAMES } from "./types";
+import { COMPONENT_BY_STEP, runsInCompose } from "./layout";
+import { STEP_NAMES } from "./types";
 
 const scenario = async (name: string) => {
   const file = path.join(import.meta.dir, "..", "scenarios", `${name}.yaml`);
   return YAML.parse(await Bun.file(file).text()) as {
-    hostChains: { key: string; type?: string; nodeProvisioning?: string }[];
+    hostChains: { key: string; type?: string }[];
   };
 };
 
-describe("host node provisioning", () => {
-  test("defaults by chain kind: solana runs as a host process, evm in compose", () => {
-    expect(resolveNodeProvisioning({ type: "solana" })).toBe("host-process");
-    expect(resolveNodeProvisioning({ type: "evm" })).toBe("container");
-    expect(resolveNodeProvisioning({})).toBe("container");
-  });
-
-  test("an explicit nodeProvisioning beats the per-kind default", () => {
-    expect(resolveNodeProvisioning({ type: "solana", nodeProvisioning: "external" })).toBe("external");
-    expect(resolveNodeProvisioning({ type: "evm", nodeProvisioning: "host-process" })).toBe("host-process");
-  });
-
-  // The reason `runsInCompose` exists rather than `!isExternalNode`: a host-process node is owned
-  // by fhevm-cli but has no compose service, so "not external" is not the same question as "does
-  // compose run it". Getting this wrong generates a compose service for the validator.
-  test("only container nodes run in compose", () => {
-    expect(runsInCompose({ nodeProvisioning: "container" })).toBe(true);
-    expect(runsInCompose({ nodeProvisioning: "host-process" })).toBe(false);
-    expect(runsInCompose({ nodeProvisioning: "external" })).toBe(false);
+describe("which nodes compose runs", () => {
+  // fhevm-cli owns every node's lifecycle; this only says how it runs one. A Solana host is always
+  // a native solana-test-validator, so the answer follows from the chain kind and is derived rather
+  // than configured.
+  test("every host runs in compose except Solana", () => {
+    expect(runsInCompose({ type: "evm" })).toBe(true);
+    expect(runsInCompose({})).toBe(true);
     expect(runsInCompose({ type: "solana" })).toBe(false);
-  });
-
-  test("only host-process nodes are fhevm-cli-managed processes", () => {
-    expect(isCliManagedHostProcess({ nodeProvisioning: "host-process" })).toBe(true);
-    expect(isCliManagedHostProcess({ nodeProvisioning: "container" })).toBe(false);
-    expect(isCliManagedHostProcess({ nodeProvisioning: "external" })).toBe(false);
-  });
-
-  test("compose ownership and cli-process ownership are mutually exclusive", () => {
-    for (const nodeProvisioning of HOST_CHAIN_NODE_PROVISIONING) {
-      expect(runsInCompose({ nodeProvisioning }) && isCliManagedHostProcess({ nodeProvisioning })).toBe(false);
-    }
   });
 });
 
@@ -67,19 +43,18 @@ describe("the host-process pipeline step", () => {
 });
 
 describe("the shipped Solana scenarios", () => {
-  // Pins the #1879 retirement itself: these declare host-process, so `fhevm-cli up` owns the
-  // validator and program deploy. If either reverts to `external`, clean-e2e.sh's dropped step 3
-  // silently stops happening and the suite runs against no Solana node at all.
-  test.each(["solana", "solana-threshold-kms"])("%s declares its Solana host as host-process", async (name) => {
-    const chains = (await scenario(name)).hostChains;
-    const solana = chains.find((chain) => chain.type === "solana");
+  // Pins the #1879 retirement: the step picks its work by finding host chains compose does not run,
+  // so a Solana host in these scenarios is what makes `up` provision the validator at all. If the
+  // `type: solana` entry goes away, clean-e2e.sh's dropped step 3 silently stops happening.
+  test.each(["solana", "solana-threshold-kms"])("%s declares a Solana host outside compose", async (name) => {
+    const solana = (await scenario(name)).hostChains.find((chain) => chain.type === "solana");
     expect(solana).toBeDefined();
-    expect(solana?.nodeProvisioning).toBe("host-process");
+    expect(runsInCompose({ type: "solana" })).toBe(false);
   });
 
   test("solana keeps its EVM host in compose", async () => {
     const evm = (await scenario("solana")).hostChains.find((chain) => chain.type === undefined);
     expect(evm).toBeDefined();
-    expect(runsInCompose(evm as { nodeProvisioning?: undefined })).toBe(true);
+    expect(runsInCompose(evm as { type?: undefined })).toBe(true);
   });
 });

--- a/test-suite/fhevm/src/scenario/resolve.ts
+++ b/test-suite/fhevm/src/scenario/resolve.ts
@@ -16,12 +16,11 @@ import {
   REPO_ROOT,
   resolveServiceOverrides,
 } from "../layout";
-import { HOST_CHAIN_NODE_PROVISIONING, HOST_CHAIN_TYPES } from "../types";
+import { HOST_CHAIN_TYPES } from "../types";
 import type {
   BlueGreenScenario,
   CoprocessorInstanceSource,
   CoprocessorScenario,
-  HostChainNodeProvisioning,
   HostChainScenario,
   HostChainType,
   KmsMode,
@@ -282,25 +281,12 @@ const parseHostChains = (parsed: Record<string, unknown>, sourceLabel: string): 
         throw new Error(`${sourceLabel}: duplicate hostChains rpcPort "${rpcPort}"`);
       }
       seenPorts.add(rpcPort);
-      const nodeProvisioning =
-        chain.nodeProvisioning === undefined
-          ? undefined
-          : normalizeScalar(chain.nodeProvisioning, `${sourceLabel}: hostChains[${index}].nodeProvisioning`);
-      if (
-        nodeProvisioning !== undefined &&
-        !HOST_CHAIN_NODE_PROVISIONING.includes(nodeProvisioning as HostChainNodeProvisioning)
-      ) {
-        throw new Error(
-          `${sourceLabel}: hostChains[${index}].nodeProvisioning "${nodeProvisioning}" must be one of: ${HOST_CHAIN_NODE_PROVISIONING.join(", ")}`,
-        );
-      }
       return {
         key,
         chainId,
         rpcPort,
         name: normalizeOptionalText(chain.name, `${sourceLabel}: hostChains[${index}].name`),
         type: type as HostChainType | undefined,
-        nodeProvisioning: nodeProvisioning as HostChainNodeProvisioning | undefined,
       };
     });
     if (!hostChains.length) {

--- a/test-suite/fhevm/src/solana/deploy.ts
+++ b/test-suite/fhevm/src/solana/deploy.ts
@@ -373,7 +373,18 @@ export const lifecycleComposeProject = (lifecycleDir: string | undefined): strin
 
 const evmHex = (bytes: Uint8Array): string => `0x${Buffer.from(bytes).toString("hex")}`;
 
-if (import.meta.main) {
+/**
+ * Brings the Solana host node online against an already-running fhevm stack: fresh geyser
+ * validator, program deploy, zama-host bootstrap from live gateway values, host-chain
+ * registration, and the host-listener.
+ *
+ * Every input falls back to the same environment variable the standalone script read, so calling
+ * this from `fhevm-cli up` and running `bun run src/solana/deploy.ts` provision identically.
+ *
+ * The validator and host-listener are detached (`unref`, own log descriptors), so this returns
+ * once they are up rather than waiting on them.
+ */
+export const provisionSolanaHostNode = async (): Promise<{ zamaHostId: string }> => {
   const lifecycleDir = process.env.DEMO_LIFECYCLE_DIR || undefined;
   const composeProject = lifecycleComposeProject(lifecycleDir);
   const logDir = process.env.SOLANA_LOG_DIR ?? "/tmp";
@@ -434,6 +445,11 @@ if (import.meta.main) {
   console.log(
     `==> Solana side-stack ready. zama_host=${zamaHostId} host_chain_id=${SOLANA_HOST_CHAIN_ID} (i64 ${SOLANA_HOST_CHAIN_ID_I64})`,
   );
+  return { zamaHostId };
+};
+
+if (import.meta.main) {
+  await provisionSolanaHostNode();
   // The validator and host-listener are detached children; exit explicitly instead of waiting on
   // anything they hold open.
   process.exit(0);

--- a/test-suite/fhevm/src/types.ts
+++ b/test-suite/fhevm/src/types.ts
@@ -15,6 +15,7 @@ export const STEP_NAMES = [
   "kms-connector",
   "bootstrap",
   "relayer",
+  "host-process",
   "test-suite",
 ] as const;
 
@@ -31,7 +32,7 @@ export const OVERRIDE_GROUPS = [
 ] as const;
 
 export const HOST_CHAIN_TYPES = ["evm", "solana"] as const;
-export const HOST_CHAIN_NODE_PROVISIONING = ["container", "external"] as const;
+export const HOST_CHAIN_NODE_PROVISIONING = ["container", "host-process", "external"] as const;
 
 export type StepName = (typeof STEP_NAMES)[number];
 export type VersionTarget = (typeof TARGETS)[number];
@@ -39,9 +40,15 @@ export type OverrideGroup = (typeof OVERRIDE_GROUPS)[number];
 /** The kind of host chain. `evm` is the default; `solana` is the RFC-021 Solana host. */
 export type HostChainType = (typeof HOST_CHAIN_TYPES)[number];
 /**
- * How the host node is provisioned. `container` = fhevm-cli runs it (and deploys + registers it);
- * `external` = an outside process owns the node + deploy + registration (the Solana host-native
- * validator). (A future `host` value could run a fhevm-cli-managed host process.)
+ * How the host node is provisioned.
+ *
+ * - `container` — fhevm-cli runs the node as a compose service, then deploys and registers it.
+ * - `host-process` — fhevm-cli runs the node as a process on this machine (a Solana validator
+ *   cannot be a compose service here: it needs the geyser plugin loaded from the worktree), then
+ *   deploys the programs and registers the chain. Compose never sees the node, but fhevm-cli still
+ *   owns its whole lifecycle.
+ * - `external` — something outside fhevm-cli owns the node, the deploy, and the registration.
+ *   fhevm-cli only writes config pointing at it.
  */
 export type HostChainNodeProvisioning = (typeof HOST_CHAIN_NODE_PROVISIONING)[number];
 
@@ -70,9 +77,10 @@ export type HostChainScenario = {
    */
   type?: HostChainType;
   /**
-   * Who provisions the host node. Omitted defaults by `type`: `evm` ⇒ `container` (fhevm-cli runs
-   * the node + deploy + registration), `solana` ⇒ `external` (the host-native validator and the
-   * solana-side bring-up own them). Set explicitly to override.
+   * Who provisions the host node. Omitted defaults by `type`: `evm` ⇒ `container`, `solana` ⇒
+   * `host-process`. In both defaults fhevm-cli owns the node, deploy, and registration — they
+   * differ only in whether compose runs it. Set explicitly to override, e.g. `external` to point
+   * at a validator something else already runs.
    */
   nodeProvisioning?: HostChainNodeProvisioning;
 };

--- a/test-suite/fhevm/src/types.ts
+++ b/test-suite/fhevm/src/types.ts
@@ -32,25 +32,12 @@ export const OVERRIDE_GROUPS = [
 ] as const;
 
 export const HOST_CHAIN_TYPES = ["evm", "solana"] as const;
-export const HOST_CHAIN_NODE_PROVISIONING = ["container", "host-process", "external"] as const;
 
 export type StepName = (typeof STEP_NAMES)[number];
 export type VersionTarget = (typeof TARGETS)[number];
 export type OverrideGroup = (typeof OVERRIDE_GROUPS)[number];
 /** The kind of host chain. `evm` is the default; `solana` is the RFC-021 Solana host. */
 export type HostChainType = (typeof HOST_CHAIN_TYPES)[number];
-/**
- * How the host node is provisioned.
- *
- * - `container` — fhevm-cli runs the node as a compose service, then deploys and registers it.
- * - `host-process` — fhevm-cli runs the node as a process on this machine (a Solana validator
- *   cannot be a compose service here: it needs the geyser plugin loaded from the worktree), then
- *   deploys the programs and registers the chain. Compose never sees the node, but fhevm-cli still
- *   owns its whole lifecycle.
- * - `external` — something outside fhevm-cli owns the node, the deploy, and the registration.
- *   fhevm-cli only writes config pointing at it.
- */
-export type HostChainNodeProvisioning = (typeof HOST_CHAIN_NODE_PROVISIONING)[number];
 
 export type CoprocessorInstanceSource =
   | { mode: "inherit" }
@@ -76,13 +63,6 @@ export type HostChainScenario = {
    * Anchor program deploy, and the Solana host-listener/finalized-account-fetcher.
    */
   type?: HostChainType;
-  /**
-   * Who provisions the host node. Omitted defaults by `type`: `evm` ⇒ `container`, `solana` ⇒
-   * `host-process`. In both defaults fhevm-cli owns the node, deploy, and registration — they
-   * differ only in whether compose runs it. Set explicitly to override, e.g. `external` to point
-   * at a validator something else already runs.
-   */
-  nodeProvisioning?: HostChainNodeProvisioning;
 };
 
 /** KMS deployment mode for a scenario. */


### PR DESCRIPTION
Stacked on #3477 — **review that first**; this branch targets `refactor/solana-test-framework`, so the diff here is only the commit on top.

First increment of zama-ai/fhevm-internal#1879 (retire `clean-e2e.sh`). It takes the load-bearing piece: the part of the bring-up that fhevm-cli structurally could not do.

## The problem

`fhevm-cli up --scenario solana` stopped one step short of a running stack. It booted every EVM service and wrote the Solana relayer and kms-connector config, then stopped — the validator, program deploy, zama-host bootstrap, host-chain registration and host-listener were left to a separate `bun run src/solana/deploy.ts` that only `clean-e2e.sh` ever made.

The consequence is the one #1879 is about: standing up the stack and running the tests were the same action, and the CLI was not the thing that did it. `bun run demo up` was a hard precondition of `bun run test:e2e`.

## The change

**A `host-process` pipeline step**, placed after `relayer` and before `test-suite`. The position is load-bearing rather than aesthetic: the bring-up reads live gateway addresses and the KMS/coprocessor signer set, so it cannot precede the steps that deploy and register them. This is the same position it occupied when `clean-e2e.sh` called it after `up` returned. The step selects the host chains compose does not run.

**`nodeProvisioning` is gone.** The first pass here added a third value to it (`host-process`) — reviewing that, the field turned out to carry no information at all. It was introduced to make provisioning *"an explicit axis instead of inferred from `type==="solana"`"*, but shipped as `defaults by type: evm⇒container, solana⇒external`, with the two Solana scenarios restating that default. The inference was renamed, not removed: `isExternalNode(chain)` was `chain.type === "solana"` behind three indirections, and no scenario ever set a value `type` did not already imply. Adding a third value made it worse — two of three in bijection with `type`, and `external` reachable from nothing.

The enum was flattening two orthogonal questions:

- ***How*** **a node runs** — compose service or host process — follows from the chain kind. A Solana host is always a native `solana-test-validator` because it loads the geyser plugin from the worktree, so a scenario asking for it in compose would not get a working node. Derived, not configured.
- ***Whether*** **we run it at all** is a different question, and it varies by which network you target, not by how a scenario describes the chain. It belongs to the network registry in zama-ai/fhevm-internal#1880, not to `HostChainScenario`.

So `isExternalNode` became `runsInCompose(chain) = (chain.type ?? "evm") !== "solana"`. Worth noting for review: all ten of the old call sites were already `!isExternalNode(...)`, and every one asks *"does compose run this node"* — so the rename also fixes the direction they read in.

`deploy.ts` becomes `provisionSolanaHostNode()` with the `import.meta.main` wrapper kept, so it still provisions standalone when a node needs rebuilding without a full stack cycle. Every input still falls back to the same environment variable, so both paths provision identically. It is imported lazily so an EVM-only `up` never loads the Solana client stack.

`clean-e2e.sh` drops its step 3.

## What this does not do

`clean-e2e.sh` is **not retired** — it is 331 lines doing five jobs, and this removes one:

| what | lines | where it should end up |
|---|---|---|
| ~~Solana side-stack bring-up~~ | ~~6~~ | **done — now the `host-process` step** |
| arm64 native Rust builder aliasing | ~180 | image build layer, not the Solana scenario |
| SDK build + `materialize-test-sdk.sh` + resolution proofs | ~11 | zama-ai/fhevm-internal#1878 |
| lock resolution + kms-core image pinning | ~26 | scenario config + the CI override seam |
| `fhevm-cli up` invocation | ~5 | stays |

The arm64 block is the biggest single piece and has nothing to do with Solana host provisioning, so it is deliberately untouched here.

## Verification

- `tsc --noEmit` clean
- 378 unit tests pass (371 + 7 new); 9 harness tests
- `shellcheck` clean on `clean-e2e.sh`; 26/26 `select-overrides.test.sh`
- `dead-surface-check.sh` clean
- `fhevm-cli up --help` advertises `host-process`; `fhevm-cli scenario list` parses both Solana scenarios

`src/provisioning.test.ts` is new and pins the behavior rather than restating it. Mutation-checked: inverting `runsInCompose` fails 4 of its 7 tests, so they catch the regression they describe.

Not exercised locally: the live bring-up itself. That needs the solana-e2e lane.
