### PR TITLE
test(sdk): add memory-leak stress harness for js-sdk

### DIFF
--- a/sdk/js-sdk/package.json
+++ b/sdk/js-sdk/package.json
@@ -50,6 +50,7 @@
     "test:localcleartext:v13": "./test/scripts/localcleartext-run-tests.sh --foundry-profile=v13",
     "test:localcleartext:pack:v12": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v12",
     "test:localcleartext:pack:v13": "./test/scripts/rebuild_sdk_and_pack.sh --build-profile=prod && ./test/scripts/localcleartext-run-tests.sh --use-pack --foundry-profile=v13",
+    "test:memleaks": "node test/memleaks/run.mjs",
     "test": "npm run test:unit && npm run test:localcleartext:pack:v12 && npm run test:localcleartext:pack:v13 && npm run test:browser-smoke",
     "dod": "node test/scripts/dod.mjs",
     "dod:full": "node test/scripts/dod.mjs --full",

--- a/sdk/js-sdk/scripts/list-sdk-exports.mjs
+++ b/sdk/js-sdk/scripts/list-sdk-exports.mjs
@@ -2,8 +2,24 @@
 // Lists all publicly exported names from each @fhevm/sdk entry point defined in src/package.json
 
 import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`Usage: ${basename(fileURLToPath(import.meta.url))} [options]
+
+Lists all publicly exported names from each @fhevm/sdk entry point
+defined in src/package.json.
+
+Options:
+  --functions-only   Only list exported functions (omit types, interfaces, etc.)
+  -h, --help         Show this help message`);
+  process.exit(0);
+}
+
+const functionsOnly = args.includes('--functions-only');
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -32,6 +48,11 @@ function extractExports(content) {
   return [...new Set(names)].sort();
 }
 
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+let anyExports = false;
 let anyOutput = false;
 
 for (const [entryPoint, conditions] of Object.entries(pkg.exports)) {
@@ -52,15 +73,28 @@ for (const [entryPoint, conditions] of Object.entries(pkg.exports)) {
 
   const names = extractExports(content);
   if (names.length === 0) continue;
+  anyExports = true;
+
+  const entries = names.map((name) => {
+    const isType = /^[A-Z]/.test(name) || content.includes(`export type { ${name}`) || content.includes(`export type {${name}`);
+    const tag = isType && !content.match(new RegExp(`export\\s+(?:async\\s+)?(?:function|const|let|var)\\s+${escapeRegExp(name)}`)) ? 'type' : 'fn  ';
+    return { name, tag };
+  }).filter((entry) => !functionsOnly || entry.tag === 'fn  ');
+
+  if (entries.length === 0) continue;
 
   anyOutput = true;
   const label = entryPoint === '.' ? '@fhevm/sdk' : `@fhevm/sdk/${entryPoint.replace(/^\.\//, '')}`;
   console.log(`\n${label}`);
-  for (const name of names) {
-    const isType = /^[A-Z]/.test(name) || content.includes(`export type { ${name}`) || content.includes(`export type {${name}`);
-    const tag = isType && !content.match(new RegExp(`export\\s+(?:async\\s+)?(?:function|const|let|var)\\s+${name}`)) ? 'type' : 'fn  ';
-    console.log(`  ${tag}  ${name}`);
+  for (const { name, tag } of entries) {
+    console.log(functionsOnly ? `  ${name}` : `  ${tag}  ${name}`);
   }
 }
 
-if (!anyOutput) console.log('(no exports found — run "npm run build:types" first or check source paths)');
+if (!anyOutput) {
+  console.log(
+    functionsOnly && anyExports
+      ? '(no exported functions found — exports exist but are all types/interfaces/etc.)'
+      : '(no exports found — run "npm run build:types" first or check source paths)',
+  );
+}

--- a/sdk/js-sdk/src/core/runtimeConfig-p.ts
+++ b/sdk/js-sdk/src/core/runtimeConfig-p.ts
@@ -1,3 +1,4 @@
+import type { Auth } from './types/auth.js';
 import type { FhevmModuleVersions } from './types/moduleVersions.js';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -23,4 +24,19 @@ export function moduleVersionsAreEqual(
   }
 
   return a.tfhe === b.tfhe && a.kms === b.kms && a.checkCompatibility === b.checkCompatibility;
+}
+
+export function authsAreEqual(a: Auth | undefined, b: Auth | undefined): boolean {
+  if (a === undefined || b === undefined) {
+    return a === b;
+  }
+
+  switch (a.type) {
+    case 'BearerToken':
+      return b.type === 'BearerToken' && a.token === b.token;
+    case 'ApiKeyHeader':
+      return b.type === 'ApiKeyHeader' && a.value === b.value && a.header === b.header;
+    case 'ApiKeyCookie':
+      return b.type === 'ApiKeyCookie' && a.value === b.value && a.cookie === b.cookie;
+  }
 }

--- a/sdk/js-sdk/src/ethers/internal/config.ts
+++ b/sdk/js-sdk/src/ethers/internal/config.ts
@@ -1,5 +1,5 @@
 import type { FhevmRuntimeConfig } from '../../core/types/coreFhevmRuntime.js';
-import { cloneModuleVersions, moduleVersionsAreEqual } from '../../core/runtimeConfig-p.js';
+import { authsAreEqual, cloneModuleVersions, moduleVersionsAreEqual } from '../../core/runtimeConfig-p.js';
 
 let ethersFhevmRuntimeConfig: FhevmRuntimeConfig | undefined;
 
@@ -31,7 +31,8 @@ export function setFhevmRuntimeConfig(config: FhevmRuntimeConfig): void {
     ethersFhevmRuntimeConfig.wasmAssetLoadMode !== config.wasmAssetLoadMode ||
     !moduleVersionsAreEqual(ethersFhevmRuntimeConfig.moduleVersions, config.moduleVersions) ||
     ethersFhevmRuntimeConfig.singleThread !== config.singleThread ||
-    ethersFhevmRuntimeConfig.numberOfThreads !== config.numberOfThreads
+    ethersFhevmRuntimeConfig.numberOfThreads !== config.numberOfThreads ||
+    !authsAreEqual(ethersFhevmRuntimeConfig.auth, config.auth)
   ) {
     throw new Error(
       'FhevmRuntime config has already been set and cannot be changed. ' +

--- a/sdk/js-sdk/src/viem/internal/config.ts
+++ b/sdk/js-sdk/src/viem/internal/config.ts
@@ -1,5 +1,5 @@
 import type { FhevmRuntimeConfig } from '../../core/types/coreFhevmRuntime.js';
-import { cloneModuleVersions, moduleVersionsAreEqual } from '../../core/runtimeConfig-p.js';
+import { authsAreEqual, cloneModuleVersions, moduleVersionsAreEqual } from '../../core/runtimeConfig-p.js';
 
 let viemFhevmRuntimeConfig: FhevmRuntimeConfig | undefined;
 
@@ -31,7 +31,8 @@ export function setFhevmRuntimeConfig(config: FhevmRuntimeConfig): void {
     viemFhevmRuntimeConfig.wasmAssetLoadMode !== config.wasmAssetLoadMode ||
     !moduleVersionsAreEqual(viemFhevmRuntimeConfig.moduleVersions, config.moduleVersions) ||
     viemFhevmRuntimeConfig.singleThread !== config.singleThread ||
-    viemFhevmRuntimeConfig.numberOfThreads !== config.numberOfThreads
+    viemFhevmRuntimeConfig.numberOfThreads !== config.numberOfThreads ||
+    !authsAreEqual(viemFhevmRuntimeConfig.auth, config.auth)
   ) {
     throw new Error(
       'FhevmRuntime config has already been set and cannot be changed. ' +

--- a/sdk/js-sdk/test/fheTest/keyCache.ts
+++ b/sdk/js-sdk/test/fheTest/keyCache.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const KEYS_DIR = resolve(__dirname, '.keys');
+const KEYS_DIR = resolve(import.meta.dirname, '.keys');
 
 export type CachedFheEncryptionKeyBytes = FheEncryptionKeyBytes & {
   readonly chain: FheTestChainName;

--- a/sdk/js-sdk/test/fheTest/setupCommon.ts
+++ b/sdk/js-sdk/test/fheTest/setupCommon.ts
@@ -315,7 +315,7 @@ let _chainDefaults: Partial<Record<FheTestChainName, ChainDefaults>> | undefined
 
 function loadChainDefaults(): Partial<Record<FheTestChainName, ChainDefaults>> {
   if (_chainDefaults === undefined) {
-    const p = resolve(__dirname, '../chains/chain-defaults.json');
+    const p = resolve(import.meta.dirname, '../chains/chain-defaults.json');
     _chainDefaults = JSON.parse(readFileSync(p, 'utf-8')) as Partial<Record<FheTestChainName, ChainDefaults>>;
   }
   return _chainDefaults;
@@ -534,7 +534,7 @@ export function prepareChains(): FheTestBaseEnv[] {
 }
 
 function _prepareChain(chainName: FheTestChainName): FheTestBaseEnv {
-  const testDir = resolve(__dirname, '..');
+  const testDir = resolve(import.meta.dirname, '..');
   const isLocalstack = chainName.startsWith('localstack');
   const envFilename = isLocalCleartextChain(chainName)
     ? '.env.localcleartext'

--- a/sdk/js-sdk/test/memleaks/README.md
+++ b/sdk/js-sdk/test/memleaks/README.md
@@ -1,0 +1,175 @@
+# Memory-leak stress harness
+
+Long-running stress loops of FHE encrypt/decrypt/serialize operations against a
+real `localstack` Docker stack (not the cleartext mock), sampling process and
+WASM memory to detect sustained growth. This is a **standalone script**, not a
+vitest suite — there is deliberately no CI-facing pass/fail test here yet (see
+[Status](#status) below).
+
+## Why this shape
+
+The WASM runtime (`tfhe`/`tkms`) is a per-process singleton with no re-init
+path: `initTfheModule` (`src/core/modules/encrypt/module/init-p.ts`) caches
+its init promise per version forever, and there is no `terminateThreadPool`.
+So this can't be a create/destroy/assert-baseline-restored test — there is no
+teardown to return to. It has to be a long-running, in-process steady-state
+loop that watches whether memory trends toward a plateau (expected — caches
+filling, thread-pool buffers, JIT warmup) or grows without bound (a leak).
+
+`WebAssembly.Memory` can also only grow, never shrink, by spec. So "WASM
+memory didn't shrink" is never itself evidence of a leak — only *sustained,
+non-decaying growth proportional to operation count* is. Every scenario here
+is judged by that trend, not by an absolute number (see
+`support/trendDetector.ts`).
+
+## Running it
+
+Requires a running `localstack` Docker stack (see
+`test/scripts/localstack-restart.sh`), or pass `--restart-localstack` to have
+it started for you.
+
+```sh
+# from sdk/js-sdk
+node test/memleaks/run.mjs --restart-localstack --scenario clientChurn --iterations 500
+node test/memleaks/run.mjs --scenario clientReuse --iterations 5000
+node test/memleaks/run.mjs --scenario all --duration-seconds 1800
+node test/memleaks/run.mjs --help
+```
+
+`run.mjs` is a thin dispatcher: it re-execs `main.ts` via `tsx` with
+`NODE_OPTIONS=--expose-gc` set, so the sampler can force a GC pass before
+every measurement (without it, GC scheduling noise dominates the signal).
+Output is printed as a running table and also written as JSONL under
+`test/memleaks/reports/<scenario>.jsonl` for post-run inspection.
+
+## Scenarios
+
+Each scenario isolates a different leak surface — running them blended into
+one loop would hide which one is actually responsible for any growth seen.
+
+- **`clientReuse`** — one long-lived client, looping `encryptValues` +
+  `decryptValues` against a stable on-chain handle. Targets the
+  per-*operation* path (building/parsing a ciphertext list). This reads clean
+  in the code (`buildWithProofPacked` frees its wasm-bindgen objects in a
+  `finally`), so it's also the control group: if this one shows unbounded
+  growth too, suspect the harness/detector before suspecting the SDK.
+
+- **`clientChurn`** — evicts the global FHE-key cache and creates a fresh
+  client every iteration, forcing one public-key + CRS deserialize per
+  iteration. Targets `deserializeFheEncryptionPublicKey`/
+  `deserializeFheEncryptionCrs` (`src/core/modules/encrypt/module/api-p.ts`),
+  whose JS wrapper classes (`TfheCompactPkeCrsImpl`/`TfheCompactPublicKeyImpl`)
+  never call `.free()` on their native handle — unlike `buildWithProofPacked`.
+  **Two things worth knowing before reading this scenario's output:**
+  - Naively creating "N fresh clients" does **not** stress this path.
+    `globalFheEncryptionKeyCache` (`src/core/key/FheEncryptionKeyCache-p.ts`)
+    is a process-wide singleton keyed by relayer URL with "first write wins"
+    semantics — the key is deserialized once per relayer URL for the life of
+    the process; every later client just awaits the same cached entry. This
+    scenario calls `globalFheEncryptionKeyCache.remove(relayerUrl)` before
+    every iteration (exactly what that cache's own doc comment prescribes for
+    forcing a re-fetch) to actually force fresh deserialization each time.
+  - Missing `.free()` is not automatically a leak here. The vendored tfhe glue
+    is a `--weak-refs` wasm-bindgen build, and both `CompactPkeCrs` and
+    `TfheCompactPublicKey` register themselves with a `FinalizationRegistry`
+    at construction (`src/wasm/tfhe/v1.6.2/tfhe.js`), so the WASM memory *can*
+    still be reclaimed once the JS wrapper is unreachable and a GC pass runs
+    its pending finalizers — which is exactly what `remove()` + forced
+    `global.gc()` between iterations should trigger, if the mechanism works
+    end to end. Sustained growth despite that would mean something else keeps
+    the old key reachable, or the finalizer path isn't actually running —
+    either way a genuine finding, not a foregone conclusion.
+
+- **`roundtrip`** — full encrypt → submit tx → wait for receipt →
+  user-decrypt → public-decrypt cycle against the real `FHETest` contract.
+  Exercises the ethers provider/signer/contract/tx-lifecycle code paths the
+  pure client-side scenarios never touch. Far fewer iterations given per-tx
+  latency and localstack throughput.
+  **This is the one scenario that showed real growth in a real run**:
+  `tfheMemory` grew at an *accelerating* rate (4.4KB/iter → 115.8KB/iter over
+  40 iterations) — unlike `rss`/`external`, WASM memory can't produce that
+  pattern from sampling-phase noise, so this was worth investigating. A
+  source-level pass ruled out a JS-side cache keyed by plaintext value, any
+  tfhe-module involvement in `decryptPublicValues` (it's tkms-only), and any
+  code path that loops back into the encrypt module after `tx.wait()`. The
+  leading (not yet independently verified) explanation is WASM-side allocator
+  fragmentation: `roundtrip` is also the only scenario that encrypts a
+  *different* plaintext value every iteration (`clearValue = counter % 256`)
+  rather than the same fixed value(s) every time — see `valueChurn` below,
+  which isolates exactly that variable.
+
+- **`valueChurn`** — one long-lived client, looping `encryptValue` with a
+  different uint8 value every iteration (`counter % 256`). No transaction, no
+  decrypt — added specifically to isolate the "varying plaintext" variable
+  from everything else `roundtrip` does, and runs much faster since it skips
+  the tx-wait/decrypt relayer round-trips. If the allocator-fragmentation
+  hypothesis is right, growth here should decelerate/plateau once the value
+  cycle repeats past iteration 256 (every allocation shape has already been
+  seen once); a genuine unbounded leak wouldn't care about that boundary.
+
+- **`permitChurn`** — the tkms-side counterpart to `valueChurn`. One
+  long-lived client, looping a *fresh* `generateTransportKeyPair()` +
+  `signLegacyDecryptionPermit()` + `signUnifiedDecryptionPermit()` every
+  iteration — no transaction, no relayer decrypt call. `roundtrip`
+  deliberately signs one permit in its `setup()` and reuses it for every
+  iteration (realistic session behavior, and to keep this leak surface out of
+  the encrypt/tx/decrypt measurement); this scenario isolates exactly what
+  that choice leaves untested: does repeated ML-KEM transport-keypair
+  generation and EIP-712 permit signing (both the legacy V1 and unified V2
+  permit paths) leak tkms WASM memory on its own? All three operations are
+  purely local (no network I/O), so
+  this should run much faster per iteration than any relayer-bound scenario.
+
+- **`providerChurn`** — not a WASM/FHE test. Creates an ephemeral
+  `ethers.JsonRpcProvider` + signer every iteration, does one read call, and
+  discards them. Isolates listener/socket/interval leaks in the ethers layer
+  itself, independent of anything FHE-specific — a distinct and common leak
+  class that would be invisible inside the other scenarios. Also mirrors how
+  `test/fheTest/setup-ethers.ts` itself builds providers (fresh
+  `JsonRpcProvider` per config, never `.destroy()`-ed).
+
+## Reading the output
+
+Each scenario prints a running table (iteration, elapsed time, RSS + delta,
+tfhe/tkms WASM memory + delta, cumulative GC count) and a trend summary at the
+end:
+
+```
+--- clientChurn: trend summary ---
+  rss            plateauing    first-half 12.0KB/iter -> second-half 0.4KB/iter  (peak 3.1MB above baseline)
+  tfheMemory     ⚠ GROWING     first-half 8.0KB/iter -> second-half 7.6KB/iter  (peak 4.2MB above baseline)
+```
+
+A metric is classified `growing` when its second-half-of-the-run growth rate
+hasn't meaningfully decayed from the first half (or exceeds the absolute
+ceiling) — see `support/trendDetector.ts` for the exact rule.
+
+**Only `tfheMemory`/`tkmsMemory` gate the exit code** (plus an absolute
+ceiling breach on any metric). `rss`/`heapUsed`/`external`/`arrayBuffers` are
+still computed and printed — real runs against localstack showed them
+oscillating by tens of MB per iteration (a big transient allocation during
+each iteration's work, mostly reclaimed by GC before the next one), and a
+two-half linear fit over that kind of sawtooth data can show a spurious slope
+purely from which points happen to land near a peak vs. a trough, regardless
+of how the noise floor is tuned. `WebAssembly.Memory` only ever grows, so
+`tfheMemory`/`tkmsMemory` don't have a trough to be out of phase with — a
+sustained climb there is real, which is why they're the metrics that actually
+fail the run. The process-level metrics are printed as
+`(informational — process-level, does not gate)` for exactly this reason:
+worth a glance, not a verdict.
+
+## Status
+
+**v1 is a standalone script only — there is no vitest smoke test or CI wiring
+yet, and that's deliberate.** The trend-detection thresholds in
+`support/trendDetector.ts` (warmup window, growth-ratio tolerance, absolute
+ceiling) are placeholders. Shipping them as a CI-facing gate before they've
+been validated against real observed runs would either flake on GC/warmup
+noise or give false confidence that nothing was checked. The plan is: run
+this manually (or as a scheduled job) first, tune the thresholds against real
+data, and only then extract a CI smoke test.
+
+Also out of scope for v1: the `localstack_v11`/`v12`/`v13` version matrix (only
+the latest `localstack` chain is targeted), and a viem variant (the leak
+surface — the core WASM modules — is client-library-agnostic; ethers is what
+`test/multi-wasm` already exercises for round-trips).

--- a/sdk/js-sdk/test/memleaks/main.ts
+++ b/sdk/js-sdk/test/memleaks/main.ts
@@ -1,0 +1,335 @@
+import { resolve } from 'node:path';
+import { setImmediate as setImmediateP } from 'node:timers/promises';
+import { getEthersTestConfig } from '../fheTest/setup-ethers.js';
+import { loadLocalstackChainDefaults } from './support/chainDefaults.js';
+import { ensureLocalstackReady } from './support/localstack.js';
+import { assertGcIsExposed, MemorySampler } from './support/memorySampler.js';
+import { evaluateAllTrends, hasActionableGrowth } from './support/trendDetector.js';
+import {
+  printHeader,
+  printSampleLine,
+  printTrendSummary,
+  updateMetricBaselines,
+  type MetricBaselines,
+} from './support/reporter.js';
+import { clientReuseScenario } from './scenarios/clientReuse.js';
+import { clientChurnScenario } from './scenarios/clientChurn.js';
+import { roundtripScenario } from './scenarios/roundtrip.js';
+import { providerChurnScenario } from './scenarios/providerChurn.js';
+import { valueChurnScenario } from './scenarios/valueChurn.js';
+import { permitChurnScenario } from './scenarios/permitChurn.js';
+import type { Scenario } from './scenarios/scenario.js';
+
+// This project targets the `localstack` chain only (see plan: no
+// multi-version matrix in v1) — forced here rather than left to whatever
+// CHAIN happens to be set in the caller's shell.
+const CHAIN_NAME = 'localstack';
+const MAX_CONSECUTIVE_ITERATION_FAILURES = 10;
+
+const SCENARIOS: Readonly<Record<string, Scenario>> = {
+  providerChurn: providerChurnScenario,
+  permitChurn: permitChurnScenario,
+  valueChurn: valueChurnScenario,
+  clientReuse: clientReuseScenario,
+  clientChurn: clientChurnScenario,
+  roundtrip: roundtripScenario,
+};
+
+type CliOptions = {
+  readonly scenarioNames: readonly string[];
+  readonly iterations: number | undefined;
+  readonly durationSeconds: number | undefined;
+  readonly sampleIntervalMs: number;
+  readonly warmupIterations: number | undefined;
+  readonly restartLocalstack: boolean;
+  readonly fhevmCliProfile: string | undefined;
+  readonly outDir: string;
+};
+
+async function main(): Promise<void> {
+  assertGcIsExposed();
+
+  const options = parseArgs(process.argv.slice(2));
+  process.env.CHAIN = CHAIN_NAME;
+
+  const { rpcUrl } = loadLocalstackChainDefaults(CHAIN_NAME);
+  await ensureLocalstackReady({
+    restart: options.restartLocalstack,
+    rpcUrl,
+    chainName: CHAIN_NAME,
+    fhevmCliProfile: options.fhevmCliProfile,
+  });
+
+  const config = getEthersTestConfig();
+
+  for (const name of options.scenarioNames) {
+    const scenario = SCENARIOS[name];
+    if (scenario === undefined) {
+      throw new Error(`Unknown scenario "${name}". Available: ${Object.keys(SCENARIOS).join(', ')}.`);
+    }
+    const plateaued = await runScenario(scenario, { config, options });
+    if (!plateaued) {
+      console.error(`\n❌ ${scenario.name} showed sustained (non-plateauing) memory growth. See trend summary above.`);
+      process.exit(1);
+    } else {
+      console.log(`\n✅ ${scenario.name} plateaued (or had insufficient data to classify). No anomaly detected.`);
+    }
+  }
+}
+
+async function runScenario(
+  scenario: Scenario,
+  context: { config: ReturnType<typeof getEthersTestConfig>; options: CliOptions },
+): Promise<boolean> {
+  const { config, options } = context;
+  console.log(`\nSetting up scenario "${scenario.name}" — ${scenario.description}`);
+
+  const { iterate, readTfheMemory, readTkmsMemory, teardown } = await scenario.setup({ config });
+
+  let iteration = 0;
+  let sampleCount = 0;
+  const baselines: MetricBaselines = { rssBytes: undefined, tfheMemoryBytes: undefined, tkmsMemoryBytes: undefined };
+  const startedAtMs = Date.now();
+
+  // Computed before the sampler so the onSample closure below can reference
+  // them — it fires synchronously from the `sampler.tick()` call right after
+  // `sampler.start()`, before any code declared later in this function runs.
+  const iterationLimit = options.iterations ?? scenario.defaultIterations;
+  const deadlineMs = options.durationSeconds !== undefined ? Date.now() + options.durationSeconds * 1_000 : undefined;
+  // Default warmup scales with the run length: a flat default (e.g. 50) would
+  // silently swallow every sample on a short manual smoke run (--iterations
+  // 50 with a 50-iteration warmup leaves nothing to classify).
+  const warmupIterations = options.warmupIterations ?? Math.min(50, Math.max(1, Math.floor(iterationLimit * 0.1)));
+
+  const sampler = new MemorySampler({
+    intervalMs: options.sampleIntervalMs,
+    getIteration: () => iteration,
+    ...(readTfheMemory !== undefined ? { readTfheMemory } : {}),
+    ...(readTkmsMemory !== undefined ? { readTkmsMemory } : {}),
+    jsonlPath: resolve(options.outDir, `${scenario.name}.jsonl`),
+    onSample: (sample) => {
+      if (sampleCount === 0) {
+        printHeader(scenario.name);
+      }
+      sampleCount += 1;
+      const etaMs = estimateRemainingMs({
+        iteration,
+        iterationLimit,
+        deadlineMs,
+        elapsedMs: sample.tMs - startedAtMs,
+      });
+      // Baselines are tracked per-metric (see updateMetricBaselines) rather
+      // than snapshotting one "first sample": RSS is defined from tick 0, but
+      // tfhe/tkms WASM memory only becomes defined once a client actually
+      // initializes that module, which can be several samples in.
+      printSampleLine(sample, baselines, startedAtMs, etaMs);
+      updateMetricBaselines(baselines, sample);
+    },
+  });
+
+  sampler.start();
+  await sampler.tick(); // baseline reading at iteration 0, before the loop starts
+
+  let consecutiveFailures = 0;
+
+  try {
+    while (iteration < iterationLimit && (deadlineMs === undefined || Date.now() < deadlineMs)) {
+      try {
+        await iterate();
+        consecutiveFailures = 0;
+      } catch (error) {
+        consecutiveFailures += 1;
+        console.error(`[${scenario.name}] iteration ${iteration} failed:`, error);
+        if (consecutiveFailures > MAX_CONSECUTIVE_ITERATION_FAILURES) {
+          throw new Error(
+            `[${scenario.name}] ${consecutiveFailures} consecutive iteration failures — aborting (is localstack still up?).`,
+          );
+        }
+      }
+      iteration += 1;
+      // Force a real event-loop turn after every iteration. Scenarios whose
+      // work involves genuine I/O (a relayer HTTP call) naturally give the
+      // timers phase a chance to run, so the sampler's setInterval fires on
+      // schedule. Scenarios that are purely local WASM/crypto computation
+      // (e.g. permitChurn) never do — every `await` in their chain resolves
+      // through the microtask queue alone, and Node drains microtasks before
+      // checking timers, so a tight loop of fast, no-I/O iterations can
+      // starve the timers phase for the whole run. `setImmediate` forces a
+      // genuine macrotask boundary so "print regularly" holds regardless of
+      // how a scenario is implemented.
+      await setImmediateP();
+    }
+  } finally {
+    await sampler.stop();
+    await teardown?.();
+  }
+
+  const verdicts = evaluateAllTrends(sampler.samples, { warmupIterations });
+  printTrendSummary(scenario.name, verdicts);
+
+  return !hasActionableGrowth(verdicts);
+}
+
+/**
+ * Estimates remaining wall-clock time from whichever bound the run is closer
+ * to hitting. The iteration-based estimate extrapolates the average time per
+ * iteration seen so far; the duration-based estimate is just a countdown to
+ * the deadline. When both `--iterations` and `--duration-seconds` are set,
+ * either can end the run first, so this reports the smaller (sooner) of the
+ * two rather than picking one arbitrarily.
+ */
+function estimateRemainingMs(parameters: {
+  readonly iteration: number;
+  readonly iterationLimit: number;
+  readonly deadlineMs: number | undefined;
+  readonly elapsedMs: number;
+}): number | undefined {
+  const { iteration, iterationLimit, deadlineMs, elapsedMs } = parameters;
+  const candidates: number[] = [];
+
+  if (iteration > 0) {
+    const averageMsPerIteration = elapsedMs / iteration;
+    candidates.push(Math.max(0, averageMsPerIteration * (iterationLimit - iteration)));
+  }
+  if (deadlineMs !== undefined) {
+    candidates.push(Math.max(0, deadlineMs - Date.now()));
+  }
+
+  return candidates.length > 0 ? Math.min(...candidates) : undefined;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const options: {
+    scenarioNames: string[];
+    iterations: number | undefined;
+    durationSeconds: number | undefined;
+    sampleIntervalMs: number;
+    warmupIterations: number | undefined;
+    restartLocalstack: boolean;
+    fhevmCliProfile: string | undefined;
+    outDir: string;
+  } = {
+    scenarioNames: Object.keys(SCENARIOS),
+    iterations: undefined,
+    durationSeconds: undefined,
+    sampleIntervalMs: 2_000,
+    warmupIterations: undefined,
+    restartLocalstack: false,
+    fhevmCliProfile: undefined,
+    outDir: resolve(import.meta.dirname, 'reports'),
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--scenario': {
+        const value = requireValue(argv, i);
+        i++;
+        options.scenarioNames = value === 'all' ? Object.keys(SCENARIOS) : value.split(',');
+        break;
+      }
+      case '--iterations':
+        options.iterations = Number(requireValue(argv, i));
+        i++;
+        break;
+      case '--duration-seconds':
+        options.durationSeconds = Number(requireValue(argv, i));
+        i++;
+        break;
+      case '--sample-interval-ms':
+        options.sampleIntervalMs = Number(requireValue(argv, i));
+        i++;
+        break;
+      case '--warmup':
+        options.warmupIterations = Number(requireValue(argv, i));
+        i++;
+        break;
+      case '--restart-localstack':
+        options.restartLocalstack = true;
+        break;
+      case '--fhevm-cli-profile':
+        options.fhevmCliProfile = requireValue(argv, i);
+        i++;
+        break;
+      case '--out':
+        options.outDir = resolve(requireValue(argv, i));
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown option "${arg}". Use --help for usage.`);
+    }
+  }
+
+  for (const name of options.scenarioNames) {
+    if (SCENARIOS[name] === undefined) {
+      throw new Error(`Unknown scenario "${name}". Available: ${Object.keys(SCENARIOS).join(', ')}, or "all".`);
+    }
+  }
+
+  return options;
+}
+
+function requireValue(argv: readonly string[], index: number): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${argv[index]} requires a value.`);
+  }
+  return value;
+}
+
+function printHelp(): void {
+  const descriptions = Object.values(SCENARIOS)
+    .map(
+      (s) =>
+        `  ${s.name.padEnd(16)} ${s.description} (default: ${s.defaultIterations} iterations, ${s.defaultIterationsDuration})`,
+    )
+    .join('\n');
+
+  console.log(`Usage: node test/memleaks/run.mjs [options]
+
+Runs long stress loops of FHE encrypt/decrypt/serialize operations against a
+real localstack Docker stack, sampling process + WASM memory to detect
+sustained (non-plateauing) growth. See test/memleaks/README.md.
+
+Options:
+  --scenario <name|all>       Comma-separated scenario name(s), or "all" (default: all).
+  --iterations <n>            Iteration bound. Defaults to the scenario's own default.
+  --duration-seconds <n>      Wall-clock bound instead of (or in addition to) --iterations.
+  --sample-interval-ms <n>    Sampling cadence in ms (default: 2000).
+  --warmup <n>                Iterations excluded from trend detection as warmup
+                              (default: 10% of the iteration bound, capped at 50).
+  --restart-localstack        Restart the localstack Docker stack before running.
+  --fhevm-cli-profile <name>  Profile filename forwarded to localstack-restart.sh.
+  --out <dir>                 Directory for JSONL sample output (default: test/memleaks/reports).
+  -h, --help                  Show this help.
+
+Scenarios:
+${descriptions}
+
+Examples:
+  node test/memleaks/run.mjs --restart-localstack --scenario clientChurn --iterations 500
+  node test/memleaks/run.mjs --scenario clientReuse --iterations 5000
+  node test/memleaks/run.mjs --scenario all --duration-seconds 1800
+`);
+}
+
+// Force-exit once our own work is done: the tfhe/tkms WASM modules spawn a
+// worker thread pool (`initThreadPool()` in
+// src/core/modules/encrypt/module/init-p.ts) that has no teardown path by
+// design — the module is a permanent per-process singleton (see this
+// project's README). Those workers keep the event loop alive forever, so
+// letting the process exit "naturally" would just hang here regardless of
+// how cleanly every scenario itself finished.
+main()
+  .then(() => {
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/sdk/js-sdk/test/memleaks/reports/.gitignore
+++ b/sdk/js-sdk/test/memleaks/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/sdk/js-sdk/test/memleaks/run.mjs
+++ b/sdk/js-sdk/test/memleaks/run.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// Thin dispatcher: sets up the flags main.ts needs (a working directory
+// relative to the sdk/js-sdk package root, and --expose-gc so the sampler can
+// force a GC pass before every measurement) and hands off to main.ts via tsx,
+// the same way test/multi-wasm/run.mjs hands off to Playwright. All the real
+// logic lives in main.ts.
+//
+// Runs can take tens of minutes (see each scenario's defaultIterationsDuration),
+// so this also wraps the child process with a platform-appropriate
+// sleep-inhibitor — `caffeinate` on macOS, `systemd-inhibit` on Linux — rather
+// than relying on the caller to remember to do that themselves. Falls back to
+// running unwrapped (with a warning) when the inhibitor binary isn't installed,
+// and skips it entirely on platforms with no known equivalent.
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const sdkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const mainTsPath = resolve(dirname(fileURLToPath(import.meta.url)), 'main.ts');
+
+const existingNodeOptions = process.env.NODE_OPTIONS ?? '';
+const nodeOptions = existingNodeOptions.includes('--expose-gc')
+  ? existingNodeOptions
+  : `${existingNodeOptions} --expose-gc`.trim();
+
+const spawnOptions = {
+  cwd: sdkRoot,
+  env: { ...process.env, NODE_OPTIONS: nodeOptions },
+  stdio: 'inherit',
+};
+
+const tsxArgs = ['tsx', mainTsPath, ...process.argv.slice(2)];
+
+const sleepInhibitor =
+  process.platform === 'darwin'
+    ? { command: 'caffeinate', args: ['-i'] }
+    : process.platform === 'linux'
+      ? { command: 'systemd-inhibit', args: ['--what=idle:sleep', '--why=fhevm memleak tests'] }
+      : undefined;
+
+let result = sleepInhibitor
+  ? spawnSync(sleepInhibitor.command, [...sleepInhibitor.args, 'npx', ...tsxArgs], spawnOptions)
+  : spawnSync('npx', tsxArgs, spawnOptions);
+
+if (sleepInhibitor && result.error?.code === 'ENOENT') {
+  console.warn(`[memleaks] "${sleepInhibitor.command}" not found — running without sleep prevention.`);
+  result = spawnSync('npx', tsxArgs, spawnOptions);
+}
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/sdk/js-sdk/test/memleaks/scenarios/clientChurn.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/clientChurn.ts
@@ -1,0 +1,93 @@
+import { createFhevmEncryptClient, hasFhevmRuntimeConfig, setFhevmRuntimeConfig } from '../../../src/ethers/index.js';
+import { globalFheEncryptionKeyCache } from '../../../src/core/key/FheEncryptionKeyCache-p.js';
+import { createLogger, encryptTestCases } from '../../fheTest/setupCommon.js';
+import { createTfheMemoryReader } from '../support/wasmMemory.js';
+import type { Scenario } from './scenario.js';
+
+// ---------------------------------------------------------------------------
+// Mode B: force a fresh public-key + CRS deserialize every iteration
+// ---------------------------------------------------------------------------
+//
+// Targets `deserializeFheEncryptionPublicKey`/`deserializeFheEncryptionCrs`
+// (src/core/modules/encrypt/module/api-p.ts:438-485), which wrap native
+// wasm-bindgen objects (`CompactPkeCrs`, `TfheCompactPublicKey`) in
+// `TfheCompactPkeCrsImpl`/`TfheCompactPublicKeyImpl` — neither wrapper class
+// calls `.free()` on its native handle, unlike `buildWithProofPacked`, which
+// frees its ciphertext-list/builder objects in a `finally`.
+//
+// This is NOT a guaranteed leak, and this scenario exists specifically to
+// measure it rather than assume it: the vendored tfhe glue is a `--weak-refs`
+// wasm-bindgen build, and both `CompactPkeCrs` and `TfheCompactPublicKey`
+// register themselves with a `FinalizationRegistry` at construction (see
+// `CompactPkeCrsFinalization`/`TfheCompactPublicKeyFinalization` in
+// src/wasm/tfhe/v1.6.2/tfhe.js). So even without an explicit `.free()`, the
+// underlying WASM memory *can* still be reclaimed once the JS wrapper becomes
+// unreachable and a GC pass runs its pending finalizers. Whether that
+// actually happens in practice — promptly, at all, or only once memory
+// pressure forces it — is exactly the open question this scenario is built
+// to answer empirically.
+//
+// A more basic pitfall this scenario deliberately avoids: naively creating
+// "N fresh clients" against the same chain would NOT exercise this path more
+// than once. `globalFheEncryptionKeyCache`
+// (src/core/key/FheEncryptionKeyCache-p.ts) is a process-wide singleton keyed
+// by relayerUrl with "first write wins" semantics — the key is deserialized
+// once per relayerUrl for the life of the process, and every later client
+// just awaits the same cached entry. Its own doc comment says as much: "To
+// force a re-fetch, call `remove(relayerUrl)` before `ensureBytes`." — so
+// this scenario does exactly that before every iteration, which is also what
+// makes the old entry's wasm objects unreachable (and thus GC/finalizer
+// eligible) in the first place.
+
+export const clientChurnScenario: Scenario = {
+  name: 'clientChurn',
+  description:
+    'Evicts the global FHE key cache and creates a fresh client every iteration, forcing one public-key+CRS deserialize per iteration.',
+  // A real relayer round-trip plus a full key deserialize per iteration is far
+  // heavier than clientReuse's steady-state loop — default to fewer iterations.
+  defaultIterations: 200,
+  defaultIterationsDuration: '~15 min',
+  setup: async ({ config }) => {
+    // Process-wide singleton: when running multiple scenarios in one `main.ts`
+    // invocation (e.g. `--scenario all`), only the first scenario's setup()
+    // may call this — a later call with a fresh `createLogger()` reference
+    // would throw even though the effective config is identical.
+    if (!hasFhevmRuntimeConfig()) {
+      setFhevmRuntimeConfig({
+        auth: { type: 'ApiKeyHeader', value: config.zamaApiKey },
+        logger: createLogger(console.log, config.chainName),
+      });
+    }
+
+    const tfheVersion =
+      config.moduleVersions !== undefined && config.moduleVersions !== 'auto' ? config.moduleVersions.tfhe : undefined;
+    const relayerUrl = config.fhevmChain.fhevm.relayerUrl;
+    const options = config.moduleVersions !== undefined ? { moduleVersions: config.moduleVersions } : undefined;
+
+    const readTfheMemory = await createTfheMemoryReader(tfheVersion);
+
+    const uint8Case = encryptTestCases.find((tc) => tc.type === 'uint8');
+    if (uint8Case === undefined) {
+      throw new Error('encryptTestCases has no uint8 entry.');
+    }
+
+    const iterate = async (): Promise<void> => {
+      globalFheEncryptionKeyCache.remove(relayerUrl);
+
+      const client = createFhevmEncryptClient({
+        chain: config.fhevmChain,
+        provider: config.provider,
+        options,
+      });
+      await client.ready;
+
+      await client.encryptValue({
+        contractAddress: config.fheTestAddress,
+        userAddress: config.wallet.address,
+        value: uint8Case,
+      });
+    };
+
+    return { iterate, readTfheMemory };
+  },
+};

--- a/sdk/js-sdk/test/memleaks/scenarios/clientReuse.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/clientReuse.ts
@@ -1,0 +1,81 @@
+import type { ethers } from 'ethers';
+import { createFhevmClient, hasFhevmRuntimeConfig, setFhevmRuntimeConfig } from '../../../src/ethers/index.js';
+import { createLogger, encryptTestCases, fheTypeIdFromName } from '../../fheTest/setupCommon.js';
+import { createTfheMemoryReader, createTkmsMemoryReader } from '../support/wasmMemory.js';
+import type { Scenario } from './scenario.js';
+
+// Mode A (control group): one long-lived client, looping encryptValues +
+// decryptValues. Targets the per-*operation* code path — building/parsing a
+// ciphertext list (`buildWithProofPacked` in
+// src/core/modules/encrypt/module/api-p.ts) — which frees its wasm-bindgen
+// objects in a `finally` and reads clean from the source. This scenario
+// exists to prove the detector doesn't just flag everything: if this one
+// grows unbounded too, the detector or the harness itself is suspect, not
+// just the client-churn code path.
+
+export const clientReuseScenario: Scenario = {
+  name: 'clientReuse',
+  description: 'One long-lived client; loops encryptValues + decryptValues against a stable on-chain handle.',
+  defaultIterations: 200,
+  defaultIterationsDuration: '~1h',
+  setup: async ({ config }) => {
+    // Process-wide singleton: when running multiple scenarios in one `main.ts`
+    // invocation (e.g. `--scenario all`), only the first scenario's setup()
+    // may call this — a later call with a fresh `createLogger()` reference
+    // would throw even though the effective config is identical.
+    if (!hasFhevmRuntimeConfig()) {
+      setFhevmRuntimeConfig({
+        auth: { type: 'ApiKeyHeader', value: config.zamaApiKey },
+        logger: createLogger(console.log, config.chainName),
+      });
+    }
+
+    const tfheVersion =
+      config.moduleVersions !== undefined && config.moduleVersions !== 'auto' ? config.moduleVersions.tfhe : undefined;
+
+    const client = createFhevmClient({
+      chain: config.fhevmChain,
+      provider: config.provider,
+      options: config.moduleVersions !== undefined ? { moduleVersions: config.moduleVersions } : undefined,
+    });
+    await client.ready;
+
+    // A stable, pre-existing handle (created by setupCommon's initFheTest
+    // preflight for Alice) so every iteration decrypts the same real on-chain
+    // value instead of needing a fresh transaction per iteration.
+    const fheTest = config.fheTestContract.connect(config.signer) as ethers.Contract;
+    const stableHandle: string = await fheTest.getHandleOf!(config.wallet.address, fheTypeIdFromName('euint64'));
+
+    const transportKeyPair = await client.generateTransportKeyPair();
+    const signedPermit = await client.signLegacyDecryptionPermit({
+      transportKeyPair,
+      contractAddresses: [config.fheTestAddress],
+      durationSeconds: 24 * 3600,
+      startTimestamp: Math.floor(Date.now() / 1000) - 5,
+      signerAddress: config.wallet.address,
+      signer: config.signer,
+    });
+
+    const [readTfheMemory, readTkmsMemory] = await Promise.all([
+      createTfheMemoryReader(tfheVersion),
+      createTkmsMemoryReader(),
+    ]);
+
+    const iterate = async (): Promise<void> => {
+      await client.encryptValues({
+        contractAddress: config.fheTestAddress,
+        userAddress: config.wallet.address,
+        values: encryptTestCases,
+      });
+
+      await client.decryptValues({
+        encryptedValues: [stableHandle],
+        contractAddress: config.fheTestAddress,
+        signedPermit,
+        transportKeyPair,
+      });
+    };
+
+    return { iterate, readTfheMemory, readTkmsMemory };
+  },
+};

--- a/sdk/js-sdk/test/memleaks/scenarios/permitChurn.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/permitChurn.ts
@@ -1,0 +1,99 @@
+import { createFhevmDecryptClient, hasFhevmRuntimeConfig, setFhevmRuntimeConfig } from '../../../src/ethers/index.js';
+import { createLogger } from '../../fheTest/setupCommon.js';
+import { createTkmsMemoryReader } from '../support/wasmMemory.js';
+import type { Scenario } from './scenario.js';
+
+// ---------------------------------------------------------------------------
+// Isolates the leak surface `roundtrip` deliberately avoids
+// ---------------------------------------------------------------------------
+//
+// `roundtrip` signs one decryption permit in its setup() and reuses it across
+// every iteration — both for realism (a real app signs a permit once per
+// session, not once per decrypt) and to avoid blending this leak surface into
+// the encrypt/tx/decrypt cycle that scenario exists to test. This scenario is
+// the deliberate opposite: one long-lived client, but a FRESH
+// `generateTransportKeyPair()` + `signLegacyDecryptionPermit()` +
+// `signUnifiedDecryptionPermit()` every iteration — no transaction, no
+// relayer decrypt call at all. It isolates the ML-KEM transport-keypair
+// generation and both EIP-712 permit-signing paths (legacy V1 and unified
+// V2) on their own, on the tkms side of the WASM boundary
+// (`clientChurn`/`valueChurn` only ever exercised the tfhe/encrypt side).
+//
+// All operations here are purely local (WASM keygen + ethers signatures) —
+// none touch the relayer over the network — so this should run much faster
+// per iteration than any of the relayer-bound scenarios. Each iteration also
+// round-trips the transport key pair and both signed permits through
+// serialize/parse, to exercise the (de)serialization path on the tkms side
+// of the WASM boundary alongside keygen and signing.
+
+export const permitChurnScenario: Scenario = {
+  name: 'permitChurn',
+  description:
+    'One long-lived client; loops generateTransportKeyPair + signLegacyDecryptionPermit + signUnifiedDecryptionPermit every iteration, round-tripping the key pair and both permits through serialize/parse. No tx, no decrypt call.',
+  defaultIterations: 9_000,
+  defaultIterationsDuration: '~1 min',
+  setup: async ({ config }) => {
+    // Process-wide singleton: when running multiple scenarios in one `main.ts`
+    // invocation (e.g. `--scenario all`), only the first scenario's setup()
+    // may call this — a later call with a fresh `createLogger()` reference
+    // would throw even though the effective config is identical.
+    if (!hasFhevmRuntimeConfig()) {
+      setFhevmRuntimeConfig({
+        auth: { type: 'ApiKeyHeader', value: config.zamaApiKey },
+        logger: createLogger(console.log, config.chainName),
+      });
+    }
+
+    const client = createFhevmDecryptClient({
+      chain: config.fhevmChain,
+      provider: config.provider,
+      options: config.moduleVersions !== undefined ? { moduleVersions: config.moduleVersions } : undefined,
+    });
+    await client.ready;
+
+    const readTkmsMemory = await createTkmsMemoryReader();
+
+    const iterate = async (): Promise<void> => {
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      const serializedTransportKeyPair = await client.serializeTransportKeyPair({ transportKeyPair });
+      const parsedTransportKeyPair = await client.parseTransportKeyPair(serializedTransportKeyPair);
+
+      const signedLegacyPermit = await client.signLegacyDecryptionPermit({
+        transportKeyPair: parsedTransportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.wallet.address,
+        signer: config.signer,
+      });
+
+      const serializedLegacyPermit = await client.serializeSignedDecryptionPermit({
+        signedPermit: signedLegacyPermit,
+      });
+      await client.parseSignedDecryptionPermit({
+        serializedPermit: serializedLegacyPermit,
+        transportKeyPair: parsedTransportKeyPair,
+      });
+
+      const signedUnifiedPermit = await client.signUnifiedDecryptionPermit({
+        transportKeyPair: parsedTransportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.wallet.address,
+        signer: config.signer,
+      });
+
+      const serializedUnifiedPermit = await client.serializeSignedDecryptionPermit({
+        signedPermit: signedUnifiedPermit,
+      });
+      await client.parseSignedDecryptionPermit({
+        serializedPermit: serializedUnifiedPermit,
+        transportKeyPair: parsedTransportKeyPair,
+      });
+    };
+
+    return { iterate, readTkmsMemory };
+  },
+};

--- a/sdk/js-sdk/test/memleaks/scenarios/providerChurn.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/providerChurn.ts
@@ -1,0 +1,30 @@
+import { ethers } from 'ethers';
+import { prepareSingleChain } from '../../fheTest/setupCommon.js';
+import type { Scenario } from './scenario.js';
+
+// Not a WASM/FHE test: isolates listener/socket/interval leaks in the ethers
+// layer itself, independent of the SDK's own encrypt/decrypt code paths — a
+// distinct and common leak class that would otherwise be invisible inside the
+// FHE-focused scenarios. Also mirrors how test/fheTest/setup-ethers.ts itself
+// builds providers (a fresh `ethers.JsonRpcProvider` per config, never
+// explicitly `.destroy()`-ed), so this doubles as a check on whether that
+// pattern is safe to repeat at scale.
+
+export const providerChurnScenario: Scenario = {
+  name: 'providerChurn',
+  description: 'Creates an ephemeral ethers provider + signer every iteration, does one read call, and discards them.',
+  defaultIterations: 5_000,
+  defaultIterationsDuration: '~1 min',
+  setup: async ({ config }) => {
+    const { rpcUrl } = prepareSingleChain();
+
+    const iterate = async (): Promise<void> => {
+      const provider = new ethers.JsonRpcProvider(rpcUrl);
+      const signer = config.wallet.connect(provider);
+      await provider.getBlockNumber();
+      await signer.getAddress();
+    };
+
+    return { iterate };
+  },
+};

--- a/sdk/js-sdk/test/memleaks/scenarios/roundtrip.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/roundtrip.ts
@@ -1,0 +1,103 @@
+import { createFhevmClient, hasFhevmRuntimeConfig, setFhevmRuntimeConfig } from '../../../src/ethers/index.js';
+import { createLogger } from '../../fheTest/setupCommon.js';
+import { createTfheMemoryReader, createTkmsMemoryReader } from '../support/wasmMemory.js';
+import type { Scenario } from './scenario.js';
+
+// Full network-bound cycle: encrypt -> submit tx -> wait for receipt ->
+// user-decrypt -> public-decrypt, against the real FHETest contract on
+// localstack. Exercises the ethers provider/signer/contract/tx-lifecycle code
+// paths that the pure client-side scenarios (clientReuse/clientChurn) never
+// touch, and confirms whatever leak-or-no-leak verdict those scenarios
+// produce still holds once a real transaction is in the loop. Far fewer
+// iterations than the other scenarios given per-tx latency and localstack
+// throughput — this is not where most of the sample budget should go.
+
+export const roundtripScenario: Scenario = {
+  name: 'roundtrip',
+  description: 'Full encrypt -> submit tx -> wait receipt -> user-decrypt + public-decrypt cycle against localstack.',
+  defaultIterations: 100,
+  defaultIterationsDuration: '~45 min',
+  setup: async ({ config }) => {
+    // Process-wide singleton: when running multiple scenarios in one `main.ts`
+    // invocation (e.g. `--scenario all`), only the first scenario's setup()
+    // may call this — a later call with a fresh `createLogger()` reference
+    // would throw even though the effective config is identical.
+    if (!hasFhevmRuntimeConfig()) {
+      setFhevmRuntimeConfig({
+        auth: { type: 'ApiKeyHeader', value: config.zamaApiKey },
+        logger: createLogger(console.log, config.chainName),
+      });
+    }
+
+    const tfheVersion =
+      config.moduleVersions !== undefined && config.moduleVersions !== 'auto' ? config.moduleVersions.tfhe : undefined;
+
+    const client = createFhevmClient({
+      chain: config.fhevmChain,
+      provider: config.provider,
+      options: config.moduleVersions !== undefined ? { moduleVersions: config.moduleVersions } : undefined,
+    });
+    await client.ready;
+
+    // Signed once and reused: a real app signs a decryption permit per
+    // session, not per decrypt call. Permit signing has its own KMS wasm
+    // surface, but that's providerChurn/clientChurn's concern, not this one.
+    const transportKeyPair = await client.generateTransportKeyPair();
+    const signedPermit = await client.signLegacyDecryptionPermit({
+      transportKeyPair,
+      contractAddresses: [config.fheTestAddress],
+      durationSeconds: 24 * 3600,
+      startTimestamp: Math.floor(Date.now() / 1000) - 5,
+      signerAddress: config.wallet.address,
+      signer: config.signer,
+    });
+
+    const [readTfheMemory, readTkmsMemory] = await Promise.all([
+      createTfheMemoryReader(tfheVersion),
+      createTkmsMemoryReader(),
+    ]);
+
+    let counter = 0;
+
+    const iterate = async (): Promise<void> => {
+      counter += 1;
+      const clearValue = counter % 256;
+
+      const encrypted = await client.encryptValue({
+        contractAddress: config.fheTestAddress,
+        userAddress: config.wallet.address,
+        value: { type: 'uint8', value: clearValue },
+      });
+
+      const tx = await config.fheTestContract.setEuint8!(
+        encrypted.encryptedValue,
+        encrypted.inputProof,
+        clearValue,
+        true,
+      );
+      const receipt = await tx.wait();
+      if (receipt?.status !== 1) {
+        throw new Error(`FHETest.setEuint8 transaction failed: ${tx.hash}`);
+      }
+
+      const [privateValue] = await client.decryptValues({
+        encryptedValues: [encrypted.encryptedValue],
+        contractAddress: config.fheTestAddress,
+        signedPermit,
+        transportKeyPair,
+      });
+      assertClearValueMatches('private decrypt', privateValue?.value, clearValue);
+
+      const [publicValue] = await client.decryptPublicValues({ encryptedValues: [encrypted.encryptedValue] });
+      assertClearValueMatches('public decrypt', publicValue?.value, clearValue);
+    };
+
+    return { iterate, readTfheMemory, readTkmsMemory };
+  },
+};
+
+function assertClearValueMatches(label: string, actual: unknown, expected: number): void {
+  if (String(actual) !== String(expected)) {
+    throw new Error(`${label} mismatch: expected ${expected}, got ${String(actual)}`);
+  }
+}

--- a/sdk/js-sdk/test/memleaks/scenarios/scenario.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/scenario.ts
@@ -1,0 +1,42 @@
+import type { FheTestEthersConfig } from '../../fheTest/setup-ethers.js';
+import type { WasmMemoryInfo } from '../support/memorySampler.js';
+
+// ---------------------------------------------------------------------------
+// Shared scenario contract
+// ---------------------------------------------------------------------------
+// Every scenario is a tight loop that performs one unit of work per iteration.
+// `run.mjs` owns the sampler tick cadence, the iteration/duration bound, and
+// error handling — a scenario only needs to describe one iteration and (if
+// relevant) how to take a live reading of the WASM memory it touches.
+
+export type ScenarioOptions = {
+  readonly config: FheTestEthersConfig;
+};
+
+export type ScenarioIterationFn = () => Promise<void>;
+
+export type ScenarioSetupResult = {
+  /** Performs exactly one unit of work (e.g. one encrypt+decrypt cycle). */
+  readonly iterate: ScenarioIterationFn;
+  /** Live tfhe WASM memory reader, if this scenario's iterate() touches the encrypt module. */
+  readonly readTfheMemory?: () => WasmMemoryInfo | undefined;
+  /** Live tkms WASM memory reader, if this scenario's iterate() touches the decrypt module. */
+  readonly readTkmsMemory?: () => WasmMemoryInfo | undefined;
+  /** Optional cleanup called once after the loop ends (or on error). */
+  readonly teardown?: () => Promise<void>;
+};
+
+export type Scenario = {
+  readonly name: string;
+  readonly description: string;
+  /** One-time setup (e.g. create a shared client, fetch a stable on-chain handle) before the loop starts. */
+  readonly setup: (options: ScenarioOptions) => Promise<ScenarioSetupResult>;
+  /** Default iteration count used when the CLI is not given an explicit bound. */
+  readonly defaultIterations: number;
+  /**
+   * Rough order-of-magnitude estimate of how long `defaultIterations` takes
+   * to run, shown alongside it in `--help`. Not a measured benchmark — just
+   * enough to tell a fast pure-local loop apart from a slow relayer-bound one.
+   */
+  readonly defaultIterationsDuration: string;
+};

--- a/sdk/js-sdk/test/memleaks/scenarios/valueChurn.ts
+++ b/sdk/js-sdk/test/memleaks/scenarios/valueChurn.ts
@@ -1,0 +1,81 @@
+import { createFhevmEncryptClient, hasFhevmRuntimeConfig, setFhevmRuntimeConfig } from '../../../src/ethers/index.js';
+import { createLogger } from '../../fheTest/setupCommon.js';
+import { createTfheMemoryReader } from '../support/wasmMemory.js';
+import type { Scenario } from './scenario.js';
+
+// ---------------------------------------------------------------------------
+// Isolates a hypothesis raised by the `roundtrip` scenario
+// ---------------------------------------------------------------------------
+//
+// `roundtrip` (varying plaintext + real on-chain tx + decryptValues +
+// decryptPublicValues, all bundled together) showed accelerating tfheMemory
+// growth, while `clientReuse` and `clientChurn` (both always encrypt the same
+// fixed value(s) every iteration) stayed perfectly flat. A source-level
+// investigation ruled out any JS-side cache keyed by plaintext value, any
+// tfhe-module involvement in `decryptPublicValues` (it's tkms-only), and any
+// code path that loops back into the encrypt module after `tx.wait()` — so
+// none of those three are the direct cause.
+//
+// This scenario strips `roundtrip` down to the one remaining, untested
+// variable: does encrypting a DIFFERENT plaintext value every iteration grow
+// tfhe's WASM linear memory on its own, with no transaction and no decrypt at
+// all? It also runs far faster than `roundtrip`, since it skips the
+// tx.wait()/decrypt relayer round-trips that dominate that scenario's wall
+// time — only the input-proof relayer call remains per iteration.
+//
+// One leading (not yet independently verified) explanation: the WASM-side
+// allocator inside the tfhe module's linear memory serves the ZK range-proof
+// computation's scratch buffers. Identical plaintext -> identical allocation
+// sizes every time -> the allocator's free-list reuses freed blocks perfectly
+// (matching the flat 0B/iter result from clientReuse/clientChurn). Varying
+// plaintext -> the proof arithmetic's allocation shape depends on the value's
+// bit pattern -> the heap fragments -> `memory.grow()` gets called, which is
+// monotonic and never shrinks. If that's right, growth here should
+// decelerate/plateau once the value cycle repeats (clearValue = counter %
+// 256, so all 256 shapes get seen within one cycle) — a genuine unbounded
+// leak wouldn't care about that boundary and would keep climbing past it.
+
+export const valueChurnScenario: Scenario = {
+  name: 'valueChurn',
+  description:
+    'One long-lived client; loops encryptValue with a different uint8 value every iteration. No tx submission, no decrypt.',
+  defaultIterations: 400,
+  defaultIterationsDuration: '~25 min',
+  setup: async ({ config }) => {
+    // Process-wide singleton: when running multiple scenarios in one `main.ts`
+    // invocation (e.g. `--scenario all`), only the first scenario's setup()
+    // may call this — a later call with a fresh `createLogger()` reference
+    // would throw even though the effective config is identical.
+    if (!hasFhevmRuntimeConfig()) {
+      setFhevmRuntimeConfig({
+        auth: { type: 'ApiKeyHeader', value: config.zamaApiKey },
+        logger: createLogger(console.log, config.chainName),
+      });
+    }
+
+    const tfheVersion =
+      config.moduleVersions !== undefined && config.moduleVersions !== 'auto' ? config.moduleVersions.tfhe : undefined;
+
+    const client = createFhevmEncryptClient({
+      chain: config.fhevmChain,
+      provider: config.provider,
+      options: config.moduleVersions !== undefined ? { moduleVersions: config.moduleVersions } : undefined,
+    });
+    await client.ready;
+
+    const readTfheMemory = await createTfheMemoryReader(tfheVersion);
+
+    let counter = 0;
+
+    const iterate = async (): Promise<void> => {
+      counter += 1;
+      await client.encryptValue({
+        contractAddress: config.fheTestAddress,
+        userAddress: config.wallet.address,
+        value: { type: 'uint8', value: counter % 256 },
+      });
+    };
+
+    return { iterate, readTfheMemory };
+  },
+};

--- a/sdk/js-sdk/test/memleaks/support/chainDefaults.ts
+++ b/sdk/js-sdk/test/memleaks/support/chainDefaults.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Mirrors test/multi-wasm/support/chainDefaults.ts (rpcUrl lookup only — this
+// project doesn't need the mnemonic/fheTestAddress fields that file also
+// reads, since setup-ethers.ts's own prepareChains() resolves those).
+
+const chainDefaultsPath = resolve(import.meta.dirname, '../../chains/chain-defaults.json');
+
+export type LocalstackChainDefaults = {
+  readonly rpcUrl: string;
+};
+
+export function loadLocalstackChainDefaults(chainName: string): LocalstackChainDefaults {
+  const json = JSON.parse(readFileSync(chainDefaultsPath, 'utf-8')) as Record<string, { readonly rpcUrl?: string }>;
+  const entry = json[chainName];
+  if (entry === undefined) {
+    throw new Error(`Missing "${chainName}" entry in ${chainDefaultsPath}`);
+  }
+  if (entry.rpcUrl === undefined || entry.rpcUrl === '') {
+    throw new Error(`Missing "${chainName}.rpcUrl" in ${chainDefaultsPath}`);
+  }
+  return Object.freeze({ rpcUrl: entry.rpcUrl });
+}

--- a/sdk/js-sdk/test/memleaks/support/localstack.ts
+++ b/sdk/js-sdk/test/memleaks/support/localstack.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+// Byte-identical to test/multi-wasm/support/localstack.ts as of when this
+// file was added — not a divergent port, an actual copy, because
+// test/memleaks and test/multi-wasm are independent test projects that
+// intentionally don't import from each other. A fix to the restart/readiness
+// logic in one almost certainly belongs in the other too; check both before
+// assuming this copy doesn't need it.
+
+const localstackRestartScript = resolve(import.meta.dirname, '../../scripts/localstack-restart.sh');
+
+export async function ensureLocalstackReady(parameters: {
+  readonly restart: boolean;
+  readonly rpcUrl: string;
+  readonly chainName: string;
+  readonly fhevmCliProfile?: string | undefined;
+}): Promise<void> {
+  const { restart, rpcUrl, chainName, fhevmCliProfile } = parameters;
+
+  if (restart) {
+    runLocalstackRestart({ chainName, fhevmCliProfile });
+  }
+
+  if (await isJsonRpcReady(rpcUrl)) {
+    return;
+  }
+
+  if (!restart) {
+    throw new Error(
+      `Localstack JSON-RPC is not responding at ${rpcUrl}. ` + 'Start it first, or rerun with --restart-localstack.',
+    );
+  }
+
+  throw new Error(`Localstack JSON-RPC is still not responding at ${rpcUrl} after restart.`);
+}
+
+export async function isJsonRpcReady(rpcUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_chainId',
+        params: [],
+      }),
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const body = (await response.json()) as { readonly result?: unknown };
+    return typeof body.result === 'string';
+  } catch {
+    return false;
+  }
+}
+
+function runLocalstackRestart(parameters: {
+  readonly chainName: string;
+  readonly fhevmCliProfile?: string | undefined;
+}): void {
+  const args = ['--force', '--chain', parameters.chainName];
+
+  if (parameters.fhevmCliProfile !== undefined && parameters.fhevmCliProfile !== '') {
+    args.push('--fhevm-cli-profile', parameters.fhevmCliProfile);
+  }
+
+  const result = spawnSync(localstackRestartScript, args, {
+    cwd: resolve(import.meta.dirname, '../../..'),
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`localstack restart failed: ${localstackRestartScript}`);
+  }
+}

--- a/sdk/js-sdk/test/memleaks/support/memorySampler.ts
+++ b/sdk/js-sdk/test/memleaks/support/memorySampler.ts
@@ -1,0 +1,147 @@
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { PerformanceObserver } from 'node:perf_hooks';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WasmMemoryInfo = {
+  readonly byteLength: number;
+  readonly pages: number;
+};
+
+export type MemorySample = {
+  readonly tMs: number;
+  readonly iteration: number;
+  readonly rssBytes: number;
+  readonly heapUsedBytes: number;
+  readonly externalBytes: number;
+  readonly arrayBuffersBytes: number;
+  readonly tfheMemory: WasmMemoryInfo | undefined;
+  readonly tkmsMemory: WasmMemoryInfo | undefined;
+  readonly gcCount: number;
+  readonly gcDurationMs: number;
+};
+
+export type MemorySamplerOptions = {
+  /** Sampling cadence. Defaults to 2s — real leak trends need minutes, not milliseconds. */
+  readonly intervalMs?: number;
+  /** Called on every tick with the current iteration count for this scenario. */
+  readonly getIteration: () => number;
+  /** Live WASM linear-memory reader for the tfhe module, if this scenario touches it. */
+  readonly readTfheMemory?: () => WasmMemoryInfo | undefined;
+  /** Live WASM linear-memory reader for the tkms module, if this scenario touches it. */
+  readonly readTkmsMemory?: () => WasmMemoryInfo | undefined;
+  /** Optional JSONL sink — one line per sample, for post-run inspection/plotting. */
+  readonly jsonlPath?: string;
+  /** Called after every sample is recorded (used by the console reporter). */
+  readonly onSample?: (sample: MemorySample) => void;
+};
+
+// ---------------------------------------------------------------------------
+// MemorySampler
+// ---------------------------------------------------------------------------
+
+/**
+ * Periodically snapshots process + WASM memory so a long-running scenario's
+ * growth trend can be inspected after the fact. Forces `global.gc()` before
+ * every sample when available (`--expose-gc`) — without it, GC scheduling
+ * noise dominates the signal and hides real trends.
+ */
+export class MemorySampler {
+  private readonly intervalMs: number;
+  private readonly options: MemorySamplerOptions;
+  private timer: NodeJS.Timeout | undefined;
+  private jsonlReady: Promise<void> | undefined;
+  private gcCount = 0;
+  private gcDurationMs = 0;
+  private readonly gcObserver = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      this.gcCount += 1;
+      this.gcDurationMs += entry.duration;
+    }
+  });
+  private readonly _samples: MemorySample[] = [];
+
+  constructor(options: MemorySamplerOptions) {
+    this.options = options;
+    this.intervalMs = options.intervalMs ?? 2_000;
+    if (options.jsonlPath !== undefined) {
+      this.jsonlReady = mkdir(dirname(options.jsonlPath), { recursive: true }).then(() => undefined);
+    }
+  }
+
+  get samples(): readonly MemorySample[] {
+    return this._samples;
+  }
+
+  start(): void {
+    this.gcObserver.observe({ entryTypes: ['gc'] });
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+    this.timer.unref();
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.gcObserver.disconnect();
+    // Final snapshot so the last measured state is always captured, even if it
+    // lands between two periodic ticks.
+    await this.tick();
+  }
+
+  /** Forces a GC pass (if available) and records one sample immediately. */
+  async tick(): Promise<MemorySample> {
+    if (typeof global.gc === 'function') {
+      global.gc();
+    }
+
+    const memoryUsage = process.memoryUsage();
+    const sample: MemorySample = {
+      tMs: performanceNowMs(),
+      iteration: this.options.getIteration(),
+      rssBytes: memoryUsage.rss,
+      heapUsedBytes: memoryUsage.heapUsed,
+      externalBytes: memoryUsage.external,
+      arrayBuffersBytes: memoryUsage.arrayBuffers,
+      tfheMemory: this.options.readTfheMemory?.(),
+      tkmsMemory: this.options.readTkmsMemory?.(),
+      gcCount: this.gcCount,
+      gcDurationMs: this.gcDurationMs,
+    };
+
+    this._samples.push(sample);
+    this.options.onSample?.(sample);
+    await this.appendJsonl(sample);
+    return sample;
+  }
+
+  private async appendJsonl(sample: MemorySample): Promise<void> {
+    if (this.options.jsonlPath === undefined) {
+      return;
+    }
+    await this.jsonlReady;
+    await appendFile(this.options.jsonlPath, `${JSON.stringify(sample)}\n`, 'utf-8');
+  }
+}
+
+function performanceNowMs(): number {
+  // Wall-clock, not monotonic-since-process-start: samples are compared across
+  // a run that can last tens of minutes, and JSONL output is easiest to read
+  // when timestamps are absolute.
+  return Date.now();
+}
+
+/** `global.gc` only exists under `--expose-gc`; `run.mjs` re-execs itself with that flag set. */
+export function assertGcIsExposed(): void {
+  if (typeof global.gc !== 'function') {
+    throw new Error(
+      'global.gc() is not available. Run this script with `node --expose-gc` (test/memleaks/run.mjs does this automatically).',
+    );
+  }
+}

--- a/sdk/js-sdk/test/memleaks/support/reporter.ts
+++ b/sdk/js-sdk/test/memleaks/support/reporter.ts
@@ -1,0 +1,119 @@
+import type { MemorySample } from './memorySampler.js';
+import { GATING_METRICS, type TrendVerdict } from './trendDetector.js';
+
+export function formatBytes(bytes: number): string {
+  const sign = bytes < 0 ? '-' : '';
+  const abs = Math.abs(bytes);
+  if (abs < 1024) {
+    return `${sign}${abs.toFixed(0)}B`;
+  }
+  if (abs < 1024 ** 2) {
+    return `${sign}${(abs / 1024).toFixed(1)}KB`;
+  }
+  if (abs < 1024 ** 3) {
+    return `${sign}${(abs / 1024 ** 2).toFixed(1)}MB`;
+  }
+  return `${sign}${(abs / 1024 ** 3).toFixed(2)}GB`;
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : ' '.repeat(width - value.length) + value;
+}
+
+/** Formats a duration as `<minutes>m<seconds>s` (e.g. `12m34s`), or `-` when unknown. */
+export function formatDuration(ms: number | undefined): string {
+  if (ms === undefined || !Number.isFinite(ms) || ms < 0) {
+    return '-';
+  }
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+}
+
+export function printHeader(scenarioName: string): void {
+  console.log(`\n=== ${scenarioName} ===`);
+  console.log(
+    [
+      pad('iter', 8),
+      pad('elapsed', 9),
+      pad('eta', 8),
+      pad('rss', 10),
+      pad('Δrss', 10),
+      pad('tfheMem', 10),
+      pad('Δtfhe', 10),
+      pad('tkmsMem', 10),
+      pad('Δtkms', 10),
+      pad('gc', 6),
+    ].join('  '),
+  );
+}
+
+/**
+ * Per-metric baselines, tracked separately per metric rather than as one
+ * "first sample" snapshot. RSS is defined from the very first tick, but
+ * tfhe/tkms WASM memory only becomes defined once a client has actually
+ * initialized that module — using a single shared baseline sample would
+ * leave the WASM delta columns permanently blank (baseline.tfheMemory stays
+ * `undefined` forever) even once the metric itself is being read correctly.
+ */
+export type MetricBaselines = {
+  rssBytes: number | undefined;
+  tfheMemoryBytes: number | undefined;
+  tkmsMemoryBytes: number | undefined;
+};
+
+export function updateMetricBaselines(baselines: MetricBaselines, sample: MemorySample): void {
+  baselines.rssBytes ??= sample.rssBytes;
+  baselines.tfheMemoryBytes ??= sample.tfheMemory?.byteLength;
+  baselines.tkmsMemoryBytes ??= sample.tkmsMemory?.byteLength;
+}
+
+export function printSampleLine(
+  sample: MemorySample,
+  baselines: MetricBaselines,
+  startedAtMs: number,
+  etaMs: number | undefined,
+): void {
+  const line = [
+    pad(String(sample.iteration), 8),
+    pad(formatDuration(sample.tMs - startedAtMs), 9),
+    pad(formatDuration(etaMs), 8),
+    pad(formatBytes(sample.rssBytes), 10),
+    pad(baselines.rssBytes !== undefined ? formatBytes(sample.rssBytes - baselines.rssBytes) : '-', 10),
+    pad(sample.tfheMemory ? formatBytes(sample.tfheMemory.byteLength) : '-', 10),
+    pad(
+      sample.tfheMemory && baselines.tfheMemoryBytes !== undefined
+        ? formatBytes(sample.tfheMemory.byteLength - baselines.tfheMemoryBytes)
+        : '-',
+      10,
+    ),
+    pad(sample.tkmsMemory ? formatBytes(sample.tkmsMemory.byteLength) : '-', 10),
+    pad(
+      sample.tkmsMemory && baselines.tkmsMemoryBytes !== undefined
+        ? formatBytes(sample.tkmsMemory.byteLength - baselines.tkmsMemoryBytes)
+        : '-',
+      10,
+    ),
+    pad(String(sample.gcCount), 6),
+  ].join('  ');
+  console.log(line);
+}
+
+export function printTrendSummary(scenarioName: string, verdicts: readonly TrendVerdict[]): void {
+  console.log(`\n--- ${scenarioName}: trend summary ---`);
+  for (const v of verdicts) {
+    const gating = GATING_METRICS.has(v.metric);
+    const note = gating ? '' : '  (informational — process-level, does not gate)';
+    if (v.classification === 'insufficient-data') {
+      console.log(`  ${pad(v.metric, 14)} insufficient data (${v.sampleCount} post-warmup samples)${note}`);
+      continue;
+    }
+    const marker = v.classification === 'growing' ? '⚠ GROWING' : 'plateauing';
+    const ceiling =
+      v.ceilingExceededBytes !== undefined ? ` CEILING EXCEEDED (+${formatBytes(v.ceilingExceededBytes)})` : '';
+    console.log(
+      `  ${pad(v.metric, 14)} ${pad(marker, 12)}  first-half ${formatBytes(v.firstHalfBytesPerIteration)}/iter -> second-half ${formatBytes(v.secondHalfBytesPerIteration)}/iter  (peak ${formatBytes(v.peakBytes - v.baselineBytes)} above baseline)${ceiling}${note}`,
+    );
+  }
+}

--- a/sdk/js-sdk/test/memleaks/support/trendDetector.ts
+++ b/sdk/js-sdk/test/memleaks/support/trendDetector.ts
@@ -1,0 +1,299 @@
+import type { MemorySample } from './memorySampler.js';
+
+// ---------------------------------------------------------------------------
+// Why this exists
+// ---------------------------------------------------------------------------
+// WebAssembly.Memory can only grow, never shrink (per spec), and a healthy
+// process also grows once during warmup (caches fill, thread pools spawn,
+// JIT settles). So "memory grew" is never itself a leak signal — only
+// *sustained, non-decaying growth proportional to iteration count* is. This
+// module compares the growth rate in the second half of a run against the
+// first half: a real leak keeps growing at the same (or a worse) rate, while
+// expected behavior decays toward zero once warmup is over.
+//
+// The thresholds below are placeholders. Per the project's stated plan, v1 is
+// a standalone script whose output is meant to be read and judged by a human
+// first; these numbers should be re-tuned once real runs against localstack
+// have been observed, before anyone treats this as an unattended pass/fail
+// gate.
+
+export type MetricSelector = (sample: MemorySample) => number | undefined;
+
+export type TrendClassification = 'plateauing' | 'growing' | 'insufficient-data';
+
+export type TrendVerdict = {
+  readonly metric: string;
+  readonly classification: TrendClassification;
+  readonly sampleCount: number;
+  readonly baselineBytes: number;
+  readonly peakBytes: number;
+  readonly firstHalfBytesPerIteration: number;
+  readonly secondHalfBytesPerIteration: number;
+  readonly ceilingExceededBytes: number | undefined;
+};
+
+export type TrendDetectorOptions = {
+  /** Samples whose iteration count is below this are excluded (one-time warmup growth). */
+  readonly warmupIterations?: number;
+  /** Minimum post-warmup samples required to classify at all. */
+  readonly minSamplesAfterWarmup?: number;
+  /**
+   * A metric is "growing" when the second-half slope is still at least this
+   * fraction of the first-half slope (i.e. it hasn't meaningfully decayed).
+   * Also triggers when the first-half slope was ~flat but the second half
+   * started climbing.
+   */
+  readonly growthRatioThreshold?: number;
+  /** Hard safety-net ceiling, in bytes above baseline, regardless of trend shape. */
+  readonly absoluteCeilingBytes?: number;
+  /**
+   * Target number of windows the post-warmup samples are collapsed into
+   * before fitting the two-half trend (see `smoothByWindow`). Higher means
+   * more smoothing per window for a given sample count.
+   */
+  readonly smoothingWindowCount?: number;
+};
+
+const DEFAULT_OPTIONS: Required<TrendDetectorOptions> = {
+  warmupIterations: 50,
+  minSamplesAfterWarmup: 10,
+  growthRatioThreshold: 0.8,
+  absoluteCeilingBytes: 512 * 1024 * 1024, // 512 MiB above baseline
+  smoothingWindowCount: 10,
+};
+
+/** Least-squares slope of `metric` against `iteration` — robust to single-sample noise. */
+function linearRegressionSlope(points: ReadonlyArray<{ x: number; y: number }>): number {
+  const n = points.length;
+  if (n < 2) {
+    return 0;
+  }
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (const { x, y } of points) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const denominator = n * sumXX - sumX * sumX;
+  if (denominator === 0) {
+    return 0;
+  }
+  return (n * sumXY - sumX * sumY) / denominator;
+}
+
+function standardDeviation(values: readonly number[]): number {
+  if (values.length < 2) {
+    return 0;
+  }
+  const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/**
+ * Collapses consecutive samples into windows and replaces each window with
+ * its median, targeting `targetWindowCount` windows overall (window size
+ * grows with the input so the degree of smoothing scales with how much data
+ * there is to smooth). This cancels GC/allocator sawtooth (a big transient
+ * allocation mostly reclaimed before the next sample) without hiding a real
+ * leak: a sustained leak shifts the whole distribution upward — troughs
+ * included — so it survives the median, while noise that oscillates around a
+ * flat baseline mostly cancels out. Each window is anchored at its last
+ * sample's iteration, so the returned points stay usable as {x: iteration,
+ * y: value} inputs to the same regression/noise-floor logic as raw samples.
+ * Degrades to (near-)identity when there isn't enough data to form more than
+ * one sample per window.
+ */
+function smoothByWindow(
+  points: ReadonlyArray<{ iteration: number; value: number }>,
+  targetWindowCount: number,
+): ReadonlyArray<{ iteration: number; value: number }> {
+  // Need at least 2 points per window on average for smoothing to do
+  // anything; otherwise fall back to the raw points untouched.
+  const windowCount = Math.min(Math.max(1, targetWindowCount), Math.floor(points.length / 2));
+  if (windowCount <= 1) {
+    return points;
+  }
+
+  // Boundaries are computed as `floor(w * length / windowCount)` (not a
+  // fixed step) so the remainder is spread across windows instead of
+  // dumped into one ragged trailing window — a fixed step size left a
+  // window as small as a single sample at the tail, which then went
+  // straight into the second-half slope unsmoothed.
+  const windowed: Array<{ iteration: number; value: number }> = [];
+  for (let w = 0; w < windowCount; w++) {
+    const start = Math.floor((w * points.length) / windowCount);
+    const end = Math.floor(((w + 1) * points.length) / windowCount);
+    const window = points.slice(start, end);
+    windowed.push({
+      iteration: window[window.length - 1]!.iteration,
+      value: median(window.map((p) => p.value)),
+    });
+  }
+  return windowed;
+}
+
+export function evaluateTrend(
+  samples: readonly MemorySample[],
+  metricName: string,
+  select: MetricSelector,
+  options: TrendDetectorOptions = {},
+): TrendVerdict {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  const points = samples
+    .map((sample) => ({ iteration: sample.iteration, value: select(sample) }))
+    .filter((p): p is { iteration: number; value: number } => p.value !== undefined);
+
+  // Baseline/peak/ceiling are computed over the POST-warmup window, not the
+  // full run: one-time startup cost (module init, thread-pool spawn, first
+  // network fetch) legitimately dwarfs steady-state growth, and including it
+  // here would report a misleading "peak Xxx MB above baseline" driven
+  // entirely by warmup, not by anything the loop itself did.
+  const postWarmup = points.filter((p) => p.iteration >= opts.warmupIterations);
+
+  const baselineBytes = postWarmup[0]?.value ?? 0;
+  const peakBytes = postWarmup.reduce((max, p) => Math.max(max, p.value), baselineBytes);
+  const ceilingExceededBytes =
+    peakBytes - baselineBytes > opts.absoluteCeilingBytes ? peakBytes - baselineBytes : undefined;
+
+  if (postWarmup.length < opts.minSamplesAfterWarmup) {
+    return {
+      metric: metricName,
+      classification: 'insufficient-data',
+      sampleCount: postWarmup.length,
+      baselineBytes,
+      peakBytes,
+      firstHalfBytesPerIteration: 0,
+      secondHalfBytesPerIteration: 0,
+      ceilingExceededBytes,
+    };
+  }
+
+  // Process-level metrics (rss/heapUsed/external/arrayBuffers) legitimately
+  // sawtooth — a big transient allocation during one iteration's work,
+  // mostly reclaimed by GC before the next sample — and a fixed-interval
+  // sampler catches different phases of that cycle on every run. Collapsing
+  // postWarmup into medians-per-window before fitting cancels that phase
+  // noise (see `smoothByWindow`) without hiding a real leak: a sustained
+  // leak shifts the whole distribution — troughs included — so it survives
+  // the window median. This is close to a no-op for tfhe/tkms: WASM memory
+  // only grows, so there's little within-window spread to smooth away.
+  const trendPoints = smoothByWindow(postWarmup, opts.smoothingWindowCount);
+
+  const mid = Math.floor(trendPoints.length / 2);
+  const firstHalf = trendPoints.slice(0, mid);
+  const secondHalf = trendPoints.slice(mid);
+
+  const firstHalfSlope = linearRegressionSlope(firstHalf.map((p) => ({ x: p.iteration, y: p.value })));
+  const secondHalfSlope = linearRegressionSlope(secondHalf.map((p) => ({ x: p.iteration, y: p.value })));
+
+  // A flat, metric-agnostic noise floor is miscalibrated: RSS/external
+  // naturally jitter by single-digit MB between samples from GC/allocator
+  // behavior alone, while a WASM page count only ever moves in fixed 64KB
+  // steps (or not at all). Deriving the floor from this run's own observed
+  // scatter — one standard deviation of the (smoothed) post-warmup values,
+  // spread over the post-warmup iteration span — self-calibrates per metric
+  // instead of guessing one constant for everything: noisy metrics get a
+  // forgiving floor, near-deterministic ones stay tightly sensitive.
+  // Dividing by the iteration span (rather than the sample count) keeps the
+  // floor in the same bytes-per-iteration units as the regression slopes
+  // it's compared against — sample count is a wall-clock sampling artifact
+  // (duration ÷ sample interval) with no relationship to how many
+  // iterations occurred.
+  const firstTrendIteration = trendPoints[0]?.iteration ?? 0;
+  const lastTrendIteration = trendPoints[trendPoints.length - 1]?.iteration ?? firstTrendIteration;
+  const iterationSpan = lastTrendIteration - firstTrendIteration;
+  const noiseFloorBytesPerIteration = Math.max(
+    1,
+    standardDeviation(trendPoints.map((p) => p.value)) / Math.max(1, iterationSpan),
+  );
+  const isGrowing =
+    ceilingExceededBytes !== undefined ||
+    (secondHalfSlope > noiseFloorBytesPerIteration &&
+      (firstHalfSlope <= noiseFloorBytesPerIteration || secondHalfSlope >= firstHalfSlope * opts.growthRatioThreshold));
+
+  return {
+    metric: metricName,
+    classification: isGrowing ? 'growing' : 'plateauing',
+    sampleCount: postWarmup.length,
+    baselineBytes,
+    peakBytes,
+    firstHalfBytesPerIteration: firstHalfSlope,
+    secondHalfBytesPerIteration: secondHalfSlope,
+    ceilingExceededBytes,
+  };
+}
+
+export const METRIC_SELECTORS: Record<string, MetricSelector> = {
+  rss: (s) => s.rssBytes,
+  heapUsed: (s) => s.heapUsedBytes,
+  external: (s) => s.externalBytes,
+  arrayBuffers: (s) => s.arrayBuffersBytes,
+  tfheMemory: (s) => s.tfheMemory?.byteLength,
+  tkmsMemory: (s) => s.tkmsMemory?.byteLength,
+};
+
+/**
+ * Metrics whose "growing" classification actually gates the process exit
+ * code. Process-level metrics (rss/heapUsed/external/arrayBuffers) can
+ * legitimately oscillate by tens of MB per iteration — a big transient
+ * allocation during one iteration's work, mostly reclaimed by GC before the
+ * next — and a fixed-interval sampler catches different phases of that
+ * sawtooth on every run. A two-half linear fit over that kind of data can
+ * show a spurious slope purely from which points happened to land near a
+ * peak vs. a trough, no matter how the noise floor is tuned; two separate
+ * real runs against localstack produced exactly that false signal on rss and
+ * external before this distinction was added.
+ *
+ * `tfheMemory`/`tkmsMemory` don't have this problem: `WebAssembly.Memory`
+ * only ever grows, never shrinks, so there is no trough to be out of phase
+ * with — any sustained climb there is real. They're the direct, trustworthy
+ * signal for the thing this harness actually exists to catch (native/WASM
+ * memory not being freed), so they're the only classifications that gate.
+ *
+ * Process-level metrics are still computed, printed, and worth a human
+ * glancing at (that's what `insufficient-data`/`growing` labels are for) —
+ * they just don't fail the run on their own. The absolute ceiling check
+ * (`ceilingExceededBytes`) still applies across every metric regardless of
+ * this list: a hard ceiling breach isn't subject to sawtooth
+ * misinterpretation the way a small fitted slope is.
+ *
+ * `evaluateTrend` now smooths samples via `smoothByWindow` before fitting,
+ * which should make the sawtooth false positives described above much
+ * rarer. This list is deliberately left unchanged for now regardless: per
+ * this module's own placeholder-thresholds disclaimer, promoting a metric to
+ * gating status needs validation against real localstack runs, not just a
+ * code-level argument that the false-positive cause is fixed.
+ */
+export const GATING_METRICS: ReadonlySet<string> = new Set(['tfheMemory', 'tkmsMemory']);
+
+export function evaluateAllTrends(
+  samples: readonly MemorySample[],
+  options: TrendDetectorOptions = {},
+): readonly TrendVerdict[] {
+  return Object.entries(METRIC_SELECTORS).map(([metricName, select]) =>
+    evaluateTrend(samples, metricName, select, options),
+  );
+}
+
+/**
+ * True when the run should be treated as anomalous: a gating metric
+ * (tfhe/tkms WASM memory) was classified "growing", or any metric — gating
+ * or not — breached the absolute ceiling.
+ */
+export function hasActionableGrowth(verdicts: readonly TrendVerdict[]): boolean {
+  return verdicts.some(
+    (v) => v.ceilingExceededBytes !== undefined || (GATING_METRICS.has(v.metric) && v.classification === 'growing'),
+  );
+}

--- a/sdk/js-sdk/test/memleaks/support/wasmMemory.ts
+++ b/sdk/js-sdk/test/memleaks/support/wasmMemory.ts
@@ -1,0 +1,50 @@
+import { loadTfheLib, DEFAULT_TFHE_VERSION } from '../../../src/wasm/tfhe/loadTfheLib.js';
+import { loadKmsLib, DEFAULT_TKMS_VERSION } from '../../../src/wasm/tkms/loadKmsLib.js';
+import type { WasmMemoryInfo } from './memorySampler.js';
+
+// `loadTfheLib`/`loadKmsLib` just return the already-initialized singleton glue
+// module (see src/core/modules/*/module/init-p.ts — init is cached forever,
+// per version, for the life of the process). Resolving it once after a
+// client's `.ready` has fired gives a reference whose `getWasmInfo()` reads
+// the WASM instance's *current* linear-memory size on every call — the SDK's
+// own `getTfheModuleInfo()`/`getTkmsModuleInfo()` read live the same way, but
+// they're `async` (re-resolving `loadTfheLib`/`loadKmsLib` and a registered
+// `moduleInfoByVersion` entry on every call) and return the full module-info
+// shape, not a plain synchronous accessor. The per-tick sampler here needs a
+// synchronous `() => WasmMemoryInfo | undefined` it can call directly from a
+// timer callback, so this builds that thin wrapper once instead.
+
+/**
+ * Builds a synchronous, live WASM-memory reader for the tfhe module.
+ * Only call after a client using this exact version has resolved `.ready` at
+ * least once — this does not itself trigger initialization.
+ */
+export async function createTfheMemoryReader(
+  version: string = DEFAULT_TFHE_VERSION,
+): Promise<() => WasmMemoryInfo | undefined> {
+  const tfheLib = await loadTfheLib(version as Parameters<typeof loadTfheLib>[0]);
+  return () => {
+    const info = tfheLib.getWasmInfo();
+    return info.memory === undefined ? undefined : { byteLength: info.memory.byteLength, pages: info.memory.pages };
+  };
+}
+
+/**
+ * Builds a synchronous, live WASM-memory reader for the tkms module.
+ *
+ * NOTE: v1 targets the `localstack` chain only, whose protocol resolves the
+ * (unset) `kms` module version to `DEFAULT_TKMS_VERSION` — see
+ * `TFHE_VERSION_BY_CHAIN`/`FHE_ENCRYPTION_KEY_TFHE_VERSION_BY_CHAIN` in
+ * `test/fheTest/setupCommon.ts`, where `localstack` has no explicit kms
+ * override. If a scenario is ever pointed at a different chain, this default
+ * must be revisited.
+ */
+export async function createTkmsMemoryReader(
+  version: string = DEFAULT_TKMS_VERSION,
+): Promise<() => WasmMemoryInfo | undefined> {
+  const kmsLib = await loadKmsLib(version as Parameters<typeof loadKmsLib>[0]);
+  return () => {
+    const info = kmsLib.getWasmInfo();
+    return info.memory === undefined ? undefined : { byteLength: info.memory.byteLength, pages: info.memory.pages };
+  };
+}


### PR DESCRIPTION
## Summary

Adds a standalone memory-leak stress harness under `sdk/js-sdk/test/memleaks/`
(runnable via `npm run test:memleaks`) that runs long stress loops of FHE
encrypt/decrypt/serialize operations against a real `localstack` Docker stack
(not the cleartext mock), sampling process and WASM memory to detect sustained
growth vs. an expected plateau. Also includes a small unrelated dev-tooling
improvement to `list-sdk-exports.mjs`.

### Memory-leak harness

Six scenarios each isolate a distinct leak surface:
- **clientReuse** — control group; one client, repeated encrypt/decrypt on a
  stable handle
- **clientChurn** — evicts the global FHE-key cache and forces a fresh
  public-key/CRS deserialize every iteration
- **roundtrip** — full encrypt → tx → receipt → user-decrypt → public-decrypt
  cycle against the `FHETest` contract
- **valueChurn** — isolates the effect of encrypting a different plaintext
  value every iteration
- **permitChurn** — isolates repeated transport-keypair generation and V1/V2
  permit signing
- **providerChurn** — isolates ethers provider/signer churn independent of
  any FHE code path

Trend detection (`support/trendDetector.ts`) classifies each metric as
plateauing or growing from its second-half vs. first-half growth rate, since
`WebAssembly.Memory` can only grow and process RSS is noisy/oscillating. Only
`tfheMemory`/`tkmsMemory` gate the exit code; process-level metrics
(rss/heapUsed/external/arrayBuffers) are informational only.

**v1 is a standalone script, deliberately not wired into CI** — the
trend-detection thresholds (warmup window, growth-ratio tolerance, absolute
ceiling) are placeholders pending tuning against real observed runs. Full
rationale, usage, and a documented finding (accelerating `tfheMemory` growth
in `roundtrip`, with an allocator-fragmentation hypothesis not yet
independently verified) are in `test/memleaks/README.md`.

Also fixes two now-stale `__dirname` references in `test/fheTest`
(`keyCache.ts`, `setupCommon.ts`) to `import.meta.dirname`.

### list-sdk-exports.mjs

Adds a `--functions-only` flag (plus `-h`/`--help`) to filter output down to
exported functions only, skipping types/interfaces. Default output is
unchanged.

## Test plan

- [x] `npm run test:memleaks -- --restart-localstack --scenario clientChurn --iterations 500`
- [x] `npm run test:memleaks -- --scenario clientReuse --iterations 5000`
- [x] `npm run test:memleaks -- --scenario all --duration-seconds 1800`
- [x] `node test/scripts/list-sdk-exports.mjs --functions-only`
