### PR TITLE
chore(sdk): dedupe base64 WASM payloads across cjs/esm builds and trim npm package weight

### DIFF
--- a/sdk/js-sdk/scripts/build/build-cjs-wasm.mjs
+++ b/sdk/js-sdk/scripts/build/build-cjs-wasm.mjs
@@ -12,6 +12,7 @@ import {
   createWasmBuildContext,
   generatedWasmLoaderRels,
   generatedWasmRels,
+  isWasmBase64DataRel,
   logWasmBuildSummary,
   removeUnexpectedTscJsOutputs,
   writeGeneratedWasmArtifacts,
@@ -41,21 +42,33 @@ cleanWasmDest(context);
 
 ////////////////////////////////////////////////////////////////////////////////
 // 1. ESM → CJS for allowed runtime JS files.
+//
+//    Auto-generated base64 WASM payloads are transpiled without a sourcemap:
+//    they're giant data-only files with no logic to step through, and the
+//    sourcemap would otherwise roughly double their published size.
 ////////////////////////////////////////////////////////////////////////////////
 
-await build({
-  entryPoints: [...transpileSet],
+const base64DataEntryPoints = [...transpileSet].filter((f) => isWasmBase64DataRel(context.sourceRel(f)));
+const codeEntryPoints = [...transpileSet].filter((f) => !isWasmBase64DataRel(context.sourceRel(f)));
+
+const sharedBuildOptions = {
   outdir: context.dest,
   outbase: WASM_SRC,
   format: 'cjs',
   platform: 'node',
   bundle: false,
-  sourcemap: 'linked',
   logLevel: 'info',
   // wasmBaseUrl.js intentionally uses import.meta.url with a CJS fallback;
   // suppress the warning since the empty-object case is already handled.
   logOverride: { 'empty-import-meta': 'silent' },
-});
+};
+
+if (codeEntryPoints.length > 0) {
+  await build({ ...sharedBuildOptions, entryPoints: codeEntryPoints, sourcemap: 'linked' });
+}
+if (base64DataEntryPoints.length > 0) {
+  await build({ ...sharedBuildOptions, entryPoints: base64DataEntryPoints, sourcemap: false });
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // 2. Copy everything else verbatim. Skips the generated sources — we regenerate

--- a/sdk/js-sdk/scripts/build/wasm-build-common.mjs
+++ b/sdk/js-sdk/scripts/build/wasm-build-common.mjs
@@ -200,6 +200,14 @@ export function logWasmBuildSummary(context) {
   console.log(`[${context.scriptName}]   KMS versions:  ${context.kmsVersions.join(', ') || '(none)'}`);
 }
 
+// Auto-generated base64-encoded WASM payloads (e.g. tfhe_bg.wasm.base64.js,
+// kms_lib_bg.wasm.base64.js). These are giant data-only files with no logic to
+// step through, so a sourcemap for them is pure dead weight in the published
+// package.
+export function isWasmBase64DataRel(rel) {
+  return /_bg\.wasm\.base64\.js$/.test(rel);
+}
+
 export function walk(dir, out = []) {
   for (const e of readdirSync(dir)) {
     const p = join(dir, e);

--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -14,7 +14,8 @@
     "!**/*.template",
     "!**/*.tsbuildinfo",
     "!vitest.config.ts",
-    "!tsconfig.json"
+    "!tsconfig.json",
+    "!wasm/tfhe/*-dev/**"
   ],
   "exports": {
     ".": {

--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -15,7 +15,8 @@
     "!**/*.tsbuildinfo",
     "!vitest.config.ts",
     "!tsconfig.json",
-    "!wasm/tfhe/*-dev/**"
+    "!wasm/tfhe/v*/**",
+    "!wasm/tkms/v*/**"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- The multi-MB base64-encoded WASM payloads (`tfhe_bg.wasm.base64.js`, `kms_lib_bg.wasm.base64.js`) were being duplicated once per build target (`src/_cjs/wasm`, `src/_esm/wasm`) even though they're byte-identical regardless of module format. Both output trees now dynamic-import the single checked-in copy under `src/wasm/<lib>/v<version>/` instead of carrying their own copy — `codegen-loaders.mjs` gains a `wasmBase64DirPrefix` option so the generated loader can point at a shared relative path, and `wasm-build-common.mjs`/`build-cjs-wasm.mjs` exclude these files from the per-target copy/transpile accordingly.
- Sourcemaps are dropped for these payloads in the CJS build (they're data-only, so a sourcemap just doubles their published size) while linked sourcemaps are kept for actual code.
- `src/package.json`'s `files` glob now excludes `wasm/tfhe/v*/**` and `wasm/tkms/v*/**` wholesale, then re-includes just the shared base64 payload per version — and excludes it again for `*-dev` versions, since npm's `files` glob can't read `versionsManifest.js`'s `tags` at pack time to know which versions are dev-only.
