### PR TITLE
fix(coprocessor): guard a green deployment against a database in the wrong state

### DIFF
--- a/charts/coprocessor/Chart.yaml
+++ b/charts/coprocessor/Chart.yaml
@@ -1,6 +1,6 @@
 name: coprocessor
 description: A helm chart to distribute and deploy Zama fhevm Co-Processor services
-version: 0.13.18
+version: 0.13.19
 apiVersion: v2
 keywords:
   - fhevm

--- a/charts/coprocessor/templates/coprocessor-db-migration.yaml
+++ b/charts/coprocessor/templates/coprocessor-db-migration.yaml
@@ -53,6 +53,8 @@ spec:
         command: ["/initialize_db.sh"]
         {{- end }}
         env:
+          - name: ALLOW_DB_BOOTSTRAP
+            value: {{ if .Values.dbMigration.allowBootstrap }}"true"{{ else }}"false"{{ end }}
           {{- with .Values.commonConfig.databaseUser }}
           - name: DATABASE_USER
             {{- if .value }}

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -215,10 +215,10 @@ polygonContractConfigMap:
 # Sets up the database schema and initial data
 dbMigration:
   enabled: true
-  # Whether this release may create an empty database. Off by default: an empty
-  # database must be set up by the release that is live, and a green (new
-  # release) fleet finds it later. Set true only for the first install of an
-  # operator; keep it false for a green release.
+  # Whether this release may create the database (the database itself and its
+  # first setup). Off by default: the database must be created by the release
+  # that is live, and a green (new release) fleet finds it later. Set true only
+  # for the first install of an operator; keep it false for a green release.
   allowBootstrap: false
 
   # Optional Helm hook annotations for Infra-owned deployment ordering.

--- a/charts/coprocessor/values.yaml
+++ b/charts/coprocessor/values.yaml
@@ -215,6 +215,11 @@ polygonContractConfigMap:
 # Sets up the database schema and initial data
 dbMigration:
   enabled: true
+  # Whether this release may create an empty database. Off by default: an empty
+  # database must be set up by the release that is live, and a green (new
+  # release) fleet finds it later. Set true only for the first install of an
+  # operator; keep it false for a green release.
+  allowBootstrap: false
 
   # Optional Helm hook annotations for Infra-owned deployment ordering.
   #
@@ -225,9 +230,13 @@ dbMigration:
   #
   # The wave1 *_branch shadow tables are deprecated in v0.15 (no v0.15 binary
   # reads or writes them) but are only dropped by a v0.16 migration; see
-  # coprocessor/fhevm-engine/db-migration/DEPRECATIONS.md. This release
-  # therefore needs no ordering between the migration Job and the service
-  # Deployments. Infra may opt into a hook only if every Job dependency is
+  # coprocessor/fhevm-engine/db-migration/DEPRECATIONS.md.
+  #
+  # Services pick their role from versioning.consensus_version at startup, a
+  # column this release's migration adds. A green (new release) fleet must start
+  # after its migration Job has run: a service that starts earlier exits with an
+  # error and restarts. For the green release, enable the hook below so Helm runs
+  # the Job before the Deployments. Every Job dependency must then be
   # pre-existing or rendered as an earlier hook with a lower hook weight.
   annotations: {}
   # annotations:

--- a/ci/preview-env/coprocessor/values-coprocessor-e2e.yaml
+++ b/ci/preview-env/coprocessor/values-coprocessor-e2e.yaml
@@ -66,6 +66,10 @@ commonConfig:
 # (or `latest` when this component didn't change in the PR).
 dbMigration:
   image: {name: hub.zama.org/ghcr/zama-ai/fhevm/coprocessor/db-migration, tag: latest}
+  # The coprocessor-<i> release runs first on each party's empty database, so it
+  # is allowed to create it. values-coprocessor-gcs-e2e.yaml sets this to false
+  # for the coprocessor-<i>-gcs release: it must find the database, not create it.
+  allowBootstrap: true
 
 #=======================================================
 hostListenerShared:

--- a/ci/preview-env/coprocessor/values-coprocessor-gcs-e2e.yaml
+++ b/ci/preview-env/coprocessor/values-coprocessor-gcs-e2e.yaml
@@ -13,6 +13,11 @@ commonConfig:
     fhevm.zama.ai/fleet: gcs
   canonicalProtocolConfigChainId: "12345"
 
+# The GCS migrator runs on the database the BCS release created; it must never
+# create one itself.
+dbMigration:
+  allowBootstrap: false
+
 upgradeController:
   enabled: true
   image: {name: hub.zama.org/ghcr/zama-ai/fhevm/coprocessor/upgrade-controller, tag: latest}

--- a/coprocessor/fhevm-engine/db-migration/initialize_db.sh
+++ b/coprocessor/fhevm-engine/db-migration/initialize_db.sh
@@ -286,6 +286,19 @@ initialize_versions_for_deployment() {
   bootstrap_versioning || { log "ERROR: failed to set initial versions"; exit 1; }
 }
 
+# A new database is created only when this release is told to. An empty database
+# must be set up by the release that is live; a newer release finds it later.
+require_bootstrap_allowed() {
+  if [ "$DEPLOYMENT_MODE" != "bootstrap" ]; then
+    return 0
+  fi
+  if [ "${ALLOW_DB_BOOTSTRAP:-false}" = "true" ]; then
+    return 0
+  fi
+  log "ERROR: empty database, but this release must not create one (ALLOW_DB_BOOTSTRAP is not true). Run the first release's migration first."
+  exit 1
+}
+
 # Add a marker before the first migration. It allows a failed setup to retry.
 prepare_version_bootstrap_intent() {
   if [ "$DEPLOYMENT_MODE" = "existing" ]; then
@@ -308,6 +321,7 @@ prepare_version_bootstrap_intent() {
 
 log "Running migrations..."
 resolve_deployment_mode
+require_bootstrap_allowed
 prepare_version_bootstrap_intent
 if [ "${RUN_MIGRATIONS_UNTIL_REMOVE_TENANTS:-}" = "true" ]; then
   # Partial migrations — the host_chains table doesn't exist yet on this path,

--- a/coprocessor/fhevm-engine/db-migration/initialize_db.sh
+++ b/coprocessor/fhevm-engine/db-migration/initialize_db.sh
@@ -230,8 +230,15 @@ precreate_pending_dcid_index() {
 
 log "-------------- Start database initialization --------------"
 
-log "Creating database..."
-sqlx database create 2>&1 | log_stream || { log "Failed to create database."; exit 1; }
+# Only a release allowed to bootstrap may create the database itself. Otherwise
+# the database must already exist: a green release never creates one.
+if [ "${ALLOW_DB_BOOTSTRAP:-false}" = "true" ]; then
+  log "Creating database..."
+  sqlx database create 2>&1 | log_stream || { log "Failed to create database."; exit 1; }
+else
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "SELECT 1" >/dev/null 2>&1 \
+    || { log "ERROR: database does not exist or is unreachable, and this release must not create one (ALLOW_DB_BOOTSTRAP is not true)."; exit 1; }
+fi
 
 # The wave1 squash (#2848) shipped an in-place edit of the already-applied
 # migration 20260616120000_bridge_tables.sql; this tree restores the original
@@ -286,8 +293,8 @@ initialize_versions_for_deployment() {
   bootstrap_versioning || { log "ERROR: failed to set initial versions"; exit 1; }
 }
 
-# A new database is created only when this release is told to. An empty database
-# must be set up by the release that is live; a newer release finds it later.
+# An empty database is set up only when this release is told to. It must be set
+# up by the release that is live; a newer release finds it later.
 require_bootstrap_allowed() {
   if [ "$DEPLOYMENT_MODE" != "bootstrap" ]; then
     return 0

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/bin/bootstrap_versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/bin/bootstrap_versioning.rs
@@ -3,6 +3,12 @@ use sqlx::postgres::PgPoolOptions;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // The migration script checks this first; the binary checks it again so the
+    // versions can never be written by a release that was not told to create the database.
+    anyhow::ensure!(
+        std::env::var("ALLOW_DB_BOOTSTRAP").is_ok_and(|v| v == "true"),
+        "ALLOW_DB_BOOTSTRAP is not true: this release must not create a database"
+    );
     let database_url = resolve_database_url_from_option(None)?;
     let (pool, _refresh) =
         connect_pool_with_options(&database_url, PgPoolOptions::new().max_connections(1), None)

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -327,10 +327,11 @@ pub struct StaleStackError {
     pub live: i64,
 }
 
-/// True if `err` is Postgres `undefined_table` (SQLSTATE 42P01) or `undefined_column`
-/// (SQLSTATE 42703) - i.e. the `versioning` row is not readable yet (migrations not applied).
+/// True if `err` is Postgres `undefined_table` (SQLSTATE 42P01) - i.e. the `versioning`
+/// table does not exist yet (migrations not applied). A missing `consensus_version` column
+/// is the previous release's database before this release's migration; that stays an error.
 fn is_unmigrated(err: &sqlx::Error) -> bool {
-    matches!(err, sqlx::Error::Database(db) if matches!(db.code().as_deref(), Some("42P01" | "42703")))
+    matches!(err, sqlx::Error::Database(db) if db.code().as_deref() == Some("42P01"))
 }
 
 /// Fetch the live consensus version singleton, or `None` if the `versioning` row is

--- a/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
+++ b/coprocessor/fhevm-engine/fhevm-engine-common/src/versioning.rs
@@ -330,7 +330,7 @@ pub struct StaleStackError {
 /// True if `err` is Postgres `undefined_table` (SQLSTATE 42P01) - i.e. the `versioning`
 /// table does not exist yet (migrations not applied). A missing `consensus_version` column
 /// is the previous release's database before this release's migration; that stays an error.
-fn is_unmigrated(err: &sqlx::Error) -> bool {
+fn is_undefined_table(err: &sqlx::Error) -> bool {
     matches!(err, sqlx::Error::Database(db) if db.code().as_deref() == Some("42P01"))
 }
 
@@ -349,7 +349,7 @@ async fn live_consensus_version(conn: &mut PgConnection) -> Result<Option<i64>, 
     .await
     {
         Ok(row) => row,
-        Err(err) if is_unmigrated(&err) => {
+        Err(err) if is_undefined_table(&err) => {
             warn!(
                     binary_consensus_version = CONSENSUS_PROTOCOL_VERSION,
                     "versioning row is not readable yet (migrations not applied?); treating as unseeded"

--- a/coprocessor/fhevm-engine/tfhe-worker/docker-compose.yml
+++ b/coprocessor/fhevm-engine/tfhe-worker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       target: db-migration
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/coprocessor
+      ALLOW_DB_BOOTSTRAP: "true"
       ACL_CONTRACT_ADDRESS: "0x339EcE85B9E11a3A3AA557582784a15d7F82AAf2"
       # Reproduces the prior behavior of the (now-deleted) insert_test_host_chain.sh,
       # which seeded chain_id=12345 with the ACL above. seed_host_chains in

--- a/coprocessor/fhevm-engine/tfhe-worker/src/tests/versioning.rs
+++ b/coprocessor/fhevm-engine/tfhe-worker/src/tests/versioning.rs
@@ -56,6 +56,31 @@ async fn gcs_mode_tracks_consensus_version_not_release() {
 }
 
 #[tokio::test]
+async fn gcs_mode_fails_before_the_consensus_column_exists() {
+    let db = setup_test_db(ImportMode::None)
+        .await
+        .expect("setup test db");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(db.db_url())
+        .await
+        .expect("connect");
+
+    // The previous release's database: versioning exists, the column does not.
+    sqlx::query("ALTER TABLE versioning DROP COLUMN consensus_version")
+        .execute(&pool)
+        .await
+        .expect("drop column");
+    let error = resolve_gcs_mode(db.db_url())
+        .await
+        .expect_err("must not pick a mode from an unmigrated database");
+    assert!(
+        format!("{error:#}").contains("consensus_version"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[tokio::test]
 async fn bootstrap_refuses_existing_database_and_consensus_downgrade() {
     let db = setup_test_db(ImportMode::None)
         .await

--- a/host-contracts/COPROCESSOR_UPGRADE_RUNBOOK.md
+++ b/host-contracts/COPROCESSOR_UPGRADE_RUNBOOK.md
@@ -10,6 +10,11 @@ A hex string (calldata) intended for submission as the action of an Aragon DAO p
 
 - The new coprocessor version is built and the release tag is known (e.g. `v0.15.0`).
 - Its `CONSENSUS_PROTOCOL_VERSION` is one above the active `versioning.consensus_version`.
+- Every operator has run the new release's database migration before starting its green
+  stack. A green service started earlier exits with an error about
+  `versioning.consensus_version` until the migration has run.
+- The green release never creates a database: keep `dbMigration.allowBootstrap` off for it (the
+  chart default). Only the first install of an operator sets it on.
 
 `--software-version` takes the release tag, never the consensus version: `v0.15.0` for the
 v0.14 to v0.15 upgrade, `v0.15.1` for a v0.15 to v0.15.1 one. The consensus version is a

--- a/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
+++ b/test-suite/fhevm/docker-compose/coprocessor-docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ${FHEVM_STATE_DIR:-../../../.fhevm}/runtime/env/coprocessor.env
     environment:
       - KEY_ID=${FHE_KEY_ID}
+      - ALLOW_DB_BOOTSTRAP=true
     command:
       - /initialize_db.sh
     volumes:

--- a/test-suite/fhevm/src/generate/compose.ts
+++ b/test-suite/fhevm/src/generate/compose.ts
@@ -695,6 +695,9 @@ const buildCoprocessorOverride = async (plan: StackSpec) => {
           bcsMigration.container_name = bcsMigrationName;
           bcsMigration.image = rewriteImageTag(bcsMigration.image, instance.source.tag);
           delete bcsMigration.build;
+          // Only the pinned release may create the database; the HEAD migration must find it.
+          bcsMigration.environment = { ...normalizeEnvironment(bcsMigration.environment), ALLOW_DB_BOOTSTRAP: "true" };
+          adjusted.environment = { ...normalizeEnvironment(adjusted.environment), ALLOW_DB_BOOTSTRAP: "false" };
           if (instance.index > 0 && bcsMigration.depends_on && typeof bcsMigration.depends_on === "object") {
             bcsMigration.depends_on = rewriteCoprocessorDependsOn(
               bcsMigration.depends_on as Record<string, unknown>,

--- a/test-suite/fhevm/src/render-compose.test.ts
+++ b/test-suite/fhevm/src/render-compose.test.ts
@@ -723,6 +723,11 @@ gcs:
       expect(doc.services["coprocessor-db-migration"]?.depends_on).toMatchObject({
         "coprocessor-bcs-db-migration": { condition: "service_completed_successfully" },
       });
+      // Only the pinned BCS migration may create the database; the HEAD one must find it.
+      const env = (name: string) =>
+        (doc.services[name] as { environment?: Record<string, string> } | undefined)?.environment;
+      expect(env("coprocessor-bcs-db-migration")).toMatchObject({ ALLOW_DB_BOOTSTRAP: "true" });
+      expect(env("coprocessor-db-migration")).toMatchObject({ ALLOW_DB_BOOTSTRAP: "false" });
       expect(doc.services["coprocessor-gcs-tfhe-worker"]?.build).toBeDefined();
       expect(
         doc.services["coprocessor-host-listener"]?.environment


### PR DESCRIPTION
## Summary

Two defensive fixes for a new release (green) deployment that meets a database in the wrong state.

- A service started before its migration no longer reads the missing `versioning.consensus_version` column as "unseeded -> blue". It fails, restarts, and resolves its role once the migration has run. A missing `versioning` table stays permissive.
- A migrator only creates an empty database when told to: `ALLOW_DB_BOOTSTRAP=true`, exposed as `dbMigration.allowBootstrap` (off by default). `initialize_db.sh` exits before creating anything otherwise; `bootstrap_versioning` checks it again.
- Chart comment and runbook: run the migration before starting green; a green release never creates a database.

Chart default change: fresh installs must set `dbMigration.allowBootstrap: true`.

Related: 
- zama-ai/fhevm-internal#2009
- zama-ai/fhevm-internal#2010