### PR TITLE
fix(coprocessor): take the Solana listener's chain id from HostConfig only

### DIFF
--- a/coprocessor/fhevm-engine/host-listener/src/bin/solana_host_listener.rs
+++ b/coprocessor/fhevm-engine/host-listener/src/bin/solana_host_listener.rs
@@ -44,10 +44,6 @@ struct Args {
     #[arg(long = "program-id", alias = "acl-program-id")]
     program_id: String,
 
-    /// Coprocessor host-chain id recorded against ingested handles.
-    #[arg(long)]
-    host_chain_id: i64,
-
     /// Dependence-chain cache size.
     #[arg(long, default_value_t = DEFAULT_DEPENDENCE_CACHE_SIZE)]
     dependence_cache_size: u16,
@@ -77,18 +73,9 @@ async fn main() -> Result<()> {
 
     let program_id = Pubkey::from_str(&args.program_id)
         .with_context(|| format!("invalid program id {}", args.program_id))?;
-    // Solana host IDs set the RFC-021 high bit and arrive through CLI as the equivalent signed i64;
-    // canonical-u64 conversion intentionally preserves that bit pattern.
-    let database_chain_id =
-        ChainId::from_canonical_u64(args.host_chain_id as u64);
-    let db = Database::new(
-        &args.database_url,
-        database_chain_id,
-        args.dependence_cache_size,
-    )
-    .await
-    .context("connect coprocessor database")?;
 
+    // The deployment's HostConfig is the one source of the chain id: it derives handles and
+    // names the database partition they are filed under, so the two can never disagree.
     let rpc = RpcClient::new_with_timeout_and_commitment(
         args.url.clone(),
         SOLANA_RPC_REQUEST_TIMEOUT,
@@ -106,6 +93,14 @@ async fn main() -> Result<()> {
         chain_id = host_config_chain_id,
         "auto-detected handle-derivation params from confirmed HostConfig"
     );
+
+    let db = Database::new(
+        &args.database_url,
+        ChainId::from_canonical_u64(host_config_chain_id),
+        args.dependence_cache_size,
+    )
+    .await
+    .context("connect coprocessor database")?;
 
     let cancel = CancellationToken::new();
     let signal_cancel = cancel.clone();

--- a/test-suite/fhevm/src/solana/deploy.ts
+++ b/test-suite/fhevm/src/solana/deploy.ts
@@ -339,7 +339,6 @@ const startHostListener = async (parameters: {
       VALIDATOR_RPC_URL,
       "--program-id",
       parameters.zamaHostId,
-      `--host-chain-id=${SOLANA_HOST_CHAIN_ID_I64}`,
     ],
     { stdin: "ignore", stdout: logFd, stderr: logFd },
   );


### PR DESCRIPTION
Item 2 of zama-ai/fhevm-internal#1972 (the issue stays open for items 1 and 3).

The Solana host-listener recorded every ingested handle under the CLI `--host-chain-id` and derived handles with `HostConfig.chain_id`, which it already fetches from the deployment it subscribes to. The two were never compared, so a wrong flag silently filed Solana rows into another chain's partition, including the EVM `12345` partition of the dual-host scenario.

The issue asked for a startup check that the two agree. Review pointed out the flag is a second source of truth for a value the process already learns from chain, so this PR removes it instead: `HostConfig` is fetched before the database is opened and its chain id names the partition. There is no mismatch left to detect, no cast, no new function and no test to maintain. The only caller, `test-suite/fhevm/src/solana/deploy.ts`, drops the argument. Net 10 insertions, 16 deletions.

Not in scope: threading `program_id` into reconstruction (item 1), removing the copied walk (item 3), deriving the id from the genesis hash (fhevm-internal#1880).
