### PR TITLE
fix(kms-connector): support single chain in config

### DIFF
--- a/kms-connector/crates/endpoint/src/core/config.rs
+++ b/kms-connector/crates/endpoint/src/core/config.rs
@@ -1,5 +1,5 @@
 use connector_utils::{
-    config::{DeserializeConfig, default_database_pool_size},
+    config::{DeserializeConfig, default_database_pool_size, deserialize_one_or_many},
     monitoring::{health::default_healthcheck_timeout, server::default_monitoring_endpoint},
 };
 use serde::Deserialize;
@@ -37,6 +37,7 @@ pub struct Config {
     #[serde(default = "default_max_allowed_contracts")]
     pub max_allowed_contracts: usize,
     /// The host chain ids accepted in ciphertext handles.
+    #[serde(deserialize_with = "deserialize_one_or_many")]
     pub supported_chain_ids: Vec<u64>,
 
     /// The service name used for tracing.
@@ -172,6 +173,39 @@ mod tests {
         assert_eq!(config.healthcheck_timeout, Duration::from_secs(7));
 
         cleanup_env_vars();
+    }
+
+    #[test]
+    #[serial(config_tests)]
+    fn test_single_supported_chain_id_from_env() {
+        cleanup_env_vars();
+        unsafe {
+            env::set_var(
+                "KMS_CONNECTOR_DATABASE_URL",
+                "postgres://postgres:postgres@localhost",
+            );
+            env::set_var("KMS_CONNECTOR_SUPPORTED_CHAIN_IDS", "1");
+        }
+
+        let config = Config::from_env_and_file::<&str>(None).unwrap();
+        assert_eq!(config.supported_chain_ids, vec![1]);
+
+        cleanup_env_vars();
+    }
+
+    #[test]
+    #[serial(config_tests)]
+    fn test_single_supported_chain_id_from_file() {
+        cleanup_env_vars();
+        let toml = r#"
+            database_url = "postgres://postgres:postgres@localhost"
+            supported_chain_ids = 1
+        "#;
+        let tmp = std::env::temp_dir().join(format!("endpoint-cfg-{}.toml", std::process::id()));
+        std::fs::write(&tmp, toml).unwrap();
+        let config = Config::from_env_and_file(Some(&tmp)).unwrap();
+        std::fs::remove_file(&tmp).ok();
+        assert_eq!(config.supported_chain_ids, vec![1]);
     }
 
     #[test]

--- a/kms-connector/crates/utils/src/config/mod.rs
+++ b/kms-connector/crates/utils/src/config/mod.rs
@@ -6,11 +6,14 @@ mod wallet;
 pub use contract::ContractConfig;
 pub use deserialize::DeserializeConfig;
 pub use error::{Error, Result};
-use sqlx::postgres::types::PgInterval;
 pub use wallet::{AwsKmsConfig, KmsWallet, TestingPrivateKey};
 
-use serde::{Deserializer, Serializer};
-use std::time::Duration;
+use serde::{
+    Deserialize, Deserializer, Serializer,
+    de::{IntoDeserializer, SeqAccess, Visitor, value::SeqAccessDeserializer},
+};
+use sqlx::postgres::types::PgInterval;
+use std::{fmt, marker::PhantomData, time::Duration};
 
 pub fn serialize_pg_interval<S>(
     interval: &PgInterval,
@@ -37,4 +40,80 @@ where
 
 pub fn default_database_pool_size() -> u32 {
     16
+}
+
+/// Deserializes a `Vec<T>` field from either a single scalar `T` or a sequence of `T`.
+///
+/// Workaround for a config-rs limitation (see https://github.com/rust-cli/config-rs/issues/120)
+/// where a scalar value is not automatically coerced into a single-element list.
+///
+/// Implemented via the `Visitor` trait (https://serde.rs/impl-deserialize.html#the-visitor-trait).
+pub fn deserialize_one_or_many<'de, D, T>(deserializer: D) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    struct OneOrManyVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for OneOrManyVisitor<T>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a single value or a sequence of values")
+        }
+
+        fn visit_seq<A>(self, seq: A) -> std::result::Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            Vec::<T>::deserialize(SeqAccessDeserializer::new(seq))
+        }
+
+        fn visit_bool<E>(self, v: bool) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            T::deserialize(v.into_deserializer()).map(|value| vec![value])
+        }
+
+        fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            T::deserialize(v.into_deserializer()).map(|value| vec![value])
+        }
+
+        fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            T::deserialize(v.into_deserializer()).map(|value| vec![value])
+        }
+
+        fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            T::deserialize(v.into_deserializer()).map(|value| vec![value])
+        }
+
+        fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            T::deserialize(v.into_deserializer()).map(|value| vec![value])
+        }
+
+        fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            T::deserialize(v.into_deserializer()).map(|value| vec![value])
+        }
+    }
+
+    deserializer.deserialize_any(OneOrManyVisitor(PhantomData))
 }


### PR DESCRIPTION
Implement deserialization of `Vec<T>` field from either a single scalar `T` or a sequence of `T`.

Workaround for a `config-rs` limitation (see https://github.com/rust-cli/config-rs/issues/120).

Implemented via the `Visitor` trait (https://serde.rs/impl-deserialize.html#the-visitor-trait). A bit verbose and scary at first, but not that complex in reality.

Without this, `KMS_CONNECTOR_SUPPORTED_CHAIN_IDS="1"` and even `KMS_CONNECTOR_SUPPORTED_CHAIN_IDS="1,"` failed to parse.
It was required to do `KMS_CONNECTOR_SUPPORTED_CHAIN_IDS="1,1"`, which is not obvious...