### PR TITLE
feat(test-suite): add operator edge-case e2e tests

### DIFF
--- a/test-suite/e2e/README.md
+++ b/test-suite/e2e/README.md
@@ -40,6 +40,20 @@ Run via the fhevm-cli profiles `erc1271-user-decryption`,
 `standard`) — see `test-suite/fhevm/README.md` — or directly with
 `npx hardhat test --grep "<describe title>" --network staging`.
 
+## Operator edge-case suite
+
+Limit-case coverage for the arithmetic, shift, rotate and cast operators:
+overshift, div/rem boundaries and the `DivisionByZero()` revert, over/underflow
+wrapping, and narrowing-cast truncation.
+
+Expected values live in `test/fhevmOperations/shiftSemantics.ts`. Shift
+semantics change in tfhe-rs >= 1.7.0, so flip `OVERSHIFT_RETURNS_ZERO` there in
+the same change as the engine version bump.
+
+```shell
+./fhevm-cli test operators --grep "edge cases" --verbose
+```
+
 ## Smoke runner (inputFlow)
 
 Runs a single on-chain smoke flow (input + add42 + decrypt) using Hardhat as a runtime

--- a/test-suite/e2e/contracts/operations/FHEVMOperatorEdgeCaseTestSuite.sol
+++ b/test-suite/e2e/contracts/operations/FHEVMOperatorEdgeCaseTestSuite.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity ^0.8.24;
+
+import "@fhevm/solidity/lib/FHE.sol";
+import {E2ECoprocessorConfig} from "../E2ECoprocessorConfigLocal.sol";
+
+/// @dev Split out of FHEVMManualTestSuite to stay under the EIP-170 contract size limit.
+contract FHEVMOperatorEdgeCaseTestSuite is E2ECoprocessorConfig {
+    bytes32[] private _resBatch;
+
+    /// @dev Shift results are ordered [shl, shr, rotl, rotr] for the scalar RHS, then the encrypted RHS.
+    function resBatch() external view returns (bytes32[] memory) {
+        return _resBatch;
+    }
+
+    function _push(euint8 v) private {
+        FHE.makePubliclyDecryptable(v);
+        _resBatch.push(euint8.unwrap(v));
+    }
+
+    function _push(euint16 v) private {
+        FHE.makePubliclyDecryptable(v);
+        _resBatch.push(euint16.unwrap(v));
+    }
+
+    function _push(euint32 v) private {
+        FHE.makePubliclyDecryptable(v);
+        _resBatch.push(euint32.unwrap(v));
+    }
+
+    function _push(euint64 v) private {
+        FHE.makePubliclyDecryptable(v);
+        _resBatch.push(euint64.unwrap(v));
+    }
+
+    function _push(euint128 v) private {
+        FHE.makePubliclyDecryptable(v);
+        _resBatch.push(euint128.unwrap(v));
+    }
+
+    function _push(euint256 v) private {
+        FHE.makePubliclyDecryptable(v);
+        _resBatch.push(euint256.unwrap(v));
+    }
+
+    function test_shifts_euint8(externalEuint8 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint8 x = FHE.fromExternal(a, inputProof);
+        euint8 n = FHE.fromExternal(e, inputProof);
+        _push(FHE.shl(x, s));
+        _push(FHE.shr(x, s));
+        _push(FHE.rotl(x, s));
+        _push(FHE.rotr(x, s));
+        _push(FHE.shl(x, n));
+        _push(FHE.shr(x, n));
+        _push(FHE.rotl(x, n));
+        _push(FHE.rotr(x, n));
+    }
+
+    function test_shifts_euint16(externalEuint16 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint16 x = FHE.fromExternal(a, inputProof);
+        euint8 n = FHE.fromExternal(e, inputProof);
+        _push(FHE.shl(x, s));
+        _push(FHE.shr(x, s));
+        _push(FHE.rotl(x, s));
+        _push(FHE.rotr(x, s));
+        _push(FHE.shl(x, n));
+        _push(FHE.shr(x, n));
+        _push(FHE.rotl(x, n));
+        _push(FHE.rotr(x, n));
+    }
+
+    function test_shifts_euint32(externalEuint32 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint32 x = FHE.fromExternal(a, inputProof);
+        euint8 n = FHE.fromExternal(e, inputProof);
+        _push(FHE.shl(x, s));
+        _push(FHE.shr(x, s));
+        _push(FHE.rotl(x, s));
+        _push(FHE.rotr(x, s));
+        _push(FHE.shl(x, n));
+        _push(FHE.shr(x, n));
+        _push(FHE.rotl(x, n));
+        _push(FHE.rotr(x, n));
+    }
+
+    function test_shifts_euint64(externalEuint64 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint64 x = FHE.fromExternal(a, inputProof);
+        euint8 n = FHE.fromExternal(e, inputProof);
+        _push(FHE.shl(x, s));
+        _push(FHE.shr(x, s));
+        _push(FHE.rotl(x, s));
+        _push(FHE.rotr(x, s));
+        _push(FHE.shl(x, n));
+        _push(FHE.shr(x, n));
+        _push(FHE.rotl(x, n));
+        _push(FHE.rotr(x, n));
+    }
+
+    function test_shifts_euint128(externalEuint128 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint128 x = FHE.fromExternal(a, inputProof);
+        euint8 n = FHE.fromExternal(e, inputProof);
+        _push(FHE.shl(x, s));
+        _push(FHE.shr(x, s));
+        _push(FHE.rotl(x, s));
+        _push(FHE.rotr(x, s));
+        _push(FHE.shl(x, n));
+        _push(FHE.shr(x, n));
+        _push(FHE.rotl(x, n));
+        _push(FHE.rotr(x, n));
+    }
+
+    function test_shifts_euint256(externalEuint256 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint256 x = FHE.fromExternal(a, inputProof);
+        euint8 n = FHE.fromExternal(e, inputProof);
+        _push(FHE.shl(x, s));
+        _push(FHE.shr(x, s));
+        _push(FHE.rotl(x, s));
+        _push(FHE.rotr(x, s));
+        _push(FHE.shl(x, n));
+        _push(FHE.shr(x, n));
+        _push(FHE.rotl(x, n));
+        _push(FHE.rotr(x, n));
+    }
+
+    function test_divrem_euint8(externalEuint8 a, uint8 d, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint8 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.div(x, d));
+        _push(FHE.rem(x, d));
+    }
+
+    function test_divrem_euint16(externalEuint16 a, uint16 d, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint16 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.div(x, d));
+        _push(FHE.rem(x, d));
+    }
+
+    function test_divrem_euint32(externalEuint32 a, uint32 d, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint32 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.div(x, d));
+        _push(FHE.rem(x, d));
+    }
+
+    function test_divrem_euint64(externalEuint64 a, uint64 d, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint64 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.div(x, d));
+        _push(FHE.rem(x, d));
+    }
+
+    function test_divrem_euint128(externalEuint128 a, uint128 d, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint128 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.div(x, d));
+        _push(FHE.rem(x, d));
+    }
+
+    function test_arith_euint8(externalEuint8 a, uint8 s, externalEuint8 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint8 x = FHE.fromExternal(a, inputProof);
+        euint8 y = FHE.fromExternal(e, inputProof);
+        _push(FHE.add(x, s));
+        _push(FHE.sub(x, s));
+        _push(FHE.mul(x, s));
+        _push(FHE.add(x, y));
+        _push(FHE.sub(x, y));
+        _push(FHE.mul(x, y));
+        _push(FHE.neg(x));
+        _push(FHE.not(x));
+    }
+
+    function test_arith_euint16(externalEuint16 a, uint16 s, externalEuint16 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint16 x = FHE.fromExternal(a, inputProof);
+        euint16 y = FHE.fromExternal(e, inputProof);
+        _push(FHE.add(x, s));
+        _push(FHE.sub(x, s));
+        _push(FHE.mul(x, s));
+        _push(FHE.add(x, y));
+        _push(FHE.sub(x, y));
+        _push(FHE.mul(x, y));
+        _push(FHE.neg(x));
+        _push(FHE.not(x));
+    }
+
+    function test_arith_euint32(externalEuint32 a, uint32 s, externalEuint32 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint32 x = FHE.fromExternal(a, inputProof);
+        euint32 y = FHE.fromExternal(e, inputProof);
+        _push(FHE.add(x, s));
+        _push(FHE.sub(x, s));
+        _push(FHE.mul(x, s));
+        _push(FHE.add(x, y));
+        _push(FHE.sub(x, y));
+        _push(FHE.mul(x, y));
+        _push(FHE.neg(x));
+        _push(FHE.not(x));
+    }
+
+    function test_arith_euint64(externalEuint64 a, uint64 s, externalEuint64 e, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint64 x = FHE.fromExternal(a, inputProof);
+        euint64 y = FHE.fromExternal(e, inputProof);
+        _push(FHE.add(x, s));
+        _push(FHE.sub(x, s));
+        _push(FHE.mul(x, s));
+        _push(FHE.add(x, y));
+        _push(FHE.sub(x, y));
+        _push(FHE.mul(x, y));
+        _push(FHE.neg(x));
+        _push(FHE.not(x));
+    }
+
+    function test_arith_euint128(
+        externalEuint128 a,
+        uint128 s,
+        externalEuint128 e,
+        bytes calldata inputProof
+    ) external {
+        delete _resBatch;
+        euint128 x = FHE.fromExternal(a, inputProof);
+        euint128 y = FHE.fromExternal(e, inputProof);
+        _push(FHE.add(x, s));
+        _push(FHE.sub(x, s));
+        _push(FHE.mul(x, s));
+        _push(FHE.add(x, y));
+        _push(FHE.sub(x, y));
+        _push(FHE.mul(x, y));
+        _push(FHE.neg(x));
+        _push(FHE.not(x));
+    }
+
+    /// @dev add/sub/mul stop at euint128; neg/not go up to euint256.
+    function test_negnot_euint256(externalEuint256 a, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint256 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.neg(x));
+        _push(FHE.not(x));
+    }
+
+    /// @dev Narrowing casts, widest target first.
+    function test_narrow_euint16(externalEuint16 a, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint16 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.asEuint8(x));
+    }
+
+    function test_narrow_euint32(externalEuint32 a, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint32 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.asEuint16(x));
+        _push(FHE.asEuint8(x));
+    }
+
+    function test_narrow_euint64(externalEuint64 a, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint64 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.asEuint32(x));
+        _push(FHE.asEuint16(x));
+        _push(FHE.asEuint8(x));
+    }
+
+    function test_narrow_euint128(externalEuint128 a, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint128 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.asEuint64(x));
+        _push(FHE.asEuint32(x));
+        _push(FHE.asEuint16(x));
+        _push(FHE.asEuint8(x));
+    }
+
+    function test_narrow_euint256(externalEuint256 a, bytes calldata inputProof) external {
+        delete _resBatch;
+        euint256 x = FHE.fromExternal(a, inputProof);
+        _push(FHE.asEuint128(x));
+        _push(FHE.asEuint64(x));
+        _push(FHE.asEuint32(x));
+        _push(FHE.asEuint16(x));
+        _push(FHE.asEuint8(x));
+    }
+}

--- a/test-suite/e2e/test/fhevmOperations/manual.ts
+++ b/test-suite/e2e/test/fhevmOperations/manual.ts
@@ -1,9 +1,11 @@
 import { assert, expect } from 'chai';
+import type { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 
 import type { FHEVMManualTestSuite } from '../../types/contracts/operations/FHEVMManualTestSuite';
 import { createInstance } from '../instance';
 import { getSigner } from '../signers';
+import { expectedRotl, expectedRotr, expectedShl, expectedShr } from './shiftSemantics';
 
 async function deployFHEVMManualTestFixture(): Promise<FHEVMManualTestSuite> {
   const admin = await getSigner(119);
@@ -15,24 +17,48 @@ async function deployFHEVMManualTestFixture(): Promise<FHEVMManualTestSuite> {
   return contract;
 }
 
-const UINT64_MASK = (1n << 64n) - 1n;
 const OVERSIZED_SHIFT_64 = 70n;
-const REDUCED_SHIFT_64 = 6n;
 const SHIFT_ROTATE_VALUE_64 = 0x123456789abcdef0n;
+const SHIFT_CASES = [
+  { bits: 8n, valueType: 'uint8', value: 0xa5n, amounts: [0n, 7n, 8n, 255n] },
+  { bits: 16n, valueType: 'uint16', value: 0xa5c3n, amounts: [0n, 15n, 16n, 255n] },
+  { bits: 32n, valueType: 'uint32', value: 0xa5c3f00fn, amounts: [0n, 31n, 32n, 255n] },
+  { bits: 64n, valueType: 'uint64', value: SHIFT_ROTATE_VALUE_64, amounts: [0n, 63n, 64n, OVERSIZED_SHIFT_64, 255n] },
+  {
+    bits: 128n,
+    valueType: 'uint128',
+    value: 0x123456789abcdef0fedcba9876543210n,
+    amounts: [0n, 127n, 128n, 255n],
+  },
+  {
+    // The shift amount is a uint8/euint8, so amount >= 256 is unrepresentable here.
+    bits: 256n,
+    valueType: 'uint256',
+    value: 0x123456789abcdef0fedcba9876543210123456789abcdef0fedcba9876543210n,
+    amounts: [0n, 255n],
+  },
+] as const;
+
+// Under the legacy modulo the amount == bits rows make every operator the identity; they
+// only become discriminating once OVERSHIFT_RETURNS_ZERO flips.
+const WIDTHS = SHIFT_CASES.map(({ bits }) => bits);
+
+// div/rem and add/sub/mul are only defined up to euint128
+const NARROW_CASES = SHIFT_CASES.filter(({ bits }) => bits <= 128n);
+
 const addr = (value: string) => ethers.getAddress(value);
 const ADDR_A = addr('0x8ba1f109551bd432803012645ac136ddd64dba72');
 const ADDR_B = addr('0x8881f109551bd432803012645ac136ddd64dba72');
 const ADDR_C = addr('0x9ba1f109551bd432803012645ac136ddd64dba72');
 const ADDR_D = addr('0x9aa1f109551bd432803012645ac136ddd64dba72');
 
-function rotl64(value: bigint, shift: bigint): bigint {
-  const normalized = shift % 64n;
-  return ((value << normalized) | (value >> (64n - normalized))) & UINT64_MASK;
-}
-
-function rotr64(value: bigint, shift: bigint): bigint {
-  const normalized = shift % 64n;
-  return ((value >> normalized) | (value << (64n - normalized))) & UINT64_MASK;
+async function decryptBatch(
+  instance: Awaited<ReturnType<typeof createInstance>>,
+  contract: Contract,
+): Promise<bigint[]> {
+  const handles = [...(await contract.resBatch())] as string[];
+  const res = await instance.publicDecrypt(handles);
+  return handles.map((h) => res.clearValues[h as `0x${string}`] as bigint);
 }
 
 async function decrypt64Result(
@@ -60,7 +86,7 @@ describe('FHEVM manual operations', function () {
   // Keep this regression isolated so operators CI can target only the
   // oversized-index path without pulling the whole manual suite.
   describe('FHEVM oversized shift and rotate indexes', function () {
-    it('shr(euint64, uint8) applies modulo semantics for indexes > bit width', async function () {
+    it('shr(euint64, uint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [{ type: 'uint64', value: SHIFT_ROTATE_VALUE_64 }],
         contractAddress: this.contractAddress,
@@ -75,10 +101,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, SHIFT_ROTATE_VALUE_64 >> REDUCED_SHIFT_64);
+      assert.equal(res, expectedShr(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('shr(euint64, euint8) applies modulo semantics for indexes > bit width', async function () {
+    it('shr(euint64, euint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [
           { type: 'uint64', value: SHIFT_ROTATE_VALUE_64 },
@@ -96,10 +122,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, SHIFT_ROTATE_VALUE_64 >> REDUCED_SHIFT_64);
+      assert.equal(res, expectedShr(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('shl(euint64, uint8) applies modulo semantics for indexes > bit width', async function () {
+    it('shl(euint64, uint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [{ type: 'uint64', value: SHIFT_ROTATE_VALUE_64 }],
         contractAddress: this.contractAddress,
@@ -114,10 +140,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, (SHIFT_ROTATE_VALUE_64 << REDUCED_SHIFT_64) & UINT64_MASK);
+      assert.equal(res, expectedShl(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('shl(euint64, euint8) applies modulo semantics for indexes > bit width', async function () {
+    it('shl(euint64, euint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [
           { type: 'uint64', value: SHIFT_ROTATE_VALUE_64 },
@@ -135,10 +161,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, (SHIFT_ROTATE_VALUE_64 << REDUCED_SHIFT_64) & UINT64_MASK);
+      assert.equal(res, expectedShl(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('rotl(euint64, uint8) applies modulo semantics for indexes > bit width', async function () {
+    it('rotl(euint64, uint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [{ type: 'uint64', value: SHIFT_ROTATE_VALUE_64 }],
         contractAddress: this.contractAddress,
@@ -153,10 +179,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, rotl64(SHIFT_ROTATE_VALUE_64, REDUCED_SHIFT_64));
+      assert.equal(res, expectedRotl(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('rotr(euint64, uint8) applies modulo semantics for indexes > bit width', async function () {
+    it('rotr(euint64, uint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [{ type: 'uint64', value: SHIFT_ROTATE_VALUE_64 }],
         contractAddress: this.contractAddress,
@@ -171,10 +197,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, rotr64(SHIFT_ROTATE_VALUE_64, REDUCED_SHIFT_64));
+      assert.equal(res, expectedRotr(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('rotr(euint64, euint8) applies modulo semantics for indexes > bit width', async function () {
+    it('rotr(euint64, euint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [
           { type: 'uint64', value: SHIFT_ROTATE_VALUE_64 },
@@ -192,10 +218,10 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, rotr64(SHIFT_ROTATE_VALUE_64, REDUCED_SHIFT_64));
+      assert.equal(res, expectedRotr(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
 
-    it('rotl(euint64, euint8) applies modulo semantics for indexes > bit width', async function () {
+    it('rotl(euint64, euint8) with an oversized index', async function () {
       const encryptedAmount = await this.instance.encryptTypedValues({
         values: [
           { type: 'uint64', value: SHIFT_ROTATE_VALUE_64 },
@@ -213,7 +239,7 @@ describe('FHEVM manual operations', function () {
           encryptedAmount.inputProof,
         ),
       );
-      assert.equal(res, rotl64(SHIFT_ROTATE_VALUE_64, REDUCED_SHIFT_64));
+      assert.equal(res, expectedRotl(SHIFT_ROTATE_VALUE_64, OVERSIZED_SHIFT_64, 64n));
     });
   });
 
@@ -1836,5 +1862,158 @@ describe('FHEVM manual operations', function () {
     const handle = await this.contract.resAdd();
     const res = await this.instance.publicDecrypt([handle]);
     assert.equal(res.clearValues[handle], ADDR_A);
+  });
+});
+
+// Top-level: these tests use their own fixture, so they must not pay for the
+// FHEVMManualTestSuite deploy in the parent beforeEach (shared signer, nonce pressure).
+describe('FHEVM manual operations - shift, rotate, div and rem edge cases', function () {
+  beforeEach(async function () {
+    this.signer = await getSigner(119);
+    this.instance = await createInstance();
+    const factory = await ethers.getContractFactory('FHEVMOperatorEdgeCaseTestSuite');
+    const contract = await factory.connect(this.signer).deploy();
+    await contract.waitForDeployment();
+    this.edge = contract as unknown as Contract;
+    this.edgeAddress = await contract.getAddress();
+  });
+  SHIFT_CASES.forEach(({ bits, valueType, value, amounts }) => {
+    amounts.forEach((amount) => {
+      it(`shl/shr/rotl/rotr(euint${bits}, ${amount}) matches reference semantics`, async function () {
+        const encryptedAmount = await this.instance.encryptTypedValues({
+          values: [
+            { type: valueType, value },
+            { type: 'uint8', value: amount },
+          ],
+          contractAddress: this.edgeAddress,
+          userAddress: this.signer.address,
+        });
+        const tx = await this.edge[`test_shifts_euint${bits}`](
+          encryptedAmount.handles[0],
+          amount,
+          encryptedAmount.handles[1],
+          encryptedAmount.inputProof,
+        );
+        await tx.wait();
+        const values = await decryptBatch(this.instance, this.edge);
+        const expected = [
+          expectedShl(value, amount, bits),
+          expectedShr(value, amount, bits),
+          expectedRotl(value, amount, bits),
+          expectedRotr(value, amount, bits),
+        ];
+        assert.deepEqual(values, [...expected, ...expected]);
+      });
+    });
+  });
+
+  NARROW_CASES.forEach(({ bits, valueType, value }) => {
+    const max = (1n << bits) - 1n;
+    (
+      [
+        [value, 1n],
+        [value, value],
+        [value, max],
+        [max, max],
+        [0n, value],
+      ] as const
+    ).forEach(([dividend, divisor]) => {
+      it(`div/rem(euint${bits}(${dividend}), ${divisor}) matches reference semantics`, async function () {
+        const encryptedAmount = await this.instance.encryptTypedValues({
+          values: [{ type: valueType, value: dividend }],
+          contractAddress: this.edgeAddress,
+          userAddress: this.signer.address,
+        });
+        const tx = await this.edge[`test_divrem_euint${bits}`](
+          encryptedAmount.handles[0],
+          divisor,
+          encryptedAmount.inputProof,
+        );
+        await tx.wait();
+        const values = await decryptBatch(this.instance, this.edge);
+        assert.deepEqual(values, [dividend / divisor, dividend % divisor]);
+      });
+    });
+
+    it(`div/rem(euint${bits}, 0) reverts`, async function () {
+      const encryptedAmount = await this.instance.encryptTypedValues({
+        values: [{ type: valueType, value }],
+        contractAddress: this.edgeAddress,
+        userAddress: this.signer.address,
+      });
+      // FHEVMExecutor reverts with DivisionByZero() before any FHE work
+      await expect(this.edge[`test_divrem_euint${bits}`](encryptedAmount.handles[0], 0n, encryptedAmount.inputProof)).to
+        .be.reverted;
+    });
+  });
+
+  NARROW_CASES.forEach(({ bits, valueType }) => {
+    const modulus = 1n << bits;
+    const max = modulus - 1n;
+    const wrap = (v: bigint) => ((v % modulus) + modulus) % modulus;
+    (
+      [
+        [max, 1n],
+        [0n, 1n],
+        [max, max],
+        [max, 2n],
+        [0n, 0n],
+      ] as const
+    ).forEach(([lhs, rhs]) => {
+      it(`add/sub/mul/neg/not(euint${bits}(${lhs}), ${rhs}) wraps`, async function () {
+        const encryptedAmount = await this.instance.encryptTypedValues({
+          values: [
+            { type: valueType, value: lhs },
+            { type: valueType, value: rhs },
+          ],
+          contractAddress: this.edgeAddress,
+          userAddress: this.signer.address,
+        });
+        const tx = await this.edge[`test_arith_euint${bits}`](
+          encryptedAmount.handles[0],
+          rhs,
+          encryptedAmount.handles[1],
+          encryptedAmount.inputProof,
+        );
+        await tx.wait();
+        const values = await decryptBatch(this.instance, this.edge);
+        const binary = [wrap(lhs + rhs), wrap(lhs - rhs), wrap(lhs * rhs)];
+        assert.deepEqual(values, [...binary, ...binary, wrap(-lhs), max - lhs]);
+      });
+    });
+  });
+
+  const MODULUS_256 = 1n << 256n;
+  [0n, MODULUS_256 - 1n].forEach((operand) => {
+    it(`neg/not(euint256(${operand === 0n ? '0' : 'MAX'})) wraps`, async function () {
+      const encryptedAmount = await this.instance.encryptTypedValues({
+        values: [{ type: 'uint256', value: operand }],
+        contractAddress: this.edgeAddress,
+        userAddress: this.signer.address,
+      });
+      const tx = await this.edge.test_negnot_euint256(encryptedAmount.handles[0], encryptedAmount.inputProof);
+      await tx.wait();
+      const values = await decryptBatch(this.instance, this.edge);
+      assert.deepEqual(values, [(MODULUS_256 - operand) % MODULUS_256, MODULUS_256 - 1n - operand]);
+    });
+  });
+
+  SHIFT_CASES.filter(({ bits }) => bits > 8n).forEach(({ bits, valueType, value }) => {
+    it(`asEuintX(euint${bits}) truncates`, async function () {
+      const encryptedAmount = await this.instance.encryptTypedValues({
+        values: [{ type: valueType, value }],
+        contractAddress: this.edgeAddress,
+        userAddress: this.signer.address,
+      });
+      const tx = await this.edge[`test_narrow_euint${bits}`](encryptedAmount.handles[0], encryptedAmount.inputProof);
+      await tx.wait();
+      const values = await decryptBatch(this.instance, this.edge);
+      assert.deepEqual(
+        values,
+        WIDTHS.filter((w) => w < bits)
+          .reverse()
+          .map((w) => value & ((1n << w) - 1n)),
+      );
+    });
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/manual.ts
+++ b/test-suite/e2e/test/fhevmOperations/manual.ts
@@ -1,10 +1,10 @@
 import { assert, expect } from 'chai';
-import type { Contract } from 'ethers';
 import { ethers } from 'hardhat';
 
 import type { FHEVMManualTestSuite } from '../../types/contracts/operations/FHEVMManualTestSuite';
 import { createInstance } from '../instance';
 import { getSigner } from '../signers';
+import { OVERSIZED_SHIFT_64, SHIFT_ROTATE_VALUE_64 } from './operatorEdgeCases';
 import { expectedRotl, expectedRotr, expectedShl, expectedShr } from './shiftSemantics';
 
 async function deployFHEVMManualTestFixture(): Promise<FHEVMManualTestSuite> {
@@ -17,49 +17,11 @@ async function deployFHEVMManualTestFixture(): Promise<FHEVMManualTestSuite> {
   return contract;
 }
 
-const OVERSIZED_SHIFT_64 = 70n;
-const SHIFT_ROTATE_VALUE_64 = 0x123456789abcdef0n;
-const SHIFT_CASES = [
-  { bits: 8n, valueType: 'uint8', value: 0xa5n, amounts: [0n, 7n, 8n, 255n] },
-  { bits: 16n, valueType: 'uint16', value: 0xa5c3n, amounts: [0n, 15n, 16n, 255n] },
-  { bits: 32n, valueType: 'uint32', value: 0xa5c3f00fn, amounts: [0n, 31n, 32n, 255n] },
-  { bits: 64n, valueType: 'uint64', value: SHIFT_ROTATE_VALUE_64, amounts: [0n, 63n, 64n, OVERSIZED_SHIFT_64, 255n] },
-  {
-    bits: 128n,
-    valueType: 'uint128',
-    value: 0x123456789abcdef0fedcba9876543210n,
-    amounts: [0n, 127n, 128n, 255n],
-  },
-  {
-    // The shift amount is a uint8/euint8, so amount >= 256 is unrepresentable here.
-    bits: 256n,
-    valueType: 'uint256',
-    value: 0x123456789abcdef0fedcba9876543210123456789abcdef0fedcba9876543210n,
-    amounts: [0n, 255n],
-  },
-] as const;
-
-// Under the legacy modulo the amount == bits rows make every operator the identity; they
-// only become discriminating once OVERSHIFT_RETURNS_ZERO flips.
-const WIDTHS = SHIFT_CASES.map(({ bits }) => bits);
-
-// div/rem and add/sub/mul are only defined up to euint128
-const NARROW_CASES = SHIFT_CASES.filter(({ bits }) => bits <= 128n);
-
 const addr = (value: string) => ethers.getAddress(value);
 const ADDR_A = addr('0x8ba1f109551bd432803012645ac136ddd64dba72');
 const ADDR_B = addr('0x8881f109551bd432803012645ac136ddd64dba72');
 const ADDR_C = addr('0x9ba1f109551bd432803012645ac136ddd64dba72');
 const ADDR_D = addr('0x9aa1f109551bd432803012645ac136ddd64dba72');
-
-async function decryptBatch(
-  instance: Awaited<ReturnType<typeof createInstance>>,
-  contract: Contract,
-): Promise<bigint[]> {
-  const handles = [...(await contract.resBatch())] as string[];
-  const res = await instance.publicDecrypt(handles);
-  return handles.map((h) => res.clearValues[h as `0x${string}`] as bigint);
-}
 
 async function decrypt64Result(
   instance: Awaited<ReturnType<typeof createInstance>>,
@@ -1862,158 +1824,5 @@ describe('FHEVM manual operations', function () {
     const handle = await this.contract.resAdd();
     const res = await this.instance.publicDecrypt([handle]);
     assert.equal(res.clearValues[handle], ADDR_A);
-  });
-});
-
-// Top-level: these tests use their own fixture, so they must not pay for the
-// FHEVMManualTestSuite deploy in the parent beforeEach (shared signer, nonce pressure).
-describe('FHEVM manual operations - shift, rotate, div and rem edge cases', function () {
-  before(async function () {
-    this.signer = await getSigner(119);
-    this.instance = await createInstance();
-    const factory = await ethers.getContractFactory('FHEVMOperatorEdgeCaseTestSuite');
-    const contract = await factory.connect(this.signer).deploy();
-    await contract.waitForDeployment();
-    this.edge = contract as unknown as Contract;
-    this.edgeAddress = await contract.getAddress();
-  });
-  SHIFT_CASES.forEach(({ bits, valueType, value, amounts }) => {
-    amounts.forEach((amount) => {
-      it(`shl/shr/rotl/rotr(euint${bits}, ${amount}) matches reference semantics`, async function () {
-        const encryptedAmount = await this.instance.encryptTypedValues({
-          values: [
-            { type: valueType, value },
-            { type: 'uint8', value: amount },
-          ],
-          contractAddress: this.edgeAddress,
-          userAddress: this.signer.address,
-        });
-        const tx = await this.edge[`test_shifts_euint${bits}`](
-          encryptedAmount.handles[0],
-          amount,
-          encryptedAmount.handles[1],
-          encryptedAmount.inputProof,
-        );
-        await tx.wait();
-        const values = await decryptBatch(this.instance, this.edge);
-        const expected = [
-          expectedShl(value, amount, bits),
-          expectedShr(value, amount, bits),
-          expectedRotl(value, amount, bits),
-          expectedRotr(value, amount, bits),
-        ];
-        assert.deepEqual(values, [...expected, ...expected]);
-      });
-    });
-  });
-
-  NARROW_CASES.forEach(({ bits, valueType, value }) => {
-    const max = (1n << bits) - 1n;
-    (
-      [
-        [value, 1n],
-        [value, value],
-        [value, max],
-        [max, max],
-        [0n, value],
-      ] as const
-    ).forEach(([dividend, divisor]) => {
-      it(`div/rem(euint${bits}(${dividend}), ${divisor}) matches reference semantics`, async function () {
-        const encryptedAmount = await this.instance.encryptTypedValues({
-          values: [{ type: valueType, value: dividend }],
-          contractAddress: this.edgeAddress,
-          userAddress: this.signer.address,
-        });
-        const tx = await this.edge[`test_divrem_euint${bits}`](
-          encryptedAmount.handles[0],
-          divisor,
-          encryptedAmount.inputProof,
-        );
-        await tx.wait();
-        const values = await decryptBatch(this.instance, this.edge);
-        assert.deepEqual(values, [dividend / divisor, dividend % divisor]);
-      });
-    });
-
-    it(`div/rem(euint${bits}, 0) reverts`, async function () {
-      const encryptedAmount = await this.instance.encryptTypedValues({
-        values: [{ type: valueType, value }],
-        contractAddress: this.edgeAddress,
-        userAddress: this.signer.address,
-      });
-      // FHEVMExecutor reverts with DivisionByZero() before any FHE work
-      await expect(this.edge[`test_divrem_euint${bits}`](encryptedAmount.handles[0], 0n, encryptedAmount.inputProof)).to
-        .be.reverted;
-    });
-  });
-
-  NARROW_CASES.forEach(({ bits, valueType }) => {
-    const modulus = 1n << bits;
-    const max = modulus - 1n;
-    const wrap = (v: bigint) => ((v % modulus) + modulus) % modulus;
-    (
-      [
-        [max, 1n],
-        [0n, 1n],
-        [max, max],
-        [max, 2n],
-        [0n, 0n],
-      ] as const
-    ).forEach(([lhs, rhs]) => {
-      it(`add/sub/mul/neg/not(euint${bits}(${lhs}), ${rhs}) wraps`, async function () {
-        const encryptedAmount = await this.instance.encryptTypedValues({
-          values: [
-            { type: valueType, value: lhs },
-            { type: valueType, value: rhs },
-          ],
-          contractAddress: this.edgeAddress,
-          userAddress: this.signer.address,
-        });
-        const tx = await this.edge[`test_arith_euint${bits}`](
-          encryptedAmount.handles[0],
-          rhs,
-          encryptedAmount.handles[1],
-          encryptedAmount.inputProof,
-        );
-        await tx.wait();
-        const values = await decryptBatch(this.instance, this.edge);
-        const binary = [wrap(lhs + rhs), wrap(lhs - rhs), wrap(lhs * rhs)];
-        assert.deepEqual(values, [...binary, ...binary, wrap(-lhs), max - lhs]);
-      });
-    });
-  });
-
-  const MODULUS_256 = 1n << 256n;
-  [0n, MODULUS_256 - 1n].forEach((operand) => {
-    it(`neg/not(euint256(${operand === 0n ? '0' : 'MAX'})) wraps`, async function () {
-      const encryptedAmount = await this.instance.encryptTypedValues({
-        values: [{ type: 'uint256', value: operand }],
-        contractAddress: this.edgeAddress,
-        userAddress: this.signer.address,
-      });
-      const tx = await this.edge.test_negnot_euint256(encryptedAmount.handles[0], encryptedAmount.inputProof);
-      await tx.wait();
-      const values = await decryptBatch(this.instance, this.edge);
-      assert.deepEqual(values, [(MODULUS_256 - operand) % MODULUS_256, MODULUS_256 - 1n - operand]);
-    });
-  });
-
-  SHIFT_CASES.filter(({ bits }) => bits > 8n).forEach(({ bits, valueType, value }) => {
-    it(`asEuintX(euint${bits}) truncates`, async function () {
-      const encryptedAmount = await this.instance.encryptTypedValues({
-        values: [{ type: valueType, value }],
-        contractAddress: this.edgeAddress,
-        userAddress: this.signer.address,
-      });
-      const tx = await this.edge[`test_narrow_euint${bits}`](encryptedAmount.handles[0], encryptedAmount.inputProof);
-      await tx.wait();
-      const values = await decryptBatch(this.instance, this.edge);
-      assert.deepEqual(
-        values,
-        WIDTHS.filter((w) => w < bits)
-          .reverse()
-          .map((w) => value & ((1n << w) - 1n)),
-      );
-    });
   });
 });

--- a/test-suite/e2e/test/fhevmOperations/manual.ts
+++ b/test-suite/e2e/test/fhevmOperations/manual.ts
@@ -1868,7 +1868,7 @@ describe('FHEVM manual operations', function () {
 // Top-level: these tests use their own fixture, so they must not pay for the
 // FHEVMManualTestSuite deploy in the parent beforeEach (shared signer, nonce pressure).
 describe('FHEVM manual operations - shift, rotate, div and rem edge cases', function () {
-  beforeEach(async function () {
+  before(async function () {
     this.signer = await getSigner(119);
     this.instance = await createInstance();
     const factory = await ethers.getContractFactory('FHEVMOperatorEdgeCaseTestSuite');

--- a/test-suite/e2e/test/fhevmOperations/operatorEdgeCases.ts
+++ b/test-suite/e2e/test/fhevmOperations/operatorEdgeCases.ts
@@ -1,0 +1,57 @@
+import type { Contract } from 'ethers';
+import { ethers } from 'hardhat';
+
+import { createInstance } from '../instance';
+import { getSigner } from '../signers';
+
+export const OVERSIZED_SHIFT_64 = 70n;
+export const SHIFT_ROTATE_VALUE_64 = 0x123456789abcdef0n;
+
+export const SHIFT_CASES = [
+  { bits: 8n, valueType: 'uint8', value: 0xa5n, amounts: [0n, 7n, 8n, 255n] },
+  { bits: 16n, valueType: 'uint16', value: 0xa5c3n, amounts: [0n, 15n, 16n, 255n] },
+  { bits: 32n, valueType: 'uint32', value: 0xa5c3f00fn, amounts: [0n, 31n, 32n, 255n] },
+  { bits: 64n, valueType: 'uint64', value: SHIFT_ROTATE_VALUE_64, amounts: [0n, 63n, 64n, OVERSIZED_SHIFT_64, 255n] },
+  {
+    bits: 128n,
+    valueType: 'uint128',
+    value: 0x123456789abcdef0fedcba9876543210n,
+    amounts: [0n, 127n, 128n, 255n],
+  },
+  {
+    // The shift amount is a uint8/euint8, so amount >= 256 is unrepresentable here.
+    bits: 256n,
+    valueType: 'uint256',
+    value: 0x123456789abcdef0fedcba9876543210123456789abcdef0fedcba9876543210n,
+    amounts: [0n, 255n],
+  },
+] as const;
+
+// Under the legacy modulo the amount == bits rows make every operator the identity; they
+// only become discriminating once OVERSHIFT_RETURNS_ZERO flips.
+export const WIDTHS = SHIFT_CASES.map(({ bits }) => bits);
+
+// div/rem and add/sub/mul are only defined up to euint128
+export const NARROW_CASES = SHIFT_CASES.filter(({ bits }) => bits <= 128n);
+
+// Deployed once per suite: every fixture entry point starts with `delete _resBatch`.
+export function useOperatorEdgeCaseFixture(): void {
+  before(async function () {
+    this.signer = await getSigner(119);
+    this.instance = await createInstance();
+    const factory = await ethers.getContractFactory('FHEVMOperatorEdgeCaseTestSuite');
+    const contract = await factory.connect(this.signer).deploy();
+    await contract.waitForDeployment();
+    this.edge = contract as unknown as Contract;
+    this.edgeAddress = await contract.getAddress();
+  });
+}
+
+export async function decryptBatch(
+  instance: Awaited<ReturnType<typeof createInstance>>,
+  contract: Contract,
+): Promise<bigint[]> {
+  const handles = [...(await contract.resBatch())] as string[];
+  const res = await instance.publicDecrypt(handles);
+  return handles.map((h) => res.clearValues[h as `0x${string}`] as bigint);
+}

--- a/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesArith.ts
+++ b/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesArith.ts
@@ -1,0 +1,43 @@
+import { assert } from 'chai';
+
+import { NARROW_CASES, decryptBatch, useOperatorEdgeCaseFixture } from './operatorEdgeCases';
+
+describe('FHEVM manual operations - arithmetic edge cases', function () {
+  useOperatorEdgeCaseFixture();
+
+  NARROW_CASES.forEach(({ bits, valueType }) => {
+    const modulus = 1n << bits;
+    const max = modulus - 1n;
+    const wrap = (v: bigint) => ((v % modulus) + modulus) % modulus;
+    (
+      [
+        [max, 1n],
+        [0n, 1n],
+        [max, max],
+        [max, 2n],
+        [0n, 0n],
+      ] as const
+    ).forEach(([lhs, rhs]) => {
+      it(`add/sub/mul/neg/not(euint${bits}(${lhs}), ${rhs}) wraps`, async function () {
+        const encryptedAmount = await this.instance.encryptTypedValues({
+          values: [
+            { type: valueType, value: lhs },
+            { type: valueType, value: rhs },
+          ],
+          contractAddress: this.edgeAddress,
+          userAddress: this.signer.address,
+        });
+        const tx = await this.edge[`test_arith_euint${bits}`](
+          encryptedAmount.handles[0],
+          rhs,
+          encryptedAmount.handles[1],
+          encryptedAmount.inputProof,
+        );
+        await tx.wait();
+        const values = await decryptBatch(this.instance, this.edge);
+        const binary = [wrap(lhs + rhs), wrap(lhs - rhs), wrap(lhs * rhs)];
+        assert.deepEqual(values, [...binary, ...binary, wrap(-lhs), max - lhs]);
+      });
+    });
+  });
+});

--- a/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesCasts.ts
+++ b/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesCasts.ts
@@ -1,0 +1,41 @@
+import { assert } from 'chai';
+
+import { SHIFT_CASES, WIDTHS, decryptBatch, useOperatorEdgeCaseFixture } from './operatorEdgeCases';
+
+describe('FHEVM manual operations - cast edge cases', function () {
+  useOperatorEdgeCaseFixture();
+
+  const MODULUS_256 = 1n << 256n;
+  [0n, MODULUS_256 - 1n].forEach((operand) => {
+    it(`neg/not(euint256(${operand === 0n ? '0' : 'MAX'})) wraps`, async function () {
+      const encryptedAmount = await this.instance.encryptTypedValues({
+        values: [{ type: 'uint256', value: operand }],
+        contractAddress: this.edgeAddress,
+        userAddress: this.signer.address,
+      });
+      const tx = await this.edge.test_negnot_euint256(encryptedAmount.handles[0], encryptedAmount.inputProof);
+      await tx.wait();
+      const values = await decryptBatch(this.instance, this.edge);
+      assert.deepEqual(values, [(MODULUS_256 - operand) % MODULUS_256, MODULUS_256 - 1n - operand]);
+    });
+  });
+
+  SHIFT_CASES.filter(({ bits }) => bits > 8n).forEach(({ bits, valueType, value }) => {
+    it(`asEuintX(euint${bits}) truncates`, async function () {
+      const encryptedAmount = await this.instance.encryptTypedValues({
+        values: [{ type: valueType, value }],
+        contractAddress: this.edgeAddress,
+        userAddress: this.signer.address,
+      });
+      const tx = await this.edge[`test_narrow_euint${bits}`](encryptedAmount.handles[0], encryptedAmount.inputProof);
+      await tx.wait();
+      const values = await decryptBatch(this.instance, this.edge);
+      assert.deepEqual(
+        values,
+        WIDTHS.filter((w) => w < bits)
+          .reverse()
+          .map((w) => value & ((1n << w) - 1n)),
+      );
+    });
+  });
+});

--- a/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesDivRem.ts
+++ b/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesDivRem.ts
@@ -1,0 +1,47 @@
+import { assert, expect } from 'chai';
+
+import { NARROW_CASES, decryptBatch, useOperatorEdgeCaseFixture } from './operatorEdgeCases';
+
+describe('FHEVM manual operations - div and rem edge cases', function () {
+  useOperatorEdgeCaseFixture();
+
+  NARROW_CASES.forEach(({ bits, valueType, value }) => {
+    const max = (1n << bits) - 1n;
+    (
+      [
+        [value, 1n],
+        [value, value],
+        [value, max],
+        [max, max],
+        [0n, value],
+      ] as const
+    ).forEach(([dividend, divisor]) => {
+      it(`div/rem(euint${bits}(${dividend}), ${divisor}) matches reference semantics`, async function () {
+        const encryptedAmount = await this.instance.encryptTypedValues({
+          values: [{ type: valueType, value: dividend }],
+          contractAddress: this.edgeAddress,
+          userAddress: this.signer.address,
+        });
+        const tx = await this.edge[`test_divrem_euint${bits}`](
+          encryptedAmount.handles[0],
+          divisor,
+          encryptedAmount.inputProof,
+        );
+        await tx.wait();
+        const values = await decryptBatch(this.instance, this.edge);
+        assert.deepEqual(values, [dividend / divisor, dividend % divisor]);
+      });
+    });
+
+    it(`div/rem(euint${bits}, 0) reverts`, async function () {
+      const encryptedAmount = await this.instance.encryptTypedValues({
+        values: [{ type: valueType, value }],
+        contractAddress: this.edgeAddress,
+        userAddress: this.signer.address,
+      });
+      // FHEVMExecutor reverts with DivisionByZero() before any FHE work
+      await expect(this.edge[`test_divrem_euint${bits}`](encryptedAmount.handles[0], 0n, encryptedAmount.inputProof)).to
+        .be.reverted;
+    });
+  });
+});

--- a/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesShifts.ts
+++ b/test-suite/e2e/test/fhevmOperations/operatorEdgeCasesShifts.ts
@@ -1,0 +1,38 @@
+import { assert } from 'chai';
+
+import { SHIFT_CASES, decryptBatch, useOperatorEdgeCaseFixture } from './operatorEdgeCases';
+import { expectedRotl, expectedRotr, expectedShl, expectedShr } from './shiftSemantics';
+
+describe('FHEVM manual operations - shift and rotate edge cases', function () {
+  useOperatorEdgeCaseFixture();
+
+  SHIFT_CASES.forEach(({ bits, valueType, value, amounts }) => {
+    amounts.forEach((amount) => {
+      it(`shl/shr/rotl/rotr(euint${bits}, ${amount}) matches reference semantics`, async function () {
+        const encryptedAmount = await this.instance.encryptTypedValues({
+          values: [
+            { type: valueType, value },
+            { type: 'uint8', value: amount },
+          ],
+          contractAddress: this.edgeAddress,
+          userAddress: this.signer.address,
+        });
+        const tx = await this.edge[`test_shifts_euint${bits}`](
+          encryptedAmount.handles[0],
+          amount,
+          encryptedAmount.handles[1],
+          encryptedAmount.inputProof,
+        );
+        await tx.wait();
+        const values = await decryptBatch(this.instance, this.edge);
+        const expected = [
+          expectedShl(value, amount, bits),
+          expectedShr(value, amount, bits),
+          expectedRotl(value, amount, bits),
+          expectedRotr(value, amount, bits),
+        ];
+        assert.deepEqual(values, [...expected, ...expected]);
+      });
+    });
+  });
+});

--- a/test-suite/e2e/test/fhevmOperations/shiftSemantics.ts
+++ b/test-suite/e2e/test/fhevmOperations/shiftSemantics.ts
@@ -1,0 +1,31 @@
+/**
+ * Reference semantics for the shift/rotate operators, mirroring tfhe-rs.
+ *
+ * tfhe-rs >= 1.7.0 returns 0 on an overshift (amount >= bit width) instead of
+ * truncating the amount. Flip the flag together with the engine version bump.
+ */
+export const OVERSHIFT_RETURNS_ZERO = false;
+
+const mask = (bits: bigint): bigint => (1n << bits) - 1n;
+
+export function expectedShl(value: bigint, amount: bigint, bits: bigint): bigint {
+  if (amount >= bits && OVERSHIFT_RETURNS_ZERO) return 0n;
+  // legacy semantics truncate an oversized amount rather than saturating
+  return (value << (amount % bits)) & mask(bits);
+}
+
+export function expectedShr(value: bigint, amount: bigint, bits: bigint): bigint {
+  if (amount >= bits && OVERSHIFT_RETURNS_ZERO) return 0n;
+  // legacy semantics truncate an oversized amount rather than saturating
+  return value >> (amount % bits);
+}
+
+export function expectedRotl(value: bigint, amount: bigint, bits: bigint): bigint {
+  const n = amount % bits;
+  return ((value << n) | (value >> (bits - n))) & mask(bits);
+}
+
+export function expectedRotr(value: bigint, amount: bigint, bits: bigint): bigint {
+  const n = amount % bits;
+  return ((value >> n) | (value << (bits - n))) & mask(bits);
+}

--- a/test-suite/fhevm/README.md
+++ b/test-suite/fhevm/README.md
@@ -350,7 +350,8 @@ When changing runtime flags, env contracts, target semantics, or external compan
 ./fhevm-cli test standard
 ./fhevm-cli test heavy
 ./fhevm-cli test operators
-./fhevm-cli test --grep "oversized shift/rotate" --verbose
+./fhevm-cli test --grep "oversized shift and rotate" --verbose
+./fhevm-cli test operators --grep "edge cases" --verbose
 ./fhevm-cli pause host
 ./fhevm-cli unpause host
 


### PR DESCRIPTION
### Summary

- `shl`/`shr`/`rotl`/`rotr` at amount `0`, `W-1`, `W`, `255` — `euint8`..`euint256`, scalar and encrypted RHS
- `div`/`rem` identities, boundaries, zero dividend, `DivisionByZero()` revert
- `add`/`sub`/`mul`/`neg`/`not` wrapping on over/underflow
- narrowing casts truncating to the target width
- `OVERSHIFT_RETURNS_ZERO` (`shiftSemantics.ts`): flip to `true` with the tfhe-rs >= 1.7.0 bump; single point of change for the new overshift behaviour

### Run

```sh
./fhevm-cli test operators --grep "edge cases" --verbose
```

Related: https://github.com/zama-ai/fhevm-internal/issues/1572
