### PR TITLE
fix(sdk): forward delegatorAddress through V2 permit parse/serialize

### DIFF
--- a/sdk/js-sdk/docs/api-reference.md
+++ b/sdk/js-sdk/docs/api-reference.md
@@ -286,11 +286,12 @@ serializeSignedDecryptionPermit(parameters: { readonly signedPermit: SignedDecry
   readonly eip712: Eip712Like;
   readonly signature: string;
   readonly signerAddress: string;
+  readonly delegatorAddress?: string | undefined;
 };
 
 parseTransportKeyPair(parameters: { readonly publicKey: string; readonly privateKey: string }): Promise<TransportKeyPair>;
 parseSignedDecryptionPermit(parameters: {
-  readonly serializedPermit: { readonly version: number; readonly eip712: Eip712Like; readonly signature: string; readonly signerAddress: string };
+  readonly serializedPermit: { readonly version: number; readonly eip712: Eip712Like; readonly signature: string; readonly signerAddress: string; readonly delegatorAddress?: string | undefined };
   readonly transportKeyPair: TransportKeyPair;
 }): Promise<SignedDecryptionPermit>;
 

--- a/sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
+++ b/sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
@@ -15,6 +15,8 @@ export type ParseSignedDecryptionPermitParameters = {
     readonly eip712: Eip712Like;
     readonly signature: string;
     readonly signerAddress: string;
+    /** V2 (unified) permits only — delegation is metadata alongside the signed message, not part of it. */
+    readonly delegatorAddress?: string | undefined;
   };
   /** The transport key pair that was used when signing the permit. */
   readonly transportKeyPair: TransportKeyPair;

--- a/sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
+++ b/sdk/js-sdk/src/core/actions/chain/parseSignedDecryptionPermit.ts
@@ -15,7 +15,6 @@ export type ParseSignedDecryptionPermitParameters = {
     readonly eip712: Eip712Like;
     readonly signature: string;
     readonly signerAddress: string;
-    /** V2 (unified) permits only — delegation is metadata alongside the signed message, not part of it. */
     readonly delegatorAddress?: string | undefined;
   };
   /** The transport key pair that was used when signing the permit. */

--- a/sdk/js-sdk/src/core/actions/chain/serializeSignedDecryptionPermit.ts
+++ b/sdk/js-sdk/src/core/actions/chain/serializeSignedDecryptionPermit.ts
@@ -17,7 +17,6 @@ export type SerializeSignedDecryptionPermitReturnType = {
   readonly eip712: Eip712Like;
   readonly signature: string;
   readonly signerAddress: string;
-  /** V2 (unified) permits only — delegation is metadata alongside the signed message, not part of it. */
   readonly delegatorAddress?: string | undefined;
 };
 

--- a/sdk/js-sdk/src/core/actions/chain/serializeSignedDecryptionPermit.ts
+++ b/sdk/js-sdk/src/core/actions/chain/serializeSignedDecryptionPermit.ts
@@ -17,6 +17,8 @@ export type SerializeSignedDecryptionPermitReturnType = {
   readonly eip712: Eip712Like;
   readonly signature: string;
   readonly signerAddress: string;
+  /** V2 (unified) permits only — delegation is metadata alongside the signed message, not part of it. */
+  readonly delegatorAddress?: string | undefined;
 };
 
 /**

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
@@ -64,6 +64,7 @@ export function serializeSignedDecryptionPermitToJSON(permit: SignedDecryptionPe
       eip712: Eip712Like;
       signature: string;
       signerAddress: string;
+      delegatorAddress?: string | undefined;
     } {
   assertIsSignedDecryptionPermit(permit, {});
 
@@ -88,6 +89,12 @@ export function serializeSignedDecryptionPermitToJSON(permit: SignedDecryptionPe
     eip712: _toJsonSafeEip712(permit.eip712),
     signature: permit.signature,
     signerAddress: permit.signerAddress,
+    // Unlike V1 (where delegation is embedded in eip712.message), V2 keeps
+    // delegation as metadata alongside the signed message — see
+    // SignedDecryptionPermitV2-p.ts — so it has to be serialized separately.
+    // Derived via the public getters (isDelegated / encryptedDataOwnerAddress),
+    // matching the "does not access private fields" contract of this function.
+    delegatorAddress: permit.isDelegated ? permit.encryptedDataOwnerAddress : undefined,
   };
 }
 

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
@@ -89,11 +89,7 @@ export function serializeSignedDecryptionPermitToJSON(permit: SignedDecryptionPe
     eip712: _toJsonSafeEip712(permit.eip712),
     signature: permit.signature,
     signerAddress: permit.signerAddress,
-    // Unlike V1 (where delegation is embedded in eip712.message), V2 keeps
-    // delegation as metadata alongside the signed message — see
-    // SignedDecryptionPermitV2-p.ts — so it has to be serialized separately.
-    // Derived via the public getters (isDelegated / encryptedDataOwnerAddress),
-    // matching the "does not access private fields" contract of this function.
+    // V2 keeps delegation as metadata alongside the signed message, not inside it
     delegatorAddress: permit.isDelegated ? permit.encryptedDataOwnerAddress : undefined,
   };
 }

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermit-p.ts
@@ -89,7 +89,6 @@ export function serializeSignedDecryptionPermitToJSON(permit: SignedDecryptionPe
     eip712: _toJsonSafeEip712(permit.eip712),
     signature: permit.signature,
     signerAddress: permit.signerAddress,
-    // V2 keeps delegation as metadata alongside the signed message, not inside it
     delegatorAddress: permit.isDelegated ? permit.encryptedDataOwnerAddress : undefined,
   };
 }

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV1-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV1-p.ts
@@ -8,7 +8,7 @@ import type { KmsExtraData } from '../types/kms-p.js';
 import type { FhevmClientFrozenContext } from '../types/fhevmClientFrozenContext-p.js';
 import { verifyKmsUserDecryptEip712V1 } from '../utils-p/decrypt/verifyKmsUserDecryptEip712V1.js';
 import { verifyKmsDelegatedUserDecryptEip712V1 } from '../utils-p/decrypt/verifyKmsDelegatedUserDecryptEip712V1.js';
-import { assertRecordNonNullableProperty } from '../base/record.js';
+import { assertRecordNonNullableProperty, isRecordNonNullableProperty } from '../base/record.js';
 import { assertRecordBytes65HexProperty } from '../base/bytes.js';
 import { addressToChecksummedAddress, assertIsAddress, assertRecordAddressProperty } from '../base/address.js';
 import { assertIsKmsUserDecryptEip712V1, createKmsUserDecryptEip712V1 } from './createKmsUserDecryptEip712V1.js';
@@ -216,6 +216,19 @@ export async function parseSignedDecryptionPermitV1(
   assertRecordNonNullableProperty(permit, 'eip712', permitName, options);
   assertRecordBytes65HexProperty(permit, 'signature', permitName, options);
   assertRecordAddressProperty(permit, 'signerAddress', permitName, options);
+
+  // V1 delegation lives inside the signed eip712 message (primaryType
+  // 'DelegatedUserDecryptRequestVerification'), unlike V2 where it's post-sign
+  // metadata alongside the message. A top-level delegatorAddress here almost
+  // certainly means the permit was built for V2 and mistakenly parsed as V1 —
+  // reject it instead of silently ignoring it.
+  if (isRecordNonNullableProperty(permit, 'delegatorAddress')) {
+    throw new Error(
+      `Unexpected 'delegatorAddress' field on a V1 permit. Delegation for V1 permits is encoded in ` +
+        `the signed eip712 message (primaryType 'DelegatedUserDecryptRequestVerification'), not as a ` +
+        `top-level field. Did you mean to parse this as a V2 (unified) permit?`,
+    );
+  }
 
   const eip712 = permit.eip712;
   assertRecordStringProperty(eip712, 'primaryType', `${permitName}.eip712`, options);

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.test.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { isSignedDecryptionPermitV2, parseSignedDecryptionPermitV2 } from './SignedDecryptionPermitV2-p.js';
+import {
+  isSignedDecryptionPermitV2,
+  parseSignedDecryptionPermitV2,
+  signDecryptionPermitV2,
+} from './SignedDecryptionPermitV2-p.js';
 
 ////////////////////////////////////////////////////////////////////////////////
 // npx vitest run --config src/vitest.config.ts src/core/kms/SignedDecryptionPermitV2-p.test.ts
@@ -50,5 +54,23 @@ describe('parseSignedDecryptionPermitV2', () => {
     await expect(
       parseSignedDecryptionPermitV2({} as never, { transportKeyPair: {} as never, permit, fhevmContext: {} as never }),
     ).rejects.toThrow();
+  });
+});
+
+describe('signDecryptionPermitV2', () => {
+  it('rejects a delegated permit when signerAddress equals delegatorAddress', async () => {
+    const address = '0x1111111111111111111111111111111111111111';
+    await expect(
+      signDecryptionPermitV2({} as never, {
+        signerAddress: address,
+        delegatorAddress: address,
+        signer: {} as never,
+        contractAddresses: [],
+        startTimestamp: 0,
+        durationSeconds: 1,
+        transportKeyPair: {} as never,
+        fhevmContext: {} as never,
+      }),
+    ).rejects.toThrow('signerAddress and delegatorAddress must be different');
   });
 });

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
@@ -94,6 +94,22 @@ export function isSignedDecryptionPermitV2(value: unknown): value is SignedDecry
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// _assertSignerIsNotDelegator
+////////////////////////////////////////////////////////////////////////////////
+
+function _assertSignerIsNotDelegator(
+  signerAddress: ChecksummedAddress,
+  delegatorAddress: ChecksummedAddress | undefined,
+): void {
+  if (delegatorAddress !== undefined && signerAddress.toLowerCase() === delegatorAddress.toLowerCase()) {
+    throw new Error(
+      'signerAddress and delegatorAddress must be different. ' +
+        'Use a non-delegated permit to decrypt your own values.',
+    );
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // _createSignedDecryptionPermitV2
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -107,6 +123,8 @@ async function _createSignedDecryptionPermitV2(
   },
 ): Promise<SignedDecryptionPermitV2> {
   const { eip712, signature } = parameters;
+
+  _assertSignerIsNotDelegator(parameters.signerAddress, parameters.delegatorAddress);
 
   // Enforced here (the choke point shared by signDecryptionPermitV2 and
   // parseSignedDecryptionPermitV2). The message field is a validated uint256
@@ -150,6 +168,7 @@ export async function signDecryptionPermitV2(
   if (delegatorAddressArg !== undefined) {
     assertIsAddress(delegatorAddressArg, {});
     delegatorAddress = addressToChecksummedAddress(delegatorAddressArg);
+    _assertSignerIsNotDelegator(signerAddress, delegatorAddress);
   }
 
   // All message construction (KMS context read + extraData version assert, duration
@@ -195,6 +214,7 @@ export async function parseSignedDecryptionPermitV2(
   // step below auto-detects EOA vs ERC-1271 against `eip712.message.userAddress`.
   assertRecordBytesHexProperty(permit, 'signature', permitName, options);
   assertRecordAddressProperty(permit, 'signerAddress', permitName, options);
+  const signerAddress = addressToChecksummedAddress(permit.signerAddress);
 
   // Delegation is post-sign metadata, not part of the signed eip712 message,
   // so it's read from the permit object itself (mirrors signDecryptionPermitV2).
@@ -202,6 +222,7 @@ export async function parseSignedDecryptionPermitV2(
   if (isRecordNonNullableProperty(permit, 'delegatorAddress')) {
     assertRecordAddressProperty(permit, 'delegatorAddress', permitName, options);
     delegatorAddress = addressToChecksummedAddress(permit.delegatorAddress);
+    _assertSignerIsNotDelegator(signerAddress, delegatorAddress);
   }
 
   const eip712 = permit.eip712;
@@ -213,8 +234,6 @@ export async function parseSignedDecryptionPermitV2(
   }
 
   assertIsKmsUserDecryptEip712V2(eip712, `${permitName}.eip712`, options);
-
-  const signerAddress = addressToChecksummedAddress(permit.signerAddress);
 
   if (eip712.message.publicKey.toLowerCase() !== transportKeyPair.publicKey.toLowerCase()) {
     throw new Error(

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
@@ -196,10 +196,8 @@ export async function parseSignedDecryptionPermitV2(
   assertRecordBytesHexProperty(permit, 'signature', permitName, options);
   assertRecordAddressProperty(permit, 'signerAddress', permitName, options);
 
-  // Delegation is post-sign metadata for a V2 permit (not part of the signed
-  // eip712 message — see createUnsignedDecryptionPermitEip712V2), so it has
-  // to be read from the permit object itself rather than derived from the
-  // eip712, mirroring the optional-address handling in signDecryptionPermitV2.
+  // Delegation is post-sign metadata, not part of the signed eip712 message,
+  // so it's read from the permit object itself (mirrors signDecryptionPermitV2).
   let delegatorAddress: ChecksummedAddress | undefined;
   if (isRecordNonNullableProperty(permit, 'delegatorAddress')) {
     assertRecordAddressProperty(permit, 'delegatorAddress', permitName, options);

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
@@ -4,7 +4,7 @@ import type { BytesHex, ChecksummedAddress, Uint8Number } from '../types/primiti
 import type { KmsSignDecryptionPermitContext, KmsSignDecryptionPermitParameters } from './SignedDecryptionPermit-p.js';
 import type { KmsExtraData } from '../types/kms-p.js';
 import type { FhevmClientFrozenContext } from '../types/fhevmClientFrozenContext-p.js';
-import { assertRecordNonNullableProperty } from '../base/record.js';
+import { assertRecordNonNullableProperty, isRecordNonNullableProperty } from '../base/record.js';
 import { assertRecordBytesHexProperty } from '../base/bytes.js';
 import { addressToChecksummedAddress, assertIsAddress, assertRecordAddressProperty } from '../base/address.js';
 import { assertRecordStringProperty } from '../base/string.js';
@@ -196,6 +196,16 @@ export async function parseSignedDecryptionPermitV2(
   assertRecordBytesHexProperty(permit, 'signature', permitName, options);
   assertRecordAddressProperty(permit, 'signerAddress', permitName, options);
 
+  // Delegation is post-sign metadata for a V2 permit (not part of the signed
+  // eip712 message — see createUnsignedDecryptionPermitEip712V2), so it has
+  // to be read from the permit object itself rather than derived from the
+  // eip712, mirroring the optional-address handling in signDecryptionPermitV2.
+  let delegatorAddress: ChecksummedAddress | undefined;
+  if (isRecordNonNullableProperty(permit, 'delegatorAddress')) {
+    assertRecordAddressProperty(permit, 'delegatorAddress', permitName, options);
+    delegatorAddress = addressToChecksummedAddress(permit.delegatorAddress);
+  }
+
   const eip712 = permit.eip712;
   assertRecordStringProperty(eip712, 'primaryType', `${permitName}.eip712`, options);
   const primaryType = (eip712 as Record<string, unknown>).primaryType;
@@ -219,6 +229,7 @@ export async function parseSignedDecryptionPermitV2(
     signature: permit.signature,
     eip712,
     signerAddress,
+    delegatorAddress,
   });
 }
 

--- a/sdk/js-sdk/src/core/types/signedDecryptionPermit.ts
+++ b/sdk/js-sdk/src/core/types/signedDecryptionPermit.ts
@@ -54,8 +54,10 @@ export type SignedDecryptionPermitV1 = SignedDecryptionPermitBase & {
  * Signed decryption permit produced by protocol v14 and above.
  *
  * Uses the unified `KmsUserDecryptEip712V2` EIP-712 shape — there is no longer
- * a separate delegated variant. The `encryptedDataOwnerAddress` is read from
- * `eip712.message.userAddress` and may differ from `signerAddress`.
+ * a separate delegated variant. `eip712.message.userAddress` always equals
+ * `signerAddress`; delegation is post-sign metadata carried alongside the
+ * signed message, not part of it, so `encryptedDataOwnerAddress` may differ
+ * from `signerAddress` even though the eip712 message never does.
  *
  * The `signature` is widened to {@link BytesHex} to carry ERC-1271 blobs (see
  * the `Signature` type parameter on {@link SignedDecryptionPermitBase}).

--- a/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.unifiedPermit.tests.ts
@@ -201,6 +201,75 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
       expect(permit.signerAddress.toLowerCase()).toBe(config.wallet.address.toLowerCase());
     });
 
+    it('signs and parses a manually-built DELEGATED unified permit (createUnsignedUnifiedDecryptionPermitEip712)', async () => {
+      // Delegation is post-sign metadata, so it's attached to the permit object
+      // handed to parseSignedDecryptionPermit rather than derived from the eip712.
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      const eip712 = await createUnsignedUnifiedDecryptionPermitEip712(client, {
+        transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.bob.wallet.address,
+      });
+
+      // Strip EIP712Domain — ethers derives it from `domain`.
+      const { EIP712Domain: _domainType, ...requestTypes } = eip712.types;
+      const signature = await config.bob.wallet.signTypedData(
+        eip712.domain as ethers.TypedDataDomain,
+        requestTypes as Record<string, ethers.TypedDataField[]>,
+        eip712.message,
+      );
+
+      const permit = await client.parseSignedDecryptionPermit({
+        serializedPermit: {
+          version: 2,
+          eip712,
+          signature,
+          signerAddress: config.bob.wallet.address,
+          delegatorAddress: config.alice.wallet.address,
+        },
+        transportKeyPair,
+      });
+
+      expect(permit.version).toBe(2);
+      expect(permit.isDelegated).toBe(true);
+      expect(permit.signerAddress.toLowerCase()).toBe(config.bob.wallet.address.toLowerCase());
+      expect(permit.encryptedDataOwnerAddress.toLowerCase()).toBe(config.alice.wallet.address.toLowerCase());
+    });
+
+    it('should serialize, parse and verify a DELEGATED unified decryption permit', async () => {
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      const signedPermit = await client.signUnifiedDecryptionPermit({
+        transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.bob.wallet.address,
+        signer: config.bob.signer,
+        delegatorAddress: config.alice.wallet.address,
+      });
+      expect(signedPermit.version).toBe(2);
+      expect(signedPermit.isDelegated).toBe(true);
+
+      const serialized = await client.serializeSignedDecryptionPermit({ signedPermit });
+      expect(serialized.version).toBe(2);
+      expect(serialized.delegatorAddress?.toLowerCase()).toBe(config.alice.wallet.address.toLowerCase());
+
+      const parsed = await client.parseSignedDecryptionPermit({
+        serializedPermit: serialized,
+        transportKeyPair,
+      });
+      expect(parsed.version).toBe(2);
+      expect(parsed.isDelegated).toBe(true);
+      expect(parsed.signerAddress.toLowerCase()).toBe(config.bob.wallet.address.toLowerCase());
+      expect(parsed.encryptedDataOwnerAddress.toLowerCase()).toBe(config.alice.wallet.address.toLowerCase());
+    });
+
     // ┌─────────────────────────────────────────────────────────────────────┐
     // │  Per-type decrypt tests (V2 permit, routed through the v3 relayer   │
     // │  user-decrypt endpoint via fetchKmsSigncryptedSharesV2)             │

--- a/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.unifiedPermit.tests.ts
@@ -270,6 +270,42 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
       expect(parsed.encryptedDataOwnerAddress.toLowerCase()).toBe(config.alice.wallet.address.toLowerCase());
     });
 
+    it('rejects signing a DELEGATED unified permit when signerAddress equals delegatorAddress', async () => {
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      await expect(
+        client.signUnifiedDecryptionPermit({
+          transportKeyPair,
+          contractAddresses: [config.fheTestAddress],
+          durationSeconds: 24 * 3600,
+          startTimestamp: Math.floor(Date.now() / 1000) - 5,
+          signerAddress: config.bob.wallet.address,
+          signer: config.bob.signer,
+          delegatorAddress: config.bob.wallet.address,
+        }),
+      ).rejects.toThrow('signerAddress and delegatorAddress must be different');
+    });
+
+    it('rejects parsing a DELEGATED unified permit when signerAddress equals delegatorAddress', async () => {
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+      const address = config.bob.wallet.address;
+
+      await expect(
+        client.parseSignedDecryptionPermit({
+          serializedPermit: {
+            version: 2,
+            eip712: { primaryType: 'UserDecryptRequestVerification', message: {} },
+            signature: `0x${'11'.repeat(65)}`,
+            signerAddress: address,
+            delegatorAddress: address,
+          },
+          transportKeyPair,
+        }),
+      ).rejects.toThrow('signerAddress and delegatorAddress must be different');
+    });
+
     // ┌─────────────────────────────────────────────────────────────────────┐
     // │  Per-type decrypt tests (V2 permit, routed through the v3 relayer   │
     // │  user-decrypt endpoint via fetchKmsSigncryptedSharesV2)             │

--- a/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
@@ -244,6 +244,42 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
       expect(parsed.encryptedDataOwnerAddress.toLowerCase()).toBe(config.alice.account.address.toLowerCase());
     });
 
+    it('rejects signing a DELEGATED unified permit when signerAddress equals delegatorAddress', async () => {
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      await expect(
+        client.signUnifiedDecryptionPermit({
+          transportKeyPair,
+          contractAddresses: [config.fheTestAddress],
+          durationSeconds: 24 * 3600,
+          startTimestamp: Math.floor(Date.now() / 1000) - 5,
+          signerAddress: config.bob.account.address,
+          signer: config.bob.account,
+          delegatorAddress: config.bob.account.address,
+        }),
+      ).rejects.toThrow('signerAddress and delegatorAddress must be different');
+    });
+
+    it('rejects parsing a DELEGATED unified permit when signerAddress equals delegatorAddress', async () => {
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+      const address = config.bob.account.address;
+
+      await expect(
+        client.parseSignedDecryptionPermit({
+          serializedPermit: {
+            version: 2,
+            eip712: { primaryType: 'UserDecryptRequestVerification', message: {} },
+            signature: `0x${'11'.repeat(65)}`,
+            signerAddress: address,
+            delegatorAddress: address,
+          },
+          transportKeyPair,
+        }),
+      ).rejects.toThrow('signerAddress and delegatorAddress must be different');
+    });
+
     // ┌─────────────────────────────────────────────────────────────────────┐
     // │  Per-type decrypt tests (V2 permit, routed through the v3 relayer   │
     // │  user-decrypt endpoint via fetchKmsSigncryptedSharesV2)             │

--- a/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
@@ -177,11 +177,8 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
     });
 
     it('signs and parses a manually-built DELEGATED unified permit (createUnsignedUnifiedDecryptionPermitEip712)', async () => {
-      // Delegation is post-sign metadata for a V2 permit — not part of the signed
-      // eip712 message — so it must be attached to the object handed to
-      // parseSignedDecryptionPermit rather than derived from the eip712 itself.
-      // This is the offline-signing shape: build unsigned, sign out-of-process,
-      // reconstruct the permit object manually with `delegatorAddress` attached.
+      // Delegation is post-sign metadata, so it's attached to the permit object
+      // handed to parseSignedDecryptionPermit rather than derived from the eip712.
       const client = await createReadyClient();
       const transportKeyPair = await client.generateTransportKeyPair();
 

--- a/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
@@ -176,6 +176,77 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
       expect(permit.signerAddress.toLowerCase()).toBe(config.account.address.toLowerCase());
     });
 
+    it('signs and parses a manually-built DELEGATED unified permit (createUnsignedUnifiedDecryptionPermitEip712)', async () => {
+      // Delegation is post-sign metadata for a V2 permit — not part of the signed
+      // eip712 message — so it must be attached to the object handed to
+      // parseSignedDecryptionPermit rather than derived from the eip712 itself.
+      // This is the offline-signing shape: build unsigned, sign out-of-process,
+      // reconstruct the permit object manually with `delegatorAddress` attached.
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      const eip712 = await createUnsignedUnifiedDecryptionPermitEip712(client, {
+        transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.bob.account.address,
+      });
+
+      const signature = await config.bob.account.signTypedData({
+        domain: eip712.domain,
+        types: eip712.types,
+        primaryType: 'UserDecryptRequestVerification',
+        message: eip712.message,
+      } as Parameters<typeof config.bob.account.signTypedData>[0]);
+
+      const permit = await client.parseSignedDecryptionPermit({
+        serializedPermit: {
+          version: 2,
+          eip712,
+          signature,
+          signerAddress: config.bob.account.address,
+          delegatorAddress: config.alice.account.address,
+        },
+        transportKeyPair,
+      });
+
+      expect(permit.version).toBe(2);
+      expect(permit.isDelegated).toBe(true);
+      expect(permit.signerAddress.toLowerCase()).toBe(config.bob.account.address.toLowerCase());
+      expect(permit.encryptedDataOwnerAddress.toLowerCase()).toBe(config.alice.account.address.toLowerCase());
+    });
+
+    it('should serialize, parse and verify a DELEGATED unified decryption permit', async () => {
+      const client = await createReadyClient();
+      const transportKeyPair = await client.generateTransportKeyPair();
+
+      const signedPermit = await client.signUnifiedDecryptionPermit({
+        transportKeyPair,
+        contractAddresses: [config.fheTestAddress],
+        durationSeconds: 24 * 3600,
+        startTimestamp: Math.floor(Date.now() / 1000) - 5,
+        signerAddress: config.bob.account.address,
+        signer: config.bob.account,
+        delegatorAddress: config.alice.account.address,
+      });
+      expect(signedPermit.version).toBe(2);
+      expect(signedPermit.isDelegated).toBe(true);
+
+      const serialized = await client.serializeSignedDecryptionPermit({ signedPermit });
+      expect(serialized.version).toBe(2);
+      expect(serialized.delegatorAddress?.toLowerCase()).toBe(config.alice.account.address.toLowerCase());
+
+      const parsed = await client.parseSignedDecryptionPermit({
+        serializedPermit: serialized,
+        transportKeyPair,
+      });
+      expect(parsed.version).toBe(2);
+      expect(parsed.isDelegated).toBe(true);
+      expect(parsed.signerAddress.toLowerCase()).toBe(config.bob.account.address.toLowerCase());
+      expect(parsed.encryptedDataOwnerAddress.toLowerCase()).toBe(config.alice.account.address.toLowerCase());
+    });
+
     // ┌─────────────────────────────────────────────────────────────────────┐
     // │  Per-type decrypt tests (V2 permit, routed through the v3 relayer   │
     // │  user-decrypt endpoint via fetchKmsSigncryptedSharesV2)             │


### PR DESCRIPTION
parseSignedDecryptionPermitV2 never read delegatorAddress off the input permit, silently dropping delegation for a manually-reconstructed V2 permit (the offline-signing shape). serializeSignedDecryptionPermitToJSON has the same gap on the other side: a delegated permit signed via signUnifiedDecryptionPermit loses its delegation on the sign -> serialize -> parse round trip.

V1 doesn't hit this because delegatorAddress lives inside eip712.message; V2 keeps it as post-sign metadata, so it has to be carried explicitly at every boundary. Adds two tests mirroring the existing manual-sign and serialize/parse patterns, covering the delegated case for both.

