### PR TITLE
chore(coprocessor): run `upgrade-controller` and `consensus-detector` tests in ci

### DIFF
--- a/.github/workflows/coprocessor-cargo-tests.yml
+++ b/.github/workflows/coprocessor-cargo-tests.yml
@@ -104,6 +104,16 @@ jobs:
             needs_localstack: false
             needs_foundry: false
             runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
+          - service: upgrade-controller
+            package: upgrade-controller
+            needs_localstack: false
+            needs_foundry: false
+            runner: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64
+          - service: consensus-detector
+            package: consensus-detector
+            needs_localstack: false
+            needs_foundry: false
+            runner: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/coprocessor/fhevm-engine/upgrade-controller/src/coprocessor_tables.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/coprocessor_tables.rs
@@ -368,9 +368,7 @@ mod tests {
         use std::collections::BTreeSet;
         use test_harness::instance::{setup_test_db, ImportMode};
 
-        let instance = setup_test_db(ImportMode::WithKeysNoSns)
-            .await
-            .expect("test db");
+        let instance = setup_test_db(ImportMode::None).await.expect("test db");
         let pool = PgPoolOptions::new()
             .max_connections(2)
             .connect(instance.db_url())

--- a/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
+++ b/coprocessor/fhevm-engine/upgrade-controller/src/lib.rs
@@ -2941,9 +2941,7 @@ mod tests {
     async fn test_pool() -> (test_harness::instance::DBInstance, Pool<Postgres>) {
         use sqlx::postgres::PgPoolOptions;
         use test_harness::instance::{setup_test_db, ImportMode};
-        let instance = setup_test_db(ImportMode::WithKeysNoSns)
-            .await
-            .expect("test db");
+        let instance = setup_test_db(ImportMode::None).await.expect("test db");
         let pool = PgPoolOptions::new()
             .max_connections(4)
             .connect(instance.db_url())


### PR DESCRIPTION
### Summary

- Adds `upgrade-controller` and `consensus-detector` to the `coprocessor-cargo-test` matrix.
- Switches the `upgrade-controller` tests from `ImportMode::WithKeysNoSns` to `ImportMode::None`, since they only cover the upgrade state machine and GCS schema. Importing the keyset per test OOM killed the runner.

Related: https://github.com/zama-ai/fhevm-internal/issues/1988