### PR TITLE
fix(solana): tie demo-vault credit accounts to the signer

### DIFF
--- a/solana/demo-dapp/idl/demo_vault.json
+++ b/solana/demo-dapp/idl/demo_vault.json
@@ -105,7 +105,8 @@
         {
           "name": "depositor_shares",
           "docs": [
-            "Depositor's share token account (destination for minted shares)."
+            "Depositor's share token account (destination for minted shares). Pinned to the signer:",
+            "a client cannot redirect the credit to a third party."
           ],
           "writable": true
         },

--- a/solana/programs/demo-vault/src/instructions/deposit.rs
+++ b/solana/programs/demo-vault/src/instructions/deposit.rs
@@ -33,10 +33,12 @@ pub struct Deposit<'info> {
     /// Vault token account whose balance is the total assets under management.
     #[account(mut)]
     pub vault_token_account: Box<Account<'info, TokenAccount>>,
-    /// Depositor's share token account (destination for minted shares).
+    /// Depositor's share token account (destination for minted shares). Pinned to the signer:
+    /// a client cannot redirect the credit to a third party.
     #[account(
         mut,
         constraint = depositor_shares.mint == share_mint.key() @ DemoVaultError::MintMismatch,
+        constraint = depositor_shares.owner == depositor.key() @ DemoVaultError::OwnerMismatch,
     )]
     pub depositor_shares: Box<Account<'info, TokenAccount>>,
     /// SPL token program.

--- a/solana/programs/demo-vault/src/instructions/withdraw.rs
+++ b/solana/programs/demo-vault/src/instructions/withdraw.rs
@@ -37,6 +37,7 @@ pub struct Withdraw<'info> {
     #[account(
         mut,
         constraint = owner_underlying.mint == underlying_mint.key() @ DemoVaultError::MintMismatch,
+        constraint = owner_underlying.owner == owner.key() @ DemoVaultError::OwnerMismatch,
     )]
     pub owner_underlying: Box<Account<'info, TokenAccount>>,
     /// SPL token program.

--- a/solana/runtime-tests/cost-snapshots/batcher_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/batcher_mollusk.json
@@ -70,7 +70,7 @@
       "max_cpi_instruction_data_bytes": 242
     },
     "redeem_settle": {
-      "compute_units": 294258,
+      "compute_units": 294283,
       "unique_accounts": 35,
       "instruction_data_bytes": 110,
       "cpi_instructions": 14,
@@ -78,7 +78,7 @@
       "max_cpi_instruction_data_bytes": 666
     },
     "settle": {
-      "compute_units": 301716,
+      "compute_units": 301741,
       "unique_accounts": 35,
       "instruction_data_bytes": 110,
       "cpi_instructions": 14,

--- a/solana/runtime-tests/cost-snapshots/vault_mollusk.json
+++ b/solana/runtime-tests/cost-snapshots/vault_mollusk.json
@@ -6,7 +6,7 @@
   },
   "measurements": {
     "deposit": {
-      "compute_units": 14814,
+      "compute_units": 14839,
       "unique_accounts": 10,
       "instruction_data_bytes": 16,
       "cpi_instructions": 2,
@@ -22,7 +22,7 @@
       "max_cpi_instruction_data_bytes": 10
     },
     "withdraw": {
-      "compute_units": 14838,
+      "compute_units": 14863,
       "unique_accounts": 10,
       "instruction_data_bytes": 16,
       "cpi_instructions": 2,

--- a/solana/runtime-tests/tests/vault_mollusk.rs
+++ b/solana/runtime-tests/tests/vault_mollusk.rs
@@ -656,6 +656,68 @@ fn mollusk_deposit_wrong_mint_token_account_rejects() {
 }
 
 #[test]
+fn mollusk_deposit_credit_to_third_party_rejects() {
+    let fixture = VaultFixture::new();
+    let depositor = Pubkey::new_unique();
+    let someone_else = Pubkey::new_unique();
+    let depositor_underlying = Pubkey::new_unique();
+    let third_party_shares = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(0, 0);
+    accounts.insert(depositor, system_account(1_000_000_000));
+    accounts.insert(
+        depositor_underlying,
+        spl_token_account(fixture.underlying_mint, depositor, 1_000),
+    );
+    // Right mint, wrong owner: the signer's debit would credit someone else's shares.
+    accounts.insert(
+        third_party_shares,
+        spl_token_account(fixture.share_mint, someone_else, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = deposit_ix(
+        &fixture,
+        depositor,
+        depositor_underlying,
+        third_party_shares,
+        1_000,
+    );
+    context.process_and_validate_instruction(
+        &ix,
+        &[vault_error(vault::DemoVaultError::OwnerMismatch)],
+    );
+}
+
+#[test]
+fn mollusk_withdraw_credit_to_third_party_rejects() {
+    let fixture = VaultFixture::new();
+    let owner = Pubkey::new_unique();
+    let someone_else = Pubkey::new_unique();
+    let owner_shares = Pubkey::new_unique();
+    let third_party_underlying = Pubkey::new_unique();
+
+    let mut accounts = fixture.accounts(1_000, 1_000);
+    accounts.insert(owner, system_account(1_000_000_000));
+    accounts.insert(
+        owner_shares,
+        spl_token_account(fixture.share_mint, owner, 1_000),
+    );
+    // Right mint, wrong owner: the signer's burn would pay out to someone else.
+    accounts.insert(
+        third_party_underlying,
+        spl_token_account(fixture.underlying_mint, someone_else, 0),
+    );
+    let context = mollusk().with_context(accounts);
+
+    let ix = withdraw_ix(&fixture, owner, owner_shares, third_party_underlying, 100);
+    context.process_and_validate_instruction(
+        &ix,
+        &[vault_error(vault::DemoVaultError::OwnerMismatch)],
+    );
+}
+
+#[test]
 fn mollusk_withdraw_foreign_share_mint_rejects() {
     let fixture = VaultFixture::new();
     let foreign = VaultFixture::new();


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1905.

The demo vault's debit accounts (`depositor_underlying`, `owner_shares`) already require the signer as owner. The credit accounts (`depositor_shares`, `owner_underlying`) checked only the mint, so a client could point a signed deposit's minted shares, or a signed withdraw's underlying payout, at a third party's token account. The signer meant to authorize the debit; the client chose where the credit went.

Change: `constraint = <credit>.owner == <signer>.key() @ OwnerMismatch` on both instructions, reusing the existing error. One mollusk rejection test per instruction (right mint, wrong owner). Cost snapshots move by 25 CU.

Not in scope: gift-on-behalf as a feature, harvest (fhevm-internal#1773). Batcher settle is unaffected, its credit accounts are batch PDAs.
