### PR TITLE
fix(coprocessor): fence remaining write paths behind the cutover lock

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/telemetry.rs
@@ -373,7 +373,24 @@ impl TransactionMetrics {
             return Ok(None);
         }
 
-        let mut trx = pool.begin().await?;
+        // Writes `transactions.completed_at`, which cutover treats as
+        // duplicated-for-isolation, so the transaction is fenced like every other write:
+        // shared cutover lock, and no writes from a retired stack. `gcs_mode` is `false`
+        // because with `Continue` it cannot change the outcome — a green binary is newer than
+        // the live version, so the retirement check passes trivially.
+        //
+        // A blocked guard is not an error here: this is latency bookkeeping, so it returns
+        // "no measurement" rather than failing the caller.
+        let Some(mut trx) = crate::versioning::begin_write_guarded(
+            pool,
+            false,
+            crate::versioning::GcsRollbackPolicy::Continue,
+        )
+        .await?
+        .into_tx() else {
+            debug!("Cutover completed — skipping transaction latency write on retired stack");
+            return Ok(None);
+        };
 
         // Lock the row to prevent duplicated histogram.observe calls
         let existing = sqlx::query!(

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -294,7 +294,7 @@ async fn assert_not_retired(conn: &mut PgConnection) -> Result<(), sqlx::Error> 
 /// stale binary can neither read nor write through it.
 ///
 /// Cost: one extra round-trip per transaction (a single indexed singleton read).
-pub async fn begin_guarded_pool(
+pub(crate) async fn begin_guarded_pool(
     pool: &Pool<Postgres>,
 ) -> Result<Transaction<'static, Postgres>, sqlx::Error> {
     let mut tx = pool.begin().await?;
@@ -303,7 +303,7 @@ pub async fn begin_guarded_pool(
 }
 
 /// Like [`begin_guarded_pool`] but begins on an already-acquired connection.
-pub async fn begin_guarded_conn(
+pub(crate) async fn begin_guarded_conn(
     conn: &mut PgConnection,
 ) -> Result<Transaction<'_, Postgres>, sqlx::Error> {
     let mut tx = conn.begin().await?;

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -18,7 +18,6 @@ use fhevm_engine_common::utils::{to_hex, HeartBeat};
 use prometheus::{register_int_counter_vec, IntCounterVec};
 use sqlx::postgres::PgConnectOptions;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::Acquire;
 use sqlx::Error as SqlxError;
 use sqlx::{PgPool, Postgres};
 use std::collections::HashSet;
@@ -236,7 +235,22 @@ impl Database {
     ) -> Result<u64, SqlxError> {
         let lock_key = slow_lane_reset_advisory_lock_key(self.chain_id);
         let mut connection = self.pool().await.acquire().await?;
-        let mut tx = connection.begin().await?;
+        // Fenced like every other write on this struct (see `new_transaction`): takes the
+        // shared cutover lock and stops on a retired stack. This already held its own
+        // `pg_try_advisory_xact_lock` for the slow-lane reset; that key is unrelated to the
+        // cutover key, so the two coexist.
+        let Some(mut tx) =
+            fhevm_engine_common::versioning::begin_write_guarded_conn(
+                &mut connection,
+                self.gcs_mode,
+                fhevm_engine_common::versioning::GcsRollbackPolicy::Continue,
+            )
+            .await?
+            .into_tx()
+        else {
+            info!("Cutover completed — skipping slow-lane promotion on retired stack");
+            return Ok(0);
+        };
         let lock_acquired = sqlx::query_scalar!(
             r#"SELECT pg_try_advisory_xact_lock($1) AS "lock_acquired!""#,
             lock_key

--- a/coprocessor/fhevm-engine/host-listener/src/kms_generation/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/kms_generation/mod.rs
@@ -2,6 +2,9 @@ use alloy::primitives::Uint;
 use alloy::rpc::types::Log;
 use anyhow::anyhow;
 use fhevm_engine_common::chain_id::ChainId;
+use fhevm_engine_common::versioning::{
+    begin_write_guarded, GcsRollbackPolicy, WriteGuard,
+};
 use sqlx::{Pool, Postgres, Transaction};
 use tracing::{error, info, warn};
 
@@ -153,8 +156,26 @@ pub async fn process_kms_generation_activations<
     db_pool: Pool<Postgres>,
     s3_client: A,
 ) -> anyhow::Result<u64> {
-    //first we handle every thing that is ready to be cancelled or activated
-    let mut tx = db_pool.begin().await?;
+    // These write `kms_key_activation_events` / `kms_crs_activation_events`, which cutover
+    // treats as duplicated-for-isolation, so the transaction has to be fenced: it takes the
+    // shared cutover lock and refuses to run on a retired stack. `gcs_mode` is `false`
+    // because with `Continue` it cannot change the outcome — a green binary is newer than the
+    // live version, so the retirement check passes trivially.
+    let mut tx = match begin_write_guarded(
+        &db_pool,
+        false,
+        GcsRollbackPolicy::Continue,
+    )
+    .await?
+    {
+        WriteGuard::Proceed(tx) => tx,
+        WriteGuard::Stop | WriteGuard::Skip => {
+            info!(
+                    "Cutover completed — skipping KMSGeneration activations on retired stack"
+                );
+            return Ok(0);
+        }
+    };
     cancel_orphaned_key_activations(&mut tx).await?;
     cancel_orphaned_crs_activations(&mut tx).await?;
     activate_ready_key_activations(&mut tx).await?;
@@ -163,7 +184,24 @@ pub async fn process_kms_generation_activations<
 
     // second we download and check keys and preprocess in background in advance so it's ready when block is finalized
     // rows are locked so there's no double work
-    let mut tx = db_pool.begin().await?;
+    //
+    // NOTE: this transaction stays open across the S3 key/CRS downloads below, so the shared
+    // cutover lock is held for as long as those take. `execute_cutover` takes the same lock
+    // exclusively and every guarded write in the fleet queues behind it, so a slow download
+    // delays cutover.
+    let mut tx = match begin_write_guarded(
+        &db_pool,
+        false,
+        GcsRollbackPolicy::Continue,
+    )
+    .await?
+    {
+        WriteGuard::Proceed(tx) => tx,
+        WriteGuard::Stop | WriteGuard::Skip => {
+            info!("Cutover completed — skipping KMSGeneration downloads on retired stack");
+            return Ok(0);
+        }
+    };
     let key_activations =
         all_pending_key_activations_to_download(&mut tx).await?;
     let crs_activations =

--- a/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
+++ b/coprocessor/fhevm-engine/sns-worker/src/aws_upload.rs
@@ -22,6 +22,7 @@ use fhevm_engine_common::pg_pool::{is_fatal_connection_error, PostgresPoolManage
 use fhevm_engine_common::telemetry;
 use fhevm_engine_common::types::CoproSigner;
 use fhevm_engine_common::utils::to_hex;
+use fhevm_engine_common::versioning::{begin_write_guarded, GcsRollbackPolicy, WriteGuard};
 use futures::future::join_all;
 use opentelemetry::trace::{Status, TraceContextExt};
 use sha2::Sha256;
@@ -124,7 +125,31 @@ async fn run_uploader_loop(
                     continue;
                 }
 
-                let mut trx = fhevm_engine_common::versioning::begin_guarded_pool(&pool).await?;
+                // This is a write transaction (it enqueues the upload task and records the
+                // digests), so it must take the shared cutover lock, not just the BEGIN-time
+                // retirement check that `begin_guarded_pool` does. Without the lock a stale
+                // write could commit after cutover retired this stack, and the lock order
+                // here (digest rows, then the mirror trigger's stripe lock) is the reverse of
+                // cutover's, which could deadlock.
+                //
+                // NOTE: the transaction stays open across the S3 upload, so the shared lock
+                // is held for a network round trip and cutover waits on it.
+                let mut trx =
+                    match begin_write_guarded(&pool, false, GcsRollbackPolicy::Continue).await? {
+                        WriteGuard::Proceed(trx) => trx,
+                        WriteGuard::Stop | WriteGuard::Skip => {
+                            info!(
+                                "Cutover completed — draining in-flight uploads, then stopping \
+                                 the uploader"
+                            );
+                            while let Some(joined) = ongoing_upload_tasks.join_next().await {
+                                if let Err(err) = propagate_joined_upload_error(joined) {
+                                    error!(error = %err, "Upload task failed while stopping");
+                                }
+                            }
+                            return Ok(());
+                        }
+                    };
 
                 // Normal jobs defer their enqueue into the spawned task: the
                 // provenance witness takes FOR KEY SHARE on the pbs row,


### PR DESCRIPTION
Five write transactions started with `begin_guarded_pool` or a raw `pool.begin()`, so they took no shared cutover lock. They could commit after `execute_cutover` retired the stack, and the SnS one could deadlock against cutover's digest merge (digest row lock then stripe lock, the reverse of cutover's order).

Now all take `begin_write_guarded` and stop on a retired stack:

- `sns-worker` S3 upload path
- `host-listener` KMS key/CRS activations and downloads
- `host-listener` slow-lane dependence-chain promotion
- `fhevm-engine-common` telemetry `end_transaction`