### PR TITLE
fix(relayer): catch stale sqlx offline data in CI

### DIFF
--- a/.github/workflows/relayer-tests.yaml
+++ b/.github/workflows/relayer-tests.yaml
@@ -198,6 +198,17 @@ jobs:
         working-directory: relayer/relayer-migrate
         run: sqlx migrate run
 
+      - name: Offline query data matches the migrations
+        # The steps above compile with SQLX_OFFLINE, which trusts .sqlx instead of
+        # checking it, so stale data would pass every other check in this workflow.
+        working-directory: relayer
+        env:
+          SQLX_OFFLINE: false
+        # DATABASE_URL is passed on the command line because the Makefile derives its
+        # own default from the compose file, which would otherwise win over the
+        # service's port.
+        run: make sqlx-check DATABASE_URL="$DATABASE_URL"
+
       - name: Run tests
         working-directory: relayer
         run: RUST_BACKTRACE=full make test-integration

--- a/relayer/.sqlx/query-8c3047bafebb9f6e2bb94b0f91adbd780b5fa96236e0f06137700480c24c0165.json
+++ b/relayer/.sqlx/query-8c3047bafebb9f6e2bb94b0f91adbd780b5fa96236e0f06137700480c24c0165.json
@@ -49,9 +49,9 @@
             "name": "user_decrypt_req_type",
             "kind": {
               "Enum": [
-                "legacy",
                 "user_decrypt",
-                "delegated_user_decrypt"
+                "delegated_user_decrypt",
+                "unified"
               ]
             }
           }

--- a/relayer/Makefile
+++ b/relayer/Makefile
@@ -343,8 +343,15 @@ db-shell: _check-postgres ## Open psql shell into local database
 sqlx-migrate: _check-sqlx-cli _check-postgres ## Run migrations via sqlx-cli
 	@cd relayer-migrate && cargo sqlx migrate run --database-url "$(DATABASE_URL)"
 
+# --all-features is required, not cosmetic: the integration test targets only compile with
+# the `integration-tests` feature, and without it prepare fails on those targets.
 sqlx-prepare: _check-sqlx-cli _check-postgres ## Prepare sqlx offline data for CI (run after schema changes)
-	@cargo sqlx prepare --database-url "$(DATABASE_URL)" -- --all-targets
+	@cargo sqlx prepare --database-url "$(DATABASE_URL)" -- --all-targets --all-features
+
+# CI compiles with SQLX_OFFLINE, which trusts .sqlx rather than checking it. Data left
+# behind by a schema change therefore compiles fine and misdescribes the database.
+sqlx-check: _check-sqlx-cli _check-postgres ## Fail if .sqlx no longer matches the migrations
+	@cargo sqlx prepare --check --database-url "$(DATABASE_URL)" -- --all-targets --all-features
 
 # ---------------------------------------------------------------------------
 ##@ Development


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1939.

`sqlx-prepare` gains `--all-features` alongside the new check. Without it `cargo sqlx prepare` stops on unresolved `ethereum_rpc_mock` imports before writing anything — which is how the stale file survived in the first place.
