### PR TITLE
fix(sdk): add Polygon mainnet chain config

### DIFF
--- a/sdk/js-sdk/README.md
+++ b/sdk/js-sdk/README.md
@@ -116,17 +116,17 @@ Reading public values works on every client, including the base client. Construc
 
 ## Import paths
 
-| Path                         | What it provides                                   |
-| ---------------------------- | -------------------------------------------------- |
-| `@fhevm/sdk/ethers`          | Client factories and runtime config (ethers.js v6) |
-| `@fhevm/sdk/viem`            | Client factories and runtime config (viem)         |
-| `@fhevm/sdk/chains`          | Chain definitions (`mainnet`, `sepolia`)           |
-| `@fhevm/sdk/types`           | Public TypeScript types and helpers                |
-| `@fhevm/sdk/actions/base`    | Base actions (standalone functions)                |
-| `@fhevm/sdk/actions/encrypt` | Encrypt actions                                    |
-| `@fhevm/sdk/actions/decrypt` | Decrypt actions                                    |
-| `@fhevm/sdk/actions/chain`   | Permit, key, and serialization actions             |
-| `@fhevm/sdk/actions/host`    | Host contract read actions                         |
+| Path                         | What it provides                                    |
+| ---------------------------- | --------------------------------------------------- |
+| `@fhevm/sdk/ethers`          | Client factories and runtime config (ethers.js v6)  |
+| `@fhevm/sdk/viem`            | Client factories and runtime config (viem)          |
+| `@fhevm/sdk/chains`          | Chain definitions (`mainnet`, `sepolia`, `polygon`) |
+| `@fhevm/sdk/types`           | Public TypeScript types and helpers                 |
+| `@fhevm/sdk/actions/base`    | Base actions (standalone functions)                 |
+| `@fhevm/sdk/actions/encrypt` | Encrypt actions                                     |
+| `@fhevm/sdk/actions/decrypt` | Decrypt actions                                     |
+| `@fhevm/sdk/actions/chain`   | Permit, key, and serialization actions              |
+| `@fhevm/sdk/actions/host`    | Host contract read actions                          |
 
 ## Browser requirements
 

--- a/sdk/js-sdk/src/core/chains/definitions/mainnet.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/mainnet.ts
@@ -13,7 +13,9 @@ export const mainnet = /*#__PURE__*/ defineFhevmChain({
       kmsVerifier: {
         address: '0x77627828a55156b04Ac0DC0eb30467f1a552BB03',
       },
-      protocolConfig: undefined, // To be filled
+      protocolConfig: {
+        address: '0xD8236B57394f90726b26aB25D38CeAC776E1a7C4',
+      },
     },
     relayerUrl: 'https://relayer.mainnet.zama.org',
     gateway: {

--- a/sdk/js-sdk/src/core/chains/definitions/polygon.ts
+++ b/sdk/js-sdk/src/core/chains/definitions/polygon.ts
@@ -1,0 +1,34 @@
+import type { FhevmChain } from '../../types/fhevmChain.js';
+import { defineFhevmChain } from '../utils.js';
+
+export const polygon: FhevmChain = /*#__PURE__*/ defineFhevmChain({
+  id: 137,
+  fhevm: {
+    contracts: {
+      acl: {
+        address: '0x6737F17e31cf26a1b62fb0362acC5a16CB156F49',
+      },
+      inputVerifier: {
+        address: '0xf40BD204B035522EaAc8E5afAdc55113Acac96ca',
+      },
+      kmsVerifier: {
+        address: '0x14e609595474874Dd6b6128376E336EfADfdBE37',
+      },
+      protocolConfig: {
+        address: '0x17f62Ab3A1Ea519703cD597410147A30Fa1a7f1e',
+      },
+    },
+    relayerUrl: 'https://relayer.mainnet.zama.org',
+    gateway: {
+      id: 261_131,
+      contracts: {
+        decryption: {
+          address: '0x0f6024a97684f7d90ddb0fAAD79cB15F2C888D24',
+        },
+        inputVerification: {
+          address: '0xcB1bB072f38bdAF0F328CdEf1Fc6eDa1DF029287',
+        },
+      },
+    },
+  },
+});

--- a/sdk/js-sdk/src/core/chains/index.ts
+++ b/sdk/js-sdk/src/core/chains/index.ts
@@ -4,4 +4,5 @@ export { defineFhevmChain } from './utils.js';
 
 export { mainnet } from './definitions/mainnet.js';
 export { sepolia } from './definitions/sepolia.js';
+export { polygon } from './definitions/polygon.js';
 export { polygonAmoy } from './definitions/polygonAmoy.js';

--- a/test-suite/e2e/hardhat.config.ts
+++ b/test-suite/e2e/hardhat.config.ts
@@ -80,6 +80,7 @@ const chainIds = {
   zwsDev: 1337,
   sepolia: 11155111,
   mainnet: 1,
+  polygon: 137,
   polygonAmoy: 80002,
   localCoprocessorL1: 123456,
   localCoprocessorL2: 654321,
@@ -125,6 +126,15 @@ function getChainConfig(chain: keyof typeof chainIds): NetworkUserConfig {
           throw new Error('MAINNET_ETH_RPC_URL (or RPC_URL) is required for mainnet network');
         }
         jsonRpcUrl = 'https://eth.llamarpc.com'; // placeholder for config validation
+      }
+      break;
+    case 'polygon':
+      jsonRpcUrl = process.env.POLYGON_RPC_URL || vars.get('POLYGON_RPC_URL', '') || process.env.RPC_URL;
+      if (!jsonRpcUrl) {
+        if (shouldWarn) {
+          throw new Error('POLYGON_RPC_URL (or RPC_URL) is required for polygon network');
+        }
+        jsonRpcUrl = 'https://polygon-rpc.com'; // placeholder for config validation
       }
       break;
     case 'polygonAmoy':
@@ -205,6 +215,7 @@ const config: HardhatUserConfig = {
     zwsDev: getChainConfig('zwsDev'),
     sepolia: getChainConfig('sepolia'),
     mainnet: getChainConfig('mainnet'),
+    polygon: getChainConfig('polygon'),
     polygonAmoy: getChainConfig('polygonAmoy'),
     localNative: getChainConfig('localNative'),
     localCoprocessor: getChainConfig('localCoprocessor'),


### PR DESCRIPTION
## Summary

- Add a `polygon` chain definition (chain id `137`) to `@fhevm/sdk/chains`, wired through
  `contracts/acl`, `inputVerifier`, `kmsVerifier`, `protocolConfig`, and the gateway
  (`decryption` / `inputVerification`) contract addresses, matching the existing
  `mainnet` / `sepolia` / `polygonAmoy` pattern.
- Export `polygon` from `chains/index.ts` and document it in the README's import-paths
  table — without the export, the definition file alone wasn't reachable via
  `@fhevm/sdk/chains`.
- Fill in the previously-unset `protocolConfig` address for `mainnet` (was `undefined //
  To be filled`), since Polygon shares the same relayer/protocol line as Ethereum
  mainnet.

## Test plan

- [x] `npm run dod` in `sdk/js-sdk` passes
- [x] Confirm the on-chain addresses (`acl`, `inputVerifier`, `kmsVerifier`,
      `protocolConfig`, gateway `decryption`/`inputVerification`) match the deployed
      Polygon mainnet contracts
