### PR TITLE
fix(sdk): correct subpath entry paths to 'core' and add 'typesVersions'

### DIFF
--- a/sdk/js-sdk/src/core/chains/package.json
+++ b/sdk/js-sdk/src/core/chains/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "types": "../../_types/chains/index.d.ts",
-  "module": "../../_esm/chains/index.js",
-  "main": "../../_cjs/chains/index.js"
+  "types": "../../_types/core/chains/index.d.ts",
+  "module": "../../_esm/core/chains/index.js",
+  "main": "../../_cjs/core/chains/index.js"
 }

--- a/sdk/js-sdk/src/package.json
+++ b/sdk/js-sdk/src/package.json
@@ -18,6 +18,34 @@
     "!wasm/tfhe/v*/**",
     "!wasm/tkms/v*/**"
   ],
+  "typesVersions": {
+    "*": {
+      "base": [
+        "./_types/core/base/index.d.ts"
+      ],
+      "chains": [
+        "./_types/core/chains/index.d.ts"
+      ],
+      "types": [
+        "./_types/core/types/index.d.ts"
+      ],
+      "actions/base": [
+        "./_types/core/actions/base/index.d.ts"
+      ],
+      "actions/chain": [
+        "./_types/core/actions/chain/index.d.ts"
+      ],
+      "actions/decrypt": [
+        "./_types/core/actions/decrypt/index.d.ts"
+      ],
+      "actions/encrypt": [
+        "./_types/core/actions/encrypt/index.d.ts"
+      ],
+      "actions/host": [
+        "./_types/core/actions/host/index.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "types": "./_types/index.d.ts",


### PR DESCRIPTION
## Problem

Eight of the twelve public subpaths exported by `@fhevm/sdk` cannot be resolved by
TypeScript under `moduleResolution: node10`:

```sh
./base  
./chains   
./types
./actions/base   
./actions/chain  
./actions/decrypt
./actions/encrypt  
./actions/host
```

A consumer writing this gets `TS2307`:

```ts
import { mainnet } from '@fhevm/sdk/chains';
// error TS2307: Cannot find module '@fhevm/sdk/chains' or its corresponding
// type declarations.
// There are types at '.../_types/core/chains/index.d.ts', but this result
// could not be resolved under your current 'moduleResolution' setting.
```

## Solution

`exports` maps `./chains` to `_types/core/chains/…`, but `moduleResolution: node10` ignores `exports` and looks for a `chains/` directory that does not exist — the sources live under `core/`.

Added `typesVersions` to `src/package.json`, mapping each flattened public subpath to its declaration file:

```jsonc
"typesVersions": {
  "*": {
    "chains": ["./_types/core/chains/index.d.ts"],
    "base":   ["./_types/core/base/index.d.ts"]
    // … 6 more
  }
}
