### PR TITLE
feat(relayer): support pre-v0.14 protocol deployments

### DIFF
--- a/ci/preview-env/relayer/values-relayer-e2e.yaml
+++ b/ci/preview-env/relayer/values-relayer-e2e.yaml
@@ -210,14 +210,17 @@ env:
     valueFrom: {configMapKeyRef: {name: gw-sc-addresses, key: input_verification.address}}
 
   # --- keyurl (KMSGeneration poller) ---
-  # HEAD relayer replaced the old static fhe_public_key/crs storage-URL config
-  # with a poller that reads the active key/CRS/KMS context straight from the
-  # KMSGeneration contract on the host chain (settings.rs: KeyUrlConfig). It
-  # resolves the active key/CRS itself once the real DKG ceremony reaches
-  # consensus, so only the contract address is wired here (poll_interval_ms is
-  # in local.yaml above). `keyurl` is a required top-level field; its absence
-  # aborts startup with 'missing configuration field "keyurl.kms_generation_address"'.
+  # `keyurl.source` selects where /v2/keyurl comes from (settings.rs: KeyUrlConfig)
+  # and is required: its absence aborts startup with
+  # 'missing configuration field "keyurl.source"'.
+  # `chain` polls the active key/CRS/KMS context straight from the KMSGeneration
+  # contract on the host chain, resolving them itself once the real DKG ceremony
+  # reaches consensus, so only the contract address is wired here (poll_interval_ms
+  # is in local.yaml above). The alternative, `config`, serves static
+  # fhe_public_key/crs values and is only for protocol deployments that predate
+  # ProtocolConfig.getCurrentKmsContextAndEpoch.
   # NB: charts/contracts appends ".address" to every ConfigMap key, hence the suffix.
+  - {name: APP_KEYURL__SOURCE, value: "chain"}
   - name: APP_KEYURL__KMS_GENERATION_ADDRESS
     valueFrom: {configMapKeyRef: {name: host-sc-addresses, key: kms_generation.address}}
 

--- a/relayer/config/.env.example
+++ b/relayer/config/.env.example
@@ -5,7 +5,9 @@ APP_NETWORKS__ROLLUP__CHAIN_ID=654321
 APP_NETWORKS__ROLLUP__RETRY_DELAY=1000
 APP_NETWORKS__ROLLUP__MAX_RECONNECTION_ATTEMPTS=3
 
-# /v2/keyurl host-chain poller: KMSGeneration address + poll interval (ms).
+# /v2/keyurl source: "chain" (host-chain poller) or "config" (static values). Required.
+# With "chain": KMSGeneration address + poll interval (ms).
+APP_KEYURL__SOURCE=chain
 APP_KEYURL__KMS_GENERATION_ADDRESS=0x1234567890123456789012345678901234567890
 APP_KEYURL__POLL_INTERVAL_MS=12000
 

--- a/relayer/config/local.mainnet.yaml.example
+++ b/relayer/config/local.mainnet.yaml.example
@@ -20,12 +20,20 @@ protocol_config:
     max_attempts: 3
     retry_interval_ms: 200
 
-# /v2/keyurl host-chain poller settings.
+# /v2/keyurl source (required). `config` serves the static values below and starts no poller —
+# needed against deployments without ProtocolConfig.getCurrentKmsContextAndEpoch. For the
+# `chain` form see config/local.yaml.example. data_id must be 0x-prefixed (env vars coerce
+# all-digit ids to numbers).
 keyurl:
-  # KMSGeneration contract address on the host chain (source for /v2/keyurl).
-  kms_generation_address: "0x0000000000000000000000000000000000000000"
-  # /v2/keyurl poll interval in ms; the poller reads at the finalized block.
-  poll_interval_ms: 12000
+  source: config
+  fhe_public_key:
+    data_id: "0x0400000000000000000000000000000000000000000000000000000000000003"
+    urls:
+      - "https://kms-public.mainnet.zama.org/PUB-p1/PublicKey/0400000000000000000000000000000000000000000000000000000000000003"
+  crs:
+    data_id: "0x0400000000000000000000000000000000000000000000000000000000000004"
+    urls:
+      - "https://kms-public.mainnet.zama.org/PUB-p1/CRS/0400000000000000000000000000000000000000000000000000000000000004"
 
 # User-decryption signature check. Gas cap for the ERC-1271 isValidSignature static call.
 user_decrypt_signature_check:

--- a/relayer/config/local.testnet.yaml.example
+++ b/relayer/config/local.testnet.yaml.example
@@ -15,12 +15,20 @@ protocol_config:
     max_attempts: 3
     retry_interval_ms: 200
 
-# /v2/keyurl host-chain poller settings.
+# /v2/keyurl source (required). `config` serves the static values below and starts no poller —
+# needed against deployments without ProtocolConfig.getCurrentKmsContextAndEpoch. For the
+# `chain` form see config/local.yaml.example. data_id must be 0x-prefixed (env vars coerce
+# all-digit ids to numbers).
 keyurl:
-  # KMSGeneration contract address on the host chain (source for /v2/keyurl).
-  kms_generation_address: "0x0000000000000000000000000000000000000000"
-  # /v2/keyurl poll interval in ms; the poller reads at the finalized block.
-  poll_interval_ms: 12000
+  source: config
+  fhe_public_key:
+    data_id: "0x0400000000000000000000000000000000000000000000000000000000000003"
+    urls:
+      - "https://kms-public.testnet.zama.org/PUB-p1/PublicKey/0400000000000000000000000000000000000000000000000000000000000003"
+  crs:
+    data_id: "0x0400000000000000000000000000000000000000000000000000000000000004"
+    urls:
+      - "https://kms-public.testnet.zama.org/PUB-p1/CRS/0400000000000000000000000000000000000000000000000000000000000004"
 
 # User-decryption signature check. Gas cap for the ERC-1271 isValidSignature static call.
 user_decrypt_signature_check:

--- a/relayer/config/local.yaml.example
+++ b/relayer/config/local.yaml.example
@@ -19,8 +19,12 @@ protocol_config:
     max_attempts: 3
     retry_interval_ms: 200
 
-# /v2/keyurl host-chain poller settings.
+# /v2/keyurl source. Required; either "chain" (poll the host chain) or "config"
+# (serve the static values below). See config/local.testnet.yaml.example for the
+# "config" form, needed against protocol deployments without
+# ProtocolConfig.getCurrentKmsContextAndEpoch.
 keyurl:
+  source: chain
   # KMSGeneration contract address on the host chain (source for /v2/keyurl).
   kms_generation_address: "0x1234567890123456789012345678901234567890"
   # /v2/keyurl poll interval in ms; the poller reads at the finalized block.

--- a/relayer/src/config/settings.rs
+++ b/relayer/src/config/settings.rs
@@ -1,3 +1,4 @@
+use crate::http::endpoints::v2::types::keyurl::KeyData;
 use crate::http::utils::redact::redact;
 use config::{Config, Environment, File};
 use derivative::Derivative;
@@ -573,13 +574,28 @@ pub struct ProtocolConfigSettings {
     pub retry: RetrySettings,
 }
 
-/// `/v2/keyurl` poller settings (KMSGeneration contract on the Ethereum host chain).
+/// `/v2/keyurl` settings, tagged by `source`. Required with no default, so a deployment
+/// cannot silently pick the wrong source.
 #[derive(Debug, Deserialize, Clone)]
-pub struct KeyUrlConfig {
-    /// KMSGeneration contract address on the Ethereum host chain (source for `/v2/keyurl`).
-    pub kms_generation_address: String,
-    /// How often the `/v2/keyurl` poller reads the active key/CRS/KMS context from the host chain.
-    pub poll_interval_ms: u64,
+#[serde(tag = "source", rename_all = "lowercase")]
+pub enum KeyUrlConfig {
+    /// Read the active key/CRS/KMS context from the Ethereum host chain (KMSGeneration +
+    /// ProtocolConfig contracts) and keep `/v2/keyurl` in sync by polling.
+    Chain {
+        /// KMSGeneration contract address on the Ethereum host chain.
+        kms_generation_address: String,
+        /// How often the poller reads the active key/CRS/KMS context from the host chain.
+        poll_interval_ms: u64,
+    },
+    /// Serve `/v2/keyurl` from static configuration; no host-chain poller runs. Required
+    /// against protocol deployments that do not implement
+    /// `ProtocolConfig.getCurrentKmsContextAndEpoch` (protocol v0.13 and earlier).
+    Config {
+        /// Served as `response.fheKeyInfo[0].fhePublicKey`.
+        fhe_public_key: KeyData,
+        /// Served as `response.crs["2048"]`.
+        crs: KeyData,
+    },
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -602,7 +618,7 @@ pub struct Settings {
     pub host_chains: Vec<HostChainConfig>,
     /// ProtocolConfig contract settings for dynamic threshold resolution
     pub protocol_config: ProtocolConfigSettings,
-    /// `/v2/keyurl` poller settings (KMSGeneration contract)
+    /// `/v2/keyurl` settings: host-chain poller or static config
     pub keyurl: KeyUrlConfig,
     /// User-decryption signature check configuration
     pub user_decrypt_signature_check: UserDecryptSignatureCheckConfig,
@@ -688,18 +704,21 @@ impl Settings {
         use alloy::primitives::Address;
         use std::str::FromStr;
 
-        let addresses = vec![
+        let mut addresses = vec![
             ("decryption", &self.gateway.contracts.decryption_address),
             (
                 "input_verification",
                 &self.gateway.contracts.input_verification_address,
             ),
             ("protocol_config", &self.protocol_config.address),
-            (
-                "keyurl.kms_generation_address",
-                &self.keyurl.kms_generation_address,
-            ),
         ];
+        if let KeyUrlConfig::Chain {
+            kms_generation_address,
+            ..
+        } = &self.keyurl
+        {
+            addresses.push(("keyurl.kms_generation_address", kms_generation_address));
+        }
 
         for (name, address) in addresses {
             if Address::from_str(address).is_err() {
@@ -766,10 +785,25 @@ impl Settings {
     }
 
     fn validate_keyurl(&self) -> Result<(), AppConfigError> {
-        if self.keyurl.poll_interval_ms < 1 {
-            return Err(AppConfigError::Config(
-                "keyurl.poll_interval_ms must be at least 1".to_string(),
-            ));
+        match &self.keyurl {
+            KeyUrlConfig::Chain {
+                poll_interval_ms, ..
+            } => {
+                if *poll_interval_ms < 1 {
+                    return Err(AppConfigError::Config(
+                        "keyurl.poll_interval_ms must be at least 1".to_string(),
+                    ));
+                }
+            }
+            KeyUrlConfig::Config {
+                fhe_public_key,
+                crs,
+            } => {
+                // Statically configured values are served verbatim to every SDK client, so a
+                // placeholder or typo has to fail here rather than at the client.
+                validate_keyurl_key_data("keyurl.fhe_public_key", fhe_public_key)?;
+                validate_keyurl_key_data("keyurl.crs", crs)?;
+            }
         }
         Ok(())
     }
@@ -834,6 +868,39 @@ impl Settings {
     }
 }
 
+/// Hex characters in a `data_id` after `0x` — the 32-byte id form `chain` mode serves.
+const KEYURL_DATA_ID_HEX_LEN: usize = 64;
+
+/// Validate one statically configured `/v2/keyurl` entry.
+///
+/// `key` is the full config key (`keyurl.fhe_public_key` / `keyurl.crs`) so an operator reading
+/// a failed startup can tell which of the two is wrong and fix it from the message alone.
+fn validate_keyurl_key_data(key: &str, key_data: &KeyData) -> Result<(), AppConfigError> {
+    // No `0x` prefix yields "", which then fails the length check.
+    let digits = key_data.data_id.strip_prefix("0x").unwrap_or("");
+    if digits.len() != KEYURL_DATA_ID_HEX_LEN || !digits.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(AppConfigError::Config(format!(
+            "{key}.data_id must be a 0x-prefixed hex string of {KEYURL_DATA_ID_HEX_LEN} digits, got: {}",
+            key_data.data_id
+        )));
+    }
+
+    if key_data.urls.is_empty() {
+        return Err(AppConfigError::Config(format!(
+            "{key}.urls must contain at least one URL"
+        )));
+    }
+    for (i, url) in key_data.urls.iter().enumerate() {
+        if let Err(e) = reqwest::Url::parse(url) {
+            return Err(AppConfigError::InvalidNetworkConfig(format!(
+                "{key}.urls[{i}] is not a valid URL ({e}): {url}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 // Helper function to get a required environment variable
 pub fn get_required_env(key: &str) -> Result<String, AppConfigError> {
     env::var(key).map_err(|_| AppConfigError::MissingEnvVar(key.to_string()))
@@ -890,7 +957,6 @@ mod tests {
         }
 
         /// Set a field value using dot notation
-        #[allow(dead_code)]
         fn set_field(mut self, path: &str, value: serde_yaml::Value) -> Self {
             let parts: Vec<&str> = path.split('.').collect();
             if let Some(parent) = self.get_parent_mut(&parts[..parts.len() - 1]) {
@@ -1159,6 +1225,241 @@ mod tests {
         );
     }
 
+    /// Deserialize `Settings` from a builder that is expected to be invalid, returning the
+    /// error message. Deserialization alone is enough: `keyurl.source` is enforced by serde.
+    fn settings_load_error(builder: ConfigBuilder) -> String {
+        let config_path = builder
+            .to_temp_file()
+            .expect("Failed to create temp config file");
+        let config = Config::builder()
+            .add_source(File::from(config_path.as_path()).format(FileFormat::Yaml))
+            .build()
+            .expect("Failed to build config");
+        let result: Result<Settings, _> = config.try_deserialize();
+        result
+            .expect_err("Configuration parsing should have failed")
+            .to_string()
+    }
+
+    /// A `keyurl` block for `source: config`, minus the top-level fields named in `omit`.
+    fn static_keyurl(omit: &[&str]) -> serde_yaml::Value {
+        let mut value: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+            source: config
+            fhe_public_key:
+              data_id: "0x0400000000000000000000000000000000000000000000000000000000000003"
+              urls: ["http://minio:9000/kms-public/PUB/PublicKey/03"]
+            crs:
+              data_id: "0x0400000000000000000000000000000000000000000000000000000000000004"
+              urls: ["http://minio:9000/kms-public/PUB/CRS/04"]
+            "#,
+        )
+        .expect("Failed to parse static keyurl block");
+        let mapping = value.as_mapping_mut().expect("keyurl block is a mapping");
+        for field in omit {
+            mapping.remove(*field);
+        }
+        value
+    }
+
+    /// Run the whole `Settings::new` path — deserialize *and* the `validate_*` pass — on a
+    /// modified example config. Uses a `.yaml` path: the format is inferred from the file name.
+    fn settings_new(builder: ConfigBuilder) -> Result<Settings, AppConfigError> {
+        let content = serde_yaml::to_string(&builder.config).expect("Failed to serialize");
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let config_path = dir.path().join("validate-keyurl.yaml");
+        std::fs::write(&config_path, content).expect("Failed to write config file");
+        Settings::new(Some(config_path.to_string_lossy().to_string()))
+    }
+
+    /// A `keyurl` builder seeded with the valid static block, for tests that then break one field.
+    fn config_keyurl_builder() -> ConfigBuilder {
+        ConfigBuilder::from_example()
+            .expect("Failed to load example config")
+            .set_field("keyurl", static_keyurl(&[]))
+    }
+
+    #[test]
+    fn test_keyurl_source_is_required() {
+        let err = settings_load_error(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .remove_field("keyurl.source"),
+        );
+        assert!(
+            err.contains("missing configuration field \"keyurl.source\""),
+            "Error should name the missing `source` field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_keyurl_source_rejects_unknown_value() {
+        let err = settings_load_error(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .set_field("keyurl.source", serde_yaml::Value::String("bogus".into())),
+        );
+        assert!(
+            err.contains("unknown variant `bogus`")
+                && err.contains("`chain`")
+                && err.contains("`config`"),
+            "Error should reject `bogus` and name the valid variants, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_keyurl_chain_requires_kms_generation_address() {
+        let err = settings_load_error(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .remove_field("keyurl.kms_generation_address"),
+        );
+        assert!(
+            err.contains("missing configuration field \"keyurl.kms_generation_address\""),
+            "Error should name the missing `kms_generation_address` field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_keyurl_chain_requires_poll_interval_ms() {
+        let err = settings_load_error(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .remove_field("keyurl.poll_interval_ms"),
+        );
+        assert!(
+            err.contains("missing configuration field \"keyurl.poll_interval_ms\""),
+            "Error should name the missing `poll_interval_ms` field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_keyurl_config_requires_fhe_public_key() {
+        let err = settings_load_error(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .set_field("keyurl", static_keyurl(&["fhe_public_key"])),
+        );
+        assert!(
+            err.contains("missing configuration field \"keyurl.fhe_public_key\""),
+            "Error should name the missing `fhe_public_key` field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_keyurl_config_requires_crs() {
+        let err = settings_load_error(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .set_field("keyurl", static_keyurl(&["crs"])),
+        );
+        assert!(
+            err.contains("missing configuration field \"keyurl.crs\""),
+            "Error should name the missing `crs` field, got: {err}"
+        );
+    }
+
+    #[test]
+    #[serial] // Settings::new reads the environment
+    fn test_keyurl_config_accepts_valid_static_values() {
+        let settings = settings_new(config_keyurl_builder())
+            .expect("A valid `keyurl.source: config` block should deserialize and validate");
+
+        match &settings.keyurl {
+            KeyUrlConfig::Config {
+                fhe_public_key,
+                crs,
+            } => {
+                assert_eq!(
+                    fhe_public_key.data_id,
+                    "0x0400000000000000000000000000000000000000000000000000000000000003"
+                );
+                assert_eq!(
+                    fhe_public_key.urls,
+                    vec!["http://minio:9000/kms-public/PUB/PublicKey/03"]
+                );
+                assert_eq!(
+                    crs.data_id,
+                    "0x0400000000000000000000000000000000000000000000000000000000000004"
+                );
+                assert_eq!(crs.urls, vec!["http://minio:9000/kms-public/PUB/CRS/04"]);
+            }
+            other => panic!("expected keyurl.source: config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_keyurl_config_rejects_empty_urls() {
+        let err = settings_new(config_keyurl_builder().set_field(
+            "keyurl.fhe_public_key.urls",
+            serde_yaml::to_value(Vec::<&str>::new()).unwrap(),
+        ))
+        .expect_err("Empty `urls` should fail validation")
+        .to_string();
+        assert!(
+            err.contains("keyurl.fhe_public_key.urls") && err.contains("at least one URL"),
+            "Error should name the offending key and the expected form, got: {err}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_keyurl_config_rejects_unparsable_url() {
+        let err = settings_new(config_keyurl_builder().set_field(
+            "keyurl.crs.urls",
+            serde_yaml::to_value(["not a url"]).unwrap(),
+        ))
+        .expect_err("An unparsable `urls` entry should fail validation")
+        .to_string();
+        assert!(
+            err.contains("keyurl.crs.urls[0]") && err.contains("not a valid URL"),
+            "Error should name the offending key and index, got: {err}"
+        );
+    }
+
+    /// The placeholder case: mainnet gitops values carry a literal `fhe-public-key-data-id`,
+    /// which would otherwise boot green and be served to every SDK client.
+    #[test]
+    #[serial]
+    fn test_keyurl_config_rejects_non_hex_data_id() {
+        let err = settings_new(config_keyurl_builder().set_field(
+            "keyurl.crs.data_id",
+            serde_yaml::Value::String("fhe-public-key-data-id".into()),
+        ))
+        .expect_err("A non-0x `data_id` should fail validation")
+        .to_string();
+        assert!(
+            err.contains("keyurl.crs.data_id") && err.contains("hex string of 64 digits"),
+            "Error should name the offending key and the expected form, got: {err}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_keyurl_config_rejects_data_id_of_wrong_length() {
+        let err = settings_new(config_keyurl_builder().set_field(
+            "keyurl.fhe_public_key.data_id",
+            serde_yaml::Value::String("0x0400000000000000000000000000000003".into()),
+        ))
+        .expect_err("A `0x` `data_id` of the wrong length should fail validation")
+        .to_string();
+        assert!(
+            err.contains("keyurl.fhe_public_key.data_id")
+                && err.contains("hex string of 64 digits"),
+            "Error should name the offending key and the expected form, got: {err}"
+        );
+    }
+
+    /// `Chain` mode must be untouched by the `Config`-mode content rules.
+    #[test]
+    #[serial]
+    fn test_keyurl_chain_mode_unaffected_by_config_validation() {
+        let settings = settings_new(ConfigBuilder::from_example().expect("example config"))
+            .expect("The unmodified example (`source: chain`) should still pass validation");
+        assert!(matches!(settings.keyurl, KeyUrlConfig::Chain { .. }));
+    }
+
     #[test]
     fn test_sql_database_url_is_redacted_in_debug_output() {
         // Create a test StorageConfig with a dummy database URL
@@ -1298,19 +1599,14 @@ mod tests {
     #[test]
     #[serial] // avoid env var leakage from parallel tests
     fn test_settings_new_rejects_invalid_address() {
-        let builder = ConfigBuilder::from_example()
-            .expect("Failed to load example config")
-            .set_field(
-                "gateway.contracts.decryption_address",
-                serde_yaml::Value::String("not-a-valid-address".into()),
-            );
-
-        let content = serde_yaml::to_string(&builder.config).expect("Failed to serialize");
-        let dir = tempfile::tempdir().expect("Failed to create temp dir");
-        let config_path = dir.path().join("test-config.yaml");
-        std::fs::write(&config_path, content).expect("Failed to write config file");
-
-        let result = Settings::new(Some(config_path.to_string_lossy().to_string()));
+        let result = settings_new(
+            ConfigBuilder::from_example()
+                .expect("Failed to load example config")
+                .set_field(
+                    "gateway.contracts.decryption_address",
+                    serde_yaml::Value::String("not-a-valid-address".into()),
+                ),
+        );
 
         assert!(
             result.is_err(),
@@ -1478,14 +1774,82 @@ mod tests {
             vec![0.01, 0.05, 0.1]
         );
 
-        // keyurl: env overrides
-        assert_eq!(
-            settings.keyurl.kms_generation_address,
-            "0x00000000000000000000000000000000000000ff"
-        );
-        assert_eq!(settings.keyurl.poll_interval_ms, 12000);
+        // keyurl: env overrides, `source` included (both YAML and env say `chain`)
+        match &settings.keyurl {
+            KeyUrlConfig::Chain {
+                kms_generation_address,
+                poll_interval_ms,
+            } => {
+                assert_eq!(
+                    kms_generation_address,
+                    "0x00000000000000000000000000000000000000ff"
+                );
+                assert_eq!(*poll_interval_ms, 12000);
+            }
+            other => panic!("expected keyurl.source: chain, got {other:?}"),
+        }
 
         // storage: env overrides
         assert!(settings.storage.sql_database_url.contains("env-override"));
+    }
+
+    /// `keyurl.source: config` from env vars alone, no `keyurl` block in any file — how the
+    /// gitops deployments that need this mode are wired. `urls` is the load-bearing part: config-rs
+    /// turns `URLS__0` / `URLS__1` into an index-keyed map, so without
+    /// `deserialize_vec_from_map_or_seq` on `KeyData::urls` this fails with "invalid type: map,
+    /// expected a sequence". Two URLs prove index order rather than collapse to one element.
+    #[test]
+    #[serial] // avoid env var leakage from parallel tests
+    fn test_keyurl_source_config_from_env_only() {
+        const KEY_DATA_ID: &str =
+            "0x0400000000000000000000000000000000000000000000000000000000000003";
+        const KEY_URL_0: &str = "http://minio-a:9000/kms-public/PUB-p1/PublicKey/03";
+        const KEY_URL_1: &str = "http://minio-b:9000/kms-public/PUB-p2/PublicKey/03";
+        const CRS_DATA_ID: &str =
+            "0x0400000000000000000000000000000000000000000000000000000000000004";
+        const CRS_URL_0: &str = "http://minio-a:9000/kms-public/PUB-p1/CRS/04";
+
+        // Base config with the whole `keyurl` block removed: every field comes from env.
+        let builder = ConfigBuilder::from_example()
+            .expect("Failed to load example config")
+            .remove_field("keyurl");
+
+        let vars = [
+            ("APP_KEYURL__SOURCE", "config"),
+            ("APP_KEYURL__FHE_PUBLIC_KEY__DATA_ID", KEY_DATA_ID),
+            ("APP_KEYURL__FHE_PUBLIC_KEY__URLS__0", KEY_URL_0),
+            ("APP_KEYURL__FHE_PUBLIC_KEY__URLS__1", KEY_URL_1),
+            ("APP_KEYURL__CRS__DATA_ID", CRS_DATA_ID),
+            ("APP_KEYURL__CRS__URLS__0", CRS_URL_0),
+        ];
+        for (key, value) in vars {
+            env::set_var(key, value);
+        }
+
+        // Settings::new — the same code path as the real app.
+        let result = settings_new(builder);
+
+        // Clean up before asserting so a failure cannot leak into other tests.
+        for (key, _) in vars {
+            env::remove_var(key);
+        }
+
+        let settings = result.expect(
+            "`keyurl.source: config` should load from env vars alone — \
+             `urls` may be missing its map-or-sequence deserializer",
+        );
+
+        match &settings.keyurl {
+            KeyUrlConfig::Config {
+                fhe_public_key,
+                crs,
+            } => {
+                assert_eq!(fhe_public_key.data_id, KEY_DATA_ID);
+                assert_eq!(fhe_public_key.urls, vec![KEY_URL_0, KEY_URL_1]);
+                assert_eq!(crs.data_id, CRS_DATA_ID);
+                assert_eq!(crs.urls, vec![CRS_URL_0]);
+            }
+            other => panic!("expected keyurl.source: config, got {other:?}"),
+        }
     }
 }

--- a/relayer/src/host/keyurl_poller.rs
+++ b/relayer/src/host/keyurl_poller.rs
@@ -22,7 +22,7 @@ use fhevm_host_bindings::ikms_generation::IKMSGeneration::IKMSGenerationInstance
 use tokio::sync::watch;
 use tracing::{error, info, warn};
 
-use crate::config::settings::{KeyUrlConfig, ProtocolConfigSettings};
+use crate::config::settings::ProtocolConfigSettings;
 use crate::host::error_redact::{redact_alloy_error, redact_error};
 use crate::host::provider::{build_host_provider, Provider};
 use crate::http::endpoints::v2::types::keyurl::{KeyData, KeyUrlResponseJson};
@@ -133,15 +133,16 @@ pub struct KeyUrlPoller {
 }
 
 impl KeyUrlPoller {
-    /// Build the poller. Reads the KMSGeneration contract addressed by `keyurl` and the
+    /// Build the poller. Reads the KMSGeneration contract at `kms_generation_address` and the
     /// ProtocolConfig contract from `protocol_config`, both over the same host-chain provider.
     pub fn new(
         protocol_config: &ProtocolConfigSettings,
-        keyurl: &KeyUrlConfig,
+        kms_generation_address: &str,
+        poll_interval_ms: u64,
     ) -> anyhow::Result<Self> {
         let provider = build_host_provider(&protocol_config.ethereum_http_rpc_url)?;
 
-        let kms_generation_address = Address::from_str(&keyurl.kms_generation_address)
+        let kms_generation_address = Address::from_str(kms_generation_address)
             .map_err(|e| anyhow::anyhow!("Invalid kms_generation_address: {e}"))?;
         let protocol_config_address = Address::from_str(&protocol_config.address)
             .map_err(|e| anyhow::anyhow!("Invalid protocol_config address: {e}"))?;
@@ -149,7 +150,7 @@ impl KeyUrlPoller {
         Ok(Self {
             kms_generation: IKMSGeneration::new(kms_generation_address, provider.clone()),
             protocol_config: IProtocolConfig::new(protocol_config_address, provider),
-            poll_interval: Duration::from_millis(keyurl.poll_interval_ms),
+            poll_interval: Duration::from_millis(poll_interval_ms),
             retry: protocol_config.retry.clone(),
             last_seen: None,
         })

--- a/relayer/src/http/endpoints/v2/handlers/keyurl.rs
+++ b/relayer/src/http/endpoints/v2/handlers/keyurl.rs
@@ -14,12 +14,10 @@ use crate::metrics::{
 
 /// HTTP handler for the `/v2/keyurl` endpoint.
 ///
-/// Reads the latest chain-sourced value from a [`tokio::sync::watch`] channel fed by the
-/// host-chain [`crate::host::keyurl_poller::KeyUrlPoller`]. The channel is seeded with the
-/// first successful poll at startup (the relayer gates startup on it), so a value is always
-/// present and reads are lock-free — no waiting or "not initialized" path is needed.
+/// Reads from a watch channel that always holds a value: the host-chain poller seeds it at
+/// startup under `source: chain`, and static config seeds it under `source: config`.
 pub struct KeyUrlHandler {
-    /// Receiver for the latest KeyUrl response, updated by the poller on each rotation.
+    /// Receiver for the served KeyUrl response; updated on each rotation in `chain` mode.
     keyurl_rx: watch::Receiver<KeyUrlResponseJson>,
 }
 
@@ -43,7 +41,6 @@ impl KeyUrlHandler {
     }
 
     pub async fn keyurl_v2(&self, headers: HeaderMap) -> impl IntoResponse {
-        // The watch channel always holds the latest chain-sourced value (seeded at startup).
         let response = self.keyurl_rx.borrow().clone();
 
         http_metrics::with_http_metrics(

--- a/relayer/src/http/endpoints/v2/types/keyurl.rs
+++ b/relayer/src/http/endpoints/v2/types/keyurl.rs
@@ -1,3 +1,4 @@
+use crate::config::settings::deserialize_vec_from_map_or_seq;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
@@ -30,19 +31,24 @@ pub struct FheKeyInfo {
     pub fhe_public_key: KeyData,
 }
 
+// Also the config type behind `keyurl.source: config`, so static values pass straight through
+// to the response. Plain `//`: doc comments here land in openapi.yml.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyData {
     /// On-chain key/CRS identifier, as a `0x`-prefixed 32-byte big-endian hex string.
+    // Config and env keys are snake_case; the response is camelCase.
+    #[serde(alias = "data_id")]
     #[schema(example = "0x0400000000000000000000000000000000000000000000000000000000000003")]
     pub data_id: String,
     /// Storage URLs for the key/CRS material.
+    // Env config delivers `URLS__0` as an index-keyed map, not a list.
+    #[serde(deserialize_with = "deserialize_vec_from_map_or_seq")]
     pub urls: Vec<String>,
 }
 
 impl KeyUrlResponseJson {
-    /// Build a chain-sourced `/v2/keyurl` response from the values the host-chain
-    /// poller read on-chain.
+    /// Build a `/v2/keyurl` response from a key and a CRS, whatever their source.
     pub fn new(fhe_public_key: KeyData, crs: KeyData) -> Self {
         let mut crs_map = HashMap::new();
         crs_map.insert(CRS_PARAM_SIZE_KEY.to_string(), crs);

--- a/relayer/src/startup.rs
+++ b/relayer/src/startup.rs
@@ -32,7 +32,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, span, Level};
 
 use crate::{
-    config::settings::Settings,
+    config::settings::{KeyUrlConfig, Settings},
+    http::endpoints::v2::types::keyurl::KeyUrlResponseJson,
     http::server::run_http_server,
     metrics,
     orchestrator::{HealthCheck, Orchestrator, TokioEventDispatcher},
@@ -150,14 +151,39 @@ pub async fn run_fhevm_relayer(
     if settings.http.endpoint.is_some() {
         info!("Starting Relayer HTTP server");
 
-        // Gate startup on the first successful host-chain poll so `/v2/keyurl` always serves a
-        // chain-sourced value; if it keeps failing the relayer exits and is restarted.
-        let mut keyurl_poller = KeyUrlPoller::new(&settings.protocol_config, &settings.keyurl)
-            .context("Failed to build KeyUrl poller")?;
-        let initial_keyurl = keyurl_poller
-            .initialize()
-            .await
-            .context("Failed to initialize /v2/keyurl from host chain")?;
+        // `/v2/keyurl` is served from a watch channel in both modes; only `chain` runs a poller.
+        let (initial_keyurl, keyurl_poller) = match &settings.keyurl {
+            KeyUrlConfig::Chain {
+                kms_generation_address,
+                poll_interval_ms,
+            } => {
+                let mut poller = KeyUrlPoller::new(
+                    &settings.protocol_config,
+                    kms_generation_address,
+                    *poll_interval_ms,
+                )
+                .context("Failed to build KeyUrl poller")?;
+                // Gate startup on the first successful host-chain poll; if it keeps failing the
+                // relayer exits and is restarted.
+                let initial = poller
+                    .initialize()
+                    .await
+                    .context("Failed to initialize /v2/keyurl from host chain")?;
+                (initial, Some(poller))
+            }
+            KeyUrlConfig::Config {
+                fhe_public_key,
+                crs,
+            } => {
+                info!(
+                    "Serving /v2/keyurl from static config; no host-chain KeyUrl poller is started"
+                );
+                (
+                    KeyUrlResponseJson::new(fhe_public_key.clone(), crs.clone()),
+                    None,
+                )
+            }
+        };
         let (keyurl_tx, keyurl_rx) = tokio::sync::watch::channel(initial_keyurl);
 
         let addr = run_http_server(
@@ -177,14 +203,16 @@ pub async fn run_fhevm_relayer(
         // Spawn the single host-chain KeyUrl poller now the endpoint is serving. Startup is
         // already gated above, so the readiness future is trivially ready; the task is tracked
         // by the orchestrator for graceful shutdown.
-        orchestrator
-            .spawn_task_and_wait_ready(
-                "keyurl_poller",
-                async move { keyurl_poller.run(keyurl_tx).await },
-                async { anyhow::Ok(()) },
-            )
-            .await
-            .context("Failed to start KeyUrl poller")?;
+        if let Some(keyurl_poller) = keyurl_poller {
+            orchestrator
+                .spawn_task_and_wait_ready(
+                    "keyurl_poller",
+                    async move { keyurl_poller.run(keyurl_tx).await },
+                    async { anyhow::Ok(()) },
+                )
+                .await
+                .context("Failed to start KeyUrl poller")?;
+        }
     };
 
     // Run metrics server

--- a/relayer/tests/common/utils.rs
+++ b/relayer/tests/common/utils.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use ethereum_rpc_mock::{
     fhevm::FhevmMockWrapper, MockConfig, MockServer, MockServerHandle, Response, UsageLimit,
 };
-use fhevm_relayer::config::settings::{HostChainConfig, Settings, StorageConfig};
+use fhevm_relayer::config::settings::{HostChainConfig, KeyUrlConfig, Settings, StorageConfig};
 use fhevm_relayer::run_fhevm_relayer;
 use fhevm_relayer::store::sql::client::PgClient;
 use fhevm_relayer::tracing::init_tracing_once;
@@ -67,17 +67,27 @@ impl HostMock {
 
         register_default_host_acl_allow_all(&server, &settings.host_chains);
 
-        // The relayer gates startup on the `/v2/keyurl` poller's first successful poll, so these
-        // have to answer before it boots.
-        let kms_generation_addr = Address::from_str(&settings.keyurl.kms_generation_address)
-            .expect("Invalid kms_generation_address in test config");
         let protocol_config_addr = Address::from_str(&settings.protocol_config.address)
             .expect("Invalid protocol_config address in test config");
-        register_default_keyurl_poller_responses(
-            &server,
-            kms_generation_addr,
-            protocol_config_addr,
-        );
+        match &settings.keyurl {
+            // The relayer gates startup on the `/v2/keyurl` poller's first successful poll, so
+            // these have to answer before it boots.
+            KeyUrlConfig::Chain {
+                kms_generation_address,
+                ..
+            } => {
+                let kms_generation_addr = Address::from_str(kms_generation_address)
+                    .expect("Invalid kms_generation_address in test config");
+                register_default_keyurl_poller_responses(
+                    &server,
+                    kms_generation_addr,
+                    protocol_config_addr,
+                );
+            }
+            KeyUrlConfig::Config { .. } => {
+                register_missing_kms_context_getters(&server, protocol_config_addr);
+            }
+        }
 
         Ok(HostMock {
             port,
@@ -1143,6 +1153,29 @@ fn register_default_keyurl_poller_responses(
         address: protocol_config_address,
         data: event.encode_log_data(),
     });
+}
+
+/// Wire the `ProtocolConfig` KMS-context getters to revert with a bare `0x`, reproducing a
+/// protocol v0.13 deployment that does not implement them. Registered rather than left
+/// unregistered so a relayer that wrongly polled fails as it does against the real deployment.
+fn register_missing_kms_context_getters(
+    host_server: &MockServer,
+    protocol_config_address: Address,
+) {
+    for selector in [
+        IProtocolConfig::getCurrentKmsContextAndEpochCall::SELECTOR,
+        IProtocolConfig::getKmsContextAnchorCall::SELECTOR,
+    ] {
+        host_server.on_call(
+            move |params| {
+                params.to == protocol_config_address
+                    && params.input.len() >= 4
+                    && params.input[0..4] == selector
+            },
+            Response::revert("0x".to_string()),
+            UsageLimit::Unlimited,
+        );
+    }
 }
 
 /// Register an ACL multicall pattern that returns an RPC error.

--- a/relayer/tests/keyurl_poller_test.rs
+++ b/relayer/tests/keyurl_poller_test.rs
@@ -17,7 +17,7 @@ use alloy::sol_types::{SolCall, SolEvent, SolValue};
 use ethereum_rpc_mock::{MockConfig, MockServer, Response, UsageLimit};
 use fhevm_host_bindings::i_protocol_config::IProtocolConfig;
 use fhevm_host_bindings::ikms_generation::IKMSGeneration;
-use fhevm_relayer::config::settings::{KeyUrlConfig, ProtocolConfigSettings, RetrySettings};
+use fhevm_relayer::config::settings::{ProtocolConfigSettings, RetrySettings};
 use fhevm_relayer::host::KeyUrlPoller;
 use tokio::sync::watch;
 
@@ -31,20 +31,15 @@ fn expected_url(segment: &str, id: u64) -> String {
     format!("{STORAGE_URL}/{STORAGE_PREFIX}/{segment}/{id_hex}")
 }
 
-fn make_config(port: u16, poll_interval_ms: u64) -> (ProtocolConfigSettings, KeyUrlConfig) {
-    let protocol_config = ProtocolConfigSettings {
+fn make_config(port: u16) -> ProtocolConfigSettings {
+    ProtocolConfigSettings {
         ethereum_http_rpc_url: format!("http://localhost:{}", port),
         address: CONTRACT_ADDR.to_string(),
         retry: RetrySettings {
             max_attempts: 3,
             retry_interval_ms: 50,
         },
-    };
-    let keyurl = KeyUrlConfig {
-        kms_generation_address: CONTRACT_ADDR.to_string(),
-        poll_interval_ms,
-    };
-    (protocol_config, keyurl)
+    }
 }
 
 fn addr() -> Address {
@@ -183,8 +178,8 @@ async fn initialize_maps_chain_state_to_response() {
     let handle = mock.start().await.unwrap();
     let port = handle.port();
 
-    let (protocol_config, keyurl) = make_config(port, 12_000);
-    let mut poller = KeyUrlPoller::new(&protocol_config, &keyurl).unwrap();
+    let protocol_config = make_config(port);
+    let mut poller = KeyUrlPoller::new(&protocol_config, CONTRACT_ADDR, 12_000).unwrap();
     let response = poller
         .initialize()
         .await
@@ -239,8 +234,8 @@ async fn run_pushes_updated_value_on_id_change() {
     let port = handle.port();
 
     // Seed via the startup fetch (reads key id 3), then run the loop on a short interval.
-    let (protocol_config, keyurl) = make_config(port, 100);
-    let mut poller = KeyUrlPoller::new(&protocol_config, &keyurl).unwrap();
+    let protocol_config = make_config(port);
+    let mut poller = KeyUrlPoller::new(&protocol_config, CONTRACT_ADDR, 100).unwrap();
     let initial = poller
         .initialize()
         .await

--- a/relayer/tests/keyurl_test.rs
+++ b/relayer/tests/keyurl_test.rs
@@ -6,12 +6,20 @@
 mod common;
 
 use crate::common::utils::{
-    test_keyurl_expected_data_id, test_keyurl_expected_url, TestSetup, TEST_KEYURL_CRS_ID,
-    TEST_KEYURL_KEY_ID,
+    test_keyurl_expected_data_id, test_keyurl_expected_url, TestSetup, TEST_CONFIG_PATH,
+    TEST_KEYURL_CRS_ID, TEST_KEYURL_KEY_ID,
 };
 use alloy::primitives::U256;
 use rstest::rstest;
 use serde_json::Value;
+
+/// Static `/v2/keyurl` values wired into the `keyurl.source: config` test config.
+const CONFIG_MODE_KEY_DATA_ID: &str =
+    "0x0400000000000000000000000000000000000000000000000000000000000003";
+const CONFIG_MODE_KEY_URL: &str = "http://minio:9000/kms-public/PUB-p1/PublicKey/0400000000000000000000000000000000000000000000000000000000000003";
+const CONFIG_MODE_CRS_DATA_ID: &str =
+    "0x0400000000000000000000000000000000000000000000000000000000000004";
+const CONFIG_MODE_CRS_URL: &str = "http://minio:9000/kms-public/PUB-p1/CRS/0400000000000000000000000000000000000000000000000000000000000004";
 
 mod helpers {
     use super::*;
@@ -151,4 +159,78 @@ async fn test_keyurl_endpoints_success() {
     let _v2_body = helpers::validate_keyurl_v2_response(v2_response).await;
 
     setup.shutdown().await;
+}
+
+/// `keyurl.source: config` against a v0.13-style deployment: the host mock reverts the
+/// KMS-context getters (`register_missing_kms_context_getters`), so a relayer that still polled
+/// could not pass its startup gate — a served response proves no poller runs.
+#[rstest]
+#[tokio::test]
+async fn test_keyurl_v2_served_from_static_config() {
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let config_path = write_config_source_config(&temp_dir);
+
+    let setup = TestSetup::new_with_config_path(Some(config_path))
+        .await
+        .expect("Relayer should start in keyurl.source: config mode without any chain KMS context");
+
+    let response = reqwest::get(&helpers::keyurl_v2_url(&setup)).await.unwrap();
+    assert_eq!(response.status(), 200, "keyurl endpoint should return 200");
+    let body: Value = response.json().await.unwrap();
+
+    let fhe_public_key = &body["response"]["fheKeyInfo"][0]["fhePublicKey"];
+    assert_eq!(
+        fhe_public_key["dataId"].as_str().unwrap(),
+        CONFIG_MODE_KEY_DATA_ID,
+        "fhePublicKey.dataId should be the configured value"
+    );
+    assert_eq!(
+        fhe_public_key["urls"].as_array().unwrap(),
+        &vec![Value::String(CONFIG_MODE_KEY_URL.to_string())],
+        "fhePublicKey.urls should be the configured values"
+    );
+
+    let crs_2048 = &body["response"]["crs"]["2048"];
+    assert_eq!(
+        crs_2048["dataId"].as_str().unwrap(),
+        CONFIG_MODE_CRS_DATA_ID,
+        "crs.2048.dataId should be the configured value"
+    );
+    assert_eq!(
+        crs_2048["urls"].as_array().unwrap(),
+        &vec![Value::String(CONFIG_MODE_CRS_URL.to_string())],
+        "crs.2048.urls should be the configured values"
+    );
+
+    setup.shutdown().await;
+}
+
+/// Copy the integration test config, replacing its `keyurl` block with a `source: config` one.
+fn write_config_source_config(temp_dir: &tempfile::TempDir) -> std::path::PathBuf {
+    let mut config: serde_yaml::Value =
+        serde_yaml::from_str(&std::fs::read_to_string(TEST_CONFIG_PATH).expect("read test config"))
+            .expect("parse test config");
+
+    let keyurl = serde_yaml::from_str::<serde_yaml::Value>(&format!(
+        "source: config
+fhe_public_key:
+  data_id: \"{CONFIG_MODE_KEY_DATA_ID}\"
+  urls:
+    - \"{CONFIG_MODE_KEY_URL}\"
+crs:
+  data_id: \"{CONFIG_MODE_CRS_DATA_ID}\"
+  urls:
+    - \"{CONFIG_MODE_CRS_URL}\"
+"
+    ))
+    .expect("parse static keyurl block");
+    config["keyurl"] = keyurl;
+
+    let config_path = temp_dir.path().join("keyurl_source_config.yaml");
+    std::fs::write(
+        &config_path,
+        serde_yaml::to_string(&config).expect("serialize config"),
+    )
+    .expect("write config");
+    config_path
 }

--- a/relayer/tests/relayer-test-config.yaml
+++ b/relayer/tests/relayer-test-config.yaml
@@ -14,6 +14,7 @@ protocol_config:
     retry_interval_ms: 100
 
 keyurl:
+  source: chain
   kms_generation_address: "0x1234567890123456789012345678901234567890"
   # Ethereum block time is ~12s; the poller reads at the FINALIZED block tag.
   # (env override in relayer-test-env-only.env changes this to 12000)

--- a/relayer/tests/relayer-test-env-only.env
+++ b/relayer/tests/relayer-test-env-only.env
@@ -56,7 +56,9 @@ APP_HTTP__METRICS__HISTOGRAM_BUCKETS__0=0.01
 APP_HTTP__METRICS__HISTOGRAM_BUCKETS__1=0.05
 APP_HTTP__METRICS__HISTOGRAM_BUCKETS__2=0.1
 
-# /v2/keyurl poller fields (YAML has different values)
+# /v2/keyurl fields (YAML has different values). `source` is set here too so the enum
+# tag is exercised through the env path, not just supplied by the YAML base.
+APP_KEYURL__SOURCE=chain
 APP_KEYURL__KMS_GENERATION_ADDRESS=0x00000000000000000000000000000000000000ff
 APP_KEYURL__POLL_INTERVAL_MS=12000
 

--- a/test-suite/fhevm/config/relayer/local.yaml
+++ b/test-suite/fhevm/config/relayer/local.yaml
@@ -114,8 +114,9 @@ log:
   show_timestamp: true
   show_target: true
 
-# /v2/keyurl host-chain poller settings.
+# /v2/keyurl host-chain poller settings. `source` is required.
 keyurl:
+  source: chain
   # KMSGeneration contract address on the host chain (source for /v2/keyurl).
   kms_generation_address: "0x3E0fBCcE61af7C01113027449eEFFF5DCd501419"
   # /v2/keyurl poll interval in ms; the poller reads at the finalized block.

--- a/test-suite/fhevm/templates/config/relayer.yaml
+++ b/test-suite/fhevm/templates/config/relayer.yaml
@@ -117,8 +117,9 @@ log:
   show_timestamp: true
   show_target: true
 
-# /v2/keyurl host-chain poller settings.
+# /v2/keyurl host-chain poller settings. `source` is required.
 keyurl:
+  source: chain
   # KMSGeneration contract address on the host chain (source for /v2/keyurl).
   kms_generation_address: "0x3E0fBCcE61af7C01113027449eEFFF5DCd501419"
   # /v2/keyurl poll interval in ms; the poller reads at the finalized block.


### PR DESCRIPTION
Adds config-driven `/v2/keyurl` for the upcoming v0.15 release, so the relayer can run against protocol v0.13. The design is described in [fhevm-internal#1937][issue].

### How it works

The change is small. `/v2/keyurl` already serves whatever sits in a watch channel, so `config` mode seeds that channel at startup and starts no poller. The variant holds `KeyData`, the response type, so the config and the response cannot drift apart.

### Configuration from env vars

Most of the diff is that idea meeting env-var configuration, which is how these deployments pass keyurl values. Config keys are snake_case while the response is camelCase, so `data_id` needs an alias. config-rs also reads `..__URLS__0` as a map rather than a list, so `urls` needs the `deserialize_vec_from_map_or_seq` helper.

### Validation and tests

Static values reach clients untouched, so config load now rejects a malformed `data_id`, empty `urls`, or a URL that does not parse — none of which the issue asks for. Protocol v0.13 is simply two missing `ProtocolConfig` getters, so the tests revert both before the relayer boots and a stray poller fails the startup gate. Chain mode, the response shape and `openapi.yml` are unchanged.

Existing deployments need `keyurl.source` added, and static URLs are now a list, so the env key is `APP_KEYURL__FHE_PUBLIC_KEY__URLS__0` rather than `…__URL`.

[issue]: https://github.com/zama-ai/fhevm-internal/issues/1937
