### PR TITLE
feat(sdk): add polygon mainnet CLI network

### DIFF
--- a/sdk/cli-js-sdk/README.md
+++ b/sdk/cli-js-sdk/README.md
@@ -140,7 +140,8 @@ fhevm-sdk delegated-user-decrypt stored --delegator 0x... --type uint16 --type u
 | `-n, --network testnet-amoy` | FHETest `0xa66bCEd74D1Df0736d0eb8E52371b1b1AAA1F0F0` on Polygon Amoy with testnet relayer config.   |
 | `-n, --network devnet`      | FHETest `0xf56a7990E63a63eC75aD9Aa07De8cB6bF7baa805` on Ethereum Sepolia with devnet relayer config. |
 | `-n, --network devnet-amoy` | FHETest `0x7553CB9124f974Ee475E5cE45482F90d5B6076BC` on Polygon Amoy with devnet relayer config.     |
-| `-n, --network mainnet`     | FHeTest `0xf56a7990E63a63eC75aD9Aa07De8cB6bF7baa805`on Ethereum Mainnet with mainnet relayer config. |
+| `-n, --network mainnet`     | FHETest `0xba4d707745689eD409d4Afac8722224f5FD78C63` on Ethereum Mainnet with mainnet relayer config. |
+| `-n, --network polygon`     | FHETest `0xFb10eda9e9b4f3f7dd928B6F32fBB94E2a20451d` on Polygon PoS with mainnet relayer config.     |
 | `--rpc-url <url>`           | Host chain RPC override. Otherwise uses the matching env var, then a public fallback.                |
 | `--relayer-url <url>`       | Relayer base URL override. `localhost:3000` becomes `http://localhost:3000`.                         |
 | `--contract <address>`      | FHETest contract override. This is command-specific, not a global option.                            |
@@ -152,6 +153,7 @@ Supported FHETest value types are `bool`, `uint8`, `uint16`, `uint32`, `uint64`,
 | Variable                | Used for                                                                                                       |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `MAINNET_RPC_URL`       | RPC for `mainnet`.                                                                                             |
+| `POLYGON_RPC_URL`       | RPC for `polygon`.                                                                                             |
 | `SEPOLIA_RPC_URL`       | RPC for `testnet` and `devnet`.                                                                                |
 | `POLYGON_AMOY_RPC_URL`  | RPC for `testnet-amoy` and `devnet-amoy`.                                                                     |
 | `ZAMA_FHEVM_API_KEY`    | Optional SDK relayer auth when the target environment requires an API key.                                     |

--- a/sdk/cli-js-sdk/packages/cli/bin/completion-server.mjs
+++ b/sdk/cli-js-sdk/packages/cli/bin/completion-server.mjs
@@ -11,7 +11,7 @@ const FHE_VALUE_TYPES = [
   "address",
 ];
 
-const NETWORKS = ["testnet", "testnet-amoy", "devnet", "devnet-amoy", "mainnet"];
+const NETWORKS = ["testnet", "testnet-amoy", "devnet", "devnet-amoy", "mainnet", "polygon"];
 const SHELLS = ["bash", "zsh", "fish", "pwsh"];
 
 const OPERATIONS = [

--- a/sdk/cli-js-sdk/packages/load-test/README.md
+++ b/sdk/cli-js-sdk/packages/load-test/README.md
@@ -74,9 +74,9 @@ Environment (read from the workspace-root `.env` or the environment):
   `delegated-user-decrypt` pools when no mnemonic is set (with a mnemonic the
   delegate is derived at a reserved HD index).
 - Host-chain RPC override: `SEPOLIA_RPC_URL` for `testnet` and `devnet`,
-  `POLYGON_AMOY_RPC_URL` for `testnet-amoy` and `devnet-amoy`, and
-  `MAINNET_RPC_URL` for
-  `mainnet`. Public network defaults are used when the matching variable and
+  `POLYGON_AMOY_RPC_URL` for `testnet-amoy` and `devnet-amoy`,
+  `MAINNET_RPC_URL` for `mainnet`, and `POLYGON_RPC_URL` for `polygon`.
+  Public network defaults are used when the matching variable and
   `--rpc-url` are both absent.
 - `ZAMA_FHEVM_API_KEY` — optional SDK and raw-relayer API-key authentication.
 - `ZAMA_FHEVM_API_KEY_B` — optional distinct API key for the candidate relayer

--- a/sdk/cli-js-sdk/packages/load-test/docs/OPERATIONS.md
+++ b/sdk/cli-js-sdk/packages/load-test/docs/OPERATIONS.md
@@ -31,6 +31,7 @@ Put credentials in the workspace-root `.env` (`sdk/cli-js-sdk/.env`):
 | `SEPOLIA_RPC_URL` | `testnet`, `devnet` handle pools | Ethereum Sepolia host-chain RPC for FHETest transactions |
 | `POLYGON_AMOY_RPC_URL` | `testnet-amoy` and `devnet-amoy` handle pools | Polygon Amoy host-chain RPC for FHETest transactions |
 | `MAINNET_RPC_URL` | `mainnet` handle pools | Ethereum Mainnet host-chain RPC for FHETest transactions |
+| `POLYGON_RPC_URL` | `polygon` handle pools | Polygon PoS host-chain RPC for FHETest transactions |
 | `LOAD_TEST_RELAYER_URL` | everything | or pass `--relayer-url` |
 | `LOAD_TEST_RELAYER_CONFIG` | config snapshot | optional; path to the relayer YAML in effect |
 | `LOAD_TEST_DATA_DIR` | pools/runs root | default `.load-test` |

--- a/sdk/cli-js-sdk/packages/load-test/src/pool/store.ts
+++ b/sdk/cli-js-sdk/packages/load-test/src/pool/store.ts
@@ -502,6 +502,7 @@ const NETWORKS = [
   "devnet",
   "devnet-amoy",
   "mainnet",
+  "polygon",
 ] as const;
 
 const safeInteger = z.number().int().safe();

--- a/sdk/cli-js-sdk/packages/load-test/test/readme.test.ts
+++ b/sdk/cli-js-sdk/packages/load-test/test/readme.test.ts
@@ -13,7 +13,8 @@ describe("README capability contract", () => {
     expect(readme).toContain(
       "`POLYGON_AMOY_RPC_URL` for `testnet-amoy` and `devnet-amoy`",
     );
-    expect(readme).toContain("`MAINNET_RPC_URL` for");
+    expect(readme).toContain("`MAINNET_RPC_URL` for `mainnet`");
+    expect(readme).toContain("`POLYGON_RPC_URL` for `polygon`");
     expect(readme).not.toContain("when the DB collector is on");
   });
 

--- a/sdk/cli-js-sdk/packages/toolkit/src/config/networks.ts
+++ b/sdk/cli-js-sdk/packages/toolkit/src/config/networks.ts
@@ -6,6 +6,7 @@ import {
 } from "@fhevm/sdk/chains";
 import {
   mainnet as viemMainnet,
+  polygon as viemPolygon,
   polygonAmoy,
   sepolia as viemSepolia,
 } from "viem/chains";
@@ -16,6 +17,7 @@ import type { NetworkConfig } from "./types";
 
 export const DEFAULT_MAINNET_RPC_URL = "https://eth.drpc.org";
 export const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
+export const DEFAULT_POLYGON_RPC_URL = "https://polygon.drpc.org";
 export const DEFAULT_POLYGON_AMOY_RPC_URL = "https://polygon-amoy.drpc.org";
 
 const devnet = defineFhevmChain({
@@ -72,6 +74,38 @@ const devnetAmoy = defineFhevmChain({
   },
 });
 
+const polygon = defineFhevmChain({
+  id: 137,
+  fhevm: {
+    contracts: {
+      acl: {
+        address: "0x6737F17e31cf26a1b62fb0362acC5a16CB156F49",
+      },
+      inputVerifier: {
+        address: "0xf40BD204B035522EaAc8E5afAdc55113Acac96ca",
+      },
+      kmsVerifier: {
+        address: "0x14e609595474874Dd6b6128376E336EfADfdBE37",
+      },
+      protocolConfig: {
+        address: "0x17f62Ab3A1Ea519703cD597410147A30Fa1a7f1e",
+      },
+    },
+    relayerUrl: "https://relayer.mainnet.zama.org",
+    gateway: {
+      id: 261_131,
+      contracts: {
+        decryption: {
+          address: "0x0f6024a97684f7d90ddb0fAAD79cB15F2C888D24",
+        },
+        inputVerification: {
+          address: "0xcB1bB072f38bdAF0F328CdEf1Fc6eDa1DF029287",
+        },
+      },
+    },
+  },
+});
+
 const NETWORK_CONFIGS = {
   "testnet": {
     fhevmChain: sepolia,
@@ -107,6 +141,13 @@ const NETWORK_CONFIGS = {
     defaultRpcUrl: DEFAULT_MAINNET_RPC_URL,
     envRpcUrl: "MAINNET_RPC_URL",
     fheTestAddress: "0xba4d707745689eD409d4Afac8722224f5FD78C63",
+  },
+  "polygon": {
+    fhevmChain: polygon,
+    hostChain: viemPolygon,
+    defaultRpcUrl: DEFAULT_POLYGON_RPC_URL,
+    envRpcUrl: "POLYGON_RPC_URL",
+    fheTestAddress: "0xFb10eda9e9b4f3f7dd928B6F32fBB94E2a20451d",
   },
 } as const satisfies Record<NetworkName, NetworkConfig>;
 

--- a/sdk/cli-js-sdk/packages/toolkit/src/types.ts
+++ b/sdk/cli-js-sdk/packages/toolkit/src/types.ts
@@ -6,6 +6,7 @@ export const NETWORKS = [
   "devnet",
   "devnet-amoy",
   "mainnet",
+  "polygon",
 ] as const;
 export type NetworkName = (typeof NETWORKS)[number];
 export const DEFAULT_NETWORK: NetworkName = "testnet";

--- a/sdk/cli-js-sdk/packages/toolkit/test/networks.test.ts
+++ b/sdk/cli-js-sdk/packages/toolkit/test/networks.test.ts
@@ -33,6 +33,26 @@ describe("custom FHEVM network definitions", () => {
     );
   });
 
+  it("configures Polygon PoS mainnet host contracts and the shared mainnet gateway", () => {
+    const config = resolveNetworkConfig("polygon");
+
+    expect(config.hostChain.id).toBe(137);
+    expect(config.envRpcUrl).toBe("POLYGON_RPC_URL");
+    expect(config.fhevmChain.fhevm.contracts.acl.address).toBe(
+      "0x6737F17e31cf26a1b62fb0362acC5a16CB156F49",
+    );
+    expect(config.fhevmChain.fhevm.contracts.protocolConfig?.address).toBe(
+      "0x17f62Ab3A1Ea519703cD597410147A30Fa1a7f1e",
+    );
+    expect(config.fhevmChain.fhevm.relayerUrl).toBe(
+      "https://relayer.mainnet.zama.org",
+    );
+    expect(config.fhevmChain.fhevm.gateway.id).toBe(261_131);
+    expect(config.fheTestAddress).toBe(
+      "0xFb10eda9e9b4f3f7dd928B6F32fBB94E2a20451d",
+    );
+  });
+
   it("does not carry per-network runtime version overrides", () => {
     for (const network of NETWORKS) {
       expect(resolveNetworkConfig(network)).not.toHaveProperty("runtime");

--- a/sdk/js-sdk/test/chains/chain-defaults.json
+++ b/sdk/js-sdk/test/chains/chain-defaults.json
@@ -83,6 +83,11 @@
     "fheTestAddress": "0xa66bCEd74D1Df0736d0eb8E52371b1b1AAA1F0F0",
     "fheTestVersion": "v2"
   },
+  "polygon_mainnet": {
+    "rpcUrl": "https://polygon-rpc.com",
+    "fheTestAddress": "0xFb10eda9e9b4f3f7dd928B6F32fBB94E2a20451d",
+    "fheTestVersion": "v2"
+  },
   "ingen_trex_cleartext": {
     "rpcUrl": "https://rpc.ingen.t-rex.network",
     "fheTestAddress": "0x7553CB9124f974Ee475E5cE45482F90d5B6076BC",


### PR DESCRIPTION
## Summary

Add `--network polygon` to `fhevm-sdk` so the CLI can target Polygon PoS mainnet (chain id 137) with the shared mainnet relayer and the deployed FHETest contract.

## Changes

- Add the `polygon` network preset (`POLYGON_RPC_URL`, host chain 137, FHETest `0xFb10eda9e9b4f3f7dd928B6F32fBB94E2a20451d`)
- Wire completion and load-test network lists
- Record the address in `sdk/js-sdk/test/chains/chain-defaults.json`

## Test plan

- [ ] `fhevm-sdk -n polygon fhe-test info` resolves chain id 137 and the FHETest address above
- [ ] `POLYGON_RPC_URL` overrides the default RPC
- [ ] Tab completion lists `polygon`

Made with [Cursor](https://cursor.com)