### PR TITLE
fix(relayer): handle SIGTERM instead of being killed

### DIFF
--- a/ci/preview-env/relayer/values-relayer-e2e.yaml
+++ b/ci/preview-env/relayer/values-relayer-e2e.yaml
@@ -174,8 +174,8 @@ configmapFiles:
           input_proof_expiry: "7d"
           cron_startup_delay_after_recovery: "30s"
       shutdown:
-        # Time to keep serving after /healthz starts failing, so the pod's removal from the
-        # service endpoints reaches the ingress controller before the socket closes.
+        # Covers the lag until the pod's removal from the service endpoints reaches
+        # the ingress controller. Shutdown must finish inside the grace period.
         lb_propagation_wait: "5s"
 
 env:

--- a/ci/preview-env/relayer/values-relayer-e2e.yaml
+++ b/ci/preview-env/relayer/values-relayer-e2e.yaml
@@ -173,6 +173,10 @@ configmapFiles:
           user_decrypt_expiry: "7d"
           input_proof_expiry: "7d"
           cron_startup_delay_after_recovery: "30s"
+      shutdown:
+        # Time to keep serving after /healthz starts failing, so the pod's removal from the
+        # service endpoints reaches the ingress controller before the socket closes.
+        lb_propagation_wait: "5s"
 
 env:
   # --- host_chains (single entry - our per-PR anvil-host) ---

--- a/relayer/Makefile
+++ b/relayer/Makefile
@@ -401,7 +401,7 @@ health: ## Check relayer health endpoints (requires running relayer)
 # and the line naming it. Add a tests/*.rs, add it to a group below:
 # test-groups-check fails the build until you do, and CI runs that check.
 GROUPS := user-decrypt delegated-user-decrypt public-decrypt input-proof \
-          admin-endpoint health keyurl keyurl-poller recovery \
+          admin-endpoint health keyurl keyurl-poller restart \
           schema-isolation threshold-resolver listener-redundancy common
 
 BINS_user-decrypt           := user_decrypt_v2_test user_decrypt_v3_test
@@ -412,7 +412,8 @@ BINS_admin-endpoint         := admin_endpoint_test
 BINS_health                 := health_test
 BINS_keyurl                 := keyurl_test
 BINS_keyurl-poller          := keyurl_poller_test
-BINS_recovery               := handled_events_test recovery_test
+# Surviving a stop is one behaviour, so its tests run as one group.
+BINS_restart                := shutdown_test handled_events_test recovery_test
 BINS_schema-isolation       := schema_isolation_test
 BINS_threshold-resolver     := threshold_resolver_test
 BINS_listener-redundancy    := listener_redundancy_test

--- a/relayer/config/local.mainnet.yaml.example
+++ b/relayer/config/local.mainnet.yaml.example
@@ -258,10 +258,6 @@ storage:
     cron_startup_delay_after_recovery: "30s"
 
 shutdown:
-  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
-  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
-  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
-  # covers the lag until that removal reaches the ingress controller - not the readiness
-  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
-  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  # Covers the lag until the pod's removal from the service endpoints reaches the ingress
+  # controller. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
   lb_propagation_wait: "5s"

--- a/relayer/config/local.mainnet.yaml.example
+++ b/relayer/config/local.mainnet.yaml.example
@@ -253,3 +253,12 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
+  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
+  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
+  # covers the lag until that removal reaches the ingress controller - not the readiness
+  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
+  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  lb_propagation_wait: "5s"

--- a/relayer/config/local.mainnet.yaml.example
+++ b/relayer/config/local.mainnet.yaml.example
@@ -256,3 +256,12 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
+  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
+  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
+  # covers the lag until that removal reaches the ingress controller - not the readiness
+  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
+  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  lb_propagation_wait: "5s"

--- a/relayer/config/local.testnet.yaml.example
+++ b/relayer/config/local.testnet.yaml.example
@@ -248,3 +248,12 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
+  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
+  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
+  # covers the lag until that removal reaches the ingress controller - not the readiness
+  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
+  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  lb_propagation_wait: "5s"

--- a/relayer/config/local.testnet.yaml.example
+++ b/relayer/config/local.testnet.yaml.example
@@ -251,3 +251,12 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
+  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
+  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
+  # covers the lag until that removal reaches the ingress controller - not the readiness
+  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
+  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  lb_propagation_wait: "5s"

--- a/relayer/config/local.testnet.yaml.example
+++ b/relayer/config/local.testnet.yaml.example
@@ -253,10 +253,6 @@ storage:
     cron_startup_delay_after_recovery: "30s"
 
 shutdown:
-  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
-  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
-  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
-  # covers the lag until that removal reaches the ingress controller - not the readiness
-  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
-  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  # Covers the lag until the pod's removal from the service endpoints reaches the ingress
+  # controller. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
   lb_propagation_wait: "5s"

--- a/relayer/config/local.yaml.example
+++ b/relayer/config/local.yaml.example
@@ -252,3 +252,12 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
+  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
+  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
+  # covers the lag until that removal reaches the ingress controller - not the readiness
+  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
+  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  lb_propagation_wait: "5s"

--- a/relayer/config/local.yaml.example
+++ b/relayer/config/local.yaml.example
@@ -249,3 +249,12 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
+  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
+  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
+  # covers the lag until that removal reaches the ingress controller - not the readiness
+  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
+  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  lb_propagation_wait: "5s"

--- a/relayer/config/local.yaml.example
+++ b/relayer/config/local.yaml.example
@@ -254,10 +254,6 @@ storage:
     cron_startup_delay_after_recovery: "30s"
 
 shutdown:
-  # How long to keep serving HTTP after `/healthz` starts answering 503, so a request routed
-  # during the window gets a clean 503 rather than a refused connection. Deleting a pod
-  # removes it from the service endpoints at the same moment it delivers SIGTERM, so this
-  # covers the lag until that removal reaches the ingress controller - not the readiness
-  # probe's own detection time (periodSeconds x failureThreshold), which the deletion path
-  # never waits for. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
+  # Covers the lag until the pod's removal from the service endpoints reaches the ingress
+  # controller. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
   lb_propagation_wait: "5s"

--- a/relayer/src/bin/fhevm-relayer.rs
+++ b/relayer/src/bin/fhevm-relayer.rs
@@ -6,6 +6,8 @@ use anyhow::Context;
 use clap::Parser;
 use fhevm_relayer::config::settings::Settings;
 use fhevm_relayer::tracing::init_tracing;
+use tokio::signal::ctrl_c;
+use tokio::signal::unix::{signal, SignalKind};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -34,14 +36,19 @@ async fn main() -> anyhow::Result<()> {
     // We need to keep the guard to force-flush on SIGINT
     let chrome_tracing_guard = init_tracing(&settings.log)?;
 
-    // Create cancellation token and handle Ctrl+C
+    // Create cancellation token and handle shutdown signals (SIGINT, SIGTERM).
+    // Kubernetes sends SIGTERM on pod termination and PID 1 must handle it, or
+    // the process dies instantly instead of draining in-flight work.
     let cancellation_token = CancellationToken::new();
     let cancel_on_signal = cancellation_token.clone();
     tokio::spawn(async move {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("Failed to listen for Ctrl+C");
-        info!("Received Ctrl+C signal, initiating shutdown...");
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
+        let signal_name = tokio::select! {
+            _ = ctrl_c() => "SIGINT",
+            _ = sigterm.recv() => "SIGTERM",
+        };
+        info!(signal = signal_name, "Shutdown signal received");
         cancel_on_signal.cancel();
     });
 

--- a/relayer/src/config/settings.rs
+++ b/relayer/src/config/settings.rs
@@ -399,6 +399,32 @@ pub struct MetricsConfig {
     pub retry_after_raw_eta_histogram_bucket: Vec<f64>,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct ShutdownConfig {
+    /// How long to keep serving HTTP after `/healthz` starts answering 503, so a request
+    /// routed during the window gets a clean 503 from a pod still listening rather than a
+    /// refused connection. Deleting a pod removes it from the service endpoints at the same
+    /// moment it delivers SIGTERM, so this covers the lag until that removal reaches the
+    /// ingress controller, not the readiness probe's own detection time. Tests set it to 0.
+    #[serde(
+        default = "default_lb_propagation_wait",
+        deserialize_with = "deserialize_human_duration"
+    )]
+    pub lb_propagation_wait: Duration,
+}
+
+fn default_lb_propagation_wait() -> Duration {
+    Duration::from_secs(5)
+}
+
+impl Default for ShutdownConfig {
+    fn default() -> Self {
+        Self {
+            lb_propagation_wait: default_lb_propagation_wait(),
+        }
+    }
+}
+
 /// Deserializes strings like "30s", "5m", "1d" into std::time::Duration.
 /// 'y' not supported
 fn deserialize_human_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
@@ -623,6 +649,9 @@ pub struct Settings {
     pub keyurl: KeyUrlConfig,
     /// User-decryption signature check configuration
     pub user_decrypt_signature_check: UserDecryptSignatureCheckConfig,
+    /// Shutdown sequencing
+    #[serde(default)]
+    pub shutdown: ShutdownConfig,
 }
 
 // Error type for application-specific configuration errors

--- a/relayer/src/config/settings.rs
+++ b/relayer/src/config/settings.rs
@@ -411,23 +411,8 @@ pub struct ShutdownConfig {
     /// refused connection. Deleting a pod removes it from the service endpoints at the same
     /// moment it delivers SIGTERM, so this covers the lag until that removal reaches the
     /// ingress controller, not the readiness probe's own detection time. Tests set it to 0.
-    #[serde(
-        default = "default_lb_propagation_wait",
-        deserialize_with = "deserialize_human_duration"
-    )]
+    #[serde(deserialize_with = "deserialize_human_duration")]
     pub lb_propagation_wait: Duration,
-}
-
-fn default_lb_propagation_wait() -> Duration {
-    Duration::from_secs(5)
-}
-
-impl Default for ShutdownConfig {
-    fn default() -> Self {
-        Self {
-            lb_propagation_wait: default_lb_propagation_wait(),
-        }
-    }
 }
 
 /// Deserializes strings like "30s", "5m", "1d" into std::time::Duration.
@@ -655,7 +640,6 @@ pub struct Settings {
     /// User-decryption signature check configuration
     pub user_decrypt_signature_check: UserDecryptSignatureCheckConfig,
     /// Shutdown sequencing
-    #[serde(default)]
     pub shutdown: ShutdownConfig,
 }
 

--- a/relayer/src/config/settings.rs
+++ b/relayer/src/config/settings.rs
@@ -406,11 +406,9 @@ pub struct MetricsConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ShutdownConfig {
-    /// How long to keep serving HTTP after `/healthz` starts answering 503, so a request
-    /// routed during the window gets a clean 503 from a pod still listening rather than a
-    /// refused connection. Deleting a pod removes it from the service endpoints at the same
-    /// moment it delivers SIGTERM, so this covers the lag until that removal reaches the
-    /// ingress controller, not the readiness probe's own detection time. Tests set it to 0.
+    /// Covers the lag until the pod's removal from the service endpoints reaches the ingress
+    /// controller. Not the readiness probe's detection time - deletion drops the endpoint as
+    /// it sends SIGTERM, so the probe path never runs.
     #[serde(deserialize_with = "deserialize_human_duration")]
     pub lb_propagation_wait: Duration,
 }

--- a/relayer/src/config/settings.rs
+++ b/relayer/src/config/settings.rs
@@ -404,6 +404,32 @@ pub struct MetricsConfig {
     pub retry_after_raw_eta_histogram_bucket: Vec<f64>,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct ShutdownConfig {
+    /// How long to keep serving HTTP after `/healthz` starts answering 503, so a request
+    /// routed during the window gets a clean 503 from a pod still listening rather than a
+    /// refused connection. Deleting a pod removes it from the service endpoints at the same
+    /// moment it delivers SIGTERM, so this covers the lag until that removal reaches the
+    /// ingress controller, not the readiness probe's own detection time. Tests set it to 0.
+    #[serde(
+        default = "default_lb_propagation_wait",
+        deserialize_with = "deserialize_human_duration"
+    )]
+    pub lb_propagation_wait: Duration,
+}
+
+fn default_lb_propagation_wait() -> Duration {
+    Duration::from_secs(5)
+}
+
+impl Default for ShutdownConfig {
+    fn default() -> Self {
+        Self {
+            lb_propagation_wait: default_lb_propagation_wait(),
+        }
+    }
+}
+
 /// Deserializes strings like "30s", "5m", "1d" into std::time::Duration.
 /// 'y' not supported
 fn deserialize_human_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
@@ -628,6 +654,9 @@ pub struct Settings {
     pub keyurl: KeyUrlConfig,
     /// User-decryption signature check configuration
     pub user_decrypt_signature_check: UserDecryptSignatureCheckConfig,
+    /// Shutdown sequencing
+    #[serde(default)]
+    pub shutdown: ShutdownConfig,
 }
 
 // Error type for application-specific configuration errors

--- a/relayer/src/gateway/arbitrum/listener.rs
+++ b/relayer/src/gateway/arbitrum/listener.rs
@@ -18,6 +18,7 @@ use alloy::{
 use async_trait::async_trait;
 use futures::StreamExt;
 use std::{str::FromStr, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 
 /// Reason why process_events() returned
 enum RecycleReason {
@@ -25,6 +26,8 @@ enum RecycleReason {
     StreamEnded,
     /// Planned connection recycle timer triggered
     RecycleTimer,
+    /// Shutdown was requested
+    ShuttingDown,
 }
 
 /// Where one subscription listener sits in the recycle stagger, so a pool of them drops and
@@ -63,6 +66,8 @@ pub struct ArbitrumListener {
     ws_url: String,
     /// Recycle-stagger position, deliberately not an identity - see [`WsRecycleStagger`].
     ws_recycle_stagger: WsRecycleStagger,
+    /// Cancelled when shutdown closes the sources of new work.
+    shutdown: CancellationToken,
 }
 
 impl ArbitrumListener {
@@ -72,6 +77,7 @@ impl ArbitrumListener {
         pool_index: usize,
         ws_url: String,
         ws_recycle_stagger: WsRecycleStagger,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             gateway_config,
@@ -79,7 +85,16 @@ impl ArbitrumListener {
             pool_index,
             ws_url,
             ws_recycle_stagger,
+            shutdown,
         })
+    }
+
+    /// Sleeps for `dur`, cut short if shutdown is requested meanwhile.
+    async fn interruptible_sleep(&self, dur: Duration) {
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => {}
+            _ = self.shutdown.cancelled() => {}
+        }
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
@@ -112,6 +127,14 @@ impl ArbitrumListener {
         );
 
         loop {
+            if self.shutdown.is_cancelled() {
+                info!(
+                    instance_id = self.pool_index,
+                    "Listener stopping (shutdown)"
+                );
+                return Ok(());
+            }
+
             // Log ERROR continuously when exceeding threshold (fatal state)
             if consecutive_failures >= max_attempts {
                 error!(
@@ -142,7 +165,8 @@ impl ArbitrumListener {
                         max_attempts = max_attempts,
                         "Failed to create provider"
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    self.interruptible_sleep(Duration::from_millis(retry_interval))
+                        .await;
                     continue;
                 }
             };
@@ -163,7 +187,8 @@ impl ArbitrumListener {
                         max_attempts = max_attempts,
                         "Failed to subscribe"
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    self.interruptible_sleep(Duration::from_millis(retry_interval))
+                        .await;
                     continue;
                 }
             };
@@ -195,7 +220,15 @@ impl ArbitrumListener {
                         max_attempts = max_attempts,
                         "WebSocket connection dropped"
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    self.interruptible_sleep(Duration::from_millis(retry_interval))
+                        .await;
+                }
+                RecycleReason::ShuttingDown => {
+                    info!(
+                        instance_id = self.pool_index,
+                        "Listener stopping (shutdown)"
+                    );
+                    return Ok(());
                 }
                 RecycleReason::RecycleTimer => {
                     // Planned recycle - reconnect immediately without delay
@@ -324,6 +357,9 @@ impl ArbitrumListener {
                         "WebSocket connection recycle timer triggered, reconnecting"
                     );
                     return RecycleReason::RecycleTimer;
+                }
+                _ = self.shutdown.cancelled() => {
+                    return RecycleReason::ShuttingDown;
                 }
             }
         }

--- a/relayer/src/gateway/arbitrum/listener.rs
+++ b/relayer/src/gateway/arbitrum/listener.rs
@@ -66,7 +66,6 @@ pub struct ArbitrumListener {
     ws_url: String,
     /// Recycle-stagger position, deliberately not an identity - see [`WsRecycleStagger`].
     ws_recycle_stagger: WsRecycleStagger,
-    /// Cancelled when shutdown closes the sources of new work.
     shutdown: CancellationToken,
 }
 
@@ -89,7 +88,6 @@ impl ArbitrumListener {
         })
     }
 
-    /// Sleeps for `dur`, cut short if shutdown is requested meanwhile.
     async fn interruptible_sleep(&self, dur: Duration) {
         tokio::select! {
             _ = tokio::time::sleep(dur) => {}

--- a/relayer/src/gateway/arbitrum/listener.rs
+++ b/relayer/src/gateway/arbitrum/listener.rs
@@ -18,6 +18,7 @@ use alloy::{
 use async_trait::async_trait;
 use futures::StreamExt;
 use std::{str::FromStr, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 
 /// Reason why process_events() returned
 enum RecycleReason {
@@ -25,6 +26,8 @@ enum RecycleReason {
     StreamEnded,
     /// Planned connection recycle timer triggered
     RecycleTimer,
+    /// Shutdown was requested
+    ShuttingDown,
 }
 
 /// Where one subscription listener sits in the recycle stagger, so a pool of them drops and
@@ -63,6 +66,8 @@ pub struct ArbitrumListener {
     ws_url: String,
     /// Recycle-stagger position, deliberately not an identity - see [`WsRecycleStagger`].
     ws_recycle_stagger: WsRecycleStagger,
+    /// Cancelled when shutdown closes the sources of new work.
+    shutdown: CancellationToken,
 }
 
 impl ArbitrumListener {
@@ -72,6 +77,7 @@ impl ArbitrumListener {
         pool_index: usize,
         ws_url: String,
         ws_recycle_stagger: WsRecycleStagger,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             gateway_config,
@@ -79,7 +85,17 @@ impl ArbitrumListener {
             pool_index,
             ws_url,
             ws_recycle_stagger,
+            shutdown,
         })
+    }
+
+    /// Sleep for `dur`, returning early if shutdown is requested meanwhile. Returns `true`
+    /// if the sleep was cut short by shutdown.
+    async fn sleep_or_shutdown(&self, dur: Duration) -> bool {
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => false,
+            _ = self.shutdown.cancelled() => true,
+        }
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
@@ -112,6 +128,14 @@ impl ArbitrumListener {
         );
 
         loop {
+            if self.shutdown.is_cancelled() {
+                info!(
+                    instance_id = self.pool_index,
+                    "Listener stopping (shutdown)"
+                );
+                return Ok(());
+            }
+
             // Log ERROR continuously when exceeding threshold (fatal state)
             if consecutive_failures >= max_attempts {
                 error!(
@@ -142,7 +166,16 @@ impl ArbitrumListener {
                         max_attempts = max_attempts,
                         "Failed to create provider"
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    if self
+                        .sleep_or_shutdown(Duration::from_millis(retry_interval))
+                        .await
+                    {
+                        info!(
+                            instance_id = self.pool_index,
+                            "Listener stopping (shutdown)"
+                        );
+                        return Ok(());
+                    }
                     continue;
                 }
             };
@@ -163,7 +196,16 @@ impl ArbitrumListener {
                         max_attempts = max_attempts,
                         "Failed to subscribe"
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    if self
+                        .sleep_or_shutdown(Duration::from_millis(retry_interval))
+                        .await
+                    {
+                        info!(
+                            instance_id = self.pool_index,
+                            "Listener stopping (shutdown)"
+                        );
+                        return Ok(());
+                    }
                     continue;
                 }
             };
@@ -195,7 +237,23 @@ impl ArbitrumListener {
                         max_attempts = max_attempts,
                         "WebSocket connection dropped"
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    if self
+                        .sleep_or_shutdown(Duration::from_millis(retry_interval))
+                        .await
+                    {
+                        info!(
+                            instance_id = self.pool_index,
+                            "Listener stopping (shutdown)"
+                        );
+                        return Ok(());
+                    }
+                }
+                RecycleReason::ShuttingDown => {
+                    info!(
+                        instance_id = self.pool_index,
+                        "Listener stopping (shutdown)"
+                    );
+                    return Ok(());
                 }
                 RecycleReason::RecycleTimer => {
                     // Planned recycle - reconnect immediately without delay
@@ -324,6 +382,9 @@ impl ArbitrumListener {
                         "WebSocket connection recycle timer triggered, reconnecting"
                     );
                     return RecycleReason::RecycleTimer;
+                }
+                _ = self.shutdown.cancelled() => {
+                    return RecycleReason::ShuttingDown;
                 }
             }
         }

--- a/relayer/src/gateway/arbitrum/polling_listener.rs
+++ b/relayer/src/gateway/arbitrum/polling_listener.rs
@@ -17,6 +17,7 @@ use alloy::{
 };
 use async_trait::async_trait;
 use std::{str::FromStr, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 
 /// HTTP polling listener that uses eth_getLogs at configurable intervals
 pub struct PollingListener {
@@ -29,6 +30,8 @@ pub struct PollingListener {
     pool_index: usize,
     /// HTTP URL for this listener
     http_url: String,
+    /// Cancelled when shutdown closes the sources of new work.
+    shutdown: CancellationToken,
 }
 
 impl PollingListener {
@@ -38,6 +41,7 @@ impl PollingListener {
         handled_events: Arc<HandledEvents>,
         pool_index: usize,
         http_url: String,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<Self> {
         // Enforce HTTP URL - polling listener requires HTTP, not WebSocket
         if !http_url.starts_with("http://") && !http_url.starts_with("https://") {
@@ -54,7 +58,17 @@ impl PollingListener {
             handled_events,
             pool_index,
             http_url,
+            shutdown,
         })
+    }
+
+    /// Sleep for `dur`, returning early if shutdown is requested meanwhile. Returns `true`
+    /// if the sleep was cut short by shutdown.
+    async fn sleep_or_shutdown(&self, dur: Duration) -> bool {
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => false,
+            _ = self.shutdown.cancelled() => true,
+        }
     }
 
     /// The block to resume polling after. Nothing is written here: the first range this
@@ -157,7 +171,16 @@ impl PollingListener {
             }
 
             // Wait for poll interval
-            tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+            if self
+                .sleep_or_shutdown(Duration::from_millis(poll_interval_ms))
+                .await
+            {
+                info!(
+                    instance_id = self.pool_index,
+                    "Polling listener stopping (shutdown)"
+                );
+                return Ok(());
+            }
 
             // Get current block number
             let current_block = match provider.get_block_number().await {
@@ -173,7 +196,16 @@ impl PollingListener {
                         consecutive_failures,
                         max_attempts
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    if self
+                        .sleep_or_shutdown(Duration::from_millis(retry_interval))
+                        .await
+                    {
+                        info!(
+                            instance_id = self.pool_index,
+                            "Polling listener stopping (shutdown)"
+                        );
+                        return Ok(());
+                    }
                     continue;
                 }
             };
@@ -210,7 +242,16 @@ impl PollingListener {
                         consecutive_failures,
                         max_attempts
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    if self
+                        .sleep_or_shutdown(Duration::from_millis(retry_interval))
+                        .await
+                    {
+                        info!(
+                            instance_id = self.pool_index,
+                            "Polling listener stopping (shutdown)"
+                        );
+                        return Ok(());
+                    }
                     continue;
                 }
             };

--- a/relayer/src/gateway/arbitrum/polling_listener.rs
+++ b/relayer/src/gateway/arbitrum/polling_listener.rs
@@ -34,7 +34,6 @@ pub struct PollingListener {
     pool_index: usize,
     /// HTTP URL for this listener
     http_url: String,
-    /// Cancelled when shutdown closes the sources of new work.
     shutdown: CancellationToken,
 }
 
@@ -66,7 +65,6 @@ impl PollingListener {
         })
     }
 
-    /// Sleeps for `dur`, cut short if shutdown is requested meanwhile.
     async fn interruptible_sleep(&self, dur: Duration) {
         tokio::select! {
             _ = tokio::time::sleep(dur) => {}

--- a/relayer/src/gateway/arbitrum/polling_listener.rs
+++ b/relayer/src/gateway/arbitrum/polling_listener.rs
@@ -16,6 +16,7 @@ use alloy::{
 };
 use async_trait::async_trait;
 use std::{str::FromStr, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 
 /// The last block a single `eth_getLogs` should cover, `max_blocks` counted inclusively.
 fn catch_up_to_block(from_block: u64, head: u64, max_blocks: u64) -> u64 {
@@ -33,6 +34,8 @@ pub struct PollingListener {
     pool_index: usize,
     /// HTTP URL for this listener
     http_url: String,
+    /// Cancelled when shutdown closes the sources of new work.
+    shutdown: CancellationToken,
 }
 
 impl PollingListener {
@@ -42,6 +45,7 @@ impl PollingListener {
         handled_events: Arc<HandledEvents>,
         pool_index: usize,
         http_url: String,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<Self> {
         // Enforce HTTP URL - polling listener requires HTTP, not WebSocket
         if !http_url.starts_with("http://") && !http_url.starts_with("https://") {
@@ -58,7 +62,16 @@ impl PollingListener {
             handled_events,
             pool_index,
             http_url,
+            shutdown,
         })
+    }
+
+    /// Sleeps for `dur`, cut short if shutdown is requested meanwhile.
+    async fn interruptible_sleep(&self, dur: Duration) {
+        tokio::select! {
+            _ = tokio::time::sleep(dur) => {}
+            _ = self.shutdown.cancelled() => {}
+        }
     }
 
     /// The block to resume polling after. Nothing is written here: the first range this
@@ -159,7 +172,16 @@ impl PollingListener {
             }
 
             if !backlog_pending {
-                tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+                self.interruptible_sleep(Duration::from_millis(poll_interval_ms))
+                    .await;
+            }
+
+            if self.shutdown.is_cancelled() {
+                info!(
+                    instance_id = self.pool_index,
+                    "Polling listener stopping (shutdown)"
+                );
+                return Ok(());
             }
 
             // Get current block number
@@ -177,7 +199,8 @@ impl PollingListener {
                         consecutive_failures,
                         max_attempts
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    self.interruptible_sleep(Duration::from_millis(retry_interval))
+                        .await;
                     continue;
                 }
             };
@@ -218,7 +241,8 @@ impl PollingListener {
                         consecutive_failures,
                         max_attempts
                     );
-                    tokio::time::sleep(Duration::from_millis(retry_interval)).await;
+                    self.interruptible_sleep(Duration::from_millis(retry_interval))
+                        .await;
                     continue;
                 }
             };

--- a/relayer/src/gateway/arbitrum/transaction/tx_processor.rs
+++ b/relayer/src/gateway/arbitrum/transaction/tx_processor.rs
@@ -11,7 +11,8 @@ use crate::{
     orchestrator::Orchestrator,
 };
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
 
 /// The Processor is responsible for bridging the throttler (Queue) and the TransactionHelper (Executor).
 pub struct GatewayTxProcessor;
@@ -20,40 +21,44 @@ impl GatewayTxProcessor {
     /// Spawns the background worker.
     ///
     /// It registers with the Orchestrator so it starts/stops cleanly with the application.
-    /// It delegates the infinite loop logic to `throttler.run_consumer`.
+    /// It delegates the infinite loop logic to `throttler.run_consumer`, which exits once
+    /// `shutdown` fires. `task_name` must be distinct per instance (input-proof, public-decrypt,
+    /// user-decrypt): three of these are spawned under the same orchestrator and would otherwise
+    /// be indistinguishable in logs and during phased shutdown.
     pub async fn orchestrator_spawn_task(
+        task_name: &str,
         throttler_worker: TxThrottlingWorker<GatewayTxTask>,
         tx_helper: Arc<TransactionHelper>,
         orchestrator: Arc<Orchestrator>,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
-        let task_name = "gateway_tx_processor";
-
         // Prepare Arcs for the background task
         let dispatcher = orchestrator.clone();
+        let worker_name = task_name.to_string();
 
         // The Task Future
         let task_future = async move {
             info!(
                 step = %WorkerStep::WorkerStarted,
-                worker = "tx_processor",
+                worker = %worker_name,
                 "Worker started"
             );
 
             // We run the consumer.
             // This function contains the infinite loop reading from the channel.
-            // It will only exit if the application shuts down or the channel is explicitly closed.
+            // It exits once `shutdown` fires, stopping the dequeue of new work.
             throttler_worker
-                .run_consumer(move |task: GatewayTxTask| {
+                .run_consumer(shutdown, move |task: GatewayTxTask| {
                     // Call the async function directly.
                     // It returns the Future that the consumer expects.
                     Self::process_single_task(tx_helper.clone(), task, dispatcher.clone())
                 })
                 .await;
 
-            warn!(
-                step = %WorkerStep::WorkerRestarting,
-                worker = "tx_processor",
-                "Worker stopped unexpectedly"
+            info!(
+                step = %WorkerStep::WorkerStopped,
+                worker = %worker_name,
+                "Worker stopped"
             );
         };
 

--- a/relayer/src/gateway/arbitrum/transaction/tx_processor.rs
+++ b/relayer/src/gateway/arbitrum/transaction/tx_processor.rs
@@ -21,10 +21,10 @@ impl GatewayTxProcessor {
     /// Spawns the background worker.
     ///
     /// It registers with the Orchestrator so it starts/stops cleanly with the application.
-    /// It delegates the infinite loop logic to `throttler.run_consumer`, which exits once
-    /// `shutdown` fires. `task_name` must be distinct per instance (input-proof, public-decrypt,
-    /// user-decrypt): three of these are spawned under the same orchestrator and would otherwise
-    /// be indistinguishable in logs and during phased shutdown.
+    /// It delegates the infinite loop logic to `throttler.run_consumer`.
+    ///
+    /// Three of these run under one orchestrator, so `task_name` must be distinct per
+    /// instance or the drain cannot say which one failed to stop.
     pub async fn orchestrator_spawn_task(
         task_name: &str,
         throttler_worker: TxThrottlingWorker<GatewayTxTask>,
@@ -44,9 +44,6 @@ impl GatewayTxProcessor {
                 "Worker started"
             );
 
-            // We run the consumer.
-            // This function contains the infinite loop reading from the channel.
-            // It exits once `shutdown` fires, stopping the dequeue of new work.
             throttler_worker
                 .run_consumer(shutdown, move |task: GatewayTxTask| {
                     // Call the async function directly.

--- a/relayer/src/gateway/arbitrum/transaction/tx_throttler.rs
+++ b/relayer/src/gateway/arbitrum/transaction/tx_throttler.rs
@@ -13,6 +13,8 @@ use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, instrument, warn};
 
 /// Queue information for ETA computation (TPS-based throttler)
@@ -164,6 +166,10 @@ pub struct TxThrottlingWorker<T> {
     control_rx: Option<mpsc::Receiver<u32>>,
     // Shared current TPS value (updated on dynamic rate changes)
     current_tps: Arc<AtomicU32>,
+    // Tracks the per-dequeued-item send task spawned in `run_consumer`. Shutdown abandons
+    // these; see the module-level shutdown note in `startup` for what a send killed
+    // mid-flight costs.
+    detached_tasks: TaskTracker,
 }
 
 impl<T> TxThrottlingSender<T>
@@ -176,6 +182,7 @@ where
         capacity_safety_margin: usize,
         tps: u32,
         enable_dynamic_rate_limiting: bool,
+        detached_tasks: TaskTracker,
     ) -> (Self, TxThrottlingWorker<T>, Option<mpsc::Sender<u32>>) {
         let (sender, receiver) = mpsc::channel(capacity);
         let tracker = Arc::new(RwLock::new(IndexMap::new()));
@@ -209,6 +216,7 @@ where
             tps,
             control_rx,
             current_tps,
+            detached_tasks,
         };
 
         (throttler, worker, control_tx)
@@ -345,7 +353,10 @@ where
         Arc::new(RateLimiter::direct(quota))
     }
 
-    pub async fn run_consumer<F, Fut>(mut self, processor: F)
+    /// Runs the dequeue loop until `shutdown` fires. Driven from the token, not channel
+    /// closure: the sender half lives in `Arc`s held permanently by the dispatcher and the
+    /// HTTP router state, so it never drops on its own.
+    pub async fn run_consumer<F, Fut>(mut self, shutdown: CancellationToken, processor: F)
     where
         F: Fn(T) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
@@ -391,10 +402,17 @@ where
                         "Task dequeued for processing"
                     );
 
-                    // 3. Process (Isolated)
+                    // 3. Process (Isolated). Tracked in the shared `detached_tasks`, but,
+                    // unlike the readiness-check work sharing that tracker (see
+                    // `readiness/throttler.rs`), deliberately not run under
+                    // `run_until_cancelled`: a send is cancel-unsafe, since the nonce
+                    // protocol (`get_increase_and_lock_nonce` -> send ->
+                    // `confirm_nonce`/`release_nonce`) has no RAII guard, and cutting it short
+                    // after the RPC call leaves the nonce lock held with no one left to
+                    // release it.
                     let proc_clone = processor.clone();
 
-                    tokio::spawn(async move {
+                    self.detached_tasks.spawn(async move {
                         // If this panics, the worker loop survives.
                         proc_clone(item).await;
                     });
@@ -406,6 +424,11 @@ where
                     // Update shared current_tps for queue info consumers
                     self.current_tps.store(new_tps, Ordering::Relaxed);
                     limiter = Self::create_limiter(new_tps);
+                }
+
+                _ = shutdown.cancelled() => {
+                    info!("Throttler Worker stopping (shutdown).");
+                    break;
                 }
 
                 else => {
@@ -456,14 +479,20 @@ mod tests {
     #[tokio::test]
     async fn test_fifo_ordering() {
         init_metrics_once();
-        let (throttler, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 10, 0, 100, false);
+        let (throttler, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            10,
+            0,
+            100,
+            false,
+            TaskTracker::new(),
+        );
         let processed = Arc::new(Mutex::new(Vec::new()));
         let processed_clone = processed.clone();
 
         tokio::spawn(async move {
             worker
-                .run_consumer(move |task| {
+                .run_consumer(CancellationToken::new(), move |task| {
                     let p = processed_clone.clone();
                     async move {
                         p.lock().unwrap().push(task.id);
@@ -485,8 +514,14 @@ mod tests {
     #[tokio::test]
     async fn test_deduplication() {
         init_metrics_once();
-        let (throttler, _worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 10, 0, 100, false);
+        let (throttler, _worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            10,
+            0,
+            100,
+            false,
+            TaskTracker::new(),
+        );
 
         throttler.push(MockTask { id: "A".into() }).await.unwrap();
 
@@ -501,8 +536,14 @@ mod tests {
     async fn test_queue_full() {
         init_metrics_once();
         // Capacity = 1
-        let (throttler, _worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 1, 0, 100, false);
+        let (throttler, _worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            1,
+            0,
+            100,
+            false,
+            TaskTracker::new(),
+        );
 
         // 1. Push OK
         assert!(throttler.push(MockTask { id: "1".into() }).await.is_ok());
@@ -525,8 +566,14 @@ mod tests {
     async fn test_position_tracking() {
         init_metrics_once();
         // Very slow rate (1 TPS) to ensure items stay in queue
-        let (throttler, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 10, 0, 1, false);
+        let (throttler, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            10,
+            0,
+            1,
+            false,
+            TaskTracker::new(),
+        );
 
         throttler.push(MockTask { id: "A".into() }).await.unwrap();
         throttler.push(MockTask { id: "B".into() }).await.unwrap();
@@ -537,7 +584,9 @@ mod tests {
 
         // Spawn worker
         tokio::spawn(async move {
-            worker.run_consumer(|_| async {}).await;
+            worker
+                .run_consumer(CancellationToken::new(), |_| async {})
+                .await;
         });
 
         // Small wait to let A start processing and be removed from map
@@ -558,8 +607,14 @@ mod tests {
         init_metrics_once();
         // 1. Setup Throttler (Worker NOT spawned yet)
         // Capacity 10 allows us to push multiple items without blocking/failing
-        let (throttler, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 10, 0, 50, false);
+        let (throttler, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            10,
+            0,
+            50,
+            false,
+            TaskTracker::new(),
+        );
 
         // 2. Push items
         // Since the worker isn't running, these sit in the Channel and the Tracker.
@@ -581,7 +636,9 @@ mod tests {
         // 4. Start Worker to drain
         // Now we verify that they are processed and removed correctly
         tokio::spawn(async move {
-            worker.run_consumer(|_| async {}).await;
+            worker
+                .run_consumer(CancellationToken::new(), |_| async {})
+                .await;
         });
 
         // Wait for drain (50 TPS is fast, 100ms is plenty)
@@ -602,14 +659,20 @@ mod tests {
         // - Items 11-20: Processed 1 every 100ms.
         // Total expected time: ~1.0 second.
         let tps = 10;
-        let (throttler, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 100, 0, tps, false);
+        let (throttler, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            100,
+            0,
+            tps,
+            false,
+            TaskTracker::new(),
+        );
         let processed_count = Arc::new(AtomicUsize::new(0));
         let counter = processed_count.clone();
 
         tokio::spawn(async move {
             worker
-                .run_consumer(move |_| {
+                .run_consumer(CancellationToken::new(), move |_| {
                     let c = counter.clone();
                     async move {
                         c.fetch_add(1, Ordering::Relaxed);
@@ -658,14 +721,20 @@ mod tests {
         init_metrics_once();
         let tps = 20;
         // Capacity large enough to hold the blast so we don't get "Queue Full" errors during setup
-        let (throttler, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 200, 0, tps, false);
+        let (throttler, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            200,
+            0,
+            tps,
+            false,
+            TaskTracker::new(),
+        );
         let processed_count = Arc::new(AtomicUsize::new(0));
         let counter = processed_count.clone();
 
         tokio::spawn(async move {
             worker
-                .run_consumer(move |_| {
+                .run_consumer(CancellationToken::new(), move |_| {
                     let c = counter.clone();
                     async move {
                         c.fetch_add(1, Ordering::Relaxed);
@@ -713,15 +782,23 @@ mod tests {
     #[tokio::test]
     async fn test_cloning_shares_state() {
         init_metrics_once();
-        let (throttler_1, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 10, 0, 100, false);
+        let (throttler_1, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            10,
+            0,
+            100,
+            false,
+            TaskTracker::new(),
+        );
 
         // Clone it (Creating a second producer handle)
         let throttler_2 = throttler_1.clone();
 
         // Spawn worker to drain queue
         tokio::spawn(async move {
-            worker.run_consumer(|_| async {}).await;
+            worker
+                .run_consumer(CancellationToken::new(), |_| async {})
+                .await;
         });
 
         // 1. Push via Clone 1
@@ -746,8 +823,14 @@ mod tests {
         // Buffer = 2
         // Soft Limit = 8
         // TPS = 100 (irrelevant as we don't start worker immediately)
-        let (throttler, worker, _control_tx) =
-            TxThrottlingSender::<MockTask>::new(TxThrottlingType::InputProof, 10, 2, 100, false);
+        let (throttler, worker, _control_tx) = TxThrottlingSender::<MockTask>::new(
+            TxThrottlingType::InputProof,
+            10,
+            2,
+            100,
+            false,
+            TaskTracker::new(),
+        );
 
         // 1. Fill up to Soft Limit (8 items)
         for i in 0..8 {
@@ -784,7 +867,9 @@ mod tests {
 
         // Drain to clean up
         tokio::spawn(async move {
-            worker.run_consumer(|_| async {}).await;
+            worker
+                .run_consumer(CancellationToken::new(), |_| async {})
+                .await;
         });
         sleep(Duration::from_millis(100)).await;
     }

--- a/relayer/src/gateway/arbitrum/transaction/tx_throttler.rs
+++ b/relayer/src/gateway/arbitrum/transaction/tx_throttler.rs
@@ -166,9 +166,7 @@ pub struct TxThrottlingWorker<T> {
     control_rx: Option<mpsc::Receiver<u32>>,
     // Shared current TPS value (updated on dynamic rate changes)
     current_tps: Arc<AtomicU32>,
-    // Tracks the per-dequeued-item send task spawned in `run_consumer`. Shutdown abandons
-    // these; see the module-level shutdown note in `startup` for what a send killed
-    // mid-flight costs.
+    // Per-item send tasks; shutdown abandons them rather than waiting.
     detached_tasks: TaskTracker,
 }
 
@@ -353,9 +351,8 @@ where
         Arc::new(RateLimiter::direct(quota))
     }
 
-    /// Runs the dequeue loop until `shutdown` fires. Driven from the token, not channel
-    /// closure: the sender half lives in `Arc`s held permanently by the dispatcher and the
-    /// HTTP router state, so it never drops on its own.
+    /// Driven from `shutdown`, not channel closure: the dispatcher and the HTTP router state
+    /// hold the sender in `Arc`s forever, so it never drops on its own.
     pub async fn run_consumer<F, Fut>(mut self, shutdown: CancellationToken, processor: F)
     where
         F: Fn(T) -> Fut + Send + Sync + 'static,
@@ -402,14 +399,9 @@ where
                         "Task dequeued for processing"
                     );
 
-                    // 3. Process (Isolated). Tracked in the shared `detached_tasks`, but,
-                    // unlike the readiness-check work sharing that tracker (see
-                    // `readiness/throttler.rs`), deliberately not run under
-                    // `run_until_cancelled`: a send is cancel-unsafe, since the nonce
-                    // protocol (`get_increase_and_lock_nonce` -> send ->
-                    // `confirm_nonce`/`release_nonce`) has no RAII guard, and cutting it short
-                    // after the RPC call leaves the nonce lock held with no one left to
-                    // release it.
+                    // 3. Process (Isolated). Not cancellable, unlike the readiness checks
+                    // sharing this tracker: the nonce protocol has no RAII guard, so cutting
+                    // a send short after the RPC leaves the nonce locked forever.
                     let proc_clone = processor.clone();
 
                     self.detached_tasks.spawn(async move {

--- a/relayer/src/gateway/mod.rs
+++ b/relayer/src/gateway/mod.rs
@@ -30,14 +30,21 @@ use arbitrum::{
     ArbitrumListener, PollingListener, WsRecycleStagger,
 };
 use std::{str::FromStr, sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 /// Initialize all gateway components including handlers and listeners.
+///
+/// `intake_shutdown` stops the gateway listeners/pollers, alongside the HTTP server and the
+/// keyurl poller, the sources of new work; `dequeue_shutdown` stops the tx and readiness
+/// processors from dequeuing, and cancels the readiness checks already running.
 pub async fn initialize_gateway(
     orchestrator: Arc<Orchestrator>,
     settings: &Settings,
     repositories: Arc<Repositories>,
     gateway_throttlers: GatewayThrottlers,
+    dequeue_shutdown: CancellationToken,
+    intake_shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     info!("Initializing gateway components");
 
@@ -55,25 +62,31 @@ pub async fn initialize_gateway(
 
     // Spawn gateway task for input proof throttler.
     GatewayTxProcessor::orchestrator_spawn_task(
+        "gateway_tx_processor_input_proof",
         gateway_throttlers.tx_throttlers.input_proof_tx_worker,
         gateway_tx_helper.clone(),
         orchestrator.clone(),
+        dequeue_shutdown.clone(),
     )
     .await?;
 
     // Spawn gateway task for public decrypt throttler.
     GatewayTxProcessor::orchestrator_spawn_task(
+        "gateway_tx_processor_public_decrypt",
         gateway_throttlers.tx_throttlers.public_decrypt_tx_worker,
         gateway_tx_helper.clone(),
         orchestrator.clone(),
+        dequeue_shutdown.clone(),
     )
     .await?;
 
     // Spawn gateway task for user decrypt throttler.
     GatewayTxProcessor::orchestrator_spawn_task(
+        "gateway_tx_processor_user_decrypt",
         gateway_throttlers.tx_throttlers.user_decrypt_tx_worker,
         gateway_tx_helper.clone(),
         orchestrator.clone(),
+        dequeue_shutdown.clone(),
     )
     .await?;
 
@@ -104,6 +117,7 @@ pub async fn initialize_gateway(
             .public_decrypt_readiness_worker,
         readiness_checker.clone(),
         orchestrator.clone(),
+        dequeue_shutdown.clone(),
     )
     .await?;
 
@@ -113,6 +127,7 @@ pub async fn initialize_gateway(
             .user_decrypt_readiness_worker,
         readiness_checker.clone(),
         orchestrator.clone(),
+        dequeue_shutdown.clone(),
     )
     .await?;
 
@@ -224,6 +239,7 @@ pub async fn initialize_gateway(
                             index: ws_stagger_index,
                             total: num_ws_listeners,
                         },
+                        intake_shutdown.clone(),
                     )
                     .await
                     .map_err(|e| {
@@ -281,6 +297,7 @@ pub async fn initialize_gateway(
                         handled_events.clone(),
                         pool_index,
                         url.clone(),
+                        intake_shutdown.clone(),
                     )
                     .map_err(|e| {
                         anyhow::anyhow!(

--- a/relayer/src/gateway/mod.rs
+++ b/relayer/src/gateway/mod.rs
@@ -35,9 +35,7 @@ use tracing::{error, info};
 
 /// Initialize all gateway components including handlers and listeners.
 ///
-/// `intake_shutdown` stops the gateway listeners/pollers, alongside the HTTP server and the
-/// keyurl poller, the sources of new work; `dequeue_shutdown` stops the tx and readiness
-/// processors from dequeuing, and cancels the readiness checks already running.
+/// For what the two tokens cover, see the shutdown sequence in `startup`.
 pub async fn initialize_gateway(
     orchestrator: Arc<Orchestrator>,
     settings: &Settings,

--- a/relayer/src/gateway/throttlers.rs
+++ b/relayer/src/gateway/throttlers.rs
@@ -1,4 +1,5 @@
 use tokio::sync::mpsc;
+use tokio_util::task::TaskTracker;
 
 use crate::{
     config::settings::Settings,
@@ -51,7 +52,12 @@ impl BouncerThrottlers {
     }
 }
 
-pub fn init_throttlers(settings: &Settings) -> (GatewayThrottlers, BouncerThrottlers) {
+/// Wire every throttler worker's per-item processing task into the shared `detached_tasks`
+/// tracker, which shutdown abandons rather than waits for.
+pub fn init_throttlers(
+    settings: &Settings,
+    detached_tasks: TaskTracker,
+) -> (GatewayThrottlers, BouncerThrottlers) {
     let tx_cfg = &settings.gateway.tx_engine.tx_throttlers;
     let enable_admin = settings.http.enable_admin_endpoint;
 
@@ -62,6 +68,7 @@ pub fn init_throttlers(settings: &Settings) -> (GatewayThrottlers, BouncerThrott
             tx_cfg.input_proof.safety_margin,
             tx_cfg.input_proof.per_seconds,
             enable_admin,
+            detached_tasks.clone(),
         );
     let (user_decrypt_tx_throttler, user_decrypt_tx_worker, throttler_control_user_decrypt) =
         TxThrottlingSender::<GatewayTxTask>::new(
@@ -70,6 +77,7 @@ pub fn init_throttlers(settings: &Settings) -> (GatewayThrottlers, BouncerThrott
             tx_cfg.user_decrypt.safety_margin,
             tx_cfg.user_decrypt.per_seconds,
             enable_admin,
+            detached_tasks.clone(),
         );
     let (public_decrypt_tx_throttler, public_decrypt_tx_worker, throttler_control_public_decrypt) =
         TxThrottlingSender::<GatewayTxTask>::new(
@@ -78,6 +86,7 @@ pub fn init_throttlers(settings: &Settings) -> (GatewayThrottlers, BouncerThrott
             tx_cfg.public_decrypt.safety_margin,
             tx_cfg.public_decrypt.per_seconds,
             enable_admin,
+            detached_tasks.clone(),
         );
 
     let rd_cfg = &settings.gateway.readiness_checker;
@@ -88,6 +97,7 @@ pub fn init_throttlers(settings: &Settings) -> (GatewayThrottlers, BouncerThrott
             rd_cfg.public_decrypt.capacity,
             rd_cfg.public_decrypt.safety_margin,
             rd_cfg.public_decrypt.max_concurrency,
+            detached_tasks.clone(),
         );
     let (user_decrypt_readiness_throttler, user_decrypt_readiness_worker) =
         ReadinessSender::<UserDecryptReadinessTask>::new(
@@ -95,6 +105,7 @@ pub fn init_throttlers(settings: &Settings) -> (GatewayThrottlers, BouncerThrott
             rd_cfg.user_decrypt.capacity,
             rd_cfg.user_decrypt.safety_margin,
             rd_cfg.user_decrypt.max_concurrency,
+            detached_tasks,
         );
 
     let tx_throttlers = TxThrottlers::new(

--- a/relayer/src/host/keyurl_poller.rs
+++ b/relayer/src/host/keyurl_poller.rs
@@ -20,6 +20,7 @@ use fhevm_host_bindings::i_protocol_config::IProtocolConfig::IProtocolConfigInst
 use fhevm_host_bindings::ikms_generation::IKMSGeneration;
 use fhevm_host_bindings::ikms_generation::IKMSGeneration::IKMSGenerationInstance;
 use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::config::settings::ProtocolConfigSettings;
@@ -326,19 +327,26 @@ impl KeyUrlPoller {
 
     /// Long-running loop: poll the active ids on the configured interval and, on any change,
     /// refetch the materials and push the new value into `tx`. RPC failures are logged and
-    /// retried on the next tick (the last served value is kept). Stops when the orchestrator
-    /// aborts the task on shutdown.
-    pub async fn run(mut self, tx: watch::Sender<KeyUrlResponseJson>) {
+    /// retried on the next tick (the last served value is kept). Stops once `shutdown` fires
+    /// (cancelled when shutdown closes the sources of new work).
+    pub async fn run(mut self, tx: watch::Sender<KeyUrlResponseJson>, shutdown: CancellationToken) {
         let mut ticker = tokio::time::interval(self.poll_interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
-            ticker.tick().await;
-            if let Err(e) = self.poll_once(&tx).await {
-                error!(
-                    error = %e,
-                    "/v2/keyurl poll failed; keeping last served value, will retry next tick"
-                );
+            tokio::select! {
+                _ = ticker.tick() => {
+                    if let Err(e) = self.poll_once(&tx).await {
+                        error!(
+                            error = %e,
+                            "/v2/keyurl poll failed; keeping last served value, will retry next tick"
+                        );
+                    }
+                }
+                _ = shutdown.cancelled() => {
+                    info!("KeyUrl poller stopping (shutdown)");
+                    return;
+                }
             }
         }
     }

--- a/relayer/src/host/keyurl_poller.rs
+++ b/relayer/src/host/keyurl_poller.rs
@@ -327,8 +327,7 @@ impl KeyUrlPoller {
 
     /// Long-running loop: poll the active ids on the configured interval and, on any change,
     /// refetch the materials and push the new value into `tx`. RPC failures are logged and
-    /// retried on the next tick (the last served value is kept). Stops once `shutdown` fires
-    /// (cancelled when shutdown closes the sources of new work).
+    /// retried on the next tick (the last served value is kept).
     pub async fn run(mut self, tx: watch::Sender<KeyUrlResponseJson>, shutdown: CancellationToken) {
         let mut ticker = tokio::time::interval(self.poll_interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/relayer/src/http/endpoints/health.rs
+++ b/relayer/src/http/endpoints/health.rs
@@ -64,6 +64,19 @@ pub async fn liveness_handler() -> impl IntoResponse {
     security(())
 )]
 pub async fn health_handler(orchestrator: Arc<Orchestrator>) -> impl IntoResponse {
+    // Once shutdown has started, report unhealthy unconditionally so the load
+    // balancer stops routing new traffic here, regardless of dependency status.
+    if orchestrator.is_shutting_down() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(HealthResponse {
+                status: "shutting_down".to_string(),
+                dependencies: None,
+            }),
+        )
+            .into_response();
+    }
+
     let (is_healthy, dependencies) = orchestrator.check_all_health().await;
 
     let status = if is_healthy {

--- a/relayer/src/http/endpoints/health.rs
+++ b/relayer/src/http/endpoints/health.rs
@@ -64,8 +64,7 @@ pub async fn liveness_handler() -> impl IntoResponse {
     security(())
 )]
 pub async fn health_handler(orchestrator: Arc<Orchestrator>) -> impl IntoResponse {
-    // Once shutdown has started, report unhealthy unconditionally so the load
-    // balancer stops routing new traffic here, regardless of dependency status.
+    // Unhealthy regardless of dependency status, so the load balancer stops routing here.
     if orchestrator.is_shutting_down() {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/relayer/src/http/server.rs
+++ b/relayer/src/http/server.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 async fn wait_for_ready(addr: SocketAddr) -> anyhow::Result<()> {
@@ -42,6 +43,7 @@ async fn wait_for_ready(addr: SocketAddr) -> anyhow::Result<()> {
     Err(anyhow::anyhow!("HTTP server failed to start"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_http_server(
     settings: &Settings,
     orchestrator: Arc<Orchestrator>,
@@ -52,6 +54,7 @@ pub async fn run_http_server(
     keyurl_rx: tokio::sync::watch::Receiver<
         crate::http::endpoints::v2::types::keyurl::KeyUrlResponseJson,
     >,
+    shutdown: CancellationToken,
 ) -> SocketAddr {
     let http = &settings.http;
     let user_decrypt_shares_threshold = settings.gateway.contracts.user_decrypt_shares_threshold;
@@ -212,7 +215,12 @@ pub async fn run_http_server(
         .spawn_task_and_wait_ready(
             "http_server_axum",
             async move {
-                axum::serve(listener, app).await.unwrap();
+                // Cancelled when shutdown stops intake: finishes in-flight HTTP
+                // requests, then stops accepting new connections.
+                axum::serve(listener, app)
+                    .with_graceful_shutdown(shutdown.cancelled_owned())
+                    .await
+                    .unwrap();
             },
             async move {
                 // Wait for HTTP server to be ready with actual health check

--- a/relayer/src/http/server.rs
+++ b/relayer/src/http/server.rs
@@ -215,8 +215,7 @@ pub async fn run_http_server(
         .spawn_task_and_wait_ready(
             "http_server_axum",
             async move {
-                // Cancelled when shutdown stops intake: finishes in-flight HTTP
-                // requests, then stops accepting new connections.
+                // Finishes accepted requests, then stops accepting connections.
                 axum::serve(listener, app)
                     .with_graceful_shutdown(shutdown.cancelled_owned())
                     .await

--- a/relayer/src/logging/steps.rs
+++ b/relayer/src/logging/steps.rs
@@ -189,10 +189,11 @@ impl fmt::Display for ListenerStep {
 /// Normal operations are DEBUG, problems are WARN.
 #[derive(Debug, Clone, Copy)]
 pub enum WorkerStep {
-    // Normal ops (DEBUG)
+    // Normal ops (DEBUG/INFO)
     WorkerStarted,
     TickCompleted,
     RowsProcessed,
+    WorkerStopped,
 
     // Problems (WARN)
     WorkerPanicked,
@@ -205,6 +206,7 @@ impl fmt::Display for WorkerStep {
             Self::WorkerStarted => "worker_started",
             Self::TickCompleted => "tick_completed",
             Self::RowsProcessed => "rows_processed",
+            Self::WorkerStopped => "worker_stopped",
             Self::WorkerPanicked => "worker_panicked",
             Self::WorkerRestarting => "worker_restarting",
         };

--- a/relayer/src/metrics/server.rs
+++ b/relayer/src/metrics/server.rs
@@ -71,8 +71,7 @@ pub async fn run_metrics_server(
         .spawn_task_and_wait_ready(
             "metrics_server_axum",
             async move {
-                // Cancelled last of all, after everything else has stopped, so
-                // metrics stay observable for as much of the shutdown sequence as possible.
+                // Its own token, but cancelled alongside the rest, not after.
                 axum::serve(listener, app)
                     .with_graceful_shutdown(shutdown.cancelled_owned())
                     .await

--- a/relayer/src/metrics/server.rs
+++ b/relayer/src/metrics/server.rs
@@ -4,6 +4,7 @@ use prometheus::{Registry, TextEncoder};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 async fn wait_for_ready(addr: SocketAddr) -> anyhow::Result<()> {
@@ -45,6 +46,7 @@ pub async fn run_metrics_server(
     registry: Registry,
     endpoint: String,
     orchestrator: Arc<Orchestrator>,
+    shutdown: CancellationToken,
 ) -> SocketAddr {
     let addr: SocketAddr = endpoint.parse().expect("Invalid metrics endpoint address");
 
@@ -69,7 +71,10 @@ pub async fn run_metrics_server(
         .spawn_task_and_wait_ready(
             "metrics_server_axum",
             async move {
+                // Cancelled last of all, after everything else has stopped, so
+                // metrics stay observable for as much of the shutdown sequence as possible.
                 axum::serve(listener, app)
+                    .with_graceful_shutdown(shutdown.cancelled_owned())
                     .await
                     .expect("metrics server failed");
             },

--- a/relayer/src/orchestrator/orchestrator.rs
+++ b/relayer/src/orchestrator/orchestrator.rs
@@ -7,8 +7,9 @@ use crate::orchestrator::TokioEventDispatcher;
 use anyhow::Error;
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-use tokio_util::sync::CancellationToken;
+use std::time::Duration;
 use tokio_util::task::TaskTracker;
 use tracing::{error, instrument};
 use uuid::Uuid;
@@ -22,7 +23,14 @@ pub struct Orchestrator {
     ///
     /// - per-event dispatch
     /// - `handled_events`' dispatch-then-complete follow-up
+    /// - per-readiness-check work
+    /// - transaction sends
+    ///
+    /// Shutdown abandons the lot rather than waiting - see the module-level note in `startup`.
     detached_tasks: TaskTracker,
+    /// Sticky readiness flag for `/healthz`: once shutdown starts, the relayer must stop
+    /// looking healthy to the load balancer even if every dependency check still passes.
+    shutting_down: AtomicBool,
 }
 
 impl Orchestrator {
@@ -35,7 +43,19 @@ impl Orchestrator {
             health_checker: Arc::new(RwLock::new(HealthChecker::new())),
             task_manager: TaskManager::new(),
             detached_tasks,
+            shutting_down: AtomicBool::new(false),
         })
+    }
+
+    /// Flip `/healthz` to unhealthy regardless of dependency status. Called once, at the very
+    /// start of the shutdown sequence, while the HTTP server keeps serving.
+    pub fn mark_not_ready(&self) {
+        self.shutting_down.store(true, Ordering::Release);
+    }
+
+    /// Whether shutdown has started. Checked by the `/healthz` handler.
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::Acquire)
     }
 
     pub fn new_internal_request_id(&self) -> Uuid {
@@ -88,12 +108,25 @@ impl Orchestrator {
             .await
     }
 
-    /// Wait for shutdown signal and gracefully shutdown all tasks
-    pub async fn run_until_shutdown(
-        &self,
-        shutdown_token: CancellationToken,
-    ) -> anyhow::Result<()> {
-        self.task_manager.run_until_shutdown(shutdown_token).await
+    /// Stop accepting new named-task spawns. Call once, before the drain.
+    pub async fn begin_task_drain(&self) {
+        self.task_manager.begin_shutdown().await;
+    }
+
+    /// Wait up to `budget` for the named tasks to exit on their own (the caller must already
+    /// have cancelled whatever drives them); abort any still running once the budget elapses.
+    pub async fn drain_named_tasks(&self, budget: Duration) {
+        self.task_manager.drain_tasks(budget).await;
+    }
+
+    /// Final safety net after the drain: abort anything left tracked.
+    pub async fn finish_task_drain(&self) {
+        self.task_manager.finish_drain().await;
+    }
+
+    /// Snapshot of the detached work not waited for at shutdown. Never drained, only reported.
+    pub fn abandoned_detached_tasks(&self) -> usize {
+        self.detached_tasks.len()
     }
 
     #[instrument(skip_all, fields(event_type=%(event.event_name()), job_id=?event.job_id()))]

--- a/relayer/src/orchestrator/orchestrator.rs
+++ b/relayer/src/orchestrator/orchestrator.rs
@@ -18,18 +18,10 @@ pub struct Orchestrator {
     event_dispatcher: Arc<TokioEventDispatcher>,
     health_checker: Arc<RwLock<HealthChecker>>,
     task_manager: TaskManager,
-    /// Short-lived, unbounded-in-number detached work that has no place in the named-task
-    /// JoinSet, all of it resumable from what Postgres and the chain cursor already hold:
-    ///
-    /// - per-event dispatch
-    /// - `handled_events`' dispatch-then-complete follow-up
-    /// - per-readiness-check work
-    /// - transaction sends
-    ///
-    /// Shutdown abandons the lot rather than waiting - see the module-level note in `startup`.
+    /// Per-event dispatch, its follow-up, readiness checks and transaction sends. Unbounded
+    /// in number and resumable from Postgres and the chain cursor, so shutdown abandons it.
     detached_tasks: TaskTracker,
-    /// Sticky readiness flag for `/healthz`: once shutdown starts, the relayer must stop
-    /// looking healthy to the load balancer even if every dependency check still passes.
+    /// Sticky: shutdown must stop the pod looking healthy while its dependencies still pass.
     shutting_down: AtomicBool,
 }
 
@@ -47,13 +39,11 @@ impl Orchestrator {
         })
     }
 
-    /// Flip `/healthz` to unhealthy regardless of dependency status. Called once, at the very
-    /// start of the shutdown sequence, while the HTTP server keeps serving.
+    /// First step of shutdown, taken while the HTTP server keeps serving.
     pub fn mark_not_ready(&self) {
         self.shutting_down.store(true, Ordering::Release);
     }
 
-    /// Whether shutdown has started. Checked by the `/healthz` handler.
     pub fn is_shutting_down(&self) -> bool {
         self.shutting_down.load(Ordering::Acquire)
     }
@@ -108,23 +98,22 @@ impl Orchestrator {
             .await
     }
 
-    /// Stop accepting new named-task spawns. Call once, before the drain.
+    // The three below are called in this order, once each; `startup` is the only caller.
+
     pub async fn begin_task_drain(&self) {
         self.task_manager.begin_shutdown().await;
     }
 
-    /// Wait up to `budget` for the named tasks to exit on their own (the caller must already
-    /// have cancelled whatever drives them); abort any still running once the budget elapses.
+    /// Whatever drives the named tasks must already be cancelled.
     pub async fn drain_named_tasks(&self, budget: Duration) {
         self.task_manager.drain_tasks(budget).await;
     }
 
-    /// Final safety net after the drain: abort anything left tracked.
     pub async fn finish_task_drain(&self) {
         self.task_manager.finish_drain().await;
     }
 
-    /// Snapshot of the detached work not waited for at shutdown. Never drained, only reported.
+    /// Reported, never drained.
     pub fn abandoned_detached_tasks(&self) -> usize {
         self.detached_tasks.len()
     }

--- a/relayer/src/orchestrator/task_manager.rs
+++ b/relayer/src/orchestrator/task_manager.rs
@@ -8,9 +8,8 @@ use tokio::task::{AbortHandle, Id, JoinSet};
 use tokio::time::timeout;
 use tracing::{info, instrument, warn};
 
-/// The `JoinSet` plus each task's name and abort handle, so a task that outlasts the drain
-/// can be named in the log line that reports it. Kept behind one mutex so spawn and shutdown
-/// always see a consistent view of "which tasks exist".
+/// A `JoinSet` cannot name what it holds, so names and abort handles sit beside it - a task
+/// that outlasts the drain is worth naming in the log. One mutex covers both.
 #[derive(Default)]
 struct TrackedTasks {
     joinset: JoinSet<()>,
@@ -18,9 +17,8 @@ struct TrackedTasks {
 }
 
 impl TrackedTasks {
-    /// Wait up to `budget` for every tracked task to finish on its own (the caller must
-    /// already have made them observe cancellation), then abort whatever is still running.
-    /// Aborting is individual, so the log line names the tasks that did not stop.
+    /// Aborts one at a time rather than calling `shutdown()`, to keep the names of the tasks
+    /// that did not stop.
     async fn drain(&mut self, budget: Duration) {
         let mut pending: HashSet<Id> = self.tasks.keys().copied().collect();
         let total = pending.len();
@@ -31,8 +29,6 @@ impl TrackedTasks {
         }
 
         let start = Instant::now();
-        // Disjoint borrows: the join loop reaps from the joinset and removes the matching
-        // bookkeeping from `tasks`, so neither can be borrowed through `self`.
         let Self { joinset, tasks } = self;
         let drained = timeout(budget, async {
             while !pending.is_empty() {
@@ -75,8 +71,7 @@ impl TrackedTasks {
         }
     }
 
-    /// Safety net for the very end of shutdown: abort anything still tracked (the drain
-    /// above leaves nothing behind) and shut the joinset down.
+    /// The drain leaves nothing behind, so anything found here escaped every predicate.
     async fn finish(&mut self) {
         if !self.tasks.is_empty() {
             let stuck: Vec<&str> = self.tasks.values().map(|(name, _)| name.as_str()).collect();
@@ -150,24 +145,17 @@ impl TaskManager {
         Ok(())
     }
 
-    /// Mark the manager as shutting down so no further tasks can be spawned. Must be
-    /// called once, before the drain.
     pub(crate) async fn begin_shutdown(&self) {
-        // Hold the lock while flipping the flag so it can never race a concurrent
-        // spawn_task_and_wait_ready call (which checks the flag under the same lock).
+        // The guard is the point: a spawn reads this flag under the same lock.
         let _guard = self.tasks.lock().await;
         self.is_shutting_down.store(true, Ordering::Release);
     }
 
-    /// Wait up to `budget` for the tracked tasks to exit on their own; abort any still
-    /// running once the budget elapses.
     pub(crate) async fn drain_tasks(&self, budget: Duration) {
         let mut tasks = self.tasks.lock().await;
         tasks.drain(budget).await;
     }
 
-    /// Final safety net: abort anything left tracked and shut the joinset down. Called
-    /// once, after the drain.
     pub(crate) async fn finish_drain(&self) {
         let mut tasks = self.tasks.lock().await;
         tasks.finish().await;

--- a/relayer/src/orchestrator/task_manager.rs
+++ b/relayer/src/orchestrator/task_manager.rs
@@ -1,15 +1,100 @@
 use anyhow::Result;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
-use tokio::task::JoinSet;
-use tokio_util::sync::CancellationToken;
-use tracing::{info, instrument};
+use tokio::task::{AbortHandle, Id, JoinSet};
+use tokio::time::timeout;
+use tracing::{info, instrument, warn};
 
-/// Internal task manager for orchestrator - handles background task lifecycle
-/// Uses tokio::sync::Mutex for async-friendly access to the shared JoinSet
+/// The `JoinSet` plus each task's name and abort handle, so a task that outlasts the drain
+/// can be named in the log line that reports it. Kept behind one mutex so spawn and shutdown
+/// always see a consistent view of "which tasks exist".
+#[derive(Default)]
+struct TrackedTasks {
+    joinset: JoinSet<()>,
+    tasks: HashMap<Id, (String, AbortHandle)>,
+}
+
+impl TrackedTasks {
+    /// Wait up to `budget` for every tracked task to finish on its own (the caller must
+    /// already have made them observe cancellation), then abort whatever is still running.
+    /// Aborting is individual, so the log line names the tasks that did not stop.
+    async fn drain(&mut self, budget: Duration) {
+        let mut pending: HashSet<Id> = self.tasks.keys().copied().collect();
+        let total = pending.len();
+
+        if total == 0 {
+            info!("No tasks to drain");
+            return;
+        }
+
+        let start = Instant::now();
+        // Disjoint borrows: the join loop reaps from the joinset and removes the matching
+        // bookkeeping from `tasks`, so neither can be borrowed through `self`.
+        let Self { joinset, tasks } = self;
+        let drained = timeout(budget, async {
+            while !pending.is_empty() {
+                let Some(result) = joinset.join_next_with_id().await else {
+                    break;
+                };
+                let id = match result {
+                    Ok((id, ())) => id,
+                    Err(join_error) => join_error.id(),
+                };
+                pending.remove(&id);
+                tasks.remove(&id);
+            }
+        })
+        .await
+        .is_ok();
+
+        if drained {
+            info!(
+                elapsed = ?start.elapsed(),
+                tasks = total,
+                "Tasks drained"
+            );
+        } else {
+            let stuck: Vec<&str> = pending
+                .iter()
+                .filter_map(|id| tasks.get(id).map(|(name, _)| name.as_str()))
+                .collect();
+            warn!(
+                ?budget,
+                remaining = stuck.len(),
+                tasks = ?stuck,
+                "Drain timeout, aborting stuck tasks"
+            );
+            for id in &pending {
+                if let Some((_, handle)) = tasks.remove(id) {
+                    handle.abort();
+                }
+            }
+        }
+    }
+
+    /// Safety net for the very end of shutdown: abort anything still tracked (the drain
+    /// above leaves nothing behind) and shut the joinset down.
+    async fn finish(&mut self) {
+        if !self.tasks.is_empty() {
+            let stuck: Vec<&str> = self.tasks.values().map(|(name, _)| name.as_str()).collect();
+            warn!(
+                remaining = stuck.len(),
+                tasks = ?stuck,
+                "Tasks left tracked after the drain, aborting"
+            );
+        }
+        self.joinset.shutdown().await;
+        self.tasks.clear();
+    }
+}
+
+/// Internal task manager for orchestrator - handles background task lifecycle.
+/// Uses tokio::sync::Mutex for async-friendly access to the shared JoinSet.
 pub(crate) struct TaskManager {
-    tasks: Mutex<JoinSet<()>>,
+    tasks: Mutex<TrackedTasks>,
     is_shutting_down: AtomicBool,
 }
 
@@ -22,7 +107,7 @@ impl Default for TaskManager {
 impl TaskManager {
     pub(crate) fn new() -> Self {
         Self {
-            tasks: Mutex::new(JoinSet::new()),
+            tasks: Mutex::new(TrackedTasks::default()),
             is_shutting_down: AtomicBool::new(false),
         }
     }
@@ -51,7 +136,10 @@ impl TaskManager {
             ));
         }
 
-        tasks.spawn(task_future);
+        let abort_handle = tasks.joinset.spawn(task_future);
+        tasks
+            .tasks
+            .insert(abort_handle.id(), (name.to_string(), abort_handle));
         drop(tasks); // Release mutex before waiting for readiness
 
         // Wait for it to be ready
@@ -62,29 +150,27 @@ impl TaskManager {
         Ok(())
     }
 
-    /// Wait for shutdown signal and gracefully shutdown all tasks
-    #[instrument(skip_all)]
-    pub(crate) async fn run_until_shutdown(&self, shutdown_token: CancellationToken) -> Result<()> {
-        info!("Waiting for shutdown signal...");
-        shutdown_token.cancelled().await;
+    /// Mark the manager as shutting down so no further tasks can be spawned. Must be
+    /// called once, before the drain.
+    pub(crate) async fn begin_shutdown(&self) {
+        // Hold the lock while flipping the flag so it can never race a concurrent
+        // spawn_task_and_wait_ready call (which checks the flag under the same lock).
+        let _guard = self.tasks.lock().await;
+        self.is_shutting_down.store(true, Ordering::Release);
+    }
 
-        info!("Shutdown signal received, stopping all tasks...");
+    /// Wait up to `budget` for the tracked tasks to exit on their own; abort any still
+    /// running once the budget elapses.
+    pub(crate) async fn drain_tasks(&self, budget: Duration) {
+        let mut tasks = self.tasks.lock().await;
+        tasks.drain(budget).await;
+    }
 
-        // Take ownership of all tasks while holding the mutex
-        // We set the shutdown flag first so any new spawn attempts will fail
-        // Then we take the tasks out so we can shut them down without holding the lock
-        // (holding the lock during shutdown could cause deadlocks if tasks try to interact with TaskManager)
-        let mut tasks = {
-            let mut task_guard = self.tasks.lock().await;
-            self.is_shutting_down.store(true, Ordering::Release);
-            std::mem::take(&mut *task_guard) // Take tasks, leave empty JoinSet behind
-        };
-
-        // Now shut down all the tasks without holding the mutex
-        tasks.shutdown().await;
-
-        info!("All tasks stopped successfully");
-        Ok(())
+    /// Final safety net: abort anything left tracked and shut the joinset down. Called
+    /// once, after the drain.
+    pub(crate) async fn finish_drain(&self) {
+        let mut tasks = self.tasks.lock().await;
+        tasks.finish().await;
     }
 }
 
@@ -92,7 +178,6 @@ impl TaskManager {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::time::Duration;
     use tokio::time::sleep;
 
     #[tokio::test]
@@ -125,25 +210,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_shutdown_prevents_new_spawns() {
-        let task_manager = TaskManager::new();
-        let shutdown_token = CancellationToken::new();
+        let task_manager = Arc::new(TaskManager::new());
 
-        // Start shutdown in background
-        let shutdown_token_clone = shutdown_token.clone();
-        let task_manager_clone = Arc::new(task_manager);
-        let shutdown_handle = tokio::spawn({
-            let task_manager = task_manager_clone.clone();
-            async move { task_manager.run_until_shutdown(shutdown_token_clone).await }
-        });
+        task_manager.begin_shutdown().await;
 
-        // Cancel immediately to trigger shutdown
-        shutdown_token.cancel();
-
-        // Wait for shutdown to start
-        sleep(Duration::from_millis(10)).await;
-
-        // Try to spawn a task after shutdown has started
-        let result = task_manager_clone
+        let result = task_manager
             .spawn_task_and_wait_ready("should_fail", async {}, async { Ok(()) })
             .await;
 
@@ -152,15 +223,11 @@ mod tests {
             result.unwrap_err().to_string().contains("shutting down"),
             "Error should mention shutdown"
         );
-
-        // Cleanup
-        shutdown_handle.await.unwrap().unwrap();
     }
 
     #[tokio::test]
-    async fn test_shutdown_completes_successfully() {
+    async fn test_drain_completes_successfully() {
         let task_manager = Arc::new(TaskManager::new());
-        let shutdown_token = CancellationToken::new();
 
         // Spawn a simple task
         let spawn_result = task_manager
@@ -176,14 +243,9 @@ mod tests {
 
         assert!(spawn_result.is_ok(), "Task should spawn successfully");
 
-        // Trigger shutdown - should complete without hanging
-        shutdown_token.cancel();
-        let shutdown_result = task_manager.run_until_shutdown(shutdown_token).await;
-
-        assert!(
-            shutdown_result.is_ok(),
-            "Shutdown should complete successfully"
-        );
+        task_manager.begin_shutdown().await;
+        task_manager.drain_tasks(Duration::from_secs(5)).await;
+        task_manager.finish_drain().await;
     }
 
     #[tokio::test]
@@ -191,7 +253,7 @@ mod tests {
         let task_manager = Arc::new(TaskManager::new());
 
         // Manually set the shutdown flag to test the specific behavior
-        task_manager.is_shutting_down.store(true, Ordering::Release);
+        task_manager.begin_shutdown().await;
 
         // Try to spawn a task - this should always fail
         let result = task_manager
@@ -205,6 +267,74 @@ mod tests {
         assert!(
             result.unwrap_err().to_string().contains("shutting down"),
             "Error should mention shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drain_allows_slow_cooperative_task_to_complete() {
+        let task_manager = Arc::new(TaskManager::new());
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = completed.clone();
+        let shutdown_token = tokio_util::sync::CancellationToken::new();
+        let token_for_task = shutdown_token.clone();
+
+        // This task ignores the cancellation signal for a while, simulating
+        // in-flight work that should be allowed to finish rather than aborted.
+        task_manager
+            .spawn_task_and_wait_ready(
+                "slow_cooperative_task",
+                async move {
+                    token_for_task.cancelled().await;
+                    sleep(Duration::from_millis(50)).await;
+                    completed_clone.store(true, Ordering::Release);
+                },
+                async { Ok(()) },
+            )
+            .await
+            .unwrap();
+
+        shutdown_token.cancel();
+        task_manager.begin_shutdown().await;
+        task_manager.drain_tasks(Duration::from_secs(5)).await;
+
+        assert!(
+            completed.load(Ordering::Acquire),
+            "Task should be allowed to complete during the drain window instead of being aborted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drain_aborts_task_that_ignores_cancellation() {
+        let task_manager = Arc::new(TaskManager::new());
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_clone = completed.clone();
+
+        // This task never observes any cancellation signal, so it must be
+        // aborted once its phase's drain timeout elapses.
+        task_manager
+            .spawn_task_and_wait_ready(
+                "stuck_task",
+                async move {
+                    sleep(Duration::from_secs(60)).await;
+                    completed_clone.store(true, Ordering::Release);
+                },
+                async { Ok(()) },
+            )
+            .await
+            .unwrap();
+
+        task_manager.begin_shutdown().await;
+        // Short drain timeout so the test stays fast.
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            task_manager.drain_tasks(Duration::from_millis(20)),
+        )
+        .await
+        .expect("drain_tasks should not hang past its budget");
+
+        assert!(
+            !completed.load(Ordering::Acquire),
+            "Stuck task should have been aborted, not allowed to complete"
         );
     }
 }

--- a/relayer/src/readiness/public_decrypt_processor.rs
+++ b/relayer/src/readiness/public_decrypt_processor.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use alloy::primitives::FixedBytes;
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 /// The Processor responsible for bridging the Readiness Throttler (Queue) and the ReadinessChecker (Executor).
@@ -30,6 +31,7 @@ impl PublicDecryptReadinessProcessor {
         throttler_worker: ReadinessWorker<PublicDecryptReadinessTask>,
         readiness_checker: Arc<ReadinessChecker>,
         orchestrator: Arc<Orchestrator>,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let task_name = "public_decrypt_readiness_processor";
 
@@ -38,9 +40,10 @@ impl PublicDecryptReadinessProcessor {
         let task_future = async move {
             info!("GatewayReadinessProcessor started.");
 
-            // Run the consumer loop
+            // Run the consumer loop; exits once `shutdown` fires, which also cancels the
+            // checks already running.
             throttler_worker
-                .run_consumer(move |task: PublicDecryptReadinessTask| {
+                .run_consumer(shutdown, move |task: PublicDecryptReadinessTask| {
                     // Clone dependencies for the individual task execution
                     let checker = readiness_checker.clone();
                     Self::process_single_task(checker, task, dispatcher.clone())

--- a/relayer/src/readiness/throttler.rs
+++ b/relayer/src/readiness/throttler.rs
@@ -153,8 +153,7 @@ pub struct ReadinessWorker<T> {
     tracker: Arc<RwLock<IndexMap<String, ()>>>,
     // Replaces TPS: Limits how many tasks can run concurrently
     max_parallelism: usize,
-    // Tracks the per-readiness-check task spawned in `run_consumer`, holding its
-    // `OwnedSemaphorePermit`. Shutdown abandons these; see `run_consumer` for why.
+    // Per-check tasks, each holding its `OwnedSemaphorePermit`.
     detached_tasks: TaskTracker,
 }
 
@@ -282,13 +281,11 @@ impl<T> ReadinessWorker<T>
 where
     T: ReadinessItem + Send + Sync + 'static,
 {
-    /// Runs the dequeue loop until `shutdown` fires, cancelling the checks already running.
-    /// Driven from the token, not channel closure: the sender halves never drop on their own.
+    /// Driven from `shutdown`, not channel closure: the sender halves never drop on their own.
     ///
-    /// A readiness check is a pure external read holding only a drop-released permit, so
-    /// cancelling one costs a repeat at the next start and its row stays `queued` for
-    /// recovery; letting it run on could instead write a terminal status recovery cannot pick
-    /// up. An item still waiting for a permit races `shutdown` the same way: row untouched.
+    /// Checks in flight are cancelled, unlike transaction sends. A check is a pure external
+    /// read, so cancelling costs a repeat at the next start; running on could write a terminal
+    /// status recovery cannot pick up.
     pub async fn run_consumer<F, Fut>(mut self, shutdown: CancellationToken, processor: F)
     where
         F: Fn(T) -> Fut + Send + Sync + 'static,
@@ -325,9 +322,8 @@ where
             // This will Wait (Async) if we have reached max_parallelism active tasks.
             // We use acquire_owned to move the permit into the spawned task.
             //
-            // Raced against `shutdown`: these checks call providers with no request timeout, so
-            // a stalled endpoint can hold every permit indefinitely, and a bare `.await` here
-            // would ignore shutdown for that whole stretch.
+            // Raced against `shutdown` because the checks call providers with no request
+            // timeout, so a stalled endpoint can hold every permit indefinitely.
             let permit = tokio::select! {
                 acquired = semaphore.clone().acquire_owned() => match acquired {
                     Ok(p) => p,
@@ -356,7 +352,6 @@ where
             let check_shutdown = shutdown.clone();
 
             self.detached_tasks.spawn(async move {
-                // Do the work, unless shutdown cuts it short.
                 check_shutdown.run_until_cancelled(proc_clone(item)).await;
 
                 // CRITICAL: Permit is dropped here automatically.
@@ -590,10 +585,8 @@ mod tests {
     }
 
     // --- Test 6: Shutdown While Waiting For A Permit ---
-    // With every permit held by a check that never returns, a second item dequeued behind it
-    // must still observe shutdown rather than blocking on `acquire_owned().await` until the
-    // holder releases. Needs the default current-thread runtime: on a multi-threaded one the
-    // worker could be parked at the top of the loop, passing the test for free.
+    // Needs the default current-thread runtime: on a multi-threaded one the worker could be
+    // parked at the top of the loop, passing the test for free.
     #[tokio::test]
     async fn test_shutdown_while_waiting_for_permit() {
         init_metrics_once();
@@ -635,21 +628,19 @@ mod tests {
         sender.push(MockTask { id: "1".into() }).await.unwrap();
         sender.push(MockTask { id: "2".into() }).await.unwrap();
 
-        // Wait until item "1" has taken the only permit, so item "2" is now parked on
-        // `acquire_owned().await` behind a holder that will never release it voluntarily.
+        // Item "2" is now parked on `acquire_owned().await` behind a holder that never
+        // releases.
         first_holds_permit.notified().await;
 
         shutdown.cancel();
 
-        // Must return promptly: shutdown observed while waiting for the permit, not only at
-        // the top of the loop.
+        // Must return promptly: shutdown observed at the permit, not only at the loop top.
         tokio::time::timeout(Duration::from_secs(2), handle)
             .await
             .expect("run_consumer did not stop when shutdown fired while a permit was held")
             .unwrap();
 
-        // Item "2" was taken off the channel but never handed a permit, so its processor must
-        // never run -- its row is left exactly as `queued` as if it had never been dequeued.
+        // Never handed a permit, so its row is left `queued` as if never dequeued.
         assert_eq!(second_processed.load(Ordering::Relaxed), 0);
     }
 }

--- a/relayer/src/readiness/throttler.rs
+++ b/relayer/src/readiness/throttler.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::{fmt, future::Future};
 use tokio::sync::{mpsc, RwLock, Semaphore};
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{error, info, instrument, warn};
 
 /// Queue information for ETA computation (concurrency-based throttler)
@@ -151,6 +153,9 @@ pub struct ReadinessWorker<T> {
     tracker: Arc<RwLock<IndexMap<String, ()>>>,
     // Replaces TPS: Limits how many tasks can run concurrently
     max_parallelism: usize,
+    // Tracks the per-readiness-check task spawned in `run_consumer`, holding its
+    // `OwnedSemaphorePermit`. Shutdown abandons these; see `run_consumer` for why.
+    detached_tasks: TaskTracker,
 }
 
 impl<T> ReadinessSender<T>
@@ -162,6 +167,7 @@ where
         capacity: usize,
         capacity_safety_margin: usize,
         max_parallelism: usize,
+        detached_tasks: TaskTracker,
     ) -> (Self, ReadinessWorker<T>) {
         let (sender, receiver) = mpsc::channel(capacity);
         let tracker = Arc::new(RwLock::new(IndexMap::new()));
@@ -182,6 +188,7 @@ where
             receiver,
             tracker,
             max_parallelism,
+            detached_tasks,
         };
 
         (sender, worker)
@@ -275,7 +282,14 @@ impl<T> ReadinessWorker<T>
 where
     T: ReadinessItem + Send + Sync + 'static,
 {
-    pub async fn run_consumer<F, Fut>(mut self, processor: F)
+    /// Runs the dequeue loop until `shutdown` fires, cancelling the checks already running.
+    /// Driven from the token, not channel closure: the sender halves never drop on their own.
+    ///
+    /// A readiness check is a pure external read holding only a drop-released permit, so
+    /// cancelling one costs a repeat at the next start and its row stays `queued` for
+    /// recovery; letting it run on could instead write a terminal status recovery cannot pick
+    /// up. An item still waiting for a permit races `shutdown` the same way: row untouched.
+    pub async fn run_consumer<F, Fut>(mut self, shutdown: CancellationToken, processor: F)
     where
         F: Fn(T) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + Send + 'static,
@@ -290,17 +304,41 @@ where
         let semaphore = Arc::new(Semaphore::new(self.max_parallelism));
         let processor = Arc::new(processor);
 
-        while let Some(item) = self.receiver.recv().await {
+        loop {
+            let item = tokio::select! {
+                item = self.receiver.recv() => match item {
+                    Some(item) => item,
+                    None => {
+                        info!("Readiness Worker stopping (All producers dropped).");
+                        break;
+                    }
+                },
+                _ = shutdown.cancelled() => {
+                    info!("Readiness Worker stopping (shutdown).");
+                    break;
+                }
+            };
+
             let id = item.get_id();
 
             // Acquire Permit (Limits Concurrency)
             // This will Wait (Async) if we have reached max_parallelism active tasks.
             // We use acquire_owned to move the permit into the spawned task.
-            let permit = match semaphore.clone().acquire_owned().await {
-                Ok(p) => p,
-                Err(_) => {
-                    // Semaphore closed, shouldn't happen unless we shutdown explicitly.
-                    error!("CRITICAL: Readiness Semaphore closed. Should never happens if not shutting down.");
+            //
+            // Raced against `shutdown`: these checks call providers with no request timeout, so
+            // a stalled endpoint can hold every permit indefinitely, and a bare `.await` here
+            // would ignore shutdown for that whole stretch.
+            let permit = tokio::select! {
+                acquired = semaphore.clone().acquire_owned() => match acquired {
+                    Ok(p) => p,
+                    Err(_) => {
+                        // Semaphore closed, shouldn't happen unless we shutdown explicitly.
+                        error!("CRITICAL: Readiness Semaphore closed. Should never happens if not shutting down.");
+                        break;
+                    }
+                },
+                _ = shutdown.cancelled() => {
+                    info!(id = %id, "Readiness Worker stopping (shutdown while waiting for a free permit); item left queued for recovery.");
                     break;
                 }
             };
@@ -313,20 +351,19 @@ where
                 metrics::queue::decrement_queue_size(self.readiness_type.as_metrics_type());
             }
 
-            // Process (Isolated)
+            // Process (Isolated), under the same token that stops this loop.
             let proc_clone = processor.clone();
+            let check_shutdown = shutdown.clone();
 
-            tokio::spawn(async move {
-                // Do the work
-                proc_clone(item).await;
+            self.detached_tasks.spawn(async move {
+                // Do the work, unless shutdown cuts it short.
+                check_shutdown.run_until_cancelled(proc_clone(item)).await;
 
                 // CRITICAL: Permit is dropped here automatically.
                 // This releases the slot for the next task in the queue.
                 drop(permit);
             });
         }
-
-        info!("Readiness Worker stopping (All producers dropped).");
     }
 }
 
@@ -372,14 +409,19 @@ mod tests {
     #[tokio::test]
     async fn test_fifo_ordering() {
         init_metrics_once();
-        let (sender, worker) =
-            ReadinessSender::<MockTask>::new(ReadinessThrottlingType::UserDecrypt, 10, 0, 100);
+        let (sender, worker) = ReadinessSender::<MockTask>::new(
+            ReadinessThrottlingType::UserDecrypt,
+            10,
+            0,
+            100,
+            TaskTracker::new(),
+        );
         let processed = Arc::new(Mutex::new(Vec::new()));
         let processed_clone = processed.clone();
 
         tokio::spawn(async move {
             worker
-                .run_consumer(move |task| {
+                .run_consumer(CancellationToken::new(), move |task| {
                     let p = processed_clone.clone();
                     async move {
                         p.lock().unwrap().push(task.id);
@@ -401,8 +443,13 @@ mod tests {
     #[tokio::test]
     async fn test_deduplication() {
         init_metrics_once();
-        let (sender, _worker) =
-            ReadinessSender::<MockTask>::new(ReadinessThrottlingType::UserDecrypt, 10, 0, 100);
+        let (sender, _worker) = ReadinessSender::<MockTask>::new(
+            ReadinessThrottlingType::UserDecrypt,
+            10,
+            0,
+            100,
+            TaskTracker::new(),
+        );
 
         sender.push(MockTask { id: "A".into() }).await.unwrap();
         sender.push(MockTask { id: "A".into() }).await.unwrap();
@@ -414,8 +461,13 @@ mod tests {
     #[tokio::test]
     async fn test_queue_full() {
         init_metrics_once();
-        let (sender, _worker) =
-            ReadinessSender::<MockTask>::new(ReadinessThrottlingType::UserDecrypt, 1, 0, 100);
+        let (sender, _worker) = ReadinessSender::<MockTask>::new(
+            ReadinessThrottlingType::UserDecrypt,
+            1,
+            0,
+            100,
+            TaskTracker::new(),
+        );
 
         assert!(sender.push(MockTask { id: "1".into() }).await.is_ok());
 
@@ -434,6 +486,7 @@ mod tests {
             100,
             0,
             max_parallelism,
+            TaskTracker::new(),
         );
 
         // Counter tracks currently ACTIVE tasks
@@ -445,7 +498,7 @@ mod tests {
 
         tokio::spawn(async move {
             worker
-                .run_consumer(move |_| {
+                .run_consumer(CancellationToken::new(), move |_| {
                     let ac = ac.clone();
                     let ms = ms.clone();
                     async move {
@@ -504,8 +557,13 @@ mod tests {
     async fn test_readiness_headroom() {
         init_metrics_once();
         // Capacity = 10, Safety = 2 -> Soft Limit = 8
-        let (sender, worker) =
-            ReadinessSender::<MockTask>::new(ReadinessThrottlingType::UserDecrypt, 10, 2, 100);
+        let (sender, worker) = ReadinessSender::<MockTask>::new(
+            ReadinessThrottlingType::UserDecrypt,
+            10,
+            2,
+            100,
+            TaskTracker::new(),
+        );
 
         for i in 0..8 {
             sender
@@ -524,8 +582,74 @@ mod tests {
 
         // Drain
         tokio::spawn(async move {
-            worker.run_consumer(|_| async {}).await;
+            worker
+                .run_consumer(CancellationToken::new(), |_| async {})
+                .await;
         });
         sleep(Duration::from_millis(100)).await;
+    }
+
+    // --- Test 6: Shutdown While Waiting For A Permit ---
+    // With every permit held by a check that never returns, a second item dequeued behind it
+    // must still observe shutdown rather than blocking on `acquire_owned().await` until the
+    // holder releases. Needs the default current-thread runtime: on a multi-threaded one the
+    // worker could be parked at the top of the loop, passing the test for free.
+    #[tokio::test]
+    async fn test_shutdown_while_waiting_for_permit() {
+        init_metrics_once();
+        // Max Parallelism = 1, so item "2" cannot get a permit until item "1" releases one.
+        let (sender, worker) = ReadinessSender::<MockTask>::new(
+            ReadinessThrottlingType::UserDecrypt,
+            10,
+            0,
+            1,
+            TaskTracker::new(),
+        );
+
+        let shutdown = CancellationToken::new();
+        let first_holds_permit = Arc::new(tokio::sync::Notify::new());
+        let second_processed = Arc::new(AtomicUsize::new(0));
+
+        let first_holds_permit_clone = first_holds_permit.clone();
+        let second_processed_clone = second_processed.clone();
+        let shutdown_clone = shutdown.clone();
+
+        let handle = tokio::spawn(async move {
+            worker
+                .run_consumer(shutdown_clone, move |task| {
+                    let first_holds_permit = first_holds_permit_clone.clone();
+                    let second_processed = second_processed_clone.clone();
+                    async move {
+                        if task.id == "1" {
+                            first_holds_permit.notify_one();
+                            // Stands in for a check whose unbounded RPC call has stalled.
+                            std::future::pending::<()>().await;
+                        } else {
+                            second_processed.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                })
+                .await;
+        });
+
+        sender.push(MockTask { id: "1".into() }).await.unwrap();
+        sender.push(MockTask { id: "2".into() }).await.unwrap();
+
+        // Wait until item "1" has taken the only permit, so item "2" is now parked on
+        // `acquire_owned().await` behind a holder that will never release it voluntarily.
+        first_holds_permit.notified().await;
+
+        shutdown.cancel();
+
+        // Must return promptly: shutdown observed while waiting for the permit, not only at
+        // the top of the loop.
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("run_consumer did not stop when shutdown fired while a permit was held")
+            .unwrap();
+
+        // Item "2" was taken off the channel but never handed a permit, so its processor must
+        // never run -- its row is left exactly as `queued` as if it had never been dequeued.
+        assert_eq!(second_processed.load(Ordering::Relaxed), 0);
     }
 }

--- a/relayer/src/readiness/user_decrypt_processor.rs
+++ b/relayer/src/readiness/user_decrypt_processor.rs
@@ -15,6 +15,7 @@ use crate::{
     },
 };
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 /// The Processor responsible for bridging the Readiness Throttler (Queue) and the ReadinessChecker (Executor).
@@ -29,6 +30,7 @@ impl UserDecryptReadinessProcessor {
         throttler_worker: ReadinessWorker<UserDecryptReadinessTask>,
         readiness_checker: Arc<ReadinessChecker>,
         orchestrator: Arc<Orchestrator>,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         let task_name = "user_decrypt_readiness_processor";
 
@@ -37,9 +39,10 @@ impl UserDecryptReadinessProcessor {
         let task_future = async move {
             info!("GatewayReadinessProcessor started.");
 
-            // Run the consumer loop
+            // Run the consumer loop; exits once `shutdown` fires, which also cancels the
+            // checks already running.
             throttler_worker
-                .run_consumer(move |task: UserDecryptReadinessTask| {
+                .run_consumer(shutdown, move |task: UserDecryptReadinessTask| {
                     // Clone dependencies for the individual task execution
                     let checker = readiness_checker.clone();
                     Self::process_single_task(checker, task, dispatcher.clone())

--- a/relayer/src/startup.rs
+++ b/relayer/src/startup.rs
@@ -48,18 +48,11 @@ use std::sync::OnceLock;
 // Global singleton registry for metrics
 static GLOBAL_REGISTRY: OnceLock<Registry> = OnceLock::new();
 
-// Shutdown exists to hand the dispatcher over, not to save in-flight work: a `queued` request
-// is recovered at the next start, an event whose handlers have not returned is re-read from
-// the chain (its cursor never advanced), and a send killed mid-flight costs at most one
-// duplicate send plus one orphaned response event - the gateway contracts mint a fresh id and
-// charge a fee per call with no dedup, so a repeat costs a fee and duplicate KMS work, never a
-// wrong result. Shutdown therefore drains only the named tasks it can order, abandons the
-// rest, and must finish inside the pod's `terminationGracePeriodSeconds` - unset in gitops, so
-// the Kubernetes default of 30s.
+// Shutdown hands the dispatcher over. Recovery, not shutdown, is what saves in-flight work,
+// so the sequence below drains the named tasks and abandons the rest - inside the pod's
+// `terminationGracePeriodSeconds`, unset in gitops and so Kubernetes' 30s.
 
-/// Bound on the HTTP server's graceful shutdown, the gateway listeners, the keyurl poller,
-/// the tx/readiness processors and the cron workers all observing cancellation and returning.
-/// Every one of them is cancel-safe, so this is a fallback, not an expected wait.
+/// Fallback - a named task reaching this stopped observing its token.
 const STOP_WORK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Main library function for the FHE Event Relayer service.
@@ -88,11 +81,9 @@ pub async fn run_fhevm_relayer(
     // === Orchestration Phase ===
     // Create orchestrator, repositories, and gateway components.
     //
-    // The three tokens name subsystems, not phases - they are all cancelled at the same
-    // moment: `intake_shutdown` closes the sources of new work (the HTTP server, the gateway
-    // listeners, the keyurl poller), `dequeue_shutdown` stops the tx/readiness processors and
-    // cron workers and cancels the readiness checks already running, and `metrics_shutdown`
-    // stops the metrics server.
+    // Three tokens, all cancelled at the same moment - they name subsystems, not phases.
+    // intake: HTTP server, gateway listeners, keyurl poller. dequeue: tx/readiness
+    // processors, cron workers, and readiness checks already running. metrics: its server.
     let detached_tasks = TaskTracker::new();
     let intake_shutdown = CancellationToken::new();
     let dequeue_shutdown = CancellationToken::new();
@@ -285,21 +276,15 @@ pub async fn run_fhevm_relayer(
     // Step 1 - stop looking healthy, keep serving.
     orchestrator.mark_not_ready();
 
-    // Step 2 - let that reach the load balancer (see `shutdown.lb_propagation_wait`'s doc for
-    // what the wait covers). Serving nobody is pointless, so skip it when no HTTP endpoint is
-    // configured.
+    // Step 2 - let that reach the load balancer.
     if settings.http.endpoint.is_some() {
         let wait = settings.shutdown.lb_propagation_wait;
         info!(?wait, "Health check failing, waiting for traffic to drain");
         tokio::time::sleep(wait).await;
     }
 
-    // Step 3 - stop working. The HTTP server finishes requests it already accepted; the
-    // gateway listeners, keyurl poller, tx/readiness processors, cron workers and metrics
-    // server stop, and running readiness checks are cancelled where they wait. Nothing is
-    // ordered against anything else: a listener's last event only spawns a handler shutdown
-    // abandons, and a queued request is already durable in Postgres. One budget drains every
-    // task - all are cancel-safe.
+    // Step 3 - stop working. Order does not matter: what is in flight is either abandoned by
+    // design or already durable in Postgres.
     intake_shutdown.cancel();
     dequeue_shutdown.cancel();
     metrics_shutdown.cancel();
@@ -309,10 +294,8 @@ pub async fn run_fhevm_relayer(
         "Named task drain complete, abandoning remaining detached work"
     );
 
-    // Step 4 - exit. The pools are left to close with the process: closing them here would
-    // wait on the connections held by the tasks just abandoned, reinstating the wait this
-    // sequence removes. `finish_task_drain` is the guard for a task that no predicate above
-    // stopped, and warns when it finds one.
+    // Step 4 - exit. Pools close with the process; closing them here would wait on the
+    // connections the abandoned tasks still hold.
     orchestrator.finish_task_drain().await;
 
     info!("Relayer shutdown complete");

--- a/relayer/src/startup.rs
+++ b/relayer/src/startup.rs
@@ -27,6 +27,7 @@ use crate::gateway::{self, throttlers::init_throttlers};
 use crate::host::{HostChainIdChecker, KeyUrlPoller, UserDecryptSignaturePreChecker};
 use anyhow::Context;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -47,6 +48,20 @@ use std::sync::OnceLock;
 // Global singleton registry for metrics
 static GLOBAL_REGISTRY: OnceLock<Registry> = OnceLock::new();
 
+// Shutdown exists to hand the dispatcher over, not to save in-flight work: a `queued` request
+// is recovered at the next start, an event whose handlers have not returned is re-read from
+// the chain (its cursor never advanced), and a send killed mid-flight costs at most one
+// duplicate send plus one orphaned response event - the gateway contracts mint a fresh id and
+// charge a fee per call with no dedup, so a repeat costs a fee and duplicate KMS work, never a
+// wrong result. Shutdown therefore drains only the named tasks it can order, abandons the
+// rest, and must finish inside the pod's `terminationGracePeriodSeconds` - unset in gitops, so
+// the Kubernetes default of 30s.
+
+/// Bound on the HTTP server's graceful shutdown, the gateway listeners, the keyurl poller,
+/// the tx/readiness processors and the cron workers all observing cancellation and returning.
+/// Every one of them is cancel-safe, so this is a fallback, not an expected wait.
+const STOP_WORK_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Main library function for the FHE Event Relayer service.
 ///
 /// This function performs the following initialization steps:
@@ -54,9 +69,7 @@ static GLOBAL_REGISTRY: OnceLock<Registry> = OnceLock::new();
 /// 2. Sets up transaction services for fhevm and gateway
 /// 3. Creates and configures event handlers
 /// 4. Starts event listeners
-/// 5. Waits for shutdown signal
-///
-/// TODO: properly shutdown tasks
+/// 5. Waits for a shutdown signal, then hands over and exits (see the sequence below)
 pub async fn run_fhevm_relayer(
     settings: Settings,
     shutdown_token: CancellationToken,
@@ -73,8 +86,17 @@ pub async fn run_fhevm_relayer(
     let registry_clone = metrics_registry.clone();
 
     // === Orchestration Phase ===
-    // Create orchestrator, repositories, and gateway components
+    // Create orchestrator, repositories, and gateway components.
+    //
+    // The three tokens name subsystems, not phases - they are all cancelled at the same
+    // moment: `intake_shutdown` closes the sources of new work (the HTTP server, the gateway
+    // listeners, the keyurl poller), `dequeue_shutdown` stops the tx/readiness processors and
+    // cron workers and cancels the readiness checks already running, and `metrics_shutdown`
+    // stops the metrics server.
     let detached_tasks = TaskTracker::new();
+    let intake_shutdown = CancellationToken::new();
+    let dequeue_shutdown = CancellationToken::new();
+    let metrics_shutdown = CancellationToken::new();
     let orchestrator = Orchestrator::new(
         Arc::new(TokioEventDispatcher::new(detached_tasks.clone())),
         detached_tasks.clone(),
@@ -94,7 +116,8 @@ pub async fn run_fhevm_relayer(
         repositories.clone() as Arc<dyn HealthCheck>,
     );
 
-    let (gateway_throttlers, bouncer_throttlers) = init_throttlers(&settings);
+    let (gateway_throttlers, bouncer_throttlers) =
+        init_throttlers(&settings, detached_tasks.clone());
 
     // Initialize all gateway components
     gateway::initialize_gateway(
@@ -102,6 +125,8 @@ pub async fn run_fhevm_relayer(
         &settings,
         repositories.clone(),
         gateway_throttlers,
+        dequeue_shutdown.clone(),
+        intake_shutdown.clone(),
     )
     .await
     .context("Failed to initialize gateway")?;
@@ -126,7 +151,11 @@ pub async fn run_fhevm_relayer(
         "Starting cron workers"
     );
     repositories
-        .register_background_workers(&orchestrator, settings.storage.cron.clone())
+        .register_background_workers(
+            &orchestrator,
+            settings.storage.cron.clone(),
+            dequeue_shutdown.clone(),
+        )
         .await
         .context("Failed to register background workers")?;
 
@@ -199,6 +228,7 @@ pub async fn run_fhevm_relayer(
             host_chain_id_checker,
             signature_prechecker,
             keyurl_rx,
+            intake_shutdown.clone(),
         )
         .await;
 
@@ -209,10 +239,11 @@ pub async fn run_fhevm_relayer(
         // already gated above, so the readiness future is trivially ready; the task is tracked
         // by the orchestrator for graceful shutdown.
         if let Some(keyurl_poller) = keyurl_poller {
+            let keyurl_intake_shutdown = intake_shutdown.clone();
             orchestrator
                 .spawn_task_and_wait_ready(
                     "keyurl_poller",
-                    async move { keyurl_poller.run(keyurl_tx).await },
+                    async move { keyurl_poller.run(keyurl_tx, keyurl_intake_shutdown).await },
                     async { anyhow::Ok(()) },
                 )
                 .await
@@ -226,6 +257,7 @@ pub async fn run_fhevm_relayer(
         registry_clone,
         metrics_endpoint,
         Arc::clone(&orchestrator),
+        metrics_shutdown.clone(),
     )
     .await;
     info!(
@@ -245,14 +277,43 @@ pub async fn run_fhevm_relayer(
     }
 
     // === Runtime Phase ===
-    // Wait for shutdown signal and shutdown all tasks via orchestrator
-    orchestrator
-        .run_until_shutdown(shutdown_token)
-        .await
-        .context("Failed during shutdown")?;
+    // Wait for the shutdown signal (SIGTERM/SIGINT, see `fhevm-relayer.rs`).
+    shutdown_token.cancelled().await;
+    info!("Shutdown signal received, starting graceful shutdown");
+    orchestrator.begin_task_drain().await;
 
-    // Ensure pools close cleanly before exit.
-    repositories.close_pools().await;
+    // Step 1 - stop looking healthy, keep serving.
+    orchestrator.mark_not_ready();
+
+    // Step 2 - let that reach the load balancer (see `shutdown.lb_propagation_wait`'s doc for
+    // what the wait covers). Serving nobody is pointless, so skip it when no HTTP endpoint is
+    // configured.
+    if settings.http.endpoint.is_some() {
+        let wait = settings.shutdown.lb_propagation_wait;
+        info!(?wait, "Health check failing, waiting for traffic to drain");
+        tokio::time::sleep(wait).await;
+    }
+
+    // Step 3 - stop working. The HTTP server finishes requests it already accepted; the
+    // gateway listeners, keyurl poller, tx/readiness processors, cron workers and metrics
+    // server stop, and running readiness checks are cancelled where they wait. Nothing is
+    // ordered against anything else: a listener's last event only spawns a handler shutdown
+    // abandons, and a queued request is already durable in Postgres. One budget drains every
+    // task - all are cancel-safe.
+    intake_shutdown.cancel();
+    dequeue_shutdown.cancel();
+    metrics_shutdown.cancel();
+    orchestrator.drain_named_tasks(STOP_WORK_TIMEOUT).await;
+    info!(
+        abandoned = orchestrator.abandoned_detached_tasks(),
+        "Named task drain complete, abandoning remaining detached work"
+    );
+
+    // Step 4 - exit. The pools are left to close with the process: closing them here would
+    // wait on the connections held by the tasks just abandoned, reinstating the wait this
+    // sequence removes. `finish_task_drain` is the guard for a task that no predicate above
+    // stopped, and warns when it finds one.
+    orchestrator.finish_task_drain().await;
 
     info!("Relayer shutdown complete");
 

--- a/relayer/src/store/sql/repositories/cron_task.rs
+++ b/relayer/src/store/sql/repositories/cron_task.rs
@@ -9,9 +9,14 @@ use crate::{
 use futures::FutureExt;
 use std::time::Duration;
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-async fn run_timeout_worker_logic(pool: PgClient, cron_config: CronConfig) {
+async fn run_timeout_worker_logic(
+    pool: PgClient,
+    cron_config: CronConfig,
+    shutdown: CancellationToken,
+) {
     let repo = TimeoutRepository::new(pool, cron_config.clone());
     let mut interval = tokio::time::interval(cron_config.timeout_cron_interval);
 
@@ -24,7 +29,10 @@ async fn run_timeout_worker_logic(pool: PgClient, cron_config: CronConfig) {
     );
 
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = interval.tick() => {}
+            _ = shutdown.cancelled() => return,
+        }
         debug!("Timeout worker tick - checking for stale requests");
 
         match repo.time_out_stale_requests().await {
@@ -50,7 +58,11 @@ async fn run_timeout_worker_logic(pool: PgClient, cron_config: CronConfig) {
     }
 }
 
-pub async fn create_timeout_worker_future(pool: PgClient, cron_config: CronConfig) {
+pub async fn create_timeout_worker_future(
+    pool: PgClient,
+    cron_config: CronConfig,
+    shutdown: CancellationToken,
+) {
     loop {
         let pool_clone = pool.clone();
         let cron_config_clone = cron_config.clone();
@@ -62,10 +74,19 @@ pub async fn create_timeout_worker_future(pool: PgClient, cron_config: CronConfi
         );
 
         let result = std::panic::AssertUnwindSafe(async {
-            run_timeout_worker_logic(pool_clone, cron_config_clone).await;
+            run_timeout_worker_logic(pool_clone, cron_config_clone, shutdown.clone()).await;
         })
         .catch_unwind()
         .await;
+
+        if shutdown.is_cancelled() {
+            info!(
+                step = %WorkerStep::WorkerStopped,
+                worker = "timeout",
+                "Worker stopped (shutdown)"
+            );
+            return;
+        }
 
         match result {
             Ok(_) => {
@@ -89,7 +110,11 @@ pub async fn create_timeout_worker_future(pool: PgClient, cron_config: CronConfi
     }
 }
 
-async fn run_expiry_worker_logic(pool: PgClient, cron_config: CronConfig) {
+async fn run_expiry_worker_logic(
+    pool: PgClient,
+    cron_config: CronConfig,
+    shutdown: CancellationToken,
+) {
     let repo = ExpiryRepository::new(pool, cron_config.clone());
 
     let mut interval = tokio::time::interval(cron_config.expiry_cron_interval);
@@ -103,10 +128,16 @@ async fn run_expiry_worker_logic(pool: PgClient, cron_config: CronConfig) {
     );
 
     // Skip the first immediate tick to avoid competing with timeout worker at startup
-    interval.tick().await;
+    tokio::select! {
+        _ = interval.tick() => {}
+        _ = shutdown.cancelled() => return,
+    }
 
     loop {
-        interval.tick().await;
+        tokio::select! {
+            _ = interval.tick() => {}
+            _ = shutdown.cancelled() => return,
+        }
         debug!("Expiry worker tick - checking for stale data");
 
         match repo.purge_stale_data().await {
@@ -132,7 +163,11 @@ async fn run_expiry_worker_logic(pool: PgClient, cron_config: CronConfig) {
     }
 }
 
-pub async fn create_expiry_worker_future(pool: PgClient, cron_config: CronConfig) {
+pub async fn create_expiry_worker_future(
+    pool: PgClient,
+    cron_config: CronConfig,
+    shutdown: CancellationToken,
+) {
     loop {
         let pool_clone = pool.clone();
 
@@ -143,10 +178,19 @@ pub async fn create_expiry_worker_future(pool: PgClient, cron_config: CronConfig
         );
 
         let result = std::panic::AssertUnwindSafe(async {
-            run_expiry_worker_logic(pool_clone, cron_config.clone()).await;
+            run_expiry_worker_logic(pool_clone, cron_config.clone(), shutdown.clone()).await;
         })
         .catch_unwind()
         .await;
+
+        if shutdown.is_cancelled() {
+            info!(
+                step = %WorkerStep::WorkerStopped,
+                worker = "expiry",
+                "Worker stopped (shutdown)"
+            );
+            return;
+        }
 
         match result {
             Ok(_) => {

--- a/relayer/src/store/sql/repositories/mod.rs
+++ b/relayer/src/store/sql/repositories/mod.rs
@@ -74,8 +74,7 @@ impl Repositories {
 
     /// Register background workers with the orchestrator for proper lifecycle management.
     /// The timeout worker always starts; the expiry worker only starts when enabled.
-    /// `shutdown` stops both workers (and their panic-restart supervisor loops) along with
-    /// the rest of the work when shutdown starts.
+    /// `shutdown` stops the workers and their panic-restart supervisor loops.
     pub async fn register_background_workers(
         &self,
         orchestrator: &Arc<Orchestrator>,

--- a/relayer/src/store/sql/repositories/mod.rs
+++ b/relayer/src/store/sql/repositories/mod.rs
@@ -22,6 +22,7 @@ use chain_cursor_repo::ChainCursorRepository;
 use input_proof_repo::InputProofRepository;
 use public_decrypt_repo::PublicDecryptRepository;
 use std::{sync::Arc, time::Duration};
+use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use user_decrypt_repo::UserDecryptRepository;
 
@@ -73,15 +74,22 @@ impl Repositories {
 
     /// Register background workers with the orchestrator for proper lifecycle management.
     /// The timeout worker always starts; the expiry worker only starts when enabled.
+    /// `shutdown` stops both workers (and their panic-restart supervisor loops) along with
+    /// the rest of the work when shutdown starts.
     pub async fn register_background_workers(
         &self,
         orchestrator: &Arc<Orchestrator>,
         cron_config: crate::config::settings::CronConfig,
+        shutdown: CancellationToken,
     ) -> anyhow::Result<()> {
         orchestrator
             .spawn_task_and_wait_ready(
                 "timeout_worker",
-                create_timeout_worker_future((*self.pg_client).clone(), cron_config.clone()),
+                create_timeout_worker_future(
+                    (*self.pg_client).clone(),
+                    cron_config.clone(),
+                    shutdown.clone(),
+                ),
                 async { Ok(()) }, // Ready immediately
             )
             .await?;
@@ -97,7 +105,11 @@ impl Repositories {
             orchestrator
                 .spawn_task_and_wait_ready(
                     "expiry_worker",
-                    create_expiry_worker_future((*self.pg_client).clone(), cron_config.clone()),
+                    create_expiry_worker_future(
+                        (*self.pg_client).clone(),
+                        cron_config.clone(),
+                        shutdown,
+                    ),
                     async { Ok(()) }, // Ready immediately
                 )
                 .await?;

--- a/relayer/tests/common/utils.rs
+++ b/relayer/tests/common/utils.rs
@@ -286,8 +286,7 @@ impl TestSetup {
         Self::new_with_config_path(Some(temp_config_path)).await
     }
 
-    /// Create test setup that keeps serving for `wait` after its health check starts
-    /// failing, instead of the zero the other setups use.
+    /// Overrides the 0s the other setups use, so a test can observe the serving window.
     #[allow(dead_code)]
     pub async fn new_with_lb_propagation_wait(wait: &str) -> anyhow::Result<Self> {
         let temp_config_dir = TempDir::new()?;
@@ -371,8 +370,7 @@ impl TestSetup {
         })
     }
 
-    /// Start the shutdown sequence without waiting for it, so a test can observe the relayer
-    /// while it is shutting down. `shutdown` still has to run afterwards to clean up.
+    /// Does not wait. `shutdown` still has to run afterwards to clean up.
     #[allow(dead_code)]
     pub fn begin_shutdown(&self) {
         self.cancellation_token.cancel();
@@ -498,9 +496,6 @@ fn create_readiness_config(
     Ok(temp_config_path)
 }
 
-/// Create a config file with low retry settings for tx_engine (2 attempts × 100ms)
-/// This config is used in tests for max retries exceeded scenarios.
-/// Copy the test config, setting how long shutdown keeps serving after `/healthz` fails.
 fn create_lb_propagation_config(
     temp_dir: &TempDir,
     wait: &str,
@@ -521,6 +516,8 @@ fn create_lb_propagation_config(
     Ok(temp_config_path)
 }
 
+/// Create a config file with low retry settings for tx_engine (2 attempts × 100ms)
+/// This config is used in tests for max retries exceeded scenarios.
 fn create_low_retry_config(temp_dir: &TempDir) -> anyhow::Result<std::path::PathBuf> {
     let temp_config_path = temp_dir.path().join("low_retry.yaml");
 

--- a/relayer/tests/common/utils.rs
+++ b/relayer/tests/common/utils.rs
@@ -286,6 +286,15 @@ impl TestSetup {
         Self::new_with_config_path(Some(temp_config_path)).await
     }
 
+    /// Create test setup that keeps serving for `wait` after its health check starts
+    /// failing, instead of the zero the other setups use.
+    #[allow(dead_code)]
+    pub async fn new_with_lb_propagation_wait(wait: &str) -> anyhow::Result<Self> {
+        let temp_config_dir = TempDir::new()?;
+        let temp_config_path = create_lb_propagation_config(&temp_config_dir, wait)?;
+        Self::new_with_config_path(Some(temp_config_path)).await
+    }
+
     /// Create test setup with admin endpoint enabled
     #[allow(dead_code)]
     pub async fn new_with_admin_endpoint() -> anyhow::Result<Self> {
@@ -360,6 +369,13 @@ impl TestSetup {
             relayer_handle,
             test_schema,
         })
+    }
+
+    /// Start the shutdown sequence without waiting for it, so a test can observe the relayer
+    /// while it is shutting down. `shutdown` still has to run afterwards to clean up.
+    #[allow(dead_code)]
+    pub fn begin_shutdown(&self) {
+        self.cancellation_token.cancel();
     }
 
     #[allow(dead_code)]
@@ -484,6 +500,27 @@ fn create_readiness_config(
 
 /// Create a config file with low retry settings for tx_engine (2 attempts × 100ms)
 /// This config is used in tests for max retries exceeded scenarios.
+/// Copy the test config, setting how long shutdown keeps serving after `/healthz` fails.
+fn create_lb_propagation_config(
+    temp_dir: &TempDir,
+    wait: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    let temp_config_path = temp_dir.path().join("lb_propagation.yaml");
+
+    let config_content = std::fs::read_to_string("tests/relayer-test-config.yaml")
+        .context("Failed to read default config")?;
+    let mut config: serde_yaml::Value =
+        serde_yaml::from_str(&config_content).context("Failed to parse YAML config")?;
+
+    config["shutdown"]["lb_propagation_wait"] = serde_yaml::Value::String(wait.to_string());
+
+    let modified_content =
+        serde_yaml::to_string(&config).context("Failed to serialize modified config")?;
+    std::fs::write(&temp_config_path, modified_content).context("Failed to write temp config")?;
+
+    Ok(temp_config_path)
+}
+
 fn create_low_retry_config(temp_dir: &TempDir) -> anyhow::Result<std::path::PathBuf> {
     let temp_config_path = temp_dir.path().join("low_retry.yaml");
 

--- a/relayer/tests/keyurl_poller_test.rs
+++ b/relayer/tests/keyurl_poller_test.rs
@@ -20,6 +20,7 @@ use fhevm_host_bindings::ikms_generation::IKMSGeneration;
 use fhevm_relayer::config::settings::{ProtocolConfigSettings, RetrySettings};
 use fhevm_relayer::host::KeyUrlPoller;
 use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 
 const CONTRACT_ADDR: &str = "0x1234567890123456789012345678901234567890";
 const STORAGE_URL: &str = "http://minio:9000/kms-public";
@@ -246,7 +247,7 @@ async fn run_pushes_updated_value_on_id_change() {
     );
 
     let (tx, mut rx) = watch::channel(initial);
-    let run_handle = tokio::spawn(async move { poller.run(tx).await });
+    let run_handle = tokio::spawn(async move { poller.run(tx, CancellationToken::new()).await });
 
     // Rotate the active key id on-chain; the poller should detect it and push the new value.
     active_key_id.store(7, Ordering::SeqCst);

--- a/relayer/tests/relayer-test-config.yaml
+++ b/relayer/tests/relayer-test-config.yaml
@@ -256,3 +256,7 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "0s"
+
+shutdown:
+  # No load balancer in front of the tests, so nothing has to notice the 503.
+  lb_propagation_wait: "0s"

--- a/relayer/tests/relayer-test-config.yaml
+++ b/relayer/tests/relayer-test-config.yaml
@@ -259,3 +259,7 @@ storage:
     # timeout checks begin, preventing false positives.
     # VALIDATION: Must be less than 10% of minimum timeout duration AND minimum expiry duration.
     cron_startup_delay_after_recovery: "0s"
+
+shutdown:
+  # No load balancer in front of the tests, so nothing has to notice the 503.
+  lb_propagation_wait: "0s"

--- a/relayer/tests/shutdown_test.rs
+++ b/relayer/tests/shutdown_test.rs
@@ -1,0 +1,96 @@
+//! Graceful shutdown tests.
+//!
+//! These assert only that shutdown terminates and that no step reached its budget - a
+//! regression guard for adding a background task without a shutdown token.
+//!
+//! The test config sets `shutdown.lb_propagation_wait` to zero, so the times below measure
+//! the work of shutting down rather than the wait for a load balancer that is not there.
+//!
+//! Not covered: SIGTERM is never sent - these cancel the token directly and do not run as
+//! PID 1.
+
+mod common;
+
+use crate::common::utils::TestSetup;
+use rstest::rstest;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
+
+/// Observed drains are microseconds and the smallest budget (`STOP_WORK_TIMEOUT`) is 5s, so
+/// this sits clear of both.
+const COOPERATIVE_SHUTDOWN_MAX: Duration = Duration::from_secs(2);
+
+/// Separates "slow" from "hung" so a deadlock fails instead of stalling the suite.
+const SHUTDOWN_HANG_LIMIT: Duration = Duration::from_secs(60);
+
+/// Shutdown terminates, and no step falls back to aborting.
+#[rstest]
+#[tokio::test]
+async fn test_shutdown_completes_without_reaching_budgets() {
+    let setup = TestSetup::new().await.expect("Failed to create test setup");
+
+    let start = Instant::now();
+    timeout(SHUTDOWN_HANG_LIMIT, setup.shutdown())
+        .await
+        .expect("shutdown never completed");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < COOPERATIVE_SHUTDOWN_MAX,
+        "shutdown took {elapsed:?}, so a step drained to its budget and aborted a task \
+         instead of the task returning on cancellation"
+    );
+}
+
+/// The same, once every task is idle at its steady-state wait - the case that catches a task
+/// which only notices cancellation while handling an inbound item.
+#[rstest]
+#[tokio::test]
+async fn test_shutdown_from_idle_relayer() {
+    let setup = TestSetup::new().await.expect("Failed to create test setup");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let start = Instant::now();
+    timeout(SHUTDOWN_HANG_LIMIT, setup.shutdown())
+        .await
+        .expect("shutdown never completed from idle");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < COOPERATIVE_SHUTDOWN_MAX,
+        "idle shutdown took {elapsed:?}, so a step drained to its budget"
+    );
+}
+
+/// The relayer keeps serving while its health check fails, so a request routed before the
+/// endpoint removal reaches the ingress controller gets a 503 from a pod still listening
+/// rather than a refused connection.
+#[rstest]
+#[tokio::test]
+async fn test_health_reports_503_while_still_serving() {
+    let setup = TestSetup::new_with_lb_propagation_wait("5s")
+        .await
+        .expect("Failed to create test setup");
+    let url = format!("http://localhost:{}/healthz", setup.http_port);
+
+    assert_eq!(
+        reqwest::get(&url).await.unwrap().status(),
+        200,
+        "the relayer should be healthy before shutdown starts"
+    );
+
+    setup.begin_shutdown();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let response = reqwest::get(&url)
+        .await
+        .expect("the HTTP server closed inside the propagation window");
+    assert_eq!(
+        response.status(),
+        503,
+        "readiness should already be failing while the server still serves"
+    );
+
+    setup.shutdown().await;
+}

--- a/relayer/tests/shutdown_test.rs
+++ b/relayer/tests/shutdown_test.rs
@@ -1,13 +1,9 @@
 //! Graceful shutdown tests.
 //!
-//! These assert only that shutdown terminates and that no step reached its budget - a
-//! regression guard for adding a background task without a shutdown token.
+//! A regression guard for adding a background task without a shutdown token: these assert
+//! only that shutdown terminates and that no step reached its budget.
 //!
-//! The test config sets `shutdown.lb_propagation_wait` to zero, so the times below measure
-//! the work of shutting down rather than the wait for a load balancer that is not there.
-//!
-//! Not covered: SIGTERM is never sent - these cancel the token directly and do not run as
-//! PID 1.
+//! SIGTERM is never sent - these cancel the token directly and do not run as PID 1.
 
 mod common;
 
@@ -16,14 +12,12 @@ use rstest::rstest;
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
 
-/// Observed drains are microseconds and the smallest budget (`STOP_WORK_TIMEOUT`) is 5s, so
-/// this sits clear of both.
+/// Observed drains are microseconds, `STOP_WORK_TIMEOUT` is 5s; this sits clear of both.
 const COOPERATIVE_SHUTDOWN_MAX: Duration = Duration::from_secs(2);
 
 /// Separates "slow" from "hung" so a deadlock fails instead of stalling the suite.
 const SHUTDOWN_HANG_LIMIT: Duration = Duration::from_secs(60);
 
-/// Shutdown terminates, and no step falls back to aborting.
 #[rstest]
 #[tokio::test]
 async fn test_shutdown_completes_without_reaching_budgets() {
@@ -42,8 +36,7 @@ async fn test_shutdown_completes_without_reaching_budgets() {
     );
 }
 
-/// The same, once every task is idle at its steady-state wait - the case that catches a task
-/// which only notices cancellation while handling an inbound item.
+/// From idle - catches a task that only notices cancellation while handling an item.
 #[rstest]
 #[tokio::test]
 async fn test_shutdown_from_idle_relayer() {
@@ -63,9 +56,7 @@ async fn test_shutdown_from_idle_relayer() {
     );
 }
 
-/// The relayer keeps serving while its health check fails, so a request routed before the
-/// endpoint removal reaches the ingress controller gets a 503 from a pod still listening
-/// rather than a refused connection.
+/// A request arriving in the propagation window gets a 503, not a refused connection.
 #[rstest]
 #[tokio::test]
 async fn test_health_reports_503_while_still_serving() {

--- a/test-suite/fhevm/config/relayer/local.yaml
+++ b/test-suite/fhevm/config/relayer/local.yaml
@@ -215,3 +215,8 @@ storage:
     user_decrypt_expiry: "7d"
     input_proof_expiry: "7d"
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # Time to keep serving after /healthz starts failing, so the pod's removal from the service
+  # endpoints reaches the ingress controller before the socket closes.
+  lb_propagation_wait: "5s"

--- a/test-suite/fhevm/config/relayer/local.yaml
+++ b/test-suite/fhevm/config/relayer/local.yaml
@@ -217,6 +217,6 @@ storage:
     cron_startup_delay_after_recovery: "30s"
 
 shutdown:
-  # Time to keep serving after /healthz starts failing, so the pod's removal from the service
-  # endpoints reaches the ingress controller before the socket closes.
+  # Covers the lag until the pod's removal from the service endpoints reaches the ingress
+  # controller. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
   lb_propagation_wait: "5s"

--- a/test-suite/fhevm/templates/config/relayer.yaml
+++ b/test-suite/fhevm/templates/config/relayer.yaml
@@ -220,6 +220,6 @@ storage:
     cron_startup_delay_after_recovery: "30s"
 
 shutdown:
-  # Time to keep serving after /healthz starts failing, so the pod's removal from the service
-  # endpoints reaches the ingress controller before the socket closes.
+  # Covers the lag until the pod's removal from the service endpoints reaches the ingress
+  # controller. Shutdown as a whole must finish inside terminationGracePeriodSeconds.
   lb_propagation_wait: "5s"

--- a/test-suite/fhevm/templates/config/relayer.yaml
+++ b/test-suite/fhevm/templates/config/relayer.yaml
@@ -218,3 +218,8 @@ storage:
     user_decrypt_expiry: "7d"
     input_proof_expiry: "7d"
     cron_startup_delay_after_recovery: "30s"
+
+shutdown:
+  # Time to keep serving after /healthz starts failing, so the pod's removal from the service
+  # endpoints reaches the ingress controller before the socket closes.
+  lb_propagation_wait: "5s"


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1945.

Second of three stacked PRs, on top of #3647 — that one first. The shutdown policy here relies on its guarantee that an unfinished event leaves the recorded chain position untouched.

One commit. The shutdown sequence is in `startup.rs`; the readiness-worker changes are the part that is easiest to miss on a first read.

## Highlights for review

**In-flight readiness checks are cancelled on shutdown; in-flight sends are not.**

Cancelling a check is safe. It only reads an external endpoint, and the semaphore permit it holds is released when its future is dropped, so nothing is left behind.

A send is different. The nonce is taken and returned by explicit calls rather than by a guard that releases on drop, so cancelling after the RPC has already gone out would leave the nonce held with nothing left running to release it. Sends are therefore neither cancelled nor awaited — they are abandoned, and the next boot re-reads nonce state from the chain.

**The connection pools are no longer closed before exit.** Closing them waits on the connections the abandoned tasks still hold.

## Test plan

Local counts were measured at the top of the three-PR stack, not at this PR's tip in isolation.

- [ ] CI: relayer unit and integration suites (locally: 232 unit / 1 skipped, 407 integration, 21 mock-RPC).
- [ ] CI: clippy `-D warnings` and `cargo fmt -p fhevm-relayer --check`, both clean locally.
