### PR TITLE
ci(coprocessor): run the blue-green preview at the compiled release

### DIFF
--- a/.github/workflows/coprocessor-docker-build.yml
+++ b/.github/workflows/coprocessor-docker-build.yml
@@ -16,11 +16,6 @@ on:
         type: boolean
         default: true
         required: false
-      build_stack_version:
-        description: "Optional compiled STACK_VERSION (BUILD_STACK_VERSION). When set, force-builds worker images so GCS is not a retag of the baseline."
-        type: string
-        default: ""
-        required: false
     secrets:
       AWS_ACCESS_KEY_S3_USER:
         required: true
@@ -62,9 +57,6 @@ on:
       upgrade_controller_build_result:
         description: "Result of the build-upgrade-controller job"
         value: ${{ jobs.build-upgrade-controller.result }}
-      image_tag:
-        description: "Published tag when build_stack_version is set (e.g. abc1234-gcs0.15.0); empty otherwise"
-        value: ${{ jobs.build-decisions.outputs.image_tag }}
   workflow_dispatch:
     inputs:
       build_db_migration:
@@ -103,11 +95,6 @@ on:
         description: "Enable/disable build for Coprocessor's Upgrade Controller"
         type: boolean
         default: true
-      build_stack_version:
-        description: "Optional compiled STACK_VERSION (BUILD_STACK_VERSION). Empty keeps the hardcoded baseline."
-        type: string
-        default: ""
-        required: false
   push:
     branches: ['main', 'release/*']
 
@@ -324,7 +311,6 @@ jobs:
       zkproof_worker: ${{ steps.decide.outputs.zkproof_worker }}
       consensus_detector: ${{ steps.decide.outputs.consensus_detector }}
       upgrade_controller: ${{ steps.decide.outputs.upgrade_controller }}
-      image_tag: ${{ steps.gcs-tag.outputs.image_tag }}
     steps:
       - id: decide
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
@@ -338,23 +324,15 @@ jobs:
             // - release: always build
             // - push: only act if latest commit; build if changes, retag otherwise
             // - workflow_call: build if changes detected, otherwise skip
-            // - workflow_call + build_stack_version: force-build workers (arg
-            //   changes the binary even when source paths are unchanged)
             // - workflow_dispatch: build if input is true, otherwise skip
             const event = process.env.EVENT_NAME;
             const needs = JSON.parse(process.env.NEEDS);
             const inputs = JSON.parse(process.env.INPUTS);
             const isLatestCommit = needs['is-latest-commit'].outputs?.is_latest === 'true';
             const isWorkflowCall = inputs.is_workflow_call ?? false;
-            const forceStackVersion = Boolean(inputs.build_stack_version);
-            const stackVersionServices = new Set([
-              'gw_listener', 'host_listener', 'sns_worker', 'tfhe_worker',
-              'tx_sender', 'zkproof_worker', 'consensus_detector', 'upgrade_controller',
-            ]);
 
             const decideAction = (name, changes, manualInput) => {
               if (event === 'release') return 'build';
-              if (forceStackVersion && isWorkflowCall && stackVersionServices.has(name)) return 'build';
               if (event === 'push') return isLatestCommit ? (changes ? 'build' : 'retag') : 'skip';
               if (isWorkflowCall) return changes ? 'build' : 'skip';
               if (!isWorkflowCall && event === 'workflow_dispatch') return manualInput ? 'build' : 'skip';
@@ -373,32 +351,13 @@ jobs:
               upgrade_controller: { changes: needs['check-changes-upgrade-controller'].outputs?.changes, build_input: inputs.build_upgrade_controller },
             };
 
-            core.info(`Event: ${event}, Is latest commit: ${isLatestCommit}, Is workflow call: ${isWorkflowCall}, build_stack_version: ${inputs.build_stack_version || ''}`);
+            core.info(`Event: ${event}, Is latest commit: ${isLatestCommit}, Is workflow call: ${isWorkflowCall}`);
             for (const [name, { changes, build_input }] of Object.entries(services)) {
               const action = decideAction(name, changes === 'true', build_input ?? false);
               core.setOutput(name, action);
               core.info(`${name}: ${action} (changes: ${changes}, build_input: ${build_input})`);
             }
 
-      # Distinct tag so a GCS compile (BUILD_STACK_VERSION) cannot overwrite the
-      # same-commit baseline image. Empty STACK_VERSION keeps common-docker's SHA.
-      - id: gcs-tag
-        env:
-          STACK_VERSION: ${{ inputs.build_stack_version }}
-          # Same precedence as ci-templates common-docker determine-tag.
-          COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          if [[ -z "${STACK_VERSION}" ]]; then
-            echo "image_tag=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ ! "${STACK_VERSION}" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
-            echo "::error::build_stack_version must be a dotted numeric version"
-            exit 1
-          fi
-          short="${COMMIT_HASH:0:7}"
-          echo "image_tag=${short}-gcs${STACK_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "GCS images will be tagged ${short}-gcs${STACK_VERSION}"
 
   ########################################################################
   #                             DB MIGRATION                             #
@@ -430,7 +389,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
 
   re-tag-db-migration-image:
     needs: [build-decisions, check-changes-db-migration]
@@ -465,8 +423,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-gw-listener-image:
     needs: [build-decisions, check-changes-gw-listener]
@@ -497,8 +453,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-host-listener-image:
     needs: [build-decisions, check-changes-host-listener]
@@ -529,8 +483,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-sns-worker-image:
     needs: [build-decisions, check-changes-sns-worker]
@@ -561,8 +513,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-tfhe-worker-image:
     needs: [build-decisions, check-changes-tfhe-worker]
@@ -593,8 +543,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-tx-sender-image:
     needs: [build-decisions, check-changes-tx-sender]
@@ -625,8 +573,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-zkproof-worker-image:
     needs: [build-decisions, check-changes-zkproof-worker]
@@ -657,8 +603,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-consensus-detector-image:
     needs: [build-decisions, check-changes-consensus-detector]
@@ -689,8 +633,6 @@ jobs:
       # cache-miss Rust builds the longest job on the merge-queue critical path.
       runs-on-amd: runs-on=${{ github.run_id }}/runner=16cpu-linux-x64/extras=s3-cache
       rust-toolchain-file-path: coprocessor/fhevm-engine/rust-toolchain.toml
-      build-args: ${{ inputs.build_stack_version != '' && format('BUILD_STACK_VERSION={0}', inputs.build_stack_version) || '' }}
-      image-tag: ${{ needs.build-decisions.outputs.image_tag }}
 
   re-tag-upgrade-controller-image:
     needs: [build-decisions, check-changes-upgrade-controller]

--- a/.github/workflows/preview-env-deploy.yml
+++ b/.github/workflows/preview-env-deploy.yml
@@ -191,13 +191,27 @@ jobs:
       nb_coprocessor: ${{ steps.check.outputs.nb_coprocessor }}
       use_blockchain_dev: ${{ steps.check.outputs.use_blockchain_dev }}
       overrides_json: ${{ steps.parse_overrides.outputs.overrides_json }}
+      stack_version: ${{ steps.stack_version.outputs.stack_version }}
     steps:
-      - name: Checkout parse-overrides script
+      - name: Checkout parse-overrides script and the stack version
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          sparse-checkout: ci/preview-env/scripts/parse-overrides.cjs
+          sparse-checkout: |
+            ci/preview-env/scripts/parse-overrides.cjs
+            coprocessor/fhevm-engine/fhevm-engine-common/src/lib.rs
           sparse-checkout-cone-mode: false
+      # The GCS tag suffix and pod label follow the compiled release, so read it
+      # from the source constant instead of pinning it here.
+      - id: stack_version
+        run: |
+          version="$(grep -m1 -oE '^\s*"[0-9]+\.[0-9]+\.[0-9]+"' \
+            coprocessor/fhevm-engine/fhevm-engine-common/src/lib.rs | tr -d ' "')"
+          if [[ -z "${version}" ]]; then
+            echo "::error::could not read stack_version!() from fhevm-engine-common/src/lib.rs"
+            exit 1
+          fi
+          echo "stack_version=${version}" >> "$GITHUB_OUTPUT"
       - id: parse_overrides
         env:
           OVERRIDES_RAW: ${{ inputs.overrides }}
@@ -347,10 +361,6 @@ jobs:
     uses: ./.github/workflows/coprocessor-docker-build.yml
     permissions: *docker_permissions
     secrets: *docker_secrets
-    with:
-      # Blue-green GCS is compiled as 0.15.0 and published as <sha>-gcs0.15.0.
-      # BCS stays the registry pin v0.14.0-7. Empty keeps the SHA / 0.14.0 baseline.
-      build_stack_version: ${{ needs.check-labels.outputs.blue_green == 'true' && '0.15.0' || '' }}
 
   build-listener:
     name: build/listener
@@ -482,6 +492,9 @@ jobs:
       REDIS_CHART_VERSION: ${{ fromJSON(needs.check-labels.outputs.overrides_json).redis_chart_version }}
       # Previous-release pin for the BCS fleet (compiled STACK_VERSION=0.14.0).
       BCS_IMAGE_TAG: "v0.14.0-7"
+      # Release the GCS fleet is compiled at; names the proposal and the
+      # gcs-<release> schema the assertions read.
+      GCS_VERSION: v${{ needs.check-labels.outputs.stack_version }}
       # In-namespace Jaeger's OTLP gRPC endpoint.
       # Only consumed when OBSERVABILITY is true.
       OTLP_ENDPOINT: "http://jaeger:4317"
@@ -524,7 +537,7 @@ jobs:
             echo "::error::blue-green requires GCS images (build_images=true). coprocessor_tfhe_worker tag is empty."
             exit 1
           fi
-          echo "RFC-021 blue-green: N=${NB_COPROCESSOR} BCS=${BCS_IMAGE_TAG} GCS=${gcs} (compiled 0.15.0)"
+          echo "RFC-021 blue-green: N=${NB_COPROCESSOR} BCS=${BCS_IMAGE_TAG} GCS=${gcs} (compiled ${GCS_VERSION#v})"
 
       ######################################################################
       # CHART SOURCES: every in-repo chart installs from this checkout's
@@ -941,9 +954,10 @@ jobs:
         #
         # RFC-021 blue-green: that release is the BCS fleet (pinned
         # BCS_IMAGE_TAG). A second release coprocessor-<i>-gcs is the GCS
-        # fleet (HEAD images compiled as 0.15.0). Gateway registration stays N.
+        # fleet (HEAD images at the compiled release). Gateway registration stays N.
         env:
           COPROC_WALLETS_JSON: ${{ steps.coproc-wallets.outputs.wallets_json }}
+          GCS_STACK_VERSION: ${{ needs.check-labels.outputs.stack_version }}
         run: bash ci/preview-env/scripts/deploy-coprocessor.sh
 
       - name: Deploy polygon coprocessor consumer (per-party Polygon consumer)
@@ -1155,7 +1169,7 @@ jobs:
           body: |
             :rocket: **e2e preview environment deployed** in namespace `${{ env.NAMESPACE }}` on zws-dev.
 
-            Topology: **${{ env.NB_KMS_CORE }}** KMS core ${{ env.NB_KMS_CORE == '1' && 'party' || 'parties' }} · **${{ env.NB_COPROCESSOR }}** coprocessor ${{ env.NB_COPROCESSOR == '1' && 'party' || 'parties' }} (each a full independent stack: its own Postgres, S3 bucket, tx-sender identity, `listener` producer, Redis broker and host-listener-consumer).${{ env.BLUE_GREEN == 'true' && ' **RFC-021 blue-green:** each party also runs a GCS fleet (`coprocessor-<i>-gcs`, compiled 0.15.0) beside BCS (`v0.14.0-7`). Gateway registration stays N.' || '' }}${{ env.DEPLOY_POLYGON == 'true' && ' Plus a **second Polygon Amoy (80002)** host chain (fresh anvil, reusing the ETH KMS key via canonical ProtocolConfig mirror).' || '' }}
+            Topology: **${{ env.NB_KMS_CORE }}** KMS core ${{ env.NB_KMS_CORE == '1' && 'party' || 'parties' }} · **${{ env.NB_COPROCESSOR }}** coprocessor ${{ env.NB_COPROCESSOR == '1' && 'party' || 'parties' }} (each a full independent stack: its own Postgres, S3 bucket, tx-sender identity, `listener` producer, Redis broker and host-listener-consumer).${{ env.BLUE_GREEN == 'true' && format(' **RFC-021 blue-green:** each party also runs a GCS fleet (`coprocessor-<i>-gcs`, compiled {0}) beside BCS (`{1}`). Gateway registration stays N.', env.GCS_VERSION, env.BCS_IMAGE_TAG) || '' }}${{ env.DEPLOY_POLYGON == 'true' && ' Plus a **second Polygon Amoy (80002)** host chain (fresh anvil, reusing the ETH KMS key via canonical ProtocolConfig mirror).' || '' }}
 
             Connect:
             ```bash
@@ -1176,7 +1190,7 @@ jobs:
             echo
             echo "Namespace \`${NAMESPACE}\` on zws-dev."
             echo
-            echo "Topology: **${NB_KMS_CORE}** KMS core parties · **${NB_COPROCESSOR}** coprocessor parties (each a full independent stack: its own Postgres, S3 bucket, tx-sender identity, listener producer, Redis broker and host-listener-consumer)$([[ "${BLUE_GREEN}" == "true" ]] && echo " · RFC-021 blue-green (BCS v0.14.0-7 + GCS from this build compiled 0.15.0)")$([[ "${DEPLOY_POLYGON}" == "true" ]] && echo " · a second Polygon Amoy (80002) host chain reusing the ETH KMS key"). Note: each coprocessor party requests substantial tfhe/sns worker capacity on the coprocessor nodepool, so nb_coprocessor > 1 multiplies the cluster resources needed."
+            echo "Topology: **${NB_KMS_CORE}** KMS core parties · **${NB_COPROCESSOR}** coprocessor parties (each a full independent stack: its own Postgres, S3 bucket, tx-sender identity, listener producer, Redis broker and host-listener-consumer)$([[ "${BLUE_GREEN}" == "true" ]] && echo " · RFC-021 blue-green (BCS ${BCS_IMAGE_TAG} + GCS from this build compiled ${GCS_VERSION#v})")$([[ "${DEPLOY_POLYGON}" == "true" ]] && echo " · a second Polygon Amoy (80002) host chain reusing the ETH KMS key"). Note: each coprocessor party requests substantial tfhe/sns worker capacity on the coprocessor nodepool, so nb_coprocessor > 1 multiplies the cluster resources needed."
             echo
             echo "Connect:"
             echo '```bash'

--- a/.github/workflows/preview-env-destroy.yml
+++ b/.github/workflows/preview-env-destroy.yml
@@ -12,7 +12,7 @@ name: preview-env-destroy
 # namespace is - see coprocessor-infra/values-postgres-coprocessor-e2e.yaml.
 #
 # Triggers (the pull_request ones mirror preview-env-deploy.yml's labels:
-# preview-env-e2e / preview-env-e2e-tests):
+# preview-env-e2e / preview-env-e2e-tests / preview-env-blue-green):
 #   - closed:    PR merged/closed -> always attempt teardown (no-op if none).
 #   - unlabeled: a preview label was removed AND no preview label remains, i.e.
 #     the label that keeps the env alive is gone. Removing only -tests while
@@ -52,16 +52,16 @@ jobs:
     # On `closed` we attempt teardown unconditionally (can't cheaply check
     # label history; the namespace step no-ops if nothing exists). On
     # `unlabeled` we only tear down when a preview label was removed AND none
-    # remains: both preview labels share the 'preview-env-e2e' prefix, so
-    # `contains(label.name, 'preview-env-e2e')` matches the removed one and
-    # `!contains(toJSON(labels.*.name), 'preview-env-e2e')` confirms no preview
-    # label is left (removing -tests while -e2e stays keeps the env).
+    # remains: every preview label shares the 'preview-env-' prefix, so
+    # `contains(label.name, 'preview-env-')` matches the removed one and
+    # `!contains(toJSON(labels.*.name), 'preview-env-')` confirms no preview
+    # label is left (removing one while another stays keeps the env).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.action == 'closed' ||
       (github.event.action == 'unlabeled' &&
-      contains(github.event.label.name, 'preview-env-e2e') &&
-      !contains(toJSON(github.event.pull_request.labels.*.name), 'preview-env-e2e'))
+      contains(github.event.label.name, 'preview-env-') &&
+      !contains(toJSON(github.event.pull_request.labels.*.name), 'preview-env-'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # The comment step needs to write to the PR; the workflow-level

--- a/ci/preview-env/101-preview-env.md
+++ b/ci/preview-env/101-preview-env.md
@@ -211,7 +211,7 @@ kubectl port-forward -n <namespace> svc/jaeger 16686:16686    # http://localhost
   the workflow runs the e2e DAG for both `@fhevm/sdk` and `@zama-fhe/relayer-sdk`
   and posts a per-test pass/fail table to the PR comment / run summary.
   Combined with `preview-env-blue-green`, that DAG runs **twice**: once during
-  `DryRunStarted` (BCS live; CI asserts each party's `"gcs-0.15.0".computations`
+  `DryRunStarted` (BCS live; CI asserts each party's `"gcs-<release>".computations`
   is non-empty) and once after cutover (`versioning=v0.15`, GCS live).
 - **Without:** the stack is deployed with an idle test-suite Job — run tests
   yourself against the namespace, or re-label with `preview-env-e2e-tests`.
@@ -262,8 +262,7 @@ kubectl delete namespace <namespace>
 - **There are no auto-pins for fhevm's own images** (coprocessor, kms-connector,
   contracts, …). Charts come from your checkout; images resolve from your base
   commit unless built this run. Check the run summary **Images** table for
-  `built`, `base-sha`, or `dispatch-override`. Blue-green GCS workers publish
-  as `<sha>-gcs0.15.0`. **Exception:** dedicated **kms-core** is always an
+  `built`, `base-sha`, or `dispatch-override`. **Exception:** dedicated **kms-core** is always an
   external pin (`kms_core_version` + `kms_repo_ref` in `parse-overrides.cjs`) —
   PR labels cannot change it without editing that file or using dispatch.
 - **Unresolvable ⇒ the run fails.** If GHCR has pruned the base commit's tags and

--- a/ci/preview-env/README.md
+++ b/ci/preview-env/README.md
@@ -49,7 +49,7 @@ ci/preview-env/
 ├── coprocessor/
 │   ├── values-coprocessor-e2e.yaml        # coprocessor overlay (one release per party: coprocessor-<i>)
 │   ├── values-coprocessor-bcs-e2e.yaml    # RFC-021 BCS overlay (pinned 0.14.0, extraSelectorLabels)
-│   ├── values-coprocessor-gcs-e2e.yaml    # RFC-021 GCS overlay (0.15.0 + upgrade-controller / consensus-detector)
+│   ├── values-coprocessor-gcs-e2e.yaml    # RFC-021 GCS overlay (compiled release + upgrade-controller / consensus-detector)
 │   ├── values-coprocessor-polygon-e2e.yaml # additive multichain overlay: adds the Polygon chains[] consumer (deploy_polygon)
 │   ├── values-coprocessor-poller-e2e.yaml # coprocessor overlay, poller-only release: S3 key/CRS download -> keys/crs tables (coprocessor-poller-<i>)
 │   ├── values-coprocessor-poller-polygon-e2e.yaml # additive multichain overlay: adds the Polygon poller (deploy_polygon)
@@ -309,7 +309,7 @@ These are different models. `nb_coprocessor > 1` is N-party unless you opt into 
 | Model | Meaning | How to enable |
 | --- | --- | --- |
 | **N-party consensus** | N on-chain identities (wallet, S3, Postgres). Gateway `NUM_COPROCESSORS=N`. | `nb_coprocessor` in `{1,2,3,5}` |
-| **Blue-green (RFC-021)** | **Two fleets of the same identity**: BCS (live `v0.14.0-7`) + GCS (HEAD compiled as `0.15.0`), shared DB/S3/wallet. Cutover is `ProtocolConfig.proposeCoprocessorUpgrade` then off-chain unanimity of all N operators. | PR label `preview-env-blue-green` (deploys, forces N=2) or dispatch `enable_blue_green=true` |
+| **Blue-green (RFC-021)** | **Two fleets of the same identity**: BCS (live `v0.14.0-7`) + GCS (HEAD at its compiled release), shared DB/S3/wallet. Cutover is `ProtocolConfig.proposeCoprocessorUpgrade` then off-chain unanimity of all N operators. | PR label `preview-env-blue-green` (deploys, forces N=2) or dispatch `enable_blue_green=true` |
 
 Blue-green does **not** register 2N gateway slots. Per party the preview keeps one listener, one Redis, one poller; BCS and GCS `hostListenerConsumer`s share that broker. GCS also runs `upgrade-controller` and `consensus-detector`. Incompatible with `deploy_polygon` and with `nb_coprocessor=1`.
 

--- a/ci/preview-env/coprocessor/values-coprocessor-gcs-e2e.yaml
+++ b/ci/preview-env/coprocessor/values-coprocessor-gcs-e2e.yaml
@@ -1,19 +1,17 @@
 # GCS (green) overlay for RFC-021 preview-env. Applied on top of
 # values-coprocessor-e2e.yaml for release coprocessor-<i>-gcs.
 #
-# Same party identity as BCS (wallet, Postgres, Redis, S3, IRSA). Images
-# come from the coprocessor CI build with BUILD_STACK_VERSION=0.15.0,
-# tagged <sha>-gcs0.15.0 (not the baseline <sha>).
-# db-migration stays on the BCS release (HEAD migrator) so GCS schema tables
-# exist before this fleet starts. Control-plane binaries run only here.
+# Same party identity as BCS (wallet, Postgres, Redis, S3, IRSA). Images come
+# from the coprocessor CI build, tagged <sha>.
+# The BCS release's migrator (pinned release) creates the database, so the
+# seeded versions are the ones the BCS binaries run. This release runs the
+# HEAD migrator on top as a Helm hook (deploy-coprocessor.sh) so the 0.15
+# columns exist before the fleet starts. Control-plane binaries run only here.
 commonConfig:
   stackVersion: "0.15.0"
   extraSelectorLabels:
     fhevm.zama.ai/fleet: gcs
   canonicalProtocolConfigChainId: "12345"
-
-dbMigration:
-  enabled: false
 
 upgradeController:
   enabled: true

--- a/ci/preview-env/scripts/deploy-coprocessor.sh
+++ b/ci/preview-env/scripts/deploy-coprocessor.sh
@@ -2,7 +2,7 @@
 # Install BCS (and optional GCS) coprocessor releases.
 # Env: NAMESPACE, NB_COPROCESSOR, BLUE_GREEN, DEPLOY_POLYGON, OBSERVABILITY,
 # AUTOMATED_TESTS, COPROCESSOR_CHART, TAGS_JSON, BCS_IMAGE_TAG, OTLP_ENDPOINT,
-# COPROC_WALLETS_JSON.
+# COPROC_WALLETS_JSON, GCS_STACK_VERSION (pod label for the GCS fleet; optional).
 set -euo pipefail
 
 polygon_args=()
@@ -47,6 +47,9 @@ party_common() {
 image_tags() {
   local tag="$1"
   bcs_images=(
+    # The pinned release creates the database, so the seeded versions are the
+    # ones its binaries run. The GCS release migrates on top of it.
+    --set-string "dbMigration.image.tag=${tag}"
     --set-string "gwListener.image.tag=${tag}"
     --set-string "hostListenerShared.image.tag=${tag}"
     --set-string "hostListenerPollerShared.image.tag=${tag}"
@@ -69,6 +72,7 @@ for i in $(seq 1 "${NB_COPROCESSOR}"); do
     image_tags "${BCS_IMAGE_TAG}"
   else
     bcs_images=(
+      --set-string "dbMigration.image.tag=$(jq -r .coprocessor_db_migration <<<"${TAGS_JSON}")"
       --set-string "gwListener.image.tag=$(jq -r .coprocessor_gw_listener <<<"${TAGS_JSON}")"
       --set-string "hostListenerShared.image.tag=$(jq -r .coprocessor_host_listener <<<"${TAGS_JSON}")"
       --set-string "hostListenerPollerShared.image.tag=$(jq -r .coprocessor_host_listener <<<"${TAGS_JSON}")"
@@ -91,7 +95,6 @@ for i in $(seq 1 "${NB_COPROCESSOR}"); do
     "${bcs_overlay[@]}" \
     "${fleet_json[@]}" \
     --set-string "fullnameOverride=coprocessor-${i}" \
-    --set-string "dbMigration.image.tag=$(jq -r .coprocessor_db_migration <<<"${TAGS_JSON}")" \
     "${common_args[@]}" \
     "${bcs_images[@]}"
 done
@@ -116,6 +119,12 @@ if [[ "${BLUE_GREEN}" == "true" ]]; then
     privkey=$(jq -r --argjson party "${i}" '.[] | select(.party == $party) | .privateKey' <<<"${COPROC_WALLETS_JSON}")
     party_common "${i}" "${privkey}" "-gcs"
     gcs_images=(
+      # HEAD migrator on the database the BCS release created. Runs as a Helm
+      # hook so it finishes before the fleet starts: a service that reads
+      # versioning before the consensus column exists treats it as unseeded
+      # and would come up blue.
+      --set-string "dbMigration.image.tag=$(jq -r .coprocessor_db_migration <<<"${TAGS_JSON}")"
+      --set-json 'dbMigration.annotations={"helm.sh/hook":"pre-install,pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation"}'
       --set-string "gwListener.image.tag=$(jq -r .coprocessor_gw_listener <<<"${TAGS_JSON}")"
       --set-string "hostListenerShared.image.tag=$(jq -r .coprocessor_host_listener <<<"${TAGS_JSON}")"
       --set-string "hostListenerPollerShared.image.tag=$(jq -r .coprocessor_host_listener <<<"${TAGS_JSON}")"
@@ -128,6 +137,12 @@ if [[ "${BLUE_GREEN}" == "true" ]]; then
       --set-string "upgradeController.image.tag=$(jq -r .coprocessor_tfhe_worker <<<"${TAGS_JSON}")"
       --set-string "consensusDetector.image.tag=$(jq -r .coprocessor_tfhe_worker <<<"${TAGS_JSON}")"
     )
+    # The label follows the compiled release when the workflow passes it; the
+    # overlay's value is the fallback for a manual run.
+    gcs_version_args=()
+    if [[ -n "${GCS_STACK_VERSION:-}" ]]; then
+      gcs_version_args=(--set-string "commonConfig.stackVersion=${GCS_STACK_VERSION}")
+    fi
     helm upgrade --install "coprocessor-${i}-gcs" "${COPROCESSOR_CHART}" \
       -n "${NAMESPACE}" -f ci/preview-env/coprocessor/values-coprocessor-e2e.yaml \
       -f ci/preview-env/coprocessor/values-coprocessor-gcs-e2e.yaml \
@@ -137,7 +152,8 @@ if [[ "${BLUE_GREEN}" == "true" ]]; then
       --set-string "consensusDetector.serviceAccountName=coprocessor-${i}" \
       --set "snsWorker.config.s3BucketName.valueFrom.configMapKeyRef.name=coprocessor-${i}" \
       "${common_args[@]}" \
-      "${gcs_images[@]}"
+      "${gcs_images[@]}" \
+      ${gcs_version_args[@]+"${gcs_version_args[@]}"}
   done
   if [[ "${AUTOMATED_TESTS}" == "true" ]]; then
     for i in $(seq 1 "${NB_COPROCESSOR}"); do

--- a/ci/preview-env/scripts/resolve-tags.cjs
+++ b/ci/preview-env/scripts/resolve-tags.cjs
@@ -143,17 +143,6 @@ module.exports = async ({ core, context, github }) => {
 
   const registry = registryClient({ core, user: process.env.GHCR_USER, token: process.env.GHCR_READ_TOKEN });
 
-  // GCS workers compiled with BUILD_STACK_VERSION publish as <sha>-gcs<ver>
-  // (see coprocessor-docker-build.yml image_tag). db-migration stays on <sha>.
-  const gcsImageTag = String(needs['build-coprocessor']?.outputs?.image_tag || '').trim();
-  const gcsBuiltKeys = new Set([
-    'coprocessor_gw_listener',
-    'coprocessor_host_listener',
-    'coprocessor_sns_worker',
-    'coprocessor_tfhe_worker',
-    'coprocessor_tx_sender',
-    'coprocessor_zkproof_worker',
-  ]);
 
   // 'success' -> freshly built+pushed; ''/undefined/'skipped' -> not built this
   // run. Anything else is FATAL: a failed build must not fall back to an older
@@ -196,7 +185,7 @@ module.exports = async ({ core, context, github }) => {
   for (const image of IMAGES) {
     const value = override(`${image.component}_version`);
     if (wasBuilt(image)) {
-      const tag = gcsImageTag && gcsBuiltKeys.has(image.key) ? gcsImageTag : shortSha;
+      const tag = shortSha;
       decisions.set(image.key, { tag, source: 'built', detail: `built this run (${tag})` });
     } else if (value) {
       decisions.set(image.key, { tag: value, source: 'dispatch-override', detail: 'explicit dispatch input' });
@@ -298,7 +287,6 @@ module.exports = async ({ core, context, github }) => {
     )
     .addRaw(
       `Base commit: ${baseWhy} \`${short(baseSha)}\`. Images built this run are tagged \`${shortSha}\`` +
-        (gcsImageTag ? `; GCS coprocessor workers use \`${gcsImageTag}\`` : '') +
         `; the rest resolve from the base commit (table below). Helm charts install from this run's ` +
         `checkout unless overridden (see preview-env-deploy.yml).\n\n`,
     )

--- a/coprocessor/fhevm-engine/consensus-detector/Dockerfile
+++ b/coprocessor/fhevm-engine/consensus-detector/Dockerfile
@@ -4,8 +4,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 
 USER root
 
@@ -28,8 +26,7 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p consensus-detector ${FEATURES} && \
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p consensus-detector && \
     cp target/${CARGO_PROFILE}/consensus-detector /tmp/consensus-detector
 
 # Stage 2: Runtime image

--- a/coprocessor/fhevm-engine/gw-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/gw-listener/Dockerfile
@@ -19,8 +19,6 @@ RUN npm install && \
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -76,8 +74,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
     fi && \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener ${FEATURES} && \
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p gw-listener && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     cp target/${CARGO_PROFILE}/gw_listener /tmp/gw_listener
 

--- a/coprocessor/fhevm-engine/host-listener/Dockerfile
+++ b/coprocessor/fhevm-engine/host-listener/Dockerfile
@@ -5,8 +5,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -59,8 +57,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
     fi && \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener ${FEATURES} && \
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p host-listener && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     cp target/${CARGO_PROFILE}/host_listener /tmp/host_listener && \
     cp target/${CARGO_PROFILE}/host_listener_poller /tmp/host_listener_poller && \

--- a/coprocessor/fhevm-engine/sns-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/sns-worker/Dockerfile
@@ -4,8 +4,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -57,8 +55,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
     fi && \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker ${FEATURES} && \
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p sns-worker && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     cp target/${CARGO_PROFILE}/sns_worker /tmp/sns_worker
 

--- a/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/tfhe-worker/Dockerfile
@@ -4,8 +4,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -57,8 +55,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
     fi && \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker ${FEATURES} && \
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p tfhe-worker && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     cp target/${CARGO_PROFILE}/tfhe_worker /tmp/tfhe_worker
 

--- a/coprocessor/fhevm-engine/transaction-sender/Dockerfile
+++ b/coprocessor/fhevm-engine/transaction-sender/Dockerfile
@@ -4,8 +4,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -57,8 +55,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
     fi && \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender ${FEATURES} && \
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p transaction-sender && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     cp target/${CARGO_PROFILE}/transaction_sender /tmp/transaction_sender
 

--- a/coprocessor/fhevm-engine/upgrade-controller/Dockerfile
+++ b/coprocessor/fhevm-engine/upgrade-controller/Dockerfile
@@ -4,8 +4,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 
 USER root
 
@@ -28,8 +26,7 @@ WORKDIR /app/coprocessor/fhevm-engine
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/app/coprocessor/fhevm-engine/target,sharing=locked \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p upgrade-controller ${FEATURES} && \
+    SQLX_OFFLINE=true BUILD_ID=$(cat BUILD_ID) cargo build --profile=${CARGO_PROFILE} -p upgrade-controller && \
     cp target/${CARGO_PROFILE}/upgrade-controller /tmp/upgrade-controller
 
 # Stage 2: Runtime image

--- a/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
+++ b/coprocessor/fhevm-engine/zkproof-worker/Dockerfile
@@ -4,8 +4,6 @@ ARG RUST_IMAGE_VERSION
 FROM ghcr.io/zama-ai/fhevm/gci/rust-glibc:${RUST_IMAGE_VERSION} AS builder
 
 ARG CARGO_PROFILE=release
-# Compiled stack version; unset => baseline (0.14.0), GCS build passes a newer one.
-ARG BUILD_STACK_VERSION
 ARG SCCACHE_BUCKET
 ARG SCCACHE_REGION=eu-west-3
 ARG SCCACHE_S3_PREFIX
@@ -57,8 +55,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
       export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/sccache_aws_secret_access_key)"; \
     fi && \
     cargo fetch && \
-    FEATURES=""; if [ -n "${BUILD_STACK_VERSION}" ]; then FEATURES="--features fhevm-engine-common/stack-version-override"; export BUILD_STACK_VERSION="${BUILD_STACK_VERSION}"; fi && \
-    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker ${FEATURES} && \
+    SQLX_OFFLINE=true cargo build --profile=${CARGO_PROFILE} -p zkproof-worker && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache >/dev/null 2>&1; then sccache --show-stats; fi && \
     cp target/${CARGO_PROFILE}/zkproof_worker /tmp/zkproof_worker
 


### PR DESCRIPTION
## Summary

- Drop `BUILD_STACK_VERSION` from the Dockerfiles and the coprocessor image workflow. Every published image reports the version its source says; GCS images are tagged `<sha>` like the rest, and the `-gcs<ver>` tag is gone.
- The preview env reads the release from `fhevm-engine-common/src/lib.rs` and passes it to the GCS pod label and to the upgrade scripts, so a bump is one edit.
- In blue-green, the pinned BCS release creates the database and the GCS release runs the HEAD migrator on top as a Helm pre-install hook. The seeded versions are blue's, and the `consensus_version` column exists before green starts. Without this, `bootstrap_versioning` seeds green's versions as live: blue is retired at start and green comes up blue.
- The preview env is torn down when any `preview-env-*` label is removed, not only `preview-env-e2e`.

The Cargo override features stay for local runs only (`run_with_localnet.sh`).
