### PR TITLE
fix(test-suite): wait for compose applied for bridge e2e tests

### DIFF
--- a/test-suite/e2e/test/bridge/confidentialBridge.ts
+++ b/test-suite/e2e/test/bridge/confidentialBridge.ts
@@ -10,12 +10,14 @@ import {
   getSigners,
 } from '../multiChain/multiChainHelper';
 import {
+  ComposeGrant,
   extractBridgeGuid,
   forgeDelivery,
   relayBridgeMessage,
   relayCompose,
   sendWithNonceRetry,
   waitForBridgedHandles,
+  waitForComposeApplied,
 } from './relay';
 
 // Mock endpoint has no executor, so the test relays itself; with a real endpoint (BRIDGE_REAL_LZ), LZ delivers and the test only waits for the HandleBridged event.
@@ -26,7 +28,9 @@ const BRIDGE_SEND_ABI = [
   'function quote(uint32 dstEid, address srcApp, bytes32 dstApp, bytes payload, bytes32[] handleList, uint64 lzComposeGas) view returns (tuple(uint256 nativeFee, uint256 lzTokenFee) fee)',
 ];
 const LZ_COMPOSE_GAS = 1_000_000n;
-const DECRYPT_TIMEOUT_MS = USE_REAL_LZ ? 420_000 : 180_000;
+// Per-step real-LZ budget (delivery, lzCompose grant, decrypt). Reverse amoy->sepolia delivery can
+// take ~30min on devnet, so this is deliberately generous; the mock relay stays fast.
+const DECRYPT_TIMEOUT_MS = USE_REAL_LZ ? 1_800_000 : 180_000;
 
 // Per-chain bridge/endpoint addresses: primary chain uses unindexed vars, others HOST_CHAIN_<i>_*.
 const bridgeAddrFor = (i: number) =>
@@ -91,7 +95,9 @@ async function notPubliclyDecryptable(end: BridgeEnd, handle: string): Promise<b
 }
 
 describe('Confidential Bridge', function () {
-  this.timeout(600_000);
+  // Round-trips chain two slow real-LZ legs (each up to ~30min delivery), so the per-test budget
+  // must clear their sum; the mock relay stays fast.
+  this.timeout(USE_REAL_LZ ? 3_600_000 : 600_000);
 
   let host: BridgeEnd;
   let chainB: BridgeEnd;
@@ -161,6 +167,13 @@ describe('Confidential Bridge', function () {
         fromBlock,
         DECRYPT_TIMEOUT_MS,
       );
+      // Wait for the lzCompose grant (empty payload => public; address => allow(user)) before
+      // returning, so callers can reuse the handle without racing the compose leg.
+      const grant: ComposeGrant =
+        payload === '0x'
+          ? { kind: 'public' }
+          : { kind: 'account', account: ethers.AbiCoder.defaultAbiCoder().decode(['address'], payload)[0] as string };
+      await waitForComposeApplied(getProvider(dst.cfg), dst.cfg.aclAddress, dstHandles, grant, DECRYPT_TIMEOUT_MS);
       return { dstHandles, ctx, compose: undefined };
     }
     const { dstHandles, compose } = await relayBridgeMessage(sendReceipt, ctx, { skipCompose });

--- a/test-suite/e2e/test/bridge/relay.ts
+++ b/test-suite/e2e/test/bridge/relay.ts
@@ -25,9 +25,16 @@ const MSGLIB_ABI = ['function validatePacket(bytes packet)'];
 const BRIDGE_EVENTS_ABI = [
   'event HandleBridged(address indexed receiverDapp, bytes32 srcHandle, bytes32 dstHandle, bytes32 guid)',
 ];
+const ACL_ABI = [
+  'function isAllowedForDecryption(bytes32 handle) view returns (bool)',
+  'function isAllowed(bytes32 handle, address account) view returns (bool)',
+];
 
 const endpointIface = new ethers.Interface(ENDPOINT_ABI);
 const bridgeIface = new ethers.Interface(BRIDGE_EVENTS_ABI);
+
+/** ACL grant the app's bridge callback applies: public decrypt (empty payload) or allow(user). */
+export type ComposeGrant = { kind: 'public' } | { kind: 'account'; account: string };
 
 // Sends a tx and waits for the receipt, retrying on NONCE_EXPIRED
 export async function sendWithNonceRetry(
@@ -226,4 +233,25 @@ export async function waitForBridgedHandles(
     await new Promise((resolve) => setTimeout(resolve, 3_000));
   }
   throw new Error(`real-LZ delivery: no HandleBridged for guid ${guid} within ${timeoutMs}ms`);
+}
+
+/** HandleBridged fires in _lzReceive; the app's ACL grant runs in the later lzCompose delivery.
+ *  Polls the dst ACL until every handle reflects that grant, so callers don't race the compose leg. */
+export async function waitForComposeApplied(
+  dstProvider: ethers.Provider,
+  aclAddress: string,
+  dstHandles: string[],
+  grant: ComposeGrant,
+  timeoutMs: number,
+): Promise<void> {
+  const acl = new ethers.Contract(aclAddress, ACL_ABI, dstProvider);
+  const isApplied = (handle: string): Promise<boolean> =>
+    grant.kind === 'public' ? acl.isAllowedForDecryption(handle) : acl.isAllowed(handle, grant.account);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const applied = await Promise.all(dstHandles.map((handle) => isApplied(handle)));
+    if (applied.every(Boolean)) return;
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  }
+  throw new Error(`real-LZ lzCompose: ACL grant (${grant.kind}) not applied within ${timeoutMs}ms`);
 }


### PR DESCRIPTION
## What

On real LayerZero, the confidential-bridge e2e tests were failing on the reverse and round-trip cases:

- **Compose race** — round-trip and compute-then-bridge-back reverted at the leg-2 `send` (or the FHE op). The test reused a bridged handle immediately after `HandleBridged`, which is emitted in `_lzReceive`. But the destination app's ACL grant (`onConfidentialBridgeReceived` → `makePubliclyDecryptable` / `allow(user)`) runs in the **separate `lzCompose` delivery**, which lands later — so the handle wasn't yet re-bridgeable/usable when the next on-chain call fired.
- **Reverse-delivery timeout** — Amoy→Sepolia LZ delivery takes ~15–30 min on devnet, well beyond the previous per-step wait, so the reverse test timed out in `waitForBridgedHandles`.

## Fix

- Add `waitForComposeApplied` (`relay.ts`): after `HandleBridged`, poll the destination ACL until the compose grant is applied — `isAllowedForDecryption` for an empty payload, or `isAllowed(handle, user)` for an address payload. `bridge()` now waits for it before returning, so callers no longer race the compose leg.
- Bump the real-LZ per-step and per-test timeouts (delivery / compose / decrypt) to match the observed reverse-LZ latency.