### PR TITLE
chore(kms-connector): chain-id in error logs

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/decryption.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     config::Config,
     event_processor::{
-        CiphertextManager, ProcessingError, RequestCheckError, RequestCheckKind,
+        CiphertextManager, HostRpcClient, ProcessingError, RequestCheckError, RequestCheckKind,
         ciphertext::VerifiedCiphertexts,
     },
 };
@@ -21,7 +21,6 @@ use fhevm_gateway_bindings::decryption::Decryption::{
     self, DecryptionInstance, HandleEntry, UserDecryptionRequest_3 as UserDecryptionRequestV2,
     delegatedUserDecryptionRequestCall, userDecryptionRequest_1Call as userDecryptionRequestCall,
 };
-use fhevm_host_bindings::acl::ACL::ACLInstance;
 use futures::{
     future::try_join_all,
     stream::{FuturesUnordered, StreamExt},
@@ -30,7 +29,7 @@ use kms_grpc::kms::v1::{Eip712DomainMsg, PublicDecryptionRequest, UserDecryption
 use sqlx::types::chrono::Utc;
 use std::collections::HashMap;
 use tracing::info;
-use user_decryption_signature::{compute_user_decrypt_digest, verify_signature};
+use user_decryption_signature::compute_user_decrypt_digest;
 
 #[derive(Clone)]
 /// The struct responsible of processing incoming decryption requests.
@@ -42,7 +41,7 @@ pub struct DecryptionProcessor<GP: Provider, HP: Provider> {
     decryption_contract: DecryptionInstance<GP>,
 
     /// The instances of the host chains `ACL` contracts used to check the decryption ACL.
-    acl_contracts: HashMap<u64, ACLInstance<HP>>,
+    host_clients: HashMap<u64, HostRpcClient<HP>>,
 
     /// The entity used to verify and collect the ciphertexts of decryption requests.
     ciphertext_manager: CiphertextManager<GP>,
@@ -59,7 +58,7 @@ where
     pub fn new(
         config: &Config,
         gateway_provider: GP,
-        acl_contracts: HashMap<u64, ACLInstance<HP>>,
+        host_clients: HashMap<u64, HostRpcClient<HP>>,
         ciphertext_manager: CiphertextManager<GP>,
     ) -> Self {
         let domain = Eip712DomainMsg {
@@ -75,7 +74,7 @@ where
         Self {
             domain,
             decryption_contract,
-            acl_contracts,
+            host_clients,
             ciphertext_manager,
             erc1271_gas_limit: config.erc1271_gas_limit,
         }
@@ -91,19 +90,14 @@ where
         try_join_all(handles.iter().map(|handle| async move {
             let ct_chain_id = extract_chain_id_from_handle(*handle)
                 .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
-            let acl_contract = self.acl_contracts.get(&ct_chain_id).ok_or_else(|| {
+            let host_client = self.host_clients.get(&ct_chain_id).ok_or_else(|| {
                 RequestCheckError::recoverable(
                     RequestCheckKind::Acl,
                     anyhow!("No ACL contract config found for chain id {ct_chain_id}"),
                 )
             })?;
 
-            if !acl_contract
-                .isAllowedForDecryption(*handle)
-                .call()
-                .await
-                .map_err(RequestCheckError::network)?
-            {
+            if !host_client.is_allowed_for_decryption(*handle).await? {
                 return Err(RequestCheckError::recoverable(
                     RequestCheckKind::Acl,
                     anyhow!("Decryption is not allowed for {handle}"),
@@ -159,7 +153,7 @@ where
         try_join_all(handles.iter().map(|handle| async move {
             let ct_chain_id = extract_chain_id_from_handle(*handle)
                 .map_err(|e| RequestCheckError::irrecoverable(RequestCheckKind::Acl, e))?;
-            let acl_contract = self.acl_contracts.get(&ct_chain_id).ok_or_else(|| {
+            let host_client = self.host_clients.get(&ct_chain_id).ok_or_else(|| {
                 RequestCheckError::recoverable(
                     RequestCheckKind::Acl,
                     anyhow!("No ACL contract config found for chain id {ct_chain_id}"),
@@ -174,7 +168,7 @@ where
 
             if let Some(delegator_addr) = delegator_address {
                 self.inner_acl_check_for_delegated_user_decryption(
-                    acl_contract,
+                    host_client,
                     *handle,
                     user_address,
                     *contract_address,
@@ -183,7 +177,7 @@ where
                 .await
             } else {
                 self.inner_acl_check_for_user_decryption(
-                    acl_contract,
+                    host_client,
                     *handle,
                     user_address,
                     *contract_address,
@@ -199,22 +193,20 @@ where
 
     async fn inner_acl_check_for_delegated_user_decryption(
         &self,
-        acl_contract: &ACLInstance<HP>,
+        host_client: &HostRpcClient<HP>,
         handle: FixedBytes<32>,
         user_address: Address,
         contract_address: Address,
         delegator_address: Address,
     ) -> Result<(), RequestCheckError> {
-        let is_delegated = acl_contract
-            .isHandleDelegatedForUserDecryption(
+        let is_delegated = host_client
+            .is_handle_delegated_for_user_decryption(
                 delegator_address,
                 user_address,
                 contract_address,
                 handle,
             )
-            .call()
-            .await
-            .map_err(RequestCheckError::network)?;
+            .await?;
 
         if !is_delegated {
             return Err(RequestCheckError::recoverable(
@@ -330,7 +322,7 @@ where
             ));
         }
 
-        let acl_contract = self.acl_contracts.get(&chain_id).ok_or_else(|| {
+        let host_client = self.host_clients.get(&chain_id).ok_or_else(|| {
             RequestCheckError::recoverable(
                 RequestCheckKind::Acl,
                 anyhow!("No ACL contract config found for chain id {chain_id}"),
@@ -357,19 +349,14 @@ where
         // order.
         tokio::try_join!(
             biased;
-            async {
-                verify_signature(
-                    acl_contract.provider(),
-                    payload.userAddress,
-                    digest,
-                    payload.signature.as_ref(),
-                    self.erc1271_gas_limit,
-                )
-                .await
-                .map_err(RequestCheckError::from)
-            },
+            host_client.verify_signature(
+                payload.userAddress,
+                digest,
+                payload.signature.as_ref(),
+                self.erc1271_gas_limit,
+            ),
             self.inner_invalidation_check_for_user_decryption_v2(
-                acl_contract,
+                host_client,
                 payload.userAddress,
                 start,
             ),
@@ -377,12 +364,12 @@ where
                 tokio::try_join!(
                     biased;
                     self.inner_ownership_check_for_user_decryption_v2(
-                        acl_contract,
+                        host_client,
                         handle_entry,
                         payload.userAddress,
                     ),
                     self.inner_allowed_contracts_check_for_user_decryption_v2(
-                        acl_contract,
+                        host_client,
                         handle_entry.handle,
                         &payload.allowedContracts,
                     ),
@@ -402,17 +389,13 @@ where
     /// `isHandleDelegatedForUserDecryption(ownerAddress, userAddress, contractAddress, handle)`.
     async fn inner_ownership_check_for_user_decryption_v2(
         &self,
-        acl_contract: &ACLInstance<HP>,
+        host_client: &HostRpcClient<HP>,
         entry: &HandleEntry,
         user_address: Address,
     ) -> Result<(), RequestCheckError> {
         let handle_hex = hex::encode(entry.handle);
         if entry.ownerAddress == user_address {
-            let user_allowed = acl_contract
-                .isAllowed(entry.handle, user_address)
-                .call()
-                .await
-                .map_err(RequestCheckError::network)?;
+            let user_allowed = host_client.is_allowed(entry.handle, user_address).await?;
             if !user_allowed {
                 return Err(RequestCheckError::recoverable(
                     RequestCheckKind::Acl,
@@ -420,16 +403,14 @@ where
                 ));
             }
         } else {
-            let is_delegated = acl_contract
-                .isHandleDelegatedForUserDecryption(
+            let is_delegated = host_client
+                .is_handle_delegated_for_user_decryption(
                     entry.ownerAddress,
                     user_address,
                     entry.contractAddress,
                     entry.handle,
                 )
-                .call()
-                .await
-                .map_err(RequestCheckError::network)?;
+                .await?;
             if !is_delegated {
                 return Err(RequestCheckError::recoverable(
                     RequestCheckKind::Acl,
@@ -449,7 +430,7 @@ where
     /// permissive mode (empty list) so callers can invoke it unconditionally.
     async fn inner_allowed_contracts_check_for_user_decryption_v2(
         &self,
-        acl_contract: &ACLInstance<HP>,
+        host_client: &HostRpcClient<HP>,
         handle: FixedBytes<32>,
         allowed_contracts: &[Address],
     ) -> Result<(), RequestCheckError> {
@@ -459,7 +440,7 @@ where
 
         let mut calls: FuturesUnordered<_> = allowed_contracts
             .iter()
-            .map(|c| async move { (c, acl_contract.isAllowed(handle, *c).call().await) })
+            .map(|c| async move { (c, host_client.is_allowed(handle, *c).await) })
             .collect();
 
         // All calls run concurrently; short-circuit on the first positive, dropping `calls`
@@ -486,18 +467,15 @@ where
     /// the user has invalidated all signatures issued before `invalidationTs`.
     async fn inner_invalidation_check_for_user_decryption_v2(
         &self,
-        acl_contract: &ACLInstance<HP>,
+        host_client: &HostRpcClient<HP>,
         user_address: Address,
         start_timestamp: U256,
     ) -> Result<(), RequestCheckError> {
-        let invalidation_ts = acl_contract
-            .decryptionSignatureInvalidatedBefore(user_address)
-            .call()
-            .await
-            .map_err(RequestCheckError::network)?;
+        let invalidation_ts = host_client
+            .decryption_signature_invalidated_before(user_address)
+            .await?;
         if start_timestamp < invalidation_ts {
             return Err(RequestCheckError::irrecoverable(
-                // TODO: reconsider Signature naming
                 RequestCheckKind::Signature,
                 anyhow!(
                     "RFC016 signature invalidated: startTimestamp {start_timestamp} < \
@@ -510,17 +488,16 @@ where
 
     async fn inner_acl_check_for_user_decryption(
         &self,
-        acl_contract: &ACLInstance<HP>,
+        host_client: &HostRpcClient<HP>,
         handle: FixedBytes<32>,
         user_address: Address,
         contract_address: Address,
     ) -> Result<(), RequestCheckError> {
-        let user_allowed_call = acl_contract.isAllowed(handle, user_address);
-        let contract_allowed_call = acl_contract.isAllowed(handle, contract_address);
-
-        let (user_allowed, contract_allowed) =
-            tokio::try_join!(biased; user_allowed_call.call(), contract_allowed_call.call())
-                .map_err(RequestCheckError::network)?;
+        let (user_allowed, contract_allowed) = tokio::try_join!(
+            biased;
+            host_client.is_allowed(handle, user_address),
+            host_client.is_allowed(handle, contract_address),
+        )?;
 
         if !user_allowed {
             return Err(RequestCheckError::recoverable(
@@ -691,12 +668,15 @@ mod tests {
             .disable_recommended_fillers()
             .connect_mocked_client(asserter);
         let chain_id = extract_chain_id_from_handle(handle).unwrap();
-        let acl_contracts = HashMap::from([(
+        let host_clients = HashMap::from([(
             chain_id,
-            ACL::new(Address::default(), mock_provider.clone()),
+            HostRpcClient::new(
+                chain_id,
+                ACL::new(Address::default(), mock_provider.clone()),
+            ),
         )]);
         let ciphertext_manager = CiphertextManager::for_test(mock_provider.clone());
-        DecryptionProcessor::new(&config, mock_provider, acl_contracts, ciphertext_manager)
+        DecryptionProcessor::new(&config, mock_provider, host_clients, ciphertext_manager)
     }
 
     #[test]
@@ -757,6 +737,29 @@ mod tests {
                 assert!(matches!(result, Err(ProcessingError::Irrecoverable(_))))
             }
         }
+    }
+
+    #[tokio::test]
+    async fn acl_errors_carry_host_chain_context() {
+        let asserter = Asserter::new();
+        let handle = rand_handle();
+        let decryption_processor = setup_test_processor(asserter.clone(), handle);
+        asserter.push_failure_msg("connection refused");
+
+        let err = decryption_processor
+            .check_ciphertexts_allowed_for_public_decryption(&[handle])
+            .await
+            .map_err(RequestCheckError::record)
+            .unwrap_err();
+
+        let chain_id = extract_chain_id_from_handle(handle).unwrap();
+        let msg = err.to_string();
+        assert!(msg.contains(&chain_id.to_string()), "{msg}");
+        assert!(
+            msg.contains(&format!("ACL contract {}", Address::ZERO)),
+            "{msg}"
+        );
+        assert!(msg.contains("connection refused"), "{msg}");
     }
 
     enum UserDecryptACLMock {

--- a/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/error.rs
@@ -6,9 +6,9 @@ use user_decryption_signature::Erc1271Error;
 
 #[derive(Debug, Error)]
 pub enum ProcessingError {
-    #[error("Processing failed with irrecoverable error: {0}")]
+    #[error("Processing failed with irrecoverable error: {0:#}")]
     Irrecoverable(anyhow::Error),
-    #[error("Processing failed: {0}")]
+    #[error("Processing failed: {0:#}")]
     Recoverable(anyhow::Error),
     #[error("Processing stopped: the operation was aborted on the KMS Core")]
     Aborted,
@@ -112,6 +112,18 @@ impl RequestCheckError {
             kind: RequestCheckKind::Network,
             source: ProcessingError::Recoverable(err.into()),
         }
+    }
+
+    /// Wraps the inner error with additional context.
+    pub fn context(mut self, ctx: String) -> Self {
+        self.source = match self.source {
+            ProcessingError::Irrecoverable(e) => ProcessingError::Irrecoverable(e.context(ctx)),
+            ProcessingError::Recoverable(e) => ProcessingError::Recoverable(e.context(ctx)),
+            // `Aborted` has no inner error (inferred from gRPC status returned by the KMS Core),
+            // so the context is dropped for now.
+            ProcessingError::Aborted => ProcessingError::Aborted,
+        };
+        self
     }
 
     /// Records the error in [`REQUEST_CHECK_ERRORS`] and unwraps it into a [`ProcessingError`].

--- a/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/mod.rs
@@ -6,6 +6,7 @@ mod kms;
 mod kms_client;
 mod processor;
 mod protocol_config;
+mod rpc;
 
 pub use ciphertext::CiphertextManager;
 pub use context::{ContextManager, DbContextManager};
@@ -15,3 +16,4 @@ pub use kms::KMSGenerationProcessor;
 pub use kms_client::{KmsClient, KmsPollTarget};
 pub use processor::{DbEventProcessor, EventProcessor};
 pub use protocol_config::{ProtocolConfigProcessor, compute_anchor_event_hash};
+pub use rpc::HostRpcClient;

--- a/kms-connector/crates/kms-worker/src/core/event_processor/rpc.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/rpc.rs
@@ -1,0 +1,95 @@
+use crate::core::event_processor::RequestCheckError;
+use alloy::{
+    primitives::{Address, B256, U256},
+    providers::Provider,
+};
+use fhevm_host_bindings::acl::ACL::ACLInstance;
+
+/// A client for one host chain's RPC node, tagged with its chain id so every error it produces
+/// carries the host chain identity.
+#[derive(Clone)]
+pub struct HostRpcClient<P> {
+    chain_id: u64,
+    acl_contract: ACLInstance<P>,
+}
+
+impl<P: Provider> HostRpcClient<P> {
+    pub fn new(chain_id: u64, acl_contract: ACLInstance<P>) -> Self {
+        Self {
+            chain_id,
+            acl_contract,
+        }
+    }
+
+    pub async fn is_allowed_for_decryption(&self, handle: B256) -> Result<bool, RequestCheckError> {
+        self.acl_contract
+            .isAllowedForDecryption(handle)
+            .call()
+            .await
+            .map_err(|e| self.acl_err(e))
+    }
+
+    pub async fn is_allowed(
+        &self,
+        handle: B256,
+        account: Address,
+    ) -> Result<bool, RequestCheckError> {
+        self.acl_contract
+            .isAllowed(handle, account)
+            .call()
+            .await
+            .map_err(|e| self.acl_err(e))
+    }
+
+    pub async fn is_handle_delegated_for_user_decryption(
+        &self,
+        delegator: Address,
+        delegate: Address,
+        contract: Address,
+        handle: B256,
+    ) -> Result<bool, RequestCheckError> {
+        self.acl_contract
+            .isHandleDelegatedForUserDecryption(delegator, delegate, contract, handle)
+            .call()
+            .await
+            .map_err(|e| self.acl_err(e))
+    }
+
+    pub async fn decryption_signature_invalidated_before(
+        &self,
+        account: Address,
+    ) -> Result<U256, RequestCheckError> {
+        self.acl_contract
+            .decryptionSignatureInvalidatedBefore(account)
+            .call()
+            .await
+            .map_err(|e| self.acl_err(e))
+    }
+
+    /// RFC-012 EIP-712/ERC-1271 signature verification, on this host chain.
+    pub async fn verify_signature(
+        &self,
+        claimed_signer: Address,
+        digest: B256,
+        signature: &[u8],
+        gas_limit: u64,
+    ) -> Result<(), RequestCheckError> {
+        user_decryption_signature::verify_signature(
+            self.acl_contract.provider(),
+            claimed_signer,
+            digest,
+            signature,
+            gas_limit,
+        )
+        .await
+        .map_err(|e| RequestCheckError::from(e).context(format!("on host chain {}", self.chain_id)))
+    }
+
+    fn acl_err(&self, e: impl Into<anyhow::Error>) -> RequestCheckError {
+        RequestCheckError::network(e).context(format!(
+            "on host chain {} (ACL contract {})",
+            self.chain_id,
+            self.acl_contract.address()
+        ))
+    }
+}

--- a/kms-connector/crates/kms-worker/src/core/kms_worker.rs
+++ b/kms-connector/crates/kms-worker/src/core/kms_worker.rs
@@ -5,7 +5,8 @@ use crate::{
         event_picker::{DbEventPicker, EventPicker},
         event_processor::{
             CiphertextManager, DbContextManager, DbEventProcessor, DecryptionProcessor,
-            EventProcessor, KMSGenerationProcessor, KmsClient, ProtocolConfigProcessor,
+            EventProcessor, HostRpcClient, KMSGenerationProcessor, KmsClient,
+            ProtocolConfigProcessor,
         },
         kms_response_publisher::DbKmsResponsePublisher,
     },
@@ -132,7 +133,7 @@ impl
         let ethereum_provider =
             connect_to_rpc_node(config.ethereum_url.clone(), config.ethereum_chain_id).await?;
 
-        let mut acl_contracts = HashMap::new();
+        let mut host_clients = HashMap::new();
         for host_chain in &config.host_chains {
             let provider = connect_to_rpc_node_with_bounds(
                 host_chain.url.clone(),
@@ -143,7 +144,8 @@ impl
             .await?;
             let acl_contract = ACL::new(host_chain.acl_address, provider);
             let host_chain_id = host_chain.chain_id;
-            if acl_contracts.insert(host_chain_id, acl_contract).is_some() {
+            let host_client = HostRpcClient::new(host_chain_id, acl_contract);
+            if host_clients.insert(host_chain_id, host_client).is_some() {
                 return Err(anyhow!(
                     "Duplicate host chain in config for chain ID {host_chain_id}"
                 ));
@@ -162,7 +164,7 @@ impl
         let decryption_processor = DecryptionProcessor::new(
             &config,
             gateway_provider.clone(),
-            acl_contracts,
+            host_clients,
             ciphertext_manager,
         );
         let kms_generation_processor = KMSGenerationProcessor::new(&config);

--- a/kms-connector/crates/kms-worker/tests/common/mod.rs
+++ b/kms-connector/crates/kms-worker/tests/common/mod.rs
@@ -19,7 +19,7 @@ use fhevm_host_bindings::acl::ACL::ACLInstance;
 use kms_worker::core::{
     Config, DbEventPicker, DbKmsResponsePublisher, KmsWorker,
     event_processor::{
-        CiphertextManager, DbContextManager, DbEventProcessor, DecryptionProcessor,
+        CiphertextManager, DbContextManager, DbEventProcessor, DecryptionProcessor, HostRpcClient,
         KMSGenerationProcessor, KmsClient, ProtocolConfigProcessor,
     },
 };
@@ -58,12 +58,12 @@ where
     let event_picker = DbEventPicker::connect(db.clone(), &config).await?;
 
     let context_manager = DbContextManager::new(db.clone(), &config, provider.clone());
-    let decryption_processor = DecryptionProcessor::new(
-        &config,
-        provider.clone(),
-        acl_contracts_mock,
-        ciphertext_manager,
-    );
+    let host_clients = acl_contracts_mock
+        .into_iter()
+        .map(|(chain_id, acl)| (chain_id, HostRpcClient::new(chain_id, acl)))
+        .collect();
+    let decryption_processor =
+        DecryptionProcessor::new(&config, provider.clone(), host_clients, ciphertext_manager);
     let kms_generation_processor = KMSGenerationProcessor::new(&config);
     let protocol_config_processor = ProtocolConfigProcessor::new(&config, provider.clone());
     let event_processor = DbEventProcessor::new(


### PR DESCRIPTION
### Motivation

When the KMS Connector is configured with multiple host chains, RPC call errors did not indicate which chain the failing node belongs to, making them hard to investigate.

### Changes

- Introduce a `HostRpcClient` wrapper (new `rpc.rs` module) around each host chain's `ACLInstance`, tagged with its chain ID. All host-chain RPC calls of the `DecryptionProcessor` (ACL checks and ERC-1271 signature verification) now go through it.
- Errors are wrapped with `on host chain {chain_id}` + ACL contract address when relevant.
- Add a generic `RequestCheckError::context` method to attach this context to the inner error.
- Rename the `DecryptionProcessor`'s `acl_contracts` field to `host_clients` accordingly.
