### PR TITLE
ci(test-suite): install published @fhevm/sdk on release docker builds

### DIFF
--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -48,6 +48,53 @@ jobs:
     uses: ./.github/workflows/is-latest-commit.yml
     if: github.event_name == 'push'
 
+  # On `release` events, resolve the npm-compatible SDK version from the
+  # release tag (e.g. `v0.14.1-0` -> `0.14.1-0`) so the docker build can
+  # install @fhevm/sdk@<version> from the registry. Off-release the output
+  # stays empty and the Dockerfile falls back to SDK_SOURCE=local.
+  #
+  # The sibling js-sdk-publish workflow also triggers on `release: published`
+  # and runs in parallel with this one — the wait step below blocks the build
+  # job until @fhevm/sdk@<version> is actually resolvable on npm, so the
+  # Dockerfile's `npm install @fhevm/sdk@<version>` doesn't race the publish.
+  # Historical js-sdk-publish runtime is ~2m30s, so 5 minutes covers it with
+  # ~2m headroom for npm CDN propagation.
+  compute-sdk-version:
+    name: Compute SDK version
+    runs-on: ubuntu-latest
+    outputs:
+      sdk_version: ${{ steps.strip.outputs.sdk_version }}
+    steps:
+      - name: Strip leading v from release tag
+        id: strip
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            echo "sdk_version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sdk_version=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for @fhevm/sdk on npm
+        if: github.event_name == 'release'
+        env:
+          SDK_VERSION: ${{ steps.strip.outputs.sdk_version }}
+        run: |
+          # Poll `npm view` until the freshly-published version is visible.
+          # 30 attempts * 10s = 5 minutes total wait.
+          for attempt in $(seq 1 30); do
+            if npm view "@fhevm/sdk@${SDK_VERSION}" version >/dev/null 2>&1; then
+              echo "@fhevm/sdk@${SDK_VERSION} is available on npm (attempt ${attempt})"
+              exit 0
+            fi
+            echo "attempt ${attempt}/30: @fhevm/sdk@${SDK_VERSION} not yet on npm, sleeping 10s..."
+            sleep 10
+          done
+          echo "::error::timed out after 5 minutes waiting for @fhevm/sdk@${SDK_VERSION} on npm" >&2
+          exit 1
+
   check-changes:
     if: github.event_name == 'push' || inputs.is_workflow_call
     uses: ./.github/workflows/check-changes-for-docker-build.yml
@@ -70,7 +117,7 @@ jobs:
           - 'sdk/js-sdk/**'
 
   build:
-    needs: [is-latest-commit, check-changes]
+    needs: [is-latest-commit, check-changes, compute-sdk-version]
     if: |
       always()
       && (
@@ -79,7 +126,7 @@ jobs:
         || (github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes == 'true')
         || (inputs.is_workflow_call && needs.check-changes.outputs.changes == 'true')
       )
-    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@542103e14b9ae6a9aea27787b8724b3b35bb3918 # v1.0.9
+    uses: zama-ai/ci-templates/.github/workflows/common-docker.yml@9d706c6ba52a0ceed3c9048227ae6b4ae40b5fe6 # main
     secrets:
       AWS_ACCESS_KEY_S3_USER: ${{ secrets.AWS_ACCESS_KEY_S3_USER }}
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
@@ -98,6 +145,12 @@ jobs:
       image-name: "fhevm/test-suite/e2e"
       docker-file: "./test-suite/e2e/Dockerfile"
       app-cache-dir: "fhevm-test-suite-e2e"
+      # SDK_SOURCE / SDK_VERSION are consumed by test-suite/e2e/Dockerfile.
+      # On `release` events install the published @fhevm/sdk@<version> from
+      # the npm registry; otherwise fall back to the local sdk/js-sdk build.
+      build-args: |
+        SDK_SOURCE=${{ github.event_name == 'release' && 'registry' || 'local' }}
+        SDK_VERSION=${{ needs.compute-sdk-version.outputs.sdk_version }}
 
   re-tag-image:
     needs: [is-latest-commit, check-changes]


### PR DESCRIPTION
Backport of PR #3637 (release/0.13.x) to release/0.14.x.

Pass SDK_SOURCE / SDK_VERSION build-args to the test-suite e2e docker build so that, on `release` events, the image bundles the published @fhevm/sdk@<version> from the npm registry instead of a workspace build. On push / workflow_dispatch / workflow_call the Dockerfile keeps its default SDK_SOURCE=local behaviour (build + pack sdk/js-sdk).

- Add compute-sdk-version job that:
  1. Strips the leading `v` from the release tag (v0.14.1-0 -> 0.14.1-0) so it slots directly into `npm install @fhevm/sdk@<version>` inside the Dockerfile's install-sdk.sh.
  2. Polls `npm view @fhevm/sdk@<version>` on release events with a 5-minute timeout, so the docker build doesn't race the sibling js-sdk-publish workflow (which also triggers on release: published and runs in parallel).
- Pass SDK_SOURCE and SDK_VERSION via the reusable workflow's `build-args` input.
- Bump the ci-templates pin from v1.0.9 to a main-branch SHA carrying the `build-args` input support.

Requires the SDK_SOURCE / SDK_VERSION Dockerfile ARGs from #3593 (or the 0.14.x backport #3606) to be present on this branch.