### PR TITLE
fix(test-suite): make the ERC-1271 Safe suite viable on Sepolia

### DIFF
--- a/test-suite/e2e/test/erc1271UserDecryption/erc1271SdkClientGap.ts
+++ b/test-suite/e2e/test/erc1271UserDecryption/erc1271SdkClientGap.ts
@@ -12,7 +12,7 @@ import {
   buildSafeMultisigSignature,
   collectSafeOwnerParts,
   deploySafeAccount,
-  deploySafeInfra,
+  resolveSafeInfra,
 } from './safe';
 
 // End-to-end coverage of `@fhevm/sdk` ERC-1271 (smart-contract-wallet) support
@@ -115,7 +115,7 @@ describe('ERC-1271 user decryption via the SDK client', function () {
     // A real Safe v1.4.1 2-of-3 proxy (owners bob/carol/dave; canonical
     // prebuilt artifacts) and a Safe-style approveHash mock wallet (owner
     // bob) — the userAddress targets of the tests.
-    const infra = await deploySafeInfra(signers.alice);
+    const infra = await resolveSafeInfra(signers.alice);
     safeAccount = await deploySafeAccount(
       infra,
       signers.alice,

--- a/test-suite/e2e/test/erc1271UserDecryption/erc1271UserDecryption.ts
+++ b/test-suite/e2e/test/erc1271UserDecryption/erc1271UserDecryption.ts
@@ -10,6 +10,7 @@ import {
   UserDecrypt,
 } from '../../types';
 import { createInstances, relayerApiKey, relayerUrl, verifyingContractAddressDecryption } from '../instance';
+import { isLiveNetwork } from '../network';
 import type { UnifiedConfig, UnifiedDecryptRequest } from '../sdk/unified/unifiedUserDecrypt';
 import {
   backdatedStartTimestamp,
@@ -32,7 +33,7 @@ import {
   buildSafeNestedMultisigSignature,
   collectSafeOwnerParts,
   deploySafeAccount,
-  deploySafeInfra,
+  resolveSafeInfra,
   safeApprovedHashPart,
   safeEthSignPart,
 } from './safe';
@@ -44,8 +45,24 @@ const KNOWN_VALUE = 123456789n;
 const DURATION_SECONDS = 7 * 24 * 60 * 60;
 // Generous window for a full user-decrypt round trip through the KMS.
 const POSITIVE_TIMEOUT_MS = 3 * 60 * 1000;
+
+/**
+ * On a local devnet a deployment lands in the next instant block; on a live
+ * network every fixture costs real block time (~12s on Sepolia) and real gas.
+ * Fixtures are provisioned LAZILY (see `lazy` below), so this budget is the
+ * per-test allowance for whatever that test's first use has to deploy, not a
+ * whole-suite up-front cost.
+ */
+const LIVE_NETWORK = isLiveNetwork();
+const FIXTURE_BUDGET_MS = LIVE_NETWORK ? 5 * 60 * 1000 : 30 * 1000;
 // Mocha timeout margin on top of the poll window (pre-poll on-chain reads + POST).
-const TIMEOUT_MARGIN_MS = 60 * 1000;
+const TIMEOUT_MARGIN_MS = 60 * 1000 + FIXTURE_BUDGET_MS;
+
+/** Deploy-on-first-use, then reuse: a `--grep`ped run only pays for the fixtures it touches. */
+const lazy = <T>(create: () => Promise<T>): (() => Promise<T>) => {
+  let pending: Promise<T> | undefined;
+  return () => (pending ??= create());
+};
 
 /**
  * ERC-1271 support for smart-account signature verification.
@@ -60,6 +77,10 @@ const TIMEOUT_MARGIN_MS = 60 * 1000;
  * the EOA fast-path positive does assert it.
  */
 describe('ERC-1271 user decryption', function () {
+  // Every test can be the one that provisions its fixture, so the suite-wide
+  // default has to cover a deployment; positives raise it further below.
+  this.timeout(TIMEOUT_MARGIN_MS);
+
   let signers: Signers;
   let instances: FhevmInstances;
   let cfg: UnifiedConfig;
@@ -73,16 +94,18 @@ describe('ERC-1271 user decryption', function () {
   let approveWalletAddress: string;
   let rejectWallet: ERC1271RejectWallet;
   let rejectWalletAddress: string;
-  let safe2of3: SafeFixture;
-  let safe3of3: SafeFixture;
-  let safe1of1: SafeFixture;
-  let safeNoHandler: SafeFixture;
+  // Safe fixtures are lazy thunks, not values: nothing below is deployed until
+  // a test awaits it, and each deploys at most once per run.
+  let safe2of3: () => Promise<SafeFixture>;
+  let safe3of3: () => Promise<SafeFixture>;
+  let safe1of1: () => Promise<SafeFixture>;
+  let safeNoHandler: () => Promise<SafeFixture>;
   // Nested v=0 contract-signature fixtures: outer 2-of-3 Safes whose first
   // owner is itself a Safe (1-of-1 dave, and 2-of-3 bob/dave/eve).
-  let innerSafe1of1: SafeAccount;
-  let innerSafe2of3: SafeAccount;
-  let nestedOuter1of1: SafeFixture;
-  let nestedOuter2of3: SafeFixture;
+  let innerSafe1of1: () => Promise<SafeAccount>;
+  let innerSafe2of3: () => Promise<SafeAccount>;
+  let nestedOuter1of1: () => Promise<SafeFixture>;
+  let nestedOuter2of3: () => Promise<SafeFixture>;
 
   /**
    * A real Safe holds no encrypted state (and has no FHE coprocessor config),
@@ -97,7 +120,8 @@ describe('ERC-1271 user decryption', function () {
   }
 
   before(async function () {
-    this.timeout(180_000);
+    // Only the four mock wallets deploy here; the Safe matrix is lazy.
+    this.timeout(LIVE_NETWORK ? 10 * 60 * 1000 : 180_000);
     // 5, not 3: the multisig tests use dave (owner) and eve (non-owner), and
     // sibling suites that touch dave/eve all pass 5. The count only limits
     // funding under HARDHAT_PARALLEL (signers.ts funds all 5 otherwise), and
@@ -139,43 +163,54 @@ describe('ERC-1271 user decryption', function () {
     rejectWalletAddress = await rejectWallet.getAddress();
     await (await rejectWallet.connect(signers.alice).initValue(KNOWN_VALUE)).wait();
 
-    // Real Safe v1.4.1 multisig wallets, deployed from the canonical prebuilt
-    // artifacts (singleton + fallback handler + proxy factory, then one proxy
-    // per threshold). Owners bob/carol/dave only ever sign SafeMessage typed
+    // Real Safe v1.4.1 multisig wallets, from the canonical prebuilt artifacts
+    // (singleton + fallback handler + proxy factory, then one proxy per
+    // configuration). Owners bob/carol/dave only ever sign SafeMessage typed
     // data offline — they pay no gas (except the approveHash positive, where
     // bob sends the approval tx).
-    const infra = await deploySafeInfra(signers.alice);
+    //
+    // Everything here is wired as a lazy thunk: the full matrix is ~23
+    // transactions, which is free against instant local blocks but minutes of
+    // real block time on a live network. Deferring means a run only pays for
+    // the fixtures its selected tests actually reach.
     const multisigOwners = [signers.bob.address, signers.carol.address, signers.dave.address];
-    const holderFactory = await ethers.getContractFactory('EncryptedValueHolder');
+    const infra = lazy(() => resolveSafeInfra(signers.alice));
     const deploySafeFixture = async (
       owners: readonly string[],
       threshold: number,
       opts?: { readonly fallbackHandler?: string },
     ): Promise<SafeFixture> => {
-      const safe = await deploySafeAccount(infra, signers.alice, owners, threshold, opts);
+      const safe = await deploySafeAccount(await infra(), signers.alice, owners, threshold, opts);
+      const holderFactory = await ethers.getContractFactory('EncryptedValueHolder');
       const holder = await holderFactory.connect(signers.alice).deploy();
       await holder.waitForDeployment();
       const holderAddress = await holder.getAddress();
       await (await holder.connect(signers.alice).initValueFor(KNOWN_VALUE, safe.address)).wait();
       return { safe, holder, holderAddress };
     };
-    safe2of3 = await deploySafeFixture(multisigOwners, 2);
-    safe3of3 = await deploySafeFixture(multisigOwners, 3);
-    safe1of1 = await deploySafeFixture([signers.dave.address], 1);
+    safe2of3 = lazy(() => deploySafeFixture(multisigOwners, 2));
+    safe3of3 = lazy(() => deploySafeFixture(multisigOwners, 3));
+    safe1of1 = lazy(() => deploySafeFixture([signers.dave.address], 1));
     // A Safe set up WITHOUT the fallback handler: it has code, but no
     // `isValidSignature` to dispatch to (see ./safe.ts).
-    safeNoHandler = await deploySafeFixture(multisigOwners, 2, { fallbackHandler: ethers.ZeroAddress });
+    safeNoHandler = lazy(() => deploySafeFixture(multisigOwners, 2, { fallbackHandler: ethers.ZeroAddress }));
 
     // Inner Safes acting as CONTRACT owners of outer Safes (v=0 parts).
-    innerSafe1of1 = await deploySafeAccount(infra, signers.alice, [signers.dave.address], 1);
-    innerSafe2of3 = await deploySafeAccount(
-      infra,
-      signers.alice,
-      [signers.bob.address, signers.dave.address, signers.eve.address],
-      2,
+    innerSafe1of1 = lazy(async () => deploySafeAccount(await infra(), signers.alice, [signers.dave.address], 1));
+    innerSafe2of3 = lazy(async () =>
+      deploySafeAccount(
+        await infra(),
+        signers.alice,
+        [signers.bob.address, signers.dave.address, signers.eve.address],
+        2,
+      ),
     );
-    nestedOuter1of1 = await deploySafeFixture([innerSafe1of1.address, signers.bob.address, signers.carol.address], 2);
-    nestedOuter2of3 = await deploySafeFixture([innerSafe2of3.address, signers.bob.address, signers.carol.address], 2);
+    nestedOuter1of1 = lazy(async () =>
+      deploySafeFixture([(await innerSafe1of1()).address, signers.bob.address, signers.carol.address], 2),
+    );
+    nestedOuter2of3 = lazy(async () =>
+      deploySafeFixture([(await innerSafe2of3()).address, signers.bob.address, signers.carol.address], 2),
+    );
 
     publicKey = (await instances.alice.generateKeypair()).publicKey;
   });
@@ -389,9 +424,9 @@ describe('ERC-1271 user decryption', function () {
   // 65-byte {r,s,v} owner parts sorted strictly ascending by signer address.
   // The blob is longer than a single ECDSA signature, so `ecrecover` on it is
   // impossible — every layer must forward it opaquely to the Safe's
-  // `isValidSignature`. Unlike the retired mock, a real Safe REVERTS on a bad
-  // blob (GS020/GS025/GS026) instead of returning a non-magic value; either
-  // way the relayer's pre-check rejects synchronously (400), and the KMS
+  // `isValidSignature`. A real Safe REVERTS on a bad blob (GS020/GS025/GS026)
+  // rather than returning a non-magic value; either way the relayer's
+  // pre-check rejects synchronously (400), and the KMS
   // Connector runs the same shared verifier again before the KMS produces
   // shares. Owners sign the SafeMessage EIP-712 wrap of the unified digest,
   // never the digest itself (see ./safe.ts).
@@ -406,7 +441,8 @@ describe('ERC-1271 user decryption', function () {
    * The handle lives on the fixture's holder contract; the Safe is only the
    * `userAddress` (a real Safe cannot hold encrypted state itself).
    */
-  async function freshMultisigRequest(fixture: SafeFixture): Promise<UnifiedDecryptRequest> {
+  async function freshMultisigRequest(provision: () => Promise<SafeFixture>): Promise<UnifiedDecryptRequest> {
+    const fixture = await provision();
     const handle = await fixture.holder.value();
     const freshKey = (await instances.alice.generateKeypair()).publicKey;
     return {
@@ -421,11 +457,12 @@ describe('ERC-1271 user decryption', function () {
 
   /** Safe-multisig blob over the unified EIP-712 digest of `req`. */
   async function multisigSignature(
-    fixture: SafeFixture,
+    provision: () => Promise<SafeFixture>,
     req: UnifiedDecryptRequest,
     owners: readonly Signer[],
     opts?: { readonly order?: 'ascending' | 'descending'; readonly trailingHex?: string },
   ): Promise<string> {
+    const fixture = await provision();
     return buildSafeMultisigSignature(fixture.safe, computeUnifiedDigest(cfg, req), owners, opts);
   }
 
@@ -570,8 +607,9 @@ describe('ERC-1271 user decryption', function () {
     // targets the SafeMessage hash of the digest, not the digest itself);
     // carol signs normally. The blob mixes a v=1 part (r = bob's address)
     // with a plain ECDSA part — a realistic Safe part-type combination.
-    await approveSafeHash(safe2of3.safe, signers.bob, digest);
-    const [carolPart] = await collectSafeOwnerParts(safe2of3.safe, digest, [signers.carol]);
+    const fixture = await safe2of3();
+    await approveSafeHash(fixture.safe, signers.bob, digest);
+    const [carolPart] = await collectSafeOwnerParts(fixture.safe, digest, [signers.carol]);
     const signature = concatSignatureParts(sortSignatureParts([safeApprovedHashPart(signers.bob.address), carolPart]));
     const { post, poll } = await requestUnifiedUserDecrypt(
       cfg,
@@ -592,7 +630,7 @@ describe('ERC-1271 user decryption', function () {
     // RAW digest; only a real Safe pins the SafeMessage-hash rule.) Note the
     // v=1 part carries no signature at all — nothing here is forgeable, which
     // is exactly why the on-chain approval must be the thing that gates it.
-    const [carolPart] = await collectSafeOwnerParts(safe2of3.safe, digest, [signers.carol]);
+    const [carolPart] = await collectSafeOwnerParts((await safe2of3()).safe, digest, [signers.carol]);
     const signature = concatSignatureParts(sortSignatureParts([safeApprovedHashPart(signers.bob.address), carolPart]));
     const { post } = await submitUnifiedRequest(cfg, req, { kind: 'raw', signature });
     expect(isSignatureRejection(post), JSON.stringify(post.raw)).to.equal(true);
@@ -604,9 +642,10 @@ describe('ERC-1271 user decryption', function () {
     const digest = computeUnifiedDigest(cfg, req);
     // Safe's eth_sign encoding: owners personal_sign the SafeMessage hash of
     // the digest and the part stores v+4 (31/32) as the type selector.
+    const { safe } = await safe2of3();
     const parts = sortSignatureParts([
-      await safeEthSignPart(safe2of3.safe, digest, signers.bob),
-      await safeEthSignPart(safe2of3.safe, digest, signers.carol),
+      await safeEthSignPart(safe, digest, signers.bob),
+      await safeEthSignPart(safe, digest, signers.carol),
     ]);
     const signature = concatSignatureParts(parts);
     const { post, poll } = await requestUnifiedUserDecrypt(
@@ -628,9 +667,9 @@ describe('ERC-1271 user decryption', function () {
     // plain ECDSA part. 227 bytes: 130 static + 32-byte length + 65 inner.
     // Measured ~83k gas incl. intrinsic vs the 100k erc1271_gas_limit.
     const signature = await buildSafeNestedMultisigSignature(
-      nestedOuter1of1.safe,
+      (await nestedOuter1of1()).safe,
       digest,
-      { safe: innerSafe1of1, owners: [signers.dave] },
+      { safe: await innerSafe1of1(), owners: [signers.dave] },
       [signers.bob],
     );
     expect(signature.length).to.equal(2 + 227 * 2);
@@ -660,9 +699,9 @@ describe('ERC-1271 user decryption', function () {
     // (relayer/src/host/signature_prechecker.rs:130-157), while the connector
     // treats the same class as recoverable and retries until it gives up.
     const signature = await buildSafeNestedMultisigSignature(
-      nestedOuter2of3.safe,
+      (await nestedOuter2of3()).safe,
       digest,
-      { safe: innerSafe2of3, owners: [signers.bob, signers.dave] },
+      { safe: await innerSafe2of3(), owners: [signers.bob, signers.dave] },
       [signers.bob],
     );
     expect(signature.length).to.equal(2 + 292 * 2);
@@ -683,9 +722,9 @@ describe('ERC-1271 user decryption', function () {
     // the nested isValidSignature reverts (inner GS026), which bubbles up
     // through the outer checkSignatures.
     const signature = await buildSafeNestedMultisigSignature(
-      nestedOuter1of1.safe,
+      (await nestedOuter1of1()).safe,
       digest,
-      { safe: innerSafe1of1, owners: [signers.eve] },
+      { safe: await innerSafe1of1(), owners: [signers.eve] },
       [signers.bob],
     );
     const { post } = await submitUnifiedRequest(cfg, req, { kind: 'raw', signature });
@@ -698,9 +737,9 @@ describe('ERC-1271 user decryption', function () {
     // Offset 65 points INSIDE the 130-byte static section — Safe's dynamic
     // bounds checks (GS021) revert before any nested call happens.
     const signature = await buildSafeNestedMultisigSignature(
-      nestedOuter1of1.safe,
+      (await nestedOuter1of1()).safe,
       digest,
-      { safe: innerSafe1of1, owners: [signers.dave] },
+      { safe: await innerSafe1of1(), owners: [signers.dave] },
       [signers.bob],
       { dynamicOffsetOverride: 65 },
     );
@@ -721,7 +760,7 @@ describe('ERC-1271 user decryption', function () {
   it('test erc1271 user decrypt multisig rejects a 3-part blob with one out-of-place part', async function () {
     const req = await freshMultisigRequest(safe3of3);
     const sorted = sortSignatureParts(
-      await collectSafeOwnerParts(safe3of3.safe, computeUnifiedDigest(cfg, req), [
+      await collectSafeOwnerParts((await safe3of3()).safe, computeUnifiedDigest(cfg, req), [
         signers.bob,
         signers.carol,
         signers.dave,
@@ -742,13 +781,14 @@ describe('ERC-1271 user decryption', function () {
     // verifies with on-chain ecrecover only — multisig ERC-1271 is v3-only by
     // design. Pin the v2 wire-level rejection as executable documentation.
     const req = await freshMultisigRequest(safe2of3);
+    const fixture = await safe2of3();
     const blob = (await multisigSignature(safe2of3, req, [signers.bob, signers.carol])).slice(2); // 260 hex chars
     const body = {
       handleContractPairs: [{ handle: req.handles[0].ctHandle, contractAddress: req.handles[0].contractAddress }],
       requestValidity: { startTimestamp: String(req.startTimestamp), durationDays: '7' },
       contractsChainId: String(chainIdFromHandle(req.handles[0].ctHandle)),
-      contractAddresses: [safe2of3.holderAddress],
-      userAddress: safe2of3.safe.address,
+      contractAddresses: [fixture.holderAddress],
+      userAddress: fixture.safe.address,
       signature: blob,
       publicKey: req.publicKey.replace(/^0x/, ''),
       extraData: '0x00',

--- a/test-suite/e2e/test/erc1271UserDecryption/safe.ts
+++ b/test-suite/e2e/test/erc1271UserDecryption/safe.ts
@@ -9,8 +9,7 @@
 // Safe — interactions go through `ethers.Contract` with the shipped ABIs.
 //
 // What the pipeline sees is unchanged — an opaque `isValidSignature(digest,
-// blob)` STATICCALL — but unlike the retired `ERC1271MultisigWallet` mock, a
-// real Safe:
+// blob)` STATICCALL. What a real Safe does behind it:
 //   - verifies signatures over the SafeMessage EIP-712 RE-HASH of the digest
 //     (`getMessageHash(digest)`, domain `{chainId, verifyingContract: proxy}`
 //     with NO name/version), never over the raw digest — every signing helper
@@ -29,8 +28,17 @@
 import SafeArtifact from '@safe-global/safe-contracts/build/artifacts/contracts/Safe.sol/Safe.json';
 import CompatibilityFallbackHandlerArtifact from '@safe-global/safe-contracts/build/artifacts/contracts/handler/CompatibilityFallbackHandler.sol/CompatibilityFallbackHandler.json';
 import SafeProxyFactoryArtifact from '@safe-global/safe-contracts/build/artifacts/contracts/proxies/SafeProxyFactory.sol/SafeProxyFactory.json';
-import { Contract, ContractFactory, TypedDataEncoder, ZeroAddress, getBytes, hexlify, randomBytes } from 'ethers';
-import type { InterfaceAbi, Signer, TypedDataDomain } from 'ethers';
+import {
+  Contract,
+  ContractFactory,
+  TypedDataEncoder,
+  ZeroAddress,
+  getBytes,
+  hexlify,
+  keccak256,
+  randomBytes,
+} from 'ethers';
+import type { InterfaceAbi, Provider, Signer, TypedDataDomain } from 'ethers';
 
 import { SignaturePart, concatSignatureParts, sortSignatureParts } from '../sdk/unified/unifiedUserDecrypt';
 
@@ -63,7 +71,89 @@ const SAFE_MESSAGE_TYPES: Record<string, Array<{ name: string; type: string }>> 
   SafeMessage: [{ name: 'message', type: 'bytes' }],
 };
 
-/** Deploy the Safe v1.4.1 singleton, fallback handler and proxy factory from the canonical artifacts. */
+/**
+ * Canonical Safe v1.4.1 deployment addresses. Safe ships these through a
+ * deterministic factory, so they are IDENTICAL on every chain Safe has been
+ * deployed to (Sepolia and mainnet included) — which is why they can be
+ * constants rather than a per-chain table.
+ */
+const CANONICAL_SAFE_V1_4_1 = {
+  singleton: '0x41675C099F32341bf84BFc5382aF534df5C7461a',
+  handler: '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99',
+  factory: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+} as const;
+
+/** A canonical-code probe is one `eth_getCode`; retry once to ride out a rate-limit blip. */
+const PROBE_ATTEMPTS = 2;
+const PROBE_RETRY_DELAY_MS = 500;
+
+/**
+ * True iff `address` already holds exactly the code `artifact` would deploy.
+ *
+ * A failed probe is treated as "not canonical" rather than fatal, so a flaky
+ * endpoint degrades to deploying instead of failing the suite. It is retried
+ * once first, and reports why: on a live network the fallback costs a full
+ * ~7M gas infra deployment, which should never happen silently because a
+ * public RPC rate-limited a single `eth_getCode`.
+ */
+async function holdsArtifactCode(
+  provider: Provider,
+  address: string,
+  artifact: { deployedBytecode: string },
+): Promise<boolean> {
+  const expected = keccak256(artifact.deployedBytecode);
+  for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt += 1) {
+    try {
+      const code = await provider.getCode(address);
+      return code !== '0x' && keccak256(code) === expected;
+    } catch (error) {
+      if (attempt === PROBE_ATTEMPTS) {
+        console.warn(
+          `[safe] canonical-code probe failed for ${address} after ${attempt} attempts; ` +
+            `deploying Safe infrastructure instead: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return false;
+      }
+      await new Promise((resolve) => setTimeout(resolve, PROBE_RETRY_DELAY_MS));
+    }
+  }
+  return false;
+}
+
+/**
+ * Safe v1.4.1 infrastructure, REUSED when the chain already has the canonical
+ * deployment and deployed from the packaged artifacts otherwise.
+ *
+ * On a live network (Sepolia, mainnet) this is both cheaper — it saves ~7M gas
+ * of singleton/handler/factory deployment per run — and strictly more faithful:
+ * the suite then exercises the very Safe contracts real users' wallets run on,
+ * not a copy. On an ephemeral devnet nothing is deployed at those addresses, so
+ * it falls back to deploying.
+ *
+ * The reuse is gated on a keccak comparison against the artifacts rather than
+ * on mere presence of code, so a chain with something else at those addresses
+ * deploys its own rather than silently testing an unknown contract.
+ */
+export async function resolveSafeInfra(deployer: Signer): Promise<SafeInfra> {
+  const provider = deployer.provider;
+  if (provider) {
+    const [singletonOk, handlerOk, factoryOk] = await Promise.all([
+      holdsArtifactCode(provider, CANONICAL_SAFE_V1_4_1.singleton, SafeArtifact),
+      holdsArtifactCode(provider, CANONICAL_SAFE_V1_4_1.handler, CompatibilityFallbackHandlerArtifact),
+      holdsArtifactCode(provider, CANONICAL_SAFE_V1_4_1.factory, SafeProxyFactoryArtifact),
+    ]);
+    if (singletonOk && handlerOk && factoryOk) {
+      return {
+        singletonAddress: CANONICAL_SAFE_V1_4_1.singleton,
+        handlerAddress: CANONICAL_SAFE_V1_4_1.handler,
+        factory: new Contract(CANONICAL_SAFE_V1_4_1.factory, SafeProxyFactoryArtifact.abi, deployer),
+      };
+    }
+  }
+  return deploySafeInfra(deployer);
+}
+
+/** Deploy the Safe v1.4.1 singleton, fallback handler and proxy factory from the packaged artifacts. */
 export async function deploySafeInfra(deployer: Signer): Promise<SafeInfra> {
   const deployFrom = async (artifact: { abi: unknown; bytecode: string }): Promise<Contract> => {
     const factory = new ContractFactory(artifact.abi as InterfaceAbi, artifact.bytecode, deployer);
@@ -255,8 +345,8 @@ export function safeApprovedHashPart(ownerAddress: string): SignaturePart {
 
 /**
  * Record the on-chain approval backing a `safeApprovedHashPart`: the owner
- * calls `approveHash` with the SafeMessage hash of `digest` — NOT the raw
- * digest, which is what the retired mock approved.
+ * calls `approveHash` with the SafeMessage hash of `digest`, not the raw
+ * digest: `checkSignatures` only ever sees the wrapped hash.
  */
 export async function approveSafeHash(safe: SafeAccount, owner: Signer, digest: string): Promise<void> {
   await (await (safe.safe.connect(owner) as Contract).approveHash(safeMessageHashOf(safe, digest))).wait();

--- a/test-suite/e2e/test/sdk/fhevm-sdk/sdk.ts
+++ b/test-suite/e2e/test/sdk/fhevm-sdk/sdk.ts
@@ -1,3 +1,4 @@
+import { canUseUnifiedDecryptionPermit } from '@fhevm/sdk/actions/base';
 import { defineFhevmChain } from '@fhevm/sdk/chains';
 import { createFhevmClient, hasFhevmRuntimeConfig, setFhevmRuntimeConfig } from '@fhevm/sdk/ethers';
 import { createFhevmCleartextClient } from '@fhevm/sdk/ethers/cleartext';
@@ -158,6 +159,13 @@ export class FhevmSdk implements SdkInstance {
     return true;
   }
 
+  /**
+   * Decrypt one handle through the LEGACY permit path (v1 permit -> relayer
+   * `/v2`). Kept legacy deliberately: this helper is shared by suites that run
+   * against older protocol versions, so it must not require the unified route.
+   * Suites asserting the UNIFIED (v3) envelope must not treat a pass here as
+   * evidence that v3 works — use `userDecryptSingleHandleUnified` for that.
+   */
   async userDecryptSingleHandle(parameters: {
     readonly handle: string;
     readonly contractAddress: string;
@@ -194,6 +202,44 @@ export class FhevmSdk implements SdkInstance {
       return BigInt(res.value);
     }
     return res.value;
+  }
+
+  /**
+   * Decrypt one handle through the UNIFIED permit path (v3). Same assertion as
+   * `userDecryptSingleHandle`, but built on `signUnifiedDecryptionPermit`, so a
+   * pass proves the v3 envelope works end to end through the public SDK — the
+   * claim the legacy helper cannot support. Returns `undefined` when the
+   * relayer does not advertise the v3 route, letting callers skip rather than
+   * fail on a deployment that legitimately has no unified endpoint.
+   */
+  async userDecryptSingleHandleUnified(parameters: {
+    readonly handle: string;
+    readonly contractAddress: string;
+    readonly signer: Signer & { readonly address: string };
+  }): Promise<ClearValueType | undefined> {
+    if (!(await canUseUnifiedDecryptionPermit(this.#fullClient))) {
+      return undefined;
+    }
+    const { handle, contractAddress, signer } = parameters;
+    const transportKeyPair = await this.#fullClient.generateTransportKeyPair();
+
+    const signedPermit = await this.#fullClient.signUnifiedDecryptionPermit({
+      contractAddresses: [contractAddress],
+      durationSeconds: 10 * 24 * 3600,
+      startTimestamp: Math.floor(Date.now() / 1000),
+      transportKeyPair,
+      signer,
+      signerAddress: signer.address,
+    });
+
+    const res = await this.#fullClient.decryptValue({
+      contractAddress,
+      transportKeyPair,
+      signedPermit,
+      encryptedValue: handle,
+    });
+
+    return typeof res.value === 'number' ? BigInt(res.value) : res.value;
   }
 
   async delegatedUserDecryptSingleHandle(parameters: {

--- a/test-suite/e2e/test/sdk/unified/unifiedUserDecrypt.ts
+++ b/test-suite/e2e/test/sdk/unified/unifiedUserDecrypt.ts
@@ -357,6 +357,10 @@ export async function submitUnifiedRequest(
   const envelope = buildEnvelope(req, signature);
 
   const url = `${relayerBaseUrl(cfg.relayerUrl)}/v3/user-decrypt`;
+  // Log the route we drive. The SDK client logs its own (legacy `/v2`) calls,
+  // so without this a reader sees only `/v2` in the output and cannot tell
+  // which component issued what.
+  console.log(`[unified] POST ${url}`);
   const resp = await fetch(url, {
     method: 'POST',
     headers: httpHeaders(cfg, true),
@@ -472,7 +476,22 @@ export function isSignatureRejection(post: PostResult): boolean {
  * negatives whose cause is a per-handle ownership/delegation ACL failure —
  * pinning the reason so the test cannot pass on an unintended failure.
  */
-export function expectRelayerAclRejection(poll: PollResult | undefined): void {
+/**
+ * Distinguish "no verdict yet" from "wrong verdict".
+ *
+ * Bare `expected 'pending' to equal 'failed'` reads as a wrong outcome when the
+ * job simply never went terminal — a request accepted on-chain instead of
+ * rejected stays non-terminal until the relayer's own `user_decrypt_timeout`
+ * (30m default) reaps it, far beyond any budget here.
+ */
+function assertReachedTerminalState(poll: PollResult | undefined): void {
+  if (poll?.status === 'pending') {
+    expect.fail(`no verdict within the poll budget — the job never went terminal. Raw: ${JSON.stringify(poll?.raw)}`);
+  }
+}
+
+export function expectRelayerAclRejection(poll: PollResult | undefined, messagePattern?: RegExp): void {
+  assertReachedTerminalState(poll);
   expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('failed');
   expect(poll?.errorLabel, JSON.stringify(poll?.raw)).to.equal('not_allowed_on_host_acl');
 }
@@ -497,6 +516,7 @@ export function expectStuckAtKms(poll: PollResult | undefined): void {
  * unrelated simulation failure.
  */
 export function expectGatewayRevert(poll: PollResult | undefined, messagePattern: RegExp): void {
+  assertReachedTerminalState(poll);
   expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('failed');
   const message = ((poll?.raw as { error?: { message?: string } })?.error?.message ?? '') as string;
   expect(message, JSON.stringify(poll?.raw)).to.match(messagePattern);

--- a/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
+++ b/test-suite/e2e/test/unifiedUserDecryption/unifiedUserDecryption.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { hexlify, randomBytes } from 'ethers';
 import { ethers } from 'hardhat';
 
 import { ERC1271OwnerWallet, EncryptedERC20, SmartWalletWithDelegation, UserDecrypt } from '../../types';
@@ -10,6 +11,7 @@ import {
   verifyingContractAddressDecryption,
 } from '../instance';
 import { isLiveNetwork } from '../network';
+import { FhevmSdk } from '../sdk/fhevm-sdk/sdk';
 import type { UnifiedConfig, UnifiedDecryptRequest } from '../sdk/unified/unifiedUserDecrypt';
 import {
   backdatedStartTimestamp,
@@ -38,6 +40,23 @@ const TIMEOUT_MARGIN_MS = 60 * 1000;
 // cannot false-pass a negative that would have succeeded a moment later.
 const NEGATIVE_WINDOW_FLOOR_MS = 60 * 1000;
 const NEGATIVE_WINDOW_CAP_MS = 4 * 60 * 1000;
+// Budget for negatives that must reach a TERMINAL verdict (relayer-`failed`).
+// These are NOT observation windows: `expectStuckAtKms` asserts that nothing
+// happens, so burning its window IS the assertion and calibrating it to the
+// positive latency is right.
+//
+// A terminal verdict is not all one thing, and the difference decides the
+// budget. An ACL rejection is decided inline, before the request is queued, so
+// it lands in ~2s on any network. A Gateway revert is not: the request is
+// pushed to the transaction throttler
+// (relayer/src/gateway/user_decrypt_handler.rs `send_to_gateway`) and the
+// verdict only exists once the tx processor's submit attempt fails and
+// dispatches InternalFailure
+// (relayer/src/gateway/arbitrum/transaction/tx_processor.rs). That is queue-
+// and chain-bound, so it deserves the budget a positive gets rather than an
+// observation window. Polling returns the moment the job goes terminal, so
+// this costs nothing on a fast stack — the same test takes ~2s locally.
+const TERMINAL_NEGATIVE_TIMEOUT_MS = POSITIVE_TIMEOUT_MS;
 const SLOW_TEST_TIMEOUT_MS = 10 * 60 * 1000;
 // Blocks to wait after an on-chain ACL delegation before the KMS Connector's
 // host-chain reads observe it (same wait the delegated-user-decryption suite uses).
@@ -141,8 +160,11 @@ describe('Unified user decryption', function () {
     );
     expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
     expect(poll?.status, JSON.stringify(poll?.raw)).to.equal('succeeded');
-    // Decrypt the same handle through the public SDK (which builds the same
-    // unified envelope on protocol >= 0.14) and assert the known plaintext.
+    // Assert the ciphertext really decrypts to the known plaintext. NOTE the
+    // route: this helper uses the SDK's LEGACY permit (relayer `/v2`), so it
+    // proves the value, NOT that the unified envelope works through the SDK —
+    // the v3 envelope is asserted by the `succeeded` poll above, and end to end
+    // through the public SDK by the dedicated unified-SDK test below.
     const clear = await instances.alice.userDecryptSingleHandle({
       handle,
       contractAddress: aliceContractAddress,
@@ -152,6 +174,32 @@ describe('Unified user decryption', function () {
     // Calibrate the async-negative observation window to this stack's latency.
     const elapsedMs = Date.now() - startedAt;
     negativeWindowMs = Math.min(Math.max(NEGATIVE_WINDOW_FLOOR_MS, 3 * elapsedMs), NEGATIVE_WINDOW_CAP_MS);
+  });
+
+  it('test unified user decrypt decrypts through the public SDK unified permit path (v3)', async function () {
+    this.timeout(POSITIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
+    // The gap this closes: every other plaintext assertion in this suite goes
+    // through the SDK's LEGACY permit (`/v2`), so none of them proves the v3
+    // envelope is usable through the public SDK — only that the raw envelope is
+    // accepted by the relayer. This drives `signUnifiedDecryptionPermit`, the
+    // path a real 0.14 dapp takes.
+    const sdk = instances.alice;
+    if (!(sdk instanceof FhevmSdk)) {
+      // Legacy @zama-fhe/relayer-sdk adapter: no unified permit to exercise.
+      this.skip();
+    }
+    const handle = await aliceContract.xUint64();
+    const clear = await sdk.userDecryptSingleHandleUnified({
+      handle,
+      contractAddress: aliceContractAddress,
+      signer: signers.alice,
+    });
+    if (clear === undefined) {
+      // Relayer does not advertise the v3 route on this deployment; the raw
+      // envelope tests above already fail loudly if it should have been there.
+      this.skip();
+    }
+    expect(clear).to.equal(18446744073709551600n);
   });
 
   it('test unified user decrypt app-bounded mode (allowedContracts=[app]) succeeds', async function () {
@@ -347,7 +395,7 @@ describe('Unified user decryption', function () {
   });
 
   it('test unified user decrypt rejects a spoofed ownerAddress (handle not owned by userAddress)', async function () {
-    this.timeout(negativeWindowMs + TIMEOUT_MARGIN_MS);
+    this.timeout(TERMINAL_NEGATIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
     const handle = await aliceContract.xUint64(); // owned by alice, not bob
     const req: UnifiedDecryptRequest = {
       handles: [directHandle(handle, aliceContractAddress, signers.bob.address)],
@@ -363,7 +411,7 @@ describe('Unified user decryption', function () {
       { kind: 'eoa', signer: signers.bob },
       {
         waitForTerminal: true,
-        timeoutMs: negativeWindowMs,
+        timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
       },
     );
     // bob's signature is valid, so the POST is accepted; the per-job host-ACL
@@ -374,7 +422,7 @@ describe('Unified user decryption', function () {
   });
 
   it('test unified user decrypt rejects a delegated handle entry when no delegation exists', async function () {
-    this.timeout(negativeWindowMs + TIMEOUT_MARGIN_MS);
+    this.timeout(TERMINAL_NEGATIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
     // ownerAddress = alice != userAddress = bob triggers the delegated branch:
     // isHandleDelegatedForUserDecryption(alice, bob, contract, handle). No
     // delegation alice -> bob exists, so the ACL check fails (the "ownerAddress
@@ -394,7 +442,7 @@ describe('Unified user decryption', function () {
       { kind: 'eoa', signer: signers.bob },
       {
         waitForTerminal: true,
-        timeoutMs: negativeWindowMs,
+        timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
       },
     );
     expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
@@ -402,7 +450,7 @@ describe('Unified user decryption', function () {
   });
 
   it('test unified user decrypt rejects a batch containing one bad handle', async function () {
-    this.timeout(negativeWindowMs + TIMEOUT_MARGIN_MS);
+    this.timeout(TERMINAL_NEGATIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
     // One legitimate bob-owned handle plus one alice-owned handle claimed as
     // bob's: authorization is all-or-nothing per request, so a single bad
     // handle rejects the whole batch — the good handle is not decrypted.
@@ -425,7 +473,7 @@ describe('Unified user decryption', function () {
       { kind: 'eoa', signer: signers.bob },
       {
         waitForTerminal: true,
-        timeoutMs: negativeWindowMs,
+        timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
       },
     );
     expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
@@ -467,6 +515,17 @@ describe('Unified user decryption', function () {
     // the relayer's format check.
     const KMS_CONTEXT_TAG = 0x07n << 248n;
     const EPOCH_TAG = 0x08n << 248n;
+
+    /**
+     * A context id that cannot exist, generated FRESH PER RUN.
+     *
+     * A fixed literal would assume nothing ever registered it — true on a
+     * devnet redeployed every boot, unverifiable on a long-lived shared
+     * environment. Drawing 16 random bytes inside the tag's counter space makes
+     * a collision impossible in practice, so a failure of the test below can
+     * never be explained away by "something registered that id earlier".
+     */
+    const unknownContextId = KMS_CONTEXT_TAG | (BigInt(hexlify(randomBytes(16))) || 1n);
 
     before(async function () {
       if (!protocolConfigAddress) {
@@ -622,12 +681,55 @@ describe('Unified user decryption', function () {
     });
 
     it('test unified user decrypt rejects extraData with an unknown contextId', async function () {
-      this.timeout(negativeWindowMs + TIMEOUT_MARGIN_MS);
-      // Versioned extraData is NOT decorative: the connector validates the
-      // embedded contextId against its context store. A fabricated, but
-      // properly 0x07-tagged, id passes the relayer's format check (and the
-      // signature covers it), but the KMS Connector rejects it and the job
-      // never succeeds.
+      this.timeout(TERMINAL_NEGATIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
+      // Versioned extraData is NOT decorative: the Gateway validates the
+      // embedded contextId at request time, before the decryption fee is
+      // collected (matching the legacy request paths). A fabricated id passes
+      // the relayer's format check (and the signature covers it), but the
+      // request transaction reverts with InvalidKmsContext during the
+      // relayer's simulation — no request is opened and no fee is charged.
+      // PRECONDITION: prove the Gateway itself considers this context invalid
+      // BEFORE we assert it rejects the request. Without this, a stuck request
+      // is ambiguous — "the Gateway failed to validate" and "the Gateway was
+      // right and our id happened to exist here" look identical from the
+      // client. Asserting it up front turns the later failure into a specific
+      // claim: the Gateway HAD the information to reject and did not.
+      //
+      // The current context is queried first as a positive control: a wrong
+      // address or a mismatched ABI would return false for everything and let
+      // the real check pass vacuously.
+      const gatewayRpcUrl = process.env.GATEWAY_RPC_URL;
+      const gatewayConfigAddress = process.env.GATEWAY_CONFIG_ADDRESS;
+      if (gatewayRpcUrl && gatewayConfigAddress) {
+        const gatewayConfig = new ethers.Contract(
+          gatewayConfigAddress,
+          ['function isValidKmsContext(uint256) view returns (bool)'],
+          new ethers.JsonRpcProvider(gatewayRpcUrl),
+        );
+        expect(
+          await gatewayConfig.isValidKmsContext(currentContextId),
+          `gateway probe is not trustworthy: the CURRENT context ${currentContextId} reads as invalid at ` +
+            `${gatewayConfigAddress}. Check GATEWAY_CONFIG_ADDRESS/GATEWAY_RPC_URL before reading the next assert.`,
+        ).to.equal(true);
+        expect(
+          await gatewayConfig.isValidKmsContext(unknownContextId),
+          `the fabricated context ${unknownContextId} exists on this gateway, so this test's premise does ` +
+            `not hold here. It is drawn from 16 random bytes per run, so this should be impossible.`,
+        ).to.equal(false);
+        console.log(
+          `[unified] gateway confirms the fabricated context is invalid (checked at ${gatewayConfigAddress})`,
+        );
+      } else {
+        console.log(
+          '[unified] SKIPPED the gateway precondition: GATEWAY_RPC_URL/GATEWAY_CONFIG_ADDRESS unset. ' +
+            'A failure below cannot distinguish "gateway did not validate" from "the id exists here".',
+        );
+      }
+
+      // Print the id: it is random per run, so without this a failure cannot be
+      // correlated with on-chain state afterwards.
+      console.log(`[unified] fabricated unknown contextId: ${hex32(unknownContextId)}`);
+
       const handle = await aliceContract.xUint64();
       const req: UnifiedDecryptRequest = {
         handles: [directHandle(handle, aliceContractAddress, signers.alice.address)],
@@ -636,7 +738,7 @@ describe('Unified user decryption', function () {
         publicKey: extraDataPublicKey,
         startTimestamp: backdatedStartTimestamp(),
         durationSeconds: DURATION_SECONDS,
-        extraData: `0x01${hex32(KMS_CONTEXT_TAG | 0xdeadbeefn)}`,
+        extraData: `0x01${hex32(unknownContextId)}`,
       };
       const { post, poll } = await requestUnifiedUserDecrypt(
         cfg,
@@ -644,12 +746,13 @@ describe('Unified user decryption', function () {
         { kind: 'eoa', signer: signers.alice },
         {
           waitForTerminal: true,
-          timeoutMs: negativeWindowMs,
+          timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
       expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
-      // InvalidKmsContext(0xdeadbeef) — selector 0x77ddbe81.
-      expectGatewayRevert(poll, /0x77ddbe81.*deadbeef/i);
+      // InvalidKmsContext(<unknownContextId>) — selector 0x77ddbe81. The id is
+      // random per run, so this cannot pass or fail because of leftover state.
+      expectGatewayRevert(poll, /0x77ddbe81/i);
     });
 
     it('test unified user decrypt rejects a malformed extraData version', async function () {
@@ -841,7 +944,7 @@ describe('Unified user decryption', function () {
     });
 
     it('test unified user decrypt rejects a delegated handle with a fabricated contractAddress', async function () {
-      this.timeout(negativeWindowMs + TIMEOUT_MARGIN_MS);
+      this.timeout(TERMINAL_NEGATIVE_TIMEOUT_MS + TIMEOUT_MARGIN_MS);
       // The delegation smartWallet -> bob exists via tokenAddress only.
       // Substituting a different contractAddress in the (unsigned) HandleEntry
       // must fail isHandleDelegatedForUserDecryption — delegation is
@@ -860,7 +963,7 @@ describe('Unified user decryption', function () {
         { kind: 'eoa', signer: signers.bob },
         {
           waitForTerminal: true,
-          timeoutMs: negativeWindowMs,
+          timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
       expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
@@ -891,7 +994,7 @@ describe('Unified user decryption', function () {
         { kind: 'eoa', signer: signers.dave },
         {
           waitForTerminal: true,
-          timeoutMs: negativeWindowMs,
+          timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
       expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);
@@ -933,7 +1036,7 @@ describe('Unified user decryption', function () {
         { kind: 'eoa', signer: signers.eve },
         {
           waitForTerminal: true,
-          timeoutMs: negativeWindowMs,
+          timeoutMs: TERMINAL_NEGATIVE_TIMEOUT_MS,
         },
       );
       expect(post.httpStatus, JSON.stringify(post.raw)).to.equal(202);


### PR DESCRIPTION
Cherry-pick of 7f755e9437 (PR #3467)

## Description:

Makes the ERC-1271 Safe suite viable on Sepolia, where it was failing in `before all`: the hook had grown to ~30 sequential deployments — free against instant local blocks, ~6 minutes at 12s blocks against a 180s timeout.

Fixtures are now lazy thunks memoised on first use, so each test pays only for what it actually reaches, inside its own timeout instead of one monolithic hook. And `resolveSafeInfra` reuses the chain's canonical Safe v1.4.1 deployment when it has one — the code at Safe's deterministic addresses on Sepolia is keccak-identical to our packaged artifacts, so live runs save ~7M gas and three deployments and exercise the Safe contracts real wallets use rather than a copy. Reuse is gated on that keccak match, so an unfamiliar chain deploys its own; ephemeral devnets are unchanged.