### PR TITLE
fix(solana): restore SDK graph after fhevm-cli up

### DIFF
--- a/solana/scripts/e2e/clean-e2e.sh
+++ b/solana/scripts/e2e/clean-e2e.sh
@@ -311,6 +311,13 @@ PY
     --allow-schema-mismatch )
 cleanup_native_rust_builder_aliases
 trap - EXIT
+# `up`'s host-process step cargo-builds host-listener, whose build.rs runs
+# `npm ci` inside host-contracts and reifies the workspace root to that graph
+# alone — wiping the SDK install above. Restore it before Vite / e2e / seed
+# resolve `@fhevm/sdk` through the symlink.
+( cd "$ROOT" && npm ci --workspace=@fhevm/sdk-dev --workspace=@fhevm/sdk --include-workspace-root=false )
+( cd "$FHEVM" && node --input-type=module -e "await import('@fhevm/sdk/solana')" )
+( cd "$FHEVM" && bun -e "await import('@fhevm/sdk/solana')" )
 # NOTE: relayer + kms-connector + solana-proof-service must run feature/solana
 # worktree code (via --override), NOT the pinned 4f42734 baseline images: the
 # prebuilt kms-connector at that tag rejects the generated Solana host_chains


### PR DESCRIPTION
## Summary
- `fhevm-cli up` cargo-builds host-listener; `build.rs` runs `npm ci` in `host-contracts/` and reifies the workspace root to that graph, wiping the SDK install `clean-e2e.sh` just did. Vite then 500s on `@noble/curves/ed25519.js`.
- Restore the same SDK workspace graph immediately after `up`, and re-prove `@fhevm/sdk/solana` imports, before the demo dApp or e2e resolve the symlink.
- Replaces #3527 with the one-file restore instead of a host-listener bindings migration.

## Test plan
- [ ] From a clean tree: `bun run demo up` then open the demo dApp — Vite should resolve `@noble/curves/ed25519.js` (no 500s)
- [ ] `clean-e2e.sh` should print the post-up `@fhevm/sdk/solana` import canaries as OK
- [ ] Existing `solana-e2e.yml` post-up SDK install remains harmless (idempotent `npm ci`)