### PR TITLE
fix(coprocessor): wait for the GCS schema before opening a green pool

### DIFF
--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -84,19 +84,20 @@ impl PostgresPoolManager {
         gcs_mode: bool,
     ) -> Option<Self> {
         let database_url = crate::utils::DatabaseURL::from(url.to_owned());
+        // Postgres ignores a missing schema in search_path, so a green pool opened
+        // too early would write to `public`. Wait for the schema.
+        if gcs_mode {
+            if let Err(err) =
+                crate::versioning::wait_for_gcs_schema(url, crate::versioning::GCS_SCHEMA_WAIT)
+                    .await
+            {
+                error!(error = %err, "GCS schema never appeared");
+                return None;
+            }
+        }
         let pool = loop {
             if cancel_token.is_cancelled() {
                 return None;
-            }
-
-            // Postgres ignores a missing schema in search_path, so a green pool
-            // opened too early would write to `public`. Wait for the schema.
-            if gcs_mode {
-                if let Err(err) = crate::versioning::assert_gcs_schema_exists(url).await {
-                    error!(error = %err, "Waiting for the GCS schema before opening the pool");
-                    sleep(retry_db_conn_interval).await;
-                    continue;
-                }
             }
 
             let statement_timeout = std::cmp::max(acquire_timeout, Duration::from_secs(10));

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/pg_pool.rs
@@ -89,6 +89,16 @@ impl PostgresPoolManager {
                 return None;
             }
 
+            // Postgres ignores a missing schema in search_path, so a green pool
+            // opened too early would write to `public`. Wait for the schema.
+            if gcs_mode {
+                if let Err(err) = crate::versioning::assert_gcs_schema_exists(url).await {
+                    error!(error = %err, "Waiting for the GCS schema before opening the pool");
+                    sleep(retry_db_conn_interval).await;
+                    continue;
+                }
+            }
+
             let statement_timeout = std::cmp::max(acquire_timeout, Duration::from_secs(10));
 
             match connect_pool_with_options_and_connect_options(

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -224,6 +224,68 @@ pub struct StaleStackError {
     pub live: String,
 }
 
+/// Fail unless the GCS schema exists.
+///
+/// Green services pin `search_path` to that schema, and Postgres ignores it when
+/// missing, so writes would go to `public`. The upgrade-controller creates it at
+/// startup; a green service that starts first must wait. Call this before
+/// opening a pool.
+pub async fn assert_gcs_schema_exists(database_url: &str) -> anyhow::Result<()> {
+    let options = crate::database::connect_options_for_database_url(
+        &crate::utils::DatabaseURL::from(database_url),
+    )
+    .await?;
+    let mut conn = PgConnection::connect_with(&options).await?;
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1)")
+            .bind(crate::database::GCS_SCHEMA)
+            .fetch_one(&mut conn)
+            .await?;
+    let _ = conn.close().await;
+    anyhow::ensure!(
+        exists,
+        "schema {} does not exist yet; waiting for the upgrade-controller to create it",
+        crate::database::GCS_SCHEMA
+    );
+    Ok(())
+}
+
+/// How long a green service waits for the upgrade-controller to create the schema.
+pub const GCS_SCHEMA_WAIT: Duration = Duration::from_secs(300);
+
+/// Wait for the GCS schema, then return.
+///
+/// Every green service starts alongside the upgrade-controller that creates the
+/// schema, so losing that race is normal and must not end the process. Give up
+/// only after `timeout`, which means the controller never got there.
+pub async fn wait_for_gcs_schema(database_url: &str, timeout: Duration) -> anyhow::Result<()> {
+    const POLL: Duration = Duration::from_secs(2);
+    let mut waited = Duration::ZERO;
+    loop {
+        match assert_gcs_schema_exists(database_url).await {
+            Ok(()) => return Ok(()),
+            Err(err) if waited >= timeout => {
+                return Err(err.context(format!(
+                    "schema {} still missing after {}s",
+                    crate::database::GCS_SCHEMA,
+                    timeout.as_secs()
+                )))
+            }
+            Err(err) => {
+                if waited.is_zero() {
+                    info!(
+                        schema = crate::database::GCS_SCHEMA,
+                        error = %err,
+                        "waiting for the upgrade-controller to create the GCS schema"
+                    );
+                }
+                tokio::time::sleep(POLL).await;
+                waited += POLL;
+            }
+        }
+    }
+}
+
 /// True if `err` is Postgres `undefined_table` (SQLSTATE 42P01) — i.e. the
 /// `versioning` table does not exist yet (migrations not applied).
 fn is_undefined_table(err: &sqlx::Error) -> bool {

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -251,7 +251,11 @@ pub async fn assert_gcs_schema_exists(database_url: &str) -> anyhow::Result<()> 
 }
 
 /// How long a green service waits for the upgrade-controller to create the schema.
-pub const GCS_SCHEMA_WAIT: Duration = Duration::from_secs(300);
+///
+/// Long enough that a slow or misconfigured controller can be fixed while the
+/// services keep waiting, short enough that a deploy that will never work still
+/// gives up instead of sitting there.
+pub const GCS_SCHEMA_WAIT: Duration = Duration::from_secs(3600);
 
 /// Wait for the GCS schema, then return.
 ///
@@ -260,10 +264,21 @@ pub const GCS_SCHEMA_WAIT: Duration = Duration::from_secs(300);
 /// only after `timeout`, which means the controller never got there.
 pub async fn wait_for_gcs_schema(database_url: &str, timeout: Duration) -> anyhow::Result<()> {
     const POLL: Duration = Duration::from_secs(2);
+    const LOG_EVERY: Duration = Duration::from_secs(30);
     let mut waited = Duration::ZERO;
+    let mut next_log = Duration::ZERO;
     loop {
         match assert_gcs_schema_exists(database_url).await {
-            Ok(()) => return Ok(()),
+            Ok(()) => {
+                if !waited.is_zero() {
+                    info!(
+                        schema = crate::database::GCS_SCHEMA,
+                        waited_secs = waited.as_secs(),
+                        "GCS schema is present; continuing startup"
+                    );
+                }
+                return Ok(());
+            }
             Err(err) if waited >= timeout => {
                 return Err(err.context(format!(
                     "schema {} still missing after {}s",
@@ -272,12 +287,15 @@ pub async fn wait_for_gcs_schema(database_url: &str, timeout: Duration) -> anyho
                 )))
             }
             Err(err) => {
-                if waited.is_zero() {
-                    info!(
+                if waited >= next_log {
+                    warn!(
                         schema = crate::database::GCS_SCHEMA,
+                        waited_secs = waited.as_secs(),
+                        timeout_secs = timeout.as_secs(),
                         error = %err,
                         "waiting for the upgrade-controller to create the GCS schema"
                     );
+                    next_log = waited + LOG_EVERY;
                 }
                 tokio::time::sleep(POLL).await;
                 waited += POLL;

--- a/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/coprocessor/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -245,6 +245,17 @@ async fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             }
         };
+    if config.gcs_mode {
+        if let Err(err) = fhevm_engine_common::versioning::wait_for_gcs_schema(
+            config.database_url.as_str(),
+            fhevm_engine_common::versioning::GCS_SCHEMA_WAIT,
+        )
+        .await
+        {
+            error!(error = %err, "GCS schema never appeared");
+            std::process::exit(1);
+        }
+    }
 
     let gw_listener = std::sync::Arc::new(GatewayListener::new(
         conf.input_verification_address,

--- a/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/tfhe_event_propagate.rs
@@ -225,6 +225,15 @@ impl Database {
         dependence_cache_size: u16,
         gcs_mode: bool,
     ) -> Result<Self> {
+        // A green pool points at the gcs schema. Postgres ignores a schema that is
+        // missing, so writes would go to public instead. Wait for it first.
+        if gcs_mode {
+            fhevm_engine_common::versioning::wait_for_gcs_schema(
+                url.as_str(),
+                fhevm_engine_common::versioning::GCS_SCHEMA_WAIT,
+            )
+            .await?;
+        }
         let (pool, pool_refresh_handle) = Self::new_pool(url, gcs_mode).await;
         let bucket_cache =
             Arc::new(tokio::sync::RwLock::new(lru::LruCache::new(

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tfhe_worker.rs
@@ -1005,6 +1005,14 @@ async fn tfhe_worker_cycle(
     // `search_path = gcs,public` so unqualified writes land in `gcs.*` and
     // shared read-only tables (keys, crs, host_chains, upgrade_state, …)
     // still resolve from `public` via fallback.
+    if gcs_mode {
+        fhevm_engine_common::versioning::wait_for_gcs_schema(
+            db_url.as_str(),
+            fhevm_engine_common::versioning::GCS_SCHEMA_WAIT,
+        )
+        .await
+        .map_err(|e| CoprocessorError::Other(e.into()))?;
+    }
     let (pool, _pool_refresh_handle) = connect_pool_with_options_and_connect_options(
         &db_url,
         sqlx::postgres::PgPoolOptions::new().max_connections(args.pg_pool_max_connections),


### PR DESCRIPTION
## Summary

- The host-listener and gw-listener pin `search_path` to the versioned GCS schema, outside the activation gate that guards the workers. Postgres ignores a missing schema in `search_path` rather than erroring, so a green service that starts before the upgrade-controller has created that schema resolves its writes to `public` instead, which is the live blue tables.
- Both now wait for the schema before opening their pool, and the pool manager runs the same check for services that build their pool through it.
- The rows written on that path today are decoded from host-chain events, every insert is `ON CONFLICT` guarded, and blue’s listener writes the same rows concurrently, so the present effect is duplicate ingestion rather than divergence.

fixes https://github.com/zama-ai/fhevm-internal/issues/1943