### PR TITLE
fix(coprocessor): keep base history for diff coverage

### DIFF
--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -174,6 +174,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
+        fetch-depth: 0
         persist-credentials: 'false'
 
     - name: Install lcov
@@ -232,8 +233,6 @@ jobs:
           exit 0
         fi
         pip install --quiet diff-cover
-        git fetch --unshallow origin
-        git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
         diff-cover /tmp/lcov.info \
           --compare-branch="origin/${BASE_REF}" \
           --diff-range-notation='...' \


### PR DESCRIPTION
## What

Fetch full history during the coverage checkout and remove the unauthenticated follow-up fetches.

## Why

`persist-credentials: false` makes the current `git fetch` calls fail before `diff-cover` runs.
