### PR TITLE
fix(sdk): mainnet protocolConfig address and browser-smoke test path

### DIFF
--- a/sdk/js-sdk/src/core/chains/definitions/mainnet.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/mainnet.ts
@@ -13,7 +13,9 @@ export const mainnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0x77627828a55156b04Ac0DC0eb30467f1a552BB03',
       },
-      protocolConfig: undefined, // To be filled
+      protocolConfig: {
+        address: '0xD8236B57394f90726b26aB25D38CeAC776E1a7C4',
+      },
     },
     relayerUrl: 'https://relayer.mainnet.zama.org',
     gateway: {

--- a/sdk/js-sdk/test/browser-smoke/playwright.config.ts
+++ b/sdk/js-sdk/test/browser-smoke/playwright.config.ts
@@ -1,10 +1,15 @@
 import { defineConfig } from '@playwright/test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const viteConfigPath = resolve(__dirname, 'vite.config.ts');
 
 export default defineConfig({
   testDir: './specs',
   timeout: 300_000,
   webServer: {
-    command: 'npx vite --config test/browser-smoke/vite.config.ts',
+    command: `npx vite --config ${JSON.stringify(viteConfigPath)}`,
     port: 3333,
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary
- Fill in the previously-unset `protocolConfig` address for the mainnet chain definition, pointing it at the deployed ProtocolConfig contract.
- Fix `test:browser-smoke`'s webServer command to pass an absolute path to `vite.config.ts`, so it's immune to Vite's root-relative re-resolution of relative `--config` paths (the vite config sets `root` two directories up, which broke the previous relative-path fix).

## Test plan
- [x] `npm run test:browser-smoke` passes locally in `sdk/js-sdk` (all 15 tests, chromium/firefox/webkit)
- [x] `js-sdk-dod` CI workflow passes
