### PR TITLE
fix(solana): pin the batcher quit refund to the user's canonical token account

### DIFF
--- a/solana/demo-dapp/idl/confidential_batcher.json
+++ b/solana/demo-dapp/idl/confidential_batcher.json
@@ -1236,7 +1236,7 @@
         {
           "name": "user_token_account",
           "docs": [
-            "validated by the token CPI."
+            "so the refund can only land with the quitting user, never back on the batch account."
           ],
           "writable": true
         },

--- a/solana/demo-dapp/src/vault/internal/generated/confidentialBatcher/instructions/quit.ts
+++ b/solana/demo-dapp/src/vault/internal/generated/confidentialBatcher/instructions/quit.ts
@@ -186,7 +186,7 @@ export type QuitAsyncInput<
   joinComputeSigner: Address<TAccountJoinComputeSigner>;
   /** validated by the token CPI and pinned below. */
   batchJoinTokenAccount: Address<TAccountBatchJoinTokenAccount>;
-  /** validated by the token CPI. */
+  /** so the refund can only land with the quitting user, never back on the batch account. */
   userTokenAccount: Address<TAccountUserTokenAccount>;
   batchBalanceValue: Address<TAccountBatchBalanceValue>;
   userBalanceValue: Address<TAccountUserBalanceValue>;
@@ -481,7 +481,7 @@ export type QuitInput<
   joinComputeSigner: Address<TAccountJoinComputeSigner>;
   /** validated by the token CPI and pinned below. */
   batchJoinTokenAccount: Address<TAccountBatchJoinTokenAccount>;
-  /** validated by the token CPI. */
+  /** so the refund can only land with the quitting user, never back on the batch account. */
   userTokenAccount: Address<TAccountUserTokenAccount>;
   batchBalanceValue: Address<TAccountBatchBalanceValue>;
   userBalanceValue: Address<TAccountUserBalanceValue>;
@@ -744,7 +744,7 @@ export type ParsedQuitInstruction<
     joinComputeSigner: TAccountMetas[10];
     /** validated by the token CPI and pinned below. */
     batchJoinTokenAccount: TAccountMetas[11];
-    /** validated by the token CPI. */
+    /** so the refund can only land with the quitting user, never back on the batch account. */
     userTokenAccount: TAccountMetas[12];
     batchBalanceValue: TAccountMetas[13];
     userBalanceValue: TAccountMetas[14];

--- a/solana/programs/confidential-batcher/src/instructions/quit.rs
+++ b/solana/programs/confidential-batcher/src/instructions/quit.rs
@@ -48,8 +48,8 @@ pub struct Quit<'info> {
     /// validated by the token CPI and pinned below.
     #[account(mut)]
     pub batch_join_token_account: UncheckedAccount<'info>,
-    /// CHECK: user's confidential token account (refund destination);
-    /// validated by the token CPI.
+    /// CHECK: user's canonical confidential token account (refund destination); pinned below
+    /// so the refund can only land with the quitting user, never back on the batch account.
     #[account(mut)]
     pub user_token_account: UncheckedAccount<'info>,
     /// CHECK: batch's stable balance encrypted value account; replaced by the token CPI.
@@ -106,6 +106,15 @@ pub fn quit<'info>(ctx: Context<'info, Quit<'info>>) -> Result<()> {
     require_keys_eq!(
         ctx.accounts.batch_join_token_account.key(),
         ct::token_account_address(mint_key, batch_authority).0,
+        BatcherError::DerivedAccountMismatch
+    );
+    // A destination equal to the source is a no-op transfer that the token program accepts;
+    // phase 2 would then zero the join while the balance stays on the batch account and is
+    // shared out to everyone else at settle. Pinning the destination to the user's canonical
+    // account rules that out, since the batch authority is a PDA and can never be the signer.
+    require_keys_eq!(
+        ctx.accounts.user_token_account.key(),
+        ct::token_account_address(mint_key, user).0,
         BatcherError::DerivedAccountMismatch
     );
 

--- a/solana/runtime-tests/tests/batcher_mollusk.rs
+++ b/solana/runtime-tests/tests/batcher_mollusk.rs
@@ -1783,12 +1783,8 @@ fn mollusk_redeem_repeat_join_accumulates_and_quit_refunds_exactly() {
     assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 40);
 }
 
-/// A user who quits before dispatch can still run the (permissionless) claim
-/// after the batch settles on the other participants: their reset encrypted value account
-/// makes the MulDiv produce an encrypted zero, the all-or-zero transfer moves
-/// nothing, and the record is marked claimed. Deposit direction only: quit,
-/// claim, and the encrypted value account reset are direction-free shared code (settle's
-/// vault CPI is the sole direction branch), so one direction pins the class.
+/// A quit whose refund destination is not the user's own token account is refused before
+/// anything moves; the join and the batch balance stay as they were.
 #[test]
 fn mollusk_quit_rejects_refund_destination_that_is_not_the_users_account() {
     let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
@@ -1826,6 +1822,12 @@ fn mollusk_quit_rejects_refund_destination_that_is_not_the_users_account() {
     assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 100);
 }
 
+/// A user who quits before dispatch can still run the (permissionless) claim
+/// after the batch settles on the other participants: their reset encrypted value account
+/// makes the MulDiv produce an encrypted zero, the all-or-zero transfer moves
+/// nothing, and the record is marked claimed. Deposit direction only: quit,
+/// claim, and the encrypted value account reset are direction-free shared code (settle's
+/// vault CPI is the sole direction branch), so one direction pins the class.
 #[test]
 fn mollusk_claim_after_quit_pays_zero() {
     let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);

--- a/solana/runtime-tests/tests/batcher_mollusk.rs
+++ b/solana/runtime-tests/tests/batcher_mollusk.rs
@@ -1790,6 +1790,43 @@ fn mollusk_redeem_repeat_join_accumulates_and_quit_refunds_exactly() {
 /// claim, and the encrypted value account reset are direction-free shared code (settle's
 /// vault CPI is the sole direction branch), so one direction pins the class.
 #[test]
+fn mollusk_quit_rejects_refund_destination_that_is_not_the_users_account() {
+    let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
+    let context = mollusk().with_context(fixture.accounts(0, 0));
+    let mut ledger = CleartextLedger::default();
+    fixture.seed_ledger(&mut ledger, (1_000, 0), (2_000, 0), (1_000_000, 0));
+
+    let keys = initialize_and_open_first_batch(&context, &fixture, 0);
+    seed_open_batch_balances(&context, &keys, &mut ledger);
+    run_join(
+        &context,
+        &fixture,
+        &keys,
+        &fixture.alice,
+        &mut ledger,
+        handle_for_chain(41, BALANCE_FHE_TYPE),
+        100,
+    );
+    let pending = keys.pending_join_value(fixture.alice.user);
+
+    // Destination = source: the token transfer would move nothing and the reset would erase
+    // the join, handing Alice's 100 to the other participants at settle.
+    let mut quit = quit_ix(&fixture, &keys, &fixture.alice);
+    let user_join = fixture.user_join(&fixture.alice);
+    for meta in quit.accounts.iter_mut() {
+        if meta.pubkey == user_join.token_account {
+            meta.pubkey = keys.join_token_account;
+        }
+    }
+    context.process_and_validate_instruction(
+        &quit,
+        &[batcher_error(batcher::BatcherError::DerivedAccountMismatch)],
+    );
+    assert_eq!(ledger.u64_at(&context, pending), 100);
+    assert_eq!(ledger.u64_at(&context, keys.join_balance_value), 100);
+}
+
+#[test]
 fn mollusk_claim_after_quit_pays_zero() {
     let fixture = BatcherFixture::new(batcher::BatchDirection::Deposit);
     let context = mollusk().with_context(fixture.accounts(0, 0));


### PR DESCRIPTION
Closes zama-ai/fhevm-internal#1904.

`quit` pinned the refund source (`batch_join_token_account`) but left the destination (`user_token_account`) to the token CPI, which accepts `from == to` as a no-op transfer. A client passing the batch join account as destination made the transfer move nothing, phase 2 then encrypted a zero onto the join, and the user's principal stayed on the batch account, to be burned inside `total_joined` at settle and paid to the other participants' claims.

Change: one `require_keys_eq!` pinning `user_token_account` to `token_account_address(join_mint, user)`. The batch authority is a PDA and the user is a signer, so the two can never be the same account, which rules out every `from == to` shape; the encrypted-zero reset therefore only runs after value moved. `quit` stays user-signed; there is no keeper path.

Test: `mollusk_quit_rejects_refund_destination_that_is_not_the_users_account` passes the batch join account as destination, expects `DerivedAccountMismatch`, and asserts `pending_join` and the batch balance are unchanged.

Not in scope: an ERC-7984 operator; `claim`, whose destination is already derived.
