### PR TITLE
fix(docker): parameterize the Rust builder base image

### DIFF
--- a/coprocessor/fhevm-engine/Dockerfile.workspace
+++ b/coprocessor/fhevm-engine/Dockerfile.workspace
@@ -31,6 +31,9 @@
 # That injection does NOT happen here, so this is the one place that needs a
 # hardcoded default.
 ARG RUST_IMAGE_VERSION=1.97.1
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # =============================================================================
 # Stage 0: Build Solidity contracts (required for host-listener, gw-listener)
@@ -65,7 +68,7 @@ RUN npm ci && \
 # =============================================================================
 # Stage 1: Build ALL Rust workspace binaries
 # =============================================================================
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG BUILD_ID=unknown
@@ -147,7 +150,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # =============================================================================
 # Stage 1b: Build sqlx-cli for db-migration
 # =============================================================================
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS sqlx_builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS sqlx_builder
 
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3

--- a/coprocessor/fhevm-engine/consensus-detector/Dockerfile
+++ b/coprocessor/fhevm-engine/consensus-detector/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build Consensus Detector
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 

--- a/coprocessor/fhevm-engine/db-migration/Dockerfile
+++ b/coprocessor/fhevm-engine/db-migration/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build DB Migration
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3

--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -1,5 +1,8 @@
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 0: Build contracts
 FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
@@ -16,7 +19,7 @@ RUN npm install && \
     DOTENV_CONFIG_PATH=.env.example npx hardhat task:deployAllGatewayContracts
 
 # Stage 1: Build GW Listener
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -1,5 +1,8 @@
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 0: Build contracts
 FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
@@ -21,7 +24,7 @@ RUN cp host-contracts/.env.example host-contracts/.env && \
     npx hardhat compile
 
 # Stage 1: Build Host Listener
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/coprocessor/fhevm-engine/sns-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-worker/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build SNS Worker
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
+++ b/coprocessor/fhevm-engine/stress-test-generator/Dockerfile
@@ -1,5 +1,8 @@
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 0: Build contracts
 FROM ghcr.io/zama-ai/fhevm/gci/nodejs:22.14.0-alpine3.21 AS contract_builder
@@ -22,7 +25,7 @@ RUN cp .env.example .env \
     && npx hardhat compile
 
 # Stage 1: Build Stress-Tool
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 

--- a/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build TFHE Worker
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build Transaction Sender
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/coprocessor/fhevm-engine/upgrade-controller/Dockerfile
+++ b/coprocessor/fhevm-engine/upgrade-controller/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build Upgrade Controller
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -1,7 +1,10 @@
 # Stage 1: Build ZK Proof Worker
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see coprocessor-docker-build.yml)
 ARG RUST_IMAGE_VERSION
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/kms-connector/Dockerfile.workspace
+++ b/kms-connector/Dockerfile.workspace
@@ -24,11 +24,14 @@
 # =============================================================================
 
 ARG RUST_IMAGE_VERSION=1.91.0
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # =============================================================================
 # Stage 1: Build ALL workspace binaries
 # =============================================================================
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET

--- a/kms-connector/connector-db/Dockerfile
+++ b/kms-connector/connector-db/Dockerfile
@@ -1,7 +1,10 @@
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 1: install DB Migration tooling
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3

--- a/kms-connector/crates/gw-listener/Dockerfile
+++ b/kms-connector/crates/gw-listener/Dockerfile
@@ -1,9 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 1: Build gw-listener
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
 ARG CARGO_PROFILE=release

--- a/kms-connector/crates/kms-worker/Dockerfile
+++ b/kms-connector/crates/kms-worker/Dockerfile
@@ -1,9 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 1: Build kms-worker
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
 ARG CARGO_PROFILE=release

--- a/kms-connector/crates/tx-sender/Dockerfile
+++ b/kms-connector/crates/tx-sender/Dockerfile
@@ -1,9 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 1: Build tx-sender
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 # The profile used to run `cargo build`
 ARG CARGO_PROFILE=release

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -3,9 +3,12 @@
 # RUST_IMAGE_VERSION is injected by CI from rust-toolchain.toml (see listener-docker-build.yml).
 # The default below is the fallback for local docker-compose builds, which do NOT inject it.
 ARG RUST_IMAGE_VERSION=1.97.1
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # ── Builder (golden rust-glibc image ships the pinned toolchain + build deps) ──
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 # Build as root; the golden image already provides the toolchain, build deps
 # (openssl-dev, gcc, build-base, ...) and the unprivileged fhevm user.

--- a/relayer/docker/relayer-migrate/Dockerfile
+++ b/relayer/docker/relayer-migrate/Dockerfile
@@ -2,9 +2,12 @@
 # RUST_IMAGE_VERSION is intentionally left without a default so the Rust toolchain
 # version has a single source of truth: relayer/rust-toolchain.toml.
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 ARG APP_NAME=relayer-migrate
 
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS build
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS build
 ARG APP_NAME
 WORKDIR /app
 USER root

--- a/relayer/docker/relayer/Dockerfile
+++ b/relayer/docker/relayer/Dockerfile
@@ -2,9 +2,12 @@
 # RUST_IMAGE_VERSION is intentionally left without a default so the Rust toolchain
 # version has a single source of truth: relayer/rust-toolchain.toml.
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 ARG APP_NAME=fhevm-relayer
 
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS build
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS build
 ARG APP_NAME
 WORKDIR /app
 USER root

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -112,10 +112,16 @@ const COPROCESSOR_RUST_IMAGE_VERSION = rustImageVersion("coprocessor/fhevm-engin
 const KMS_CONNECTOR_RUST_IMAGE_VERSION = rustImageVersion("kms-connector/rust-toolchain.toml");
 const RELAYER_RUST_IMAGE_VERSION = rustImageVersion("relayer/rust-toolchain.toml");
 
+// Registry/repo of the Rust builder base every component Dockerfile builds FROM. The published
+// golden image is amd64-only (ci-templates' common-docker.yml has a linux/amd64-only build matrix
+// and no arm runner input), so an arm64 host builds that base locally and points the builds at it
+// instead of retagging someone else's image name.
+const RUST_BUILDER_IMAGE = process.env.RUST_BUILDER_IMAGE ?? "ghcr.io/zama-ai/fhevm/gci/rust-glibc";
+
 const coprocessorBuildSpec = (target: string) =>
   buildSpec("../../..", "coprocessor/fhevm-engine/Dockerfile.workspace", {
     target,
-    args: { RUST_IMAGE_VERSION: COPROCESSOR_RUST_IMAGE_VERSION },
+    args: { RUST_IMAGE_VERSION: COPROCESSOR_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
   });
 
 const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknown>>> = {
@@ -134,19 +140,19 @@ const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknow
   },
   "kms-connector": {
     "kms-connector-db-migration": buildSpec("../../..", "kms-connector/connector-db/Dockerfile", {
-      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION },
+      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
     }),
     "kms-connector-gw-listener": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
       target: "gw-listener",
-      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION },
+      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
     }),
     "kms-connector-kms-worker": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
       target: "kms-worker",
-      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION },
+      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
     }),
     "kms-connector-tx-sender": buildSpec("../../..", "kms-connector/Dockerfile.workspace", {
       target: "tx-sender",
-      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION },
+      args: { RUST_IMAGE_VERSION: KMS_CONNECTOR_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
     }),
   },
   "listener-core": {
@@ -154,10 +160,10 @@ const COMPONENT_BUILD_SPECS: Record<string, Record<string, Record<string, unknow
   },
   relayer: {
     "relayer-db-migration": buildSpec("../../..", "relayer/docker/relayer-migrate/Dockerfile", {
-      args: { RUST_IMAGE_VERSION: RELAYER_RUST_IMAGE_VERSION },
+      args: { RUST_IMAGE_VERSION: RELAYER_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
     }),
     relayer: buildSpec("../../..", "relayer/docker/relayer/Dockerfile", {
-      args: { RUST_IMAGE_VERSION: RELAYER_RUST_IMAGE_VERSION },
+      args: { RUST_IMAGE_VERSION: RELAYER_RUST_IMAGE_VERSION, RUST_BUILDER_IMAGE },
     }),
   },
   "gateway-mocked-payment": {

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import YAML from "yaml";
 
 import { generateComposeOverrides, loadMergedComposeDoc, serviceNameList } from "./generate/compose";
-import { TEMPLATE_COMPOSE_DIR, composePath, envPath } from "./layout";
+import { REPO_ROOT, TEMPLATE_COMPOSE_DIR, composePath, envPath } from "./layout";
 import { presetBundle } from "./resolve/target";
 import {
   parseBlueGreenScenario,
@@ -166,6 +166,43 @@ describe("render-compose", () => {
       expect(doc.services["listener-publisher-for-anvil"]?.build).toBeTruthy();
       expect(doc.services["listener-redis"]).toBeUndefined();
     });
+  });
+
+  // Every Dockerfile that builds FROM the golden Rust base must resolve the image through
+  // ${RUST_BUILDER_IMAGE}, declared in global scope. An ARG declared after any FROM is stage-scoped
+  // and expands to empty inside a FROM, producing `FROM :1.97.1` — so scope is the thing to pin.
+  test("every Rust builder FROM is parameterized, with the ARG in global scope", async () => {
+    const files = (await Array.fromAsync(new Bun.Glob("**/Dockerfile*").scan({ cwd: REPO_ROOT })))
+      .filter((f) => !f.includes("node_modules") && !f.includes(".claude/"))
+      .map((f) => path.join(REPO_ROOT, f));
+    let checked = 0;
+    for (const file of files) {
+      const lines = (await Bun.file(file).text()).split("\n");
+      if (!lines.some((line) => line.includes("gci/rust-glibc"))) continue;
+      checked += 1;
+      const firstFrom = lines.findIndex((line) => line.trimStart().startsWith("FROM "));
+      const declared = lines.findIndex((line) => /^\s*ARG\s+RUST_BUILDER_IMAGE=/.test(line));
+      expect(`${file}: declares ARG RUST_BUILDER_IMAGE`).toBe(declared >= 0 ? `${file}: declares ARG RUST_BUILDER_IMAGE` : file);
+      expect(declared).toBeLessThan(firstFrom);
+      for (const line of lines) {
+        if (line.trimStart().startsWith("FROM ") && line.includes("gci/rust-glibc")) {
+          throw new Error(`${file}: FROM still hardcodes the builder registry: ${line.trim()}`);
+        }
+      }
+    }
+    expect(checked).toBeGreaterThan(15);
+  });
+
+  // Any build spec that pins the toolchain version must also pin where the base comes from;
+  // otherwise the Dockerfile default silently wins, which is right on amd64 and wrong on arm64 —
+  // a failure that never surfaces in CI, since every CI runner is linux-x64.
+  test("no Rust build spec pins the version without the builder image", async () => {
+    const source = await Bun.file(path.join(import.meta.dir, "generate", "compose.ts")).text();
+    const pins = source.match(/args: \{[^}]*RUST_IMAGE_VERSION[^}]*\}/g) ?? [];
+    expect(pins.length).toBeGreaterThan(0);
+    for (const pin of pins) {
+      expect(pin).toContain("RUST_BUILDER_IMAGE");
+    }
   });
 
   test("renders multi-instance coprocessor overrides with local poller siblings", async () => {

--- a/test-suite/gateway-stress/Dockerfile
+++ b/test-suite/gateway-stress/Dockerfile
@@ -1,9 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG RUST_IMAGE_VERSION
+# Registry/repo of the Rust builder base. Defaults to the published golden image; override
+# it to build against a locally-built base (the published one is amd64-only).
+ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
 
 # Stage 1: Build gateway-stress tool
-FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
+FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
 ARG SCCACHE_BUCKET


### PR DESCRIPTION
Standalone infrastructure fix, extracted from Solana e2e work but not Solana-specific. Targets `main`.

## The problem

Twenty Dockerfiles across coprocessor, kms-connector, relayer, listener and gateway-stress build from a hardcoded base:

```dockerfile
ARG RUST_IMAGE_VERSION
FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
```

Only the **tag** is a build arg. The registry and repo are literals, so a caller can choose the toolchain version but not where the base comes from.

That image is published amd64-only — and not transiently. The shared `zama-ai/ci-templates` `common-docker.yml` that every one of these images publishes through:

- has a build matrix with exactly one entry, `linux/amd64`
- exposes only a `runs-on-amd` input — **there is no arm runner input**, so a caller could not request arm64 even if it wanted to
- creates its "multiarch" manifest with `docker manifest create … --amend …-amd64-prod` — a manifest list containing one architecture

The workflow is named *"Docker Build and Push with Multiarch Manifest"*, but structurally publishes a single arch. That applies to every image built through the template, not just this one.

Consequence: an arm64 host has no supported way to substitute a locally-built base. The workaround that grew up around this (in `solana/scripts/e2e/clean-e2e.sh`) is ~180 lines that build the base natively under a fingerprinted cache tag, **retag it as the upstream image name**, let compose build against the impostor, then restore the previous tag — with an image-ID guard, a backup tag, and an EXIT trap, all of which exist only because the name had to be hijacked.

## The change

```dockerfile
ARG RUST_IMAGE_VERSION
ARG RUST_BUILDER_IMAGE=ghcr.io/zama-ai/fhevm/gci/rust-glibc
FROM ${RUST_BUILDER_IMAGE}:${RUST_IMAGE_VERSION} AS builder
```

The ARG is declared in **global scope**, before the first `FROM`. That placement is load-bearing: an `ARG` declared after any `FROM` is stage-scoped and expands to empty *inside* a `FROM`, silently yielding `FROM :1.97.1`. All 20 files already declared exactly one global `ARG RUST_IMAGE_VERSION`, so the new one sits directly beside it.

The default is the current value, so **every existing caller — including all of CI — builds byte-identically**. `fhevm-cli` passes it through the build args it already generates, overridable via `RUST_BUILDER_IMAGE` in the environment.

## Why this is worth doing separately

It is not Solana's problem. These Dockerfiles and `compose.ts` are all on `main`; only the workaround happens to live on a Solana branch. Once this lands, that ~180-line block collapses to "build the base once, export one env var" — but the fix is useful to anyone on Apple silicon building any of these components, which is why it is its own PR against `main` rather than a Solana-branch change.

## Verification

- `tsc --noEmit` clean; 313 unit tests pass
- all 20 Dockerfiles verified to declare the ARG before their first `FROM`, and no `FROM` hardcodes the registry any more
- two invariants pinned in `render-compose.test.ts`, both mutation-checked (reverting one Dockerfile to a hardcoded `FROM` fails one; dropping the arg from one build spec fails one):
  - every Dockerfile that uses the golden Rust base resolves it through `${RUST_BUILDER_IMAGE}`, declared in global scope
  - no build spec pins the toolchain version without also pinning the builder image — the failure mode otherwise is a Dockerfile default that is right on amd64 and wrong on arm64, which no CI runner would ever catch, since every runner here is `linux-x64`

**Not verified locally: an actual image build.** The change is static and the default preserves current behavior exactly, but the real evidence is CI building these images.

## Follow-ups, not in this PR

- **The upstream fix.** The arm64 gap in `ci-templates` has never been raised — no issue in any `zama-ai` repo matches arm64 / rust-glibc / apple-silicon / multiarch, and the workaround landed inside an unrelated PR as two `fix(solana):` commits with no ticket. Adding an arm64 leg to `common-docker.yml` is the actual fix; this PR just makes it possible to work without one.
- **`listener/Dockerfile` hardcodes `ARG RUST_IMAGE_VERSION=1.97.1`** as a fallback because its compose build spec passes no args, duplicating `rust-toolchain.toml`. Left alone here; it drifts independently of this change.
