### PR TITLE
refactor(coprocessor): add disable synthetic ops cli ops and use it to fix the blue-green e2e

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/bin/consumer.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/consumer.rs
@@ -100,6 +100,13 @@ struct Args {
 
     #[arg(
         long,
+        default_value_t = false,
+        help = "Stop injecting the synthetic work a GCS listener uses to anchor consensus"
+    )]
+    pub disable_synthetic_ops: bool,
+
+    #[arg(
+        long,
         default_value_t = 0,
         help = "Max dependent ops per chain before slow-lane (0 disables; startup promotes all chains to fast)"
     )]
@@ -192,6 +199,7 @@ async fn main() -> anyhow::Result<()> {
         dependent_ops_max_per_chain: args.dependent_ops_max_per_chain,
         chain_id: args.chain_id,
         gcs_mode,
+        disable_synthetic_ops: args.disable_synthetic_ops,
         canonical_protocol_config_chain_id: args.protocol_config.chain_id,
     };
 

--- a/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/poller.rs
@@ -142,6 +142,13 @@ struct Args {
 
     #[arg(
         long,
+        default_value_t = false,
+        help = "Stop injecting the synthetic work a GCS listener uses to anchor consensus"
+    )]
+    pub disable_synthetic_ops: bool,
+
+    #[arg(
+        long,
         default_value_t = 0,
         help = "Max dependent ops per chain before slow-lane (0 disables; startup promotes all chains to fast)"
     )]
@@ -234,6 +241,7 @@ async fn main() -> anyhow::Result<()> {
         dependence_cross_block: args.dependence_cross_block,
         dependent_ops_max_per_chain: args.dependent_ops_max_per_chain,
         gcs_mode,
+        disable_synthetic_ops: args.disable_synthetic_ops,
         canonical_protocol_config_chain_id: args.protocol_config.chain_id,
     };
 

--- a/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/cmd/mod.rs
@@ -188,6 +188,13 @@ pub struct Args {
     )]
     pub timeout_request_websocket: u64,
 
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Stop injecting the synthetic work a GCS listener uses to anchor consensus"
+    )]
+    pub disable_synthetic_ops: bool,
+
     /// Print the compiled-in coprocessor stack version and exit.
     #[arg(long)]
     pub stack_version: bool,
@@ -1002,6 +1009,7 @@ async fn db_insert_block(
                 dependence_cross_block: args.dependence_cross_block,
                 dependent_ops_max_per_chain: args.dependent_ops_max_per_chain,
                 is_protocol_config_listener,
+                disable_synthetic_ops: args.disable_synthetic_ops,
             },
         )
         .await;

--- a/coprocessor/fhevm-engine/host-listener/src/consumer/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/consumer/mod.rs
@@ -57,6 +57,7 @@ pub struct ConsumerConfig {
     pub dependent_ops_max_per_chain: u32,
     pub chain_id: String,
     pub gcs_mode: bool,
+    pub disable_synthetic_ops: bool,
     pub canonical_protocol_config_chain_id: Option<u64>,
 }
 
@@ -376,6 +377,7 @@ pub async fn run_consumer(config: ConsumerConfig) -> Result<()> {
         dependence_cross_block: config.dependence_cross_block,
         dependent_ops_max_per_chain: config.dependent_ops_max_per_chain,
         is_protocol_config_listener,
+        disable_synthetic_ops: config.disable_synthetic_ops,
     };
 
     // Runtime stack mode + `event_stack_version_upgraded` listener: at cutover

--- a/coprocessor/fhevm-engine/host-listener/src/database/ingest.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/database/ingest.rs
@@ -47,6 +47,7 @@ pub struct IngestOptions {
     /// configured `--canonical-protocol-config-chain-id`. When false, the listener silently
     /// skips `ProtocolConfig.CoprocessorUpgradeProposed` events.
     pub is_protocol_config_listener: bool,
+    pub disable_synthetic_ops: bool,
 }
 
 /// Converts a block timestamp to a UTC `PrimitiveDateTime`.
@@ -365,7 +366,7 @@ pub async fn ingest_block_logs(
     // logs go through the normal decode below, so `fhe_event_count`, `is_allowed`, the
     // dependence chain and `schedule_order` are all derived by the production path. Blue
     // never injects, so `public` stays untouched. See `database::synthetic_ops`.
-    let synthetic = if db.gcs_mode() {
+    let synthetic = if db.gcs_mode() && !options.disable_synthetic_ops {
         synthetic_logs_for_block(
             &mut tx,
             chain_id,

--- a/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/poller/mod.rs
@@ -152,6 +152,7 @@ pub struct PollerConfig {
     pub dependence_cross_block: bool,
     pub dependent_ops_max_per_chain: u32,
     pub gcs_mode: bool,
+    pub disable_synthetic_ops: bool,
     pub canonical_protocol_config_chain_id: Option<u64>,
 }
 
@@ -422,6 +423,7 @@ pub async fn run_poller(config: PollerConfig) -> Result<()> {
                 dependence_cross_block: config.dependence_cross_block,
                 dependent_ops_max_per_chain: config.dependent_ops_max_per_chain,
                 is_protocol_config_listener,
+                disable_synthetic_ops: config.disable_synthetic_ops,
             };
             match ingest_with_retry(
                 chain_id,

--- a/coprocessor/fhevm-engine/host-listener/tests/bridge_handler_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/bridge_handler_tests.rs
@@ -432,6 +432,7 @@ async fn ingest_fallback_block_at(
         dependence_cross_block: true,
         dependent_ops_max_per_chain: 0,
         is_protocol_config_listener: false,
+        disable_synthetic_ops: false,
     };
     let chain_id = db.chain_id;
     ingest_block_logs(

--- a/coprocessor/fhevm-engine/host-listener/tests/host_listener_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/host_listener_integration_tests.rs
@@ -246,6 +246,7 @@ async fn setup_with_block_time(
         dependent_ops_max_per_chain: 0,
         timeout_request_websocket: 30,
         stack_version: false,
+        disable_synthetic_ops: false,
     };
     let health_check_url = format!("http://127.0.0.1:{}", args.health_port);
 
@@ -415,6 +416,7 @@ async fn ingest_dependent_burst_seeded(
             dependence_cross_block: true,
             dependent_ops_max_per_chain,
             is_protocol_config_listener: true,
+            disable_synthetic_ops: false,
         },
     )
     .await?;
@@ -751,6 +753,7 @@ async fn test_slow_lane_cross_block_sustained_below_cap_stays_fast_locally(
                 dependence_cross_block: true,
                 dependent_ops_max_per_chain: cap,
                 is_protocol_config_listener: true,
+                disable_synthetic_ops: false,
             },
         )
         .await?;
@@ -1369,6 +1372,7 @@ async fn test_only_catchup_loop_requires_negative_start_at_block(
         dependent_ops_max_per_chain: 0,
         timeout_request_websocket: 30,
         stack_version: false,
+        disable_synthetic_ops: false,
     };
 
     let result = main(args).await;

--- a/coprocessor/fhevm-engine/host-listener/tests/keygen_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/keygen_integration_tests.rs
@@ -446,6 +446,7 @@ where
         dependence_cross_block: true,
         dependent_ops_max_per_chain: 0,
         is_protocol_config_listener: true,
+        disable_synthetic_ops: false,
     };
 
     ingest_block_logs(

--- a/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
+++ b/coprocessor/fhevm-engine/host-listener/tests/poller_integration_tests.rs
@@ -176,6 +176,7 @@ async fn poller_catches_up_to_safe_tip(
         dependence_cross_block: false,
         dependent_ops_max_per_chain: 0,
         gcs_mode: false,
+        disable_synthetic_ops: false,
         canonical_protocol_config_chain_id: Some(chain_id.as_u64()),
     };
 

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -6,18 +6,18 @@ import { type DecryptionRunner, runKmsGenerationProfile } from "./kms-generation
 import { runKmsGenerationAbortProfile } from "./kms-generation-abort";
 import { runKmsContextSwitchProfile } from "./kms-context-switch";
 import { DRIFT_CLEANUP_SQL, DRIFT_INSTALL_SQL, parseDriftInstanceIndex, parsePositiveInteger } from "../drift";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import { PreflightError, formatCliError } from "../errors";
 import { dockerInspect } from "../flow/readiness";
 import { pause, shellEscape, unpause } from "../flow/up-flow";
 import { hostReachableRpcUrl, readEnvFile, withHexPrefix } from "../utils/fs";
-import { run, runWithHeartbeat } from "../utils/process";
+import { composeEnv, run, runWithHeartbeat } from "../utils/process";
 import { loadState } from "../state/state";
 import { topologyForState } from "../stack-spec/stack-spec";
 import {
   COPROCESSOR_DB_CONTAINER,
+  PROJECT,
+  composePath,
   DEFAULT_CHAIN_ID,
   DEFAULT_POSTGRES_DB,
   DEFAULT_POSTGRES_PASSWORD,
@@ -296,54 +296,68 @@ const gcsHostListeners = async () => {
 
 /** Recreates every GCS host-listener with synthetic-op injection on or off.
  *
- *  `--disable-synthetic-ops` is a command argument fixed when the container is created,
- *  so restarting cannot change it. Write a compose override carrying the adjusted
- *  command and recreate the services from it. */
+ *  A container's command is fixed when it is created, so restarting cannot change it.
+ *  Each host chain has its own compose file, so the listeners are grouped by the file
+ *  set their own labels name and every group is brought up from that set. */
 const setSyntheticOps = async (enabled: boolean) => {
   const containers = await gcsHostListeners();
   if (containers.length === 0) {
-    throw new Error("found no GCS host-listener containers");
+    throw new PreflightError("found no GCS host-listener containers");
   }
-  const meta = await run(
-    ["docker", "inspect", ...containers, "--format",
-      '{{index .Config.Labels "com.docker.compose.project"}}\t' +
-      '{{index .Config.Labels "com.docker.compose.project.config_files"}}\t' +
-      '{{index .Config.Labels "com.docker.compose.service"}}\t' +
-      "{{json .Config.Cmd}}"],
-    { allowFailure: true },
-  );
+  const format = [
+    '{{index .Config.Labels "com.docker.compose.project.config_files"}}',
+    '{{index .Config.Labels "com.docker.compose.service"}}',
+    "{{json .Config.Cmd}}",
+  ].join("\t");
+  const meta = await run(["docker", "inspect", ...containers, "--format", format], { allowFailure: true });
   if (meta.code !== 0) {
-    throw new Error(`docker inspect failed: ${meta.stderr.trim()}`);
-  }
-  const rows = meta.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
-    .map((line) => line.split("\t"));
-  const project = rows[0]?.[0];
-  const configFiles = rows[0]?.[1];
-  if (!project || !configFiles) {
-    throw new Error("GCS host-listeners carry no compose project labels");
+    throw new PreflightError(`docker inspect failed: ${meta.stderr.trim()}`);
   }
 
-  const services: Record<string, { command: string[] }> = {};
-  for (const [, , service, commandJson] of rows) {
-    if (!service || !commandJson || commandJson === "null") {
-      throw new Error(`cannot read the command of GCS host-listener service "${service}"`);
+  const groups = new Map<string, Record<string, { command: string[] }>>();
+  for (const line of meta.stdout.split(/\r?\n/).map((entry) => entry.trim()).filter(Boolean)) {
+    const [files, service, commandJson] = line.split("\t");
+    if (!files || !service || !commandJson || commandJson === "null") {
+      throw new PreflightError(`compose labels are missing on "${service || containers.join(", ")}"`);
     }
-    const base = (JSON.parse(commandJson) as string[]).filter((arg) => arg !== SYNTHETIC_OPS_OFF);
-    services[service] = { command: enabled ? base : [...base, SYNTHETIC_OPS_OFF] };
+    const command = (JSON.parse(commandJson) as string[]).filter((entry) => entry !== SYNTHETIC_OPS_OFF);
+    if (!enabled) {
+      command.push(SYNTHETIC_OPS_OFF);
+    }
+    const group = groups.get(files) ?? {};
+    group[service] = { command };
+    groups.set(files, group);
   }
 
-  // Compose parses YAML, and JSON is valid YAML — no serializer needed.
-  const overridePath = join(tmpdir(), `fhevm-synthetic-ops-${enabled ? "on" : "off"}.yml`);
-  await Bun.write(overridePath, JSON.stringify({ services }));
-
-  const argv = ["docker", "compose", "-p", project];
-  for (const file of configFiles.split(",")) argv.push("-f", file);
-  argv.push("-f", overridePath, "up", "-d", "--force-recreate", "--no-deps", ...Object.keys(services));
-  const up = await run(argv, { allowFailure: true });
-  if (up.code !== 0) {
-    throw new Error(`recreating the GCS host-listeners failed: ${up.stderr.trim()}`);
+  const env = await composeEnv("coprocessor");
+  const recreated: string[] = [];
+  for (const [index, [files, services]] of [...groups].entries()) {
+    // Compose parses YAML, and JSON is valid YAML — no serializer needed.
+    const override = composePath(`synthetic-ops-${index}`);
+    await Bun.write(override, JSON.stringify({ services }));
+    const up = await run(
+      [
+        "docker",
+        "compose",
+        "-p",
+        PROJECT,
+        ...files.split(",").flatMap((file) => ["-f", file]),
+        "-f",
+        override,
+        "up",
+        "-d",
+        "--force-recreate",
+        "--no-deps",
+        ...Object.keys(services),
+      ],
+      { env, allowFailure: true },
+    );
+    if (up.code !== 0) {
+      throw new PreflightError(`recreating the GCS host-listeners failed: ${up.stderr.trim()}`);
+    }
+    recreated.push(...Object.keys(services));
   }
-  return Object.keys(services);
+  return recreated.sort();
 };
 
 /** Finds the expected drift warning for a specific injected handle. */

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -1035,17 +1035,6 @@ const runBlueGreenProfile = async (
   // fires the timeout — true even with a single operator. [4/11] starts them again, and
   // the successful upgrade from [6/11] runs with injection active on every operator.
   console.log(`\n[2/11] failed upgrade: one operator cannot report (no unanimity → no cutover)`);
-  // Silence the operator before proposing: the window opens 15 blocks out and closes
-  // at 45, and stopping containers after the proposal would spend that window here.
-  const silencedListeners = await lastOperatorGcsListeners();
-  if (silencedListeners.length === 0) {
-    throw new Error("found no GCS host-listener containers to silence");
-  }
-  for (const container of silencedListeners) {
-    await dockerLifecycle("stop", container);
-  }
-  console.log(`OK:   stopped ${silencedListeners.join(", ")} — that operator ingests nothing`);
-
   const failGwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
@@ -1063,6 +1052,29 @@ const runBlueGreenProfile = async (
   console.log(
     `OK:   activation emitted (windows=${failWindows} gw_start=${failGwStartBlock})`,
   );
+
+  // The GCS host-listener writes the upgrade_state row, so stop it only once every
+  // operator has one. DryRunStarted still follows, driven by blue's progress.
+  for (const db of operatorDatabases) {
+    await waitUntil({
+      label: `${db}  upgrade_state rows written`,
+      timeoutSecs: 60,
+      check: async () =>
+        (await psqlQuery(
+          db,
+          `SELECT CASE WHEN COUNT(*)=${hostChains.length} THEN 'ready' ELSE 'waiting' END
+             FROM upgrade_state WHERE stack_role='GCS';`,
+        )) === "ready",
+    });
+  }
+  const silencedListeners = await lastOperatorGcsListeners();
+  if (silencedListeners.length === 0) {
+    throw new Error("found no GCS host-listener containers to silence");
+  }
+  for (const container of silencedListeners) {
+    await dockerLifecycle("stop", container);
+  }
+  console.log(`OK:   stopped ${silencedListeners.join(", ")} — that operator ingests nothing`);
 
   console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted, then submit a Gateway-only input proof`);
   for (const db of operatorDatabases) {

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -274,6 +274,32 @@ const coprocessorGwListeners = async () => {
     .filter((line) => /^coprocessor(\d+)?-gw-listener$/.test(line));
 };
 
+/** Every GCS host-listener container of the highest-index operator: the listener, the
+ *  poller and the consumer, on every host chain, so nothing of that operator ingests.
+ *  Multi-chain scenarios suffix the extra chains (`…-host-listener-poller-chain-b`), so
+ *  this matches on prefix rather than anchoring the end. */
+const lastOperatorGcsListeners = async () => {
+  const result = await run(["docker", "ps", "--format", "{{.Names}}"], { allowFailure: true });
+  if (result.code !== 0) {
+    throw new PreflightError(result.stderr.trim() || "docker ps failed");
+  }
+  const listeners = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^coprocessor(\d+)?-gcs-host-listener(-|$)/.test(line));
+  const prefixes = [...new Set(listeners.map((name) => name.split("-gcs-")[0]!))].sort();
+  const last = prefixes[prefixes.length - 1];
+  return listeners.filter((name) => name.startsWith(`${last}-gcs-`)).sort();
+};
+
+/** Starts or stops a container, failing loudly so a missed step cannot pass silently. */
+const dockerLifecycle = async (action: "stop" | "start", container: string) => {
+  const result = await run(["docker", action, container], { allowFailure: true });
+  if (result.code !== 0) {
+    throw new Error(`docker ${action} ${container} failed: ${result.stderr.trim()}`);
+  }
+};
+
 /** Finds the expected drift warning for a specific injected handle. */
 const findDriftWarning = (output: string, expectedHandleHex: string, needle: string = DRIFT_WARNING) => {
   for (const line of output.split(/\r?\n/)) {
@@ -997,11 +1023,13 @@ const runBlueGreenProfile = async (
     return `[${tuples.join(",")}]`;
   };
 
-  // Host chains stay quiet (no non-trivial FHE op) while [3/11] anchors the Gateway
-  // track with one input. Cutover needs at least one non-trivial host anchor, so the
-  // controller withholds the hosts and commitment_timeout rolls back every row — the
-  // rollback this asserts. A regression that notified quiet hosts would cut over.
-  console.log(`\n[2/11] failed upgrade: Gateway input, hosts quiet (no non-trivial host → no cutover)`);
+  // The GCS listeners inject synthetic ops, so a chain anchors on work of its own and
+  // an idle chain no longer withholds cutover. Unanimity now fails only when an operator
+  // cannot take part: stop one operator's host-listeners so it ingests nothing and never
+  // reports a matching hash. Its consensus-detector keeps running, so it still arms and
+  // fires the timeout — true even with a single operator. [4/11] starts them again, and
+  // the successful upgrade from [6/11] runs with injection active on every operator.
+  console.log(`\n[2/11] failed upgrade: one operator cannot report (no unanimity → no cutover)`);
   const failGwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
@@ -1019,6 +1047,14 @@ const runBlueGreenProfile = async (
   console.log(
     `OK:   activation emitted (windows=${failWindows} gw_start=${failGwStartBlock})`,
   );
+  const silencedListeners = await lastOperatorGcsListeners();
+  if (silencedListeners.length === 0) {
+    throw new Error("found no GCS host-listener containers to silence");
+  }
+  for (const container of silencedListeners) {
+    await dockerLifecycle("stop", container);
+  }
+  console.log(`OK:   stopped ${silencedListeners.join(", ")} — that operator ingests nothing`);
 
   console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted, then submit a Gateway-only input proof`);
   for (const db of operatorDatabases) {
@@ -1037,8 +1073,8 @@ const runBlueGreenProfile = async (
         )) === "ready",
     });
   }
-  // Verify one Gateway input inside the window. Host chains get no non-trivial FHE
-  // op, so cutover must be withheld and the window must time out (asserted in [4/11]).
+  // Verify one Gateway input inside the window. The silenced operator never reports,
+  // so unanimity cannot form and the window must time out (asserted in [4/11]).
   await run(gatewayInputProbeArgv);
   console.log(`OK:   Gateway input submitted (host chains remain quiet)`);
 
@@ -1093,6 +1129,10 @@ const runBlueGreenProfile = async (
     }
     console.log(`OK:   ${db}  PAUSED/failed, latches cleared, v0.14 kept, gcs schema recreated empty`);
   }
+  for (const container of silencedListeners) {
+    await dockerLifecycle("start", container);
+  }
+  console.log(`OK:   restarted ${silencedListeners.join(", ")} — every operator ingests again`);
 
   // Deploy ERC20 + mint before the proposal so the balance handle lands in
   // public.ciphertexts with block_number < start_block. Transfers during the

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -6,6 +6,9 @@ import { type DecryptionRunner, runKmsGenerationProfile } from "./kms-generation
 import { runKmsGenerationAbortProfile } from "./kms-generation-abort";
 import { runKmsContextSwitchProfile } from "./kms-context-switch";
 import { DRIFT_CLEANUP_SQL, DRIFT_INSTALL_SQL, parseDriftInstanceIndex, parsePositiveInteger } from "../drift";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { PreflightError, formatCliError } from "../errors";
 import { dockerInspect } from "../flow/readiness";
 import { pause, shellEscape, unpause } from "../flow/up-flow";
@@ -274,35 +277,73 @@ const coprocessorGwListeners = async () => {
     .filter((line) => /^coprocessor(\d+)?-gw-listener$/.test(line));
 };
 
-/** Every GCS host-listener container of the highest-index operator: the listener, the
- *  poller and the consumer, on every host chain, so nothing of that operator ingests.
- *  Multi-chain scenarios suffix the extra chains (`…-host-listener-poller-chain-b`), so
- *  this matches on prefix rather than anchoring the end. */
-const lastOperatorGcsListeners = async () => {
-  const result = await run(["docker", "ps", "--format", "{{.Names}}"], { allowFailure: true });
+/** Turns off the synthetic work a GCS listener injects to anchor consensus. */
+const SYNTHETIC_OPS_OFF = "--disable-synthetic-ops";
+
+/** Every GCS host-listener container, on every operator and host chain. Multi-chain
+ *  scenarios suffix the extra chains, so this matches on prefix. */
+const gcsHostListeners = async () => {
+  const result = await run(["docker", "ps", "-a", "--format", "{{.Names}}"], { allowFailure: true });
   if (result.code !== 0) {
     throw new PreflightError(result.stderr.trim() || "docker ps failed");
   }
-  const listeners = result.stdout
+  return result.stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .filter((line) => /^coprocessor(\d+)?-gcs-host-listener(-|$)/.test(line));
-  const prefixes = [...new Set(listeners.map((name) => name.split("-gcs-")[0]!))].sort();
-  const last = prefixes[prefixes.length - 1];
-  return listeners.filter((name) => name.startsWith(`${last}-gcs-`)).sort();
+    .filter((line) => /^coprocessor(\d+)?-gcs-host-listener(-|$)/.test(line))
+    .sort();
 };
 
-/** Starts or stops a container, failing loudly so a missed step cannot pass silently.
- *  Stops kill immediately: the default 10s grace per container would outlast the
- *  dry-run window these are stopped for. */
-const dockerLifecycle = async (action: "stop" | "start", container: string) => {
-  const argv = action === "stop"
-    ? ["docker", "stop", "-t", "0", container]
-    : ["docker", "start", container];
-  const result = await run(argv, { allowFailure: true });
-  if (result.code !== 0) {
-    throw new Error(`docker ${action} ${container} failed: ${result.stderr.trim()}`);
+/** Recreates every GCS host-listener with synthetic-op injection on or off.
+ *
+ *  `--disable-synthetic-ops` is a command argument fixed when the container is created,
+ *  so restarting cannot change it. Write a compose override carrying the adjusted
+ *  command and recreate the services from it. */
+const setSyntheticOps = async (enabled: boolean) => {
+  const containers = await gcsHostListeners();
+  if (containers.length === 0) {
+    throw new Error("found no GCS host-listener containers");
   }
+  const meta = await run(
+    ["docker", "inspect", ...containers, "--format",
+      '{{index .Config.Labels "com.docker.compose.project"}}\t' +
+      '{{index .Config.Labels "com.docker.compose.project.config_files"}}\t' +
+      '{{index .Config.Labels "com.docker.compose.service"}}\t' +
+      "{{json .Config.Cmd}}"],
+    { allowFailure: true },
+  );
+  if (meta.code !== 0) {
+    throw new Error(`docker inspect failed: ${meta.stderr.trim()}`);
+  }
+  const rows = meta.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+    .map((line) => line.split("\t"));
+  const project = rows[0]?.[0];
+  const configFiles = rows[0]?.[1];
+  if (!project || !configFiles) {
+    throw new Error("GCS host-listeners carry no compose project labels");
+  }
+
+  const services: Record<string, { command: string[] }> = {};
+  for (const [, , service, commandJson] of rows) {
+    if (!service || !commandJson || commandJson === "null") {
+      throw new Error(`cannot read the command of GCS host-listener service "${service}"`);
+    }
+    const base = (JSON.parse(commandJson) as string[]).filter((arg) => arg !== SYNTHETIC_OPS_OFF);
+    services[service] = { command: enabled ? base : [...base, SYNTHETIC_OPS_OFF] };
+  }
+
+  // Compose parses YAML, and JSON is valid YAML — no serializer needed.
+  const overridePath = join(tmpdir(), `fhevm-synthetic-ops-${enabled ? "on" : "off"}.yml`);
+  await Bun.write(overridePath, JSON.stringify({ services }));
+
+  const argv = ["docker", "compose", "-p", project];
+  for (const file of configFiles.split(",")) argv.push("-f", file);
+  argv.push("-f", overridePath, "up", "-d", "--force-recreate", "--no-deps", ...Object.keys(services));
+  const up = await run(argv, { allowFailure: true });
+  if (up.code !== 0) {
+    throw new Error(`recreating the GCS host-listeners failed: ${up.stderr.trim()}`);
+  }
+  return Object.keys(services);
 };
 
 /** Finds the expected drift warning for a specific injected handle. */
@@ -1028,13 +1069,13 @@ const runBlueGreenProfile = async (
     return `[${tuples.join(",")}]`;
   };
 
-  // The GCS listeners inject synthetic ops, so a chain anchors on work of its own and
-  // an idle chain no longer withholds cutover. Unanimity now fails only when an operator
-  // cannot take part: stop one operator's host-listeners so it ingests nothing and never
-  // reports a matching hash. Its consensus-detector keeps running, so it still arms and
-  // fires the timeout — true even with a single operator. [4/11] starts them again, and
-  // the successful upgrade from [6/11] runs with injection active on every operator.
-  console.log(`\n[2/11] failed upgrade: one operator cannot report (no unanimity → no cutover)`);
+  // Host chains stay quiet (no non-trivial FHE op) while [3/11] anchors the Gateway
+  // track with one input. Recreate the GCS listeners with injection off first, so
+  // nothing manufactures work of its own and the window times out into the rollback
+  // this asserts. [4/11] turns it back on for the upgrade that succeeds.
+  console.log(`\n[2/11] failed upgrade: Gateway input, hosts quiet (no non-trivial host \u2192 no cutover)`);
+  const disabled = await setSyntheticOps(false);
+  console.log(`OK:   recreated ${disabled.length} GCS host-listener service(s) with synthetic ops disabled`);
   const failGwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
@@ -1052,29 +1093,6 @@ const runBlueGreenProfile = async (
   console.log(
     `OK:   activation emitted (windows=${failWindows} gw_start=${failGwStartBlock})`,
   );
-
-  // The GCS host-listener writes the upgrade_state row, so stop it only once every
-  // operator has one. DryRunStarted still follows, driven by blue's progress.
-  for (const db of operatorDatabases) {
-    await waitUntil({
-      label: `${db}  upgrade_state rows written`,
-      timeoutSecs: 60,
-      check: async () =>
-        (await psqlQuery(
-          db,
-          `SELECT CASE WHEN COUNT(*)=${hostChains.length} THEN 'ready' ELSE 'waiting' END
-             FROM upgrade_state WHERE stack_role='GCS';`,
-        )) === "ready",
-    });
-  }
-  const silencedListeners = await lastOperatorGcsListeners();
-  if (silencedListeners.length === 0) {
-    throw new Error("found no GCS host-listener containers to silence");
-  }
-  for (const container of silencedListeners) {
-    await dockerLifecycle("stop", container);
-  }
-  console.log(`OK:   stopped ${silencedListeners.join(", ")} — that operator ingests nothing`);
 
   console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted, then submit a Gateway-only input proof`);
   for (const db of operatorDatabases) {
@@ -1149,10 +1167,8 @@ const runBlueGreenProfile = async (
     }
     console.log(`OK:   ${db}  PAUSED/failed, latches cleared, v0.14 kept, gcs schema recreated empty`);
   }
-  for (const container of silencedListeners) {
-    await dockerLifecycle("start", container);
-  }
-  console.log(`OK:   restarted ${silencedListeners.join(", ")} — every operator ingests again`);
+  const reenabled = await setSyntheticOps(true);
+  console.log(`OK:   recreated ${reenabled.length} GCS host-listener service(s) with synthetic ops enabled`);
 
   // Deploy ERC20 + mint before the proposal so the balance handle lands in
   // public.ciphertexts with block_number < start_block. Transfers during the

--- a/test-suite/fhevm/src/commands/test.ts
+++ b/test-suite/fhevm/src/commands/test.ts
@@ -292,9 +292,14 @@ const lastOperatorGcsListeners = async () => {
   return listeners.filter((name) => name.startsWith(`${last}-gcs-`)).sort();
 };
 
-/** Starts or stops a container, failing loudly so a missed step cannot pass silently. */
+/** Starts or stops a container, failing loudly so a missed step cannot pass silently.
+ *  Stops kill immediately: the default 10s grace per container would outlast the
+ *  dry-run window these are stopped for. */
 const dockerLifecycle = async (action: "stop" | "start", container: string) => {
-  const result = await run(["docker", action, container], { allowFailure: true });
+  const argv = action === "stop"
+    ? ["docker", "stop", "-t", "0", container]
+    : ["docker", "start", container];
+  const result = await run(argv, { allowFailure: true });
   if (result.code !== 0) {
     throw new Error(`docker ${action} ${container} failed: ${result.stderr.trim()}`);
   }
@@ -1030,6 +1035,17 @@ const runBlueGreenProfile = async (
   // fires the timeout — true even with a single operator. [4/11] starts them again, and
   // the successful upgrade from [6/11] runs with injection active on every operator.
   console.log(`\n[2/11] failed upgrade: one operator cannot report (no unanimity → no cutover)`);
+  // Silence the operator before proposing: the window opens 15 blocks out and closes
+  // at 45, and stopping containers after the proposal would spend that window here.
+  const silencedListeners = await lastOperatorGcsListeners();
+  if (silencedListeners.length === 0) {
+    throw new Error("found no GCS host-listener containers to silence");
+  }
+  for (const container of silencedListeners) {
+    await dockerLifecycle("stop", container);
+  }
+  console.log(`OK:   stopped ${silencedListeners.join(", ")} — that operator ingests nothing`);
+
   const failGwBlock = Number((await run(
     ["cast", "block-number", "--rpc-url", gatewayRpcUrl],
   )).stdout.trim());
@@ -1047,14 +1063,6 @@ const runBlueGreenProfile = async (
   console.log(
     `OK:   activation emitted (windows=${failWindows} gw_start=${failGwStartBlock})`,
   );
-  const silencedListeners = await lastOperatorGcsListeners();
-  if (silencedListeners.length === 0) {
-    throw new Error("found no GCS host-listener containers to silence");
-  }
-  for (const container of silencedListeners) {
-    await dockerLifecycle("stop", container);
-  }
-  console.log(`OK:   stopped ${silencedListeners.join(", ")} — that operator ingests nothing`);
 
   console.log(`\n[3/11] failed upgrade: wait for GCS DryRunStarted, then submit a Gateway-only input proof`);
   for (const db of operatorDatabases) {


### PR DESCRIPTION
## Summary

- Add `--disable-synthetic-ops` to the host-listener, so injection can be turned off without shipping a new binary if it misbehaves. Off by default.
- Fixes the blue-green e2e by using this flag for the failure tests
- Recreates the GCS listeners with the flag for the failure test cases, and again without it for the success test cases, so the upgrade that succeeds still runs with injection active

Related: https://github.com/zama-ai/fhevm-internal/issues/1957