### PR TITLE
chore: unblock CI on KMS connector

### DIFF
--- a/kms-connector/.cargo/audit.toml
+++ b/kms-connector/.cargo/audit.toml
@@ -4,7 +4,8 @@
 [advisories]
 # The ignored vulnerability RUSTSEC-2023-0071 is due to sqlx-mysql which is not used
 # The ignored vulnerability RUSTSEC-2025-0111 is affecting only the testcontainers only used for testing
-ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0111"]
+# The ignored vulnerability RUSTSEC-2026-0258 low severity and a real fix is tracked in https://github.com/zama-ai/fhevm-internal/issues/1923
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0111", "RUSTSEC-2026-0258"]
 informational_warnings = ["unmaintained"]
 severity_threshold = "medium"
 


### PR DESCRIPTION
Small fix to unblock CI for now. Follow-up issue added [here](https://github.com/zama-ai/fhevm-internal/issues/1923)