### PR TITLE
test(coprocessor): add benchmarks and test suite updates for GPU

### DIFF
--- a/.github/actions/gpu_setup/action.yml
+++ b/.github/actions/gpu_setup/action.yml
@@ -1,13 +1,16 @@
-name: Setup Cuda
-description: Setup Cuda on Hyperstack or GitHub instance
+name: Setup CUDA
+description: Set up CUDA and its host compiler on a GPU runner
 
 inputs:
   cuda-version:
-    description: Version of Cuda to use
+    description: Space-separated acceptable CUDA versions; installs the first if none are present
     required: true
-  github-instance:
-    description: Instance is hosted on GitHub
-    default: 'false'
+  gcc-version:
+    description: Version of GCC to use as the CUDA host compiler
+    required: true
+  cloud-provider:
+    description: Cloud provider hosting the GPU runner
+    required: true
 
 runs:
   using: "composite"
@@ -16,25 +19,126 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        sudo apt update
-        curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo gpg --dearmour -o /etc/apt/trusted.gpg.d/kitware.gpg
-        sudo chmod 644 /etc/apt/trusted.gpg.d/kitware.gpg
-        echo 'deb [signed-by=/etc/apt/trusted.gpg.d/kitware.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-        sudo apt update
-        sudo apt install -y cmake cmake-format libclang-dev
+        # Download outside the checkout: a downloaded file left in the workspace
+        # makes the tree dirty, which reportable benchmark targets refuse to
+        # measure on.
+        CMAKE_SCRIPT="${RUNNER_TEMP}/cmake-${CMAKE_VERSION}-linux-x86_64.sh"
+        wget -O "${CMAKE_SCRIPT}" \
+          https://github.com/Kitware/CMake/releases/download/v"${CMAKE_VERSION}"/cmake-"${CMAKE_VERSION}"-linux-x86_64.sh
+        echo "${CMAKE_SCRIPT_SHA}  ${CMAKE_SCRIPT}" | sha256sum --check
+        sudo bash "${CMAKE_SCRIPT}" \
+          --skip-license --prefix=/usr/ --exclude-subdir
 
-    - name: Install CUDA
-      if: inputs.github-instance == 'true'
+        # Reset the package lists so apt-get update cannot trip over stale
+        # metadata baked into the image.
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+
+        # Wait for the dpkg lock rather than failing on it: a freshly booted
+        # image is still running its apt-daily timers. The wait covers every
+        # lock holder, which masking and purging unattended-upgrades did not —
+        # it left apt-daily itself running.
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install -y cmake-format libclang-dev
+      env:
+        CMAKE_VERSION: 3.29.6
+        CMAKE_SCRIPT_SHA: 6e4fada5cba3472ae503a11232b6580786802f0879cead2741672bf65d97488a
+
+    - name: Install GCC
+      shell: bash
+      env:
+        GCC_VERSION: ${{ inputs.gcc-version }}
+      run: |
+        sudo apt-get -o DPkg::Lock::Timeout=600 install -y gcc-"${GCC_VERSION}" g++-"${GCC_VERSION}"
+        command -v gcc-"${GCC_VERSION}"
+        command -v g++-"${GCC_VERSION}"
+
+    - name: Check CUDA installation
+      id: check-cuda
       shell: bash
       env:
         CUDA_VERSION: ${{ inputs.cuda-version }}
       run: |
-        TOOLKIT_VERSION="$(echo ${CUDA_VERSION} | sed 's/\(.*\)\.\(.*\)/\1-\2/')"
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-        sudo dpkg -i cuda-keyring_1.1-1_all.deb
-        sudo apt update
-        sudo apt -y install cuda-toolkit-${TOOLKIT_VERSION}
+        read -ra CUDA_VERSIONS <<< "${CUDA_VERSION}"
+        if bash ci/detect_cuda.sh "${CUDA_VERSIONS[@]}"; then
+          echo "cuda-is-installed=true" >> "${GITHUB_OUTPUT}"
+          echo "An acceptable CUDA toolkit is already installed"
+        else
+          echo "cuda-is-installed=false" >> "${GITHUB_OUTPUT}"
+          echo "No acceptable CUDA toolkit was found; installation is required"
+        fi
 
-    - name: Check device is detected
+    - name: Install CUDA
+      if: steps.check-cuda.outputs.cuda-is-installed != 'true'
       shell: bash
-      run: nvidia-smi
+      env:
+        CUDA_VERSION: ${{ inputs.cuda-version }}
+        CUDA_KEYRING_PACKAGE: cuda-keyring_1.1-1_all.deb
+        CUDA_KEYRING_SHA: d93190d50b98ad4699ff40f4f7af50f16a76dac3bb8da1eaaf366d47898ff8df
+      run: |
+        CUDA_INSTALL_VERSION="${CUDA_VERSION%% *}"
+        TOOLKIT_VERSION="$(echo "${CUDA_INSTALL_VERSION}" | sed 's/\(.*\)\.\(.*\)/\1-\2/')"
+
+        # Take the repository for the distribution actually running, not a fixed
+        # one: the GPU images differ per cloud (jammy on hyperstack, noble on
+        # scaleway), and installing one distribution's CUDA packages on another
+        # lets apt resolve the conflict by removing or restarting packages the
+        # runner itself depends on.
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        if [ "${ID:-}" != "ubuntu" ]; then
+          echo "Unsupported distribution '${ID:-unknown}': no NVIDIA CUDA repository mapping" >&2
+          exit 1
+        fi
+        CUDA_REPO="ubuntu${VERSION_ID//./}"
+        echo "Installing CUDA ${CUDA_INSTALL_VERSION} from the ${CUDA_REPO} repository"
+
+        # Download outside the checkout, as above.
+        CUDA_KEYRING="${RUNNER_TEMP}/${CUDA_KEYRING_PACKAGE}"
+        wget -O "${CUDA_KEYRING}" \
+          "https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO}/x86_64/${CUDA_KEYRING_PACKAGE}"
+        # The keyring package is the same artifact across repositories, so one
+        # pin covers them. If NVIDIA ever diverges them this fails loudly rather
+        # than installing an unverified keyring: re-pin for the new repository.
+        if ! echo "${CUDA_KEYRING_SHA}  ${CUDA_KEYRING}" | sha256sum --check; then
+          echo "Keyring checksum mismatch for ${CUDA_REPO}; update CUDA_KEYRING_SHA" >&2
+          exit 1
+        fi
+        sudo dpkg -i "${CUDA_KEYRING}"
+
+        # Reset the package lists so apt-get update cannot trip over stale
+        # metadata baked into the image.
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+
+        # Wait for the dpkg lock rather than failing on it: a freshly booted
+        # image is still running its apt-daily timers. The wait covers every
+        # lock holder, which masking and purging unattended-upgrades did not —
+        # it left apt-daily itself running.
+        sudo apt-get -o DPkg::Lock::Timeout=600 update
+        sudo apt-get -o DPkg::Lock::Timeout=600 install -y cuda-toolkit-"${TOOLKIT_VERSION}"
+
+    - name: Export CUDA variables
+      shell: bash
+      env:
+        CUDA_VERSION: ${{ inputs.cuda-version }}
+      run: |
+        read -ra CUDA_VERSIONS <<< "${CUDA_VERSION}"
+        bash ci/export_cuda_vars.sh "${GITHUB_ENV}" "${GITHUB_PATH}" "${CUDA_VERSIONS[@]}"
+
+    - name: Export host compiler variables
+      shell: bash
+      env:
+        GCC_VERSION: ${{ inputs.gcc-version }}
+      run: |
+        {
+          echo "CC=/usr/bin/gcc-${GCC_VERSION}"
+          echo "CXX=/usr/bin/g++-${GCC_VERSION}"
+          echo "CUDAHOSTCXX=/usr/bin/g++-${GCC_VERSION}"
+        } >> "${GITHUB_ENV}"
+
+    - name: Check setup
+      shell: bash
+      run: |
+        command -v nvcc
+        nvidia-smi

--- a/.github/actions/gpu_setup/action.yml
+++ b/.github/actions/gpu_setup/action.yml
@@ -74,7 +74,11 @@ runs:
       env:
         CUDA_VERSION: ${{ inputs.cuda-version }}
         CUDA_KEYRING_PACKAGE: cuda-keyring_1.1-1_all.deb
-        CUDA_KEYRING_SHA: d93190d50b98ad4699ff40f4f7af50f16a76dac3bb8da1eaaf366d47898ff8df
+        # One checksum per repository: the keyring package is built per
+        # distribution (its sources.list entry names the repository), so the
+        # jammy and noble artifacts differ.
+        CUDA_KEYRING_SHA_UBUNTU2204: d93190d50b98ad4699ff40f4f7af50f16a76dac3bb8da1eaaf366d47898ff8df
+        CUDA_KEYRING_SHA_UBUNTU2404: d2a6b11c096396d868758b86dab1823b25e14d70333f1dfa74da5ddaf6a06dba
       run: |
         CUDA_INSTALL_VERSION="${CUDA_VERSION%% *}"
         TOOLKIT_VERSION="$(echo "${CUDA_INSTALL_VERSION}" | sed 's/\(.*\)\.\(.*\)/\1-\2/')"
@@ -91,17 +95,26 @@ runs:
           exit 1
         fi
         CUDA_REPO="ubuntu${VERSION_ID//./}"
+        # Select the checksum alongside the repository; a release without a pin
+        # fails here rather than installing an unverified keyring.
+        case "${CUDA_REPO}" in
+          ubuntu2204) CUDA_KEYRING_SHA="${CUDA_KEYRING_SHA_UBUNTU2204}" ;;
+          ubuntu2404) CUDA_KEYRING_SHA="${CUDA_KEYRING_SHA_UBUNTU2404}" ;;
+          *)
+            echo "No keyring checksum pinned for ${CUDA_REPO}; add CUDA_KEYRING_SHA_${CUDA_REPO^^}" >&2
+            exit 1
+            ;;
+        esac
         echo "Installing CUDA ${CUDA_INSTALL_VERSION} from the ${CUDA_REPO} repository"
 
         # Download outside the checkout, as above.
         CUDA_KEYRING="${RUNNER_TEMP}/${CUDA_KEYRING_PACKAGE}"
         wget -O "${CUDA_KEYRING}" \
           "https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO}/x86_64/${CUDA_KEYRING_PACKAGE}"
-        # The keyring package is the same artifact across repositories, so one
-        # pin covers them. If NVIDIA ever diverges them this fails loudly rather
-        # than installing an unverified keyring: re-pin for the new repository.
+        # A mismatch means NVIDIA re-published the package: re-pin from a fresh
+        # download of that repository's artifact rather than skipping the check.
         if ! echo "${CUDA_KEYRING_SHA}  ${CUDA_KEYRING}" | sha256sum --check; then
-          echo "Keyring checksum mismatch for ${CUDA_REPO}; update CUDA_KEYRING_SHA" >&2
+          echo "Keyring checksum mismatch for ${CUDA_REPO}; update CUDA_KEYRING_SHA_${CUDA_REPO^^}" >&2
           exit 1
         fi
         sudo dpkg -i "${CUDA_KEYRING}"

--- a/.github/actions/gpu_setup/action.yml
+++ b/.github/actions/gpu_setup/action.yml
@@ -3,13 +3,13 @@ description: Set up CUDA and its host compiler on a GPU runner
 
 inputs:
   cuda-version:
-    description: Space-separated acceptable CUDA versions; installs the first if none are present
+    description: >-
+      Space-separated acceptable CUDA versions; installs the first if none are
+      present. List one version to pin every runner to it: a pre-installed
+      toolkit only counts when it is listed.
     required: true
   gcc-version:
     description: Version of GCC to use as the CUDA host compiler
-    required: true
-  cloud-provider:
-    description: Cloud provider hosting the GPU runner
     required: true
 
 runs:

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -15,6 +15,12 @@ on:
           - "dex"
           - "synthetics"
           - "all"
+          - "main_block_one_shot"
+      one_shot_scenarios:
+        description: "Reportable one-shot scenarios (space-separated, only used by the main_block_one_shot set; empty runs the canonical suite)"
+        required: false
+        type: string
+        default: ""
       batch_size:
         description: "Batch sizes (# FHE operations executed per batch)"
         required: true
@@ -38,6 +44,12 @@ on:
           - "THROUGHPUT"
           - "LATENCY"
         default: "ALL"
+
+# Queue dispatches rather than letting two runs compete for the single AWS bench
+# profile: one run's teardown would stop the instance the other is using.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -88,13 +100,10 @@ jobs:
     steps:
       - name: Install git LFS
         run: |
-          # Wait for apt locks to be released (e.g., unattended-upgrades may hold the lock on fresh instances)
-          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
-            echo "Waiting for apt lock to be released..."
-            sleep 5
-          done
-          sudo apt-get update
-          sudo apt-get install -y git-lfs
+          # A fresh instance is still running its apt-daily timers, so wait for
+          # the dpkg lock through apt itself rather than polling for it here.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y git-lfs
           git lfs install
 
       - name: Checkout fhevm-backend
@@ -123,11 +132,11 @@ jobs:
       - name: Install cargo dependencies
         run: |
           sudo systemctl stop docker
-          DEBIAN_FRONTEND=noninteractive sudo apt-get remove -y docker docker-engine docker.io containerd runc
-          DEBIAN_FRONTEND=noninteractive sudo apt-get purge -y docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-compose
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -o DPkg::Lock::Timeout=600 remove -y docker docker-engine docker.io containerd runc
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -o DPkg::Lock::Timeout=600 purge -y docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-compose
           sudo rm -rf /etc/bash_completion.d/docker /usr/local/bin/docker-compose /etc/bash_completion.d/docker-compose
-          DEBIAN_FRONTEND=noninteractive sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y protobuf-compiler cmake \
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -o DPkg::Lock::Timeout=600 update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -o DPkg::Lock::Timeout=600 install -y protobuf-compiler cmake \
                                                                  pkg-config libssl-dev \
                                                                  libclang-dev docker-compose-v2 \
                                                                  docker.io acl
@@ -164,9 +173,20 @@ jobs:
           username: ${{ secrets.CGR_USERNAME }}
           password: ${{ secrets.CGR_PASSWORD }}
 
+      # The one-shot suite needs a schema, not an image: bring up postgres and
+      # apply the migrations with the sqlx CLI installed above. Building the
+      # migration image here would compile the whole workspace a second time,
+      # under whole-machine load, for a binary this benchmark never runs.
       - name: Init database
-        run: make init_db
+        run: |
+          if [[ "${BENCHMARKS}" == "main_block_one_shot" ]]; then
+            make bench_db_up
+          else
+            make init_db
+          fi
         working-directory: coprocessor/fhevm-engine/tfhe-worker
+        env:
+          BENCHMARKS: ${{ inputs.benchmarks }}
 
       - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -178,6 +198,7 @@ jobs:
           docker run --rm -d -p 4566:4566 --name localstack localstack/localstack:4.14.0
 
       - name: Run benchmarks on CPU
+        if: ${{ inputs.benchmarks != 'main_block_one_shot' }}
         run: |
           DATABASE_URL=postgresql://postgres:postgres@localhost:5432/coprocessor TXN_SENDER_TEST_GLOBAL_LOCALSTACK=1 BENCHMARK_BATCH_SIZE="${BATCH_SIZE}" BENCHMARK_TYPE="${BENCHMARK_TYPE}" FHEVM_DF_SCHEDULE="${SCHEDULING_POLICY}" make -e "benchmark_${BENCHMARKS}_cpu"
         working-directory: coprocessor/fhevm-engine/tfhe-worker
@@ -187,7 +208,40 @@ jobs:
           SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
           BENCHMARKS: ${{ inputs.benchmarks }}
 
+      # The cargo cache restores "target", which holds CRITERION_HOME. Drop any
+      # artifact an earlier attempt on this commit left there: it would carry a
+      # matching revision, so the parse step would accept it and publish the
+      # earlier attempt's numbers. This runs even when an earlier step failed,
+      # because the parse step does too.
+      - name: Drop stale one-shot artifacts
+        if: ${{ !cancelled() && inputs.benchmarks == 'main_block_one_shot' }}
+        run: rm -rf "${CRITERION_HOME}/benchmark-runs"
+        env:
+          CRITERION_HOME: ${{ github.workspace }}/coprocessor/fhevm-engine/target/criterion
+
+      # The reportable one-shot suite measures each canonical workload once
+      # instead of sampling through Criterion, so it runs its own Make target and
+      # writes JSON artifacts under "${CRITERION_HOME}/benchmark-runs". The
+      # "batch_size" input does not apply: each scenario derives its own
+      # work-item batch, which the parser records in the reported parameters.
+      - name: Run reportable one-shot benchmarks on CPU
+        if: ${{ inputs.benchmarks == 'main_block_one_shot' }}
+        run: |
+          if [[ -n "${ONE_SHOT_SCENARIOS}" ]]; then
+            export BENCH_ONE_SHOT_SCENARIOS="${ONE_SHOT_SCENARIOS}"
+          fi
+          make print_bench_one_shot_scenarios
+          BENCH_ONE_SHOT_RECREATE_DB=1 FHEVM_DF_SCHEDULE="${SCHEDULING_POLICY}" \
+            make -e benchmark_erc20_main_block_one_shot_suite_cpu
+        working-directory: coprocessor/fhevm-engine/tfhe-worker
+        env:
+          ONE_SHOT_SCENARIOS: ${{ inputs.one_shot_scenarios }}
+          SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
+          FHEVM_BENCH_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/coprocessor
+          CRITERION_HOME: ${{ github.workspace }}/coprocessor/fhevm-engine/target/criterion
+
       - name: Parse results
+        if: ${{ inputs.benchmarks != 'main_block_one_shot' }}
         run: |
           python3 ./ci/benchmark_parser.py coprocessor/fhevm-engine/target/criterion "${RESULTS_FILENAME}" \
           --database coprocessor \
@@ -208,13 +262,49 @@ jobs:
           BATCH_SIZE: ${{ inputs.batch_size }}
           SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
 
+      # Runs even when a scenario failed, so the scenarios that did complete are
+      # still reported. Missing expected scenarios fail this step.
+      - name: Parse one-shot results
+        if: ${{ !cancelled() && inputs.benchmarks == 'main_block_one_shot' }}
+        run: |
+          if [[ -n "${ONE_SHOT_SCENARIOS}" ]]; then
+            export BENCH_ONE_SHOT_SCENARIOS="${ONE_SHOT_SCENARIOS}"
+          fi
+          expected_scenarios="$(make --no-print-directory -C coprocessor/fhevm-engine/tfhe-worker \
+            print_bench_one_shot_scenarios | tr ' ' ',')"
+          python3 ./ci/benchmark_one_shot_parser.py \
+          coprocessor/fhevm-engine/target/criterion/benchmark-runs "${RESULTS_FILENAME}" \
+          --database coprocessor \
+          --hardware "hpc7a.96xlarge" \
+          --backend cpu \
+          --project-version "${COMMIT_HASH}" \
+          --branch "${GH_REF_NAME}" \
+          --commit-date "${COMMIT_DATE}" \
+          --bench-date "${BENCH_DATE}" \
+          --expected-scenarios "${expected_scenarios}" \
+          --expected-revision "${BUILD_REVISION}" \
+          --name-suffix "schedule_${SCHEDULING_POLICY}"
+        env:
+          ONE_SHOT_SCENARIOS: ${{ inputs.one_shot_scenarios }}
+          RESULTS_FILENAME: ${{ env.RESULTS_FILENAME }}
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+          BUILD_REVISION: ${{ github.sha }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          COMMIT_DATE: ${{ env.COMMIT_DATE }}
+          BENCH_DATE: ${{ env.BENCH_DATE }}
+          SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
+
+      # A parser step writes its results file before reporting per-case failures,
+      # so publish whatever was parsed even when it flagged some of them.
       - name: Upload parsed results artifact
+        if: ${{ !cancelled() && hashFiles(env.RESULTS_FILENAME) != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ github.sha }}_${{ inputs.benchmarks }}_cpu
           path: ${{ env.RESULTS_FILENAME }}
 
       - name: Checkout Slab repo
+        if: ${{ !cancelled() && hashFiles(env.RESULTS_FILENAME) != '' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: zama-ai/slab
@@ -223,8 +313,20 @@ jobs:
           token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
 
       - name: Send data to Slab
+        if: ${{ !cancelled() && hashFiles(env.RESULTS_FILENAME) != '' }}
         shell: bash
         run: |
+          # Name what is being stored. A rejection from Slab reports only that it
+          # could not store the content, so the series identity — above all the
+          # hardware, which has to be known on its side — is the first thing to
+          # check and the last thing the log otherwise shows.
+          python3 -c "
+          import json, sys
+          series = json.load(open(sys.argv[1]))
+          print(f\"Sending {len(series['points'])} points to Slab\")
+          for field in ('database', 'hardware', 'branch', 'project_version'):
+              print(f'  {field}: {series[field]}')
+          " "${RESULTS_FILENAME}"
           python3 slab/scripts/data_sender.py "${RESULTS_FILENAME}" "${JOB_SECRET}" \
           --slab-url "${SLAB_URL}"
         env:

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -256,7 +256,7 @@ jobs:
         env:
           ONE_SHOT_SCENARIOS: ${{ inputs.one_shot_scenarios }}
           SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
-          FHEVM_BENCH_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/coprocessor
+          BENCH_DB_URL: postgresql://postgres:postgres@localhost:5432/coprocessor
           CRITERION_HOME: ${{ github.workspace }}/coprocessor/fhevm-engine/target/criterion
 
       - name: Parse results

--- a/.github/workflows/coprocessor-benchmark-cpu.yml
+++ b/.github/workflows/coprocessor-benchmark-cpu.yml
@@ -46,9 +46,10 @@ on:
         default: "ALL"
 
 # Queue dispatches rather than letting two runs compete for the single AWS bench
-# profile: one run's teardown would stop the instance the other is using.
+# profile: one run's teardown would stop the instance the other is using. Keyed
+# on the Slab profile, so any other workflow using it queues here too.
 concurrency:
-  group: ${{ github.workflow }}
+  group: slab-aws-bench
   cancel-in-progress: false
 
 env:
@@ -83,7 +84,8 @@ jobs:
     name: coprocessor-benchmarks-cpu/benchmarks-cpu (bpr)
     needs: setup-instance
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
-    continue-on-error: true
+    # No continue-on-error: a failed one-shot scenario must fail the run, not
+    # only its job. Teardown runs under always() regardless.
     timeout-minutes: 720  # 12 hours
     permissions:
       contents: 'read' # Required to checkout repository code
@@ -152,7 +154,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            coprocessor/fhevm-engine/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
@@ -208,11 +210,28 @@ jobs:
           SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
           BENCHMARKS: ${{ inputs.benchmarks }}
 
-      # The cargo cache restores "target", which holds CRITERION_HOME. Drop any
-      # artifact an earlier attempt on this commit left there: it would carry a
-      # matching revision, so the parse step would accept it and publish the
-      # earlier attempt's numbers. This runs even when an earlier step failed,
-      # because the parse step does too.
+      # The Makefile's canonical list drives CI; benches/erc20.rs defines the
+      # scenarios it can run. They are maintained by hand in two places, so
+      # refuse to run a suite whose two lists disagree instead of measuring a
+      # subset and reporting it as the suite.
+      - name: Check the one-shot scenario list is consistent
+        if: ${{ inputs.benchmarks == 'main_block_one_shot' }}
+        working-directory: coprocessor/fhevm-engine/tfhe-worker
+        run: |
+          expected=$(make -s print_bench_one_shot_scenarios | tr ' ' '\n' | sort)
+          declared=$(awk '/^const MAIN_BLOCK_ONE_SHOT_SCENARIOS/,/^\];/' benches/erc20.rs \
+            | sed -n 's/^ *name: "\([a-z0-9_]*\)",$/\1/p' | sort)
+          if [ "${expected}" != "${declared}" ]; then
+            echo "Makefile BENCH_ONE_SHOT_CANONICAL_SCENARIOS and benches/erc20.rs MAIN_BLOCK_ONE_SHOT_SCENARIOS disagree:" >&2
+            diff <(echo "${expected}") <(echo "${declared}") >&2 || true
+            exit 1
+          fi
+
+      # The cargo cache restores the workspace target directory, which holds
+      # CRITERION_HOME. Drop any artifact an earlier attempt on this commit left
+      # there: it would carry a matching revision, so the parse step would
+      # accept it and publish the earlier attempt's numbers. This runs even when
+      # an earlier step failed, because the parse step does too.
       - name: Drop stale one-shot artifacts
         if: ${{ !cancelled() && inputs.benchmarks == 'main_block_one_shot' }}
         run: rm -rf "${CRITERION_HOME}/benchmark-runs"
@@ -336,7 +355,9 @@ jobs:
 
   teardown-instance:
     name: coprocessor-benchmarks-cpu/teardown
-    if: ${{ always() && needs.setup-instance.result == 'success' }}
+    # Gate on the runner label, not on the setup job's result (see the GPU
+    # workflow): a partially failed start can still hold a billed instance.
+    if: ${{ always() && needs.setup-instance.outputs.runner-name != '' }}
     needs: [ setup-instance, benchmarks-cpu ]
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     permissions:

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -1,4 +1,4 @@
-# Run all fhevm coprocessor benchmarks on a GPU instance on Hyperstack and return parsed results to Slab CI bot.
+# Run all fhevm coprocessor benchmarks on a cloud GPU instance and return parsed results to Slab CI bot.
 name: coprocessor-benchmark-gpu
 
 permissions: {}
@@ -11,14 +11,19 @@ on:
         required: true
         type: choice
         options:
-          - "l40 (n3-L40x1)"
-          - "single-h100 (n3-H100x1)"
-          - "2-h100 (n3-H100x2)"
-          - "4-h100 (n3-H100x4)"
-          - "multi-h100 (n3-H100x8)"
-          - "multi-h100-nvlink (n3-H100x8-NVLink)"
-          - "multi-h100-sxm5 (n3-H100x8-SXM5)"
-          - "multi-h100-sxm5_fallback (n3-H100x8-SXM5)"
+          - "hyperstack::l40 (n3-L40x1)"
+          - "hyperstack::4-l40 (n3-L40x4)"
+          - "hyperstack::multi-a100-nvlink (n3-A100x8-NVLink)"
+          - "hyperstack::single-h100 (n3-H100x1)"
+          - "hyperstack::2-h100 (n3-H100x2)"
+          - "hyperstack::4-h100 (n3-H100x4)"
+          - "hyperstack::multi-h100 (n3-H100x8)"
+          - "hyperstack::multi-h100-nvlink (n3-H100x8-NVLink)"
+          - "hyperstack::multi-h100-sxm5 (n3-H100-SXM5x8)"
+          - "scaleway::multi-h100-sxm5 (H100-SXM-8-80G)"
+          - "scaleway::4-h100-sxm5 (H100-SXM-4-80G)"
+          - "scaleway::2-h100-sxm5 (H100-SXM-2-80G)"
+          - "scaleway::single-h100 (H100-1-80G)"
       benchmarks:
         description: "Benchmark set"
         required: true
@@ -28,6 +33,12 @@ on:
           - "dex"
           - "synthetics"
           - "all"
+          - "main_block_one_shot"
+      one_shot_scenarios:
+        description: "Reportable one-shot scenarios (space-separated, only used by the main_block_one_shot set; empty runs the canonical suite)"
+        required: false
+        type: string
+        default: ""
       batch_size:
         description: "Batch sizes (# FHE operations executed per batch)"
         required: true
@@ -60,6 +71,13 @@ on:
           - "LATENCY"
         default: "ALL"
 
+# Two runs holding the same Slab profile can have one run's teardown stop the
+# instance the other is still working on, which surfaces as an unexplained
+# cancellation mid-step. Queue same-profile dispatches instead of racing them.
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.profile }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   RESULTS_FILENAME: parsed_benchmark_results_${{ github.sha }}.json
@@ -76,18 +94,26 @@ jobs:
     permissions:
       contents: 'read' # Required to checkout repository code
     outputs:
+      backend: ${{ steps.parse_profile.outputs.backend }}
       profile: ${{ steps.parse_profile.outputs.profile }}
-      hardware_name: ${{ steps.parse_hardware_name.outputs.name }}
+      hardware_name: ${{ steps.parse_profile.outputs.hardware }}
+      cloud_provider: ${{ steps.parse_profile.outputs.cloud_provider }}
     steps:
-      - name: Parse profile
-        id: parse_profile
-        run: |
-          echo "profile=$(echo "${PROFILE}" | sed 's|\(.*\)[[:space:]](.*)|\1|')" >> "${GITHUB_OUTPUT}"
+      - name: Checkout fhevm-backend
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
 
-      - name: Parse hardware name
-        id: parse_hardware_name
-        run: |
-          echo "name=$(echo "${PROFILE}" | sed 's|.*[[:space:]](\(.*\))|\1|')" >> "${GITHUB_OUTPUT}"
+      # The profile parser reads ci/slab.toml through tomllib, which the runner
+      # image only ships from Python 3.11 on.
+      - name: Use Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: '3.11'
+
+      - name: Parse profile and hardware name
+        id: parse_profile
+        run: python3 ci/parse_benchmark_profile.py "${PROFILE}" "${GITHUB_OUTPUT}"
 
   setup-instance:
     name: coprocessor-benchmark-gpu/setup-instance
@@ -100,13 +126,13 @@ jobs:
     steps:
       - name: Start remote instance
         id: start-remote-instance
-        uses: zama-ai/slab-github-runner@79939325c3c429837c10d6041e4fd8589d328bac
+        uses: zama-ai/slab-github-runner@d4a5bb6e2a4b8aa19a10f596d7f142006a7e2c21 # v1.6.3
         with:
           mode: start
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          backend: hyperstack
+          backend: ${{ needs.parse-inputs.outputs.backend }}
           profile: ${{ needs.parse-inputs.outputs.profile }}
 
   benchmark:
@@ -136,13 +162,10 @@ jobs:
     steps:
       - name: Install git LFS
         run: |
-          # Wait for apt locks to be released (e.g., unattended-upgrades may hold the lock on fresh instances)
-          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
-            echo "Waiting for apt lock to be released..."
-            sleep 5
-          done
-          sudo apt-get update
-          sudo apt-get install -y git-lfs
+          # A fresh instance is still running its apt-daily timers, so wait for
+          # the dpkg lock through apt itself rather than polling for it here.
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y git-lfs
           git lfs install
 
       - name: Checkout fhevm-backend
@@ -167,6 +190,27 @@ jobs:
           echo "PATH=$PATH:${CUDA_PATH}/bin" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
 
+      # A job that ends as "The operation was canceled." with no failing command
+      # lost its host rather than its command: out of disk, out of memory, or a
+      # reclaimed instance. Only a log already streaming can say which, so record
+      # the exhaustible resources and the toolkit actually selected. Keep this
+      # ahead of the heavy build, which is what consumes them.
+      - name: Log host resources
+        run: |
+          echo "::group::disk"
+          df -h
+          echo "::endgroup::"
+          echo "::group::memory"
+          free -h
+          swapon --show || true
+          echo "::endgroup::"
+          echo "::group::toolkit"
+          echo "cores: $(nproc)"
+          echo "CUDA_PATH=${CUDA_PATH:-unset}"
+          command -v nvcc && nvcc --version | tail -2
+          nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+          echo "::endgroup::"
+
       - name: Get benchmark details
         run: |
           {
@@ -183,11 +227,21 @@ jobs:
 
       - name: Install cargo dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler cmake pkg-config libssl-dev \
-                                  libclang-dev docker-compose-v2 docker.io acl
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y protobuf-compiler cmake pkg-config libssl-dev \
+                                  libclang-dev acl
+          if ! command -v docker >/dev/null 2>&1; then
+            sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker.io
+          fi
+          if ! docker compose version >/dev/null 2>&1; then
+            if dpkg-query --show --showformat='${Status}' containerd.io 2>/dev/null | grep -q "ok installed"; then
+              sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker-compose-plugin
+            else
+              sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker-compose-v2
+            fi
+          fi
+          sudo systemctl start docker
           sudo usermod -aG docker "$USER"
-          newgrp docker
           sudo setfacl --modify user:"$USER":rw /var/run/docker.sock
           cargo +stable install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
@@ -218,9 +272,23 @@ jobs:
           username: ${{ secrets.CGR_USERNAME }}
           password: ${{ secrets.CGR_PASSWORD }}
 
+      # The one-shot suite needs a schema, not an image: bring up postgres and
+      # apply the migrations with the sqlx CLI installed above. Building the
+      # migration image here would compile the whole workspace a second time,
+      # under whole-machine load, for a binary this benchmark never runs.
       - name: Init database
-        run: make init_db
+        run: |
+          bash "${GITHUB_WORKSPACE}/ci/log_host_resources.sh" 30 &
+          sampler=$!
+          trap 'kill "${sampler}" 2>/dev/null || true' EXIT
+          if [[ "${BENCHMARKS}" == "main_block_one_shot" ]]; then
+            make bench_db_up
+          else
+            make init_db
+          fi
         working-directory: coprocessor/fhevm-engine/tfhe-worker
+        env:
+          BENCHMARKS: ${{ inputs.benchmarks }}
 
       - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -236,6 +304,7 @@ jobs:
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
 
       - name: Run benchmarks on GPU
+        if: ${{ inputs.benchmarks != 'main_block_one_shot' }}
         run: |
           BENCHMARK_BATCH_SIZE="${BATCH_SIZE}" FHEVM_DF_SCHEDULE="${SCHEDULING_POLICY}" BENCHMARK_TYPE="${BENCHMARK_TYPE}" OPTIMIZATION_TARGET="${OPTIMIZATION_TARGET}" make -e "benchmark_${BENCHMARKS}_gpu"
         working-directory: coprocessor/fhevm-engine/tfhe-worker
@@ -246,12 +315,52 @@ jobs:
           BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           OPTIMIZATION_TARGET: ${{ inputs.optimization_target }}
 
+      # The cargo cache restores "target", which holds CRITERION_HOME. Drop any
+      # artifact an earlier attempt on this commit left there: it would carry a
+      # matching revision, so the parse step would accept it and publish the
+      # earlier attempt's numbers. This runs even when an earlier step failed,
+      # because the parse step does too.
+      - name: Drop stale one-shot artifacts
+        if: ${{ !cancelled() && inputs.benchmarks == 'main_block_one_shot' }}
+        run: rm -rf "${CRITERION_HOME}/benchmark-runs"
+        env:
+          CRITERION_HOME: ${{ github.workspace }}/coprocessor/fhevm-engine/target/criterion
+
+      # The reportable one-shot suite measures each canonical workload once
+      # instead of sampling through Criterion, so it runs its own Make target and
+      # writes JSON artifacts under "${CRITERION_HOME}/benchmark-runs". The
+      # "batch_size" input does not apply: each scenario derives its own
+      # work-item batch, which the parser records in the reported parameters.
+      - name: Run reportable one-shot benchmarks on GPU
+        if: ${{ inputs.benchmarks == 'main_block_one_shot' }}
+        run: |
+          # The job's other memory peak, and long enough that a host dying here
+          # is otherwise unattributable. See ci/log_host_resources.sh.
+          bash "${GITHUB_WORKSPACE}/ci/log_host_resources.sh" 30 &
+          sampler=$!
+          trap 'kill "${sampler}" 2>/dev/null || true' EXIT
+          if [[ -n "${ONE_SHOT_SCENARIOS}" ]]; then
+            export BENCH_ONE_SHOT_SCENARIOS="${ONE_SHOT_SCENARIOS}"
+          fi
+          make print_bench_one_shot_scenarios
+          BENCH_ONE_SHOT_RECREATE_DB=1 OPTIMIZATION_TARGET="${OPTIMIZATION_TARGET}" \
+            FHEVM_DF_SCHEDULE="${SCHEDULING_POLICY}" \
+            make -e benchmark_erc20_main_block_one_shot_suite_gpu
+        working-directory: coprocessor/fhevm-engine/tfhe-worker
+        env:
+          ONE_SHOT_SCENARIOS: ${{ inputs.one_shot_scenarios }}
+          OPTIMIZATION_TARGET: ${{ inputs.optimization_target }}
+          SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
+          FHEVM_BENCH_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/coprocessor
+          CRITERION_HOME: ${{ github.workspace }}/coprocessor/fhevm-engine/target/criterion
+
       - name: Parse results
+        if: ${{ inputs.benchmarks != 'main_block_one_shot' }}
         run: |
           python3 ./ci/benchmark_parser.py coprocessor/fhevm-engine/target/criterion "${RESULTS_FILENAME}" \
           --database coprocessor \
           --hardware "${HW_NAME}" \
-          --backend gpu \
+          --backend cuda \
           --project-version "${COMMIT_HASH}" \
           --branch "${GH_REF_NAME}" \
           --commit-date "${COMMIT_DATE}" \
@@ -270,13 +379,51 @@ jobs:
           SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
           OPTIMIZATION_TARGET: ${{ inputs.optimization_target }}
 
+      # Runs even when a scenario failed, so the scenarios that did complete are
+      # still reported. Missing expected scenarios fail this step.
+      - name: Parse one-shot results
+        if: ${{ !cancelled() && inputs.benchmarks == 'main_block_one_shot' }}
+        run: |
+          if [[ -n "${ONE_SHOT_SCENARIOS}" ]]; then
+            export BENCH_ONE_SHOT_SCENARIOS="${ONE_SHOT_SCENARIOS}"
+          fi
+          expected_scenarios="$(make --no-print-directory -C coprocessor/fhevm-engine/tfhe-worker \
+            print_bench_one_shot_scenarios | tr ' ' ',')"
+          python3 ./ci/benchmark_one_shot_parser.py \
+          coprocessor/fhevm-engine/target/criterion/benchmark-runs "${RESULTS_FILENAME}" \
+          --database coprocessor \
+          --hardware "${HW_NAME}" \
+          --backend cuda \
+          --project-version "${COMMIT_HASH}" \
+          --branch "${GH_REF_NAME}" \
+          --commit-date "${COMMIT_DATE}" \
+          --bench-date "${BENCH_DATE}" \
+          --expected-scenarios "${expected_scenarios}" \
+          --expected-revision "${BUILD_REVISION}" \
+          --name-suffix "schedule_${SCHEDULING_POLICY}-optimization_target_${OPTIMIZATION_TARGET}"
+        env:
+          ONE_SHOT_SCENARIOS: ${{ inputs.one_shot_scenarios }}
+          RESULTS_FILENAME: ${{ env.RESULTS_FILENAME }}
+          HW_NAME: ${{ needs.parse-inputs.outputs.hardware_name }}
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+          BUILD_REVISION: ${{ github.sha }}
+          SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          COMMIT_DATE: ${{ env.COMMIT_DATE }}
+          BENCH_DATE: ${{ env.BENCH_DATE }}
+          OPTIMIZATION_TARGET: ${{ inputs.optimization_target }}
+
+      # A parser step writes its results file before reporting per-case failures,
+      # so publish whatever was parsed even when it flagged some of them.
       - name: Upload parsed results artifact
+        if: ${{ !cancelled() && hashFiles(env.RESULTS_FILENAME) != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ${{ github.sha }}_${{ inputs.benchmarks }}_${{ needs.parse-inputs.outputs.profile }}
           path: ${{ env.RESULTS_FILENAME }}
 
       - name: Checkout Slab repo
+        if: ${{ !cancelled() && hashFiles(env.RESULTS_FILENAME) != '' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: zama-ai/slab
@@ -285,8 +432,20 @@ jobs:
           token: ${{ secrets.REPO_CHECKOUT_TOKEN }}
 
       - name: Send data to Slab
+        if: ${{ !cancelled() && hashFiles(env.RESULTS_FILENAME) != '' }}
         shell: bash
         run: |
+          # Name what is being stored. A rejection from Slab reports only that it
+          # could not store the content, so the series identity — above all the
+          # hardware, which has to be known on its side — is the first thing to
+          # check and the last thing the log otherwise shows.
+          python3 -c "
+          import json, sys
+          series = json.load(open(sys.argv[1]))
+          print(f\"Sending {len(series['points'])} points to Slab\")
+          for field in ('database', 'hardware', 'branch', 'project_version'):
+              print(f'  {field}: {series[field]}')
+          " "${RESULTS_FILENAME}"
           python3 slab/scripts/data_sender.py "${RESULTS_FILENAME}" "${JOB_SECRET}" \
           --slab-url "${SLAB_URL}"
         env:
@@ -304,7 +463,7 @@ jobs:
     steps:
       - name: Stop remote instance
         id: stop-instance
-        uses: zama-ai/slab-github-runner@79939325c3c429837c10d6041e4fd8589d328bac
+        uses: zama-ai/slab-github-runner@d4a5bb6e2a4b8aa19a10f596d7f142006a7e2c21 # v1.6.3
         with:
           mode: stop
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -144,21 +144,6 @@ jobs:
     permissions:
       contents: 'read' # Required to checkout repository code
       packages: 'read' # Required to read GitHub packages/container registry
-    strategy:
-      fail-fast: false
-      # explicit include-based build matrix, of known valid options
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            cuda: "12.2"
-            gcc: 11
-    env:
-      CUDA_PATH: "/usr/local/cuda-${{ matrix.cuda }}"
-      CUDA_MODULE_LOADER: "EAGER"
-      CC: "/usr/bin/gcc-${{ matrix.gcc }}"
-      CXX: "/usr/bin/g++-${{ matrix.gcc }}"
-      CUDAHOSTCXX: "/usr/bin/g++-${{ matrix.gcc }}"
-
     steps:
       - name: Install git LFS
         run: |
@@ -178,17 +163,12 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
 
-      - name: Setup Hyperstack dependencies
+      - name: Setup GPU dependencies
         uses: ./.github/actions/gpu_setup
         with:
-          cuda-version: ${{ matrix.cuda }}
-          github-instance: ${{ env.SECRETS_AVAILABLE == 'false' }}
-
-      - name: Export CUDA variables
-        shell: bash
-        run: |
-          echo "PATH=$PATH:${CUDA_PATH}/bin" >> "${GITHUB_PATH}"
-          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
+          cuda-version: "12.8 12.2"
+          gcc-version: 12
+          cloud-provider: ${{ needs.parse-inputs.outputs.cloud_provider }}
 
       # A job that ends as "The operation was canceled." with no failing command
       # lost its host rather than its command: out of disk, out of memory, or a
@@ -228,7 +208,10 @@ jobs:
       - name: Install cargo dependencies
         run: |
           sudo apt-get -o DPkg::Lock::Timeout=600 update
-          sudo apt-get -o DPkg::Lock::Timeout=600 install -y protobuf-compiler cmake pkg-config libssl-dev \
+          # No cmake here: the GPU setup step installed a CMake newer than the
+          # distro package, which tfhe-cuda-backend requires, and apt would
+          # overwrite it with the older one.
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y protobuf-compiler pkg-config libssl-dev \
                                   libclang-dev acl
           if ! command -v docker >/dev/null 2>&1; then
             sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker.io

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -74,8 +74,11 @@ on:
 # Two runs holding the same Slab profile can have one run's teardown stop the
 # instance the other is still working on, which surfaces as an unexplained
 # cancellation mid-step. Queue same-profile dispatches instead of racing them.
+# The group is keyed on the Slab profile ALONE, not on the workflow: the GPU
+# test and image-build workflows use the same profiles, and a per-workflow
+# group would let them race this one for the instance.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.profile }}
+  group: slab-${{ inputs.profile }}
   cancel-in-progress: false
 
 env:
@@ -139,7 +142,9 @@ jobs:
     name: coprocessor-benchmark-gpu/benchmark-gpu (bpr)
     needs: [ parse-inputs, setup-instance ]
     runs-on: ${{ needs.setup-instance.outputs.runner-name }}
-    continue-on-error: true
+    # No continue-on-error: the one-shot suite exits non-zero when a scenario
+    # fails, and that has to fail the run, not only paint one job red while
+    # the run concludes green. Teardown runs under always() regardless.
     timeout-minutes: 720  # 12 hours
     permissions:
       contents: 'read' # Required to checkout repository code
@@ -236,7 +241,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            coprocessor/fhevm-engine/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
@@ -300,11 +305,28 @@ jobs:
           BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           OPTIMIZATION_TARGET: ${{ inputs.optimization_target }}
 
-      # The cargo cache restores "target", which holds CRITERION_HOME. Drop any
-      # artifact an earlier attempt on this commit left there: it would carry a
-      # matching revision, so the parse step would accept it and publish the
-      # earlier attempt's numbers. This runs even when an earlier step failed,
-      # because the parse step does too.
+      # The Makefile's canonical list drives CI; benches/erc20.rs defines the
+      # scenarios it can run. They are maintained by hand in two places, so
+      # refuse to run a suite whose two lists disagree instead of measuring a
+      # subset and reporting it as the suite.
+      - name: Check the one-shot scenario list is consistent
+        if: ${{ inputs.benchmarks == 'main_block_one_shot' }}
+        working-directory: coprocessor/fhevm-engine/tfhe-worker
+        run: |
+          expected=$(make -s print_bench_one_shot_scenarios | tr ' ' '\n' | sort)
+          declared=$(awk '/^const MAIN_BLOCK_ONE_SHOT_SCENARIOS/,/^\];/' benches/erc20.rs \
+            | sed -n 's/^ *name: "\([a-z0-9_]*\)",$/\1/p' | sort)
+          if [ "${expected}" != "${declared}" ]; then
+            echo "Makefile BENCH_ONE_SHOT_CANONICAL_SCENARIOS and benches/erc20.rs MAIN_BLOCK_ONE_SHOT_SCENARIOS disagree:" >&2
+            diff <(echo "${expected}") <(echo "${declared}") >&2 || true
+            exit 1
+          fi
+
+      # The cargo cache restores the workspace target directory, which holds
+      # CRITERION_HOME. Drop any artifact an earlier attempt on this commit left
+      # there: it would carry a matching revision, so the parse step would
+      # accept it and publish the earlier attempt's numbers. This runs even when
+      # an earlier step failed, because the parse step does too.
       - name: Drop stale one-shot artifacts
         if: ${{ !cancelled() && inputs.benchmarks == 'main_block_one_shot' }}
         run: rm -rf "${CRITERION_HOME}/benchmark-runs"
@@ -440,7 +462,11 @@ jobs:
 
   teardown-instance:
     name: coprocessor-benchmark-gpu/teardown
-    if: ${{ always() && needs.setup-instance.result == 'success' }}
+    # Gate on the runner label, not on the setup job's result: a start that
+    # registered the runner and then failed a later step still holds a billed
+    # instance that must be stopped. A start that never emitted a label left
+    # nothing this job could address.
+    if: ${{ always() && needs.setup-instance.outputs.runner-name != '' }}
     needs: [ setup-instance, benchmark ]
     runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     permissions:

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -166,9 +166,11 @@ jobs:
       - name: Setup GPU dependencies
         uses: ./.github/actions/gpu_setup
         with:
-          cuda-version: "12.8 12.2"
+          # 12.8 only, for the same reason as coprocessor-gpu-tests: a listed
+          # pre-installed 12.2 would keep hyperstack on a different toolchain
+          # than Scaleway, and benchmark numbers must be comparable across them.
+          cuda-version: "12.8"
           gcc-version: 12
-          cloud-provider: ${{ needs.parse-inputs.outputs.cloud_provider }}
 
       # A job that ends as "The operation was canceled." with no failing command
       # lost its host rather than its command: out of disk, out of memory, or a

--- a/.github/workflows/coprocessor-benchmark-gpu.yml
+++ b/.github/workflows/coprocessor-benchmark-gpu.yml
@@ -358,7 +358,7 @@ jobs:
           ONE_SHOT_SCENARIOS: ${{ inputs.one_shot_scenarios }}
           OPTIMIZATION_TARGET: ${{ inputs.optimization_target }}
           SCHEDULING_POLICY: ${{ inputs.scheduling_policy }}
-          FHEVM_BENCH_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/coprocessor
+          BENCH_DB_URL: postgresql://postgres:postgres@localhost:5432/coprocessor
           CRITERION_HOME: ${{ github.workspace }}/coprocessor/fhevm-engine/target/criterion
 
       - name: Parse results

--- a/.github/workflows/coprocessor-gpu-tests.yml
+++ b/.github/workflows/coprocessor-gpu-tests.yml
@@ -46,6 +46,9 @@ jobs:
               - coprocessor/fhevm-engine/scheduler/build.rs
               - coprocessor/proto/**
               - '.github/workflows/coprocessor-gpu-tests.yml'
+              - '.github/actions/gpu_setup/**'
+              - 'ci/detect_cuda.sh'
+              - 'ci/export_cuda_vars.sh'
               - ci/slab.toml
 
   setup-instance:
@@ -61,7 +64,7 @@ jobs:
       - name: Start remote instance
         id: start-remote-instance
         if: env.SECRETS_AVAILABLE == 'true'
-        uses: zama-ai/slab-github-runner@79939325c3c429837c10d6041e4fd8589d328bac
+        uses: zama-ai/slab-github-runner@d4a5bb6e2a4b8aa19a10f596d7f142006a7e2c21 # v1.6.3
         with:
           mode: start
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
@@ -82,26 +85,11 @@ jobs:
     permissions:
       contents: 'read' # Required to checkout repository code
       packages: 'read' # Required to read GitHub packages/container registry
-    strategy:
-      fail-fast: false
-      # explicit include-based build matrix, of known valid options
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            cuda: "12.2"
-            gcc: 11
-    env:
-      CUDA_PATH: "/usr/local/cuda-${{ matrix.cuda }}"
-      CUDA_MODULE_LOADER: "EAGER"
-      CC: "/usr/bin/gcc-${{ matrix.gcc }}"
-      CXX: "/usr/bin/g++-${{ matrix.gcc }}"
-      CUDAHOSTCXX: "/usr/bin/g++-${{ matrix.gcc }}"
-
     steps:
       - name: Install git LFS
         run: |
-          sudo apt-get update
-          sudo apt-get install -y git-lfs
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y git-lfs
           git lfs install
 
       - name: Checkout fhevm
@@ -113,17 +101,12 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
 
-      - name: Setup Hyperstack dependencies
+      - name: Setup GPU dependencies
         uses: ./.github/actions/gpu_setup
         with:
-          cuda-version: ${{ matrix.cuda }}
-          github-instance: ${{ env.SECRETS_AVAILABLE == 'false' }}
-
-      - name: Export CUDA variables
-        shell: bash
-        run: |
-          echo "PATH=$PATH:${CUDA_PATH}/bin" >> "${GITHUB_PATH}"
-          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
+          cuda-version: "12.8 12.2"
+          gcc-version: 12
+          cloud-provider: hyperstack
 
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
@@ -132,11 +115,24 @@ jobs:
 
       - name: Install cargo dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler cmake pkg-config libssl-dev \
-                                  libclang-dev docker-compose-v2 docker.io acl
+          sudo apt-get -o DPkg::Lock::Timeout=600 update
+          # No cmake here: the GPU setup step installed a CMake newer than the
+          # distro package, which tfhe-cuda-backend requires, and apt would
+          # overwrite it with the older one.
+          sudo apt-get -o DPkg::Lock::Timeout=600 install -y protobuf-compiler pkg-config libssl-dev \
+                                  libclang-dev acl
+          if ! command -v docker >/dev/null 2>&1; then
+            sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker.io
+          fi
+          if ! docker compose version >/dev/null 2>&1; then
+            if dpkg-query --show --showformat='${Status}' containerd.io 2>/dev/null | grep -q "ok installed"; then
+              sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker-compose-plugin
+            else
+              sudo apt-get -o DPkg::Lock::Timeout=600 install -y docker-compose-v2
+            fi
+          fi
+          sudo systemctl start docker
           sudo usermod -aG docker "$USER"
-          newgrp docker
           sudo setfacl --modify user:"$USER":rw /var/run/docker.sock
           cargo install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked
 
@@ -196,7 +192,7 @@ jobs:
       - name: Stop remote instance
         id: stop-instance
         if: env.SECRETS_AVAILABLE == 'true'
-        uses: zama-ai/slab-github-runner@79939325c3c429837c10d6041e4fd8589d328bac
+        uses: zama-ai/slab-github-runner@d4a5bb6e2a4b8aa19a10f596d7f142006a7e2c21 # v1.6.3
         with:
           mode: stop
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}

--- a/.github/workflows/coprocessor-gpu-tests.yml
+++ b/.github/workflows/coprocessor-gpu-tests.yml
@@ -104,9 +104,12 @@ jobs:
       - name: Setup GPU dependencies
         uses: ./.github/actions/gpu_setup
         with:
-          cuda-version: "12.8 12.2"
+          # 12.8 only: the hyperstack images ship 12.2, and accepting it here
+          # left them on 12.2 while a fresh Scaleway host installed 12.8, so the
+          # toolchain differed per provider. Pinning one version installs it
+          # wherever it is missing.
+          cuda-version: "12.8"
           gcc-version: 12
-          cloud-provider: hyperstack
 
       - name: Install latest stable
         uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203

--- a/ci/benchmark_one_shot_parser.py
+++ b/ci/benchmark_one_shot_parser.py
@@ -1,0 +1,407 @@
+"""
+benchmark_one_shot_parser
+-------------------------
+
+Parse reportable Main-baseline one-shot benchmark artifacts and dump them in the
+Slab series format produced by ``benchmark_parser.py``.
+
+The reportable one-shot targets
+(``make benchmark_erc20_main_block_baseline_{cpu,gpu}``) do not go through
+Criterion: each run measures a single logical workload once and writes a JSON
+artifact to ``<criterion home>/benchmark-runs/reportable-main-one-shot-*.json``.
+``benchmark_parser.py`` only understands Criterion result directories, so the
+one-shot runs need this converter to reach Slab.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+ONE_SECOND_IN_NANOSECONDS = 1e9
+ONE_SECOND_IN_MILLISECONDS = 1e3
+
+# Every point the coprocessor sends to Slab is recorded with this operator type:
+# Criterion runs get it from `OperatorType::Atomic`, which serializes under its
+# variant name. Keep one-shot points in the same category.
+OPERATOR_TYPE = "Atomic"
+BENCH_CLASS = "evaluate"
+BENCH_NAME = "erc20::transfer::main_block_one_shot"
+# Short labels for the reported series. The measurement's own name is long
+# enough that a test name built from it outruns the ones Slab already stores,
+# and the precise metric stays recorded in the point's parameters.
+METRIC_LABELS = {
+    "post_commit_worker_visible_to_terminal_outputs": "worker_visible_to_terminals",
+    "post_first_commit_worker_visible_to_final_terminal_outputs": (
+        "first_commit_to_final_terminals"
+    ),
+    "commit_start_to_terminal_outputs_upper_bound": "commit_start_to_terminals_bound",
+}
+# Artifact layout this parser understands, written by
+# `persist_main_block_one_shot_artifact`. A bump there must be handled here.
+SUPPORTED_SCHEMA_VERSION = 2
+ARTIFACT_NAME_PATTERN = re.compile(
+    r"reportable-main-one-shot-[0-9a-f]+-(?P<timestamp>\d+)\.json"
+)
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "results",
+    help="Directory containing reportable-main-one-shot-*.json artifacts",
+)
+parser.add_argument("output_file", help="File storing parsed results")
+parser.add_argument(
+    "-d",
+    "--database",
+    dest="database",
+    help="Name of the database used to store results",
+)
+parser.add_argument(
+    "-w",
+    "--hardware",
+    dest="hardware",
+    help="Hardware reference used to perform benchmark",
+)
+parser.add_argument(
+    "-V", "--project-version", dest="project_version", help="Commit hash reference"
+)
+parser.add_argument(
+    "-b",
+    "--branch",
+    dest="branch",
+    help="Git branch name on which benchmark was performed",
+)
+parser.add_argument(
+    "--commit-date",
+    dest="commit_date",
+    help="Timestamp of commit hash used in project_version",
+)
+parser.add_argument(
+    "--bench-date", dest="bench_date", help="Timestamp when benchmark was run"
+)
+parser.add_argument(
+    "--name-suffix",
+    dest="name_suffix",
+    default="",
+    help="Suffix to append to each of the result test names",
+)
+parser.add_argument(
+    "--backend",
+    dest="backend",
+    default="cpu",
+    help="Backend on which benchmarks have run",
+)
+parser.add_argument(
+    "--append-results",
+    dest="append_results",
+    action="store_true",
+    help="Append parsed results to an existing file",
+)
+parser.add_argument(
+    "--expected-scenarios",
+    dest="expected_scenarios",
+    default="",
+    help="Comma-separated scenarios that must be present, the program will exit"
+    " with an error if one of them produced no artifact",
+)
+parser.add_argument(
+    "--expected-revision",
+    dest="expected_revision",
+    default="",
+    help="Commit the artifacts must have been built from, to reject leftover"
+    " artifacts of an earlier run on a reused workspace",
+)
+
+
+def artifact_files(directory):
+    """
+    List one-shot artifacts, oldest first.
+
+    Artifact names end with the run timestamp in milliseconds, which orders runs
+    chronologically. A name that does not carry one cannot be placed in that
+    order, so it is skipped with a warning rather than taken as the sort key:
+    raising here would lose the runs that did report.
+
+    :param directory: directory holding the artifacts as :class:`pathlib.Path`
+
+    :return: :class:`list` of :class:`pathlib.Path`
+    """
+    timestamped = []
+    for path in directory.glob("reportable-main-one-shot-*.json"):
+        match = ARTIFACT_NAME_PATTERN.fullmatch(path.name)
+        if match is None:
+            print(f"Warning: ignoring artifact with unexpected name '{path.name}'")
+            continue
+        timestamped.append((int(match.group("timestamp")), path))
+    return [path for _, path in sorted(timestamped, key=lambda item: item[0])]
+
+
+def latest_run_per_scenario(directory, expected_revision=""):
+    """
+    Keep the last usable run of each scenario found in ``directory``.
+
+    An artifact this parser cannot trust is announced and dropped: an unreadable
+    file, an unknown schema version, or a run built from another commit (a
+    leftover in a reused workspace or a restored target cache). Dropping is not
+    silent tolerance — because a dropped artifact no longer stands in for a
+    scenario, ``--expected-scenarios`` still fails a run whose scenario has no
+    fresh artifact, while a stale file alongside complete fresh results no longer
+    fails a run that measured everything it was asked to.
+
+    :param directory: directory holding the artifacts as :class:`pathlib.Path`
+    :param expected_revision: commit the artifacts must be built from, if known
+
+    :return: :class:`dict` of scenario name to parsed artifact content
+    """
+    runs = {}
+    for path in artifact_files(directory):
+        try:
+            content = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as err:
+            print(f"Warning: ignoring unreadable artifact '{path.name}': {err}")
+            continue
+        if content.get("run_mode") != "reportable":
+            continue
+        schema_version = content.get("schema_version")
+        if schema_version != SUPPORTED_SCHEMA_VERSION:
+            print(
+                f"Warning: ignoring artifact '{path.name}' with schema version"
+                f" {schema_version}, expected {SUPPORTED_SCHEMA_VERSION}"
+            )
+            continue
+        revision = content.get("build", {}).get("revision")
+        if expected_revision and revision != expected_revision:
+            print(
+                f"Warning: ignoring artifact '{path.name}' built from revision"
+                f" {revision}, expected {expected_revision}"
+            )
+            continue
+        try:
+            scenario = content["result"]["scenario"]
+        except (KeyError, TypeError) as err:
+            print(f"Warning: ignoring artifact '{path.name}' with no scenario: {err}")
+            continue
+        runs[scenario] = content
+    return runs
+
+
+def _create_point(value, test_name, bench_type, params, display_name):
+    return {
+        "value": value,
+        "test": test_name,
+        "name": display_name,
+        "class": BENCH_CLASS,
+        "type": bench_type,
+        "operator": OPERATOR_TYPE,
+        "params": params,
+    }
+
+
+def scenario_parameters(content):
+    """
+    Parameters to report the scenario's points under.
+
+    Points are stored against a typed parameter record — bit size, crypto
+    parameter alias and operand type are columns, not free-form keys — so a
+    one-shot run reports the same record every other benchmark does, flattened
+    the way ``benchmark_parser.py`` flattens it: the display name and operator
+    type are carried on the point itself, and the crypto parameters sit at the
+    same level as the rest. The workload's own facts are in the run artifact and
+    in the test name.
+
+    :param content: parsed artifact content as :class:`dict`
+
+    :return: :class:`dict` of parameters
+    """
+    parameters = dict(content["result"]["bench_parameters"])
+    parameters.pop("display_name", None)
+    parameters.pop("operator_type", None)
+    crypto_parameters = parameters.pop("crypto_parameters", None)
+    if crypto_parameters:
+        parameters.update(crypto_parameters)
+    return {name: value for name, value in parameters.items() if value is not None}
+
+
+def parse_scenario(content, name_suffix):
+    """
+    Turn one artifact into its Slab data points.
+
+    The primary metric is reported as a latency in nanoseconds, and both FHE
+    operation and transfer rates are derived from it as throughputs.
+
+    :param content: parsed artifact content as :class:`dict`
+    :param name_suffix: a :class:`str` suffix to apply to each test name
+
+    :return: tuple of :class:`list` as (data points, parsing failures)
+    """
+    result = content["result"]
+    scenario = result["scenario"]
+    params = scenario_parameters(content)
+    primary_ms = result["post_commit_worker_visible_to_terminal_outputs_ms"]
+    upper_bound_ms = result["commit_start_to_terminal_outputs_upper_bound_ms"]
+
+    for metric_name, value_ms in (
+        ("primary metric", primary_ms),
+        ("commit-start upper bound", upper_bound_ms),
+    ):
+        if value_ms <= 0:
+            return [], [(scenario, f"non-positive {metric_name}: {value_ms} ms")]
+
+    primary_seconds = primary_ms / ONE_SECOND_IN_MILLISECONDS
+    measurements = [
+        (
+            result["measurement_methodology"]["primary_metric"],
+            "latency",
+            primary_ms * ONE_SECOND_IN_NANOSECONDS / ONE_SECOND_IN_MILLISECONDS,
+        ),
+        (
+            "commit_start_to_terminal_outputs_upper_bound",
+            "latency",
+            upper_bound_ms * ONE_SECOND_IN_NANOSECONDS / ONE_SECOND_IN_MILLISECONDS,
+        ),
+        (
+            "fhe_operations_per_second",
+            "throughput",
+            result["computation_count"] / primary_seconds,
+        ),
+        (
+            "transfers_per_second",
+            "throughput",
+            result["logical_block"]["transfer_count"] / primary_seconds,
+        ),
+    ]
+
+    points = []
+    for metric_name, bench_type, value in measurements:
+        label = METRIC_LABELS.get(metric_name, metric_name)
+        display_name = "::".join([BENCH_NAME, scenario, label])
+        # Follow the naming every stored point uses: the display name is stable
+        # per benchmark, and the test name carries the statistic and the run's
+        # suffix. A one-shot measures its workload once, so the run is its own
+        # mean and there is no deviation to report.
+        test_name = "_".join(filter(None, [display_name, "mean", name_suffix]))
+        points.append(
+            _create_point(value, test_name, bench_type, params, display_name)
+        )
+    return points, []
+
+
+def dump_results(parsed_results, filename, input_args):
+    """
+    Dump parsed results formatted as JSON to file.
+
+    :param parsed_results: :class:`list` of data points
+    :param filename: filename for dump file as :class:`pathlib.Path`
+    :param input_args: CLI input arguments
+    """
+    for point in parsed_results:
+        point["backend"] = input_args.backend
+
+    if input_args.append_results:
+        parsed_content = json.loads(filename.read_text(encoding="utf-8"))
+        parsed_content["points"].extend(parsed_results)
+        filename.write_text(json.dumps(parsed_content), encoding="utf-8")
+    else:
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        series = {
+            "database": input_args.database,
+            "hardware": input_args.hardware,
+            "project_version": input_args.project_version,
+            "branch": input_args.branch,
+            "insert_date": input_args.bench_date,
+            "commit_date": input_args.commit_date,
+            "points": parsed_results,
+        }
+        filename.write_text(json.dumps(series), encoding="utf-8")
+
+
+def check_mandatory_args(input_args):
+    """
+    Check for availability of required input arguments, the program will exit if
+    one of them is not present. If `append_results` flag is set, all the
+    required arguments will be ignored.
+
+    :param input_args: CLI input arguments
+    """
+    if input_args.append_results:
+        return
+
+    missing_args = [
+        arg_name
+        for arg_name in (
+            "database",
+            "hardware",
+            "project_version",
+            "branch",
+            "commit_date",
+            "bench_date",
+        )
+        if not getattr(input_args, arg_name)
+    ]
+    if missing_args:
+        for arg_name in missing_args:
+            print(f"Missing required argument: --{arg_name.replace('_', '-')}")
+        sys.exit(1)
+
+
+def main(input_args):
+    results_dir = pathlib.Path(input_args.results)
+    if not results_dir.is_dir():
+        print(f"No one-shot artifact directory at '{results_dir}'")
+        sys.exit(1)
+
+    runs = latest_run_per_scenario(results_dir, input_args.expected_revision)
+    if not runs:
+        print(f"No usable reportable one-shot artifact found in '{results_dir}'")
+        sys.exit(1)
+
+    parsed_results = []
+    failures = []
+    for scenario, content in sorted(runs.items()):
+        print(f"Parsing one-shot scenario '{scenario}'... ")
+        # One unparsable artifact must not cost the scenarios that did report:
+        # this step publishes what it could parse and fails afterwards.
+        try:
+            points, scenario_failures = parse_scenario(content, input_args.name_suffix)
+        except (KeyError, TypeError, ZeroDivisionError) as err:
+            failures.append((scenario, f"failed to parse artifact: {err!r}"))
+            continue
+        parsed_results.extend(points)
+        failures.extend(scenario_failures)
+
+    expected = [
+        scenario.strip()
+        for scenario in input_args.expected_scenarios.split(",")
+        if scenario.strip()
+    ]
+    for scenario in expected:
+        if scenario not in runs:
+            failures.append((scenario, "no reportable artifact for expected scenario"))
+
+    # Writing an empty series would let the workflow publish "results" holding no
+    # measurement at all; leave no file behind so the upload and send steps skip.
+    if not parsed_results:
+        print("\nNo data point could be parsed")
+        print("-----------------------------")
+        for name, error in failures:
+            print(f"[{name}] {error}")
+        sys.exit(1)
+
+    output_file = pathlib.Path(input_args.output_file)
+    print(f"Dump parsed results into '{output_file.resolve()}' ... ", end="")
+    dump_results(parsed_results, output_file, input_args)
+    print("Done")
+
+    if failures:
+        print("\nParsing failed for some results")
+        print("-------------------------------")
+        for name, error in failures:
+            print(f"[{name}] {error}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    check_mandatory_args(args)
+    main(args)

--- a/ci/detect_cuda.sh
+++ b/ci/detect_cuda.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -u
+
+# Ignore find errors from directories that the runner cannot inspect.
+mapfile -t NVCC_FOUND < <(
+  find /usr/local -executable -name "nvcc" 2>/dev/null | sort
+  find /usr/bin -executable -name "nvcc" 2>/dev/null | sort
+)
+
+set -eo pipefail
+
+if [ "${#NVCC_FOUND[@]}" -eq 0 ]; then
+  echo "nvcc not found; CUDA does not appear to be installed" >&2
+  exit 1
+fi
+
+# Callers derive the toolkit prefix as the parent of nvcc's directory, so only
+# accept an nvcc whose prefix actually holds a toolkit. A distribution-packaged
+# /usr/bin/nvcc reports a perfectly good version but yields /usr as its prefix,
+# whose lib64 does not exist on Debian multiarch: preferring it would export a
+# prefix pointing at directories that are not there.
+NVCC_CANDIDATES=()
+DETECTED_VERSIONS=()
+for NVCC_PATH in "${NVCC_FOUND[@]}"; do
+  PREFIX=$(dirname "$(dirname "${NVCC_PATH}")")
+  # Accept either library layout: rejecting a usable toolkit is not harmless,
+  # it makes the caller install a second one over an image that already ships
+  # what was asked for.
+  if [ ! -f "${PREFIX}/include/cuda_runtime.h" ] ||
+    { [ ! -d "${PREFIX}/lib64" ] && [ ! -d "${PREFIX}/lib" ]; }; then
+    echo "Ignoring ${NVCC_PATH}: ${PREFIX} is not laid out as a toolkit root" >&2
+    continue
+  fi
+  NVCC_CANDIDATES+=("${NVCC_PATH}")
+  DETECTED_VERSIONS+=("$("${NVCC_PATH}" --version |
+    sed -n 's/.*release \([0-9]*\.[0-9]*\).*/\1/p')")
+done
+
+if [ "${#NVCC_CANDIDATES[@]}" -eq 0 ]; then
+  echo "No nvcc found in a usable toolkit layout: ${NVCC_FOUND[*]}" >&2
+  exit 1
+fi
+
+# An image may carry several toolkits. Honour the caller's order of preference
+# rather than whichever one `find` happens to reach first, so a run cannot
+# silently measure on an older toolkit than the one it asked for.
+for CUDA_VERSION in "$@"; do
+  for INDEX in "${!NVCC_CANDIDATES[@]}"; do
+    if [ "${DETECTED_VERSIONS[${INDEX}]}" = "${CUDA_VERSION}" ]; then
+      echo "${NVCC_CANDIDATES[${INDEX}]}"
+      exit 0
+    fi
+  done
+done
+
+echo "Expected one of CUDA version(s): $* but detected ${DETECTED_VERSIONS[*]}" >&2
+exit 1

--- a/ci/export_cuda_vars.sh
+++ b/ci/export_cuda_vars.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 GITHUB_ENV GITHUB_PATH CUDA_VERSION [CUDA_VERSION...]" >&2
+  exit 1
+fi
+
+GITHUB_ENV="${1}"
+GITHUB_PATH="${2}"
+shift 2
+
+NVCC_PATH=$(bash "$(dirname "$0")/detect_cuda.sh" "$@")
+CUDA_PATH=$(dirname "$(dirname "${NVCC_PATH}")")
+
+# detect_cuda.sh accepts either library layout, so export the one that is there.
+if [ -d "${CUDA_PATH}/lib64" ]; then
+  CUDA_LIBRARY_PATH="${CUDA_PATH}/lib64"
+else
+  CUDA_LIBRARY_PATH="${CUDA_PATH}/lib"
+fi
+# Never leave an empty entry: the loader reads it as the current directory, which
+# would let a stray .so in a build or test directory take precedence.
+if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+  CUDA_LIBRARY_PATH="${CUDA_LIBRARY_PATH}:${LD_LIBRARY_PATH}"
+fi
+
+{
+  echo "CUDA_PATH=${CUDA_PATH}"
+  echo "CUDACXX=${NVCC_PATH}"
+  echo "LD_LIBRARY_PATH=${CUDA_LIBRARY_PATH}"
+  echo "CUDA_MODULE_LOADER=EAGER"
+  echo "PATH=${PATH}:${CUDA_PATH}/bin"
+} >> "${GITHUB_ENV}"
+
+echo "${CUDA_PATH}/bin" >> "${GITHUB_PATH}"

--- a/ci/log_host_resources.sh
+++ b/ci/log_host_resources.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Print one host-resource line per interval until killed.
+#
+# Meant to run in the background of a long CI step. A runner that loses its host
+# — out of memory, out of disk, or a reclaimed instance — reports as "The
+# operation was canceled." with no failing command, and no later step runs to
+# collect evidence. Only output already streamed to the live log survives, so
+# the last line printed here is the account of what the host looked like as it
+# died.
+
+set -uo pipefail
+
+INTERVAL="${1:-30}"
+
+while true; do
+  # Tolerate a probe failing rather than ending the sampler.
+  DISK=$(df -h --output=avail / 2>/dev/null | tail -1 | tr -d ' ' || echo "?")
+  MEM_AVAIL=$(free -m 2>/dev/null | awk '/^Mem:/ {print $7}' || echo "?")
+  SWAP_USED=$(free -m 2>/dev/null | awk '/^Swap:/ {print $3}' || echo "?")
+  LOAD=$(cut -d ' ' -f1-3 /proc/loadavg 2>/dev/null || echo "?")
+  printf '[host] %s disk_avail=%s mem_avail=%sMi swap_used=%sMi load=%s\n' \
+    "$(date -u +%H:%M:%S)" "${DISK}" "${MEM_AVAIL}" "${SWAP_USED}" "${LOAD}"
+  sleep "${INTERVAL}"
+done

--- a/ci/parse_benchmark_profile.py
+++ b/ci/parse_benchmark_profile.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import tomllib
+
+
+BACKEND_MAP = {
+    "hyperstack": "hyperstack",
+    "scaleway": "terraform",
+}
+
+
+def parse_profile(profile_string, output_file, slab_toml):
+    parts = profile_string.split("::", 1)
+    if len(parts) != 2:
+        sys.exit(
+            f"Invalid profile format '{profile_string}'; expected "
+            "'provider::profile-name (hardware-name)'"
+        )
+
+    provider, profile_and_hardware = parts
+    split_profile = profile_and_hardware.split()
+    if len(split_profile) != 2:
+        sys.exit(
+            f"Invalid profile format '{profile_and_hardware}'; expected "
+            "'provider::profile-name (hardware-name)'"
+        )
+
+    profile_name = split_profile[0]
+    hardware_name = split_profile[1].removeprefix("(").removesuffix(")")
+
+    if provider not in BACKEND_MAP:
+        known_providers = ", ".join(sorted(BACKEND_MAP))
+        sys.exit(f"Unknown provider '{provider}'; known providers: {known_providers}")
+
+    slab_backend = BACKEND_MAP[provider]
+    profile = f"{provider}-{profile_name}" if slab_backend == "terraform" else profile_name
+
+    with open(slab_toml, "rb") as slab_file:
+        slab = tomllib.load(slab_file)
+
+    available_profiles = slab.get("backend", {}).get(slab_backend, {})
+    if profile not in available_profiles:
+        known_profiles = ", ".join(sorted(available_profiles))
+        sys.exit(
+            f"Profile '{profile}' not found under [backend.{slab_backend}] in "
+            f"{slab_toml}; known profiles: {known_profiles}"
+        )
+
+    entry = available_profiles[profile]
+    expected_hardware = entry.get("flavor_name") or entry.get("instance_type")
+    if expected_hardware is None:
+        sys.exit(
+            f"Profile '{profile}' in {slab_toml} has neither flavor_name nor instance_type"
+        )
+    if hardware_name != expected_hardware:
+        sys.exit(
+            f"Hardware '{hardware_name}' does not match expected '{expected_hardware}' "
+            f"for profile '{profile}' in {slab_toml}"
+        )
+
+    with open(output_file, "a", encoding="utf-8") as output:
+        for name, value in (
+            ("backend", slab_backend),
+            ("profile", profile),
+            ("hardware", hardware_name),
+            ("cloud_provider", provider),
+        ):
+            output.write(f"{name}={value}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Parse and validate a GPU benchmark provider/profile string"
+    )
+    parser.add_argument("profile_string")
+    parser.add_argument("output_file")
+    parser.add_argument("--slab-toml", default="ci/slab.toml")
+    arguments = parser.parse_args()
+    parse_profile(arguments.profile_string, arguments.output_file, arguments.slab_toml)

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -10,6 +10,18 @@ image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
 flavor_name = "n3-L40x1"
 user = "ubuntu"
 
+[backend.hyperstack.4-l40]
+environment_name = "canada"
+image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
+flavor_name = "n3-L40x4"
+user = "ubuntu"
+
+[backend.hyperstack.multi-a100-nvlink]
+environment_name = "canada"
+image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
+flavor_name = "n3-A100x8-NVLink"
+user = "ubuntu"
+
 [backend.hyperstack.2-h100]
 environment_name = "canada"
 image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
@@ -44,6 +56,31 @@ user = "ubuntu"
 environment_name = "us-1"
 image_name = "Ubuntu Server 22.04 LTS R535 CUDA 12.2"
 flavor_name = "n3-H100-SXM5x8"
+user = "ubuntu"
+
+[backend.terraform.scaleway-multi-h100-sxm5]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-SXM-8-80G"
+user = "ubuntu"
+
+[backend.terraform.scaleway-4-h100-sxm5]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-SXM-4-80G"
+user = "ubuntu"
+
+[backend.terraform.scaleway-2-h100-sxm5]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-SXM-2-80G"
+user = "ubuntu"
+
+[backend.terraform.scaleway-single-h100]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-1-80G"
+user = "ubuntu"
+
+[backend.terraform.scaleway-single-h100_fallback]
+script_path = "ci/terraform_scripts/scaleway/terraform.tf"
+instance_type = "H100-1-80G"
 user = "ubuntu"
 
 [backend.aws.bench]

--- a/ci/terraform_scripts/scaleway/terraform.tf
+++ b/ci/terraform_scripts/scaleway/terraform.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.73"
+    }
+  }
+  required_version = "~> 1.14"
+}
+
+provider "scaleway" {
+  zone = "fr-par-2"
+}
+
+# Provided through the Slab server environment.
+variable "project_id" {
+  type        = string
+  description = "Scaleway project ID to attach the instance to"
+}
+
+# Provided through ci/slab.toml.
+variable "instance_type" {
+  type        = string
+  description = "Scaleway instance type"
+}
+
+# Provided by the Slab server.
+variable "instance_label" {
+  type        = string
+  description = "Instance name displayed in the Scaleway console"
+}
+
+# Provided by the Slab server.
+variable "user_data" {
+  type        = string
+  description = "Cloud-init script run when the instance starts"
+}
+
+resource "scaleway_instance_ip" "github_runner" {
+  project_id = var.project_id
+}
+
+data "scaleway_instance_security_group" "github_runner" {
+  project_id = var.project_id
+  name       = "github-actions-runner"
+}
+
+data "scaleway_instance_image" "gpu_benchmark_image" {
+  project_id = var.project_id
+  name       = "tfhe-rs-ubuntu-24-cuda"
+}
+
+resource "scaleway_instance_server" "scaleway_gpu_instance" {
+  project_id = var.project_id
+  image      = data.scaleway_instance_image.gpu_benchmark_image.id
+  type       = var.instance_type
+  name       = var.instance_label
+
+  root_volume {
+    size_in_gb = 200
+  }
+
+  ip_id = scaleway_instance_ip.github_runner.id
+
+  user_data = {
+    "cloud-init" = var.user_data
+  }
+
+  security_group_id = data.scaleway_instance_security_group.github_runner.id
+}
+
+output "instance_id" {
+  value       = scaleway_instance_server.scaleway_gpu_instance.id
+  description = "Unique ID of the Scaleway instance"
+}
+
+# The reachable address of the instance. Every other backend hands the Slab
+# server something it can reach the runner on; without it Slab can only see an
+# opaque instance ID here.
+output "instance_ip" {
+  value       = scaleway_instance_ip.github_runner.address
+  description = "Public IP address of the Scaleway instance"
+}

--- a/coprocessor/fhevm-engine/tfhe-worker/Makefile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Makefile
@@ -24,7 +24,8 @@ BENCH_ONE_SHOT_RECREATE_DB ?= 0
 # Wall-clock budget per scenario, including its build, in seconds; 0 disables it.
 # The whole suite must fit the CI job timeout with room for instance setup, so
 # this bounds one wedged scenario rather than letting it starve the others:
-# 6 canonical scenarios x 3600s leaves half of a 720-minute job spare.
+# 7 canonical scenarios x 3600s is 420 of a 720-minute job, leaving 300 minutes
+# for the first scenario's cold build, instance setup and reporting.
 BENCH_ONE_SHOT_SCENARIO_TIMEOUT ?= 3600
 # Keep each canonical logical block in one Main scheduling acquisition. Callers
 # may still override this for a deliberate dispatch-shape experiment.
@@ -73,6 +74,14 @@ init_db:
 # benchmark itself builds, never the one in that image.
 BENCH_DB_URL ?= postgresql://postgres:postgres@127.0.0.1:5432/coprocessor
 BENCH_DB_MIGRATIONS ?= ../db-migration/migrations
+# The database the reportable benches connect to. Defaults to the one this
+# Makefile migrates and resets, so migration, reset and execution name ONE
+# target; an override must point all three at the same database (checked by
+# the suite when it resets between scenarios).
+export FHEVM_BENCH_DATABASE_URL ?= $(BENCH_DB_URL)
+# Database name of BENCH_DB_URL, for statements that address it by name: the
+# last path segment, with any query string dropped.
+BENCH_DB_NAME = $(lastword $(subst /, ,$(firstword $(subst ?, ,$(BENCH_DB_URL)))))
 
 .PHONY: bench_db_up
 bench_db_up:
@@ -95,7 +104,7 @@ migrate_bench_db:
 .PHONY: reset_bench_db
 reset_bench_db:
 	docker compose exec -T db psql -U postgres -d postgres \
-	  -c "DROP DATABASE IF EXISTS coprocessor WITH (FORCE);"
+	  -c "DROP DATABASE IF EXISTS \"$(BENCH_DB_NAME)\" WITH (FORCE);"
 	$(MAKE) migrate_bench_db
 
 .PHONY: recreate_db
@@ -162,6 +171,11 @@ define run_one_shot_suite
 	@$(BENCH_ONE_SHOT_SCENARIO_CHECK)set -u; \
 	: "A dirty worktree is not a per-scenario failure: report it once up front"; \
 	$(MAKE) check_main_block_baseline_clean_source || exit 2; \
+	: "Reset and execution must address the same database, or the reset wipes one while the benches keep the other's rows"; \
+	if [ "$(BENCH_ONE_SHOT_RECREATE_DB)" = "1" ] && [ "$$FHEVM_BENCH_DATABASE_URL" != "$(BENCH_DB_URL)" ]; then \
+	  echo "BENCH_ONE_SHOT_RECREATE_DB=1 resets BENCH_DB_URL ($(BENCH_DB_URL)) but the benches run against FHEVM_BENCH_DATABASE_URL ($$FHEVM_BENCH_DATABASE_URL); point both at one database" >&2; \
+	  exit 2; \
+	fi; \
 	failed=""; \
 	for scenario in $(BENCH_ONE_SHOT_SCENARIOS); do \
 	  if [ "$(BENCH_ONE_SHOT_RECREATE_DB)" = "1" ]; then \

--- a/coprocessor/fhevm-engine/tfhe-worker/README.md
+++ b/coprocessor/fhevm-engine/tfhe-worker/README.md
@@ -188,9 +188,12 @@ leaves the metric. Latencies are in nanoseconds; the rate metrics are already
 per second.
 
 The panels filter on hardware and branch, not on backend. Backend follows from
-the machine — a GPU flavor only ever stores `cuda` — so filtering on it adds a
-way for a panel to come back empty without adding a distinction. It is still
-recorded, and the diagnostics below print it.
+the machine — a GPU flavor stores `cuda`, a CPU one `cpu` — so filtering on it
+adds a way for a panel to come back empty without adding a distinction. It is
+still recorded, and the diagnostics below print it. GPU points recorded before
+the one-shot suite landed carry the older label `gpu`; the label was unified to
+`cuda` for every GPU series, so a backend filter spanning that change has to
+accept both.
 
 Primary metric per scenario, in milliseconds. The label differs between the
 paced and unpaced workloads, which is why two are matched:
@@ -283,7 +286,8 @@ SELECT
   max(1000 / (m.value / 1e9)) FILTER (WHERE split_part(test.name, '::', 4) = 'cross_tx_dependent_1000_50x20') AS cross_tx_dependent_1000_50x20,
   max(300 / (m.value / 1e9)) FILTER (WHERE split_part(test.name, '::', 4) = 'auction_300') AS auction_300,
   max(1000 / (m.value / 1e9)) FILTER (WHERE split_part(test.name, '::', 4) = 'traffic_1000_200x5_10x100_lag2') AS traffic_1000_200x5_10x100_lag2,
-  max(1000 / (m.value / 1e9)) FILTER (WHERE split_part(test.name, '::', 4) = 'traffic_join_1000_200x5_20acct_lag2') AS traffic_join_1000_200x5_20acct_lag2
+  max(1000 / (m.value / 1e9)) FILTER (WHERE split_part(test.name, '::', 4) = 'traffic_join_1000_200x5_20acct_lag2') AS traffic_join_1000_200x5_20acct_lag2,
+  max(250 / (m.value / 1e9)) FILTER (WHERE split_part(test.name, '::', 4) = 'skewed_chains_250_1x200_50x1') AS skewed_chains_250_1x200_50x1
 FROM benchmark.metrics AS m
 JOIN benchmark.test AS test ON test.id = m.test_id
 JOIN benchmark.hardware AS h ON h.id = m.hardware_id
@@ -323,7 +327,8 @@ SELECT
   max(m.value) FILTER (WHERE split_part(test.name, '::', 4) = 'cross_tx_dependent_1000_50x20') AS cross_tx_dependent_1000_50x20,
   max(m.value) FILTER (WHERE split_part(test.name, '::', 4) = 'auction_300') AS auction_300,
   max(m.value) FILTER (WHERE split_part(test.name, '::', 4) = 'traffic_1000_200x5_10x100_lag2') AS traffic_1000_200x5_10x100_lag2,
-  max(m.value) FILTER (WHERE split_part(test.name, '::', 4) = 'traffic_join_1000_200x5_20acct_lag2') AS traffic_join_1000_200x5_20acct_lag2
+  max(m.value) FILTER (WHERE split_part(test.name, '::', 4) = 'traffic_join_1000_200x5_20acct_lag2') AS traffic_join_1000_200x5_20acct_lag2,
+  max(m.value) FILTER (WHERE split_part(test.name, '::', 4) = 'skewed_chains_250_1x200_50x1') AS skewed_chains_250_1x200_50x1
 FROM benchmark.metrics AS m
 JOIN benchmark.test AS test ON test.id = m.test_id
 JOIN benchmark.hardware AS h ON h.id = m.hardware_id
@@ -374,7 +379,8 @@ WITH scenario (bench, transfers, ord) AS (
     ('cross_tx_dependent_1000_50x20', 1000, 3),
     ('auction_300', 300, 4),
     ('traffic_1000_200x5_10x100_lag2', 1000, 5),
-    ('traffic_join_1000_200x5_20acct_lag2', 1000, 6)
+    ('traffic_join_1000_200x5_20acct_lag2', 1000, 6),
+    ('skewed_chains_250_1x200_50x1', 250, 7)
 ), latest AS (
   SELECT DISTINCT ON (pv.name, s.bench, h.name)
     left(pv.name, 7) AS commit,

--- a/coprocessor/fhevm-engine/tfhe-worker/benches/utils.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/benches/utils.rs
@@ -909,6 +909,15 @@ pub async fn insert_tfhe_event(
 /// chain. The auction fixture instead preserves its 300 EVM transaction IDs
 /// while intentionally executing their same-L1-block graph as one legacy
 /// scheduling chain.
+///
+/// Every staged computation also gets its `dependence_chain` row materialized
+/// here, because the bench worker runs with DCID locking enabled: it only
+/// acquires work whose chain has an `'updated'`, unowned, zero-dependency row
+/// in `dependence_chain`. Without that row the staged computations are never
+/// picked up and the fixture stalls on its own wait timeout. The insert is
+/// `DO NOTHING` on purpose -- one-shot fixtures call
+/// [`upsert_legacy_dependence_chain`] afterwards with real dependency counts
+/// and dependents, and those values must win.
 pub async fn insert_tfhe_event_with_dependence_chain(
     db: &ListenerDatabase,
     tx: &mut Transaction<'_>,
@@ -917,6 +926,20 @@ pub async fn insert_tfhe_event_with_dependence_chain(
     dependence_chain: Handle,
     is_allowed: bool,
 ) -> Result<bool, sqlx::Error> {
+    // Bench staging bypasses ordered block ingestion, so nothing else creates
+    // the DCID row the locking worker needs before it can claim this work.
+    // Seed a ready, unowned, zero-dependency chain; `DO NOTHING` leaves any
+    // richer row already written by `upsert_legacy_dependence_chain` intact.
+    sqlx::query(
+        "INSERT INTO dependence_chain ( \
+             dependence_chain_id, status, last_updated_at, dependency_count, dependents, \
+             block_hash, block_height, schedule_priority \
+         ) VALUES ($1, 'updated', NOW(), 0, '{}', ''::bytea, 0, 0) \
+         ON CONFLICT (dependence_chain_id) DO NOTHING",
+    )
+    .bind(dependence_chain.to_vec())
+    .execute(&mut **tx)
+    .await?;
     // Bench staging bypasses ordered block ingestion, so derive the same
     // authoritative transaction-local origin bits from rows already staged
     // for this fixture transaction.

--- a/test-suite/e2e/test/consensus/README.md
+++ b/test-suite/e2e/test/consensus/README.md
@@ -71,3 +71,26 @@ the harness itself and run in the ordinary suite without a stack.
 
 The multi-coprocessor topology launcher is provided separately (it is
 infrastructure, not part of this test suite).
+
+## Host daemon access
+
+Restart and fault scenarios act on explicitly named coprocessor containers, so
+the e2e runner container (`test-suite-e2e-debug`) is given the host Docker
+socket at `/var/run/docker.sock`. This is unrestricted control of the host
+daemon: anything running in that container can stop, start, or recreate **any**
+container on the host, not just the stack's. The socket is inert for ordinary
+E2E tests.
+
+The wiring is generated, not tracked in
+`test-suite/fhevm/docker-compose/test-suite-docker-compose.yml`: the local CLI
+emits it into the runtime compose override for the `test-suite` component
+(`dockerSocketRuntime` in `test-suite/fhevm/src/generate/compose.ts`) and only
+when a socket is actually present on the host — the path follows a `unix://`
+`DOCKER_HOST` and otherwise defaults to `/var/run/docker.sock`. A host with no
+socket (rootless Docker, or a remote `tcp://` daemon) simply gets no mount, and
+the runner container still starts; the fault scenarios are the only thing that
+needs the socket. The supplementary group id is read from the socket itself at
+generation time rather than guessed, so it matches whatever owns the socket on
+that host. Note that CI runners which grant socket access through an ACL
+(`setfacl`) rather than group ownership are not covered by a supplementary
+group, and the fault scenarios cannot drive the daemon there.

--- a/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-
   test-suite-e2e-debug:
     container_name: fhevm-test-suite-e2e-debug
     image: ghcr.io/zama-ai/fhevm/test-suite/e2e:${TEST_SUITE_VERSION}
@@ -11,5 +10,15 @@ services:
     network_mode: "container:fhevm-minio"
     env_file:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/env/test-suite.env
+    # Restart and fault tests act on explicitly named coprocessor containers.
+    # The socket is inert for ordinary E2E tests, but without it the consensus
+    # harness could only claim a restart happened rather than performing one.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    # Docker sockets are normally root:docker mode 0660. Keep the runner
+    # unprivileged but add the host socket group explicitly; CI/local callers
+    # may override this default with `DOCKER_GID=$(stat -c %g /var/run/docker.sock)`.
+    group_add:
+      - '${DOCKER_GID:-999}'
     command:
       - tail -f /dev/null

--- a/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/test-suite-docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
   test-suite-e2e-debug:
     container_name: fhevm-test-suite-e2e-debug
     image: ghcr.io/zama-ai/fhevm/test-suite/e2e:${TEST_SUITE_VERSION}
@@ -10,15 +11,5 @@ services:
     network_mode: "container:fhevm-minio"
     env_file:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/env/test-suite.env
-    # Restart and fault tests act on explicitly named coprocessor containers.
-    # The socket is inert for ordinary E2E tests, but without it the consensus
-    # harness could only claim a restart happened rather than performing one.
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    # Docker sockets are normally root:docker mode 0660. Keep the runner
-    # unprivileged but add the host socket group explicitly; CI/local callers
-    # may override this default with `DOCKER_GID=$(stat -c %g /var/run/docker.sock)`.
-    group_add:
-      - '${DOCKER_GID:-999}'
     command:
       - tail -f /dev/null

--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -5,6 +5,7 @@ import {
   LEGACY_RELAYER_MIGRATE_IMAGE_REPOSITORY,
   MODERN_RELAYER_IMAGE_REPOSITORY,
   MODERN_RELAYER_MIGRATE_IMAGE_REPOSITORY,
+  assertSupportedBundleScenario,
   bootstrapUsesHostKmsGeneration,
   canonicalProtocolConfigSeedingUsesEnv,
   compatArgPolicyForPinnedTag,
@@ -38,6 +39,29 @@ describe("compat", () => {
       compatTag: "v0.15.0",
     });
     expect(replaceRegistrySourceTag(hotfix, "v0.15.0")).toEqual({ mode: "registry", tag: "v0.15.0" });
+  });
+
+  test("requires a full local coprocessor build for multi-node consensus topologies", () => {
+    const scenario = testDefaultScenario({ topology: { count: 3, threshold: 3 } });
+    const versions = {
+      target: "latest-main" as const,
+      lockName: "latest-main.json",
+      env: {} as Record<string, string>,
+      sources: [],
+    };
+    expect(() => assertSupportedBundleScenario({ versions, overrides: [], scenario })).toThrow(
+      "require a full local coprocessor build",
+    );
+    expect(() =>
+      assertSupportedBundleScenario({ versions, overrides: [{ group: "coprocessor" }], scenario }),
+    ).not.toThrow();
+    expect(() =>
+      assertSupportedBundleScenario({
+        versions,
+        overrides: [{ group: "coprocessor", services: ["coprocessor-host-listener"] }],
+        scenario,
+      }),
+    ).toThrow("require a full local coprocessor build");
   });
 
   test("flags relayer v1 vs test-suite v2 incompatibility", () => {

--- a/test-suite/fhevm/src/compat.test.ts
+++ b/test-suite/fhevm/src/compat.test.ts
@@ -41,27 +41,62 @@ describe("compat", () => {
     expect(replaceRegistrySourceTag(hotfix, "v0.15.0")).toEqual({ mode: "registry", tag: "v0.15.0" });
   });
 
-  test("requires a full local coprocessor build for multi-node consensus topologies", () => {
-    const scenario = testDefaultScenario({ topology: { count: 3, threshold: 3 } });
+  test("multi-node consensus topologies need one coprocessor revision, not a local build", () => {
+    const scenario = testDefaultScenario({
+      topology: { count: 3, threshold: 3 },
+      instances: [0, 1, 2].map((index) => ({ index, source: { mode: "inherit" as const }, env: {}, args: {} })),
+    });
     const versions = {
       target: "latest-main" as const,
       lockName: "latest-main.json",
-      env: {} as Record<string, string>,
+      env: { COPROCESSOR_TFHE_WORKER_VERSION: "v0.15.0" } as Record<string, string>,
       sources: [],
     };
-    expect(() => assertSupportedBundleScenario({ versions, overrides: [], scenario })).toThrow(
-      "require a full local coprocessor build",
-    );
+    // The published bundle on every node is one revision: the orchestrated CI
+    // path runs exactly this, with no override at all.
+    expect(() => assertSupportedBundleScenario({ versions, overrides: [], scenario })).not.toThrow();
+    // A full local build on every node is one revision too.
     expect(() =>
       assertSupportedBundleScenario({ versions, overrides: [{ group: "coprocessor" }], scenario }),
     ).not.toThrow();
+    // A service-scoped override mixes local and published services.
     expect(() =>
       assertSupportedBundleScenario({
         versions,
         overrides: [{ group: "coprocessor", services: ["coprocessor-host-listener"] }],
         scenario,
       }),
-    ).toThrow("require a full local coprocessor build");
+    ).toThrow("service-scoped coprocessor override (coprocessor-host-listener)");
+    // Instances on different sources are different revisions.
+    const mixed = testDefaultScenario({
+      topology: { count: 3, threshold: 3 },
+      instances: [
+        { index: 0, source: { mode: "local" }, env: {}, args: {} },
+        { index: 1, source: { mode: "registry", tag: "v0.14.0" }, env: {}, args: {} },
+        { index: 2, source: { mode: "inherit" }, env: {}, args: {} },
+      ],
+    });
+    expect(() => assertSupportedBundleScenario({ versions, overrides: [], scenario: mixed })).toThrow(
+      /instance sources differ: .*local \(instance 0\).*registry:v0\.14\.0 \(instance 1\).*bundle \(instance 2\)/,
+    );
+    // An explicit registry tag equal to the bundle's is the same revision.
+    const pinnedToBundle = testDefaultScenario({
+      topology: { count: 2, threshold: 2 },
+      instances: [
+        { index: 0, source: { mode: "registry", tag: "v0.15.0" }, env: {}, args: {} },
+        { index: 1, source: { mode: "inherit" }, env: {}, args: {} },
+      ],
+    });
+    expect(() => assertSupportedBundleScenario({ versions, overrides: [], scenario: pinnedToBundle })).not.toThrow();
+    // A single node is never a consensus comparison; partial overrides stay legal there.
+    const single = testDefaultScenario({ topology: { count: 1, threshold: 1 } });
+    expect(() =>
+      assertSupportedBundleScenario({
+        versions,
+        overrides: [{ group: "coprocessor", services: ["coprocessor-host-listener"] }],
+        scenario: single,
+      }),
+    ).not.toThrow();
   });
 
   test("flags relayer v1 vs test-suite v2 incompatibility", () => {

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -543,6 +543,21 @@ export const validateBundleCompatibility = (state: Pick<CompatState, "versions">
 export const assertSupportedBundleScenario = (state: CompatState) => {
   const scenario = "scenario" in state ? state.scenario : state.coprocessor;
   if (!scenario) return; // blue-green stack spec — handled by its own compat path
+  if (scenario.kind === "coprocessor-consensus" && (scenario.topology?.count ?? 1) > 1) {
+    // Byte-consensus topologies compare persisted ciphertext bytes across
+    // coprocessors, which is only meaningful when every node runs the same
+    // software revision.  Requiring a full local coprocessor build avoids
+    // silently pairing the scenario with an older published
+    // listener/migration/worker image; partial service overrides cannot
+    // guarantee one revision.
+    const overrides = effectiveCompatOverrides(state);
+    const fullLocalCoprocessor = overrides.some((override) => override.group === "coprocessor" && !override.services?.length);
+    if (!fullLocalCoprocessor) {
+      throw new Error(
+        "Consensus scenarios require a full local coprocessor build (use --build or --override coprocessor) so listener, migration, and worker are from the same revision.",
+      );
+    }
+  }
   const hostChains = scenario.hostChains;
   if (hostChains.length <= 1 || !requiresLegacySingleChainCoprocessor(state)) {
     return;

--- a/test-suite/fhevm/src/compat/compat.ts
+++ b/test-suite/fhevm/src/compat/compat.ts
@@ -3,7 +3,7 @@
  */
 import { effectiveOverrides } from "../scenario/resolve";
 import type { StackSpec } from "../stack-spec/stack-spec";
-import type { CoprocessorInstanceSource, State } from "../types";
+import type { CoprocessorInstanceSource, ResolvedCoprocessorScenario, State } from "../types";
 
 type CompatSemver = readonly [number, number, number];
 type CompatService =
@@ -539,24 +539,72 @@ export const validateBundleCompatibility = (state: Pick<CompatState, "versions">
   return issues;
 };
 
+/**
+ * Rejects a multi-node consensus scenario whose nodes would not all run the
+ * same coprocessor revision.
+ *
+ * Byte-consensus compares persisted ciphertext bytes across coprocessors,
+ * which is only meaningful when every node runs the same software revision.
+ * Two shapes break that and are refused: a service-scoped coprocessor
+ * override, which mixes locally built services with published ones; and
+ * instances whose effective sources differ (one local, one published, or two
+ * different published tags). A single published tag for every node, or a full
+ * local build for every node, both satisfy the premise and pass -- the
+ * orchestrated CI path runs the published bundle with no override at all.
+ */
+const assertSingleCoprocessorRevision = (
+  state: CompatState,
+  scenario: Pick<ResolvedCoprocessorScenario, "instances">,
+) => {
+  const overrides = effectiveCompatOverrides(state);
+  const partial = overrides.find((override) => override.group === "coprocessor" && override.services?.length);
+  if (partial) {
+    throw new Error(
+      "Consensus scenarios need every coprocessor service on every node from one revision; " +
+        `a service-scoped coprocessor override (${(partial.services ?? []).join(", ")}) mixes locally built ` +
+        "services with published ones. Use --override coprocessor (or --build) for a full local build, or no " +
+        "coprocessor override to run the bundle's published images.",
+    );
+  }
+  // An inherited instance builds locally only under an EXPLICIT full
+  // coprocessor override; scenario-owned sources (`mode: local` on some
+  // instance) never change how a sibling `inherit` instance sources its
+  // images, and `assertScenarioOverrideCompatibility` already refuses
+  // explicit overrides alongside scenario-owned sources.
+  const fullLocal = state.overrides.some((override) => override.group === "coprocessor" && !override.services?.length);
+  const bundleTag = state.versions.env.COPROCESSOR_TFHE_WORKER_VERSION ?? "";
+  const revisionOf = (source: CoprocessorInstanceSource) => {
+    switch (source.mode) {
+      case "local":
+        return "local";
+      case "registry":
+        return source.tag === bundleTag ? "bundle" : `registry:${source.tag}`;
+      default:
+        return fullLocal ? "local" : "bundle";
+    }
+  };
+  const nodesByRevision = new Map<string, number[]>();
+  scenario.instances.forEach((instance, position) => {
+    const revision = revisionOf(instance.source);
+    nodesByRevision.set(revision, [...(nodesByRevision.get(revision) ?? []), instance.index ?? position]);
+  });
+  if (nodesByRevision.size > 1) {
+    const detail = [...nodesByRevision]
+      .map(([revision, indexes]) => `${revision} (instance ${indexes.join(", ")})`)
+      .join(" vs ");
+    throw new Error(
+      `Consensus scenarios need every node on one coprocessor revision; instance sources differ: ${detail}. ` +
+        "Align the instance sources, or use --override coprocessor to build every node locally.",
+    );
+  }
+};
+
 /** Rejects multi-chain scenarios when the resolved coprocessor bundle predates multi-chain support. */
 export const assertSupportedBundleScenario = (state: CompatState) => {
   const scenario = "scenario" in state ? state.scenario : state.coprocessor;
   if (!scenario) return; // blue-green stack spec — handled by its own compat path
   if (scenario.kind === "coprocessor-consensus" && (scenario.topology?.count ?? 1) > 1) {
-    // Byte-consensus topologies compare persisted ciphertext bytes across
-    // coprocessors, which is only meaningful when every node runs the same
-    // software revision.  Requiring a full local coprocessor build avoids
-    // silently pairing the scenario with an older published
-    // listener/migration/worker image; partial service overrides cannot
-    // guarantee one revision.
-    const overrides = effectiveCompatOverrides(state);
-    const fullLocalCoprocessor = overrides.some((override) => override.group === "coprocessor" && !override.services?.length);
-    if (!fullLocalCoprocessor) {
-      throw new Error(
-        "Consensus scenarios require a full local coprocessor build (use --build or --override coprocessor) so listener, migration, and worker are from the same revision.",
-      );
-    }
+    assertSingleCoprocessorRevision(state, scenario);
   }
   const hostChains = scenario.hostChains;
   if (hostChains.length <= 1 || !requiresLegacySingleChainCoprocessor(state)) {

--- a/test-suite/fhevm/src/flow/readiness.ts
+++ b/test-suite/fhevm/src/flow/readiness.ts
@@ -348,22 +348,52 @@ export const discoverKmsSigners = async (
   throw new MinioError(`Could not discover ${parties} KMS signer(s) after 60 attempts (${lastFailure})`);
 };
 
-/** Waits until one material artifact becomes available through host-reachable MinIO. */
-export const ensureMaterial = async (url: string) => {
+/**
+ * Waits until one of the supplied material artifacts is available through
+ * host-reachable MinIO.  Probing alternatives together preserves the normal
+ * bootstrap retry budget when a bundle supports more than one wire format.
+ */
+export const ensureOneMaterial = async (urls: readonly string[]) => {
+  if (!urls.length) {
+    throw new PreflightError("At least one material URL is required");
+  }
   for (let attempt = 0; attempt <= 30; attempt += 1) {
-    try {
-      const response = await fetch(hostReachableMaterialUrl(url), { method: "HEAD" });
-      if (response.ok) {
-        return;
-      }
-    } catch {
-      // retry
+    const available = await Promise.all(
+      urls.map(async (url) => {
+        try {
+          return (await fetch(hostReachableMaterialUrl(url), { method: "HEAD" })).ok;
+        } catch {
+          return false;
+        }
+      }),
+    );
+    if (available.some(Boolean)) {
+      return;
     }
     if (attempt === 30) {
-      throw new MinioError(`Material not ready: ${url}`);
+      throw new MinioError(`Material not ready: ${urls.join(" or ")}`);
     }
     await Bun.sleep(1_000);
   }
+};
+
+/** Waits until one material artifact becomes available through host-reachable MinIO. */
+export const ensureMaterial = async (url: string) => ensureOneMaterial([url]);
+
+/**
+ * Waits for the server-side part of an FHE key activation.  Current kms-core
+ * publishes that material as a `CompressedXofKeySet`; older bundles publish a
+ * plain `ServerKey`.  PublicKey and CRS availability alone is not sufficient:
+ * a coprocessor cannot materialize `keys` or start a TFHE worker without one
+ * of these authenticated server-side blobs.
+ */
+const ensureServerKeyMaterial = async (baseUrl: string, keyPrefix: string, keyId: string) => {
+  const root = `${baseUrl}/kms-public/${keyPrefix}`;
+  const candidates = [
+    `${root}/CompressedXofKeySet/${keyId}`,
+    `${root}/ServerKey/${keyId}`,
+  ];
+  await ensureOneMaterial(candidates);
 };
 
 /** Calls a contract view through cast and interprets the result as a boolean. */
@@ -451,6 +481,7 @@ export const probeBootstrap = async (state: State) => {
     const actualCrsKeyId = actualCrs.toString(16).padStart(64, "0");
     await Promise.all([
       ensureMaterial(`${discovery.endpoints.minioExternal}/kms-public/${keyPrefix}/PublicKey/${actualFheKeyId}`),
+      ensureServerKeyMaterial(discovery.endpoints.minioExternal, keyPrefix, actualFheKeyId),
       ensureMaterial(`${discovery.endpoints.minioExternal}/kms-public/${keyPrefix}/CRS/${actualCrsKeyId}`),
     ]);
     if (discovery.fheKeyId !== actualFheKeyId || discovery.crsKeyId !== actualCrsKeyId) {

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -2,7 +2,7 @@
  * Generates compose overrides for local builds, scenario instances, and compatibility-adjusted service commands.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
@@ -726,6 +726,55 @@ export const buildKmsConnectorOverride = async (plan: StackSpec) => {
   return { services };
 };
 
+/** The universal test-runner service that consensus restart and fault tests drive. */
+const TEST_SUITE_RUNNER_SERVICE = "test-suite-e2e-debug";
+const CONTAINER_DOCKER_SOCKET = "/var/run/docker.sock";
+
+/**
+ * Resolves the host Docker socket, when one is actually there. The path follows a
+ * `unix://` `DOCKER_HOST` and otherwise falls back to the default socket location; a
+ * remote daemon (`tcp://`), a rootless setup, or a missing socket all resolve to
+ * `undefined`. The gid is read off the socket itself rather than guessed.
+ */
+export const dockerSocketRuntime = (
+  env: NodeJS.ProcessEnv = process.env,
+): { path: string; gid: number } | undefined => {
+  const dockerHost = env.DOCKER_HOST ?? "";
+  if (dockerHost && !dockerHost.startsWith("unix://")) {
+    // A remote daemon (`tcp://`, `ssh://`) is not reachable through a local socket, so
+    // there is nothing to mount even when the default socket path happens to exist.
+    return undefined;
+  }
+  const socketPath = dockerHost ? dockerHost.slice("unix://".length) : CONTAINER_DOCKER_SOCKET;
+  try {
+    const stat = statSync(socketPath);
+    if (!stat.isSocket()) {
+      return undefined;
+    }
+    return { path: socketPath, gid: stat.gid };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Hands the host Docker socket to the e2e runner so restart and fault tests can act on
+ * explicitly named containers; the socket is inert for ordinary E2E tests. This is
+ * generated rather than tracked in the static compose file because both halves are host
+ * facts: the socket group id is read from the socket at generation time (guessing it
+ * grants nothing), and a host without a socket must still be able to start the runner.
+ */
+const applyDockerSocketRuntime = (services: ComposeDoc["services"]) => {
+  const socket = dockerSocketRuntime();
+  if (!socket) {
+    return;
+  }
+  const service = services[TEST_SUITE_RUNNER_SERVICE] ?? {};
+  service.volumes = [`${socket.path}:${CONTAINER_DOCKER_SOCKET}`];
+  service.group_add = [String(socket.gid)];
+  services[TEST_SUITE_RUNNER_SERVICE] = service;
+};
+
 /** Builds the generated compose override for one component. */
 const buildComposeOverride = async (component: string, plan: StackSpec) => {
   if (component === "coprocessor") {
@@ -757,15 +806,10 @@ const buildComposeOverride = async (component: string, plan: StackSpec) => {
     if (build) {
       next.build = build;
     }
-    // The generated file is layered over the static test-suite compose file.
-    // Keep the socket group in the static file only: Docker Compose appends
-    // `group_add` values from both files, and an identical Docker GID makes
-    // the merged configuration invalid.  The local override changes only the
-    // image/build source, so it must not repeat this inherited runtime field.
-    if (component === "test-suite") {
-      delete next.group_add;
-    }
     services[name] = next;
+  }
+  if (component === "test-suite") {
+    applyDockerSocketRuntime(services);
   }
   return { services };
 };
@@ -944,6 +988,9 @@ const buildExtraCoprocessorListenerOverride = async (
 export const generatedComposeComponents = (plan: Pick<StackSpec, "overrides" | "kms">) =>
   new Set([
     "coprocessor",
+    // Always generated: it carries the host Docker socket wiring for the e2e runner,
+    // which depends on host facts rather than on any local build override.
+    "test-suite",
     ...(plan.kms.mode === "threshold" ? ["core-threshold", "kms-connector"] : []),
     ...plan.overrides.flatMap((override) => GROUP_BUILD_COMPONENTS[override.group]),
   ]);

--- a/test-suite/fhevm/src/readiness.test.ts
+++ b/test-suite/fhevm/src/readiness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { waitForRpc } from "./flow/readiness";
+import { ensureOneMaterial, waitForRpc } from "./flow/readiness";
 
 describe("waitForRpc", () => {
   test("retries until eth_chainId returns a JSON-RPC result", async () => {
@@ -23,6 +23,28 @@ describe("waitForRpc", () => {
     try {
       await waitForRpc("http://localhost:8545");
       expect(calls).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("ensureOneMaterial", () => {
+  test("accepts a published compressed keyset without waiting for the legacy key path", async () => {
+    const originalFetch = globalThis.fetch;
+    const requested: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      requested.push(url);
+      return new Response(null, { status: url.includes("CompressedXofKeySet") ? 200 : 404 });
+    }) as unknown as typeof fetch;
+    try {
+      await ensureOneMaterial([
+        "http://minio:9000/kms-public/PUB/CompressedXofKeySet/key-id",
+        "http://minio:9000/kms-public/PUB/ServerKey/key-id",
+      ]);
+      expect(requested).toHaveLength(2);
+      expect(requested[0]).toContain("CompressedXofKeySet");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { statSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import YAML from "yaml";
 
 import {
   blueGreenServiceNames,
+  dockerSocketRuntime,
   generateComposeOverrides,
   loadMergedComposeDoc,
   serviceNameList,
 } from "./generate/compose";
-import { TEMPLATE_COMPOSE_DIR, composePath, envPath } from "./layout";
+import { COMPOSE_OUT_DIR, TEMPLATE_COMPOSE_DIR, composePath, envPath } from "./layout";
 import { presetBundle } from "./resolve/target";
 import {
   parseBlueGreenScenario,
@@ -100,6 +103,14 @@ const testSuiteOverrideState: State = {
   scenario: testDefaultScenario(),
 };
 
+// Single-instance, no local builds: the test-suite override then contains only whatever
+// the generator adds on its own, which is the host Docker socket wiring.
+const socketWiringState: State = {
+  ...state,
+  overrides: [],
+  scenario: testDefaultScenario(),
+};
+
 const kmsConnectorOverrideState: State = {
   ...state,
   overrides: [{ group: "kms-connector" }],
@@ -128,6 +139,53 @@ instances:
         - --initial-block-time=2
 `),
   ),
+};
+
+/** Runs a test body with `DOCKER_HOST` pinned to a known value, restoring it after. */
+const withDockerHost = async <T>(value: string | undefined, run: () => Promise<T>) => {
+  const previous = process.env.DOCKER_HOST;
+  if (value === undefined) {
+    delete process.env.DOCKER_HOST;
+  } else {
+    process.env.DOCKER_HOST = value;
+  }
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DOCKER_HOST;
+    } else {
+      process.env.DOCKER_HOST = previous;
+    }
+  }
+};
+
+/** Runs a test body against a real, listening unix socket in a temporary directory. */
+const withUnixSocket = async <T>(run: (socketPath: string) => Promise<T>) => {
+  const dir = await mkdtemp(path.join(tmpdir(), "fhevm-docker-sock-"));
+  const socketPath = path.join(dir, "docker.sock");
+  const server = Bun.listen({ unix: socketPath, socket: { data() {} } });
+  try {
+    return await run(socketPath);
+  } finally {
+    server.stop(true);
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+/** Collects every service in every generated compose override, keyed by file and name. */
+const generatedServices = async () => {
+  const entries = await readdir(COMPOSE_OUT_DIR);
+  const services: Array<[string, Record<string, unknown>]> = [];
+  for (const entry of entries.filter((name) => name.endsWith(".yml"))) {
+    const doc = YAML.parse(await readFile(path.join(COMPOSE_OUT_DIR, entry), "utf8")) as {
+      services?: Record<string, Record<string, unknown>>;
+    };
+    for (const [name, service] of Object.entries(doc.services ?? {})) {
+      services.push([`${entry}:${name}`, service]);
+    }
+  }
+  return services;
 };
 
 describe("render-compose", () => {
@@ -375,18 +433,21 @@ describe("render-compose", () => {
     });
   });
 
-  test("does not duplicate the test-suite Docker socket group in a local build override", async () => {
-    await withTempStateDir(async () => {
-      await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
-      await writeFile(envPath("coprocessor"), "\n");
-      await generateComposeOverrides(testSuiteOverrideState, stackSpecForState(testSuiteOverrideState));
-      const doc = YAML.parse(await readFile(composePath("test-suite"), "utf8")) as {
-        services: Record<string, { image?: string; build?: unknown; group_add?: unknown }>;
-      };
-      const testSuite = doc.services["test-suite-e2e-debug"];
-      expect(testSuite?.image).toContain(":fhevm-local");
-      expect(testSuite?.build).toBeTruthy();
-      expect(testSuite?.group_add).toBeUndefined();
+  test("renders a test-suite local build override without daemon access on a socketless host", async () => {
+    await withDockerHost("unix:///nonexistent/docker.sock", async () => {
+      await withTempStateDir(async () => {
+        await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+        await writeFile(envPath("coprocessor"), "\n");
+        await generateComposeOverrides(testSuiteOverrideState, stackSpecForState(testSuiteOverrideState));
+        const doc = YAML.parse(await readFile(composePath("test-suite"), "utf8")) as {
+          services: Record<string, { image?: string; build?: unknown; volumes?: unknown; group_add?: unknown }>;
+        };
+        const testSuite = doc.services["test-suite-e2e-debug"];
+        expect(testSuite?.image).toContain(":fhevm-local");
+        expect(testSuite?.build).toBeTruthy();
+        expect(testSuite?.volumes).toBeUndefined();
+        expect(testSuite?.group_add).toBeUndefined();
+      });
     });
   });
 
@@ -777,5 +838,114 @@ gcs:
       expect(blue.command).toContain("--bucket-name=coproc-0");
       expect(blue.command?.filter((arg) => arg.startsWith("--bucket-name-"))).toEqual([]);
     });
+  });
+});
+
+describe("test-suite docker socket runtime", () => {
+  test("dockerSocketRuntime resolves a unix DOCKER_HOST socket with its group id", async () => {
+    await withUnixSocket(async (socketPath) => {
+      const runtime = dockerSocketRuntime({ DOCKER_HOST: `unix://${socketPath}` });
+      expect(runtime?.path).toBe(socketPath);
+      expect(runtime?.gid).toBe(statSync(socketPath).gid);
+    });
+  });
+
+  test("dockerSocketRuntime returns undefined for a missing socket", () => {
+    expect(dockerSocketRuntime({ DOCKER_HOST: "unix:///nonexistent/docker.sock" })).toBeUndefined();
+  });
+
+  test("dockerSocketRuntime treats a remote DOCKER_HOST as socketless", async () => {
+    await withUnixSocket(async (socketPath) => {
+      // A tcp:// daemon is never local, even while a unix socket exists elsewhere.
+      expect(dockerSocketRuntime({ DOCKER_HOST: "tcp://127.0.0.1:2375" })).toBeUndefined();
+      expect(dockerSocketRuntime({ DOCKER_HOST: `unix://${socketPath}` })).toBeDefined();
+    });
+  });
+
+  test("dockerSocketRuntime falls back to the default socket path without DOCKER_HOST", () => {
+    // The fallback path is a host fact, so only the path it probes is asserted here.
+    const runtime = dockerSocketRuntime({});
+    expect(runtime === undefined || runtime.path === "/var/run/docker.sock").toBe(true);
+  });
+
+  test("grants the e2e runner the host docker socket when one exists", async () => {
+    await withUnixSocket(async (socketPath) => {
+      await withDockerHost(`unix://${socketPath}`, async () => {
+        await withTempStateDir(async () => {
+          await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+          await writeFile(envPath("coprocessor"), "\n");
+          await generateComposeOverrides(socketWiringState, stackSpecForState(socketWiringState));
+          const doc = YAML.parse(await readFile(composePath("test-suite"), "utf8")) as {
+            services: Record<string, { volumes?: string[]; group_add?: string[] }>;
+          };
+          const runner = doc.services["test-suite-e2e-debug"];
+          expect(runner?.volumes).toEqual([`${socketPath}:/var/run/docker.sock`]);
+          expect(runner?.group_add).toEqual([String(statSync(socketPath).gid)]);
+          const others = (await generatedServices()).filter(([key]) => key !== "test-suite.yml:test-suite-e2e-debug");
+          expect(others.length).toBeGreaterThan(0);
+          for (const [key, service] of others) {
+            expect(YAML.stringify({ [key]: service })).not.toContain("/var/run/docker.sock");
+            expect(service.group_add).toBeUndefined();
+          }
+        });
+      });
+    });
+  });
+
+  test("keeps the local build override alongside the socket wiring", async () => {
+    await withUnixSocket(async (socketPath) => {
+      await withDockerHost(`unix://${socketPath}`, async () => {
+        await withTempStateDir(async () => {
+          await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+          await writeFile(envPath("coprocessor"), "\n");
+          await generateComposeOverrides(testSuiteOverrideState, stackSpecForState(testSuiteOverrideState));
+          const doc = YAML.parse(await readFile(composePath("test-suite"), "utf8")) as {
+            services: Record<string, { image?: string; build?: unknown; volumes?: string[]; group_add?: string[] }>;
+          };
+          const runner = doc.services["test-suite-e2e-debug"];
+          expect(runner?.image).toContain(":fhevm-local");
+          expect(runner?.build).toBeTruthy();
+          expect(runner?.volumes).toEqual([`${socketPath}:/var/run/docker.sock`]);
+          expect(runner?.group_add).toEqual([String(statSync(socketPath).gid)]);
+        });
+      });
+    });
+  });
+
+  test("renders an empty test-suite override on a host without a docker socket", async () => {
+    await withDockerHost("unix:///nonexistent/docker.sock", async () => {
+      await withTempStateDir(async () => {
+        await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+        await writeFile(envPath("coprocessor"), "\n");
+        await generateComposeOverrides(socketWiringState, stackSpecForState(socketWiringState));
+        const doc = YAML.parse(await readFile(composePath("test-suite"), "utf8")) as {
+          services: Record<string, { volumes?: unknown; group_add?: unknown }>;
+        };
+        expect(doc.services).toEqual({});
+        expect(doc.services["test-suite-e2e-debug"]?.volumes).toBeUndefined();
+        expect(doc.services["test-suite-e2e-debug"]?.group_add).toBeUndefined();
+      });
+    });
+  });
+
+  test("leaves the runner socketless when DOCKER_HOST points at a remote daemon", async () => {
+    await withDockerHost("tcp://127.0.0.1:2375", async () => {
+      await withTempStateDir(async () => {
+        await mkdir(path.dirname(envPath("coprocessor")), { recursive: true });
+        await writeFile(envPath("coprocessor"), "\n");
+        await generateComposeOverrides(socketWiringState, stackSpecForState(socketWiringState));
+        const doc = YAML.parse(await readFile(composePath("test-suite"), "utf8")) as {
+          services: Record<string, unknown>;
+        };
+        expect(doc.services).toEqual({});
+      });
+    });
+  });
+
+  test("the tracked test-suite compose file carries no docker socket wiring", async () => {
+    const raw = await readFile(path.join(TEMPLATE_COMPOSE_DIR, "test-suite-docker-compose.yml"), "utf8");
+    expect(raw).not.toContain("docker.sock");
+    expect(raw).not.toContain("group_add");
+    expect(raw).not.toContain("DOCKER_GID");
   });
 });


### PR DESCRIPTION
Adds CPU/GPU CI reporting for the seven one-shot benchmark scenarios, including Slab result parsing, partial-result reporting, and failure propagation. Updates GPU provisioning with Scaleway profiles, bump to CUDA 12.8/GCC 12, and resource logging.

Also seeds benchmark dependence-chain rows, aligns benchmark database configuration, adds consensus revision checks, waits for server-key material during bootstrap, and conditionally mounts the host Docker socket for E2E fault tests.

