### PR TITLE
chore(kms-connector): give the Solana public-decrypt proof carrier one owner

### DIFF
--- a/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
+++ b/kms-connector/crates/kms-worker/src/core/event_processor/solana_user_decrypt.rs
@@ -85,6 +85,10 @@ use zama_solana_acl::{EncryptedValue, MmrProof};
 /// Transport-blob mode byte for a historical-access MMR proof (see `mmr_proof_bytes`).
 pub const MMR_PROOF_MODE_HISTORICAL: u8 = 0x01;
 /// Transport-blob mode byte for a public-decrypt MMR proof.
+///
+/// Part of the temporary public-decrypt proof carrier (see
+/// `connector_utils::types::solana_extra_data::SOLANA_EXTRA_DATA_VERSION_MMR_PROOF` for its
+/// ownership and removal condition). Outlives the v0 user-decrypt protocol this module hosts.
 pub const MMR_PROOF_MODE_PUBLIC: u8 = 0x02;
 /// Upper bound on `MmrProof::siblings` accepted from an untrusted request, matching the MMR's
 /// `u64` height ceiling (`mmr.rs` iterates heights `0..64`); bounds the decode-time allocation.
@@ -414,6 +418,12 @@ pub async fn check_solana_handles_acl(
 
 /// Solana public-decryption ACL check. There is no live "is public" flag: public-ness is only
 /// provable via a `PublicDecryptLeaf` MMR leaf carried in `extraData`.
+///
+/// Outlives the v0 user-decrypt protocol this module hosts: when the v0 path is deleted, this
+/// entry point and everything it reaches (the account fetch, the proof-blob decoder, the
+/// failure classifier, the mode-byte constants) must be re-homed, not removed — public decrypt
+/// has no other authorization path. `kms-worker/tests/solana_public_decrypt_carrier.rs` pins
+/// this surface from outside the module.
 pub async fn check_solana_handles_public_decrypt(
     host: &SolanaHost,
     handles: &[HandleBytes],

--- a/kms-connector/crates/kms-worker/tests/solana_public_decrypt_carrier.rs
+++ b/kms-connector/crates/kms-worker/tests/solana_public_decrypt_carrier.rs
@@ -1,0 +1,280 @@
+//! The public-decrypt proof carrier, pinned from outside the module that hosts it.
+//!
+//! Solana public decrypt has no live on-chain "is public" flag: public-ness is only provable by a
+//! `PublicDecryptLeaf` MMR proof, and that proof travels in the version-`0x03` `extraData`
+//! container. The container is temporary transport — it exists because the gateway interface has
+//! no typed fields for a public-decrypt proof, and it is due for removal once such fields exist —
+//! but while it exists, it is the only thing standing between a Solana public decrypt and a silent
+//! fail-closed outage.
+//!
+//! Every assertion here already holds inside `event_processor::solana_user_decrypt`'s own test
+//! module. That module is scheduled for deletion together with the v0 user-decrypt path, and a
+//! test deleted together with the code it guarded guards nothing. So the same properties are
+//! pinned here, from the outside, through the public entry point and a real RPC round-trip:
+//! a mock `getAccountInfo` endpoint serves the encrypted value account bytes, and
+//! [`check_solana_handles_public_decrypt`] does everything else it does in production.
+//!
+//! Wire bytes are pinned as literals, not as imports of the constants that produce them: if the
+//! carrier version or the proof mode byte is renumbered, or the carrier is torn down without the
+//! public-decrypt path being re-homed first, these tests fail by construction rather than
+//! following the rename.
+
+mod solana_support;
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use connector_utils::types::solana_extra_data::{
+    encode_solana_extra_data_context_only, encode_solana_extra_data_mmr_proof,
+};
+use kms_worker::core::event_processor::{
+    ProcessingError,
+    solana_user_decrypt::{SolanaHost, check_solana_handles_public_decrypt},
+};
+use kms_worker::core::solana_v2_fetcher::SolanaV2Fetcher;
+use mocktail::server::MockServer;
+use solana_pubkey::Pubkey;
+use solana_support::{EncryptedValueAccountFixture, PROGRAM_ID};
+use zama_solana_acl::MmrProof;
+
+/// The `extraData` version byte that carries a public-decrypt proof. A literal, deliberately not
+/// the production constant: this pin is what turns "the carrier was torn down without re-homing
+/// public decrypt" into a readable test failure instead of a silent one.
+const PROOF_CARRIER_VERSION: u8 = 0x03;
+
+/// The mode byte of a public-decrypt proof blob, as the client writes it on the wire.
+const PUBLIC_PROOF_MODE: u8 = 0x02;
+
+/// The mode byte of a historical-access proof blob — the one mode the public path must refuse.
+const HISTORICAL_PROOF_MODE: u8 = 0x01;
+
+fn h(tag: u8) -> [u8; 32] {
+    [tag; 32]
+}
+
+/// The full proof transport blob: 1-byte mode prefix ‖ Borsh(MmrProof).
+fn proof_blob(mode: u8, proof: &MmrProof) -> Vec<u8> {
+    let mut blob = vec![mode];
+    blob.extend_from_slice(&borsh::to_vec(proof).expect("the fixture proof serializes"));
+    blob
+}
+
+/// A carrier whose body is well-formed but whose version byte is not the proof-carrier version.
+fn carrier_with_version(version: u8, valid_carrier: &[u8]) -> Vec<u8> {
+    let mut blob = valid_carrier.to_vec();
+    blob[0] = version;
+    blob
+}
+
+/// Starts a mock Solana RPC serving exactly one account: the fixture's encrypted value account,
+/// matched on the byte-exact `getAccountInfo` request the fetcher builds (which pins the account
+/// key, base64 encoding, and confirmed commitment). Returns the server (kept alive by the caller)
+/// and a host wired to it.
+async fn host_serving(fixture: &EncryptedValueAccountFixture) -> (MockServer, SolanaHost) {
+    let account = fixture.account();
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "context": { "slot": 1 },
+            "value": {
+                "owner": Pubkey::new_from_array(account.owner).to_string(),
+                "data": [BASE64_STANDARD.encode(&account.data), "base64"],
+                "lamports": 1,
+                "executable": false,
+                "rentEpoch": 0,
+            },
+        },
+    });
+
+    let mut server = MockServer::new_http("solana-rpc");
+    let request_body = SolanaV2Fetcher::account_info_request_body(&fixture.account_key);
+    server.mock(move |when, then| {
+        when.post().json(request_body.clone());
+        then.json(response.clone());
+    });
+    server.start().await.expect("the mock RPC starts");
+
+    let host = SolanaHost {
+        program_id: PROGRAM_ID,
+        fetcher: SolanaV2Fetcher::new(
+            server.base_url().expect("the mock RPC has a URL").clone(),
+            reqwest::Client::new(),
+        ),
+    };
+    (server, host)
+}
+
+/// A host whose RPC answers nothing: for requests that must be refused before any account is
+/// read. If the path under test unexpectedly reaches the network, the fetch fails and the
+/// assertions on the refusal shape catch it.
+async fn host_without_accounts() -> (MockServer, SolanaHost) {
+    let server = MockServer::new_http("solana-rpc-empty");
+    server.start().await.expect("the mock RPC starts");
+    let host = SolanaHost {
+        program_id: PROGRAM_ID,
+        fetcher: SolanaV2Fetcher::new(
+            server.base_url().expect("the mock RPC has a URL").clone(),
+            reqwest::Client::new(),
+        ),
+    };
+    (server, host)
+}
+
+/// An encrypted value account whose first leaf seals public-ness of `sealed`, after which the
+/// value moved on to `successor` — the shape every exact-handle assertion needs.
+fn public_then_updated(sealed: [u8; 32], successor: [u8; 32]) -> EncryptedValueAccountFixture {
+    let mut fixture = EncryptedValueAccountFixture::new(sealed, &[[0x42; 32]]);
+    fixture.mark_public();
+    fixture.update(successor);
+    fixture
+}
+
+fn public_carrier(fixture: &EncryptedValueAccountFixture, blob: Vec<u8>) -> Vec<u8> {
+    encode_solana_extra_data_mmr_proof(
+        [0u8; 32],
+        fixture.encrypted_value_id(),
+        fixture.encrypted_value.leaf_count,
+        &blob,
+    )
+}
+
+#[tokio::test]
+async fn a_public_leaf_authorizes_exactly_its_sealed_handle() {
+    let fixture = public_then_updated(h(20), h(21));
+    let blob = proof_blob(PUBLIC_PROOF_MODE, &fixture.proof(0));
+    let carrier = public_carrier(&fixture, blob);
+    let (_server, host) = host_serving(&fixture).await;
+
+    check_solana_handles_public_decrypt(&host, &[h(20)], &carrier)
+        .await
+        .expect("a PublicDecryptLeaf sealed for this handle authorizes it");
+}
+
+#[tokio::test]
+async fn a_public_leaf_does_not_authorize_the_handle_that_replaced_it() {
+    let fixture = public_then_updated(h(20), h(21));
+    let blob = proof_blob(PUBLIC_PROOF_MODE, &fixture.proof(0));
+    let carrier = public_carrier(&fixture, blob);
+    let (_server, host) = host_serving(&fixture).await;
+
+    let err = check_solana_handles_public_decrypt(&host, &[h(21)], &carrier)
+        .await
+        .expect_err("a PublicDecryptLeaf for the old handle must not authorize its successor");
+    // The proof was built at the live leaf count, so the mismatch is classified as a view that
+    // may still converge — retried, never granted.
+    assert!(matches!(err, ProcessingError::Recoverable(_)), "got: {err}");
+}
+
+#[tokio::test]
+async fn a_historical_leaf_does_not_authorize_public_decrypt() {
+    // No public leaf anywhere: the only sealed leaf is the historical-access one that `update`
+    // wrote for the subject. Presenting it under the public mode byte must not verify.
+    let mut fixture = EncryptedValueAccountFixture::new(h(30), &[[0x42; 32]]);
+    fixture.update(h(31));
+    let blob = proof_blob(PUBLIC_PROOF_MODE, &fixture.proof(0));
+    let carrier = public_carrier(&fixture, blob);
+    let (_server, host) = host_serving(&fixture).await;
+
+    let err = check_solana_handles_public_decrypt(&host, &[h(30)], &carrier)
+        .await
+        .expect_err("a historical-access leaf must not prove public-ness");
+    assert!(matches!(err, ProcessingError::Recoverable(_)), "got: {err}");
+}
+
+#[test]
+fn the_proof_carrier_version_is_pinned_by_literal() {
+    // If this fails, the carrier's version byte changed — or the carrier is gone — while the
+    // public-decrypt path still depends on it. Re-home the proof before touching the container.
+    let carrier = encode_solana_extra_data_mmr_proof([0u8; 32], [9u8; 32], 1, &[0xab]);
+    assert_eq!(
+        carrier[0], PROOF_CARRIER_VERSION,
+        "the public-decrypt proof carrier must keep its version byte"
+    );
+}
+
+#[tokio::test]
+async fn a_carrier_of_another_version_yields_no_proof() {
+    let fixture = public_then_updated(h(20), h(21));
+    let blob = proof_blob(PUBLIC_PROOF_MODE, &fixture.proof(0));
+    let valid_carrier = public_carrier(&fixture, blob);
+    let (_server, host) = host_without_accounts().await;
+
+    // A context-only carrier, and a version this connector has never issued: both must refuse
+    // explicitly before reading any account — never parse the body under the wrong layout.
+    let context_only = encode_solana_extra_data_context_only([0u8; 32]);
+    let unknown_version = carrier_with_version(0x09, &valid_carrier);
+
+    for carrier in [context_only, unknown_version] {
+        let err = check_solana_handles_public_decrypt(&host, &[h(20)], &carrier)
+            .await
+            .expect_err("a carrier of another version must not yield a proof");
+        match err {
+            ProcessingError::Irrecoverable(e) => assert!(
+                e.to_string()
+                    .contains("requires a PublicDecryptLeaf MMR proof"),
+                "got: {e}"
+            ),
+            other => panic!("a missing proof must be terminal, got: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn the_public_path_accepts_only_its_own_mode_byte() {
+    // The same valid proof of the same public leaf, presented under the historical mode byte:
+    // the public path must refuse on the mode alone, before any verification outcome.
+    let fixture = public_then_updated(h(20), h(21));
+    let blob = proof_blob(HISTORICAL_PROOF_MODE, &fixture.proof(0));
+    let carrier = public_carrier(&fixture, blob);
+    let (_server, host) = host_serving(&fixture).await;
+
+    let err = check_solana_handles_public_decrypt(&host, &[h(20)], &carrier)
+        .await
+        .expect_err("the public path must reject the historical mode byte");
+    match err {
+        ProcessingError::Irrecoverable(e) => {
+            assert!(e.to_string().contains("requires MMR proof mode"), "got: {e}")
+        }
+        other => panic!("a wrong mode byte must be terminal, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn a_public_decrypt_request_without_a_proof_refuses_explicitly() {
+    let fixture = public_then_updated(h(20), h(21));
+    let (_server, host) = host_without_accounts().await;
+
+    // A well-formed carrier whose proof section is empty: named value, no proof.
+    let empty_proof = public_carrier(&fixture, Vec::new());
+
+    for carrier in [Vec::new(), empty_proof] {
+        let err = check_solana_handles_public_decrypt(&host, &[h(20)], &carrier)
+            .await
+            .expect_err("public decrypt without a proof must refuse, not consult a live flag");
+        match err {
+            ProcessingError::Irrecoverable(e) => assert!(
+                e.to_string()
+                    .contains("requires a PublicDecryptLeaf MMR proof"),
+                "got: {e}"
+            ),
+            other => panic!("a proofless public decrypt must be terminal, got: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn public_decrypt_authorizes_one_handle_per_request() {
+    let fixture = public_then_updated(h(20), h(21));
+    let blob = proof_blob(PUBLIC_PROOF_MODE, &fixture.proof(0));
+    let carrier = public_carrier(&fixture, blob);
+    let (_server, host) = host_without_accounts().await;
+
+    let err = check_solana_handles_public_decrypt(&host, &[h(20), h(21)], &carrier)
+        .await
+        .expect_err("a public decrypt names exactly one handle");
+    match err {
+        ProcessingError::Irrecoverable(e) => {
+            assert!(e.to_string().contains("exactly one handle"), "got: {e}")
+        }
+        other => panic!("a multi-handle public decrypt must be terminal, got: {other:?}"),
+    }
+}

--- a/kms-connector/crates/utils/src/types/solana_extra_data.rs
+++ b/kms-connector/crates/utils/src/types/solana_extra_data.rs
@@ -174,19 +174,22 @@ pub const SOLANA_EXTRA_DATA_VERSION_CONTEXT_ONLY: u8 = 0x01;
 /// `extraData` version byte carrying the KMS context id PLUS the MMR-proof tail
 /// (`acl_value_key ‖ proof_slot ‖ mmr_proof_len ‖ mmr_proof_bytes`).
 ///
-/// DEVIATION FROM THE REFERENCE DESIGN: the reference design carried `aclValueKey` / `mmrProof` /
-/// `proofSlot` as typed `UserDecryptionRequestSolanaPayload` fields (RFC-021-style). Adding those
-/// fields is a `gateway-contracts` Solidity + codegen change, and this workstream is scoped to
-/// `kms-connector/` + `sdk/js-sdk/` only (gateway-contracts is owned by a different, in-flight
-/// workstream and is not even read-only-listed here). Packing the MMR tail into the existing
-/// `extraData` blob — versioned so a `v0x01` (context-only) request is unambiguous from a `v0x03`
-/// (MMR-proof) request — reuses the one Solana-specific "escape hatch" field the gateway interface
-/// already has, at zero gateway-contracts cost. `mmr_proof_bytes` is still committed **verbatim**
-/// into the [`SOLANA_USER_DECRYPT_DOMAIN_TAG`] request commitment, so the signature-binding property is
-/// unaffected by this transport choice; only the origin of `acl_value_key` / `proof_slot` /
-/// `mmr_proof_bytes` on the decode side differs from the reference (extraData here, typed fields
-/// there). If/when `gateway-contracts` grows the typed fields, this module's signing-message builder is
-/// unchanged and only [`parse_solana_user_decrypt_extra_data`] (and its call site) should move.
+/// TEMPORARY PROOF CARRIER, OWNED BY PUBLIC DECRYPT. The gateway interface has no typed fields
+/// for a public-decrypt inclusion proof, so the proof travels in this versioned `extraData`
+/// container. This is transitional support for one flow, not protocol surface:
+///
+/// - Removal condition: typed proof carriage for public decrypt — a `gateway-contracts`
+///   interface change, owned outside this workstream. Once the gateway carries the proof in
+///   typed fields, this container, its strict parser and its encoders are deleted; the
+///   container must not outlive that change.
+/// - Until then it must not be torn down either: there is no live on-chain "is public" flag,
+///   so a Solana public decrypt without this carrier fails closed — silently, for every
+///   request. `kms-worker/tests/solana_public_decrypt_carrier.rs` pins the carrier and the
+///   full public-decrypt path from outside the modules scheduled for rewrite.
+///
+/// The v0 user-decrypt path still routes its historical/public proof tail through this
+/// container; that use is deleted together with the rest of the v0 protocol and places no
+/// constraint on the container's future.
 pub const SOLANA_EXTRA_DATA_VERSION_MMR_PROOF: u8 = 0x03;
 
 /// The Solana user-decrypt auth fields carried in `extraData`, beyond the typed gateway fields.
@@ -209,6 +212,9 @@ pub struct SolanaUserDecryptExtraData {
 /// Returns `None` unless the blob is exactly the proof-tail version and its length prefix matches
 /// the full body. Public decrypt uses this strict form because a missing or malformed proof must
 /// fail closed instead of silently routing to a no-proof path.
+///
+/// Part of the temporary proof carrier — see [`SOLANA_EXTRA_DATA_VERSION_MMR_PROOF`] for its
+/// ownership, status and removal condition.
 ///
 /// The client-side encoder is `buildSolanaUserDecryptMmrProofExtraData` in
 /// `sdk/js-sdk/src/core/coprocessor/SolanaUserDecrypt-p.ts` — a hand-mirrored codec across


### PR DESCRIPTION
Preparatory slice of the host-generic user-decrypt stack.

The Solana public-decrypt inclusion proof keeps travelling in the versioned `extraData` container, but the container is re-documented as a **temporary carrier owned by the public-decrypt flow**: an explicit removal condition (typed proof carriage on the gateway interface, owned outside this workstream) and an explicit keep-alive condition (no live on-chain "is public" flag — without the carrier a Solana public decrypt fails closed, silently). `kms-worker/tests/solana_public_decrypt_carrier.rs` pins the carrier and the full public-decrypt path from outside the modules the rest of the stack rewrites.

No behavior change.

### Stack

| # | PR | scope |
|---|----|-------|
| 1 | 👉 this | chore(kms-connector): proof carrier gets one owner |
| 2 | #3525 | permit container + gateway overload + connector wiring |
| 3 | #3523 | relayer |
| 4 | #3549 | sdk client path + consumers |
