### PR TITLE
docs(solana): record that verify_threshold ignores unknown signers on purpose

### DIFF
--- a/solana/docs/EVM_PARITY.md
+++ b/solana/docs/EVM_PARITY.md
@@ -183,7 +183,11 @@ connector's canonical-PDA + MMR-proof verification (DD-032; materiality now live
    `eip712::verify_threshold` — EVM `InputVerifier` parity, replacing the former single-signer /
    threshold-1 path. Admin-gated rotation via `set_coprocessor_signers`. Remaining forward work is the
    gateway-sync authority + the real proof/transciphering service behind the attestation
-   (FUTURE_DESIGN §1), not the trust model.
+   (FUTURE_DESIGN §1), not the trust model. One intentional divergence: `verify_threshold`
+   ignores signatures that recover to an address outside the signer set, where the EVM
+   `InputVerifier`/`KMSVerifier` revert on any unknown signer. An outsider signature cannot
+   raise the distinct-in-set count, so the threshold is enforced identically; skipping keeps a
+   packet live across signer rotation instead of failing it (fhevm-internal#1888, won't fix).
 2. **No host-side test/mock bypass remains.** The former `mock_input_verified_and_bind` input
    short-circuit, admin toggles, zero creation-entropy fallback, and event-only `test_emit_*`
    instructions were removed entirely (DD-014).

--- a/solana/programs/zama-host/src/eip712.rs
+++ b/solana/programs/zama-host/src/eip712.rs
@@ -167,7 +167,12 @@ pub fn recover_evm_address(digest: &[u8; 32], signature: &[u8; 65]) -> Option<[u
 }
 
 /// True iff at least `threshold` DISTINCT signatures recover to addresses in `signer_set`.
-/// Mirrors the EVM verifiers' recover -> in-set -> unique >= threshold discipline.
+///
+/// Signatures that fail to recover or recover to an address outside `signer_set` are ignored
+/// rather than failing the check. This is a deliberate divergence from the EVM `InputVerifier`
+/// and `KMSVerifier`, which revert on any unknown signer: an outsider signature cannot raise
+/// the count, so skipping it costs nothing in safety and keeps an otherwise valid packet live
+/// (for example one still carrying a signature from a signer rotated out of the set).
 pub fn verify_threshold(
     digest: &[u8; 32],
     signatures: &[[u8; 65]],


### PR DESCRIPTION
Documentation-only close-out of zama-ai/fhevm-internal#1888.

`eip712::verify_threshold` skips signatures that recover to an address outside the configured signer set, where the EVM `InputVerifier` / `KMSVerifier` revert with `InvalidSigner`. The Solana behaviour is kept on purpose:

- An outsider signature cannot raise the distinct-in-set count, so the threshold is enforced identically on both chains. There is no safety difference.
- Skipping keeps an otherwise valid attestation or KMS certificate live when it still carries a signature from a signer rotated out of the set, instead of forcing a resubmission.
- The extra secp256k1 recovery is paid by the submitter and bounded by transaction size.

Changes: the doc comment on `verify_threshold` no longer claims to mirror the EVM verifiers, and `EVM_PARITY.md` records the divergence next to the DD-041 signer-set item. No code behaviour changes.