### PR TITLE
fix(sdk): fix linter errors on release/0.14.x

### DIFF
--- a/.github/workflows/test-suite-docker-build.yml
+++ b/.github/workflows/test-suite-docker-build.yml
@@ -35,7 +35,7 @@ on:
       - published
   workflow_dispatch:
   push:
-    branches: ['main', 'release/*']
+    branches: ["main", "release/*"]
 
 permissions: {}
 
@@ -54,9 +54,9 @@ jobs:
     secrets:
       GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
     permissions:
-      actions: 'read' # Required to read workflow run information
-      contents: 'read' # Required to checkout repository code
-      pull-requests: 'read' # Required to read pull request information
+      actions: "read" # Required to read workflow run information
+      contents: "read" # Required to checkout repository code
+      pull-requests: "read" # Required to read pull request information
     with:
       caller-workflow-event-name: ${{ github.event_name }}
       caller-workflow-event-before: ${{ github.event.before }}
@@ -67,6 +67,7 @@ jobs:
           - '.github/workflows/test-suite-docker-build.yml'
           - 'test-suite/e2e/**'
           - 'library-solidity/**'
+          - 'sdk/js-sdk/**'
 
   build:
     needs: [is-latest-commit, check-changes]
@@ -84,12 +85,12 @@ jobs:
       AWS_SECRET_KEY_S3_USER: ${{ secrets.AWS_SECRET_KEY_S3_USER }}
       BLOCKCHAIN_ACTIONS_TOKEN: ${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}
     permissions:
-      actions: 'read' # Required to read workflow run information
-      contents: 'read' # Required to checkout repository code
-      pull-requests: 'read' # Required to read pull request information
-      attestations: 'write' # Required to create build attestations
-      packages: 'write' # Required to publish Docker images
-      id-token: 'write' # Required for OIDC authentication
+      actions: "read" # Required to read workflow run information
+      contents: "read" # Required to checkout repository code
+      pull-requests: "read" # Required to read pull request information
+      attestations: "write" # Required to create build attestations
+      packages: "write" # Required to publish Docker images
+      id-token: "write" # Required for OIDC authentication
     with:
       working-directory: "."
       docker-context: "."
@@ -106,10 +107,10 @@ jobs:
         github.event_name == 'push' && needs.is-latest-commit.outputs.is_latest == 'true' && needs.check-changes.outputs.changes != 'true'
       )
     permissions:
-      actions: 'read' # Required to read workflow run information
-      contents: 'read' # Required to checkout repository code
-      packages: 'write' # Required to publish Docker images
-      id-token: 'write' # Required for OIDC authentication
+      actions: "read" # Required to read workflow run information
+      contents: "read" # Required to checkout repository code
+      packages: "write" # Required to publish Docker images
+      id-token: "write" # Required for OIDC authentication
     uses: ./.github/workflows/re-tag-docker-image.yml
     with:
       image-name: "fhevm/test-suite/e2e"

--- a/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
+++ b/sdk/js-sdk/src/core/kms/SignedDecryptionPermitV2-p.ts
@@ -101,7 +101,7 @@ function _assertSignerIsNotDelegator(
   signerAddress: ChecksummedAddress,
   delegatorAddress: ChecksummedAddress | undefined,
 ): void {
-  if (delegatorAddress !== undefined && signerAddress.toLowerCase() === delegatorAddress.toLowerCase()) {
+  if (signerAddress.toLowerCase() === delegatorAddress?.toLowerCase()) {
     throw new Error(
       'signerAddress and delegatorAddress must be different. ' +
         'Use a non-delegated permit to decrypt your own values.',

--- a/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/ethers-common/clientDecrypt.unifiedPermit.tests.ts
@@ -296,7 +296,7 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
         client.parseSignedDecryptionPermit({
           serializedPermit: {
             version: 2,
-            eip712: { primaryType: 'UserDecryptRequestVerification', message: {} },
+            eip712: { primaryType: 'UserDecryptRequestVerification', domain: {}, types: {}, message: {} },
             signature: `0x${'11'.repeat(65)}`,
             signerAddress: address,
             delegatorAddress: address,

--- a/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
+++ b/sdk/js-sdk/test/fheTest/viem-common/clientDecrypt.unifiedPermit.tests.ts
@@ -270,7 +270,7 @@ export function defineClientDecryptUnifiedPermitTests(parameters: {
         client.parseSignedDecryptionPermit({
           serializedPermit: {
             version: 2,
-            eip712: { primaryType: 'UserDecryptRequestVerification', message: {} },
+            eip712: { primaryType: 'UserDecryptRequestVerification', domain: {}, types: {}, message: {} },
             signature: `0x${'11'.repeat(65)}`,
             signerAddress: address,
             delegatorAddress: address,


### PR DESCRIPTION
## Summary
- Fix an `@typescript-eslint/prefer-optional-chain` lint error in `_assertSignerIsNotDelegator` by rewriting the delegator check as `signerAddress.toLowerCase() === delegatorAddress?.toLowerCase()`, preserving the same behavior (a `string === undefined` comparison never matches).
- Fix a `tsc` type error (`TS2739`) in two `clientDecrypt.unifiedPermit.tests.ts` suites (ethers-common and viem-common) where a test's `eip712` literal was missing the `domain` and `types` fields required by `Eip712Like`; added empty placeholders since the delegator-equality check under test throws before either field is read.
- Normalize quoting style (single → double quotes) in `test-suite-docker-build.yml` and add `sdk/js-sdk/**` to its `check-changes` path filters so SDK changes trigger this workflow.
